### PR TITLE
chore(tracer): revert "limit memory usage for extra services reports"

### DIFF
--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -179,7 +179,7 @@ class Config(object):
     available and can be updated by users.
     """
 
-    _extra_services_queue = multiprocessing.Queue(512)  # type: multiprocessing.Queue
+    _extra_services_queue = multiprocessing.Queue()  # type: multiprocessing.Queue
 
     class _HTTPServerConfig(object):
         _error_statuses = "500-599"  # type: str
@@ -422,12 +422,12 @@ class Config(object):
         return self._config[name]
 
     def _add_extra_service(self, service_name: str) -> None:
-        from queue import Full
+        from queue import Empty
 
-        if self._remote_config_enabled and service_name != self.service:
+        if service_name != self.service:
             try:
                 self._extra_services_queue.put_nowait(service_name)
-            except Full:  # nosec
+            except Empty:  # nosec
                 pass
             except BaseException:
                 log.debug("unexpected failure with _add_extra_service", exc_info=True)

--- a/tests/contrib/flask/test_flask_appsec.py
+++ b/tests/contrib/flask/test_flask_appsec.py
@@ -927,8 +927,6 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             )
 
     def test_multiple_service_name(self):
-        import time
-
         import flask
 
         import ddtrace
@@ -938,15 +936,8 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             ddtrace.Pin.override(flask.Flask, service=service_name, tracer=ddtrace.tracer)
             return "Ok %s" % service_name, 200
 
-        with override_global_config(dict(_remote_config_enabled=True)):
-            self._aux_appsec_prepare_tracer()
-            assert ddtrace.config._remote_config_enabled
-            resp = self.client.get("/new_service/awesome_test")
-            assert resp.status_code == 200
-            assert get_response_body(resp) == "Ok awesome_test"
-            for _ in range(10):
-                time.sleep(1)
-                if "awesome_test" in ddtrace.config._get_extra_services():
-                    break
-            else:
-                raise AssertionError("extra service not found")
+        self._aux_appsec_prepare_tracer()
+        resp = self.client.get("/new_service/awesome_test")
+        assert resp.status_code == 200
+        assert get_response_body(resp) == "Ok awesome_test"
+        assert "awesome_test" in ddtrace.config._get_extra_services()


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#7060, which broke the `internal` test suite due to that suite not being run pre-merge.

- [x] foobar