### PR TITLE
ci(docs): update deprecated interface anchor

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -68,4 +68,4 @@ Use the following patterns to identify the deprecated environment variables in a
 Legacy tracing interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Reference the :ref:`2.x release note <removed-2.0-tracing-interfaces>` to identify and remove the deprecated legacy tracing interfaces in a code base.
+Reference the :ref:`2.x release note<2.0-removed-tracing-interfaces>` to identify and remove the deprecated legacy tracing interfaces in a code base.

--- a/releasenotes/notes/release-2.0-3af0045e2261bd02.yaml
+++ b/releasenotes/notes/release-2.0-3af0045e2261bd02.yaml
@@ -75,7 +75,7 @@ prelude: >
       - :ref:`📝<remove-trace-obfuscation-query-string-pattern>`
 
 
-  .. _removed-2.0-tracing-interfaces:
+  .. _2.0-removed-tracing-interfaces:
 
 
   Removed deprecated library interfaces


### PR DESCRIPTION
This fixes the failing CI docs job because of a duplicated anchor in reno release notes.
 
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
