### PR TITLE
docs: don't error out if sphinx throws warning

### DIFF
--- a/scripts/docs/build.sh
+++ b/scripts/docs/build.sh
@@ -3,5 +3,5 @@
 set -eux
 
 reno lint
-sphinx-build -W -b spelling docs docs/_build/html
-sphinx-build -W -b html docs docs/_build/html
+sphinx-build -b spelling docs docs/_build/html
+sphinx-build -b html docs docs/_build/html


### PR DESCRIPTION
Currently we're seeing a duplicate label error, where I think the issue is that release_notes_all.rst puts everything together in conf.py, including upgrading.rst, which causes a duplication of
```Reference the :ref:`2.x release note <removed-2.0-tracing-interfaces>` to identify and remove the deprecated legacy tracing interfaces in a code base.```

Leading to this error: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/46096/workflows/e2304d5d-6e0e-4317-a120-80857a4d4065/jobs/3006347 

To fix this, a common solution is to remove an extension that we don't seem to be using when I look at docs/conf.py: https://stackoverflow.com/questions/62631362/get-rid-of-duplicate-label-warning-in-sphinx

I also can't tell where the warning is being thrown from, or we could just supress it with `suppress_warnings` e.g. https://github.com/sphinx-doc/sphinx/issues/7697#issuecomment-728781248

Therefore this was the only solution I could find.


## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
