### PR TITLE
chore(kafka): use core api for data streams monitoring [backport 1.20]

### DIFF
--- a/ddtrace/contrib/kafka/patch.py
+++ b/ddtrace/contrib/kafka/patch.py
@@ -1,7 +1,4 @@
-import time
-
 import confluent_kafka
-from confluent_kafka import TopicPartition
 
 from ddtrace import config
 from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
@@ -20,7 +17,6 @@ from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.utils import ArgumentError
 from ddtrace.internal.utils import get_argument_value
-from ddtrace.internal.utils import set_argument_value
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.pin import Pin
 
@@ -121,37 +117,7 @@ def traced_produce(func, instance, args, kwargs):
         value = None
     message_key = kwargs.get("key", "")
     partition = kwargs.get("partition", -1)
-    if config._data_streams_enabled:
-        # inject data streams context
-        core.dispatch("kafka.produce.start", [instance, args, kwargs])
-
-        on_delivery_kwarg = "on_delivery"
-        on_delivery_arg = 5
-        on_delivery = None
-        try:
-            on_delivery = get_argument_value(args, kwargs, on_delivery_arg, on_delivery_kwarg)
-        except ArgumentError:
-            on_delivery_kwarg = "callback"
-            on_delivery_arg = 4
-            try:
-                on_delivery = get_argument_value(args, kwargs, on_delivery_arg, on_delivery_kwarg)
-            except ArgumentError:
-                on_delivery = None
-
-        def wrapped_callback(err, msg):
-            if err is None:
-                if pin.tracer.data_streams_processor:
-                    pin.tracer.data_streams_processor.track_kafka_produce(
-                        msg.topic(), msg.partition(), msg.offset() or -1, time.time()
-                    )
-            if on_delivery is not None:
-                on_delivery(err, msg)
-
-        try:
-            args, kwargs = set_argument_value(args, kwargs, on_delivery_arg, on_delivery_kwarg, wrapped_callback)
-        except ArgumentError:
-            # we set the callback even if it's not set by the client, to track produce calls correctly.
-            kwargs[on_delivery_kwarg] = wrapped_callback
+    core.dispatch("kafka.produce.start", [instance, args, kwargs])
 
     with pin.tracer.trace(
         schematize_messaging_operation(kafkax.PRODUCE, provider="kafka", direction=SpanDirection.OUTBOUND),
@@ -191,15 +157,8 @@ def traced_poll(func, instance, args, kwargs):
         span.set_tag_str(kafkax.RECEIVED_MESSAGE, str(message is not None))
         span.set_tag_str(kafkax.GROUP_ID, instance._group_id)
         if message is not None:
-            if config._data_streams_enabled:
-                core.set_item("kafka_topic", message.topic())
-                core.dispatch("kafka.consume.start", [instance, message])
-                if instance._auto_commit:
-                    # it's not exactly true, but if auto commit is enabled, we consider that a message is acknowledged
-                    # when it's read.
-                    pin.tracer.data_streams_processor.track_kafka_commit(
-                        instance._group_id, message.topic(), message.partition(), message.offset() or -1, time.time()
-                    )
+            core.set_item("kafka_topic", message.topic())
+            core.dispatch("kafka.consume.start", [instance, message])
 
             message_key = message.key() or ""
             message_offset = message.offset() or -1
@@ -220,17 +179,6 @@ def traced_commit(func, instance, args, kwargs):
     if not pin or not pin.enabled():
         return func(*args, **kwargs)
 
-    if config._data_streams_enabled:
-        message = get_argument_value(args, kwargs, 0, "message", True)
-        # message and offset are mutually exclusive. Only one parameter can be passed.
-        if message is not None:
-            offsets = [TopicPartition(message.topic(), message.partition(), offset=message.offset())]
-        else:
-            offsets = get_argument_value(args, kwargs, 1, "offsets", True)
+    core.dispatch("kafka.commit.start", [instance, args, kwargs])
 
-        if offsets:
-            for offset in offsets:
-                pin.tracer.data_streams_processor.track_kafka_commit(
-                    instance._group_id, offset.topic, offset.partition, offset.offset or -1, time.time()
-                )
     return func(*args, **kwargs)

--- a/ddtrace/internal/datastreams/__init__.py
+++ b/ddtrace/internal/datastreams/__init__.py
@@ -1,14 +1,23 @@
-from . import kafka  # noqa:F401
+from ddtrace import config
+from ddtrace.internal import agent
+
+from ...internal.utils.importlib import require_modules
 
 
+required_modules = ["confluent_kafka"]
 _processor = None
+
+if config._data_streams_enabled:
+    with require_modules(required_modules) as missing_modules:
+        if not missing_modules:
+            from . import kafka  # noqa:F401
 
 
 def data_streams_processor():
-    from . import processor
-
     global _processor
-    if not _processor:
-        _processor = processor.DataStreamsProcessor()
+    if config._data_streams_enabled and not _processor:
+        from . import processor
+
+        _processor = processor.DataStreamsProcessor(agent.get_trace_url())
 
     return _processor

--- a/ddtrace/internal/datastreams/kafka.py
+++ b/ddtrace/internal/datastreams/kafka.py
@@ -1,6 +1,7 @@
 import time
 
 from confluent_kafka import TopicPartition
+import six
 
 from ddtrace import config
 from ddtrace.internal import core
@@ -10,7 +11,7 @@ from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils import set_argument_value
 
 
-INT_TYPES = (int,)
+INT_TYPES = six.integer_types
 
 
 def dsm_kafka_message_produce(instance, args, kwargs):

--- a/ddtrace/internal/datastreams/kafka.py
+++ b/ddtrace/internal/datastreams/kafka.py
@@ -1,6 +1,16 @@
+import time
+
+from confluent_kafka import TopicPartition
+
 from ddtrace import config
 from ddtrace.internal import core
 from ddtrace.internal.datastreams.processor import PROPAGATION_KEY
+from ddtrace.internal.utils import ArgumentError
+from ddtrace.internal.utils import get_argument_value
+from ddtrace.internal.utils import set_argument_value
+
+
+INT_TYPES = (int,)
 
 
 def dsm_kafka_message_produce(instance, args, kwargs):
@@ -13,6 +23,29 @@ def dsm_kafka_message_produce(instance, args, kwargs):
     headers[PROPAGATION_KEY] = encoded_pathway
     kwargs["headers"] = headers
 
+    on_delivery_kwarg = "on_delivery"
+    on_delivery_arg = 5
+    on_delivery = None
+    try:
+        on_delivery = get_argument_value(args, kwargs, on_delivery_arg, on_delivery_kwarg)
+    except ArgumentError:
+        on_delivery_kwarg = "callback"
+        on_delivery_arg = 4
+        on_delivery = get_argument_value(args, kwargs, on_delivery_arg, on_delivery_kwarg, optional=True)
+
+    def wrapped_callback(err, msg):
+        if err is None:
+            reported_offset = msg.offset() if isinstance(msg.offset(), INT_TYPES) else -1
+            processor().track_kafka_produce(msg.topic(), msg.partition(), reported_offset, time.time())
+        if on_delivery is not None:
+            on_delivery(err, msg)
+
+    try:
+        args, kwargs = set_argument_value(args, kwargs, on_delivery_arg, on_delivery_kwarg, wrapped_callback)
+    except ArgumentError:
+        # we set the callback even if it's not set by the client, to track produce calls correctly.
+        kwargs[on_delivery_kwarg] = wrapped_callback
+
 
 def dsm_kafka_message_consume(instance, message):
     from . import data_streams_processor as processor
@@ -24,7 +57,39 @@ def dsm_kafka_message_consume(instance, message):
     ctx = processor().decode_pathway(headers.get(PROPAGATION_KEY, None))
     ctx.set_checkpoint(["direction:in", "group:" + group, "topic:" + topic, "type:kafka"])
 
+    if instance._auto_commit:
+        # it's not exactly true, but if auto commit is enabled, we consider that a message is acknowledged
+        # when it's read.
+        reported_offset = message.offset() if isinstance(message.offset(), INT_TYPES) else -1
+        processor().track_kafka_commit(
+            instance._group_id, message.topic(), message.partition(), reported_offset, time.time()
+        )
+
+
+def dsm_kafka_message_commit(instance, args, kwargs):
+    from . import data_streams_processor as processor
+
+    message = get_argument_value(args, kwargs, 0, "message", optional=True)
+
+    offsets = []
+    if message is not None:
+        # We need to add one to message offsets to make them mean the same thing as offsets
+        # passed in by the offsets keyword
+        reported_offset = message.offset() + 1 if isinstance(message.offset(), INT_TYPES) else -1
+        offsets = [TopicPartition(message.topic(), message.partition(), reported_offset)]
+    else:
+        offsets = get_argument_value(args, kwargs, 1, "offsets", True) or []
+
+    for offset in offsets:
+        # When offsets is passed in as an arg, its an exact value for the next expected message.
+        # When message is passed in Kafka reports msg.offset() + 1.  We add +1 above to message
+        # offsets to make them mean the same thing as passed in offsets, then subtract 1 universally
+        # here from both
+        reported_offset = offset.offset - 1 if isinstance(offset.offset, INT_TYPES) else -1
+        processor().track_kafka_commit(instance._group_id, offset.topic, offset.partition, reported_offset, time.time())
+
 
 if config._data_streams_enabled:
     core.on("kafka.produce.start", dsm_kafka_message_produce)
     core.on("kafka.consume.start", dsm_kafka_message_consume)
+    core.on("kafka.commit.start", dsm_kafka_message_commit)

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -1028,14 +1028,6 @@ class Tracer(object):
         """
         with self._shutdown_lock:
             # Thread safety: Ensures tracer is shutdown synchronously
-            try:
-                # Data streams tries to flush data on shutdown.
-                # Adding a try except here to ensure we don't crash the application if the agent is killed before
-                # the application for example.
-                self.data_streams_processor.shutdown(timeout)
-            except Exception as e:
-                if config._data_streams_enabled:
-                    log.warning("Failed to shutdown data streams processor: %s", repr(e))
             span_processors = self._span_processors
             deferred_processors = self._deferred_processors
             self._span_processors = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,11 +162,11 @@ exclude-modules = '''
   # TODO: resolve slot inheritance issues with profiling
   | ddtrace.profiling.collector
   | ddtrace,appsec,iast,_taint_tracking.vendor
-  | ddtrace.appsec._ddwaf.ddwaf_types
-  | ddtrace.appsec._iast._taint_tracking
-  | ddtrace.appsec._iast._ast.aspects
-  | ddtrace.appsec._iast._taint_utils
-  | ddtrace.appsec._iast.taint_sinks.sql_injection
+  | ddtrace.appsec.ddwaf.ddwaf_types
+  | ddtrace.appsec.iast._taint_tracking
+  | ddtrace.appsec.iast._ast.aspects
+  | ddtrace.appsec.iast._taint_utils
+  | ddtrace.appsec.iast.taint_sinks.sql_injection
   # DSM specific contribs
   | ddtrace.internal.datastreams.kafka
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,11 +162,13 @@ exclude-modules = '''
   # TODO: resolve slot inheritance issues with profiling
   | ddtrace.profiling.collector
   | ddtrace,appsec,iast,_taint_tracking.vendor
-  | ddtrace.appsec.ddwaf.ddwaf_types
-  | ddtrace.appsec.iast._taint_tracking
-  | ddtrace.appsec.iast._ast.aspects
-  | ddtrace.appsec.iast._taint_utils
-  | ddtrace.appsec.iast.taint_sinks.sql_injection
+  | ddtrace.appsec._ddwaf.ddwaf_types
+  | ddtrace.appsec._iast._taint_tracking
+  | ddtrace.appsec._iast._ast.aspects
+  | ddtrace.appsec._iast._taint_utils
+  | ddtrace.appsec._iast.taint_sinks.sql_injection
+  # DSM specific contribs
+  | ddtrace.internal.datastreams.kafka
 )
 '''
 

--- a/releasenotes/notes/dsm-fix-offsets-and-metrics-7e34b2734667e986.yaml
+++ b/releasenotes/notes/dsm-fix-offsets-and-metrics-7e34b2734667e986.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    DSM: fix off-by-one metric issue and error where statistics weren't calculated when the core API was used.

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -16,6 +16,8 @@ from ddtrace.contrib.kafka.patch import patch
 from ddtrace.contrib.kafka.patch import unpatch
 from ddtrace.filters import TraceFilter
 import ddtrace.internal.datastreams  # noqa: F401 - used as part of mock patching
+from ddtrace.internal.datastreams.processor import ConsumerPartitionKey
+from ddtrace.internal.datastreams.processor import PartitionKey
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from tests.contrib.config import KAFKA_CONFIG
 from tests.utils import DummyTracer
@@ -96,6 +98,29 @@ def consumer(tracer, kafka_topic):
             "auto.offset.reset": "earliest",
         }
     )
+
+    tp = TopicPartition(kafka_topic, 0)
+    tp.offset = 0  # we want to read the first message
+    _consumer.commit(offsets=[tp])
+    Pin.override(_consumer, tracer=tracer)
+    _consumer.subscribe([kafka_topic])
+    yield _consumer
+    _consumer.close()
+
+
+@pytest.fixture
+def non_auto_commit_consumer(tracer, kafka_topic):
+    _consumer = confluent_kafka.Consumer(
+        {
+            "bootstrap.servers": BOOTSTRAP_SERVERS,
+            "group.id": GROUP_ID,
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": False,
+        }
+    )
+    tp = TopicPartition(kafka_topic, 0)
+    tp.offset = 0  # we want to read the first message
+    _consumer.commit(offsets=[tp])
     Pin.override(_consumer, tracer=tracer)
     _consumer.subscribe([kafka_topic])
     yield _consumer
@@ -314,6 +339,7 @@ def test_data_streams_kafka(dsm_processor, consumer, producer, kafka_topic):
         del dsm_processor._current_context.value
     except AttributeError:
         pass
+    producer.produce(kafka_topic, PAYLOAD, key="test_key_1")
     producer.produce(kafka_topic, PAYLOAD, key="test_key_2")
     producer.flush()
     message = None
@@ -455,3 +481,103 @@ if __name__ == "__main__":
     out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, out.decode()
     assert err == b"", err.decode()
+
+
+def test_data_streams_kafka_offset_monitoring_messages(dsm_processor, non_auto_commit_consumer, producer, kafka_topic):
+    def _read_single_message(consumer):
+        message = None
+        while message is None or str(message.value()) != str(PAYLOAD):
+            message = consumer.poll(1.0)
+            if message:
+                consumer.commit(asynchronous=False, message=message)
+                return message
+
+    PAYLOAD = bytes("data streams", encoding="utf-8") if six.PY3 else bytes("data streams")
+    consumer = non_auto_commit_consumer
+    try:
+        del dsm_processor._current_context.value
+    except AttributeError:
+        pass
+    buckets = dsm_processor._buckets
+    producer.produce(kafka_topic, PAYLOAD, key="test_key_1")
+    producer.produce(kafka_topic, PAYLOAD, key="test_key_2")
+    producer.flush()
+
+    _message = _read_single_message(consumer)  # noqa: F841
+
+    assert len(buckets) == 1
+    assert list(buckets.values())[0].latest_produce_offsets[PartitionKey(kafka_topic, 0)] > 0
+    assert consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset == 1
+    assert list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey("test_group", kafka_topic, 0)] == 0
+
+    _message = _read_single_message(consumer)  # noqa: F841
+    assert consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset == 2
+    assert list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey("test_group", kafka_topic, 0)] == 1
+
+
+def test_data_streams_kafka_offset_monitoring_offsets(dsm_processor, non_auto_commit_consumer, producer, kafka_topic):
+    def _read_single_message(consumer):
+        message = None
+        while message is None or str(message.value()) != str(PAYLOAD):
+            message = consumer.poll(1.0)
+            if message and message.offset() is not None:
+                tp = TopicPartition(message.topic(), message.partition())
+                tp.offset = message.offset() + 1
+                offsets = [tp]
+
+                consumer.commit(asynchronous=False, offsets=offsets)
+                return message
+
+    consumer = non_auto_commit_consumer
+    PAYLOAD = bytes("data streams", encoding="utf-8") if six.PY3 else bytes("data streams")
+    try:
+        del dsm_processor._current_context.value
+    except AttributeError:
+        pass
+    producer.produce(kafka_topic, PAYLOAD, key="test_key_1")
+    producer.produce(kafka_topic, PAYLOAD, key="test_key_2")
+    producer.flush()
+
+    _message = _read_single_message(consumer)  # noqa: F841
+
+    buckets = dsm_processor._buckets
+    assert len(buckets) == 1
+    assert list(buckets.values())[0].latest_produce_offsets[PartitionKey(kafka_topic, 0)] > 0
+    assert consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset == 1
+    assert list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey("test_group", kafka_topic, 0)] == 0
+
+    _message = _read_single_message(consumer)  # noqa: F841
+    assert consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset == 2
+    assert list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey("test_group", kafka_topic, 0)] == 1
+
+
+def test_data_streams_kafka_offset_monitoring_auto_commit(dsm_processor, consumer, producer, kafka_topic):
+    def _read_single_message(consumer):
+        message = None
+        while message is None or str(message.value()) != str(PAYLOAD):
+            message = consumer.poll(1.0)
+            if message:
+                return message
+
+    PAYLOAD = bytes("data streams", encoding="utf-8") if six.PY3 else bytes("data streams")
+    try:
+        del dsm_processor._current_context.value
+    except AttributeError:
+        pass
+    producer.produce(kafka_topic, PAYLOAD, key="test_key_1")
+    producer.produce(kafka_topic, PAYLOAD, key="test_key_2")
+    producer.flush()
+
+    _message = _read_single_message(consumer)  # noqa: F841
+    consumer.commit(asynchronous=False)
+
+    buckets = dsm_processor._buckets
+    assert len(buckets) == 1
+    assert list(buckets.values())[0].latest_produce_offsets[PartitionKey(kafka_topic, 0)] > 0
+    assert consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset == 1
+    assert list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey("test_group", kafka_topic, 0)] == 0
+
+    _message = _read_single_message(consumer)  # noqa: F841
+    consumer.commit(asynchronous=False)
+    assert consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset == 2
+    assert list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey("test_group", kafka_topic, 0)] == 1

--- a/tests/datastreams/test_processor.py
+++ b/tests/datastreams/test_processor.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 from ddtrace.internal.datastreams.processor import ConsumerPartitionKey
@@ -52,3 +53,47 @@ def test_kafka_offset_monitoring():
     assert processor._buckets[bucket_time_ns].latest_produce_offsets[PartitionKey("topic1", 1)] == 34
     assert processor._buckets[bucket_time_ns].latest_produce_offsets[PartitionKey("topic1", 2)] == 10
     assert processor._buckets[bucket_time_ns].latest_commit_offsets[ConsumerPartitionKey("group1", "topic1", 1)] == 14
+
+
+def test_processor_atexit(ddtrace_run_python_code_in_subprocess):
+    code = """
+import pytest
+import sys
+import time
+
+from ddtrace.internal.datastreams.processor import DataStreamsProcessor
+from ddtrace.internal.atexit import register_on_exit_signal
+
+def fake_flush(*args, **kwargs):
+    print("Fake flush called")
+
+_exit = False
+def set_exit():
+    global _exit
+    _exit = True
+
+def run_test():
+    processor = DataStreamsProcessor("http://localhost:8126")
+    processor._flush_stats_with_backoff = fake_flush
+    processor.stop(5)  # Stop period processing/flushing
+
+    now = time.time()
+    processor.on_checkpoint_creation(1, 2, ["direction:out", "topic:topicA", "type:kafka"], now, 1, 1)
+    now_ns = int(now * 1e9)
+    bucket_time_ns = int(now_ns - (now_ns % 1e10))
+    aggr_key = (",".join(["direction:out", "topic:topicA", "type:kafka"]), 1, 2)
+    assert processor._buckets[bucket_time_ns].pathway_stats[aggr_key].full_pathway_latency.count == 1
+
+    counter = 0
+    while counter < 500 and not _exit:
+        counter += 1
+        time.sleep(0.1)
+
+register_on_exit_signal(set_exit)
+run_test()
+"""
+
+    env = os.environ.copy()
+    env["DD_DATA_STREAMS_ENABLED"] = "True"
+    out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env, timeout=5)
+    assert out.decode().strip() == "Fake flush called"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1117,10 +1117,14 @@ def call_program(*args, **kwargs):
     timeout = kwargs.pop("timeout", None)
     close_fds = sys.platform != "win32"
     subp = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=close_fds, **kwargs)
-    if PY2:
-        # Python 2 doesn't support timeout
-        stdout, stderr = subp.communicate()
-    else:
+    try:
+        if PY2:
+            # Python 2 doesn't support timeout
+            stdout, stderr = subp.communicate()
+        else:
+            stdout, stderr = subp.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        subp.terminate()
         stdout, stderr = subp.communicate(timeout=timeout)
     return stdout, stderr, subp.wait(), subp.pid
 


### PR DESCRIPTION
This commit swaps out all remaining DSM code in the kafka integration to
use the core API.

This commit also contains the addition of two tests and fixes to the
commit wrapper which were required to safely transition.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
