### PR TITLE
chore(asm): migrate appsec asm_request_context to drop python2 compatibility

### DIFF
--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -1,6 +1,14 @@
 import contextlib
 import functools
-from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Generator
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Tuple
+from urllib import parse
 
 from ddtrace import config
 from ddtrace.appsec import _handlers
@@ -8,18 +16,9 @@ from ddtrace.appsec._constants import SPAN_DATA_NAMES
 from ddtrace.appsec._constants import WAF_CONTEXT_NAMES
 from ddtrace.appsec._iast._utils import _is_iast_enabled
 from ddtrace.internal import core
-from ddtrace.internal.compat import parse
 from ddtrace.internal.constants import REQUEST_PATH_PARAMS
 from ddtrace.internal.logger import get_logger
-
-
-if TYPE_CHECKING:
-    from typing import Any
-    from typing import Callable
-    from typing import Generator
-    from typing import List
-    from typing import Optional
-    from typing import Tuple
+from ddtrace.span import Span
 
 
 log = get_logger(__name__)
@@ -35,7 +34,7 @@ _BLOCK_CALL = "block"
 _WAF_RESULTS = "waf_results"
 
 
-GLOBAL_CALLBACKS = {}  # type: dict[str, Any]
+GLOBAL_CALLBACKS: Dict[str, Any] = {}
 
 
 class ASM_Environment:
