### PR TITLE
fix(tracer): downgrade default trace api from v05 to v04 [backport #6947 to 1.x]

### DIFF
--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -35,8 +35,6 @@ from ..constants import _HTTPLIB_NO_TRACE_REQUEST
 from ..encoding import JSONEncoderV2
 from ..logger import get_logger
 from ..runtime import container
-from ..serverless import in_azure_function_consumption_plan
-from ..serverless import in_gcp_function
 from ..sma import SimpleMovingAverage
 from .writer_client import AgentWriterClientV3
 from .writer_client import AgentWriterClientV4
@@ -500,11 +498,8 @@ class AgentWriter(HTTPWriter):
         #      as a safety precaution.
         #      https://docs.python.org/3/library/sys.html#sys.platform
         is_windows = sys.platform.startswith("win") or sys.platform.startswith("cygwin")
-        default_api_version = (
-            "v0.4" if (is_windows or in_gcp_function() or in_azure_function_consumption_plan()) else "v0.5"
-        )
 
-        self._api_version = api_version or config._trace_api or (default_api_version if priority_sampling else "v0.3")
+        self._api_version = api_version or config._trace_api or ("v0.4" if priority_sampling else "v0.3")
         if is_windows and self._api_version == "v0.5":
             raise RuntimeError(
                 "There is a known compatibility issue with v0.5 API and Windows, "

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -135,6 +135,7 @@ metadata
 microservices
 middleware
 middlewares
+misencoded
 moderations
 mongoengine
 multiline

--- a/releasenotes/notes/downgrade-encoding-to-v05-96458e1942295721.yaml
+++ b/releasenotes/notes/downgrade-encoding-to-v05-96458e1942295721.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    tracing: Encoding traces in the v05 format has a known issue for
+    applications generating spans at a high frequency, causing approximately
+    1/10000000 spans to be misencoded.
+    This change sets ``DD_TRACE_API_VERSION`` to ``v04`` by default. 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -124,7 +124,7 @@ def test_uds_wrong_socket_path():
         mock.call(
             "failed to send, dropping %d traces to intake at %s after %d retries",
             1,
-            "unix:///tmp/ddagent/nosockethere/{}/traces".format(encoding if encoding else "v0.5"),
+            "unix:///tmp/ddagent/nosockethere/{}/traces".format(encoding if encoding else "v0.4"),
             3,
         )
     ]
@@ -382,7 +382,7 @@ def test_trace_generates_error_logs_when_hostname_invalid():
         mock.call(
             "failed to send, dropping %d traces to intake at %s after %d retries",
             1,
-            "http://bad:1111/{}/traces".format(encoding if encoding else "v0.5"),
+            "http://bad:1111/{}/traces".format(encoding if encoding else "v0.4"),
             3,
         )
     ]
@@ -471,7 +471,7 @@ def test_trace_with_invalid_payload_generates_error_log():
         [
             mock.call(
                 "failed to send traces to intake at %s: HTTP error status %s, reason %s",
-                "http://localhost:8126/v0.5/traces",
+                "http://localhost:8126/v0.4/traces",
                 400,
                 "Bad Request",
             )
@@ -550,9 +550,9 @@ def test_api_version_downgrade_generates_no_warning_logs():
 
     from ddtrace import tracer as t
 
-    encoding = os.environ["DD_TRACE_API_VERSION"]
+    encoding = os.environ["DD_TRACE_API_VERSION"] or "v0.4"
     t._writer._downgrade(None, None, t._writer._clients[0])
-    assert t._writer._endpoint == {"v0.5": "v0.4/traces", "v0.4": "v0.3/traces"}[encoding or "v0.5"]
+    assert t._writer._endpoint == {"v0.5": "v0.4/traces", "v0.4": "v0.3/traces"}[encoding]
     with mock.patch("ddtrace.internal.writer.writer.log") as log:
         t.trace("operation", service="my-svc").finish()
         t.shutdown()

--- a/tests/snapshots/test_extended_sampling_resource.json
+++ b/tests/snapshots/test_extended_sampling_resource.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "should_not_send",
-    "service": "",
+    "service": null,
     "resource": "mycoolre$ource",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -26,13 +24,11 @@
 [
   {
     "name": "should_send",
-    "service": "",
+    "service": null,
     "resource": "something else",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",

--- a/tests/snapshots/test_extended_sampling_tags.json
+++ b/tests/snapshots/test_extended_sampling_tags.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "should_not_send",
-    "service": "",
+    "service": null,
     "resource": "should_not_send",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -27,13 +25,11 @@
 [
   {
     "name": "should_send",
-    "service": "",
+    "service": null,
     "resource": "should_send",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "banana": "True",

--- a/tests/snapshots/test_extended_sampling_tags_and_resource.json
+++ b/tests/snapshots/test_extended_sampling_tags_and_resource.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "should_not_send",
-    "service": "",
+    "service": null,
     "resource": "mycoolre$ource",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -27,13 +25,11 @@
 [
   {
     "name": "should_send1",
-    "service": "",
+    "service": null,
     "resource": "should_send1",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "banana": "True",
@@ -52,13 +48,11 @@
 [
   {
     "name": "should_send2",
-    "service": "",
+    "service": null,
     "resource": "banana",
     "trace_id": 2,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -77,13 +71,11 @@
 [
   {
     "name": "should_send3",
-    "service": "",
+    "service": null,
     "resource": "mycoolre$ource",
     "trace_id": 3,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "banana": "True",

--- a/tests/snapshots/test_extended_sampling_tags_glob.json
+++ b/tests/snapshots/test_extended_sampling_tags_glob.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "should_not_send",
-    "service": "",
+    "service": null,
     "resource": "should_not_send",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -27,13 +25,11 @@
 [
   {
     "name": "should_send",
-    "service": "",
+    "service": null,
     "resource": "should_send",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",

--- a/tests/snapshots/test_sampling_with_default_sample_rate_1.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_1.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "trace2",
-    "service": "",
+    "service": null,
     "resource": "trace2",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -25,13 +23,11 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 11602,
        "start": 1692637140104307759
      }]]

--- a/tests/snapshots/test_sampling_with_default_sample_rate_1_and_manual_drop.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_1_and_manual_drop.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "trace6",
-    "service": "",
+    "service": null,
     "resource": "trace6",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-4",
       "language": "python",
@@ -24,13 +22,11 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 16195,
        "start": 1691163616781394547
      }]]

--- a/tests/snapshots/test_sampling_with_default_sample_rate_1_and_manual_keep.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_1_and_manual_keep.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "trace7",
-    "service": "",
+    "service": null,
     "resource": "trace7",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-4",
       "language": "python",
@@ -24,13 +22,11 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 15852,
        "start": 1691163616795612344
      }]]

--- a/tests/snapshots/test_sampling_with_default_sample_rate_1_and_rule_0.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_1_and_rule_0.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "trace5",
-    "service": "",
+    "service": null,
     "resource": "trace5",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -25,13 +23,11 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 10017,
        "start": 1692637140145900065
      }]]

--- a/tests/snapshots/test_sampling_with_default_sample_rate_1_and_rule_1.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_1_and_rule_1.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "trace4",
-    "service": "",
+    "service": null,
     "resource": "trace4",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -25,13 +23,11 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 9941,
        "start": 1692637140131765552
      }]]

--- a/tests/snapshots/test_sampling_with_default_sample_rate_tiny.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_tiny.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "trace3",
-    "service": "",
+    "service": null,
     "resource": "trace3",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -25,13 +23,11 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 10120,
        "start": 1692637140116692585
      }]]

--- a/tests/snapshots/test_sampling_with_defaults.json
+++ b/tests/snapshots/test_sampling_with_defaults.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "trace1",
-    "service": "",
+    "service": null,
     "resource": "trace1",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -24,13 +22,11 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 10853,
        "start": 1691163616713219858
      }]]

--- a/tests/snapshots/test_sampling_with_rate_limit_3.json
+++ b/tests/snapshots/test_sampling_with_rate_limit_3.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "trace5",
-    "service": "",
+    "service": null,
     "resource": "trace5",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -25,13 +23,11 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 11067,
        "start": 1692390478003347011
      }]]

--- a/tests/snapshots/test_sampling_with_sample_rate_1_and_rate_limit_0.json
+++ b/tests/snapshots/test_sampling_with_sample_rate_1_and_rate_limit_0.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "trace5",
-    "service": "",
+    "service": null,
     "resource": "trace5",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -26,13 +24,11 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 13513,
        "start": 1692390477975743489
      }]]

--- a/tests/snapshots/test_sampling_with_sample_rate_1_and_rate_limit_3_and_rule_0.json
+++ b/tests/snapshots/test_sampling_with_sample_rate_1_and_rate_limit_3_and_rule_0.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "trace5",
-    "service": "",
+    "service": null,
     "resource": "trace5",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -26,13 +24,11 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 10378,
        "start": 1692390477989570486
      }]]

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "aiohttp.request",
-    "service": "",
+    "service": null,
     "resource": "aiohttp.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "aiohttp_client",
@@ -31,13 +30,11 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": "",
+       "service": null,
        "resource": "TCPConnector.connect",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "aiohttp"
        },

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request_post.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request_post.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "aiohttp.request",
-    "service": "",
+    "service": null,
     "resource": "aiohttp.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "aiohttp_client",
@@ -31,13 +30,11 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": "",
+       "service": null,
        "resource": "TCPConnector.connect",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "aiohttp"
        },

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_500_request.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_500_request.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "aiohttp.request",
-    "service": "",
+    "service": null,
     "resource": "aiohttp.request",
     "trace_id": 0,
     "span_id": 1,
@@ -31,13 +31,11 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": "",
+       "service": null,
        "resource": "TCPConnector.connect",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "aiohttp"
        },

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_auth_200_request.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_auth_200_request.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "aiohttp.request",
-    "service": "",
+    "service": null,
     "resource": "aiohttp.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "aiohttp_client",
@@ -31,13 +30,11 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": "",
+       "service": null,
        "resource": "TCPConnector.connect",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "aiohttp"
        },

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[None].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[None].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "aiohttp_client",
@@ -36,8 +35,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "aiohttp"
        },

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v0].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v0].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "aiohttp_client",
@@ -36,8 +35,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "aiohttp"
        },

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v1].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v1].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",
@@ -38,8 +37,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "aiohttp"
        },

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_service_name_pin.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_service_name_pin.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -37,8 +36,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "aiohttp"

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_multiple.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_multiple.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "aiohttp.request",
-    "service": "",
+    "service": null,
     "resource": "aiohttp.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "aiohttp_client",
@@ -31,13 +30,11 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": "",
+       "service": null,
        "resource": "TCPConnector.connect",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "aiohttp"
        },
@@ -47,13 +44,12 @@
 [
   {
     "name": "aiohttp.request",
-    "service": "",
+    "service": null,
     "resource": "aiohttp.request",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "aiohttp_client",
@@ -77,13 +73,11 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": "",
+       "service": null,
        "resource": "TCPConnector.connect",
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "aiohttp"
        },
@@ -93,13 +87,12 @@
 [
   {
     "name": "aiohttp.request",
-    "service": "",
+    "service": null,
     "resource": "aiohttp.request",
     "trace_id": 2,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "aiohttp_client",
@@ -123,13 +116,11 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": "",
+       "service": null,
        "resource": "TCPConnector.connect",
        "trace_id": 2,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "aiohttp"
        },

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_parenting.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_parenting.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "parent",
-    "service": "",
+    "service": null,
     "resource": "parent",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -24,13 +22,12 @@
   },
      {
        "name": "aiohttp.request",
-       "service": "",
+       "service": null,
        "resource": "aiohttp.request",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
-       "error": 0,
        "meta": {
          "component": "aiohttp_client",
          "http.method": "GET",
@@ -45,13 +42,11 @@
      },
         {
           "name": "TCPConnector.connect",
-          "service": "",
+          "service": null,
           "resource": "TCPConnector.connect",
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "component": "aiohttp"
           },

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_query_string.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_query_string.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "aiohttp.request",
-    "service": "",
+    "service": null,
     "resource": "aiohttp.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "aiohttp_client",
@@ -32,13 +31,11 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": "",
+       "service": null,
        "resource": "TCPConnector.connect",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "aiohttp"
        },

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[None].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[None].json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "aiohttp.request",
-    "service": "",
+    "service": null,
     "resource": "aiohttp.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "aiohttp_client",
@@ -31,13 +30,11 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": "",
+       "service": null,
        "resource": "TCPConnector.connect",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "aiohttp"
        },

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v0].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v0].json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "aiohttp.request",
-    "service": "",
+    "service": null,
     "resource": "aiohttp.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "aiohttp_client",
@@ -31,13 +30,11 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": "",
+       "service": null,
        "resource": "TCPConnector.connect",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "aiohttp"
        },

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v1].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v1].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",
@@ -38,8 +37,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "aiohttp"
        },

--- a/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot.json
+++ b/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "aiohttp.template",
-    "service": "",
+    "service": null,
     "resource": "aiohttp.template",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "template",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "aiohttp.template": "/template.jinja2",

--- a/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot[pyloop].json
+++ b/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot[pyloop].json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "aiohttp.template",
-    "service": "",
+    "service": null,
     "resource": "aiohttp.template",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "template",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "aiohttp.template": "/template.jinja2",

--- a/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot_patched_server[True].json
+++ b/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot_patched_server[True].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -38,7 +37,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "template",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "aiohttp.template": "/template.jinja2",

--- a/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot_patched_server[pyloop-True].json
+++ b/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot_patched_server[pyloop-True].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -38,7 +37,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "template",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "aiohttp.template": "/template.jinja2",

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_async_with_usage.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_async_with_usage.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "mysql.query",
-    "service": "",
+    "service": null,
     "resource": "SELECT 1",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "aiomysql",

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_pin_override[True].json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_pin_override[True].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "aiomysql",

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_queries.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_queries.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "mysql.query",
-    "service": "",
+    "service": null,
     "resource": "select 'Jellysmack'",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "aiomysql",
@@ -35,7 +34,7 @@
 [
   {
     "name": "mysql.query",
-    "service": "",
+    "service": null,
     "resource": "select * from some_non_existant_table",
     "trace_id": 1,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v0].json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v0].json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "mysql.query",
-    "service": "",
+    "service": null,
     "resource": "select 'dba4x4'",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "aiomysql",

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v1].json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v1].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "db.name",

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_unspecified_service_v1.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_unspecified_service_v1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "db.name",

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v0.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v0.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "aiomysql",

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v1.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "db.name",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_basic_request.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_basic_request.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_closed_connection_pool.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_closed_connection_pool.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_cmd_max_length.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_cmd_max_length.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_decoding_non_utf8_args.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_decoding_non_utf8_args.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_decoding_non_utf8_pipeline_args.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_decoding_non_utf8_pipeline_args.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_decoding_non_utf8_pipeline_args_13.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_decoding_non_utf8_pipeline_args_13.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_long_command.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_long_command.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_override_service_name.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_override_service_name.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -42,7 +41,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -76,7 +74,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_parenting.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_parenting.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -31,7 +29,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "aioredis",
@@ -58,7 +55,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "redis",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "aioredis",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_parenting_13.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_parenting_13.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -31,7 +29,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "aioredis",
@@ -58,7 +55,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "redis",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "aioredis",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_pin.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_pin.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_pipeline_traced.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_pipeline_traced.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_pipeline_traced_13.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_pipeline_traced_13.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_pipeline_traced_context_manager_transaction.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_pipeline_traced_context_manager_transaction.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[None-None].json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[None-None].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[None-None]_13.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[None-None]_13.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[None-mysvc].json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[None-mysvc].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[None-mysvc]_13.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[None-mysvc]_13.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[v0-None].json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[v0-None].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[v0-None]_13.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[v0-None]_13.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[v0-mysvc].json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[v0-mysvc].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[v0-mysvc]_13.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[v0-mysvc]_13.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[v1-None].json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[v1-None].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",
@@ -42,7 +41,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[v1-None]_13.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[v1-None]_13.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",
@@ -42,7 +41,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[v1-mysvc].json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[v1-mysvc].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",
@@ -42,7 +41,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[v1-mysvc]_13.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_schematization_of_service_and_operation[v1-mysvc]_13.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",
@@ -42,7 +41,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_two_traced_pipelines.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_two_traced_pipelines.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -31,7 +29,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "aioredis",
@@ -58,7 +55,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "redis",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "aioredis",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_two_traced_pipelines_13.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_two_traced_pipelines_13.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -31,7 +29,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "aioredis",
@@ -58,7 +55,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "redis",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "aioredis",

