### PR TITLE
ci: fix build release actions [backport 2.0]

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Build sdist
         run: |
-          pip install 'cython<3'
+          pip install cython
           python setup.py sdist
       - uses: actions/upload-artifact@v3
         with:
@@ -109,7 +109,6 @@ jobs:
 
   upload_pypi:
     needs:
-      - build_wheels_py36
       - build_wheels_py37
       - build_wheels_py38
       - build_wheels_py39

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -1,4 +1,4 @@
-name: Build Python 3.6+
+name: Build Python 3
 
 on:
   workflow_call:
@@ -44,7 +44,7 @@ jobs:
         with:
           platforms: all
 
-      - name: Build wheels python 3.6 and above
+      - name: Build wheels
         uses: pypa/cibuildwheel@v2.14.0
         env:
           # configure cibuildwheel to build native archs ('auto'), and some


### PR DESCRIPTION
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
