### PR TITLE
chore(tracer): limit memory usage for extra services reports

### DIFF
--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -179,7 +179,7 @@ class Config(object):
     available and can be updated by users.
     """
 
-    _extra_services_queue = multiprocessing.Queue()  # type: multiprocessing.Queue
+    _extra_services_queue = multiprocessing.Queue(512)  # type: multiprocessing.Queue
 
     class _HTTPServerConfig(object):
         _error_statuses = "500-599"  # type: str
@@ -422,12 +422,12 @@ class Config(object):
         return self._config[name]
 
     def _add_extra_service(self, service_name: str) -> None:
-        from queue import Empty
+        from queue import Full
 
         if service_name != self.service:
             try:
                 self._extra_services_queue.put_nowait(service_name)
-            except Empty:  # nosec
+            except Full:  # nosec
                 pass
             except BaseException:
                 log.debug("unexpected failure with _add_extra_service", exc_info=True)

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -424,7 +424,7 @@ class Config(object):
     def _add_extra_service(self, service_name: str) -> None:
         from queue import Full
 
-        if service_name != self.service:
+        if self._remote_config_enabled and service_name != self.service:
             try:
                 self._extra_services_queue.put_nowait(service_name)
             except Full:  # nosec

--- a/tests/contrib/flask/test_flask_appsec.py
+++ b/tests/contrib/flask/test_flask_appsec.py
@@ -943,7 +943,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         assert resp.status_code == 200
         assert get_response_body(resp) == "Ok awesome_test"
         for _ in range(10):
-            time.sleep(0.2)
+            time.sleep(1)
             if "awesome_test" in ddtrace.config._get_extra_services():
                 break
         else:

--- a/tests/contrib/flask/test_flask_appsec.py
+++ b/tests/contrib/flask/test_flask_appsec.py
@@ -927,6 +927,8 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             )
 
     def test_multiple_service_name(self):
+        import time
+
         import flask
 
         import ddtrace
@@ -940,4 +942,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         resp = self.client.get("/new_service/awesome_test")
         assert resp.status_code == 200
         assert get_response_body(resp) == "Ok awesome_test"
-        assert "awesome_test" in ddtrace.config._get_extra_services()
+        for _ in range(10):
+            time.sleep(0.2)
+            if "awesome_test" in ddtrace.config._get_extra_services():
+                break
+        else:
+            raise AssertionError("extra service not found")


### PR DESCRIPTION
Small guard for unreleased feature merged in https://github.com/DataDog/dd-trace-py/pull/6929

- add check to not fill the queue if remote config is not enabled
- add max size to the queue to avoid any memory leak in case of a remote config malfunction that would lead to never empty the queue. If the queue is full, new service names will be silently discarded.
- improve flask unit test of the feature to avoid flakiness due to thread concurrency.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
