### PR TITLE
fix(iast): add aspect ranges error

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
@@ -1,5 +1,15 @@
 #include "AspectOperatorAdd.h"
 
+/**
+ * This function updates result_o object with taint information of candidate_text and/or text_to_add
+ *
+ * @param result_o The result object to which the aspect will be added.
+ * @param candidate_text The candidate text object to which the aspect will be added.
+ * @param text_to_add The text aspect to be added.
+ * @param tx_taint_map The taint range map that stores taint information.
+ *
+ * @return A new result object with the taint information.
+ */
 PyObject*
 add_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* text_to_add, TaintRangeMapType* tx_taint_map)
 {
@@ -35,7 +45,7 @@ add_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* text_to_add, 
         return res_new_id;
     }
 
-    auto tainted = initializer->allocate_tainted_object(to_candidate_text);
+    auto tainted = initializer->allocate_tainted_object_copy(to_candidate_text);
     tainted->add_ranges_shifted(to_text_to_add, (long)len_candidate_text);
     const auto& res_new_id = new_pyobject_id(result_o, len_result_o);
     Py_DECREF(result_o);
@@ -44,6 +54,20 @@ add_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* text_to_add, 
     return res_new_id;
 }
 
+/**
+ * Adds aspect, override all python Add operations.
+ *
+ * The AST Visitor (ddtrace/appsec/_iast/_ast/visitor.py) replaces all "+" operations in Python code with this function.
+ * This function takes 2 arguments. If the operation is 'a = b + c', this function should be 'a = api_add_aspect(b, c)'.
+ * This function connects Python with the C++ function 'add_aspect'.
+ *
+ * @param self The Python extension module.
+ * @param args An array of Python objects containing the candidate text and text aspect.
+ * @param nargs The number of arguments in the 'args' array.
+ *
+ * @return A new Python object representing the result of adding the aspect to the candidate text, considering taint
+ * information.
+ */
 PyObject*
 api_add_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 {

--- a/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
@@ -104,6 +104,37 @@ Initializer::allocate_tainted_object()
     return new TaintedObject();
 }
 
