### PR TITLE
chore(iast): remove new_pyobject_id param

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
@@ -5,7 +5,6 @@
 PyObject*
 index_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* idx, TaintRangeMapType* tx_taint_map)
 {
-    size_t len_result_o{ get_pyobject_size(result_o) };
     auto idx_long = PyLong_AsLong(idx);
     TaintRangeRefs ranges_to_set;
     auto ranges = get_ranges(candidate_text);
@@ -16,7 +15,7 @@ index_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* idx, TaintR
         }
     }
 
-    const auto& res_new_id = new_pyobject_id(result_o, len_result_o);
+    const auto& res_new_id = new_pyobject_id(result_o);
     Py_DECREF(result_o);
 
     if (ranges_to_set.empty()) {

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
@@ -51,7 +51,7 @@ aspect_join_str(PyObject* sep,
         }
     }
 
-    PyObject* new_result{ new_pyobject_id(result, PyUnicode_GET_LENGTH(result)) };
+    PyObject* new_result{ new_pyobject_id(result) };
     set_tainted_object(new_result, result_to, tx_taint_map);
     Py_DECREF(result);
     return new_result;
@@ -132,7 +132,7 @@ aspect_join(PyObject* sep, PyObject* result, PyObject* iterable_elements, TaintR
         }
     }
 