--- a/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_unicode_request.json
+++ b/tests/snapshots/tests.contrib.aioredis.test_aioredis.test_unicode_request.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_analytics_with_rate.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_analytics_with_rate.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_analytics_without_rate.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_analytics_without_rate.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_basics.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_basics.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_cmd_max_length.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_cmd_max_length.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_long_command.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_long_command.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_opentracing.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_opentracing.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -31,7 +29,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "aredis",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_pipeline_immediate.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_pipeline_immediate.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_pipeline_traced.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_pipeline_traced.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_unicode.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_unicode.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_bad_query.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_bad_query.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_configure_service_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_configure_service_name_env_v0.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_configure_service_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_configure_service_name_env_v1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "unnamed-python-service",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "unnamed-python-service",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_connect.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_connect.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_connection_methods.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_connection_methods.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -72,7 +70,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -105,7 +102,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -138,7 +134,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -171,7 +166,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_cursor.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_cursor.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -72,7 +70,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -105,7 +102,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -138,7 +134,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -171,7 +166,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_cursor_manual.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_cursor_manual.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -72,7 +70,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -105,7 +102,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -138,7 +134,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -171,7 +166,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_parenting.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_parenting.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -33,13 +32,11 @@
 [
   {
     "name": "parent",
-    "service": "",
+    "service": null,
     "resource": "parent",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -62,7 +59,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "asyncpg",
@@ -83,13 +79,11 @@
 [
   {
     "name": "parent2",
-    "service": "",
+    "service": null,
     "resource": "parent2",
     "trace_id": 2,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -113,7 +107,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_select.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_select.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_service_override_pin.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_service_override_pin.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_span_name_by_schema[v0].json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_span_name_by_schema[v0].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_span_name_by_schema[v1].json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_span_name_by_schema[v1].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "db.name",
@@ -40,7 +39,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "db.name",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_unspecified_service_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_unspecified_service_name_env_v0.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_unspecified_service_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_unspecified_service_name_env_v1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "db.name",
@@ -40,7 +39,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "db.name",

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[ClassHandler-class_handler].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[ClassHandler-class_handler].json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "aws.lambda",
-    "service": "",
+    "service": null,
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -24,13 +22,11 @@
   },
      {
        "name": "result-trace",
-       "service": "",
+       "service": null,
        "resource": "result-trace",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 18783,
        "start": 1691161784459734381
      }]]

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[StaticHandler-static_handler].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[StaticHandler-static_handler].json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "aws.lambda",
-    "service": "",
+    "service": null,
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -24,13 +22,11 @@
   },
      {
        "name": "result-trace",
-       "service": "",
+       "service": null,
        "resource": "result-trace",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 20269,
        "start": 1691161784453016249
      }]]

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[handler2-instance_handler].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[handler2-instance_handler].json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "aws.lambda",
-    "service": "",
+    "service": null,
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -24,13 +22,11 @@
   },
      {
        "name": "result-trace",
-       "service": "",
+       "service": null,
        "resource": "result-trace",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 18933,
        "start": 1691161784465284474
      }]]

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[handler3-instance_handler_with_code].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[handler3-instance_handler_with_code].json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "aws.lambda",
-    "service": "",
+    "service": null,
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -24,13 +22,11 @@
   },
      {
        "name": "result-trace",
-       "service": "",
+       "service": null,
        "resource": "result-trace",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 19529,
        "start": 1691161784470564547
      }]]

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_continue_on_early_trace_ending.json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_continue_on_early_trace_ending.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "aws.lambda",
-    "service": "",
+    "service": null,
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_file_patching.json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_file_patching.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "aws.lambda",
-    "service": "",
+    "service": null,
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_module_patching.json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_module_patching.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "result-trace",
-    "service": "",
+    "service": null,
     "resource": "result-trace",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[-100].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[-100].json
@@ -1,12 +1,11 @@
 [[
   {
     "name": "aws.lambda",
-    "service": "",
+    "service": null,
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
@@ -26,13 +25,11 @@
   },
      {
        "name": "timeout",
-       "service": "",
+       "service": null,
        "resource": "timeout",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 200258517,
        "start": 1691161771833341867
      }]]

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[100].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[100].json
@@ -1,12 +1,11 @@
 [[
   {
     "name": "aws.lambda",
-    "service": "",
+    "service": null,
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
@@ -26,13 +25,11 @@
   },
      {
        "name": "timeout",
-       "service": "",
+       "service": null,
        "resource": "timeout",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 200158722,
        "start": 1691161777881972654
      }]]

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[10].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[10].json
@@ -1,12 +1,11 @@
 [[
   {
     "name": "aws.lambda",
-    "service": "",
+    "service": null,
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
@@ -26,13 +25,11 @@
   },
      {
        "name": "timeout",
-       "service": "",
+       "service": null,
        "resource": "timeout",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 290280174,
        "start": 1691161774867341917
      }]]

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[200].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[200].json
@@ -1,12 +1,11 @@
 [[
   {
     "name": "aws.lambda",
-    "service": "",
+    "service": null,
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
@@ -26,13 +25,11 @@
   },
      {
        "name": "timeout",
-       "service": "",
+       "service": null,
        "resource": "timeout",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 100225899,
        "start": 1691161780889337821
      }]]

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_child.json
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_child.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -36,8 +35,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "a": "b"

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_success.json
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_success.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "1.7.1",
       "_dd.appsec.waf.version": "1.14.0",
@@ -54,8 +53,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -70,8 +67,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -86,8 +81,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -102,8 +95,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -118,8 +109,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -134,8 +123,6 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -150,8 +137,6 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -166,8 +151,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -182,8 +165,6 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -198,8 +179,6 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -214,8 +193,6 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -230,8 +207,6 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -246,8 +221,6 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -262,8 +235,6 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -278,8 +249,6 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "component": "django"
@@ -294,8 +263,6 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "component": "django"
@@ -310,8 +277,6 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -326,8 +291,6 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -342,8 +305,6 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -358,8 +319,6 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -374,8 +333,6 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -390,8 +347,6 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -406,8 +361,6 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -422,8 +375,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -438,8 +389,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "1.7.1",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"nfd-000-006\",\n      \"name\": \"Detect failed attempt to fetch sensitive files\",\n      \"tags\": {\n        \"category\": \"attack_attempt\",\n        \"confidence\": \"1\",\n        \"type\": \"security_scanner\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"^404$\",\n        \"parameters\": [\n          {\n            \"address\": \"server.response.status\",\n            \"highlight\": [\n              \"404\"\n            ],\n            \"key_path\": [],\n            \"value\": \"404\"\n          }\n        ]\n      },\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"\\\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)\",\n        \"parameters\": [\n          {\n            \"address\": \"server.request.uri.raw\",\n            \"highlight\": [\n              \".git\"\n            ],\n            \"key_path\": [],\n            \"value\": \"/.git\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
@@ -60,8 +59,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -76,8 +73,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -92,8 +87,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -108,8 +101,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -124,8 +115,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -140,8 +129,6 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -156,8 +143,6 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -172,8 +157,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -188,8 +171,6 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -204,8 +185,6 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -220,8 +199,6 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -236,8 +213,6 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -252,8 +227,6 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -268,8 +241,6 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -284,8 +255,6 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "component": "django"
@@ -300,8 +269,6 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "component": "django"
@@ -316,8 +283,6 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -332,8 +297,6 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -349,7 +312,6 @@
                                      "span_id": 26,
                                      "parent_id": 23,
                                      "type": "template",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django",
@@ -365,8 +327,6 @@
                                      "trace_id": 0,
                                      "span_id": 27,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -381,8 +341,6 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -397,8 +355,6 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -413,8 +369,6 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -429,8 +383,6 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -445,8 +397,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -461,8 +411,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-001\",\n      \"name\": \"Block IP addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"blocking\",\n        \"type\": \"ip_addresses\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"ip_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"http.client_ip\",\n            \"highlight\": [\n              \"8.8.4.4\"\n            ],\n            \"key_path\": [],\n            \"value\": \"8.8.4.4\"\n          }\n        ]\n      }\n    ]\n  }\n]}",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403_json.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403_json.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-001\",\n      \"name\": \"Block IP addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"blocking\",\n        \"type\": \"ip_addresses\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"ip_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"http.client_ip\",\n            \"highlight\": [\n              \"8.8.4.4\"\n            ],\n            \"key_path\": [],\n            \"value\": \"8.8.4.4\"\n          }\n        ]\n      }\n    ]\n  }\n]}",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_nomatch_200.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_nomatch_200.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.14.0",
@@ -54,8 +53,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -70,8 +67,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -86,8 +81,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -102,8 +95,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -118,8 +109,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -134,8 +123,6 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -150,8 +137,6 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -166,8 +151,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -182,8 +165,6 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -198,8 +179,6 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -214,8 +193,6 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -230,8 +207,6 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -246,8 +221,6 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -262,8 +235,6 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -278,8 +249,6 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "component": "django"
@@ -294,8 +263,6 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "component": "django"
@@ -310,8 +277,6 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -326,8 +291,6 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -342,8 +305,6 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -358,8 +319,6 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -374,8 +333,6 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -390,8 +347,6 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -406,8 +361,6 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -422,8 +375,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -438,8 +389,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,8 +40,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -57,8 +54,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -73,8 +68,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -89,8 +82,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -105,8 +96,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -121,8 +110,6 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -137,8 +124,6 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -153,8 +138,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -169,8 +152,6 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -185,8 +166,6 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -201,8 +180,6 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -217,8 +194,6 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -233,8 +208,6 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -249,8 +222,6 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -265,8 +236,6 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "component": "django"
@@ -281,8 +250,6 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "component": "django"
@@ -297,8 +264,6 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -313,8 +278,6 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -329,8 +292,6 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -345,8 +306,6 @@
                                      "trace_id": 0,
                                      "span_id": 27,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -361,8 +320,6 @@
                                      "trace_id": 0,
                                      "span_id": 28,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -377,8 +334,6 @@
                                      "trace_id": 0,
                                      "span_id": 29,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -394,7 +349,6 @@
                                      "span_id": 30,
                                      "parent_id": 23,
                                      "type": "template",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django",
@@ -410,8 +364,6 @@
                                      "trace_id": 0,
                                      "span_id": 31,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -426,8 +378,6 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -442,8 +392,6 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -458,8 +406,6 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -474,8 +420,6 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -490,8 +434,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -506,8 +448,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_111x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_111x.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,8 +38,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -55,8 +52,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -71,8 +66,6 @@
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -87,8 +80,6 @@
        "trace_id": 0,
        "span_id": 5,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -103,8 +94,6 @@
        "trace_id": 0,
        "span_id": 6,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -119,8 +108,6 @@
        "trace_id": 0,
        "span_id": 7,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -135,8 +122,6 @@
        "trace_id": 0,
        "span_id": 8,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -151,8 +136,6 @@
        "trace_id": 0,
        "span_id": 9,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -167,8 +150,6 @@
        "trace_id": 0,
        "span_id": 10,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -184,7 +165,6 @@
        "span_id": 11,
        "parent_id": 1,
        "type": "template",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django",
@@ -200,8 +180,6 @@
        "trace_id": 0,
        "span_id": 12,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -216,8 +194,6 @@
        "trace_id": 0,
        "span_id": 13,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -232,8 +208,6 @@
        "trace_id": 0,
        "span_id": 14,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -248,8 +222,6 @@
        "trace_id": 0,
        "span_id": 15,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -264,8 +236,6 @@
        "trace_id": 0,
        "span_id": 16,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -280,8 +250,6 @@
        "trace_id": 0,
        "span_id": 17,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -296,8 +264,6 @@
        "trace_id": 0,
        "span_id": 18,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_18x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_18x.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "django",
@@ -38,8 +37,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "django"
        },
@@ -53,8 +50,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "django"
        },
@@ -68,8 +63,6 @@
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "django"
        },
@@ -83,8 +76,6 @@
        "trace_id": 0,
        "span_id": 5,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "django"
        },
@@ -98,8 +89,6 @@
        "trace_id": 0,
        "span_id": 6,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "django"
        },
@@ -113,8 +102,6 @@
        "trace_id": 0,
        "span_id": 7,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "django"
        },
@@ -128,8 +115,6 @@
        "trace_id": 0,
        "span_id": 8,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "django"
        },
@@ -144,7 +129,6 @@
        "span_id": 9,
        "parent_id": 1,
        "type": "template",
-       "error": 0,
        "meta": {
          "component": "django",
          "django.template.engine.class": "django.template.engine.Engine"
@@ -159,8 +143,6 @@
        "trace_id": 0,
        "span_id": 10,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "django"
        },
@@ -174,8 +156,6 @@
        "trace_id": 0,
        "span_id": 11,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "django"
        },
@@ -189,8 +169,6 @@
        "trace_id": 0,
        "span_id": 12,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "django"
        },
@@ -204,8 +182,6 @@
        "trace_id": 0,
        "span_id": 13,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "django"
        },
@@ -219,8 +195,6 @@
        "trace_id": 0,
        "span_id": 14,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "django"
        },
@@ -234,8 +208,6 @@
        "trace_id": 0,
        "span_id": 15,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "django"
        },
@@ -249,8 +221,6 @@
        "trace_id": 0,
        "span_id": 16,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "django"
        },

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_21x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_21x.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "django",
@@ -39,8 +38,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "django"
        },
@@ -54,8 +51,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "component": "django"
           },
@@ -69,8 +64,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "component": "django"
           },
@@ -84,8 +77,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "component": "django"
              },
@@ -99,8 +90,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "component": "django"
              },
@@ -114,8 +103,6 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "component": "django"
                 },
@@ -129,8 +116,6 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "component": "django"
                 },
@@ -144,8 +129,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "component": "django"
                    },
@@ -159,8 +142,6 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "component": "django"
                    },
@@ -174,8 +155,6 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "component": "django"
                       },
@@ -189,8 +168,6 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "component": "django"
                       },
@@ -204,8 +181,6 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "component": "django"
                          },
@@ -219,8 +194,6 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "component": "django"
                             },
@@ -234,8 +207,6 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "component": "django"
                             },
@@ -249,8 +220,6 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "component": "django"
                                },
@@ -264,8 +233,6 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "component": "django"
                                   },
@@ -279,8 +246,6 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "component": "django"
                                      },
@@ -294,8 +259,6 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "component": "django"
                                      },
@@ -309,8 +272,6 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "component": "django"
                                      },
@@ -324,8 +285,6 @@
                                      "trace_id": 0,
                                      "span_id": 27,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "component": "django"
                                      },
@@ -339,8 +298,6 @@
                                      "trace_id": 0,
                                      "span_id": 28,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "component": "django"
                                      },
@@ -354,8 +311,6 @@
                                      "trace_id": 0,
                                      "span_id": 29,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "component": "django"
                                      },
@@ -370,7 +325,6 @@
                                      "span_id": 30,
                                      "parent_id": 23,
                                      "type": "template",
-                                     "error": 0,
                                      "meta": {
                                        "component": "django",
                                        "django.template.engine.class": "django.template.engine.Engine"
@@ -385,8 +339,6 @@
                                      "trace_id": 0,
                                      "span_id": 31,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "component": "django"
                                      },
@@ -400,8 +352,6 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "component": "django"
                             },
@@ -415,8 +365,6 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "component": "django"
                          },
@@ -430,8 +378,6 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "component": "django"
                       },
@@ -445,8 +391,6 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "component": "django"
                 },
@@ -460,8 +404,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "component": "django"
              },
