### PR TITLE
chore(release): make script support 1.x and 2.x releases

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -8,6 +8,7 @@ from datadog_api_client import Configuration
 from datadog_api_client.v1.api.notebooks_api import NotebooksApi
 from github import Github
 import requests
+import re
 
 
 """This release notes script is built to create a release notes draft 
@@ -113,6 +114,7 @@ def create_release_draft(dd_repo, base, rc, patch, latest_branch):
         rn_raw = generate_rn(branch)
         rn_sections_clean = create_release_notes_sections(rn_raw, branch)
         # combine the release note sections into a string in the correct order
+        import pdb; pdb.set_trace()
         rn = ""
         rn_key_order = [
             "Prelude",
@@ -162,7 +164,7 @@ def generate_rn(branch):
 def create_release_notes_sections(rn_raw, branch):
     # get anything in unreleased section in case there were updates since the last RC
     unreleased = clean_rn(rn_raw)
-    unreleased = unreleased.split("###")[1:]
+    unreleased = re.split(r"(#)\1{2,}", unreleased)[1:]
     try:
         unreleased_sections = dict(section.split("\n\n-") for section in unreleased)
         for key in unreleased_sections.keys():
@@ -178,7 +180,7 @@ def create_release_notes_sections(rn_raw, branch):
     for rn in rns:
         if rn.startswith("%s.0" % branch):
             # cut out the version section
-            sections = rn.split("###")[1:]
+            sections = re.split(r"(#)\1{2,}", rn)[1:]
             prelude_section = {}
             # if there is a prelude, we need to grab that separately since it has different syntax
             if sections[0].startswith(" Prelude\n\n"):
@@ -389,7 +391,7 @@ def create_notebook(dd_repo, name, rn, base, latest_branch):
 
     print("\nNotebook created at %s\n" % nb_url)
 
-    # eliminate duplicates of handles for the slack message
+    # eliminate duplicates of handles for the slack messages
     author_slack_handles = " ".join(set(author_slack_handles))
 
     print("Message to post in #apm-python-release once deployed to staging:\n")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -8,14 +8,13 @@ from datadog_api_client import Configuration
 from datadog_api_client.v1.api.notebooks_api import NotebooksApi
 from github import Github
 import requests
-import re
 
 
-"""This release notes script is built to create a release notes draft 
+"""This release notes script is built to create a release notes draft
 for release candidates, patches, and minor releases.
 
 Setup:
-1. Create a Personal access token (classic), not a fine grained one, on Github: 
+1. Create a Personal access token (classic), not a fine grained one, on Github:
 https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic # noqa
 2. Give the Github token repo, user, audit_log, project permissions. On the next page authorize your token for Datadog SSO.
 3. Add `export GH_TOKEN=<github token>` to your `.zhrc` file.
@@ -25,7 +24,7 @@ https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/c
 
 6. Install pandoc with `brew install pandoc`
 
-Create an activate a virtual environment, and install required packages : 
+Create an activate a virtual environment, and install required packages :
 `python -m venv venv && source venv/bin/activate && pip install pygithub requests datadog-api-client reno`
 
 
@@ -40,7 +39,7 @@ Optional:
     RC - Whether or not this is a release candidate. e.g. RC=1 or RC=0
     PATCH - Whether or not this a patch release. e.g. PATCH=1 or PATCH=0
     PRINT - Whether or not the release notes should be printed to CLI or be used to create a Github release. Default is 0 e.g. PRINT=1 or PRINT=0
-    NOTEBOOK - Whether or not to create a notebook in staging. Note this only works for RC1s since those are usually what we create notebooks for.  
+    NOTEBOOK - Whether or not to create a notebook in staging. Note this only works for RC1s since those are usually what we create notebooks for.
     Default is 1 for RC1s, 0 for everything else e.g. NOTEBOOK=0 or NOTEBOOK=1
 Examples:
 Generate release notes and staging testing notebook for next release candidate version of 2.11: `BASE=2.11 RC=1 python release.py`
@@ -400,7 +399,7 @@ def create_notebook(dd_repo, name, rn, base, latest_branch):
 
     print("Message to post in #apm-python-release once deployed to staging:\n")
     print(
-        """It's time to test the {version} release candidate! The owners of pull requests with release notes in {version} are {author_slack_handles}. 
+        """It's time to test the {version} release candidate! The owners of pull requests with release notes in {version} are {author_slack_handles}.
 Everyone mentioned here: before the end of the day tomorrow, please ensure that you've filled in the testing strategy in the release notebook {nb_url} on all release notes you're the owner of, according to the expectations here: https://datadoghq.atlassian.net/wiki/spaces/APMPY/pages/2868085694/Staging+testing+expectations+for+dd-trace-py+contributors
 You can start doing your tests immediately, using {version}.
 


### PR DESCRIPTION
I tested this manually for rc, patch, and minor releases, all seemed good. 

This also makes an improvement, allowing the addition of sub-sections within our normal sections. Before something like `###### Whatever` as a header would cause issues due to us splitting on `###` now a more complex regex was introduced to avoid splitting on those, and therefore dropping them.
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
