### PR TITLE
fix(dbm): ensure peer service is str for py2.7

### DIFF
--- a/ddtrace/propagation/_database_monitoring.py
+++ b/ddtrace/propagation/_database_monitoring.py
@@ -5,6 +5,7 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.settings.peer_service import PeerServiceConfig
 from ddtrace.vendor.sqlcommenter import generate_sql_comment as _generate_sql_comment
 
+from ..internal import compat
 from ..internal.utils import get_argument_value
 from ..internal.utils import set_argument_value
 from ..settings import _config as dd_config
@@ -75,7 +76,7 @@ class _DBM_Propagator(object):
         peer_service_enabled = PeerServiceConfig().set_defaults_enabled
         service_name_key = db_span.service
         if peer_service_enabled:
-            service_name_key = db_span.get_tags().get("db.name") or db_span.service
+            service_name_key = compat.ensure_str(db_span.get_tags().get("db.name") or db_span.service)
 
         dbm_tags = {
             DBM_PARENT_SERVICE_NAME_KEY: dd_config.service,

--- a/ddtrace/propagation/_database_monitoring.py
+++ b/ddtrace/propagation/_database_monitoring.py
@@ -76,7 +76,8 @@ class _DBM_Propagator(object):
         peer_service_enabled = PeerServiceConfig().set_defaults_enabled
         service_name_key = db_span.service
         if peer_service_enabled:
-            service_name_key = compat.ensure_str(db_span.get_tags().get("db.name") or db_span.service)
+            db_name = db_span.get_tags().get("db.name")
+            service_name_key = compat.ensure_str(db_name) if db_name else db_span.service
 
         dbm_tags = {
             DBM_PARENT_SERVICE_NAME_KEY: dd_config.service,


### PR DESCRIPTION
This change is a forward port of a fix from https://github.com/DataDog/dd-trace-py/pull/7034 that makes the database monitoring propagation logic compatible with Python 2.7. That change was necessary because the 1.x release line still supports Python 2.

It's not strictly necessary to forward-port this change, but I think it makes sense to do forward ports when they're easy, since it will tend to keep future backports from getting hairy.

There's no changelog because this change is a no-op.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
