### PR TITLE
fix: remove dependencies pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,12 +30,12 @@ dependencies = [
     "envier",
     "importlib_metadata; python_version<'3.8'",
     "opentelemetry-api>=1",
-    "psutil==5.6.7",
+    "psutil>=5.6.7",
     "protobuf>=3",
     "setuptools; python_version>='3.12'",
     "six>=1.12.0",
     "typing_extensions",
-    "wrapt==1.15.0",
+    "wrapt>=1.15.0",
     "xmltodict>=0.12",
 ]
 

--- a/releasenotes/notes/remove-deps-pinning-6280837438c921a1.yaml
+++ b/releasenotes/notes/remove-deps-pinning-6280837438c921a1.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    This relax some dependencies version restrictions, to avoid installation issues of ddrace 2.0.0


### PR DESCRIPTION
Pinning dependencies in a library is usually  bad practice.
Because:
* library consumers do not control its update, they can install bug
  fixes, hot fixes and security fixes of these dependencies anymore.
* wheels will not be availlable for the pinned versions on all
  platforms.
* some other libraries can't be installed anymore if their requirements
  don't stricly match the pinned version

These pins have been added here:
https://github.com/DataDog/dd-trace-py/commit/5d94749903adc48d8a890849a1494ad28cd9bc40#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L45

I don't think it was done on purpose, so I proposed to revert them.

Fixes #7144
Fixes 7142

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