-    PyObject* new_result{ new_pyobject_id(result, get_pyobject_size(result)) };
+    PyObject* new_result{ new_pyobject_id(result) };
     set_tainted_object(new_result, result_to, tx_taint_map);
     Py_DECREF(result);
     return new_result;

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
@@ -15,7 +15,6 @@ add_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* text_to_add, 
 {
     size_t len_candidate_text{ get_pyobject_size(candidate_text) };
     size_t len_text_to_add{ get_pyobject_size(text_to_add) };
-    size_t len_result_o{ get_pyobject_size(result_o) };
 
     if (len_text_to_add == 0 and len_candidate_text > 0) {
         return candidate_text;
@@ -26,7 +25,7 @@ add_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* text_to_add, 
 
     const auto& to_candidate_text = get_tainted_object(candidate_text, tx_taint_map);
     if (to_candidate_text and to_candidate_text->get_ranges().size() >= TaintedObject::TAINT_RANGE_LIMIT) {
-        const auto& res_new_id = new_pyobject_id(result_o, len_result_o);
+        const auto& res_new_id = new_pyobject_id(result_o);
         Py_DECREF(result_o);
         // If left side is already at the maximum taint ranges, we just reuse its
         // ranges, we don't need to look at left side.
@@ -39,7 +38,7 @@ add_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* text_to_add, 
         return result_o;
     }
     if (!to_text_to_add) {
-        const auto& res_new_id = new_pyobject_id(result_o, len_result_o);
+        const auto& res_new_id = new_pyobject_id(result_o);
         Py_DECREF(result_o);
         set_tainted_object(res_new_id, to_candidate_text, tx_taint_map);
         return res_new_id;
@@ -47,7 +46,7 @@ add_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* text_to_add, 
 
     auto tainted = initializer->allocate_tainted_object_copy(to_candidate_text);
     tainted->add_ranges_shifted(to_text_to_add, (long)len_candidate_text);
-    const auto& res_new_id = new_pyobject_id(result_o, len_result_o);
+    const auto& res_new_id = new_pyobject_id(result_o);
     Py_DECREF(result_o);
     set_tainted_object(res_new_id, tainted, tx_taint_map);
 

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.cpp
@@ -1,7 +1,7 @@
 #include "TaintedOps.h"
 
 PyObject*
-new_pyobject_id(PyObject* tainted_object, Py_ssize_t object_length)
+new_pyobject_id(PyObject* tainted_object)
 {
     if (PyUnicode_Check(tainted_object)) {
         PyObject* empty_unicode = PyUnicode_New(0, 127);
@@ -37,9 +37,8 @@ PyObject*
 api_new_pyobject_id(PyObject* Py_UNUSED(module), PyObject* args)
 {
     PyObject* tainted_object;
-    Py_ssize_t object_length;
-    PyArg_ParseTuple(args, "On", &tainted_object, &object_length);
-    return new_pyobject_id(tainted_object, object_length);
+    PyArg_ParseTuple(args, "O", &tainted_object);
+    return new_pyobject_id(tainted_object);
 }
 
 bool

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.h
@@ -10,7 +10,7 @@ using namespace pybind11::literals;
 namespace py = pybind11;
 
 PyObject*
-new_pyobject_id(PyObject* tainted_object, Py_ssize_t object_length);
+new_pyobject_id(PyObject* tainted_object);
 
 PyObject*
 api_new_pyobject_id(PyObject* Py_UNUSED(module), PyObject* args);

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -78,8 +78,8 @@ __all__ = [
 ]
 
 
-def taint_pyobject(pyobject, source_name, source_value, source_origin=None, start=0):
-    # type: (Any, Any, Any, OriginType, int) -> Any
+def taint_pyobject(pyobject, source_name, source_value, source_origin=None):
+    # type: (Any, Any, Any, OriginType) -> Any
     # Request is not analyzed
     if not oce.request_has_quota:
         return pyobject
@@ -95,7 +95,7 @@ def taint_pyobject(pyobject, source_name, source_value, source_origin=None, star
     if source_origin is None:
         source_origin = OriginType.PARAMETER
     source = Source(source_name, source_value, source_origin)
-    pyobject_range = TaintRange(start, len(pyobject), source)
+    pyobject_range = TaintRange(0, len(pyobject), source)
     set_ranges(pyobject_newid, [pyobject_range])
     _set_metric_iast_executed_source(source_origin)
     return pyobject_newid

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -78,8 +78,8 @@ __all__ = [
 ]
 
 
-def taint_pyobject(pyobject, source_name, source_value, source_origin=None, start=0, len_pyobject=None):
-    # type: (Any, Any, Any, OriginType, int, Optional[int]) -> Any
+def taint_pyobject(pyobject, source_name, source_value, source_origin=None, start=0):
+    # type: (Any, Any, Any, OriginType, int) -> Any
     # Request is not analyzed
     if not oce.request_has_quota:
         return pyobject
@@ -87,9 +87,7 @@ def taint_pyobject(pyobject, source_name, source_value, source_origin=None, star
     if not pyobject or not isinstance(pyobject, (str, bytes, bytearray)):
         return pyobject
 
-    if not len_pyobject:
-        len_pyobject = len(pyobject)
-    pyobject_newid = new_pyobject_id(pyobject, len_pyobject)
+    pyobject_newid = new_pyobject_id(pyobject)
     if isinstance(source_name, (bytes, bytearray)):
         source_name = str(source_name, encoding="utf8")
     if isinstance(source_value, (bytes, bytearray)):
@@ -97,7 +95,7 @@ def taint_pyobject(pyobject, source_name, source_value, source_origin=None, star
     if source_origin is None:
         source_origin = OriginType.PARAMETER
     source = Source(source_name, source_value, source_origin)
-    pyobject_range = TaintRange(start, len_pyobject, source)
+    pyobject_range = TaintRange(start, len(pyobject), source)
     set_ranges(pyobject_newid, [pyobject_range])
     _set_metric_iast_executed_source(source_origin)
     return pyobject_newid

--- a/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
@@ -18,54 +18,39 @@ class TestOperatorJoinReplacement(object):
     def test_string_join_tainted_joiner(self):  # type: () -> None
         # taint "joi" from "-joiner-"
         string_input = taint_pyobject(
-            pyobject="-joiner-",
-            source_name="joiner",
-            source_value="foo",
-            source_origin=OriginType.PARAMETER,
-            start=1,
-            len_pyobject=3,
+            pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER, start=1
         )
         it = ["a", "b", "c"]
 
         result = mod.do_join(string_input, it)
         assert result == "a-joiner-b-joiner-c"
         ranges = get_tainted_ranges(result)
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "joi"
-        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "joi"
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "joiner-b"
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "joiner-c"
 
     def test_string_join_tainted_joiner_bytes(self):  # type: () -> None
         # taint "joi" from "-joiner-"
         string_input = taint_pyobject(
-            pyobject=b"-joiner-",
-            source_name="joiner",
-            source_value="foo",
-            source_origin=OriginType.PARAMETER,
-            start=1,
-            len_pyobject=3,
+            pyobject=b"-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER, start=1
         )
         it = [b"a", b"b", b"c"]
         result = mod.do_join(string_input, it)
         assert result == b"a-joiner-b-joiner-c"
         ranges = get_tainted_ranges(result)
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == b"joi"
-        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == b"joi"
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == b"joiner-b"
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == b"joiner-c"
 
     def test_string_join_tainted_joiner_bytes_bytearray(self):  # type: () -> None
         # taint "joi" from "-joiner-"
         string_input = taint_pyobject(
-            pyobject=b"-joiner-",
-            source_name="joiner",
-            source_value="foo",
-            source_origin=OriginType.PARAMETER,
-            start=1,
-            len_pyobject=3,
+            pyobject=b"-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER, start=1
         )
         it = [bytearray(b"a"), bytearray(b"b"), bytearray(b"c")]
         result = mod.do_join(string_input, it)
         assert result == b"a-joiner-b-joiner-c"
         ranges = get_tainted_ranges(result)
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == b"joi"
-        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == b"joi"
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == b"joiner-b"
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == b"joiner-c"
 
     def test_string_join_tainted_joiner_bytearray(self):  # type: () -> None
         # taint "joi" from "-joiner-"
@@ -75,15 +60,14 @@ class TestOperatorJoinReplacement(object):
             source_value="foo",
             source_origin=OriginType.PARAMETER,
             start=1,
-            len_pyobject=3,
         )
         it = [bytearray(b"a"), bytearray(b"b"), bytearray(b"c")]
 
         result = mod.do_join(string_input, it)
         assert result == bytearray(b"a-joiner-b-joiner-c")
         ranges = get_tainted_ranges(result)
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == bytearray(b"joi")
-        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == bytearray(b"joi")
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == bytearray(b"joiner-b")
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == bytearray(b"joiner-c")
 
     def test_string_join_tainted_joiner_bytearray_bytes(self):  # type: () -> None
         # taint "joi" from "-joiner-"
@@ -93,52 +77,36 @@ class TestOperatorJoinReplacement(object):
             source_value="foo",
             source_origin=OriginType.PARAMETER,
             start=1,
-            len_pyobject=3,
         )
         it = [b"a", b"b", b"c"]
 
         result = mod.do_join(string_input, it)
         assert result == bytearray(b"a-joiner-b-joiner-c")
         ranges = get_tainted_ranges(result)
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == bytearray(b"joi")
-        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == bytearray(b"joi")
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == bytearray(b"joiner-b")
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == bytearray(b"joiner-c")
 
     def test_string_join_tainted_joined(self):  # type: () -> None
         string_input = "-joiner-"
         it = [
             taint_pyobject(
-                pyobject="aaaa",
-                source_name="joiner",
-                source_value="foo",
-                source_origin=OriginType.PARAMETER,
-                start=0,
-                len_pyobject=3,
+                pyobject="aaaa", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER, start=0
             ),
             "bbbb",
             taint_pyobject(
-                pyobject="cccc",
-                source_name="joiner",
-                source_value="foo",
-                source_origin=OriginType.PARAMETER,
-                start=0,
-                len_pyobject=3,
+                pyobject="cccc", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER, start=0
             ),
         ]
 
         result = mod.do_join(string_input, it)
         ranges = get_tainted_ranges(result)
         assert result == "aaaa-joiner-bbbb-joiner-cccc"
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "aaa"
-        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "ccc"
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "aaaa"
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "cccc"
 
     def test_string_join_tainted_all(self):  # type: () -> None
         string_input = taint_pyobject(
-            pyobject="-joiner-",
-            source_name="joiner",
-            source_value="foo",
-            source_origin=OriginType.PARAMETER,
-            start=1,
-            len_pyobject=2,
+            pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER, start=1
         )
         it = [
             taint_pyobject(
@@ -147,7 +115,6 @@ class TestOperatorJoinReplacement(object):
                 source_value="foo",
                 source_origin=OriginType.PARAMETER,
                 start=0,
-                len_pyobject=1,
             ),
             "bbbb",
             taint_pyobject(
@@ -156,7 +123,6 @@ class TestOperatorJoinReplacement(object):
                 source_value="foo",
                 source_origin=OriginType.PARAMETER,
                 start=0,
-                len_pyobject=4,
             ),
             taint_pyobject(
                 pyobject="dddd",
@@ -164,7 +130,6 @@ class TestOperatorJoinReplacement(object):
                 source_value="foo",
                 source_origin=OriginType.PARAMETER,
                 start=0,
-                len_pyobject=3,
             ),
             taint_pyobject(
                 pyobject="eeee",
@@ -172,7 +137,6 @@ class TestOperatorJoinReplacement(object):
                 source_value="foo",
                 source_origin=OriginType.PARAMETER,
                 start=0,
-                len_pyobject=2,
             ),
             taint_pyobject(
                 pyobject="ffff",
@@ -180,7 +144,6 @@ class TestOperatorJoinReplacement(object):
                 source_value="foo",
                 source_origin=OriginType.PARAMETER,
                 start=0,
-                len_pyobject=3,
             ),
             taint_pyobject(
                 pyobject="gggg",
@@ -188,7 +151,6 @@ class TestOperatorJoinReplacement(object):
                 source_value="foo",
                 source_origin=OriginType.PARAMETER,
                 start=0,
-                len_pyobject=4,
             ),
         ]
 
@@ -196,7 +158,20 @@ class TestOperatorJoinReplacement(object):
         ranges = get_tainted_ranges(result)
         assert result == "aaaa-joiner-bbbb-joiner-cccc-joiner-dddd-joiner-eeee-joiner-ffff-joiner-gggg"
         pos = 0
-        for results in ("a", "jo", "jo", "cccc", "jo", "ddd", "jo", "ee", "jo", "fff", "jo", "gggg"):
+        for results in (
+            "aaaa",
+            "joiner-b",
+            "joiner-c",
+            "cccc",
+            "joiner-d",
+            "dddd",
+            "joiner-e",
+            "eeee",
+            "joiner-f",
+            "ffff",
+            "joiner-g",
+            "gggg",
+        ):
             assert result[ranges[pos].start : (ranges[pos].start + ranges[pos].length)] == results
             pos += 1
 
@@ -214,15 +189,14 @@ class TestOperatorJoinReplacement(object):
             source_value="foo",
             source_origin=OriginType.PARAMETER,
             start=0,
-            len_pyobject=3,
         )
         result = mod.do_join_tuple(tainted_base_string)
         assert result == "abcde1abcde2abcde3"
 
         ranges = get_tainted_ranges(result)
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "abc"
-        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "abc"
-        assert result[ranges[2].start : (ranges[2].start + ranges[2].length)] == "abc"
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "abcde"
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "abcde"
+        assert result[ranges[2].start : (ranges[2].start + ranges[2].length)] == "abcde"
 
     def test_string_join_set(self):  # type: () -> None
         # Not tainted
@@ -237,14 +211,13 @@ class TestOperatorJoinReplacement(object):
             source_value="foo",
             source_origin=OriginType.PARAMETER,
             start=0,
-            len_pyobject=3,
         )
         result = mod.do_join_set(tainted_base_string)
 
         ranges = get_tainted_ranges(result)
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "abc"
-        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "abc"
-        assert result[ranges[2].start : (ranges[2].start + ranges[2].length)] == "abc"
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "abcde"
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "abcde"
+        assert result[ranges[2].start : (ranges[2].start + ranges[2].length)] == "abcde"
 
     def test_string_join_generator(self):
         # type: () -> None
@@ -261,15 +234,14 @@ class TestOperatorJoinReplacement(object):
             source_value="foo",
             source_origin=OriginType.PARAMETER,
             start=0,
-            len_pyobject=3,
         )
         result = mod.do_join_generator(tainted_base_string)
         assert result == "abcdeabcdeabcde"
 
         ranges = get_tainted_ranges(result)
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "abc"
-        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "abc"
-        assert result[ranges[2].start : (ranges[2].start + ranges[2].length)] == "abc"
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "abcde"
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "abcde"
+        assert result[ranges[2].start : (ranges[2].start + ranges[2].length)] == "abcde"
 
     def test_string_join_args_kwargs(self):
         # type: () -> None
@@ -285,14 +257,13 @@ class TestOperatorJoinReplacement(object):
             source_value="foo",
             source_origin=OriginType.PARAMETER,
             start=1,
-            len_pyobject=5,
         )
         result = mod.do_join_args_kwargs(tainted_base_string, ("f", "g"))
         assert result == "f-abcde-g"
 
         ranges = get_tainted_ranges(result)
         assert len(ranges) == 1
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "abcde"
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "abcde-g"
 
     def test_string_join_empty_iterable_joiner_tainted(self):
         # type: () -> None
@@ -308,7 +279,6 @@ class TestOperatorJoinReplacement(object):
             source_value="foo",
             source_origin=OriginType.PARAMETER,
             start=1,
-            len_pyobject=5,
         )
         result = mod.do_join_args_kwargs(tainted_base_string, "")
         assert result == ""
@@ -330,7 +300,6 @@ class TestOperatorJoinReplacement(object):
             source_value="foo",
             source_origin=OriginType.PARAMETER,
             start=0,
-            len_pyobject=4,
         )
         result = mod.do_join_args_kwargs(base_string, tainted_fghi)
         assert result == "fghi"