@@ -475,8 +417,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "component": "django"
           },

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_3x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_3x.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -44,8 +43,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -60,8 +57,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -76,8 +71,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -92,8 +85,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -108,8 +99,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -124,8 +113,6 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -140,8 +127,6 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -156,8 +141,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -172,8 +155,6 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -188,8 +169,6 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -204,8 +183,6 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -220,8 +197,6 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -236,8 +211,6 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -252,8 +225,6 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -268,8 +239,6 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "component": "django"
@@ -284,8 +253,6 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "component": "django"
@@ -300,8 +267,6 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -316,8 +281,6 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -332,8 +295,6 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -348,8 +309,6 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -364,8 +323,6 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -380,8 +337,6 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -396,8 +351,6 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -412,8 +365,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -428,8 +379,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_traced_simple_app.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_traced_simple_app.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "asgi.request",
-    "service": "",
+    "service": null,
     "resource": "GET /traced-simple-asgi-app/",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "asgi.version": "3.0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_500_3x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_500_3x.json
@@ -44,8 +44,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -60,8 +58,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -76,8 +72,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -92,8 +86,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -108,8 +100,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -124,8 +114,6 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -140,8 +128,6 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -156,8 +142,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -172,8 +156,6 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -188,8 +170,6 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -204,8 +184,6 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -220,8 +198,6 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -236,8 +212,6 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -252,8 +226,6 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -268,8 +240,6 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "component": "django"
@@ -284,8 +254,6 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "component": "django"
@@ -300,8 +268,6 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -316,8 +282,6 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -332,7 +296,6 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
-                                     "type": "",
                                      "error": 1,
                                      "meta": {
                                        "_dd.base_service": "",
@@ -351,8 +314,6 @@
                                      "trace_id": 0,
                                      "span_id": 27,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -367,8 +328,6 @@
                                      "trace_id": 0,
                                      "span_id": 28,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -383,8 +342,6 @@
                                      "trace_id": 0,
                                      "span_id": 29,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -399,8 +356,6 @@
                                      "trace_id": 0,
                                      "span_id": 30,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -416,7 +371,6 @@
                                      "span_id": 31,
                                      "parent_id": 23,
                                      "type": "template",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django",
@@ -432,8 +386,6 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -448,8 +400,6 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -464,8 +414,6 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -480,8 +428,6 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -496,8 +442,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -512,8 +456,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_django_resource_handler.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_django_resource_handler.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -44,8 +43,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -60,8 +57,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -76,8 +71,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -92,8 +85,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -108,8 +99,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -124,8 +113,6 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -140,8 +127,6 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -156,8 +141,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -172,8 +155,6 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -188,8 +169,6 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -204,8 +183,6 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -220,8 +197,6 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -236,8 +211,6 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -252,8 +225,6 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -268,8 +239,6 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "component": "django"
@@ -284,8 +253,6 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "component": "django"
@@ -300,8 +267,6 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -316,8 +281,6 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -332,8 +295,6 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -348,8 +309,6 @@
                                         "trace_id": 0,
                                         "span_id": 27,
                                         "parent_id": 26,
-                                        "type": "",
-                                        "error": 0,
                                         "meta": {
                                           "_dd.base_service": "",
                                           "component": "django"
@@ -364,8 +323,6 @@
                                         "trace_id": 0,
                                         "span_id": 28,
                                         "parent_id": 26,
-                                        "type": "",
-                                        "error": 0,
                                         "meta": {
                                           "_dd.base_service": "",
                                           "component": "django"
@@ -380,8 +337,6 @@
                                            "trace_id": 0,
                                            "span_id": 29,
                                            "parent_id": 28,
-                                           "type": "",
-                                           "error": 0,
                                            "meta": {
                                              "_dd.base_service": "",
                                              "component": "django"
@@ -396,8 +351,6 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -412,8 +365,6 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -428,8 +379,6 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -444,8 +393,6 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -460,8 +407,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -476,8 +421,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,8 +40,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -57,8 +54,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -73,8 +68,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -89,8 +82,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -105,8 +96,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -121,8 +110,6 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -137,8 +124,6 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -153,8 +138,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -169,8 +152,6 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -185,8 +166,6 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -201,8 +180,6 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -217,8 +194,6 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -233,8 +208,6 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -249,8 +222,6 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -265,8 +236,6 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "component": "django"
@@ -281,8 +250,6 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "component": "django"
@@ -297,8 +264,6 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -313,8 +278,6 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -329,8 +292,6 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -345,8 +306,6 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -361,8 +320,6 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -377,8 +334,6 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -393,8 +348,6 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -409,8 +362,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -425,8 +376,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_111x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_111x.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -40,8 +39,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -56,8 +53,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -72,8 +67,6 @@
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -88,8 +81,6 @@
        "trace_id": 0,
        "span_id": 5,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -104,8 +95,6 @@
        "trace_id": 0,
        "span_id": 6,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -120,8 +109,6 @@
        "trace_id": 0,
        "span_id": 7,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -136,8 +123,6 @@
        "trace_id": 0,
        "span_id": 8,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -152,8 +137,6 @@
        "trace_id": 0,
        "span_id": 9,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -168,8 +151,6 @@
        "trace_id": 0,
        "span_id": 10,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -184,8 +165,6 @@
        "trace_id": 0,
        "span_id": 11,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -200,8 +179,6 @@
        "trace_id": 0,
        "span_id": 12,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -216,8 +193,6 @@
        "trace_id": 0,
        "span_id": 13,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -232,8 +207,6 @@
        "trace_id": 0,
        "span_id": 14,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -248,8 +221,6 @@
        "trace_id": 0,
        "span_id": 15,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -264,8 +235,6 @@
        "trace_id": 0,
        "span_id": 16,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_21x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_21x.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "django",
@@ -39,8 +38,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "django"
        },
@@ -54,8 +51,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "component": "django"
           },
@@ -69,8 +64,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "component": "django"
           },
@@ -84,8 +77,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "component": "django"
              },
@@ -99,8 +90,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "component": "django"
              },
@@ -114,8 +103,6 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "component": "django"
                 },
@@ -129,8 +116,6 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "component": "django"
                 },
@@ -144,8 +129,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "component": "django"
                    },
@@ -159,8 +142,6 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "component": "django"
                    },
@@ -174,8 +155,6 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "component": "django"
                       },
@@ -189,8 +168,6 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "component": "django"
                       },
@@ -204,8 +181,6 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "component": "django"
                          },
@@ -219,8 +194,6 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "component": "django"
                             },
@@ -234,8 +207,6 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "component": "django"
                             },
@@ -249,8 +220,6 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "component": "django"
                                },
@@ -264,8 +233,6 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "component": "django"
                                   },
@@ -279,8 +246,6 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "component": "django"
                                      },
@@ -294,8 +259,6 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "component": "django"
                                      },
@@ -309,8 +272,6 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "component": "django"
                                      },
@@ -324,8 +285,6 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "component": "django"
                             },
@@ -339,8 +298,6 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "component": "django"
                          },
@@ -354,8 +311,6 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "component": "django"
                       },
@@ -369,8 +324,6 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "component": "django"
                 },
@@ -384,8 +337,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "component": "django"
              },
@@ -399,8 +350,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "component": "django"
           },

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,8 +40,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -57,8 +54,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -73,8 +68,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -89,8 +82,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -105,8 +96,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -121,8 +110,6 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -137,8 +124,6 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -153,8 +138,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -169,8 +152,6 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -185,8 +166,6 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -201,8 +180,6 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -217,8 +194,6 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -233,8 +208,6 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -249,8 +222,6 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -265,8 +236,6 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "component": "django"
@@ -281,8 +250,6 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "component": "django"
@@ -297,8 +264,6 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -313,8 +278,6 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -329,8 +292,6 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -345,8 +306,6 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -361,8 +320,6 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -377,8 +334,6 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -393,8 +348,6 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -409,8 +362,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -425,8 +376,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_111x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_111x.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -40,8 +39,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -56,8 +53,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -72,8 +67,6 @@
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -88,8 +81,6 @@
        "trace_id": 0,
        "span_id": 5,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -104,8 +95,6 @@
        "trace_id": 0,
        "span_id": 6,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -120,8 +109,6 @@
        "trace_id": 0,
        "span_id": 7,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -136,8 +123,6 @@
        "trace_id": 0,
        "span_id": 8,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -152,8 +137,6 @@
        "trace_id": 0,
        "span_id": 9,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -168,8 +151,6 @@
        "trace_id": 0,
        "span_id": 10,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -184,8 +165,6 @@
        "trace_id": 0,
        "span_id": 11,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -200,8 +179,6 @@
        "trace_id": 0,
        "span_id": 12,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -216,8 +193,6 @@
        "trace_id": 0,
        "span_id": 13,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -232,8 +207,6 @@
        "trace_id": 0,
        "span_id": 14,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -248,8 +221,6 @@
        "trace_id": 0,
        "span_id": 15,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -264,8 +235,6 @@
        "trace_id": 0,
        "span_id": 16,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_21x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_21x.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "django",
@@ -39,8 +38,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "django"
        },
@@ -54,8 +51,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "component": "django"
           },
@@ -69,8 +64,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "component": "django"
           },
@@ -84,8 +77,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "component": "django"
              },
@@ -99,8 +90,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "component": "django"
              },
@@ -114,8 +103,6 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "component": "django"
                 },
@@ -129,8 +116,6 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "component": "django"
                 },
@@ -144,8 +129,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "component": "django"
                    },
@@ -159,8 +142,6 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "component": "django"
                    },
@@ -174,8 +155,6 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "component": "django"
                       },
@@ -189,8 +168,6 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "component": "django"
                       },
@@ -204,8 +181,6 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "component": "django"
                          },
@@ -219,8 +194,6 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "component": "django"
                             },
@@ -234,8 +207,6 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "component": "django"
                             },
@@ -249,8 +220,6 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "component": "django"
                                },
@@ -264,8 +233,6 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "component": "django"
                                   },
@@ -279,8 +246,6 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "component": "django"
                                      },
@@ -294,8 +259,6 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "component": "django"
                                      },
@@ -309,8 +272,6 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "component": "django"
                                      },
@@ -324,8 +285,6 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "component": "django"
                             },
@@ -339,8 +298,6 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "component": "django"
                          },
@@ -354,8 +311,6 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "component": "django"
                       },
@@ -369,8 +324,6 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "component": "django"
                 },
@@ -384,8 +337,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "component": "django"
              },
@@ -399,8 +350,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "component": "django"
           },

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg2_query_default.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg2_query_default.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -37,7 +36,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "psycopg",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg3_query_default.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg3_query_default.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -37,7 +36,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "psycopg",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -43,8 +42,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -59,8 +56,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -75,8 +70,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -91,8 +84,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -107,8 +98,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -123,8 +112,6 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -139,8 +126,6 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -155,8 +140,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -171,8 +154,6 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -187,8 +168,6 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -203,8 +182,6 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -219,8 +196,6 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -235,8 +210,6 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -251,8 +224,6 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -267,8 +238,6 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "component": "django"
@@ -283,8 +252,6 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "component": "django"
@@ -299,8 +266,6 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -315,8 +280,6 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -331,8 +294,6 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -347,8 +308,6 @@
                                         "trace_id": 0,
                                         "span_id": 29,
                                         "parent_id": 26,
-                                        "type": "",
-                                        "error": 0,
                                         "meta": {
                                           "_dd.base_service": "",
                                           "component": "django"
@@ -363,8 +322,6 @@
                                         "trace_id": 0,
                                         "span_id": 30,
                                         "parent_id": 26,
-                                        "type": "",
-                                        "error": 0,
                                         "meta": {
                                           "_dd.base_service": "",
                                           "component": "django"
@@ -379,8 +336,6 @@
                                            "trace_id": 0,
                                            "span_id": 32,
                                            "parent_id": 30,
-                                           "type": "",
-                                           "error": 0,
                                            "meta": {
                                              "_dd.base_service": "",
                                              "component": "django"
@@ -395,8 +350,6 @@
                                      "trace_id": 0,
                                      "span_id": 27,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -411,8 +364,6 @@
                                      "trace_id": 0,
                                      "span_id": 28,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -428,7 +379,6 @@
                                         "span_id": 31,
                                         "parent_id": 28,
                                         "type": "template",
-                                        "error": 0,
                                         "meta": {
                                           "_dd.base_service": "",
                                           "component": "django",
@@ -446,7 +396,6 @@
                                            "span_id": 33,
                                            "parent_id": 31,
                                            "type": "cache",
-                                           "error": 0,
                                            "meta": {
                                              "_dd.base_service": "",
                                              "component": "django",
@@ -466,8 +415,6 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -482,8 +429,6 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -498,8 +443,6 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -514,8 +457,6 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -530,8 +471,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -546,8 +485,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_111x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_111x.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -42,8 +41,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -58,8 +55,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -74,8 +69,6 @@
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -90,8 +83,6 @@
        "trace_id": 0,
        "span_id": 5,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -106,8 +97,6 @@
        "trace_id": 0,
        "span_id": 6,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -122,8 +111,6 @@
        "trace_id": 0,
        "span_id": 7,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -138,8 +125,6 @@
        "trace_id": 0,
        "span_id": 8,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -154,8 +139,6 @@
        "trace_id": 0,
        "span_id": 9,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -170,8 +153,6 @@
        "trace_id": 0,
        "span_id": 10,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -186,8 +167,6 @@
           "trace_id": 0,
           "span_id": 18,
           "parent_id": 10,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -202,8 +181,6 @@
              "trace_id": 0,
              "span_id": 20,
              "parent_id": 18,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -218,8 +195,6 @@
        "trace_id": 0,
        "span_id": 11,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -235,7 +210,6 @@
           "span_id": 19,
           "parent_id": 11,
           "type": "template",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django",
@@ -253,7 +227,6 @@
              "span_id": 21,
              "parent_id": 19,
              "type": "cache",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django",
@@ -273,8 +246,6 @@
        "trace_id": 0,
        "span_id": 12,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -289,8 +260,6 @@
        "trace_id": 0,
        "span_id": 13,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -305,8 +274,6 @@
        "trace_id": 0,
        "span_id": 14,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -321,8 +288,6 @@
        "trace_id": 0,
        "span_id": 15,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -337,8 +302,6 @@
        "trace_id": 0,
        "span_id": 16,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -353,8 +316,6 @@
        "trace_id": 0,
        "span_id": 17,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_templates_disabled_3x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_templates_disabled_3x.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -45,8 +44,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -61,8 +58,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -77,8 +72,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -93,8 +86,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -109,8 +100,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -125,8 +114,6 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -141,8 +128,6 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -157,8 +142,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -173,8 +156,6 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -189,8 +170,6 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -205,8 +184,6 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -221,8 +198,6 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -237,8 +212,6 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -253,8 +226,6 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -269,8 +240,6 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "component": "django"
@@ -285,8 +254,6 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "component": "django"
@@ -301,8 +268,6 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -317,8 +282,6 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -333,8 +296,6 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -349,8 +310,6 @@
                                      "trace_id": 0,
                                      "span_id": 27,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -365,8 +324,6 @@
                                      "trace_id": 0,
                                      "span_id": 28,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -381,8 +338,6 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -397,8 +352,6 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -413,8 +366,6 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -429,8 +380,6 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -445,8 +394,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -461,8 +408,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_templates_enabled_3x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_templates_enabled_3x.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -45,8 +44,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -61,8 +58,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -77,8 +72,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -93,8 +86,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -109,8 +100,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -125,8 +114,6 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -141,8 +128,6 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -157,8 +142,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -173,8 +156,6 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -189,8 +170,6 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -205,8 +184,6 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -221,8 +198,6 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -237,8 +212,6 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -253,8 +226,6 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -269,8 +240,6 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "component": "django"
@@ -285,8 +254,6 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "component": "django"
@@ -301,8 +268,6 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -317,8 +282,6 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -333,8 +296,6 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -349,8 +310,6 @@
                                      "trace_id": 0,
                                      "span_id": 27,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -365,8 +324,6 @@
                                      "trace_id": 0,
                                      "span_id": 28,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -382,7 +339,6 @@
                                         "span_id": 29,
                                         "parent_id": 28,
                                         "type": "template",
-                                        "error": 0,
                                         "meta": {
                                           "_dd.base_service": "",
                                           "component": "django",
@@ -399,8 +355,6 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -415,8 +369,6 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -431,8 +383,6 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -447,8 +397,6 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -463,8 +411,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -479,8 +425,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,8 +40,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -57,8 +54,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -73,8 +68,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -89,8 +82,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -105,8 +96,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -121,8 +110,6 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -137,8 +124,6 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -153,8 +138,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -169,8 +152,6 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -185,8 +166,6 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -201,8 +180,6 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -217,8 +194,6 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -233,8 +208,6 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -249,8 +222,6 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -265,8 +236,6 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "component": "django"
@@ -281,8 +250,6 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "component": "django"
@@ -297,8 +264,6 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -313,8 +278,6 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -329,8 +292,6 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
-                                     "type": "",
-                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -345,8 +306,6 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -361,8 +320,6 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -377,8 +334,6 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -393,8 +348,6 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -409,8 +362,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -425,8 +376,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"

--- a/tests/snapshots/tests.contrib.django_hosts.test_django.test_django_hosts_request.json
+++ b/tests/snapshots/tests.contrib.django_hosts.test_django.test_django_hosts_request.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,8 +40,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -57,8 +54,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -73,8 +68,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -89,8 +82,6 @@
              "trace_id": 0,
              "span_id": 5,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -105,8 +96,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -121,8 +110,6 @@
                 "trace_id": 0,
                 "span_id": 8,
                 "parent_id": 6,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -137,8 +124,6 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 6,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -153,8 +138,6 @@
                    "trace_id": 0,
                    "span_id": 11,
                    "parent_id": 9,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -169,8 +152,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 9,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -185,8 +166,6 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 12,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -201,8 +180,6 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 12,
-                      "type": "",
-                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -217,8 +194,6 @@
                          "trace_id": 0,
                          "span_id": 16,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -233,8 +208,6 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -249,8 +222,6 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -265,8 +236,6 @@
                                "trace_id": 0,
                                "span_id": 21,
                                "parent_id": 19,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "component": "django"
@@ -281,8 +250,6 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 19,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "component": "django"
@@ -297,8 +264,6 @@
                                   "trace_id": 0,
                                   "span_id": 24,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "component": "django"
@@ -313,8 +278,6 @@
                                   "trace_id": 0,
                                   "span_id": 25,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "component": "django"
@@ -329,8 +292,6 @@
                                   "trace_id": 0,
                                   "span_id": 26,
                                   "parent_id": 22,
-                                  "type": "",
-                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "component": "django"
@@ -345,8 +306,6 @@
                                "trace_id": 0,
                                "span_id": 23,
                                "parent_id": 19,
-                               "type": "",
-                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "component": "django"
@@ -361,8 +320,6 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
-                            "type": "",
-                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -377,8 +334,6 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
-                         "type": "",
-                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -393,8 +348,6 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 9,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -409,8 +362,6 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 6,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -425,8 +376,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"

--- a/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch.json
+++ b/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -40,7 +39,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch2.json
+++ b/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch2.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "elasticsearch",
@@ -37,7 +36,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "elasticsearch",

--- a/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch5.json
+++ b/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch5.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "elasticsearch",
@@ -37,7 +36,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "elasticsearch",

--- a/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch6.json
+++ b/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch6.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch7.json
+++ b/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch7.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples0]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples0]_6_9.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "fastapi",
@@ -60,8 +58,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": ""
           },

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples0]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples0]_9.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "http.request",
-    "service": "",
+    "service": null,
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "httpx",
@@ -38,7 +37,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "fastapi",
@@ -64,7 +62,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "fastapi",
@@ -85,8 +82,6 @@
              "trace_id": 0,
              "span_id": 4,
              "parent_id": 3,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": ""
              },

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples1]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples1]_6_9.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "fastapi",
@@ -60,8 +58,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": ""
           },

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples1]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples1]_9.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "http.request",
-    "service": "",
+    "service": null,
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "httpx",
@@ -38,7 +37,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "fastapi",
@@ -64,7 +62,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "fastapi",
@@ -85,8 +82,6 @@
              "trace_id": 0,
              "span_id": 4,
              "parent_id": 3,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": ""
              },

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples2]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples2]_6_9.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "fastapi",
@@ -38,7 +37,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "component": "fastapi",
          "http.method": "GET",
