### PR TITLE
fix(debugging): keep instrumentation hook state on fork

### DIFF
--- a/ddtrace/debugging/_probe/remoteconfig.py
+++ b/ddtrace/debugging/_probe/remoteconfig.py
@@ -282,7 +282,7 @@ class DebuggerRemoteConfigSubscriber(RemoteConfigSubscriber):
             # Nothing else to do.
             return
 
-        log.debug("[%s][P: %s] Dynamic Instrumentation Updated", os.getpid(), os.getppid())
+        log.debug("[%s][P: %s] Dynamic Instrumentation received new data", os.getpid(), os.getppid())
         for metadata, config in zip(data["metadata"], data["config"]):
             if metadata is None:
                 log.debug(

--- a/ddtrace/internal/remoteconfig/_pubsub.py
+++ b/ddtrace/internal/remoteconfig/_pubsub.py
@@ -67,6 +67,7 @@ from typing import TYPE_CHECKING  # noqa:F401
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.remoteconfig._publishers import RemoteConfigPublisherBase  # noqa:F401
 from ddtrace.internal.remoteconfig._subscribers import RemoteConfigSubscriber  # noqa:F401
+from ddtrace.internal.service import ServiceStatus
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -85,6 +86,8 @@ class PubSub(object):
     _subscriber = None  # type: RemoteConfigSubscriber
 
     def start_subscriber(self):
+        if self._subscriber.status is ServiceStatus.RUNNING:
+            return
         self._subscriber.start()
 
     def restart_subscriber(self, join=False):

--- a/ddtrace/internal/remoteconfig/_subscribers.py
+++ b/ddtrace/internal/remoteconfig/_subscribers.py
@@ -27,7 +27,7 @@ class RemoteConfigSubscriber(PeriodicService):
         self._callback = callback
         self._name = name
 
-        log.debug("[PID %d] %s initialized", os.getpid(), self)
+        log.debug("[PID %d] Subscriber %s initialized", os.getpid(), self._name)
 
     def _exec_callback(self, data, test_tracer=None):
         # type: (SharedDataType, Optional[Tracer]) -> None

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -516,6 +516,7 @@ class RemoteConfigClient(object):
     def _process_response(self, data):
         # type: (Mapping[str, Any]) -> None
         try:
+            log.debug("[%s][P: %s] Received RC data: %r", os.getpid(), os.getppid(), data)
             payload = self.converter.structure_attrs_fromdict(data, AgentPayload)
         except Exception:
             log.debug("invalid agent payload received: %r", data, exc_info=True)

--- a/releasenotes/notes/fix-debugger-keep-instrumentation-hook-state-on-fork-a02f42aa854c496a.yaml
+++ b/releasenotes/notes/fix-debugger-keep-instrumentation-hook-state-on-fork-a02f42aa854c496a.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: fixed an issue that might have caused the dynamic
+    instrumentation service to lose information about instrumentation to be
+    applied to a process after a fork.


### PR DESCRIPTION
We refactor the enable/disable/restart logic for the Dynamic Instrumentation service to ensure that any instrumentation hooks created from any RC configuration received is propagated to the child processes after a fork.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