@@ -45,17 +44,17 @@ class ASM_Environment:
     It is contained into a ContextVar.
     """
 
-    def __init__(self, active=False):  # type: (bool) -> None
-        self.active = active
-        self.span = None
-        self.span_asm_context = None  # type: None | contextlib.AbstractContextManager
-        self.waf_addresses = {}  # type: dict[str, Any]
-        self.callbacks = {}  # type: dict[str, Any]
-        self.telemetry = {}  # type: dict[str, Any]
-        self.addresses_sent = set()  # type: set[str]
+    def __init__(self, active: bool = False):
+        self.active: bool = active
+        self.span: Optional[Span] = None
+        self.span_asm_context: Optional[contextlib.AbstractContextManager] = None
+        self.waf_addresses: Dict[str, Any] = {}
+        self.callbacks: Dict[str, Any] = {}
+        self.telemetry: Dict[str, Any] = {}
+        self.addresses_sent: Set[str] = set()
 
 
-def _get_asm_context():
+def _get_asm_context() -> ASM_Environment:
     env = core.get_item("asm_env")
     if env is None:
         env = ASM_Environment()
@@ -63,17 +62,17 @@ def _get_asm_context():
     return env
 
 
-def free_context_available():  # type: () -> bool
+def free_context_available() -> bool:
     env = _get_asm_context()
     return env.active and env.span is None
 
 
-def in_context():  # type: () -> bool
+def in_context() -> bool:
     env = _get_asm_context()
     return env.active
 
 
-def is_blocked():  # type: () -> bool
+def is_blocked() -> bool:
     try:
         env = _get_asm_context()
         if not env.active or env.span is None:
@@ -83,7 +82,7 @@ def is_blocked():  # type: () -> bool
         return False
 
 
-def register(span, span_asm_context=None):
+def register(span: Span, span_asm_context=None) -> None:
     env = _get_asm_context()
     if not env.active:
         log.debug("registering a span with no active asm context")
@@ -92,7 +91,7 @@ def register(span, span_asm_context=None):
     env.span_asm_context = span_asm_context
 
 
-def unregister(span):
+def unregister(span: Span) -> None:
     env = _get_asm_context()
     if env.span_asm_context is not None and env.span is span:
         env.span_asm_context.__exit__(None, None, None)
@@ -136,7 +135,7 @@ class _DataHandler:
             self.active = False
 
 
-def set_value(category, address, value):  # type: (str, str, Any) -> None
+def set_value(category: str, address: str, value: Any) -> None:
     env = _get_asm_context()
     if not env.active:
         log.debug("setting %s address %s with no active asm context", category, address)
@@ -146,7 +145,7 @@ def set_value(category, address, value):  # type: (str, str, Any) -> None
         asm_context_attr[address] = value
 
 
-def set_headers_response(headers):  # type: (Any) -> None
+def set_headers_response(headers: Any) -> None:
     if headers is not None:
         set_waf_address(SPAN_DATA_NAMES.RESPONSE_HEADERS_NO_COOKIES, headers, _get_asm_context().span)
 
@@ -161,7 +160,7 @@ def set_body_response(body_response):
         set_waf_address(SPAN_DATA_NAMES.RESPONSE_BODY, parsed_body)
 
 
-def set_waf_address(address, value, span=None):  # type: (str, Any, Any) -> None
+def set_waf_address(address: str, value: Any, span: Optional[Span] = None) -> None:
     if address == SPAN_DATA_NAMES.REQUEST_URI_RAW:
         parse_address = parse.urlparse(value)
         no_scheme = parse.ParseResult("", "", *parse_address[2:])
@@ -175,7 +174,7 @@ def set_waf_address(address, value, span=None):  # type: (str, Any, Any) -> None
         core.set_item(address, value, span=span)
 
 
-def get_value(category, address, default=None):  # type: (str, str, Any) -> Any
+def get_value(category: str, address: str, default: Any = None) -> Any:
     env = _get_asm_context()
     if not env.active:
         log.debug("getting %s address %s with no active asm context", category, address)
@@ -186,11 +185,11 @@ def get_value(category, address, default=None):  # type: (str, str, Any) -> Any
     return default
 
 
-def get_waf_address(address, default=None):  # type: (str, Any) -> Any
+def get_waf_address(address: str, default: Any = None) -> Any:
     return get_value(_WAF_ADDRESSES, address, default=default)
 
 
-def get_waf_addresses(default=None):  # type: (Any) -> Any
+def get_waf_addresses(default: Any = None) -> Any:
     env = _get_asm_context()
     if not env.active:
         log.debug("getting WAF addresses with no active asm context")
@@ -198,7 +197,7 @@ def get_waf_addresses(default=None):  # type: (Any) -> Any
     return env.waf_addresses
 
 
-def add_context_callback(function, global_callback=False):  # type: (Any, bool) -> None
+def add_context_callback(function, global_callback: bool = False) -> None:
     if global_callback:
         callbacks = GLOBAL_CALLBACKS.setdefault(_CONTEXT_CALL, [])
     else:
@@ -207,7 +206,7 @@ def add_context_callback(function, global_callback=False):  # type: (Any, bool) 
         callbacks.append(function)
 
 
-def remove_context_callback(function, global_callback=False):  # type: (Any, bool) -> None
+def remove_context_callback(function, global_callback: bool = False) -> None:
     if global_callback:
         callbacks = GLOBAL_CALLBACKS.get(_CONTEXT_CALL)
     else:
@@ -216,27 +215,26 @@ def remove_context_callback(function, global_callback=False):  # type: (Any, boo
         callbacks[:] = list([cb for cb in callbacks if cb != function])
 
 
-def set_waf_callback(value):  # type: (Any) -> None
+def set_waf_callback(value) -> None:
     set_value(_CALLBACKS, _WAF_CALL, value)
 
 
-def call_waf_callback(custom_data=None):
-    # type: (dict[str, Any] | None) -> None
+def call_waf_callback(custom_data: Optional[Dict[str, Any]] = None) -> None:
     if not config._appsec_enabled:
         return
     callback = get_value(_CALLBACKS, _WAF_CALL)
     if callback:
-        return callback(custom_data)
+        callback(custom_data)
     else:
         log.warning("WAF callback called but not set")
 
 
-def set_ip(ip):  # type: (Optional[str]) -> None
+def set_ip(ip: Optional[str]) -> None:
     if ip is not None:
         set_waf_address(SPAN_DATA_NAMES.REQUEST_HTTP_IP, ip, _get_asm_context().span)
 
 
-def get_ip():  # type: () -> Optional[str]
+def get_ip() -> Optional[str]:
     return get_value(_WAF_ADDRESSES, SPAN_DATA_NAMES.REQUEST_HTTP_IP)
 
 
@@ -245,24 +243,24 @@ def get_ip():  # type: () -> Optional[str]
 # early point set_headers is usually called
 
 
-def set_headers(headers):  # type: (Any) -> None
+def set_headers(headers: Any) -> None:
     if headers is not None:
         set_waf_address(SPAN_DATA_NAMES.REQUEST_HEADERS_NO_COOKIES, headers, _get_asm_context().span)
 
 
-def get_headers():  # type: () -> Optional[Any]
+def get_headers() -> Optional[Any]:
     return get_value(_WAF_ADDRESSES, SPAN_DATA_NAMES.REQUEST_HEADERS_NO_COOKIES, {})
 
 
-def set_headers_case_sensitive(case_sensitive):  # type: (bool) -> None
+def set_headers_case_sensitive(case_sensitive: bool) -> None:
     set_waf_address(SPAN_DATA_NAMES.REQUEST_HEADERS_NO_COOKIES_CASE, case_sensitive, _get_asm_context().span)
 
 
-def get_headers_case_sensitive():  # type: () -> bool
+def get_headers_case_sensitive() -> bool:
     return get_value(_WAF_ADDRESSES, SPAN_DATA_NAMES.REQUEST_HEADERS_NO_COOKIES_CASE, False)  # type : ignore
 
 
-def set_block_request_callable(_callable):  # type: (Optional[Callable]) -> None
+def set_block_request_callable(_callable: Optional[Callable]) -> None:
     """
     Sets a callable that could be use to do a best-effort to block the request. If
     the callable need any params, like headers, they should be curried with
