### PR TITLE
chore(tornado): add http.route tags to tornado requests

### DIFF
--- a/ddtrace/contrib/tornado/handlers.py
+++ b/ddtrace/contrib/tornado/handlers.py
@@ -57,6 +57,14 @@ def execute(func, handler, args, kwargs):
 
         setattr(handler.request, REQUEST_SPAN_KEY, request_span)
 
+        for rule in handler.application.wildcard_router.rules:
+            if rule.matcher.match(handler.request) is not None and hasattr(rule.matcher, "_path"):
+                request_span.set_tag_str("http.route", rule.matcher._path)
+                break
+        else:
+            request_span.set_tag_str("http.route", '^$')
+
+
         return func(*args, **kwargs)
 
 

--- a/tests/contrib/tornado/test_tornado_web.py
+++ b/tests/contrib/tornado/test_tornado_web.py
@@ -42,6 +42,7 @@ class TestTornadoWeb(TornadoTestCase):
         assert "web" == request_span.span_type
         assert "tests.contrib.tornado.web.app.SuccessHandler" == request_span.resource
         assert "GET" == request_span.get_tag("http.method")
+        assert "^$" == request_span.get_tag("http.route")
         assert_span_http_status_code(request_span, 200)
         if config.tornado.trace_query_string:
             assert query_string == request_span.get_tag(http.QUERY_STRING)
@@ -84,6 +85,7 @@ class TestTornadoWeb(TornadoTestCase):
         assert_span_http_status_code(request_span, 500)
         assert self.get_url("/status_code/500") == request_span.get_tag(http.URL)
         assert 1 == request_span.error
+        assert request_span.get_tag("http.route") == "/status_code/%s"
         assert request_span.get_tag("component") == "tornado"
         assert request_span.get_tag("span.kind") == "server"
 


### PR DESCRIPTION
## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
