### PR TITLE
docs: append timestamp awareness to logs docs and example code

### DIFF
--- a/ddtrace/contrib/logging/__init__.py
+++ b/ddtrace/contrib/logging/__init__.py
@@ -46,6 +46,13 @@ Make sure that your log format exactly matches the following::
         log.info('Hello, World!')
 
     hello()
+
+Note that most host based setups log by default in UTC time.
+if the log timestamps aren't automatically formatted as UTC, the logging formatter can be updated to use UTC.
+For more information, review https://docs.datadoghq.com/logs/guide/logs-not-showing-expected-timestamp/
+
+    import time
+    logging.Formatter.converter = time.gmtime
 """
 
 from ...internal.utils.importlib import require_modules

--- a/ddtrace/contrib/logging/__init__.py
+++ b/ddtrace/contrib/logging/__init__.py
@@ -48,12 +48,13 @@ Make sure that your log format exactly matches the following::
     hello()
 
 Note that most host based setups log by default in UTC time.
-if the log timestamps aren't automatically formatted as UTC, the logging formatter can be updated to use UTC::
+If the log timestamps aren't automatically formatted as UTC, the logging formatter can be updated to use UTC::
 
     import time
     logging.Formatter.converter = time.gmtime
 
-For more information, review https://docs.datadoghq.com/logs/guide/logs-not-showing-expected-timestamp/
+For more information, please see the attached guide on common timestamp issues:
+https://docs.datadoghq.com/logs/guide/logs-not-showing-expected-timestamp/
 """
 
 from ...internal.utils.importlib import require_modules

--- a/ddtrace/contrib/logging/__init__.py
+++ b/ddtrace/contrib/logging/__init__.py
@@ -47,8 +47,8 @@ Make sure that your log format exactly matches the following::
 
     hello()
 
-Note that most host based setups log by default in UTC time.
-If the log timestamps aren't automatically formatted as UTC, the logging formatter can be updated to use UTC::
+Note that most host based setups log by default to UTC time.
+If the log timestamps aren't automatically formatted as UTC, `logging.Formatter` can be updated to use UTC::
 
     import time
     logging.Formatter.converter = time.gmtime

--- a/ddtrace/contrib/logging/__init__.py
+++ b/ddtrace/contrib/logging/__init__.py
@@ -48,7 +48,7 @@ Make sure that your log format exactly matches the following::
     hello()
 
 Note that most host based setups log by default to UTC time.
-If the log timestamps aren't automatically formatted as UTC, `logging.Formatter` can be updated to use UTC::
+If the log timestamps aren't automatically in UTC, the formatter can be updated to use UTC::
 
     import time
     logging.Formatter.converter = time.gmtime

--- a/ddtrace/contrib/logging/__init__.py
+++ b/ddtrace/contrib/logging/__init__.py
@@ -48,11 +48,12 @@ Make sure that your log format exactly matches the following::
     hello()
 
 Note that most host based setups log by default in UTC time.
-if the log timestamps aren't automatically formatted as UTC, the logging formatter can be updated to use UTC.
-For more information, review https://docs.datadoghq.com/logs/guide/logs-not-showing-expected-timestamp/
+if the log timestamps aren't automatically formatted as UTC, the logging formatter can be updated to use UTC::
 
     import time
     logging.Formatter.converter = time.gmtime
+
+For more information, review https://docs.datadoghq.com/logs/guide/logs-not-showing-expected-timestamp/
 """
 
 from ...internal.utils.importlib import require_modules


### PR DESCRIPTION
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