@@ -272,7 +270,7 @@ def set_block_request_callable(_callable):  # type: (Optional[Callable]) -> None
         set_value(_CALLBACKS, _BLOCK_CALL, _callable)
 
 
-def block_request():  # type: () -> None
+def block_request() -> None:
     """
     Calls or returns the stored block request callable, if set.
     """
@@ -283,7 +281,7 @@ def block_request():  # type: () -> None
         log.debug("Block request called but block callable not set by framework")
 
 
-def get_data_sent():  # type: () -> set[str] | None
+def get_data_sent() -> Set[str]:
     env = _get_asm_context()
     if not env.active:
         log.debug("getting addresses sent with no active asm context")
@@ -291,15 +289,19 @@ def get_data_sent():  # type: () -> set[str] | None
     return env.addresses_sent
 
 
-def asm_request_context_set(remote_ip=None, headers=None, headers_case_sensitive=False, block_request_callable=None):
-    # type: (Optional[str], Any, bool, Optional[Callable]) -> None
+def asm_request_context_set(
+    remote_ip: Optional[str] = None,
+    headers: Any = None,
+    headers_case_sensitive: bool = False,
+    block_request_callable: Optional[Callable] = None,
+) -> None:
     set_ip(remote_ip)
     set_headers(headers)
     set_headers_case_sensitive(headers_case_sensitive)
     set_block_request_callable(block_request_callable)
 
 
-def set_waf_results(result_data, result_info, is_blocked):  # type: (Any, Any, bool) -> None
+def set_waf_results(result_data, result_info, is_blocked) -> None:
     three_lists = get_waf_results()
     if three_lists is not None:
         list_results_data, list_result_info, list_is_blocked = three_lists
@@ -308,19 +310,21 @@ def set_waf_results(result_data, result_info, is_blocked):  # type: (Any, Any, b
         list_is_blocked.append(is_blocked)
 
 
-def get_waf_results():  # type: () -> Tuple[List[Any], List[Any], List[bool]] | None
+def get_waf_results() -> Optional[Tuple[List[Any], List[Any], List[bool]]]:
     return get_value(_TELEMETRY, _WAF_RESULTS)
 
 
-def reset_waf_results():  # type: () -> None
+def reset_waf_results() -> None:
     set_value(_TELEMETRY, _WAF_RESULTS, ([], [], []))
 
 
 @contextlib.contextmanager
 def asm_request_context_manager(
-    remote_ip=None, headers=None, headers_case_sensitive=False, block_request_callable=None
-):
-    # type: (Optional[str], Any, bool, Optional[Callable]) -> Generator[_DataHandler|None, None, None]
+    remote_ip: Optional[str] = None,
+    headers: Any = None,
+    headers_case_sensitive: bool = False,
+    block_request_callable: Optional[Callable] = None,
+) -> Generator[_DataHandler | None, None, None]:
     """
     The ASM context manager
     """
@@ -334,13 +338,16 @@ def asm_request_context_manager(
         yield None
 
 
-def _start_context(remote_ip, headers, headers_case_sensitive, block_request_callable):
+def _start_context(
+    remote_ip: Optional[str], headers: Any, headers_case_sensitive: bool, block_request_callable: Optional[Callable]
+) -> Optional[_DataHandler]:
     if config._appsec_enabled:
         resources = _DataHandler()
         asm_request_context_set(remote_ip, headers, headers_case_sensitive, block_request_callable)
         _handlers.listen()
         listen_context_handlers()
         return resources
+    return None
 
 
 def _on_context_started(ctx):


### PR DESCRIPTION
drop python 2 and ddtrace.internal.compat dependency in appsec/_deduplication.py
Also add more type hints.

follows https://github.com/DataDog/dd-trace-py/pull/7150

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
