### PR TITLE
fix(rcm): add git metadata to requests

### DIFF
--- a/ddtrace/internal/gitmetadata.py
+++ b/ddtrace/internal/gitmetadata.py
@@ -124,3 +124,15 @@ def clean_tags(tags):
     tags.pop(COMMIT_SHA, None)
 
     return tags
+
+
+def update_tags(tags):
+    clean_tags(tags)
+
+    repository_url, commit_sha = get_git_tags()
+
+    if repository_url:
+        tags[REPOSITORY_URL] = repository_url
+
+    if commit_sha:
+        tags[COMMIT_SHA] = commit_sha

--- a/ddtrace/internal/gitmetadata.py
+++ b/ddtrace/internal/gitmetadata.py
@@ -126,7 +126,7 @@ def clean_tags(tags):
     return tags
 
 
-def update_tags(tags):
+def add_tags(tags):
     clean_tags(tags)
 
     repository_url, commit_sha = get_git_tags()

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -179,7 +179,7 @@ class RemoteConfigClient(object):
         tags = ddtrace.config.tags.copy()
 
         # Add git metadata tags, if available
-        gitmetadata.update_tags(tags)
+        gitmetadata.add_tags(tags)
 
         if ddtrace.config.env:
             tags["env"] = ddtrace.config.env

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -21,6 +21,7 @@ import six
 import ddtrace
 from ddtrace.appsec._capabilities import _appsec_rc_capabilities
 from ddtrace.internal import agent
+from ddtrace.internal import gitmetadata
 from ddtrace.internal import runtime
 from ddtrace.internal.hostname import get_hostname
 from ddtrace.internal.logger import get_logger
@@ -176,6 +177,10 @@ class RemoteConfigClient(object):
                 self._headers["Datadog-Container-Id"] = container_id
 
         tags = ddtrace.config.tags.copy()
+
+        # Add git metadata tags, if available
+        gitmetadata.update_tags(tags)
+
         if ddtrace.config.env:
             tags["env"] = ddtrace.config.env
         if ddtrace.config.version:

--- a/ddtrace/settings/dynamic_instrumentation.py
+++ b/ddtrace/settings/dynamic_instrumentation.py
@@ -1,5 +1,6 @@
 from envier import En
 
+from ddtrace.internal import gitmetadata
 from ddtrace.internal.agent import get_trace_url
 from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
 from ddtrace.internal.utils.config import get_application_name
@@ -15,6 +16,9 @@ def _derive_tags(c):
     # type: (En) -> str
     _tags = dict(env=ddconfig.env, version=ddconfig.version, debugger_version=get_version())
     _tags.update(ddconfig.tags)
+
+    # Add git metadata tags, if available
+    gitmetadata.add_tags(_tags)
 
     return ",".join([":".join((k, v)) for (k, v) in _tags.items() if v is not None])
 

--- a/releasenotes/notes/fix-rc-git-metadata-in-request-bc95d730be17831a.yaml
+++ b/releasenotes/notes/fix-rc-git-metadata-in-request-bc95d730be17831a.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    remote config: Add git metadata to configuration requests to ensure Source
+    Code Integration (SCI) works as expected with services that require it.


### PR DESCRIPTION
We make sure that git metadata is added to the tags when making requests for configuration to the agent. This allows SCI to work as expected with services that rely on the git metadata to be transmitted with RC requests.

We also add the tags to every DI upload.

## Testing strategy

This will be covered by system tests.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