@@ -58,8 +56,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "duration": 28304,
           "start": 1691166901137325786
         }]]

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples2]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples2]_9.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",
@@ -40,7 +39,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "component": "fastapi",
          "http.method": "GET",
@@ -62,7 +60,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "component": "fastapi",
             "http.method": "GET",
@@ -82,8 +79,6 @@
              "trace_id": 0,
              "span_id": 4,
              "parent_id": 3,
-             "type": "",
-             "error": 0,
              "duration": 86457,
              "start": 1691166910649033755
            }]]

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples3]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples3]_6_9.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "fastapi",
@@ -38,7 +37,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "component": "fastapi",
          "http.method": "GET",
@@ -58,8 +56,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "duration": 26869,
           "start": 1691166901856948993
         }]]

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples3]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples3]_9.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "httpx",
@@ -38,7 +37,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "component": "fastapi",
          "http.method": "GET",
@@ -60,7 +58,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "component": "fastapi",
             "http.method": "GET",
@@ -80,8 +77,6 @@
              "trace_id": 0,
              "span_id": 4,
              "parent_id": 3,
-             "type": "",
-             "error": 0,
              "duration": 87587,
              "start": 1691166911366639806
            }]]

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples4]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples4]_6_9.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "fastapi",
@@ -38,7 +37,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "component": "fastapi",
          "http.method": "GET",
@@ -58,8 +56,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "duration": 44074,
           "start": 1691166902578225677
         }]]

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples4]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples4]_9.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "httpx",
@@ -38,7 +37,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "component": "fastapi",
          "http.method": "GET",
@@ -60,7 +58,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "component": "fastapi",
             "http.method": "GET",
@@ -80,8 +77,6 @@
              "trace_id": 0,
              "span_id": 4,
              "parent_id": 3,
-             "type": "",
-             "error": 0,
              "duration": 85739,
              "start": 1691166912035584642
            }]]

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples5]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples5]_6_9.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "fastapi",
@@ -38,7 +37,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "component": "fastapi",
          "http.method": "GET",
@@ -58,8 +56,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "duration": 26097,
           "start": 1691166903278571376
         }]]

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples5]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples5]_9.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",
@@ -40,7 +39,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "component": "fastapi",
          "http.method": "GET",
@@ -62,7 +60,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "component": "fastapi",
             "http.method": "GET",
@@ -82,8 +79,6 @@
              "trace_id": 0,
              "span_id": 4,
              "parent_id": 3,
-             "type": "",
-             "error": 0,
              "duration": 88214,
              "start": 1691166912732966652
            }]]

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_subapp_no_aggregate_snapshot.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_subapp_no_aggregate_snapshot.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -38,7 +37,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "fastapi",
@@ -59,8 +57,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": ""
           },

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_subapp_snapshot.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_subapp_snapshot.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "fastapi",
@@ -60,8 +58,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": ""
           },

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_table_query_snapshot.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_table_query_snapshot.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -38,8 +37,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": ""
        },
@@ -55,7 +52,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -86,8 +82,6 @@
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": ""
        },

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_tracing_in_middleware.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_tracing_in_middleware.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -38,8 +37,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": ""
        },
@@ -53,8 +50,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": ""
           },

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-001\",\n      \"name\": \"Block IP addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"blocking\",\n        \"type\": \"ip_addresses\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"ip_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"http.client_ip\",\n            \"highlight\": [\n              \"8.8.4.4\"\n            ],\n            \"key_path\": [],\n            \"value\": \"8.8.4.4\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
@@ -54,8 +53,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env]_220.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-001\",\n      \"name\": \"Block IP addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"blocking\",\n        \"type\": \"ip_addresses\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"ip_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"http.client_ip\",\n            \"highlight\": [\n              \"8.8.4.4\"\n            ],\n            \"key_path\": [],\n            \"value\": \"8.8.4.4\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
@@ -54,8 +53,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-001\",\n      \"name\": \"Block IP addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"blocking\",\n        \"type\": \"ip_addresses\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"ip_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"http.client_ip\",\n            \"highlight\": [\n              \"8.8.4.4\"\n            ],\n            \"key_path\": [],\n            \"value\": \"8.8.4.4\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
@@ -54,8 +53,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-001\",\n      \"name\": \"Block IP addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"blocking\",\n        \"type\": \"ip_addresses\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"ip_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"http.client_ip\",\n            \"highlight\": [\n              \"8.8.4.4\"\n            ],\n            \"key_path\": [],\n            \"value\": \"8.8.4.4\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
@@ -54,8 +53,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.14.0",
@@ -53,8 +52,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -71,8 +68,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -87,8 +82,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -103,8 +96,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -119,8 +110,6 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 6,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -136,7 +125,6 @@
                 "span_id": 11,
                 "parent_id": 10,
                 "type": "system",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "cmd.exec": "['/bin/ls', '-l', '/']",
@@ -154,7 +142,6 @@
                    "span_id": 12,
                    "parent_id": 11,
                    "type": "system",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "cmd.exec": "['os.fork']",
@@ -170,8 +157,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -186,8 +171,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -202,8 +185,6 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -218,8 +199,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env]_220.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.14.0",
@@ -53,8 +52,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -71,8 +68,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -87,8 +82,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -103,8 +96,6 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 5,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -120,7 +111,6 @@
                 "span_id": 10,
                 "parent_id": 9,
                 "type": "system",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "cmd.exec": "['/bin/ls', '-l', '/']",
@@ -138,7 +128,6 @@
                    "span_id": 11,
                    "parent_id": 10,
                    "type": "system",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "cmd.exec": "['os.fork']",
@@ -154,8 +143,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -170,8 +157,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -186,8 +171,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -202,8 +185,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.14.0",
@@ -53,8 +52,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -71,8 +68,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -87,8 +82,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -103,8 +96,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -119,8 +110,6 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 6,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -136,7 +125,6 @@
                 "span_id": 11,
                 "parent_id": 10,
                 "type": "system",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "cmd.exit_code": "0",
@@ -153,8 +141,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -169,8 +155,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -185,8 +169,6 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -201,8 +183,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env]_220.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.14.0",
@@ -53,8 +52,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -71,8 +68,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -87,8 +82,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -103,8 +96,6 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 5,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -120,7 +111,6 @@
                 "span_id": 10,
                 "parent_id": 9,
                 "type": "system",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "cmd.exit_code": "0",
@@ -137,8 +127,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -153,8 +141,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -169,8 +155,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -185,8 +169,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.14.0",
@@ -53,8 +52,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -71,8 +68,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -87,8 +82,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -103,8 +96,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -119,8 +110,6 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 6,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -136,7 +125,6 @@
                 "span_id": 11,
                 "parent_id": 10,
                 "type": "system",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": ""
                 },
@@ -151,7 +139,6 @@
                 "span_id": 12,
                 "parent_id": 10,
                 "type": "system",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "cmd.exec": "['dir', '-li', '/']",
@@ -169,7 +156,6 @@
                 "span_id": 13,
                 "parent_id": 10,
                 "type": "system",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "cmd.exec": "['dir', '-li', '/']",
@@ -186,8 +172,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -202,8 +186,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -218,8 +200,6 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -234,8 +214,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env]_220.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.14.0",
@@ -53,8 +52,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -71,8 +68,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -87,8 +82,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -103,8 +96,6 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 5,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -120,7 +111,6 @@
                 "span_id": 10,
                 "parent_id": 9,
                 "type": "system",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": ""
                 },
@@ -135,7 +125,6 @@
                 "span_id": 11,
                 "parent_id": 9,
                 "type": "system",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "cmd.exec": "['dir', '-li', '/']",
@@ -153,7 +142,6 @@
                 "span_id": 12,
                 "parent_id": 9,
                 "type": "system",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "cmd.exec": "['dir', '-li', '/']",
@@ -170,8 +158,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -186,8 +172,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -202,8 +186,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -218,8 +200,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.14.0",
@@ -53,8 +52,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -71,8 +68,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -87,8 +82,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -103,8 +96,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -119,8 +110,6 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 6,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -136,7 +125,6 @@
                 "span_id": 11,
                 "parent_id": 10,
                 "type": "system",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": ""
                 },
@@ -151,7 +139,6 @@
                 "span_id": 12,
                 "parent_id": 10,
                 "type": "system",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "cmd.exit_code": "0",
@@ -169,7 +156,6 @@
                 "span_id": 13,
                 "parent_id": 10,
                 "type": "system",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "cmd.exit_code": "0",
@@ -186,8 +172,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -202,8 +186,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -218,8 +200,6 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -234,8 +214,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env]_220.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.14.0",
@@ -53,8 +52,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -71,8 +68,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -87,8 +82,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -103,8 +96,6 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 5,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -120,7 +111,6 @@
                 "span_id": 10,
                 "parent_id": 9,
                 "type": "system",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": ""
                 },
@@ -135,7 +125,6 @@
                 "span_id": 11,
                 "parent_id": 9,
                 "type": "system",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "cmd.exit_code": "0",
@@ -153,7 +142,6 @@
                 "span_id": 12,
                 "parent_id": 9,
                 "type": "system",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "cmd.exit_code": "0",
@@ -170,8 +158,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -186,8 +172,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -202,8 +186,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -218,8 +200,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.14.0",
@@ -54,8 +53,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -73,8 +70,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -89,8 +84,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -105,8 +98,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -121,8 +112,6 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 6,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -137,8 +126,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -153,8 +140,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -169,8 +154,6 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -185,8 +168,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.14.0",
@@ -54,8 +53,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -73,8 +70,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -89,8 +84,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -105,8 +98,6 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 5,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -121,8 +112,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -137,8 +126,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -153,8 +140,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -169,8 +154,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-002\",\n      \"name\": \"Block User Addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"security_response\",\n        \"type\": \"block_user\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"exact_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"usr.id\",\n            \"highlight\": [\n              \"123456\"\n            ],\n            \"key_path\": [],\n            \"value\": \"123456\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
@@ -64,8 +63,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -86,8 +83,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -102,8 +97,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -118,7 +111,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
           "error": 1,
           "meta": {
             "_dd.base_service": "",
@@ -137,7 +129,6 @@
              "trace_id": 0,
              "span_id": 11,
              "parent_id": 6,
-             "type": "",
              "error": 1,
              "meta": {
                "_dd.base_service": "",
@@ -156,8 +147,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -172,8 +161,6 @@
              "trace_id": 0,
              "span_id": 12,
              "parent_id": 7,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -188,8 +175,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -204,8 +189,6 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -220,8 +203,6 @@
           "trace_id": 0,
           "span_id": 10,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -236,8 +217,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-002\",\n      \"name\": \"Block User Addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"security_response\",\n        \"type\": \"block_user\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"exact_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"usr.id\",\n            \"highlight\": [\n              \"123456\"\n            ],\n            \"key_path\": [],\n            \"value\": \"123456\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
@@ -64,8 +63,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -86,8 +83,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -102,7 +97,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
           "error": 1,
           "meta": {
             "_dd.base_service": "",
@@ -121,7 +115,6 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 5,
-             "type": "",
              "error": 1,
              "meta": {
                "_dd.base_service": "",
@@ -140,8 +133,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -156,8 +147,6 @@
              "trace_id": 0,
              "span_id": 11,
              "parent_id": 6,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -172,8 +161,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -188,8 +175,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -204,8 +189,6 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -220,8 +203,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_200[flask_default_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_200[flask_default_env].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,8 +40,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -59,8 +56,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -75,8 +70,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -91,8 +84,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -107,8 +98,6 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 6,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -123,8 +112,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -139,8 +126,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -155,8 +140,6 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -171,8 +154,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_200[flask_default_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_200[flask_default_env]_220.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,8 +40,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -59,8 +56,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -75,8 +70,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -91,8 +84,6 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 5,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -107,8 +98,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -123,8 +112,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -139,8 +126,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -155,8 +140,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_get_user[flask_default_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_get_user[flask_default_env].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -47,8 +46,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -65,8 +62,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -81,8 +76,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -97,8 +90,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -113,8 +104,6 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 6,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -129,8 +118,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -145,8 +132,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -161,8 +146,6 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -177,8 +160,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_get_user[flask_default_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_get_user[flask_default_env]_220.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -47,8 +46,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -65,8 +62,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -81,8 +76,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -97,8 +90,6 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 5,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -113,8 +104,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -129,8 +118,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -145,8 +132,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -161,8 +146,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_stream[flask_default_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_stream[flask_default_env].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,8 +40,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -59,8 +56,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -75,8 +70,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -91,8 +84,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -107,8 +98,6 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 6,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -123,8 +112,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -139,8 +126,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -155,8 +140,6 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -171,8 +154,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_stream[flask_default_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_stream[flask_default_env]_220.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,8 +40,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask",
@@ -59,8 +56,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -75,8 +70,6 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -91,8 +84,6 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 5,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -107,8 +98,6 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -123,8 +112,6 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -139,8 +126,6 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"
@@ -155,8 +140,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "flask"

--- a/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_execute.json
+++ b/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_execute.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -33,7 +32,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -50,7 +48,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -67,7 +64,6 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",

--- a/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_execute_with_resolvers.json
+++ b/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_execute_with_resolvers.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -33,7 +32,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -50,7 +48,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -67,7 +64,6 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -88,7 +84,6 @@
           "span_id": 5,
           "parent_id": 4,
           "type": "graphql",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "graphql"
@@ -104,7 +99,6 @@
           "span_id": 6,
           "parent_id": 4,
           "type": "graphql",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "graphql"
@@ -120,7 +114,6 @@
           "span_id": 7,
           "parent_id": 4,
           "type": "graphql",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "graphql"
@@ -136,7 +129,6 @@
           "span_id": 8,
           "parent_id": 4,
           "type": "graphql",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "graphql"

--- a/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_failing_execute.json
+++ b/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_failing_execute.json
@@ -35,7 +35,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -52,7 +51,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -33,7 +32,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -50,7 +48,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -67,7 +64,6 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_error.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_error.json
@@ -35,7 +35,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_execute_with_middleware.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_execute_with_middleware.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "test-execute-instrumentation",
-    "service": "",
+    "service": null,
     "resource": "test-execute-instrumentation",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -30,7 +28,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -50,7 +47,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -73,7 +69,6 @@
           "span_id": 5,
           "parent_id": 3,
           "type": "graphql",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "graphql"
@@ -88,8 +83,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 5,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": ""
              },
@@ -104,7 +97,6 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -127,7 +119,6 @@
           "span_id": 6,
           "parent_id": 4,
           "type": "graphql",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "graphql"
@@ -142,8 +133,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 6,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": ""
              },

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_with_traced_resolver.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_with_traced_resolver.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -33,7 +32,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -50,7 +48,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -67,7 +64,6 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -89,7 +85,6 @@
           "span_id": 5,
           "parent_id": 4,
           "type": "graphql",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "graphql"

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-None].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-None].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -33,7 +32,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -50,7 +48,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -67,7 +64,6 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-v0].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-v0].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -33,7 +32,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -50,7 +48,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",
@@ -67,7 +64,6 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "graphql",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-v1].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-v1].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "graphql",
@@ -32,7 +31,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "component": "graphql",
          "graphql.source": "query HELLO { hello }"
@@ -48,7 +46,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "component": "graphql",
          "graphql.source": "query HELLO { hello }"
@@ -64,7 +61,6 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "component": "graphql",
          "graphql.operation.name": "HELLO",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-None].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-None].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "graphql",
