### PR TITLE
chore(asm): migrate appsec utils to drop python2 compatibility

### DIFF
--- a/ddtrace/appsec/_utils.py
+++ b/ddtrace/appsec/_utils.py
@@ -19,7 +19,7 @@ log = get_logger(__name__)
 def parse_form_params(body: str) -> Dict[str, Union[str, List[str]]]:
     """Return a dict of form data after HTTP form parsing"""
     body_params = body.replace("+", " ")
-    req_body: Dict[str, Union[str, list[str]]] = dict()
+    req_body: Dict[str, Union[str, List[str]]] = dict()
     for item in body_params.split("&"):
         key, equal, val = item.partition("=")
         if equal:

--- a/ddtrace/appsec/_utils.py
+++ b/ddtrace/appsec/_utils.py
@@ -1,29 +1,25 @@
 import os
-from typing import TYPE_CHECKING
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Union
+from urllib import parse
 
 from ddtrace.appsec import _asm_request_context
 from ddtrace.appsec._constants import API_SECURITY
 from ddtrace.constants import APPSEC_ENV
-from ddtrace.internal.compat import parse
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.http import _get_blocked_template  # noqa
 from ddtrace.settings import _config as config
 
 
-if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any
-
-    from ddtrace.internal.compat import text_type as unicode
-
-
 log = get_logger(__name__)
 
 
-def parse_form_params(body):
-    # type: (unicode) -> dict[unicode, unicode|list[unicode]]
+def parse_form_params(body: str) -> Dict[str, Union[str, List[str]]]:
     """Return a dict of form data after HTTP form parsing"""
     body_params = body.replace("+", " ")
-    req_body = dict()  # type: dict[unicode, unicode|list[unicode]]
+    req_body: Dict[str, Union[str, list[str]]] = dict()
     for item in body_params.split("&"):
         key, equal, val = item.partition("=")
         if equal:
@@ -39,8 +35,7 @@ def parse_form_params(body):
     return req_body
 
 
-def parse_form_multipart(body):
-    # type: (unicode) -> dict[unicode, Any]
+def parse_form_multipart(body: str) -> Dict[str, Any]:
     """Return a dict of form data after HTTP form parsing"""
     import email
     import json
@@ -122,14 +117,13 @@ def parse_response_body(raw_body):
         return req_body
 
 
-def _appsec_rc_features_is_enabled():
-    # type: () -> bool
+def _appsec_rc_features_is_enabled() -> bool:
     if config._remote_config_enabled:
         return APPSEC_ENV not in os.environ
     return False
 
 
-class _UserInfoRetriever(object):
+class _UserInfoRetriever:
     def __init__(self, user):
         self.user = user
 


### PR DESCRIPTION
drop python 2 and ddtrace.internal.compat dependency in appsec/_utils.py

follows https://github.com/DataDog/dd-trace-py/pull/7135

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