+TaintedObjectPtr
+Initializer::allocate_ranges_into_taint_object(TaintRangeRefs ranges)
+{
+    auto toptr = allocate_tainted_object();
+    toptr->set_values(std::move(ranges));
+    return toptr;
+}
+
+TaintedObjectPtr Initializer::allocate_tainted_object(TaintedObjectPtr from)
+{
+    if (!from) {
+        return allocate_tainted_object();
+    }
+    return allocate_ranges_into_taint_object(std::move(from->ranges_));
+}
+
+TaintedObjectPtr Initializer::allocate_ranges_into_taint_object_copy(const TaintRangeRefs& ranges)
+{
+    auto toptr = allocate_tainted_object();
+    toptr->copy_values(ranges);
+    return toptr;
+}
+
+TaintedObjectPtr Initializer::allocate_tainted_object_copy(const TaintedObjectPtr& from)
+{
+    if (!from) {
+        return allocate_tainted_object();
+    }
+    return allocate_ranges_into_taint_object_copy(from->ranges_);
+}
+
 void
 Initializer::release_tainted_object(TaintedObjectPtr tobj)
 {

--- a/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.h
@@ -25,66 +25,124 @@ class Initializer
     unordered_set<TaintRangeMapType*> active_map_addreses;
 
   public:
+    /**
+     * Constructor for the Initializer class.
+     */
     Initializer();
 
-    TaintRangeMapType* create_tainting_map();
+    /**
+     * Creates a new taint range map.
+     *
+     * @return A pointer to the created taint range map.
+     */
+    TaintRangeMapType *create_tainting_map();
 
-    void free_tainting_map(TaintRangeMapType* tx_map);
+    /**
+     * Frees a taint range map.
+     *
+     * @param tx_map The taint range map to be freed.
+     */
+    void free_tainting_map(TaintRangeMapType *tx_map);
 
-    static TaintRangeMapType* get_tainting_map();
+    /**
+     * Gets the current taint range map.
+     *
+     * @return A pointer to the current taint range map.
+     */
+    static TaintRangeMapType *get_tainting_map();
 
+    /**
+     * Clears all active taint maps.
+     */
     void clear_tainting_maps();
 
+    /**
+     * Gets the number of tainted objects.
+     *
+     * @return The number of tainted objects.
+     */
     static int num_objects_tainted();
 
+    /**
+     * Gets the size of the Initializer object.
+     *
+     * @return The size of the Initializer object.
+     */
     int initializer_size();
 
+    /**
+     * Gets the size of active map addresses.
+     *
+     * @return The size of active map addresses.
+     */
     int active_map_addreses_size();
 
+    /**
+     * Creates a new taint tracking context.
+     */
     void create_context();
 
+    /**
+     * Destroys the current taint tracking context.
+     */
     void destroy_context();
 
+    /**
+     * Resets the current taint tracking context.
+     */
     void reset_context();
 
+    /**
+     * Gets the ID of the current taint tracking context.
+     *
+     * @return The ID of the current taint tracking context.
+     */
     static size_t context_id();
 
-    // FIXME: these should be static functions of TaintedObject
+    /**
+     * Allocates a new tainted object.
 
-    // IMPORTANT: if the returned object is not assigned to the map, you have
-    // responsibility of calling release_tainted_object on it or you'll have a
-    // leak.
+     * IMPORTANT: if the returned object is not assigned to the map, you have responsibility of calling
+     * release_tainted_object on it or you'll have a leak.
+     *
+     * IMPORTANT2: allocate_ranges_into_taint_object moves the owner of the ranges, if you know the ranges of the original
+     * tainted object should be used more times, use instead allocate_ranges_into_taint_object_copy.
+     *
+     * @return A pointer to the allocated tainted object.
+     */
     TaintedObjectPtr allocate_tainted_object();
 
-    TaintedObjectPtr allocate_tainted_object(TaintRangeRefs ranges)
-    {
-        auto toptr = allocate_tainted_object();
-        toptr->set_values(std::move(ranges));
-        return toptr;
-    }
+    /**
+     * Allocates a new tainted object as a copy of an existing object.
+     *
+     * @param from The existing tainted object to copy.
+     * @return A pointer to the allocated tainted object.
+     */
+    TaintedObjectPtr allocate_tainted_object(TaintedObjectPtr from);
 
-    TaintedObjectPtr allocate_tainted_object_copy(const TaintRangeRefs& ranges)
-    {
-        auto toptr = allocate_tainted_object();
-        toptr->copy_values(ranges);
-        return toptr;
-    }
+    /**
+     * Allocates taint ranges into new tainted object.
+     *
+     * @param ranges The taint ranges to assign to the allocated object.
+     * @return A pointer to the allocated tainted object.
+     */
+    TaintedObjectPtr allocate_ranges_into_taint_object(TaintRangeRefs ranges);
 
-    TaintedObjectPtr allocate_tainted_object(TaintedObjectPtr from)
-    {
-        if (!from) {
-            return allocate_tainted_object();
-        }
-        return allocate_tainted_object(std::move(from->ranges_));
-    }
+    /**
+     * Allocates and copy taint ranges into new tainted object.
+     *
+     * @param ranges The taint ranges to assign to the allocated object.
+     * @return A pointer to the allocated tainted object.
+     */
+    TaintedObjectPtr allocate_ranges_into_taint_object_copy(const TaintRangeRefs& ranges);
 
-    TaintedObjectPtr allocate_tainted_object_copy(const TaintedObjectPtr& from)
-    {
-        if (!from) {
-            return allocate_tainted_object();
-        }
-        return allocate_tainted_object_copy(from->ranges_);
-    }
+    /**
+     * Allocates and copy taint ranges from a Tainted Object into new tainted object.
+     *
+     * @param from The existing tainted object to copy.
+     * @return A pointer to the allocated tainted object.
+     */
+    TaintedObjectPtr allocate_tainted_object_copy(const TaintedObjectPtr& from);
 
     void release_tainted_object(TaintedObjectPtr tobj);
 

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
@@ -161,7 +161,7 @@ set_ranges(const PyObject* str, const TaintRangeRefs& ranges, TaintRangeMapType*
 
     auto hash = get_unique_id(str);
     auto it = tx_map->find(hash);
-    auto new_tainted_object = initializer->allocate_tainted_object(ranges);
+    auto new_tainted_object = initializer->allocate_ranges_into_taint_object(ranges);
     set_fast_tainted_if_notinterned_unicode(str);
     new_tainted_object->incref();
     if (it != tx_map->end()) {

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.cpp
@@ -33,6 +33,12 @@ void
 TaintedObject::add_ranges_shifted(TaintedObjectPtr tainted_object, long offset, int max_length, int orig_offset)
 {
     const auto& ranges = tainted_object->get_ranges();
+    add_ranges_shifted(ranges, offset, max_length, orig_offset);
+}
+
+void
+TaintedObject::add_ranges_shifted(TaintRangeRefs ranges, long offset, int max_length, int orig_offset)
+{
     const auto to_add = (long)min(ranges.size(), TAINT_RANGE_LIMIT - ranges_.size());
     if (!ranges.empty() and to_add > 0) {
         ranges_.reserve(ranges_.size() + to_add);

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.h
@@ -38,6 +38,8 @@ class TaintedObject
 
     void add_ranges_shifted(TaintedObject* tainted_object, long offset, int max_length = -1, int orig_offset = -1);
 
+    void add_ranges_shifted(TaintRangeRefs ranges, long offset, int max_length = -1, int orig_offset = -1);
+
     explicit operator string();
 
     void move_ranges_to_stack();

--- a/tests/appsec/iast/aspects/test_add_aspect.py
+++ b/tests/appsec/iast/aspects/test_add_aspect.py
@@ -138,6 +138,113 @@ def test_add_aspect_tainting_right_hand(obj1, obj2, should_be_tainted):
             assert len(tainted_ranges) == len(get_tainted_ranges(obj1)) + len(get_tainted_ranges(obj2))
 
 
+@pytest.mark.parametrize(
+    "obj1",
+    [
+        "abc",
+        b"abc",
+    ],
+)
+def test_add_aspect_tainting_add_itself(obj1):
+    obj1 = taint_pyobject(
+        pyobject=obj1,
+        source_name="test_add_aspect_tainting_left_hand",
+        source_value=obj1,
+        source_origin=OriginType.PARAMETER,
+    )
+
+    result = ddtrace_aspects.add_aspect(obj1, obj1)
+    assert result == obj1 + obj1
+
+    assert is_pyobject_tainted(result) is True
+    ranges_result = get_tainted_ranges(result)
+    assert len(ranges_result) == 2
+    assert ranges_result[0].start == 0
+    assert ranges_result[0].length == 3
+    assert ranges_result[1].start == 3
+    assert ranges_result[1].length == 3
+
+
+@pytest.mark.parametrize(
+    "obj1",
+    [
+        "abc",
+        b"abc",
+    ],
+)
+def test_add_aspect_tainting_add_itself_twice(obj1):
+    obj1 = taint_pyobject(
+        pyobject=obj1,
+        source_name="test_add_aspect_tainting_left_hand",
+        source_value=obj1,
+        source_origin=OriginType.PARAMETER,
+    )
+
+    result = ddtrace_aspects.add_aspect(obj1, obj1)
+    result = ddtrace_aspects.add_aspect(obj1, obj1)
+    assert result == obj1 + obj1
+
+    assert is_pyobject_tainted(result) is True
+    ranges_result = get_tainted_ranges(result)
+    assert len(ranges_result) == 2
+    assert ranges_result[0].start == 0
+    assert ranges_result[0].length == 3
+    assert ranges_result[1].start == 3
+    assert ranges_result[1].length == 3
+
+
+@pytest.mark.parametrize(
+    "obj1, obj2",
+    [
+        ("abc", "def"),
+        (b"abc", b"def"),
+    ],
+)
+def test_add_aspect_tainting_add_right_twice(obj1, obj2):
+    obj1 = taint_pyobject(
+        pyobject=obj1,
+        source_name="test_add_aspect_tainting_left_hand",
+        source_value=obj1,
+        source_origin=OriginType.PARAMETER,
+    )
+
+    result = ddtrace_aspects.add_aspect(obj1, obj2)
+    result = ddtrace_aspects.add_aspect(obj1, obj2)
+    assert result == obj1 + obj2
+
+    assert is_pyobject_tainted(result) is True
+    ranges_result = get_tainted_ranges(result)
+    assert len(ranges_result) == 1
+    assert ranges_result[0].start == 0
+    assert ranges_result[0].length == 3
+
+
+@pytest.mark.parametrize(
+    "obj1, obj2",
+    [
+        ("abc", "def"),
+        (b"abc", b"def"),
+    ],
+)
+def test_add_aspect_tainting_add_left_twice(obj1, obj2):
+    obj1 = taint_pyobject(
+        pyobject=obj1,
+        source_name="test_add_aspect_tainting_left_hand",
+        source_value=obj1,
+        source_origin=OriginType.PARAMETER,
+    )
+
+    result = ddtrace_aspects.add_aspect(obj2, obj1)  # noqa
+    result = ddtrace_aspects.add_aspect(obj2, obj1)
+    assert result == obj2 + obj1
+
+    assert is_pyobject_tainted(result) is True
+    ranges_result = get_tainted_ranges(result)
+    assert len(ranges_result) == 1
+    assert ranges_result[0].start == 3
+    assert ranges_result[0].length == 3
+
+
 def test_taint_ranges_as_evidence_info_nothing_tainted():
     text = "nothing tainted"
     value_parts, sources = taint_ranges_as_evidence_info(text)

--- a/tests/appsec/iast/test_iast_propagation_path.py
+++ b/tests/appsec/iast/test_iast_propagation_path.py
@@ -61,14 +61,13 @@ def test_propagation_path_1_origin_1_propagation(origin1, iast_span_defaults):
     _assert_vulnerability(span_report, value_parts, "propagation_path_1_source_1_prop")
 
 
-@pytest.mark.skip(reason="aspect add fails when var1 + var1")
 @pytest.mark.parametrize(
     "origin1",
     [
-        ("taintsource"),
-        ("1"),
-        (b"taintsource1"),
-        (bytearray(b"taintsource1")),
+        "taintsource",
+        "1",
+        b"taintsource1",
+        bytearray(b"taintsource1"),
     ],
 )
 def test_propagation_path_1_origins_2_propagations(origin1, iast_span_defaults):


### PR DESCRIPTION
Fix errors on `aspect_add` when:
```python
a = b + b
get_ranges(a) # ranges from b, not b + b
```

```python
a = b + b
a = b + b
get_ranges(a) # empty ranges
```

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