@@ -32,7 +31,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "component": "graphql",
          "graphql.source": "query HELLO { hello }"
@@ -48,7 +46,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "component": "graphql",
          "graphql.source": "query HELLO { hello }"
@@ -64,7 +61,6 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "component": "graphql",
          "graphql.operation.name": "HELLO",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-v0].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-v0].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "graphql",
@@ -32,7 +31,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "component": "graphql",
          "graphql.source": "query HELLO { hello }"
@@ -48,7 +46,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "component": "graphql",
          "graphql.source": "query HELLO { hello }"
@@ -64,7 +61,6 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "component": "graphql",
          "graphql.operation.name": "HELLO",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-v1].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-v1].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "graphql",
@@ -32,7 +31,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "component": "graphql",
          "graphql.source": "query HELLO { hello }"
@@ -48,7 +46,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "component": "graphql",
          "graphql.source": "query HELLO { hello }"
@@ -64,7 +61,6 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
-       "error": 0,
        "meta": {
          "component": "graphql",
          "graphql.operation.name": "HELLO",

--- a/tests/snapshots/tests.contrib.grpc.test_grpc.test_method_service.json
+++ b/tests/snapshots/tests.contrib.grpc.test_grpc.test_method_service.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "grpc",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -42,7 +41,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "grpc",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "grpc_server",
@@ -71,7 +69,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "grpc",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -107,7 +104,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "grpc",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "grpc_server",

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-None].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-None].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -36,8 +35,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "wsgi"
@@ -53,7 +50,6 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "wsgi",
@@ -69,8 +65,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-v0].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-v0].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -36,8 +35,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "wsgi"
@@ -53,7 +50,6 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "wsgi",
@@ -69,8 +65,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-v1].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-v1].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "wsgi",
@@ -35,8 +34,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi"
        },
@@ -51,7 +48,6 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "component": "wsgi",
             "span.kind": "server"
@@ -66,8 +62,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi",
          "result_class": "list_iterator"

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-None].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-None].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "wsgi",
@@ -35,8 +34,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi"
        },
@@ -51,7 +48,6 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "component": "wsgi",
             "span.kind": "server"
@@ -66,8 +62,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi",
          "result_class": "list_iterator"

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-v0].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-v0].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "wsgi",
@@ -35,8 +34,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi"
        },
@@ -51,7 +48,6 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "component": "wsgi",
             "span.kind": "server"
@@ -66,8 +62,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi",
          "result_class": "list_iterator"

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-v1].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-v1].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "wsgi",
@@ -35,8 +34,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi"
        },
@@ -51,7 +48,6 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "component": "wsgi",
             "span.kind": "server"
@@ -66,8 +62,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi",
          "result_class": "list_iterator"

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_traced_basic[gunicorn_server_settings0].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_traced_basic[gunicorn_server_settings0].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "wsgi",
@@ -35,8 +34,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi"
        },
@@ -51,7 +48,6 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "component": "wsgi",
             "span.kind": "server"
@@ -66,8 +62,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi",
          "result_class": "list_iterator"

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_configure_service_name.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_configure_service_name.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_configure_service_name_env.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_configure_service_name_env.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.base_service": "global-service-name",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_get_200.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_get_200.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "http.request",
-    "service": "",
+    "service": null,
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "httpx",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_get_500.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_get_500.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "http.request",
-    "service": "",
+    "service": null,
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_request_headers.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_request_headers.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "http.request",
-    "service": "",
+    "service": null,
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "httpx",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_default.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_default.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "httpx",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v0.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "httpx",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v0.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "http.request",
-    "service": "",
+    "service": null,
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "httpx",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_default.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_default.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "http.request",
-    "service": "",
+    "service": null,
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "httpx",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v0.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "http.request",
-    "service": "",
+    "service": null,
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "httpx",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_split_by_domain.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_split_by_domain.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_trace_query_string.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_trace_query_string.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "http.request",
-    "service": "",
+    "service": null,
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "httpx",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_analytics_with_rate.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_analytics_with_rate.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -44,7 +43,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_analytics_without_rate.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_analytics_without_rate.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -44,7 +43,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_message[False].json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_message[False].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -43,7 +42,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_message[True].json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_message[True].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -43,7 +42,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[None-None].json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[None-None].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -43,7 +42,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[None-mysvc].json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[None-mysvc].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
@@ -43,7 +42,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[v0-None].json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[v0-None].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -43,7 +42,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[v0-mysvc].json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[v0-mysvc].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
@@ -43,7 +42,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[v1-None].json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[v1-None].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "kafka",
@@ -42,7 +41,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "messaging.kafka.bootstrap.servers",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[v1-mysvc].json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[v1-mysvc].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "kafka",
@@ -42,7 +41,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "messaging.kafka.bootstrap.servers",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_service_override.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_service_override.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -43,7 +42,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_service_override_env_var.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_service_override_env_var.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -43,7 +42,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_ai21_llm_sync.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_ai21_llm_sync.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.llms.ai21.AI21",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.ai21.parameters.countPenalty.applyToEmojis": "True",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_cohere_llm_sync.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_cohere_llm_sync.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.llms.cohere.Cohere",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_cohere_math_chain.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_cohere_math_chain.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.chains.llm_math.base.LLMMathChain",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.inputs.question": "what is thirteen raised to the .3432 power?",
@@ -31,13 +29,11 @@
   },
      {
        "name": "langchain.request",
-       "service": "",
+       "service": null,
        "resource": "langchain.chains.llm.LLMChain",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "langchain.request.inputs.question": "what is thirteen raised to the .3432 power?",
          "langchain.request.inputs.stop": "['```output']",
@@ -56,13 +52,11 @@
      },
         {
           "name": "langchain.request",
-          "service": "",
+          "service": null,
           "resource": "langchain.llms.cohere.Cohere",
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "langchain.request.api_key": "...key>",
             "langchain.request.cohere.parameters.frequency_penalty": "0.0",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_fake_embedding_document.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_fake_embedding_document.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.embeddings.fake.FakeEmbeddings",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_fake_embedding_query.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_fake_embedding_query.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.embeddings.fake.FakeEmbeddings",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_huggingfacehub_llm_sync.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_huggingfacehub_llm_sync.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.llms.huggingface_hub.HuggingFaceHub",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_call.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_call.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.chat_models.openai.ChatOpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_generate.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_generate.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.chat_models.openai.ChatOpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_stream.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_stream.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.chat_models.openai.ChatOpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_sync_call_39.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_sync_call_39.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.chat_models.openai.ChatOpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_sync_generate_39.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_sync_generate_39.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.chat_models.openai.ChatOpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_embedding_document.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_embedding_document.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.embeddings.openai.OpenAIEmbeddings",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_embedding_query.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_embedding_query.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.embeddings.openai.OpenAIEmbeddings",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_integration.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_integration.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",
@@ -46,13 +44,11 @@
   },
      {
        "name": "openai.request",
-       "service": "",
+       "service": null,
        "resource": "createCompletion",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "openai",
          "openai.api_base": "https://api.openai.com/v1",
@@ -94,7 +90,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "http",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "requests",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_async.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_async.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_error.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_error.json
@@ -1,12 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_stream.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_stream.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_sync.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_sync.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_sync_39.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_sync_39.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_sync_multiple_prompts.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_sync_multiple_prompts.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_sync_multiple_prompts_39.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_sync_multiple_prompts_39.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_math_chain.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_math_chain.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.chains.llm_math.base.LLMMathChain",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.inputs.question": "what is two raised to the fifty-fourth power?",
@@ -35,13 +33,11 @@
   },
      {
        "name": "langchain.request",
-       "service": "",
+       "service": null,
        "resource": "langchain.chains.llm.LLMChain",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "langchain.request.inputs.question": "what is two raised to the fifty-fourth power?",
          "langchain.request.inputs.stop": "['```output']",
@@ -64,13 +60,11 @@
      },
         {
           "name": "langchain.request",
-          "service": "",
+          "service": null,
           "resource": "langchain.llms.openai.OpenAI",
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "langchain.request.api_key": "...key>",
             "langchain.request.model": "text-davinci-003",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.chains.sequential.SequentialChain",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.inputs.style": "a 90s rapper",
@@ -36,13 +34,11 @@
   },
      {
        "name": "langchain.request",
-       "service": "",
+       "service": null,
        "resource": "langchain.chains.transform.TransformChain",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "langchain.request.inputs.style": "a 90s rapper",
          "langchain.request.inputs.text": "\\n        Chains allow us to combine multiple\\n\\n\\n        components together to create a single, coherent application.\\n\\n    ...",
@@ -58,13 +54,11 @@
      },
      {
        "name": "langchain.request",
-       "service": "",
+       "service": null,
        "resource": "langchain.chains.llm.LLMChain",
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "langchain.request.inputs.output_text": "\\n Chains allow us to combine multiple\\n components together to create a single, coherent application.\\n For example, we can cre...",
          "langchain.request.inputs.style": "a 90s rapper",
@@ -86,13 +80,11 @@
      },
         {
           "name": "langchain.request",
-          "service": "",
+          "service": null,
           "resource": "langchain.llms.openai.OpenAI",
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 3,
-          "type": "",
-          "error": 0,
           "meta": {
             "langchain.request.api_key": "...key>",
             "langchain.request.model": "text-davinci-003",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain_with_multiple_llm_async.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain_with_multiple_llm_async.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.chains.sequential.SequentialChain",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.inputs.input_text": "\\n            I have convinced myself that there is absolutely nothing in the world, no sky, no earth, no minds, no\\n           ...",
@@ -34,13 +32,11 @@
   },
      {
        "name": "langchain.request",
-       "service": "",
+       "service": null,
        "resource": "langchain.chains.llm.LLMChain",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "langchain.request.inputs.input_text": "\\n            I have convinced myself that there is absolutely nothing in the world, no sky, no earth, no minds, no\\n           ...",
          "langchain.request.prompt": "Paraphrase this text:\\n\\n        {input_text}\\n\\n        Paraphrase: ",
@@ -60,13 +56,11 @@
      },
         {
           "name": "langchain.request",
-          "service": "",
+          "service": null,
           "resource": "langchain.llms.openai.OpenAI",
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "langchain.request.api_key": "...key>",
             "langchain.request.model": "text-davinci-003",
@@ -98,13 +92,11 @@
         },
      {
        "name": "langchain.request",
-       "service": "",
+       "service": null,
        "resource": "langchain.chains.llm.LLMChain",
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "langchain.request.inputs.input_text": "\\n            I have convinced myself that there is absolutely nothing in the world, no sky, no earth, no minds, no\\n           ...",
          "langchain.request.inputs.paraphrased_output": "\\nI have convinced myself that there is no physical world - no sky, earth, minds, or bodies. Does this mean that I don't exist e...",
@@ -125,13 +117,11 @@
      },
         {
           "name": "langchain.request",
-          "service": "",
+          "service": null,
           "resource": "langchain.llms.openai.OpenAI",
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 3,
-          "type": "",
-          "error": 0,
           "meta": {
             "langchain.request.api_key": "...key>",
             "langchain.request.model": "text-davinci-003",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain_with_multiple_llm_sync.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain_with_multiple_llm_sync.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.chains.sequential.SequentialChain",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.inputs.input_text": "\\n            I have convinced myself that there is absolutely nothing in the world, no sky, no earth, no minds, no\\n           ...",
@@ -34,13 +32,11 @@
   },
      {
        "name": "langchain.request",
-       "service": "",
+       "service": null,
        "resource": "langchain.chains.llm.LLMChain",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "langchain.request.inputs.input_text": "\\n            I have convinced myself that there is absolutely nothing in the world, no sky, no earth, no minds, no\\n           ...",
          "langchain.request.prompt": "Paraphrase this text:\\n\\n        {input_text}\\n\\n        Paraphrase: ",
@@ -60,13 +56,11 @@
      },
         {
           "name": "langchain.request",
-          "service": "",
+          "service": null,
           "resource": "langchain.llms.openai.OpenAI",
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "langchain.request.api_key": "...key>",
             "langchain.request.model": "text-davinci-003",
@@ -98,13 +92,11 @@
         },
      {
        "name": "langchain.request",
-       "service": "",
+       "service": null,
        "resource": "langchain.chains.llm.LLMChain",
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "langchain.request.inputs.input_text": "\\n            I have convinced myself that there is absolutely nothing in the world, no sky, no earth, no minds, no\\n           ...",
          "langchain.request.inputs.paraphrased_output": "\\nI have come to the conclusion that there is nothing in the world such as the sky, the earth, minds, or bodies. Does this mean ...",
@@ -125,13 +117,11 @@
      },
         {
           "name": "langchain.request",
-          "service": "",
+          "service": null,
           "resource": "langchain.llms.openai.OpenAI",
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 3,
-          "type": "",
-          "error": 0,
           "meta": {
             "langchain.request.api_key": "...key>",
             "langchain.request.model": "text-davinci-003",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-None].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-None].json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",
@@ -46,13 +44,11 @@
   },
      {
        "name": "openai.request",
-       "service": "",
+       "service": null,
        "resource": "createCompletion",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "openai",
          "openai.api_base": "https://api.openai.com/v1",
@@ -94,7 +90,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "http",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "requests",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-v0].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-v0].json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",
@@ -46,13 +44,11 @@
   },
      {
        "name": "openai.request",
-       "service": "",
+       "service": null,
        "resource": "createCompletion",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "openai",
          "openai.api_base": "https://api.openai.com/v1",
@@ -94,7 +90,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "http",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "requests",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-v1].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-v1].json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",
@@ -51,8 +49,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "openai",
          "openai.api_base": "https://api.openai.com/v1",
