### PR TITLE
fix(iast): decouple executed sink metric call [backport 2.0]

### DIFF
--- a/ddtrace/appsec/_iast/taint_sinks/_base.py
+++ b/ddtrace/appsec/_iast/taint_sinks/_base.py
@@ -11,7 +11,6 @@ from ddtrace.internal.utils.cache import LFUCache
 from ddtrace.settings import _config
 
 from .. import oce
-from .._metrics import _set_metric_iast_executed_sink
 from .._overhead_control_engine import Operation
 from .._utils import _has_to_scrub
 from .._utils import _is_evidence_value_parts
@@ -131,8 +130,6 @@ class VulnerabilityBase(Operation):
             else:
                 log.debug("Unexpected evidence_value type: %s", type(evidence_value))
                 evidence = Evidence(value="")
-
-            _set_metric_iast_executed_sink(cls.vulnerability_type)
 
             report = core.get_item(IAST.CONTEXT_KEY, span=span)
             if report:

--- a/ddtrace/appsec/_iast/taint_sinks/ast_taint.py
+++ b/ddtrace/appsec/_iast/taint_sinks/ast_taint.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from .._metrics import _set_metric_iast_executed_sink
 from ..constants import DEFAULT_WEAK_RANDOMNESS_FUNCTIONS
 from .weak_randomness import WeakRandomness
 