@@ -353,7 +322,6 @@ class TestOperatorJoinReplacement(object):
             source_value="foo",
             source_origin=OriginType.PARAMETER,
             start=0,
-            len_pyobject=2,
         )
         result = mod.do_join_args_kwargs(base_string, tainted_fg)
         assert result == "f+abcde-g"
@@ -377,13 +345,12 @@ class TestOperatorJoinReplacement(object):
             source_value="foo",
             source_origin=OriginType.PARAMETER,
             start=0,
-            len_pyobject=1,
         )
         result = mod.do_join_args_kwargs(base_string, tainted_fg)
         assert result == "f-abcde-g"
 
         ranges = get_tainted_ranges(result)
-        assert len(ranges) == 1
+        assert len(ranges) == 2
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "f"
 
     def test_string_join_iterable_second_half_tainted(self):
@@ -400,7 +367,6 @@ class TestOperatorJoinReplacement(object):
             source_value="foo",
             source_origin=OriginType.PARAMETER,
             start=1,
-            len_pyobject=1,
         )
         result = mod.do_join_args_kwargs(base_string, tainted_fg)
         assert result == "f-abcde-g"
@@ -423,13 +389,12 @@ class TestOperatorJoinReplacement(object):
             source_value="foo",
             source_origin=OriginType.PARAMETER,
             start=1,
