### PR TITLE
chore(asm): migrate appsec handlers to drop python2 compatibility

### DIFF
--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -1,7 +1,8 @@
 import functools
+from io import BytesIO
 import json
+from json import JSONDecodeError
 
-from six import BytesIO
 from wrapt import wrap_function_wrapper as _w
 from wrapt.importer import when_imported
 import xmltodict
@@ -15,12 +16,6 @@ from ddtrace.internal import core
 from ddtrace.internal.constants import HTTP_REQUEST_BLOCKED
 from ddtrace.internal.logger import get_logger
 
-
-try:
-    from json import JSONDecodeError
-except ImportError:
-    # handling python 2.X import error
-    JSONDecodeError = ValueError  # type: ignore
 
 log = get_logger(__name__)
 _BODY_METHODS = {"POST", "PUT", "DELETE", "PATCH"}

--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -1,7 +1,6 @@
 import functools
-from io import BytesIO
+import io
 import json
-from json import JSONDecodeError
 
 from wrapt import wrap_function_wrapper as _w
 from wrapt.importer import when_imported
@@ -38,7 +37,7 @@ def _on_request_span_modifier(
             if not seekable:
                 content_length = int(environ.get("CONTENT_LENGTH", 0))
                 body = wsgi_input.read(content_length) if content_length else wsgi_input.read()
-                environ["wsgi.input"] = BytesIO(body)
+                environ["wsgi.input"] = io.BytesIO(body)
 
         try:
             if content_type == "application/json" or content_type == "text/json":
@@ -59,7 +58,7 @@ def _on_request_span_modifier(
             RuntimeError,
             TypeError,
             ValueError,
-            JSONDecodeError,
+            json.JSONDecodeError,
             xmltodict.expat.ExpatError,
             xmltodict.ParsingInterrupted,
         ):
@@ -70,7 +69,7 @@ def _on_request_span_modifier(
                 if seekable:
                     wsgi_input.seek(0)
                 else:
-                    environ["wsgi.input"] = BytesIO(body)
+                    environ["wsgi.input"] = io.BytesIO(body)
     return req_body
 
 


### PR DESCRIPTION
drop python 2 and six dependency in `appsec/_handlers.py`

follows https://github.com/DataDog/dd-trace-py/pull/7136

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
