### PR TITLE
ci(redis): fix python<3.7 support

### DIFF
--- a/ddtrace/internal/compat.py
+++ b/ddtrace/internal/compat.py
@@ -46,10 +46,6 @@ PYTHON_VERSION_INFO = sys.version_info
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock  # type: ignore  # noqa
 
 try:
     from builtin import TimeoutError

--- a/tests/contrib/redis/test_redis.py
+++ b/tests/contrib/redis/test_redis.py
@@ -7,7 +7,6 @@ from ddtrace import Pin
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.contrib.redis.patch import patch
 from ddtrace.contrib.redis.patch import unpatch
-from ddtrace.internal.compat import mock
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from tests.opentracer.utils import init_tracer
 from tests.utils import DummyTracer
@@ -15,6 +14,12 @@ from tests.utils import TracerTestCase
 from tests.utils import snapshot
 
 from ..config import REDIS_CONFIG
+
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock  # type: ignore  # noqa
 
 
 class TestRedisPatch(TracerTestCase):


### PR DESCRIPTION
Reverts the following commit: https://github.com/DataDog/dd-trace-py/pull/7025/commits/80ff6f357f08efaefd53d446a50247f2eb0897d3.

Fixes the failing v1.20.2 build action: https://github.com/DataDog/dd-trace-py/actions/runs/6314357914/job/17150041391.

- Mock is installed in all dd-trace-py venvs: https://github.com/DataDog/dd-trace-py/blob/v1.20.2/riotfile.py#L90
- Mock is not listed as a ddtrace dependency: https://github.com/DataDog/dd-trace-py/blob/v1.20.2/setup.py#L538
  - These two conditions create a scenario where this [commit](https://github.com/DataDog/dd-trace-py/pull/7025/commits/80ff6f357f08efaefd53d446a50247f2eb0897d3) passed all tests but caused `ddtrace` smoke tests in the 1.20.2 release to fail. Since mock is not a ddtrace dependency this import should should be declared in test files.
  - This issue only impacts the 1.20 release line. The broken commit was not merged to 2.x, 2.0, or 1.19 



## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