-            len_pyobject=1,
         )
         result = mod.do_join_args_kwargs(base_string, tainted_fgh)
         assert result == "f+abcde-g+abcde-h"
 
         ranges = get_tainted_ranges(result)
-        assert len(ranges) == 1
+        assert len(ranges) == 2
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "g"
 
     def test_string_join_joiner_tainted(self):
@@ -441,13 +406,12 @@ class TestOperatorJoinReplacement(object):
             source_value="foo",
             source_origin=OriginType.PARAMETER,
             start=1,
-            len_pyobject=5,
         )
         result = mod.do_join_args_kwargs(tainted_base_string, "fg")
         assert result == "f-abcde-g"
 
         ranges = get_tainted_ranges(result)
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "abcde"
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "abcde-g"
 
     def test_string_join_all_tainted(self):
         # type: () -> None
@@ -458,7 +422,6 @@ class TestOperatorJoinReplacement(object):
             source_value="foo",
             source_origin=OriginType.PARAMETER,
             start=1,
-            len_pyobject=5,
         )
         tainted_fghi = taint_pyobject(
             pyobject="fghi",
@@ -466,16 +429,15 @@ class TestOperatorJoinReplacement(object):
             source_value="foo",
             source_origin=OriginType.PARAMETER,
             start=0,
-            len_pyobject=4,
         )
         result = mod.do_join_args_kwargs(tainted_base_string, tainted_fghi)
         assert result == "f+abcde-g+abcde-h+abcde-i"
 
         ranges = get_tainted_ranges(result)
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "f"
-        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "abcde"
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "abcde-g"
         assert result[ranges[2].start : (ranges[2].start + ranges[2].length)] == "g"
