### PR TITLE
chore(asm): migrate appsec deduplication to drop python2 compatibility

### DIFF
--- a/ddtrace/appsec/_deduplications.py
+++ b/ddtrace/appsec/_deduplications.py
@@ -10,13 +10,13 @@ class deduplication:
 
     def __init__(self, func):
         self.func = func
-        self._last_timestamp = time.time()
-        self.reported_logs = dict()  # type: Dict[int, float]
+        self._last_timestamp: float = time.time()
+        self.reported_logs: Dict[int, float] = dict()
 
-    def get_last_time_reported(self, raw_log_hash):
-        return self.reported_logs.get(raw_log_hash)
+    def get_last_time_reported(self, raw_log_hash: int) -> float:
+        return self.reported_logs.get(raw_log_hash, 0.0)
 
-    def is_deduplication_enabled(self):
+    def is_deduplication_enabled(self) -> bool:
         return asbool(os.environ.get("_DD_APPSEC_DEDUPLICATION_ENABLED", "true"))
 
     def __call__(self, *args, **kwargs):
@@ -26,7 +26,7 @@ class deduplication:
         else:
             raw_log_hash = hash("".join([str(arg) for arg in args]))
             last_reported_timestamp = self.get_last_time_reported(raw_log_hash)
-            if last_reported_timestamp is None or time.time() > last_reported_timestamp:
+            if time.time() > last_reported_timestamp:
                 result = self.func(*args, **kwargs)
                 self.reported_logs[raw_log_hash] = time.time() + self._time_lapse
         return result


### PR DESCRIPTION
drop python 2 in appsec/_deduplication.py and small refactor

follows https://github.com/DataDog/dd-trace-py/pull/7138

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
