### PR TITLE
fix(internal): closure bytecode wrapping for Python 3.11 [backport #7044 to 1.20]

### DIFF
--- a/releasenotes/notes/fix-py311-closure-wrapping-fed33b584d65a844.yaml
+++ b/releasenotes/notes/fix-py311-closure-wrapping-fed33b584d65a844.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix an issue that could have caused some tracing integrations to create
+    invalid references to objects in Python frames, ultimately causing profiling
+    tools to potentially induce a segmentation fault.

--- a/tests/internal/test_wrapping.py
+++ b/tests/internal/test_wrapping.py
@@ -202,3 +202,27 @@ def test_wrap_stack():
     wrap(f, wrapper)
 
     assert [frame.f_code.co_name for frame in f()[:4]] == ["f", "wrapper", "f", "test_wrap_stack"]
+
+
+def test_wrap_closure():
+    channel = []
+
+    def wrapper(f, args, kwargs):
+        channel.append((args, kwargs))
+        retval = f(*args, **kwargs)
+        channel.append(retval)
+        return retval
+
+    def outer(answer=42):
+        def f(a, b, c=None):
+            return (a, b, c, answer)
+
+        return f
+
+    wrap(outer, wrapper)
+
+    closure = outer()
+    wrap(closure, wrapper)
+
+    assert closure(1, 2, 3) == (1, 2, 3, 42)
+    assert channel == [((42,), {}), closure, ((1, 2, 3), {}), (1, 2, 3, 42)]


### PR DESCRIPTION
Backport of #7044 to 1.20

We fix the bytecode wrapping for closures to ensure that the frame objects don't end up referencing missing data, ultimately resulting in a segmentation fault in profiling tools.

Fixes #6701.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