-        assert result[ranges[3].start : (ranges[3].start + ranges[3].length)] == "abcde"
+        assert result[ranges[3].start : (ranges[3].start + ranges[3].length)] == "abcde-h"
         assert result[ranges[4].start : (ranges[4].start + ranges[4].length)] == "h"
-        assert result[ranges[5].start : (ranges[5].start + ranges[5].length)] == "abcde"
+        assert result[ranges[5].start : (ranges[5].start + ranges[5].length)] == "abcde-i"
         assert result[ranges[6].start : (ranges[6].start + ranges[6].length)] == "i"

--- a/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
@@ -18,39 +18,39 @@ class TestOperatorJoinReplacement(object):
     def test_string_join_tainted_joiner(self):  # type: () -> None
         # taint "joi" from "-joiner-"
         string_input = taint_pyobject(
-            pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER, start=1
+            pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
         )
         it = ["a", "b", "c"]
 
         result = mod.do_join(string_input, it)
         assert result == "a-joiner-b-joiner-c"
         ranges = get_tainted_ranges(result)
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "joiner-b"
-        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "joiner-c"
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "-joiner-"
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "-joiner-"
 
     def test_string_join_tainted_joiner_bytes(self):  # type: () -> None
         # taint "joi" from "-joiner-"
         string_input = taint_pyobject(
-            pyobject=b"-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER, start=1
+            pyobject=b"-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
         )
         it = [b"a", b"b", b"c"]
         result = mod.do_join(string_input, it)
         assert result == b"a-joiner-b-joiner-c"
         ranges = get_tainted_ranges(result)
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == b"joiner-b"
-        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == b"joiner-c"
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == b"-joiner-"
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == b"-joiner-"
 
     def test_string_join_tainted_joiner_bytes_bytearray(self):  # type: () -> None
         # taint "joi" from "-joiner-"
         string_input = taint_pyobject(
-            pyobject=b"-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER, start=1
+            pyobject=b"-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
         )
         it = [bytearray(b"a"), bytearray(b"b"), bytearray(b"c")]
         result = mod.do_join(string_input, it)
         assert result == b"a-joiner-b-joiner-c"
         ranges = get_tainted_ranges(result)
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == b"joiner-b"
-        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == b"joiner-c"
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == b"-joiner-"
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == b"-joiner-"
 
     def test_string_join_tainted_joiner_bytearray(self):  # type: () -> None
         # taint "joi" from "-joiner-"
