### PR TITLE
fix(kafka): avoid overriding  methods in Producers and Consumers [backports #6976 to 1.20]

### DIFF
--- a/ddtrace/internal/utils/__init__.py
+++ b/ddtrace/internal/utils/__init__.py
@@ -19,6 +19,7 @@ def get_argument_value(
     kwargs,  # type: Dict[str, Any]
     pos,  # type: int
     kw,  # type: str
+    optional=False,  # type: bool
 ):
     # type: (...) -> Optional[Any]
     """
@@ -41,6 +42,8 @@ def get_argument_value(
         try:
             return args[pos]
         except IndexError:
+            if optional:
+                return None
             raise ArgumentError("%s (at position %d)" % (kw, pos))
 
 

--- a/releasenotes/notes/fix-kafka-commit-offsets-d86039c29e04259e.yaml
+++ b/releasenotes/notes/fix-kafka-commit-offsets-d86039c29e04259e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    kafka: Fixes ``ValueError`` raised when ``Consumer.commit(offsets=...)`` is called.

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -4,6 +4,7 @@ import time
 
 import confluent_kafka
 from confluent_kafka import KafkaException
+from confluent_kafka import TopicPartition
 from confluent_kafka import admin as kafka_admin
 import mock
 import pytest
@@ -188,6 +189,36 @@ def test_message(producer, consumer, tombstone, kafka_topic):
     message = None
     while message is None:
         message = consumer.poll(1.0)
+
+
+@pytest.mark.snapshot(ignores=["metrics.kafka.message_offset"])
+def test_commit(producer, consumer, kafka_topic):
+    producer.produce(kafka_topic, PAYLOAD, key=KEY)
+    producer.flush()
+    message = None
+    while message is None:
+        message = consumer.poll(1.0)
+    consumer.commit(message)
+
+
+@pytest.mark.snapshot(ignores=["metrics.kafka.message_offset"])
+def test_commit_with_offset(producer, consumer, kafka_topic):
+    producer.produce(kafka_topic, PAYLOAD, key=KEY)
+    producer.flush()
+    message = None
+    while message is None:
+        message = consumer.poll(1.0)
+    consumer.commit(offsets=[TopicPartition(kafka_topic)])
+
+
+@pytest.mark.snapshot(ignores=["metrics.kafka.message_offset"])
+def test_commit_with_only_async_arg(producer, consumer, kafka_topic):
+    producer.produce(kafka_topic, PAYLOAD, key=KEY)
+    producer.flush()
+    message = None
+    while message is None:
+        message = consumer.poll(1.0)
+    consumer.commit(asynchronous=False)
 
 
 @pytest.mark.snapshot(

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_commit.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_commit.json
@@ -1,0 +1,68 @@
+[[
+  {
+    "name": "kafka.consume",
+    "service": "kafka",
+    "resource": "kafka.consume",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "meta": {
+      "_dd.base_service": "",
+      "_dd.p.dm": "-0",
+      "component": "kafka",
+      "kafka.group_id": "test_group",
+      "kafka.message_key": "test_key",
+      "kafka.received_message": "True",
+      "kafka.tombstone": "False",
+      "kafka.topic": "test_commit",
+      "language": "python",
+      "messaging.system": "kafka",
+      "runtime-id": "4cf20234df69485781c43482565d9d82",
+      "span.kind": "consumer"
+    },
+    "metrics": {
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "kafka.message_offset": -1,
+      "kafka.partition": 0,
+      "process_id": 222
+    },
+    "duration": 187877000,
+    "start": 1695310282564811000
+  }],
+[
+  {
+    "name": "kafka.produce",
+    "service": "kafka",
+    "resource": "kafka.produce",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "meta": {
+      "_dd.base_service": "",
+      "_dd.p.dm": "-0",
+      "component": "kafka",
+      "kafka.message_key": "test_key",
+      "kafka.tombstone": "False",
+      "kafka.topic": "test_commit",
+      "language": "python",
+      "messaging.kafka.bootstrap.servers": "localhost:29092",
+      "messaging.system": "kafka",
+      "runtime-id": "4cf20234df69485781c43482565d9d82",
+      "span.kind": "producer"
+    },
+    "metrics": {
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "kafka.partition": -1,
+      "process_id": 222
+    },
+    "duration": 135000,
+    "start": 1695310277502282000
+  }]]

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_commit_with_offset.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_commit_with_offset.json
@@ -1,0 +1,68 @@
+[[
+  {
+    "name": "kafka.consume",
+    "service": "kafka",
+    "resource": "kafka.consume",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "meta": {
+      "_dd.base_service": "",
+      "_dd.p.dm": "-0",
+      "component": "kafka",
+      "kafka.group_id": "test_group",
+      "kafka.message_key": "test_key",
+      "kafka.received_message": "True",
+      "kafka.tombstone": "False",
+      "kafka.topic": "test_commit_with_offset",
+      "language": "python",
+      "messaging.system": "kafka",
+      "runtime-id": "9a7c9425ae8745c1bb8d35d2514f8958",
+      "span.kind": "consumer"
+    },
+    "metrics": {
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "kafka.message_offset": -1,
+      "kafka.partition": 0,
+      "process_id": 6340
+    },
+    "duration": 307084000,
+    "start": 1695311385900323000
+  }],
+[
+  {
+    "name": "kafka.produce",
+    "service": "kafka",
+    "resource": "kafka.produce",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "meta": {
+      "_dd.base_service": "",
+      "_dd.p.dm": "-0",
+      "component": "kafka",
+      "kafka.message_key": "test_key",
+      "kafka.tombstone": "False",
+      "kafka.topic": "test_commit_with_offset",
+      "language": "python",
+      "messaging.kafka.bootstrap.servers": "localhost:29092",
+      "messaging.system": "kafka",
+      "runtime-id": "9a7c9425ae8745c1bb8d35d2514f8958",
+      "span.kind": "producer"
+    },
+    "metrics": {
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "kafka.partition": -1,
+      "process_id": 6340
+    },
+    "duration": 99000,
+    "start": 1695311382892915000
+  }]]

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_commit_with_only_async_arg.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_commit_with_only_async_arg.json
@@ -1,0 +1,68 @@
+[[
+  {
+    "name": "kafka.consume",
+    "service": "kafka",
+    "resource": "kafka.consume",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "meta": {
+      "_dd.base_service": "",
+      "_dd.p.dm": "-0",
+      "component": "kafka",
+      "kafka.group_id": "test_group",
+      "kafka.message_key": "test_key",
+      "kafka.received_message": "True",
+      "kafka.tombstone": "False",
+      "kafka.topic": "test_commit_with_only_async_arg",
+      "language": "python",
+      "messaging.system": "kafka",
+      "runtime-id": "15fa67b4ad1e498aa489305814d88a75",
+      "span.kind": "consumer"
+    },
+    "metrics": {
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "kafka.message_offset": -1,
+      "kafka.partition": 0,
+      "process_id": 35657
+    },
+    "duration": 343409000,
+    "start": 1695323048560969000
+  }],
+[
+  {
+    "name": "kafka.produce",
+    "service": "kafka",
+    "resource": "kafka.produce",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "worker",
+    "meta": {
+      "_dd.base_service": "",
+      "_dd.p.dm": "-0",
+      "component": "kafka",
+      "kafka.message_key": "test_key",
+      "kafka.tombstone": "False",
+      "kafka.topic": "test_commit_with_only_async_arg",
+      "language": "python",
+      "messaging.kafka.bootstrap.servers": "localhost:29092",
+      "messaging.system": "kafka",
+      "runtime-id": "15fa67b4ad1e498aa489305814d88a75",
+      "span.kind": "producer"
+    },
+    "metrics": {
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "kafka.partition": -1,
+      "process_id": 35657
+    },
+    "duration": 280000,
+    "start": 1695323045564363000
+  }]]


### PR DESCRIPTION
Backports #6976 

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