@@ -94,7 +90,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "http",
-          "error": 0,
           "meta": {
             "_dd.peer.service.source": "out.host",
             "component": "requests",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-None].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-None].json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",
@@ -51,8 +49,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "openai",
          "openai.api_base": "https://api.openai.com/v1",
@@ -94,7 +90,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "http",
-          "error": 0,
           "meta": {
             "_dd.base_service": "mysvc",
             "component": "requests",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-v0].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-v0].json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",
@@ -51,8 +49,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "openai",
          "openai.api_base": "https://api.openai.com/v1",
@@ -94,7 +90,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "http",
-          "error": 0,
           "meta": {
             "_dd.base_service": "mysvc",
             "component": "requests",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-v1].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-v1].json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",
@@ -51,8 +49,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "openai",
          "openai.api_base": "https://api.openai.com/v1",
@@ -94,7 +90,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "http",
-          "error": 0,
           "meta": {
             "_dd.peer.service.source": "out.host",
             "component": "requests",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_retrieval_chain.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_retrieval_chain.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.chains.qa_with_sources.retrieval.RetrievalQAWithSourcesChain",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.inputs.question": "Who was Alan Turing?",
@@ -35,13 +33,11 @@
   },
      {
        "name": "langchain.request",
-       "service": "",
+       "service": null,
        "resource": "langchain.vectorstores.pinecone.Pinecone",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "langchain.request.api_key": "...key>",
          "langchain.request.pinecone.environment": "<not-a-real-env>",
@@ -81,13 +77,11 @@
      },
         {
           "name": "langchain.request",
-          "service": "",
+          "service": null,
           "resource": "langchain.embeddings.openai.OpenAIEmbeddings",
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "langchain.request.api_key": "...key>",
             "langchain.request.inputs.0.text": "Who was Alan Turing?",
@@ -106,13 +100,11 @@
         },
      {
        "name": "langchain.request",
-       "service": "",
+       "service": null,
        "resource": "langchain.chains.combine_documents.stuff.StuffDocumentsChain",
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "langchain.request.inputs.input_documents": "[Document(page_content='A brilliant mathematician and cryptographer Alan was to become the founder of modern-day computer scienc...",
          "langchain.request.inputs.question": "Who was Alan Turing?",
@@ -134,13 +126,11 @@
      },
         {
           "name": "langchain.request",
-          "service": "",
+          "service": null,
           "resource": "langchain.chains.llm.LLMChain",
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 3,
-          "type": "",
-          "error": 0,
           "meta": {
             "langchain.request.inputs.question": "Who was Alan Turing?",
             "langchain.request.inputs.summaries": "Content: A brilliant mathematician and cryptographer Alan was to become the founder of modern-day computer science and artificia...",
@@ -163,13 +153,11 @@
         },
            {
              "name": "langchain.request",
-             "service": "",
+             "service": null,
              "resource": "langchain.llms.openai.OpenAI",
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 5,
-             "type": "",
-             "error": 0,
              "meta": {
                "langchain.request.api_key": "...key>",
                "langchain.request.model": "text-davinci-003",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_retrieval_chain_39.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_retrieval_chain_39.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.chains.qa_with_sources.retrieval.RetrievalQAWithSourcesChain",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.inputs.question": "Who was Alan Turing?",
@@ -35,13 +33,11 @@
   },
      {
        "name": "langchain.request",
-       "service": "",
+       "service": null,
        "resource": "langchain.vectorstores.pinecone.Pinecone",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "langchain.request.api_key": "...key>",
          "langchain.request.pinecone.environment": "<not-a-real-env>",
@@ -81,13 +77,11 @@
      },
         {
           "name": "langchain.request",
-          "service": "",
+          "service": null,
           "resource": "langchain.embeddings.openai.OpenAIEmbeddings",
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "langchain.request.api_key": "...key>",
             "langchain.request.inputs.0.text": "Who was Alan Turing?",
@@ -106,13 +100,11 @@
         },
      {
        "name": "langchain.request",
-       "service": "",
+       "service": null,
        "resource": "langchain.chains.combine_documents.stuff.StuffDocumentsChain",
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "langchain.request.inputs.input_documents": "[Document(page_content='A brilliant mathematician and cryptographer Alan was to become the founder of modern-day computer scienc...",
          "langchain.request.inputs.question": "Who was Alan Turing?",
@@ -134,13 +126,11 @@
      },
         {
           "name": "langchain.request",
-          "service": "",
+          "service": null,
           "resource": "langchain.chains.llm.LLMChain",
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 3,
-          "type": "",
-          "error": 0,
           "meta": {
             "langchain.request.inputs.question": "Who was Alan Turing?",
             "langchain.request.inputs.summaries": "Content: A brilliant mathematician and cryptographer Alan was to become the founder of modern-day computer science and artificia...",
@@ -163,13 +153,11 @@
         },
            {
              "name": "langchain.request",
-             "service": "",
+             "service": null,
              "resource": "langchain.llms.openai.OpenAI",
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 5,
-             "type": "",
-             "error": 0,
              "meta": {
                "langchain.request.api_key": "...key>",
                "langchain.request.model": "text-davinci-003",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_similarity_search.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_similarity_search.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "langchain.request",
-    "service": "",
+    "service": null,
     "resource": "langchain.vectorstores.pinecone.Pinecone",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "langchain.request.api_key": "...key>",
@@ -40,13 +38,11 @@
   },
      {
        "name": "langchain.request",
-       "service": "",
+       "service": null,
        "resource": "langchain.embeddings.openai.OpenAIEmbeddings",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "langchain.request.api_key": "...key>",
          "langchain.request.inputs.0.text": "Who was Alan Turing?",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_analytics_with_rate_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_analytics_with_rate_snapshot_post_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_analytics_with_rate_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_analytics_with_rate_snapshot_pre_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_analytics_without_rate_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_analytics_without_rate_snapshot_post_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_analytics_without_rate_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_analytics_without_rate_snapshot_pre_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_commit_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_commit_snapshot_post_1_1.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_commit_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_commit_snapshot_pre_1_1.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_many_fetchall_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_many_fetchall_snapshot_post_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -42,7 +41,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -76,7 +74,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_many_fetchall_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_many_fetchall_snapshot_pre_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -42,7 +41,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -76,7 +74,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_proc_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_proc_snapshot_post_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_proc_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_proc_snapshot_pre_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_fetchall_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_fetchall_snapshot_post_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_fetchall_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_fetchall_snapshot_pre_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_snapshot_post_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_snapshot_pre_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema0]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema0]_post_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema0]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema0]_pre_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema1]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema1]_post_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema1]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema1]_pre_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema2]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema2]_post_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "db.name",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema2]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema2]_pre_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "db.name",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema3]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema3]_post_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema3]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema3]_pre_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema4]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema4]_post_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema4]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema4]_pre_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema5]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema5]_post_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "db.name",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema5]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema5]_pre_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "db.name",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_fetchall_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_fetchall_snapshot_post_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_fetchall_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_fetchall_snapshot_pre_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_snapshot_post_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_snapshot_pre_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_mariadb_service_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_mariadb_service_snapshot_post_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_mariadb_service_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_mariadb_service_snapshot_pre_1_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_achat_completion.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_achat_completion.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createChatCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_acompletion.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_acompletion.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_acreate_moderation.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_acreate_moderation.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createModeration",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_aedit.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_aedit.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createEdit",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_aembedding.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_aembedding.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createEmbedding",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_atranscribe.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_atranscribe.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createTranscription",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_atranslate.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_atranslate.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createTranslation",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_chat_completion.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_chat_completion.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createChatCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_completion.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_completion.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_create_moderation.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_create_moderation.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createModeration",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_edit.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_edit.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createEdit",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_embedding.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_embedding.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createEmbedding",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_embedding_array_of_token_arrays.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_embedding_array_of_token_arrays.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createEmbedding",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_embedding_string_array.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_embedding_string_array.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createEmbedding",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_embedding_token_array.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_embedding_token_array.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createEmbedding",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_file_acreate.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_file_acreate.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createFile",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_file_adelete.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_file_adelete.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "deleteFile",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_file_create.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_file_create.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createFile",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_file_delete.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_file_delete.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "deleteFile",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_file_download.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_file_download.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "downloadFile",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_file_list.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_file_list.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "listFiles",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_file_retrieve.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_file_retrieve.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "retrieveFile",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_acancel.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_acancel.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "cancelFineTune",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_acreate.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_acreate.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createFineTune",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_cancel.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_cancel.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "cancelFineTune",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_create.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_create.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createFineTune",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_delete.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_delete.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "deleteModel",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_list.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_list.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "listFineTunes",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_list_events.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_list_events.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "listFineTuneEvents",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_retrieve.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_retrieve.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "retrieveFineTune",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_image_acreate.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_image_acreate.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createImage",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_image_aedit.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_image_aedit.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createImageEdit",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_image_avariation.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_image_avariation.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createImageVariation",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_image_b64_json_response.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_image_b64_json_response.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createImage",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_image_create.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_image_create.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createImage",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_image_edit.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_image_edit.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createImageEdit",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_image_edit_binary_input.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_image_edit_binary_input.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createImageEdit",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_image_variation.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_image_variation.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createImageVariation",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_integration_async.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_integration_async.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_integration_service_name[None-None].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_integration_service_name[None-None].json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",
@@ -50,7 +48,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "requests",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_integration_service_name[None-v0].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_integration_service_name[None-v0].json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",
@@ -50,7 +48,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "requests",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_integration_service_name[None-v1].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_integration_service_name[None-v1].json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",
@@ -50,7 +48,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
-       "error": 0,
        "meta": {
          "_dd.peer.service.source": "out.host",
          "component": "requests",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_integration_service_name[mysvc-None].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_integration_service_name[mysvc-None].json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",
@@ -50,7 +48,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
-       "error": 0,
        "meta": {
          "_dd.base_service": "mysvc",
          "component": "requests",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_integration_service_name[mysvc-v0].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_integration_service_name[mysvc-v0].json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",
@@ -50,7 +48,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
-       "error": 0,
        "meta": {
          "_dd.base_service": "mysvc",
          "component": "requests",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_integration_service_name[mysvc-v1].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_integration_service_name[mysvc-v1].json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",
@@ -50,7 +48,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
-       "error": 0,
        "meta": {
          "_dd.peer.service.source": "out.host",
          "component": "requests",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_integration_sync.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_integration_sync.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",
@@ -50,7 +48,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "requests",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_misuse.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_misuse.json
@@ -1,12 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_model_list.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_model_list.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "listModels",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_model_retrieve.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_model_retrieve.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "retrieveModel",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_span_finish_on_stream_error.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_span_finish_on_stream_error.json
@@ -1,12 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_transcribe.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_transcribe.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createTranscription",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_translate.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_translate.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "openai.request",
-    "service": "",
+    "service": null,
     "resource": "createTranslation",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.psycopg.test_psycopg.test_composed_query_encoding.json
+++ b/tests/snapshots/tests.contrib.psycopg.test_psycopg.test_composed_query_encoding.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.psycopg.test_psycopg.test_postgres_dbm_propagation_tag.json
+++ b/tests/snapshots/tests.contrib.psycopg.test_psycopg.test_postgres_dbm_propagation_tag.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
@@ -43,7 +42,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
@@ -80,7 +78,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
@@ -116,7 +113,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
@@ -153,7 +149,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
@@ -189,7 +184,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",

--- a/tests/snapshots/tests.contrib.psycopg.test_psycopg_snapshot.test_connect_traced.json
+++ b/tests/snapshots/tests.contrib.psycopg.test_psycopg_snapshot.test_connect_traced.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.psycopg2.test_psycopg.test_composed_query_encoding.json
+++ b/tests/snapshots/tests.contrib.psycopg2.test_psycopg.test_composed_query_encoding.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.psycopg2.test_psycopg.test_postgres_dbm_propagation_tag.json
+++ b/tests/snapshots/tests.contrib.psycopg2.test_psycopg.test_postgres_dbm_propagation_tag.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
@@ -43,7 +42,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
@@ -80,7 +78,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
@@ -116,7 +113,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",

--- a/tests/snapshots/tests.contrib.psycopg2.test_psycopg_snapshot.test_connect_traced.json
+++ b/tests/snapshots/tests.contrib.psycopg2.test_psycopg_snapshot.test_connect_traced.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.pyramid.test_pyramid.test_simple_pyramid_app_endpoint.json
+++ b/tests/snapshots/tests.contrib.pyramid.test_pyramid.test_simple_pyramid_app_endpoint.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "pyramid",

--- a/tests/snapshots/tests.contrib.pyramid.test_pyramid.test_simple_pyramid_app_endpoint[ddtrace-run_pserve_tests_contrib_pyramid_pserve_app_development.ini].json
+++ b/tests/snapshots/tests.contrib.pyramid.test_pyramid.test_simple_pyramid_app_endpoint[ddtrace-run_pserve_tests_contrib_pyramid_pserve_app_development.ini].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.pyramid.test_pyramid.test_simple_pyramid_app_endpoint[ddtrace-run_python_tests_contrib_pyramid_app_app.py].json
+++ b/tests/snapshots/tests.contrib.pyramid.test_pyramid.test_simple_pyramid_app_endpoint[ddtrace-run_python_tests_contrib_pyramid_app_app.py].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_analytics_with_rate.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_analytics_with_rate.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_analytics_without_rate.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_analytics_without_rate.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_basics.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_basics.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_custom_cmd_length.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_custom_cmd_length.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_custom_cmd_length_env.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_custom_cmd_length_env.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_env_user_specified_redis_service.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_env_user_specified_redis_service.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -42,7 +41,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_long_command.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_long_command.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_meta_override.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_meta_override.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_opentracing.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_opentracing.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -31,7 +29,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "redis",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_pipeline_immediate.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_pipeline_immediate.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_pipeline_traced.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_pipeline_traced.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_service_precedence.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_service_precedence.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "app-svc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_unicode.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_unicode.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_user_specified_service.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_user_specified_service.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_basic_request.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_basic_request.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_client_name.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_client_name.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -31,7 +29,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "redis",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_decoding_non_utf8_args.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_decoding_non_utf8_args.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_decoding_non_utf8_pipeline_args.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_decoding_non_utf8_pipeline_args.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_long_command.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_long_command.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_override_service_name.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_override_service_name.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -42,7 +41,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -76,7 +74,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_parenting.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_parenting.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -31,7 +29,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "redis",
@@ -58,7 +55,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "redis",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "redis",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_pin.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_pin.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_pipeline_traced.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_pipeline_traced.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_pipeline_traced_context_manager_transaction.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_pipeline_traced_context_manager_transaction.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_two_traced_pipelines.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_two_traced_pipelines.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -31,7 +29,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "redis",
@@ -58,7 +55,6 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "redis",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "redis",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_unicode_request.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_unicode_request.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rediscluster.test.test_cmd_max_length.json
+++ b/tests/snapshots/tests.contrib.rediscluster.test.test_cmd_max_length.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -38,7 +37,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_False_worker_service_None.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_False_worker_service_None.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -35,8 +34,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "rq",
@@ -54,7 +51,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_False_worker_service_custom-worker-service.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_False_worker_service_custom-worker-service.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "rq",
@@ -34,8 +33,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "rq",
          "job.id": "503d25d4-c7d5-451c-8b83-8f7e467b4dba"
@@ -52,7 +49,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_None_worker_service_None.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_None_worker_service_None.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -36,7 +35,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -66,8 +64,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_None_worker_service_custom-worker-service.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_None_worker_service_custom-worker-service.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -36,7 +35,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
-       "error": 0,
        "meta": {
          "_dd.p.dm": "-0",
          "component": "rq",
@@ -65,8 +63,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "component": "rq",
             "job.id": "da5d74e6-52f8-411a-9a6f-e748344c3e62"

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_queue_failing_job.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_queue_failing_job.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -35,7 +34,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
        "error": 1,
        "meta": {
          "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_queue_failing_job_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_queue_failing_job_pre_1_10_1.json
@@ -38,7 +38,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
        "error": 1,
        "meta": {
          "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_queue_pin_service.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_queue_pin_service.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -36,7 +35,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -66,8 +64,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema0].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema0].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -66,7 +65,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
           "error": 1,
           "meta": {
             "_dd.base_service": "",
@@ -87,8 +85,6 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema0]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema0]_pre_1_10_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -66,7 +65,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
           "error": 1,
           "meta": {
             "_dd.base_service": "",
@@ -87,8 +85,6 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema1].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema1].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -66,7 +65,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
           "error": 1,
           "meta": {
             "_dd.base_service": "",
@@ -87,8 +85,6 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema1]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema1]_pre_1_10_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -66,7 +65,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
           "error": 1,
           "meta": {
             "_dd.base_service": "",
@@ -87,8 +85,6 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema2].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema2].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "rq",
@@ -64,7 +63,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
           "error": 1,
           "meta": {
             "component": "rq",
@@ -84,8 +82,6 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema2]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema2]_pre_1_10_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "rq",
@@ -64,7 +63,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
           "error": 1,
           "meta": {
             "component": "rq",
@@ -84,8 +82,6 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema3].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema3].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "rq",
@@ -64,7 +63,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
           "error": 1,
           "meta": {
             "component": "rq",
@@ -84,8 +82,6 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema3]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema3]_pre_1_10_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "rq",
@@ -64,7 +63,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
           "error": 1,
           "meta": {
             "component": "rq",
@@ -84,8 +82,6 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema4].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema4].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "rq",
@@ -64,7 +63,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
           "error": 1,
           "meta": {
             "component": "rq",
@@ -84,8 +82,6 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema4]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema4]_pre_1_10_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "rq",
@@ -64,7 +63,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
           "error": 1,
           "meta": {
             "component": "rq",
@@ -84,8 +82,6 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema5].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema5].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "rq",
@@ -64,7 +63,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
           "error": 1,
           "meta": {
             "component": "rq",
@@ -84,8 +82,6 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema5]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema5]_pre_1_10_1.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "rq",
@@ -64,7 +63,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
           "error": 1,
           "meta": {
             "component": "rq",
@@ -84,8 +82,6 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_sync_queue_enqueue.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_sync_queue_enqueue.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -35,8 +34,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -36,7 +35,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -66,8 +64,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_config_service.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_config_service.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -36,7 +35,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -66,8 +64,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_multiple_jobs.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_multiple_jobs.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -36,7 +35,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -66,8 +64,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "rq",
@@ -85,7 +81,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -114,7 +109,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -144,8 +138,6 @@
           "trace_id": 1,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "rq",
@@ -163,7 +155,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -192,7 +183,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -222,8 +212,6 @@
           "trace_id": 2,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_pin_service.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_pin_service.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -36,7 +35,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -66,8 +64,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_worker_class_job.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_worker_class_job.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -36,7 +35,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -66,8 +64,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "rq",
@@ -85,7 +81,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -114,7 +109,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -144,8 +138,6 @@
           "trace_id": 1,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_worker_failing_job.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_worker_failing_job.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -66,7 +65,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
           "error": 1,
           "meta": {
             "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -37,8 +36,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": ""
        },
@@ -54,7 +51,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -84,8 +80,6 @@
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": ""
        },

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http_pre_21.9.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http_pre_21.9.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -36,8 +35,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": ""
        },