@@ -59,15 +59,14 @@ class TestOperatorJoinReplacement(object):
             source_name="joiner",
             source_value="foo",
             source_origin=OriginType.PARAMETER,
-            start=1,
         )
         it = [bytearray(b"a"), bytearray(b"b"), bytearray(b"c")]
 
         result = mod.do_join(string_input, it)
         assert result == bytearray(b"a-joiner-b-joiner-c")
         ranges = get_tainted_ranges(result)
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == bytearray(b"joiner-b")
-        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == bytearray(b"joiner-c")
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == bytearray(b"-joiner-")
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == bytearray(b"-joiner-")
 
     def test_string_join_tainted_joiner_bytearray_bytes(self):  # type: () -> None
         # taint "joi" from "-joiner-"
@@ -76,25 +75,24 @@ class TestOperatorJoinReplacement(object):
             source_name="joiner",
             source_value="foo",
             source_origin=OriginType.PARAMETER,
-            start=1,
         )
         it = [b"a", b"b", b"c"]
 
         result = mod.do_join(string_input, it)
         assert result == bytearray(b"a-joiner-b-joiner-c")
         ranges = get_tainted_ranges(result)
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == bytearray(b"joiner-b")
-        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == bytearray(b"joiner-c")
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == bytearray(b"-joiner-")
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == bytearray(b"-joiner-")
 
     def test_string_join_tainted_joined(self):  # type: () -> None
         string_input = "-joiner-"
         it = [
             taint_pyobject(
-                pyobject="aaaa", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER, start=0
+                pyobject="aaaa", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
             ),
             "bbbb",
             taint_pyobject(
-                pyobject="cccc", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER, start=0
+                pyobject="cccc", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
             ),
         ]
 
