### PR TITLE
fix(rcm): start error when remote config subscriber thread is stopped

### DIFF
--- a/ddtrace/internal/remoteconfig/_pubsub.py
+++ b/ddtrace/internal/remoteconfig/_pubsub.py
@@ -87,8 +87,8 @@ class PubSub(object):
     def start_subscriber(self):
         self._subscriber.start()
 
-    def restart_subscriber(self):
-        self._subscriber.force_restart()
+    def restart_subscriber(self, join=False):
+        self._subscriber.force_restart(join)
 
     def _poll_data(self, test_tracer=None):
         # type: (Optional[Tracer]) -> None

--- a/ddtrace/internal/remoteconfig/worker.py
+++ b/ddtrace/internal/remoteconfig/worker.py
@@ -92,7 +92,7 @@ class RemoteConfigPoller(periodic.PeriodicService):
         log.debug("[%s][P: %s] Remote Config Poller fork. Starting Pubsub services", os.getpid(), os.getppid())
         self._client.renew_id()
         for pubsub in self._client.get_pubsubs():
-            pubsub.restart_subscriber()
+            pubsub.restart_subscriber(True)
 
     def _poll_data(self, test_tracer=None):
         """Force subscribers to poll new data. This function is only used in tests"""
@@ -124,7 +124,7 @@ class RemoteConfigPoller(periodic.PeriodicService):
         forksafe.unregister(self.start_subscribers)
         atexit.unregister(self.disable)
 
-        self.stop()
+        self.stop(join=join)
 
     def _stop_service(self, *args, **kwargs):
         # type: (...) -> None
@@ -174,6 +174,7 @@ class RemoteConfigPoller(periodic.PeriodicService):
 
     def __exit__(self, *args):
         # type: (...) -> None
+        self.stop_subscribers(True)
         self.disable()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from os.path import splitext
 import subprocess
 import sys
 from tempfile import NamedTemporaryFile
+import threading
 import time
 
 from _pytest.runner import call_and_report
@@ -376,7 +377,7 @@ def git_repo(git_repo_empty):
 
 def _stop_remote_config_worker():
     if remoteconfig_poller._worker:
-        remoteconfig_poller._stop_service()
+        remoteconfig_poller._stop_service(True)
         remoteconfig_poller._worker = None
 
 
@@ -388,3 +389,7 @@ def remote_config_worker():
         yield
     finally:
         _stop_remote_config_worker()
+
+    # Check remote config poller and Subscriber threads stop correctly
+    # we have 2 threads: main thread and telemetry thread. TODO: verify if that alive thread is a bug
+    assert threading.active_count() == 2


### PR DESCRIPTION
When the remote config poller is trying to start a stopped subscriber, `Subscriber.is_running` is False (OK), but `Subscriber._th_worker` is a stopped thread (ERROR: the thread `_th_worker` must be equal to None).

This PR introduces:
- Validation that the thread is None before trying to start it.
- Setting it to None when calling `Subscriber.stop`. If not, an exception is raised when calling `Subscriber._th_worker.start()` on a stopped thread.
- Joining threads when stopping them in tests. We had a potential flaky test error because subscribers were not stopped correctly.

Extra ball: Removed an unnecessary loop on `_th_worker` (PeriodicThread).


## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