@@ -53,7 +50,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -82,8 +78,6 @@
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": ""
        },

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_sanic_errors.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_sanic_errors.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_sanic_errors_pre_21.9.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_sanic_errors_pre_21.9.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema0].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema0].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema1].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema1].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema2].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema2].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "db.name",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema3].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema3].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema4].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema4].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema5].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema5].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "db.name",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_analytics_with_rate.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_analytics_with_rate.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_analytics_without_rate.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_analytics_without_rate.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_commit.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_commit.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_executemany_insert.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_executemany_insert.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchall.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchall.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchall_multiple_rows.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchall_multiple_rows.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchone.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchone.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_executemany_insert.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_executemany_insert.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -31,7 +29,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "snowflake",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchall.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchall.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -31,7 +29,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "snowflake",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchall_multiple_rows.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchall_multiple_rows.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -31,7 +29,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "snowflake",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchone.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchone.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -31,7 +29,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "snowflake",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_pin_override.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_pin_override.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_rollback.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_rollback.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_service_env.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_service_env.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "snowflake",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_settings_override.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_settings_override.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema0]_36.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema0]_36.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "starlette",
@@ -64,7 +62,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "starlette",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema0]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema0]_rest.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -38,7 +37,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "starlette",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema1]_36.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema1]_36.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "starlette",
@@ -64,7 +62,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "starlette",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema1]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema1]_rest.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -38,7 +37,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "starlette",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema2]_36.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema2]_36.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",
@@ -40,7 +39,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "component": "starlette",
          "http.method": "GET",
@@ -61,7 +59,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "component": "starlette",
             "http.method": "GET",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema2]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema2]_rest.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "starlette",
@@ -37,7 +36,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "component": "starlette",
          "http.method": "GET",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema3]_36.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema3]_36.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "component": "starlette",
          "http.method": "GET",
@@ -63,7 +61,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "component": "starlette",
             "http.method": "GET",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema3]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema3]_rest.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "starlette",
@@ -37,7 +36,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "component": "starlette",
          "http.method": "GET",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema4]_36.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema4]_36.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "component": "starlette",
          "http.method": "GET",
@@ -63,7 +61,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "component": "starlette",
             "http.method": "GET",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema4]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema4]_rest.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "starlette",
@@ -37,7 +36,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "component": "starlette",
          "http.method": "GET",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema5]_36.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema5]_36.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",
@@ -40,7 +39,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "component": "starlette",
          "http.method": "GET",
@@ -61,7 +59,6 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "component": "starlette",
             "http.method": "GET",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema5]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema5]_rest.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "starlette",
@@ -37,7 +36,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "component": "starlette",
          "http.method": "GET",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_subapp_no_aggregate_snapshot.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_subapp_no_aggregate_snapshot.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -38,7 +37,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "starlette",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_subapp_snapshot.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_subapp_snapshot.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "starlette",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_table_query_snapshot.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_table_query_snapshot.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,7 +38,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "sqlalchemy",
@@ -63,7 +61,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -95,7 +92,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "sqlalchemy",

--- a/tests/snapshots/tests.contrib.urllib3.test_urllib3.test_urllib3_connectionpool_snapshot.json
+++ b/tests/snapshots/tests.contrib.urllib3.test_urllib3.test_urllib3_connectionpool_snapshot.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.urllib3.test_urllib3.test_urllib3_poolmanager_snapshot.json
+++ b/tests/snapshots/tests.contrib.urllib3.test_urllib3.test_urllib3_poolmanager_snapshot.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_200.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_200.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -36,8 +35,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "wsgi"
@@ -53,7 +50,6 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "wsgi",
@@ -69,8 +65,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_500_py2.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_500_py2.json
@@ -37,7 +37,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
        "error": 1,
        "meta": {
          "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_500_py3.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_500_py3.json
@@ -37,7 +37,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
        "error": 1,
        "meta": {
          "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_base_exception_in_wsgi_app_py2.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_base_exception_in_wsgi_app_py2.json
@@ -37,7 +37,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
        "error": 1,
        "meta": {
          "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_base_exception_in_wsgi_app_py3.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_base_exception_in_wsgi_app_py3.json
@@ -37,7 +37,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
        "error": 1,
        "meta": {
          "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_chunked.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_chunked.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -36,8 +35,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "wsgi"
@@ -53,7 +50,6 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "wsgi",
@@ -69,8 +65,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_distributed_tracing_nested.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_distributed_tracing_nested.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 1234,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "component": "wsgi",
@@ -34,8 +33,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "wsgi"
@@ -51,7 +48,6 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "wsgi",
@@ -71,8 +67,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "wsgi"
@@ -88,7 +82,6 @@
                 "span_id": 8,
                 "parent_id": 6,
                 "type": "web",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "wsgi",
@@ -104,8 +97,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "wsgi",
@@ -122,7 +113,6 @@
           "span_id": 5,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "wsgi",
@@ -138,8 +128,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_generator_exit_ignored_snapshot.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_generator_exit_ignored_snapshot.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -36,8 +35,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "wsgi"
@@ -53,7 +50,6 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "wsgi",
@@ -69,8 +65,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-None].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-None].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -36,8 +35,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "wsgi"
@@ -53,7 +50,6 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "wsgi",
@@ -69,8 +65,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-v0].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-v0].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -36,8 +35,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "wsgi"
@@ -53,7 +50,6 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "wsgi",
@@ -69,8 +65,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-v1].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-v1].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "wsgi",
@@ -35,8 +34,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi"
        },
@@ -51,7 +48,6 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "component": "wsgi",
             "span.kind": "server"
@@ -66,8 +62,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi",
          "result_class": "list"

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-None].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-None].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "wsgi",
@@ -35,8 +34,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi"
        },
@@ -51,7 +48,6 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "component": "wsgi",
             "span.kind": "server"
@@ -66,8 +62,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi",
          "result_class": "list"

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-v0].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-v0].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "wsgi",
@@ -35,8 +34,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi"
        },
@@ -51,7 +48,6 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "component": "wsgi",
             "span.kind": "server"
@@ -66,8 +62,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi",
          "result_class": "list"

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-v1].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-v1].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "wsgi",
@@ -35,8 +34,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi"
        },
@@ -51,7 +48,6 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
-          "error": 0,
           "meta": {
             "component": "wsgi",
             "span.kind": "server"
@@ -66,8 +62,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "component": "wsgi",
          "result_class": "list"

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_wsgi_base_middleware.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_wsgi_base_middleware.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -35,8 +34,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "app_tag": "app test tag set",
@@ -55,8 +52,6 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_wsgi_base_middleware_500.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_wsgi_base_middleware_500.json
@@ -37,7 +37,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
        "error": 1,
        "meta": {
          "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_analytics_with_rate.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_analytics_with_rate.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_analytics_without_rate.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_analytics_without_rate.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_basics.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_basics.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_cmd_max_length.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_cmd_max_length.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_long_command.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_long_command.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_opentracing.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_opentracing.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -31,7 +29,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "yaaredis",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_pipeline_immediate.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_pipeline_immediate.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_pipeline_traced.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_pipeline_traced.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema0].json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema0].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema1].json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema1].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema2].json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema2].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",
@@ -42,7 +41,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema3].json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema3].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema4].json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema4].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
@@ -41,7 +40,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema5].json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema5].json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",
@@ -42,7 +41,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.peer.service.source": "out.host",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_unicode.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_unicode.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.integration.test_context_snapshots.test_context_multiprocess.json
+++ b/tests/snapshots/tests.integration.test_context_snapshots.test_context_multiprocess.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "work",
-    "service": "",
+    "service": null,
     "resource": "work",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -24,13 +22,11 @@
   },
      {
        "name": "proc",
-       "service": "",
+       "service": null,
        "resource": "proc",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.p.dm": "-0",
          "language": "python",

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_env_vars.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_env_vars.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "env": "prod",

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_filters.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_filters.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "root",
-    "service": "",
+    "service": null,
     "resource": "root",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "boop": "beep",
@@ -25,13 +23,11 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "boop": "beep"
        },

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_multiple_traces.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_multiple_traces.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -34,8 +32,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": ""
        },
@@ -50,8 +46,6 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -78,8 +72,6 @@
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": ""
        },

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_sampling.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_sampling.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "trace7",
-    "service": "",
+    "service": null,
     "resource": "trace7",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-4",
       "language": "python",
@@ -25,26 +23,22 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 11715,
        "start": 1690574476628770928
      }],
 [
   {
     "name": "trace6",
-    "service": "",
+    "service": null,
     "resource": "trace6",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "language": "python",
       "runtime-id": "6f2eeb0b30c54268b96f6eca8a2d66ba"
@@ -61,26 +55,22 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 12752,
        "start": 1690574476627692203
      }],
 [
   {
     "name": "trace5",
-    "service": "",
+    "service": null,
     "resource": "trace5",
     "trace_id": 2,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "language": "python",
       "runtime-id": "6f2eeb0b30c54268b96f6eca8a2d66ba"
@@ -97,26 +87,22 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 2,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 7332,
        "start": 1690574476626585194
      }],
 [
   {
     "name": "trace4",
-    "service": "",
+    "service": null,
     "resource": "trace4",
     "trace_id": 3,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -134,26 +120,22 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 3,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 7522,
        "start": 1690574476625479881
      }],
 [
   {
     "name": "trace3",
-    "service": "",
+    "service": null,
     "resource": "trace3",
     "trace_id": 4,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "language": "python",
       "runtime-id": "6f2eeb0b30c54268b96f6eca8a2d66ba"
@@ -170,26 +152,22 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 4,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 7704,
        "start": 1690574476624305295
      }],
 [
   {
     "name": "trace2",
-    "service": "",
+    "service": null,
     "resource": "trace2",
     "trace_id": 5,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -207,26 +185,22 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 5,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 7840,
        "start": 1690574476622978394
      }],
 [
   {
     "name": "trace1",
-    "service": "",
+    "service": null,
     "resource": "trace1",
     "trace_id": 6,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -243,13 +217,11 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 6,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 13539,
        "start": 1690574476621625665
      }]]

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_setting_span_tags_and_metrics_generates_no_error_logs[v0.5].json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_setting_span_tags_and_metrics_generates_no_error_logs[v0.5].json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_single_trace_single_span.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_single_trace_single_span.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_synchronous_writer.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_synchronous_writer.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -30,8 +28,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": ""
        },
@@ -46,8 +42,6 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -70,8 +64,6 @@
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": ""
        },

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_tracer_trace_across_fork.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_tracer_trace_across_fork.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "parent",
-    "service": "",
+    "service": null,
     "resource": "parent",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -24,13 +22,11 @@
   },
      {
        "name": "child",
-       "service": "",
+       "service": null,
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "language": "python",
          "runtime-id": "36f1a5c9396e469291422d40f4296160"

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_tracer_trace_across_multiple_forks.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_tracer_trace_across_multiple_forks.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "parent",
-    "service": "",
+    "service": null,
     "resource": "parent",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -24,13 +22,11 @@
   },
      {
        "name": "child1",
-       "service": "",
+       "service": null,
        "resource": "child1",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "language": "python",
          "runtime-id": "60f937fe2fa5494c8aeceab4b18a5174"
@@ -46,13 +42,11 @@
      },
         {
           "name": "child2",
-          "service": "",
+          "service": null,
           "resource": "child2",
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "language": "python",
             "runtime-id": "0a98b167e74c408abbb58db3fd26a2e7"

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_tracetagsprocessor_only_adds_new_tags.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_tracetagsprocessor_only_adds_new_tags.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "web.request",
-    "service": "",
+    "service": null,
     "resource": "web.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",

--- a/tests/snapshots/tests.integration.test_propagation.test_sampling_decision_downstream.json
+++ b/tests/snapshots/tests.integration.test_propagation.test_sampling_decision_downstream.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 5678,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-4",

--- a/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer0].json
+++ b/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer0].json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "p",
-    "service": "",
+    "service": null,
     "resource": "p",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 5678,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-1",
       "_dd.p.test": "value",
@@ -25,13 +23,11 @@
   },
      {
        "name": "c1",
-       "service": "",
+       "service": null,
        "resource": "c1",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.p.test": "value"
        },
@@ -40,13 +36,11 @@
      },
      {
        "name": "c2",
-       "service": "",
+       "service": null,
        "resource": "c2",
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.p.test": "value"
        },
@@ -55,13 +49,11 @@
      },
         {
           "name": "gc",
-          "service": "",
+          "service": null,
           "resource": "gc",
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 3,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.p.test": "value"
           },

--- a/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer1].json
+++ b/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer1].json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "p",
-    "service": "",
+    "service": null,
     "resource": "p",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 5678,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-1",
       "_dd.p.test": "value",
