### PR TITLE
ci: add pipe mode to more CI utils using riot

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -155,7 +155,7 @@ commands:
                 steps:
                   - run:
                       name: "Waiting for << parameters.wait >>"
-                      command: riot -v run -s 'wait' << parameters.wait >>
+                      command: riot -P -v run -s 'wait' << parameters.wait >>
             - when:
                 condition:
                   << parameters.trace_agent_url >> != ""
@@ -310,7 +310,7 @@ jobs:
       - run:
           name: "Generate base virtual environments."
           # DEV: riot list -i tracer lists all supported Python versions
-          command: "riot list -i tracer | circleci tests split | xargs -I PY riot -v generate --python=PY"
+          command: "riot list -i tracer | circleci tests split | xargs -I PY riot -P -v generate --python=PY"
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: Generate config
           command: |
             pip3 install riot==0.19.0
-            riot -v run --pass-env -s circleci-gen-config -- -v
+            riot -P -v run --pass-env -s circleci-gen-config -- -v
       - continuation/continue:
           configuration_path: .circleci/config.gen.yml
 

--- a/scripts/compile-and-prune-test-requirements
+++ b/scripts/compile-and-prune-test-requirements
@@ -8,7 +8,7 @@ active_hashes=($($RIOT_CMD list --hash-only))
 echo "Building requirements lockfiles for riot hashes that don't have them"
 for hash in "${active_hashes[@]}"
 do
-    [[ ! -f .riot/requirements/"$hash".txt ]] && $RIOT_CMD -v requirements "$hash"
+    [[ ! -f .riot/requirements/"$hash".txt ]] && $RIOT_CMD -P -v requirements "$hash"
 done
 
 echo "Removing requirements lockfiles for riot hashes that don't exist"


### PR DESCRIPTION
These were missed in https://github.com/DataDog/dd-trace-py/pull/6941 .

## pipe-moded lines with some variation of `riot -v`:
```
romain.komorn@COMP-CLXFH7L2J3 dd-trace-py % rg -. 'riot.*-v'  | rg -- '-P'
.circleci/config.templ.yml:                      command: riot -P -v run -s 'wait' << parameters.wait >>
.circleci/config.templ.yml:          command: "riot list -i tracer | circleci tests split | xargs -I PY riot -P -v generate --python=PY"
.circleci/config.yml:            riot -P -v run --pass-env -s circleci-gen-config -- -v
scripts/compile-and-prune-test-requirements:    [[ ! -f .riot/requirements/"$hash".txt ]] && $RIOT_CMD -P -v requirements "$hash"
scripts/run-test-suite:    if ! $DDTEST_CMD riot -P -v run --exitfirst --pass-env -s $hash $DDTRACE_FLAG $COVERAGE_FLAG; then
```

## Remaining non-pipe-moded lines are either docs or a script that doesn't call `riot`:
```
romain.komorn@COMP-CLXFH7L2J3 dd-trace-py % rg -. 'riot.*-v'  | rg -v -- '-P'
docs/contributing-integrations.rst:   > DD_AGENT_PORT=9126 riot -v run --pass-env <test_suite_name>
docs/contributing-testing.rst:6. In the test-runner shell, run the tests with ``$ riot -v run --pass-env -s -p 3.10 <suite_name> -- -s -vv -k 'test_name1 or test_name2'``.
docs/contributing-testing.rst:    $ riot -v run -s -p 3.10 <suite_name> -- -s -vv -k 'test_name1 or test_name2'
docs/contributing-testing.rst:    $ DD_AGENT_PORT=9126 riot -v run --pass-env ...
scripts/cformat.sh:    for file in $(find "$THIS_DIR" -name '*.[c|cpp|h]' | grep -v '.riot/' | grep -v 'ddtrace/vendor/' | grep -v 'ddtrace/appsec/_iast/_taint_tracking/cmake-build-debug/' | grep -v '^ddtrace/appsec/_iast/_taint_tracking/_vendor/')
```

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