@@ -26,6 +27,7 @@ def ast_funcion(
 
     if cls.__class__.__module__ == "random" and cls_name == "Random" and func_name in DEFAULT_WEAK_RANDOMNESS_FUNCTIONS:
         # Weak, run the analyzer
+        _set_metric_iast_executed_sink(WeakRandomness.vulnerability_type)
         WeakRandomness.report(evidence_value=cls_name + "." + func_name)
 
     return func(*args, **kwargs)

--- a/ddtrace/appsec/_iast/taint_sinks/command_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/command_injection.py
@@ -172,6 +172,7 @@ class CommandInjection(VulnerabilityBase):
 def _iast_report_cmdi(shell_args):
     # type: (Union[str, List[str]]) -> None
     report_cmdi = ""
+    from .._metrics import _set_metric_iast_executed_sink
     from .._taint_tracking import get_tainted_ranges
     from .._taint_tracking.aspects import join_aspect
 
@@ -184,4 +185,5 @@ def _iast_report_cmdi(shell_args):
         report_cmdi = shell_args
 
     if report_cmdi:
+        _set_metric_iast_executed_sink(CommandInjection.vulnerability_type)
         CommandInjection.report(evidence_value=report_cmdi)

--- a/ddtrace/appsec/_iast/taint_sinks/insecure_cookie.py
+++ b/ddtrace/appsec/_iast/taint_sinks/insecure_cookie.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from ddtrace.internal.compat import six
 
 from .. import oce
+from .._metrics import _set_metric_iast_executed_sink
 from ..constants import EVIDENCE_COOKIE
 from ..constants import VULN_INSECURE_COOKIE
 from ..constants import VULN_NO_HTTPONLY_COOKIE
@@ -46,10 +47,12 @@ def asm_check_cookies(cookies):  # type: (Optional[Dict[str, str]]) -> None
         evidence = "%s=%s" % (cookie_key, cookie_value)
 
         if ";secure" not in lvalue:
+            _set_metric_iast_executed_sink(InsecureCookie.vulnerability_type)
             InsecureCookie.report(evidence_value=evidence)
             return
 
         if ";httponly" not in lvalue:
+            _set_metric_iast_executed_sink(NoHttpOnlyCookie.vulnerability_type)
             NoHttpOnlyCookie.report(evidence_value=evidence)
             return
 
@@ -66,3 +69,4 @@ def asm_check_cookies(cookies):  # type: (Optional[Dict[str, str]]) -> None
 
         if report_samesite:
             NoSameSite.report(evidence_value=evidence)
+            _set_metric_iast_executed_sink(NoSameSite.vulnerability_type)

--- a/ddtrace/appsec/_iast/taint_sinks/path_traversal.py
+++ b/ddtrace/appsec/_iast/taint_sinks/path_traversal.py
@@ -47,8 +47,10 @@ def patch():
 def open_path_traversal(*args, **kwargs):
     if oce.request_has_quota and PathTraversal.has_quota():
         try:
+            from .._metrics import _set_metric_iast_executed_sink
             from .._taint_tracking import is_pyobject_tainted
 
+            _set_metric_iast_executed_sink(PathTraversal.vulnerability_type)
             if is_pyobject_tainted(args[0]):
                 PathTraversal.report(evidence_value=args[0])
         except Exception:

--- a/ddtrace/appsec/_iast/taint_sinks/weak_cipher.py
+++ b/ddtrace/appsec/_iast/taint_sinks/weak_cipher.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from ddtrace.internal.logger import get_logger
 
 from .. import oce
+from .._metrics import _set_metric_iast_executed_sink
 from .._metrics import _set_metric_iast_instrumented_sink
 from .._patch import set_and_check_module_is_patched
 from .._patch import set_module_unpatched
@@ -128,6 +129,7 @@ def wrapped_aux_blowfish_function(wrapped, instance, args, kwargs):
 @WeakCipher.wrap
 def wrapped_rc4_function(wrapped, instance, args, kwargs):
     # type: (Callable, Any, Any, Any) -> Any
+    _set_metric_iast_executed_sink(WeakCipher.vulnerability_type)
     WeakCipher.report(
         evidence_value="RC4",
     )
@@ -139,6 +141,7 @@ def wrapped_function(wrapped, instance, args, kwargs):
     # type: (Callable, Any, Any, Any) -> Any
     if hasattr(instance, "_dd_weakcipher_algorithm"):
         evidence = instance._dd_weakcipher_algorithm + "_" + str(instance.__class__.__name__)
+        _set_metric_iast_executed_sink(WeakCipher.vulnerability_type)
         WeakCipher.report(
             evidence_value=evidence,
         )
@@ -151,6 +154,7 @@ def wrapped_cryptography_function(wrapped, instance, args, kwargs):
     # type: (Callable, Any, Any, Any) -> Any
     algorithm_name = instance.algorithm.name.lower()
     if algorithm_name in get_weak_cipher_algorithms():
+        _set_metric_iast_executed_sink(WeakCipher.vulnerability_type)
         WeakCipher.report(
             evidence_value=algorithm_name,
         )

--- a/ddtrace/appsec/_iast/taint_sinks/weak_hash.py
+++ b/ddtrace/appsec/_iast/taint_sinks/weak_hash.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from ddtrace.internal.logger import get_logger
 
 from .. import oce
+from .._metrics import _set_metric_iast_executed_sink
 from .._metrics import _set_metric_iast_instrumented_sink
 from .._patch import set_and_check_module_is_patched
 from .._patch import set_module_unpatched
@@ -126,6 +127,7 @@ def patch():
 def wrapped_digest_function(wrapped, instance, args, kwargs):
     # type: (Callable, Any, Any, Any) -> Any
     if instance.name.lower() in get_weak_hash_algorithms():
+        _set_metric_iast_executed_sink(WeakHash.vulnerability_type)
         WeakHash.report(
             evidence_value=instance.name,
         )
@@ -148,6 +150,7 @@ def wrapped_sha1_function(wrapped, instance, args, kwargs):
 def wrapped_new_function(wrapped, instance, args, kwargs):
     # type: (Callable, Any, Any, Any) -> Any
     if args[0].lower() in get_weak_hash_algorithms():
+        _set_metric_iast_executed_sink(WeakHash.vulnerability_type)
         WeakHash.report(
             evidence_value=args[0].lower(),
         )
@@ -156,6 +159,7 @@ def wrapped_new_function(wrapped, instance, args, kwargs):
 
 def wrapped_function(wrapped, evidence, instance, args, kwargs):
     # type: (Callable, str, Any, Any, Any) -> Any
+    _set_metric_iast_executed_sink(WeakHash.vulnerability_type)
     WeakHash.report(
         evidence_value=evidence,
     )

--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -110,9 +110,11 @@ class TracedCursor(wrapt.ObjectProxy):
 
             if _is_iast_enabled():
                 try:
+                    from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
                     from ddtrace.appsec._iast._taint_utils import check_tainted_args
                     from ddtrace.appsec._iast.taint_sinks.sql_injection import SqlInjection
 
+                    _set_metric_iast_executed_sink(SqlInjection.vulnerability_type)
                     if check_tainted_args(args, kwargs, pin.tracer, self._self_config.integration_name, method):
                         SqlInjection.report(evidence_value=args[0])
                 except Exception:

--- a/ddtrace/contrib/dbapi_async/__init__.py
+++ b/ddtrace/contrib/dbapi_async/__init__.py
@@ -73,9 +73,11 @@ class TracedAsyncCursor(TracedCursor):
             s.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
             if _is_iast_enabled():
+                from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
                 from ddtrace.appsec._iast._taint_utils import check_tainted_args
                 from ddtrace.appsec._iast.taint_sinks.sql_injection import SqlInjection
 
+                _set_metric_iast_executed_sink(SqlInjection.vulnerability_type)
                 if check_tainted_args(args, kwargs, pin.tracer, self._self_config.integration_name, method):
                     SqlInjection.report(evidence_value=args[0])
 

--- a/releasenotes/notes/fix-executed-sink-telemetry-metric-1d961a4e618a4843.yaml
+++ b/releasenotes/notes/fix-executed-sink-telemetry-metric-1d961a4e618a4843.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    IAST: fix executed sink telemetry metric as it is not really linked to vulnerability report.


### PR DESCRIPTION
Backport 0a8275454acfd115d4cd6a05a008562175308264 from #7149 to 2.0.

IAST: Fix executed sink telemetry metric by extracting it from the report and calling it separately, as we may reach the sink point without reporting a vulnerability.

Testing strategy: Existing telemetry system tests (there is a corner case that they are not covering at the moment)

## Checklist
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
