### PR TITLE
ci: use pipe mode when calling riot run in run-test-suite [backport 1.x]

### DIFF
--- a/scripts/run-test-suite
+++ b/scripts/run-test-suite
@@ -27,7 +27,7 @@ if ! [[ -v CIRCLECI && $CIRCLE_BRANCH =~ [0-9]\.x ]]; then
 fi
 
 for hash in $RIOT_HASHES; do
-    if ! $DDTEST_CMD riot -v run --exitfirst --pass-env -s $hash $DDTRACE_FLAG $COVERAGE_FLAG; then
+    if ! $DDTEST_CMD riot -P -v run --exitfirst --pass-env -s $hash $DDTRACE_FLAG $COVERAGE_FLAG; then
         if [[ -v CIRCLECI ]]; then
             circleci step halt
         fi

--- a/tests/.suitespec.json
+++ b/tests/.suitespec.json
@@ -8,6 +8,7 @@
         "$harness": [
             "riotfile.py",
             "scripts/ddtest",
+            "scripts/run-test-suite",
             "hatch.toml",
             "tests/conftest.py",
             "tests/__init__.py",

--- a/tests/suitespec.py
+++ b/tests/suitespec.py
@@ -20,7 +20,8 @@ def get_patterns(suite: str) -> t.Set[str]:
     'ddtrace/settings/dynamic_instrumentation.py', 'ddtrace/settings/exception_debugging.py',
     'ddtrace/settings/http.py', 'ddtrace/settings/integration.py', 'ddtrace/span.py', 'ddtrace/tracer.py',
     'ddtrace/tracing/*', 'ddtrace/version.py', 'hatch.toml', 'pyproject.toml', 'riotfile.py', 'scripts/ddtest',
-    'setup.cfg', 'setup.py', 'tests/.suitespec.json', 'tests/__init__.py', 'tests/conftest.py', 'tests/debugging/*']
+    'scripts/run-test-suite', 'setup.cfg', 'setup.py', 'tests/.suitespec.json', 'tests/__init__.py',
+    'tests/conftest.py', 'tests/debugging/*']
     >>> get_patterns("foobar")
     set()
     >>> sorted(get_patterns("urllib3"))  # doctest: +NORMALIZE_WHITESPACE
@@ -33,9 +34,10 @@ def get_patterns(suite: str) -> t.Set[str]:
     'ddtrace/py.typed', 'ddtrace/sampler.py', 'ddtrace/settings/__init__.py',
     'ddtrace/settings/_database_monitoring.py', 'ddtrace/settings/config.py', 'ddtrace/settings/http.py',
     'ddtrace/settings/integration.py', 'ddtrace/span.py', 'ddtrace/tracer.py', 'ddtrace/tracing/*',
-    'ddtrace/version.py', 'hatch.toml', 'pyproject.toml', 'riotfile.py', 'scripts/ddtest', 'setup.cfg', 'setup.py',
-    'tests/.suitespec.json', 'tests/__init__.py', 'tests/conftest.py', 'tests/contrib/__init__.py',
-    'tests/contrib/patch.py', 'tests/contrib/urllib3/*', 'tests/snapshots/tests.contrib.urllib3.*']
+    'ddtrace/version.py', 'hatch.toml', 'pyproject.toml', 'riotfile.py', 'scripts/ddtest', 'scripts/run-test-suite',
+    'setup.cfg', 'setup.py', 'tests/.suitespec.json', 'tests/__init__.py', 'tests/conftest.py',
+    'tests/contrib/__init__.py', 'tests/contrib/patch.py', 'tests/contrib/urllib3/*',
+    'tests/snapshots/tests.contrib.urllib3.*']
     """
     compos = SUITESPEC["components"]
     if suite not in SUITESPEC["suites"]:


### PR DESCRIPTION
Backport b406ab127c09fd5dbc55a6a0d3a80adf2cf18f0e from #6941 to 1.x.

This switches the output to use pipe mode (which, among other things, prints every line without wrapping) as a safety mechanism to prevents reoccurrences of secrets leaking into logs because they were unexpected wrapped by `riot`'s pretty output. 

`riot -v run` is the only place where we show environment variables.

This also adds `scripts/run-test-suite` to the harness suite spec so that all tests get re-run if the script changes (since that is likely the desired scenario). 

# Testing
## Before
![image](https://github.com/DataDog/dd-trace-py/assets/136473744/5a2d49a2-656b-4ce1-b1dc-1fc999467136)
## After
![image](https://github.com/DataDog/dd-trace-py/assets/136473744/74e00f1f-192d-4e7a-99cd-cbfdb5203b01)

Note that this is an immediate band-aid, not a long-term strategy.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
