### PR TITLE
fix(git): fix git version extraction

### DIFF
--- a/ddtrace/ext/git.py
+++ b/ddtrace/ext/git.py
@@ -143,7 +143,11 @@ def extract_user_info(cwd=None):
 
 def extract_git_version(cwd=None):
     output = _git_subprocess_cmd("--version")
-    version_info = tuple([int(part) for part in output.split()[2].split(".")])
+    try:
+        version_info = tuple([int(part) for part in output.split()[2].split(".")])
+    except ValueError:
+        log.error("Git version not found, it is not following the desired version format.")
+        return 0, 0, 0
     return version_info
 
 

--- a/ddtrace/ext/git.py
+++ b/ddtrace/ext/git.py
@@ -146,7 +146,7 @@ def extract_git_version(cwd=None):
     try:
         version_info = tuple([int(part) for part in output.split()[2].split(".")])
     except ValueError:
-        log.error("Git version not found, it is not following the desired version format.")
+        log.error("Git version not found, it is not following the desired version format: {}".format(output))
         return 0, 0, 0
     return version_info
 

--- a/ddtrace/ext/git.py
+++ b/ddtrace/ext/git.py
@@ -146,7 +146,7 @@ def extract_git_version(cwd=None):
     try:
         version_info = tuple([int(part) for part in output.split()[2].split(".")])
     except ValueError:
-        log.error("Git version not found, it is not following the desired version format: {}".format(output))
+        log.error("Git version not found, it is not following the desired version format: %s", output)
         return 0, 0, 0
     return version_info
 

--- a/ddtrace/ext/git.py
+++ b/ddtrace/ext/git.py
@@ -143,7 +143,7 @@ def extract_user_info(cwd=None):
 
 def extract_git_version(cwd=None):
     output = _git_subprocess_cmd("--version")
-    version_info = tuple([int(part) for part in output.split()[-1].split(".")])
+    version_info = tuple([int(part) for part in output.split()[2].split(".")])
     return version_info
 
 

--- a/releasenotes/notes/fix-git-version-extraction-8db3a639976e725c.yaml
+++ b/releasenotes/notes/fix-git-version-extraction-8db3a639976e725c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    CI Visibility: Fixes incorrect Git version extraction

--- a/tests/tracer/test_ci.py
+++ b/tests/tracer/test_ci.py
@@ -263,6 +263,13 @@ def test_get_rev_list_git_lt_223(git_repo):
         )
 
 
+def test_invalid_git_version(git_repo):
+    with mock.patch("ddtrace.ext.git._git_subprocess_cmd", return_value="git version 2.6.13a (invalid)"):
+        assert git.extract_git_version(cwd=git_repo) == (0, 0, 0)
+    with mock.patch("ddtrace.ext.git._git_subprocess_cmd", return_value="git version (invalid)"):
+        assert git.extract_git_version(cwd=git_repo) == (0, 0, 0)
+
+
 def test_is_shallow_repository_true(git_repo):
     with mock.patch("ddtrace.ext.git._git_subprocess_cmd", return_value="true") as mock_git_subprocess:
         assert git._is_shallow_repository(cwd=git_repo) is True

--- a/tests/tracer/test_ci.py
+++ b/tests/tracer/test_ci.py
@@ -263,6 +263,13 @@ def test_get_rev_list_git_lt_223(git_repo):
         )
 
 
+def test_valid_git_version(git_repo):
+    with mock.patch("ddtrace.ext.git._git_subprocess_cmd", return_value="git version 2.6.13 (Apple 256)"):
+        assert git.extract_git_version(cwd=git_repo) == (2, 6, 13)
+    with mock.patch("ddtrace.ext.git._git_subprocess_cmd", return_value="git version 2.6.13"):
+        assert git.extract_git_version(cwd=git_repo) == (2, 6, 13)
+
+
 def test_invalid_git_version(git_repo):
     with mock.patch("ddtrace.ext.git._git_subprocess_cmd", return_value="git version 2.6.13a (invalid)"):
         assert git.extract_git_version(cwd=git_repo) == (0, 0, 0)


### PR DESCRIPTION
## Motivation

This PR aims to fix Git version extraction which was relying on getting the last argument of `git --version` output. This is invalid since it could happen that the output: `git version 2.39.3 (Apple Git-145)`

[JIRA issue](https://datadoghq.atlassian.net/browse/CIAPP-7884?atlOrigin=eyJpIjoiNGJhODU0YzM3NDlkNGMxZWIzNWI4NWE3NzJmOWE0NmYiLCJwIjoiaiJ9)

## What has been changed?

Instead, we extract the Git version with the 3rd argument (`2.39.3`), which is in line with how `dd-trace-js` operates.

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
