### PR TITLE
fix(lib-injection): log only to stderr when in debug mode (#6978)

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -207,6 +207,8 @@ sqlite
 stacktrace
 starlette
 statsd
+stderr
+stdout
 stringable
 subclass
 subdirectory

--- a/lib-injection/sitecustomize.py
+++ b/lib-injection/sitecustomize.py
@@ -4,6 +4,7 @@ containing the ddtrace package compatible with the current Python version and pl
 """
 import os
 import sys
+import time
 
 
 debug_mode = os.environ.get("DD_TRACE_DEBUG", "").lower() in ("true", "1", "t")
@@ -28,9 +29,10 @@ def _log(msg, *args, level="info"):
     This function is provided instead of built-in Python logging since we can't rely on any logger
     being configured.
     """
-    if not debug_mode and level == "debug":
-        return
-    print("%s:datadog.autoinstrumentation(pid: %d): " % (level.upper(), os.getpid()) + msg % args, file=sys.stderr)
+    if debug_mode:
+        asctime = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+        msg = "[%s] [%s] datadog.autoinstrumentation(pid: %d): " % (asctime, level.upper(), os.getpid()) + msg % args
+        print(msg, file=sys.stderr)
 
 
 try:

--- a/releasenotes/notes/lib-inject-logs-1b56f004763853f7.yaml
+++ b/releasenotes/notes/lib-inject-logs-1b56f004763853f7.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    lib-injection: changes the log output to opt-in. Logging to stderr could interfere with applications. Logs can still be sent to stderr using `DD_TRACE_DEBUG=1`.


### PR DESCRIPTION
The stderr logs are noisy and not actionable when running many Python scripts on a system. It is also possible that the injection breaks scripts and applications that rely on specific stderr output.

The logs can still be printed to stderr when using `DD_TRACE_DEBUG=1`.

It was considered to write the logs to [system
logs](https://docs.python.org/3/library/syslog.html) but opted against until we can better evaluate it as an approach. There are some risks like permission issues, noise and usability that need to be explored a little bit more before going ahead with it. For now we just opt into stderr logs with `DD_TRACE_DEBUG=1`.

Public docs PR: https://github.com/DataDog/documentation/pull/19944

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
