### PR TITLE
ci: add circle CI directory to harness suite

### DIFF
--- a/tests/.suitespec.json
+++ b/tests/.suitespec.json
@@ -12,7 +12,8 @@
             "hatch.toml",
             "tests/conftest.py",
             "tests/__init__.py",
-            "tests/.suitespec.json"
+            "tests/.suitespec.json",
+            ".circleci/*"
         ],
         "core": [
             "ddtrace/internal/*",

--- a/tests/suitespec.py
+++ b/tests/suitespec.py
@@ -13,30 +13,30 @@ def get_patterns(suite: str) -> t.Set[str]:
     """Get the patterns for a suite
 
     >>> sorted(get_patterns("debugger"))  # doctest: +NORMALIZE_WHITESPACE
-    ['ddtrace/__init__.py', 'ddtrace/_hooks.py', 'ddtrace/_logger.py', 'ddtrace/_monkey.py', 'ddtrace/_tracing/*',
-    'ddtrace/auto.py', 'ddtrace/bootstrap/*', 'ddtrace/commands/*', 'ddtrace/constants.py', 'ddtrace/context.py',
-    'ddtrace/debugging/*', 'ddtrace/filters.py', 'ddtrace/internal/*', 'ddtrace/pin.py', 'ddtrace/provider.py',
-    'ddtrace/py.typed', 'ddtrace/sampler.py', 'ddtrace/settings/__init__.py', 'ddtrace/settings/config.py',
-    'ddtrace/settings/dynamic_instrumentation.py', 'ddtrace/settings/exception_debugging.py',
-    'ddtrace/settings/http.py', 'ddtrace/settings/integration.py', 'ddtrace/span.py', 'ddtrace/tracer.py',
-    'ddtrace/tracing/*', 'ddtrace/version.py', 'hatch.toml', 'pyproject.toml', 'riotfile.py', 'scripts/ddtest',
-    'scripts/run-test-suite', 'setup.cfg', 'setup.py', 'tests/.suitespec.json', 'tests/__init__.py',
-    'tests/conftest.py', 'tests/debugging/*']
+    ['.circleci/*', 'ddtrace/__init__.py', 'ddtrace/_hooks.py', 'ddtrace/_logger.py', 'ddtrace/_monkey.py',
+    'ddtrace/_tracing/*', 'ddtrace/auto.py', 'ddtrace/bootstrap/*', 'ddtrace/commands/*', 'ddtrace/constants.py',
+    'ddtrace/context.py', 'ddtrace/debugging/*', 'ddtrace/filters.py', 'ddtrace/internal/*', 'ddtrace/pin.py',
+    'ddtrace/provider.py', 'ddtrace/py.typed', 'ddtrace/sampler.py', 'ddtrace/settings/__init__.py',
+    'ddtrace/settings/config.py', 'ddtrace/settings/dynamic_instrumentation.py',
+    'ddtrace/settings/exception_debugging.py', 'ddtrace/settings/http.py', 'ddtrace/settings/integration.py',
+    'ddtrace/span.py', 'ddtrace/tracer.py', 'ddtrace/tracing/*', 'ddtrace/version.py', 'hatch.toml', 'pyproject.toml',
+    'riotfile.py', 'scripts/ddtest', 'scripts/run-test-suite', 'setup.cfg', 'setup.py', 'tests/.suitespec.json',
+    'tests/__init__.py', 'tests/conftest.py', 'tests/debugging/*']
     >>> get_patterns("foobar")
     set()
     >>> sorted(get_patterns("urllib3"))  # doctest: +NORMALIZE_WHITESPACE
-    ['ddtrace/__init__.py', 'ddtrace/_hooks.py', 'ddtrace/_logger.py', 'ddtrace/_monkey.py', 'ddtrace/_tracing/*',
-    'ddtrace/auto.py', 'ddtrace/bootstrap/*', 'ddtrace/commands/*', 'ddtrace/constants.py', 'ddtrace/context.py',
-    'ddtrace/contrib/__init__.py', 'ddtrace/contrib/_trace_utils_llm.py', 'ddtrace/contrib/trace_utils.py',
-    'ddtrace/contrib/trace_utils_async.py', 'ddtrace/contrib/urllib3/*', 'ddtrace/ext/__init__.py',
-    'ddtrace/ext/http.py', 'ddtrace/ext/net.py', 'ddtrace/ext/sql.py', 'ddtrace/ext/test.py', 'ddtrace/ext/user.py',
-    'ddtrace/filters.py', 'ddtrace/internal/*', 'ddtrace/pin.py', 'ddtrace/propagation/*', 'ddtrace/provider.py',
-    'ddtrace/py.typed', 'ddtrace/sampler.py', 'ddtrace/settings/__init__.py',
-    'ddtrace/settings/_database_monitoring.py', 'ddtrace/settings/config.py', 'ddtrace/settings/http.py',
-    'ddtrace/settings/integration.py', 'ddtrace/span.py', 'ddtrace/tracer.py', 'ddtrace/tracing/*',
-    'ddtrace/version.py', 'hatch.toml', 'pyproject.toml', 'riotfile.py', 'scripts/ddtest', 'scripts/run-test-suite',
-    'setup.cfg', 'setup.py', 'tests/.suitespec.json', 'tests/__init__.py', 'tests/conftest.py',
-    'tests/contrib/__init__.py', 'tests/contrib/patch.py', 'tests/contrib/urllib3/*',
+    ['.circleci/*', 'ddtrace/__init__.py', 'ddtrace/_hooks.py', 'ddtrace/_logger.py', 'ddtrace/_monkey.py',
+    'ddtrace/_tracing/*', 'ddtrace/auto.py', 'ddtrace/bootstrap/*', 'ddtrace/commands/*', 'ddtrace/constants.py',
+    'ddtrace/context.py', 'ddtrace/contrib/__init__.py', 'ddtrace/contrib/_trace_utils_llm.py',
+    'ddtrace/contrib/trace_utils.py', 'ddtrace/contrib/trace_utils_async.py', 'ddtrace/contrib/urllib3/*',
+    'ddtrace/ext/__init__.py', 'ddtrace/ext/http.py', 'ddtrace/ext/net.py', 'ddtrace/ext/sql.py',
+    'ddtrace/ext/test.py', 'ddtrace/ext/user.py', 'ddtrace/filters.py', 'ddtrace/internal/*', 'ddtrace/pin.py',
+    'ddtrace/propagation/*', 'ddtrace/provider.py', 'ddtrace/py.typed', 'ddtrace/sampler.py',
+    'ddtrace/settings/__init__.py', 'ddtrace/settings/_database_monitoring.py', 'ddtrace/settings/config.py',
+    'ddtrace/settings/http.py', 'ddtrace/settings/integration.py', 'ddtrace/span.py', 'ddtrace/tracer.py',
+    'ddtrace/tracing/*', 'ddtrace/version.py', 'hatch.toml', 'pyproject.toml', 'riotfile.py', 'scripts/ddtest',
+    'scripts/run-test-suite', 'setup.cfg', 'setup.py', 'tests/.suitespec.json', 'tests/__init__.py',
+    'tests/conftest.py', 'tests/contrib/__init__.py', 'tests/contrib/patch.py', 'tests/contrib/urllib3/*',
     'tests/snapshots/tests.contrib.urllib3.*']
     """
     compos = SUITESPEC["components"]


### PR DESCRIPTION
All tests suites should run if the CircleCI config, templates (or preemptively: anything CircleCI related), changes.  

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
