### PR TITLE
chore(botocore): don't log an error when kinesis payload isn't json

### DIFF
--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -292,7 +292,7 @@ def get_kinesis_data_object(data):
     - json string
     - byte encoded json string
     - base64 encoded json string
-    If it's neither of these, then we leave the message as it is.
+    If it's none of these, then we leave the message as it is.
     """
 
     # check if data is a json string
@@ -313,7 +313,7 @@ def get_kinesis_data_object(data):
         data_str = base64.b64decode(data).decode("ascii")
         return get_json_from_str(data_str)
     except Exception:
-        log.error("Unable to parse payload, unable to inject trace context.")
+        log.debug("Unable to parse payload, unable to inject trace context.")
 
     return None, None
 


### PR DESCRIPTION
We are using boto3 to push protobuf encoded data to kinesis. We noticed the following error in our logs:

```
Unable to parse payload, unable to inject trace context.
```

It seems that any data that isn't json encoded will cause this error message. I don't believe there's any requirement for data to be json encoded so I believe this should not be an error level log.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