@@ -106,7 +104,7 @@ class TestOperatorJoinReplacement(object):
 
     def test_string_join_tainted_all(self):  # type: () -> None
         string_input = taint_pyobject(
-            pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER, start=1
+            pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
         )
         it = [
             taint_pyobject(
@@ -114,7 +112,6 @@ class TestOperatorJoinReplacement(object):
                 source_name="joiner",
                 source_value="foo",
                 source_origin=OriginType.PARAMETER,
-                start=0,
             ),
             "bbbb",
             taint_pyobject(
@@ -122,35 +119,30 @@ class TestOperatorJoinReplacement(object):
                 source_name="joiner",
                 source_value="foo",
                 source_origin=OriginType.PARAMETER,
-                start=0,
             ),
             taint_pyobject(
                 pyobject="dddd",
                 source_name="joiner",
                 source_value="foo",
                 source_origin=OriginType.PARAMETER,
-                start=0,
             ),
             taint_pyobject(
                 pyobject="eeee",
                 source_name="joiner",
                 source_value="foo",
                 source_origin=OriginType.PARAMETER,
-                start=0,
             ),
             taint_pyobject(
                 pyobject="ffff",
                 source_name="joiner",
                 source_value="foo",
                 source_origin=OriginType.PARAMETER,
-                start=0,
             ),
             taint_pyobject(
                 pyobject="gggg",
                 source_name="joiner",
                 source_value="foo",
                 source_origin=OriginType.PARAMETER,
-                start=0,
             ),
         ]
 
@@ -160,16 +152,16 @@ class TestOperatorJoinReplacement(object):
         pos = 0
         for results in (
             "aaaa",
-            "joiner-b",
-            "joiner-c",
+            "-joiner-",
+            "-joiner-",
             "cccc",
-            "joiner-d",
+            "-joiner-",
             "dddd",
-            "joiner-e",
+            "-joiner-",
             "eeee",
-            "joiner-f",
+            "-joiner-",
             "ffff",
-            "joiner-g",
+            "-joiner-",
             "gggg",
         ):
             assert result[ranges[pos].start : (ranges[pos].start + ranges[pos].length)] == results
@@ -188,7 +180,6 @@ class TestOperatorJoinReplacement(object):
             source_name="joiner",
             source_value="foo",
             source_origin=OriginType.PARAMETER,
-            start=0,
         )
         result = mod.do_join_tuple(tainted_base_string)
         assert result == "abcde1abcde2abcde3"
@@ -210,7 +201,6 @@ class TestOperatorJoinReplacement(object):
             source_name="joiner",
             source_value="foo",
             source_origin=OriginType.PARAMETER,
-            start=0,
         )
         result = mod.do_join_set(tainted_base_string)
 
@@ -233,7 +223,6 @@ class TestOperatorJoinReplacement(object):
             source_name="joiner",
             source_value="foo",
             source_origin=OriginType.PARAMETER,
-            start=0,
         )
         result = mod.do_join_generator(tainted_base_string)
         assert result == "abcdeabcdeabcde"
@@ -256,14 +245,13 @@ class TestOperatorJoinReplacement(object):
             source_name="joiner",
             source_value="foo",
             source_origin=OriginType.PARAMETER,
-            start=1,
         )
         result = mod.do_join_args_kwargs(tainted_base_string, ("f", "g"))
         assert result == "f-abcde-g"
 
         ranges = get_tainted_ranges(result)
         assert len(ranges) == 1
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "abcde-g"
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "-abcde-"
 
     def test_string_join_empty_iterable_joiner_tainted(self):
         # type: () -> None
@@ -278,7 +266,6 @@ class TestOperatorJoinReplacement(object):
             source_name="joiner",
             source_value="foo",
             source_origin=OriginType.PARAMETER,
-            start=1,
         )
         result = mod.do_join_args_kwargs(tainted_base_string, "")
         assert result == ""
@@ -299,7 +286,6 @@ class TestOperatorJoinReplacement(object):
             source_name="fghi",
             source_value="foo",
             source_origin=OriginType.PARAMETER,
-            start=0,
         )
         result = mod.do_join_args_kwargs(base_string, tainted_fghi)
         assert result == "fghi"
