### PR TITLE
fix(profiling): import protobuf only if needed

### DIFF
--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -27,8 +27,6 @@ from ddtrace.profiling.collector import memalloc
 from ddtrace.profiling.collector import stack
 from ddtrace.profiling.collector import stack_event
 from ddtrace.profiling.collector import threading
-from ddtrace.profiling.exporter import file
-from ddtrace.profiling.exporter import http
 from ddtrace.settings.profiling import config
 
 from . import _asyncio
@@ -138,6 +136,10 @@ class _ProfilerInstance(service.Service):
         # type: (...) -> List[exporter.Exporter]
         _OUTPUT_PPROF = config.output_pprof
         if _OUTPUT_PPROF:
+            # DEV: Import this only if needed to avoid importing protobuf
+            # unnecessarily
+            from ddtrace.profiling.exporter import file
+
             return [
                 file.PprofFileExporter(prefix=_OUTPUT_PPROF),
             ]
@@ -187,6 +189,10 @@ class _ProfilerInstance(service.Service):
             )
 
         if self._export_py_enabled:
+            # DEV: Import this only if needed to avoid importing protobuf
+            # unnecessarily
+            from ddtrace.profiling.exporter import http
+
             return [
                 http.PprofHTTPExporter(
                     service=self.service,

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -268,3 +268,4 @@ Gitlab
 Enablement
 hotspot
 CMake
+libdatadog

--- a/releasenotes/notes/fix-profiler-protobuf-if-needed-9c64068ab27e7352.yaml
+++ b/releasenotes/notes/fix-profiler-protobuf-if-needed-9c64068ab27e7352.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    profiling: Load the protobuf module only if needed to avoid interfering with
+    the module state for applications that also make use of it. The protobuf
+    module is used in file and classic Python HTTP export. It is not needed for
+    the libdatadog-based exporter.


### PR DESCRIPTION
Importing protobuf when this is a shared dependency with the tracer might cause issues. We make sure to import it only if necessary. This means that we can avoid importing the protobuf Python module when exporting exclusively via libdatadog.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