@@ -25,13 +23,11 @@
   },
      {
        "name": "c1",
-       "service": "",
+       "service": null,
        "resource": "c1",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.p.test": "value"
        },
@@ -40,13 +36,11 @@
      },
      {
        "name": "c2",
-       "service": "",
+       "service": null,
        "resource": "c2",
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.p.test": "value"
        },
@@ -55,13 +49,11 @@
      },
         {
           "name": "gc",
-          "service": "",
+          "service": null,
           "resource": "gc",
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 3,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.p.test": "value"
           },

--- a/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer2].json
+++ b/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer2].json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "p",
-    "service": "",
+    "service": null,
     "resource": "p",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 5678,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-1",
       "_dd.p.test": "value",
@@ -26,13 +24,11 @@
   },
      {
        "name": "c1",
-       "service": "",
+       "service": null,
        "resource": "c1",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.p.dm": "-1",
          "_dd.p.test": "value",
@@ -48,13 +44,11 @@
      },
      {
        "name": "c2",
-       "service": "",
+       "service": null,
        "resource": "c2",
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.p.test": "value"
        },
@@ -63,13 +57,11 @@
      },
         {
           "name": "gc",
-          "service": "",
+          "service": null,
           "resource": "gc",
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 3,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.p.test": "value"
           },

--- a/tests/snapshots/tests.integration.test_trace_stats.test_sampling_rate[1.0].json
+++ b/tests/snapshots/tests.integration.test_trace_stats.test_sampling_rate[1.0].json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "operation",
-    "service": "",
+    "service": null,
     "resource": "operation",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -26,13 +24,11 @@
 [
   {
     "name": "operation",
-    "service": "",
+    "service": null,
     "resource": "operation",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -51,13 +47,11 @@
 [
   {
     "name": "operation",
-    "service": "",
+    "service": null,
     "resource": "operation",
     "trace_id": 2,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -76,13 +70,11 @@
 [
   {
     "name": "operation",
-    "service": "",
+    "service": null,
     "resource": "operation",
     "trace_id": 3,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -101,13 +93,11 @@
 [
   {
     "name": "operation",
-    "service": "",
+    "service": null,
     "resource": "operation",
     "trace_id": 4,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -126,13 +116,11 @@
 [
   {
     "name": "operation",
-    "service": "",
+    "service": null,
     "resource": "operation",
     "trace_id": 5,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -151,13 +139,11 @@
 [
   {
     "name": "operation",
-    "service": "",
+    "service": null,
     "resource": "operation",
     "trace_id": 6,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -176,13 +162,11 @@
 [
   {
     "name": "operation",
-    "service": "",
+    "service": null,
     "resource": "operation",
     "trace_id": 7,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -201,13 +185,11 @@
 [
   {
     "name": "operation",
-    "service": "",
+    "service": null,
     "resource": "operation",
     "trace_id": 8,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -226,13 +208,11 @@
 [
   {
     "name": "operation",
-    "service": "",
+    "service": null,
     "resource": "operation",
     "trace_id": 9,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",

--- a/tests/snapshots/tests.integration.test_trace_stats.test_single_span_sampling[sampling_rule0].json
+++ b/tests/snapshots/tests.integration.test_trace_stats.test_single_span_sampling[sampling_rule0].json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 13700571859906052169,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": ""
     },

--- a/tests/snapshots/tests.integration.test_trace_stats.test_single_span_sampling[sampling_rule1].json
+++ b/tests/snapshots/tests.integration.test_trace_stats.test_single_span_sampling[sampling_rule1].json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-3",
@@ -31,8 +29,6 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "_dd.base_service": ""
        },

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_ddtrace_mixed_parenting.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_ddtrace_mixed_parenting.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "otel-top-level",
-    "service": "",
+    "service": null,
     "resource": "otel-top-level",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -24,61 +22,51 @@
   },
      {
        "name": "ddtrace-top-level",
-       "service": "",
+       "service": null,
        "resource": "ddtrace-top-level",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 101975430,
        "start": 1691164174283377785
      },
         {
           "name": "ddtrace-child",
-          "service": "",
+          "service": null,
           "resource": "ddtrace-child",
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "duration": 40291630,
           "start": 1691164174303607026
         },
         {
           "name": "otel-child",
-          "service": "",
+          "service": null,
           "resource": "otel-child",
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "duration": 41164537,
           "start": 1691164174344146455
         },
            {
              "name": "ddtrace-grandchild",
-             "service": "",
+             "service": null,
              "resource": "ddtrace-grandchild",
              "trace_id": 0,
              "span_id": 5,
              "parent_id": 4,
-             "type": "",
-             "error": 0,
              "duration": 20721650,
              "start": 1691164174364534600
            },
               {
                 "name": "otel-grandchild",
-                "service": "",
+                "service": null,
                 "resource": "otel-grandchild",
                 "trace_id": 0,
                 "span_id": 6,
                 "parent_id": 5,
-                "type": "",
-                "error": 0,
                 "duration": 20354052,
                 "start": 1691164174364742772
               }]]

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_multithreading.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_multithreading.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "otel-threading-root",
-    "service": "",
+    "service": null,
     "resource": "otel-threading-root",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -24,13 +22,11 @@
   },
      {
        "name": "s1",
-       "service": "",
+       "service": null,
        "resource": "s1",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "runtime-id": "29953bb1123f44a79c3c786defdb1bd5"
        },
@@ -43,37 +39,31 @@
      },
         {
           "name": "s2",
-          "service": "",
+          "service": null,
           "resource": "s2",
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "duration": 25074000,
           "start": 1675884559879940000
         },
         {
           "name": "s3",
-          "service": "",
+          "service": null,
           "resource": "s3",
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "duration": 65061000,
           "start": 1675884559905077000
         },
      {
        "name": "s1",
-       "service": "",
+       "service": null,
        "resource": "s1",
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "runtime-id": "29953bb1123f44a79c3c786defdb1bd5"
        },
@@ -86,37 +76,31 @@
      },
         {
           "name": "s2",
-          "service": "",
+          "service": null,
           "resource": "s2",
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 3,
-          "type": "",
-          "error": 0,
           "duration": 25047000,
           "start": 1675884559880075000
         },
         {
           "name": "s3",
-          "service": "",
+          "service": null,
           "resource": "s3",
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 3,
-          "type": "",
-          "error": 0,
           "duration": 61776000,
           "start": 1675884559905155000
         },
      {
        "name": "s1",
-       "service": "",
+       "service": null,
        "resource": "s1",
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "runtime-id": "29953bb1123f44a79c3c786defdb1bd5"
        },
@@ -129,37 +113,31 @@
      },
         {
           "name": "s2",
-          "service": "",
+          "service": null,
           "resource": "s2",
           "trace_id": 0,
           "span_id": 10,
           "parent_id": 4,
-          "type": "",
-          "error": 0,
           "duration": 25005000,
           "start": 1675884559880182000
         },
         {
           "name": "s3",
-          "service": "",
+          "service": null,
           "resource": "s3",
           "trace_id": 0,
           "span_id": 11,
           "parent_id": 4,
-          "type": "",
-          "error": 0,
           "duration": 61815000,
           "start": 1675884559905219000
         },
      {
        "name": "s1",
-       "service": "",
+       "service": null,
        "resource": "s1",
        "trace_id": 0,
        "span_id": 5,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "runtime-id": "29953bb1123f44a79c3c786defdb1bd5"
        },
@@ -172,25 +150,21 @@
      },
         {
           "name": "s2",
-          "service": "",
+          "service": null,
           "resource": "s2",
           "trace_id": 0,
           "span_id": 12,
           "parent_id": 5,
-          "type": "",
-          "error": 0,
           "duration": 24964000,
           "start": 1675884559880280000
         },
         {
           "name": "s3",
-          "service": "",
+          "service": null,
           "resource": "s3",
           "trace_id": 0,
           "span_id": 13,
           "parent_id": 5,
-          "type": "",
-          "error": 0,
           "duration": 61841000,
           "start": 1675884559905263000
         }]]

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_span_parenting.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_span_parenting.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "otel-root",
-    "service": "",
+    "service": null,
     "resource": "otel-root",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -24,49 +22,41 @@
   },
      {
        "name": "otel-parent1",
-       "service": "",
+       "service": null,
        "resource": "otel-parent1",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 101305442,
        "start": 1691164174023443313
      },
         {
           "name": "otel-child1",
-          "service": "",
+          "service": null,
           "resource": "otel-child1",
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "duration": 60367898,
           "start": 1691164174064181692
         },
      {
        "name": "orphan1",
-       "service": "",
+       "service": null,
        "resource": "orphan1",
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 102511059,
        "start": 1691164174124877672
      },
      {
        "name": "otel-parent2",
-       "service": "",
+       "service": null,
        "resource": "otel-parent2",
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "runtime-id": "370b7d1e226648e4b58d1faeeb4884d8"
        },
@@ -79,13 +69,11 @@
      },
         {
           "name": "otel-child2",
-          "service": "",
+          "service": null,
           "resource": "otel-child2",
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 4,
-          "type": "",
-          "error": 0,
           "meta": {
             "runtime-id": "370b7d1e226648e4b58d1faeeb4884d8"
           },

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_trace_across_fork.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_trace_across_fork.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "root",
-    "service": "",
+    "service": null,
     "resource": "root",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -24,13 +22,11 @@
   },
      {
        "name": "task",
-       "service": "",
+       "service": null,
        "resource": "task",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "language": "python",
          "runtime-id": "d0c70dc4dfb240c78a993aed893ddb46",

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_trace_multiple_coroutines.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_trace_multiple_coroutines.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "root",
-    "service": "",
+    "service": null,
     "resource": "root",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -24,49 +22,41 @@
   },
      {
        "name": "corountine 1",
-       "service": "",
+       "service": null,
        "resource": "corountine 1",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 20236068,
        "start": 1691164174559983603
      },
      {
        "name": "corountine 2",
-       "service": "",
+       "service": null,
        "resource": "corountine 2",
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 20310665,
        "start": 1691164174580484576
      },
      {
        "name": "corountine 3",
-       "service": "",
+       "service": null,
        "resource": "corountine 3",
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 20204009,
        "start": 1691164174600931973
      },
      {
        "name": "corountine 4",
-       "service": "",
+       "service": null,
        "resource": "corountine 4",
        "trace_id": 0,
        "span_id": 5,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "duration": 20316636,
        "start": 1691164174621392975
      }]]

--- a/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes.json
+++ b/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes.json
@@ -6,8 +6,6 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -37,8 +35,6 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_kind.json
+++ b/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_kind.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "otel-client",
-    "service": "",
+    "service": null,
     "resource": "otel-client",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -26,13 +24,11 @@
 [
   {
     "name": "otel-server",
-    "service": "",
+    "service": null,
     "resource": "otel-server",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -51,13 +47,11 @@
 [
   {
     "name": "otel-producer",
-    "service": "",
+    "service": null,
     "resource": "otel-producer",
     "trace_id": 2,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -76,13 +70,11 @@
 [
   {
     "name": "otel-consumer",
-    "service": "",
+    "service": null,
     "resource": "otel-consumer",
     "trace_id": 3,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -101,13 +93,11 @@
 [
   {
     "name": "otel-internal",
-    "service": "",
+    "service": null,
     "resource": "otel-internal",
     "trace_id": 4,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_ddtrace_run].json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_ddtrace_run].json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "test-otel-distributed-trace",
-    "service": "",
+    "service": null,
     "resource": "test-otel-distributed-trace",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -30,7 +28,6 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
-       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -66,8 +63,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask",
@@ -84,8 +79,6 @@
              "trace_id": 0,
              "span_id": 5,
              "parent_id": 3,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -100,8 +93,6 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 3,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -116,8 +107,6 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 3,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -132,8 +121,6 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
-                "type": "",
-                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "flask"
@@ -148,8 +135,6 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 11,
-                   "type": "",
-                   "error": 0,
                    "meta": {
                      "_dd.base_service": ""
                    },
@@ -163,8 +148,6 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 3,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -179,8 +162,6 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 3,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -195,8 +176,6 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 3,
-             "type": "",
-             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -211,8 +190,6 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_opentelemetry_instrument].json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_opentelemetry_instrument].json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "test-otel-distributed-trace",
-    "service": "",
+    "service": null,
     "resource": "test-otel-distributed-trace",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -24,13 +22,11 @@
   },
      {
        "name": "/otel",
-       "service": "",
+       "service": null,
        "resource": "/otel",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "http.flavor": "1.1",
          "http.host": "0.0.0.0:8001",
@@ -60,13 +56,11 @@
      },
         {
           "name": "otel-flask-manual-span",
-          "service": "",
+          "service": null,
           "resource": "otel-flask-manual-span",
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "type": "",
-          "error": 0,
           "duration": 15000,
           "start": 1675884561933174000
         }]]

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_with_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_with_default_args.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "rename-start-current-span",
-    "service": "",
+    "service": null,
     "resource": "rename-start-current-span",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_without_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_without_default_args.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "root-span",
-    "service": "",
+    "service": null,
     "resource": "root-span",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -24,13 +22,11 @@
   },
      {
        "name": "rename-start-current-span",
-       "service": "",
+       "service": null,
        "resource": "rename-start-current-span",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "span.kind": "server",
          "start_current_span_tag": "start_cspan_val"

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_ignore_exceptions.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_ignore_exceptions.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "otel-error-span",
-    "service": "",
+    "service": null,
     "resource": "otel-error-span",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_with_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_with_default_args.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "rename-start-span",
-    "service": "",
+    "service": null,
     "resource": "rename-start-span",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_without_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_without_default_args.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "root-span",
-    "service": "",
+    "service": null,
     "resource": "root-span",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -24,13 +22,11 @@
   },
      {
        "name": "rename-start-span",
-       "service": "",
+       "service": null,
        "resource": "rename-start-span",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "type": "",
-       "error": 0,
        "meta": {
          "span.kind": "client",
          "start_span_tag": "start_span_val"

--- a/tests/snapshots/tests.telemetry.test_telemetry.test_telemetry_enabled_on_first_tracer_flush.json
+++ b/tests/snapshots/tests.telemetry.test_telemetry.test_telemetry_enabled_on_first_tracer_flush.json
@@ -1,13 +1,11 @@
 [[
   {
     "name": "test-telemetry",
-    "service": "",
+    "service": null,
     "resource": "test-telemetry",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
-    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -35,7 +35,6 @@ from ddtrace.contrib.trace_utils import set_user
 from ddtrace.ext import user
 from ddtrace.internal import telemetry
 from ddtrace.internal._encoding import MsgpackEncoderV03
-from ddtrace.internal._encoding import MsgpackEncoderV05
 from ddtrace.internal.serverless import has_aws_lambda_agent_extension
 from ddtrace.internal.serverless import in_aws_lambda
 from ddtrace.internal.writer import AgentWriter
@@ -1865,7 +1864,7 @@ def test_fork_pid(tracer):
 
 def test_tracer_api_version():
     t = Tracer()
-    assert isinstance(t._writer._encoder, MsgpackEncoderV05)
+    assert isinstance(t._writer._encoder, MsgpackEncoderV03)
 
     t.configure(api_version="v0.3")
     assert isinstance(t._writer._encoder, MsgpackEncoderV03)

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -734,7 +734,7 @@ def test_writer_recreate_api_version(init_api_version, api_version, endpoint, en
         # defaults
         ("darwin", None, None, None, False, "v0.3"),
         # Default with priority sample
-        ("darwin", None, None, True, False, "v0.5"),
+        ("darwin", None, None, True, False, "v0.4"),
         # Explicitly setting api version
         ("darwin", "v0.4", None, True, False, "v0.4"),
         # Explicitly set version takes precedence


### PR DESCRIPTION
Backport of #6947 to 1.x

## Description

Encoding traces in the v05 format has known issues for applications generating spans at a high frequency. Although this issue impacts 1/1000000 spans, these misformated payloads have the potential to degrade internal servoces.

## Motivation

Resolves an incident.

## Risk 

This change may introduce a small performance regression in some applications: https://github.com/DataDog/dd-trace-py/commit/1c12c0ab496de9fb168d82ec1fdfea18a328be61#diff-0b32c6cdae8bdd01786317bcabebf73dbb57e535adab74c94858fda05da411ef

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
