### PR TITLE
chore(asm): migrate appsec constants to drop python2 compatibility

### DIFF
--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -1,17 +1,11 @@
 import os
-from typing import TYPE_CHECKING
-
-import six
+from typing import Any
+from typing import Iterator
 
 from ddtrace.internal.constants import HTTP_REQUEST_BLOCKED
 from ddtrace.internal.constants import REQUEST_PATH_PARAMS
 from ddtrace.internal.constants import RESPONSE_HEADERS
 from ddtrace.internal.constants import STATUS_403_TYPE_AUTO
-
-
-if TYPE_CHECKING:
-    from typing import Any
-    from typing import Iterator
 
 
 class Constant_Class(type):
@@ -23,12 +17,10 @@ class Constant_Class(type):
         for constant_name, constant_value in APPSEC: ...
     """
 
-    def __setattr__(self, __name, __value):
-        # type: ("Constant_Class", str, Any) -> None
+    def __setattr__(self, __name: str, __value: Any) -> None:
         raise TypeError("Constant class does not support item assignment: %s.%s" % (self.__name__, __name))
 
-    def __iter__(self):
-        # type: ("Constant_Class") -> Iterator[tuple[str, Any]]
+    def __iter__(self) -> Iterator[str]:
         def aux():
             for t in self.__dict__.items():
                 if not t[0].startswith("_"):
@@ -36,21 +28,17 @@ class Constant_Class(type):
 
         return aux()
 
-    def get(self, k, default=None):
-        # type: ("Constant_Class", str, Any) -> Any
+    def get(self, k: str, default: Any = None) -> Any:
         return self.__dict__.get(k, default)
 
-    def __contains__(self, k):
-        # type: ("Constant_Class", str) -> bool
+    def __contains__(self, k: str) -> bool:
         return k in self.__dict__
 
-    def __getitem__(self, k):
-        # type: ("Constant_Class", str) -> Any
+    def __getitem__(self, k: str) -> Any:
         return self.__dict__[k]
 
 
-@six.add_metaclass(Constant_Class)  # required for python2/3 compatibility
-class APPSEC(object):
+class APPSEC(metaclass=Constant_Class):
     """Specific constants for AppSec"""
 
     ENV = "DD_APPSEC_ENABLED"
@@ -76,8 +64,7 @@ class APPSEC(object):
     USER_MODEL_NAME_FIELD = "DD_USER_MODEL_NAME_FIELD"
 
 
-@six.add_metaclass(Constant_Class)  # required for python2/3 compatibility
-class IAST(object):
+class IAST(metaclass=Constant_Class):
     """Specific constants for IAST"""
 
     ENV = "DD_IAST_ENABLED"
@@ -91,8 +78,7 @@ class IAST(object):
     SEP_MODULES = ","
 
 
-@six.add_metaclass(Constant_Class)  # required for python2/3 compatibility
-class WAF_DATA_NAMES(object):
+class WAF_DATA_NAMES(metaclass=Constant_Class):
     """string names used by the waf library for requesting data from requests"""
 
     REQUEST_BODY = "server.request.body"
@@ -110,8 +96,7 @@ class WAF_DATA_NAMES(object):
     PROCESSOR_SETTINGS = "waf.context.processor"
 
 
-@six.add_metaclass(Constant_Class)  # required for python2/3 compatibility
-class SPAN_DATA_NAMES(object):
+class SPAN_DATA_NAMES(metaclass=Constant_Class):
     """string names used by the library for tagging data from requests in context or span"""
 
     REQUEST_BODY = "http.request.body"
@@ -130,8 +115,7 @@ class SPAN_DATA_NAMES(object):
     RESPONSE_BODY = "http.response.body"
 
 
-@six.add_metaclass(Constant_Class)  # required for python2/3 compatibility
-class API_SECURITY(object):
+class API_SECURITY(metaclass=Constant_Class):
     """constants related to API Security"""
 
     ENV_VAR_ENABLED = "DD_EXPERIMENTAL_API_SECURITY_ENABLED"
@@ -147,8 +131,7 @@ class API_SECURITY(object):
     MAX_PAYLOAD_SIZE = 0x1000000  # 16MB maximum size
 
 
-@six.add_metaclass(Constant_Class)  # required for python2/3 compatibility
-class WAF_CONTEXT_NAMES(object):
+class WAF_CONTEXT_NAMES(metaclass=Constant_Class):
     """string names used by the library for tagging data from requests in context"""
 
     RESULTS = "http.request.waf.results"
@@ -156,8 +139,7 @@ class WAF_CONTEXT_NAMES(object):
     CALLBACK = "http.request.waf.callback"
 
 
-@six.add_metaclass(Constant_Class)  # required for python2/3 compatibility
-class WAF_ACTIONS(object):
+class WAF_ACTIONS(metaclass=Constant_Class):
     """string identifier for actions returned by the waf"""
 
     BLOCK = "block"
@@ -176,8 +158,7 @@ class WAF_ACTIONS(object):
     }
 
 
-@six.add_metaclass(Constant_Class)  # required for python2/3 compatibility
-class PRODUCTS(object):
+class PRODUCTS(metaclass=Constant_Class):
     """string identifier for remote config products"""
 
     ASM = "ASM"
@@ -186,8 +167,7 @@ class PRODUCTS(object):
     ASM_FEATURES = "ASM_FEATURES"
 
 
-@six.add_metaclass(Constant_Class)  # required for python2/3 compatibility
-class LOGIN_EVENTS_MODE(object):
+class LOGIN_EVENTS_MODE(metaclass=Constant_Class):
     """
     string identifier for the mode of the user login events. Can be:
     DISABLED: automatic login events are disabled.
@@ -203,8 +183,7 @@ class LOGIN_EVENTS_MODE(object):
     SDK = "sdk"
 
 
-@six.add_metaclass(Constant_Class)  # required for python2/3 compatibility
-class DEFAULT(object):
+class DEFAULT(metaclass=Constant_Class):
     ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
     RULES = os.path.join(ROOT_DIR, "rules.json")
     API_SECURITY_PARAMETERS = os.path.join(ROOT_DIR, "_api_security/processors.json")


### PR DESCRIPTION
drop python 2 in appsec/_constants.py

follows https://github.com/DataDog/dd-trace-py/pull/7102

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