@@ -321,7 +307,6 @@ class TestOperatorJoinReplacement(object):
             source_name="fg",
             source_value="foo",
             source_origin=OriginType.PARAMETER,
-            start=0,
         )
         result = mod.do_join_args_kwargs(base_string, tainted_fg)
         assert result == "f+abcde-g"
@@ -344,7 +329,6 @@ class TestOperatorJoinReplacement(object):
             source_name="fg",
             source_value="foo",
             source_origin=OriginType.PARAMETER,
-            start=0,
         )
         result = mod.do_join_args_kwargs(base_string, tainted_fg)
         assert result == "f-abcde-g"
@@ -366,14 +350,13 @@ class TestOperatorJoinReplacement(object):
             source_name="fg",
             source_value="foo",
             source_origin=OriginType.PARAMETER,
-            start=1,
         )
         result = mod.do_join_args_kwargs(base_string, tainted_fg)
         assert result == "f-abcde-g"
 
         ranges = get_tainted_ranges(result)
-        assert len(ranges) == 1
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "g"
+        assert len(ranges) == 2
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "f"
 
     def test_string_join_iterable_middle_tainted(self):
         # type: () -> None
@@ -388,14 +371,13 @@ class TestOperatorJoinReplacement(object):
             source_name="fgh",
             source_value="foo",
             source_origin=OriginType.PARAMETER,
-            start=1,
         )
         result = mod.do_join_args_kwargs(base_string, tainted_fgh)
         assert result == "f+abcde-g+abcde-h"
 
         ranges = get_tainted_ranges(result)
-        assert len(ranges) == 2
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "g"
+        assert len(ranges) == 3
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "f"
 
     def test_string_join_joiner_tainted(self):
         # type: () -> None
@@ -405,13 +387,12 @@ class TestOperatorJoinReplacement(object):
             source_name="joiner",
             source_value="foo",
             source_origin=OriginType.PARAMETER,
-            start=1,
         )
         result = mod.do_join_args_kwargs(tainted_base_string, "fg")
         assert result == "f-abcde-g"
 
         ranges = get_tainted_ranges(result)
-        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "abcde-g"
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "-abcde-"
 
     def test_string_join_all_tainted(self):
         # type: () -> None
@@ -421,23 +402,21 @@ class TestOperatorJoinReplacement(object):
             source_name="joiner",
             source_value="foo",
             source_origin=OriginType.PARAMETER,
-            start=1,
         )
         tainted_fghi = taint_pyobject(
             pyobject="fghi",
             source_name="fghi",
             source_value="foo",
             source_origin=OriginType.PARAMETER,
-            start=0,
         )
         result = mod.do_join_args_kwargs(tainted_base_string, tainted_fghi)
         assert result == "f+abcde-g+abcde-h+abcde-i"
 
         ranges = get_tainted_ranges(result)
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "f"
-        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "abcde-g"
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "+abcde-"
         assert result[ranges[2].start : (ranges[2].start + ranges[2].length)] == "g"
-        assert result[ranges[3].start : (ranges[3].start + ranges[3].length)] == "abcde-h"
+        assert result[ranges[3].start : (ranges[3].start + ranges[3].length)] == "+abcde-"
         assert result[ranges[4].start : (ranges[4].start + ranges[4].length)] == "h"
-        assert result[ranges[5].start : (ranges[5].start + ranges[5].length)] == "abcde-i"
+        assert result[ranges[5].start : (ranges[5].start + ranges[5].length)] == "+abcde-"
         assert result[ranges[6].start : (ranges[6].start + ranges[6].length)] == "i"

--- a/tests/appsec/iast/taint_sinks/test_command_injection_redacted.py
+++ b/tests/appsec/iast/taint_sinks/test_command_injection_redacted.py
@@ -32,8 +32,7 @@ ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 def _taint_pyobject_multiranges(pyobject, elements):
     pyobject_ranges = []
 
-    len_pyobject = len(pyobject)
-    pyobject_newid = new_pyobject_id(pyobject, len_pyobject)
+    pyobject_newid = new_pyobject_id(pyobject)
 
     for element in elements:
         source_name, source_value, source_origin, start, len_range = element


### PR DESCRIPTION
IAST C++ refactor, remove `object_len` from `new_pyobject_id` C++ function

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
