### PR TITLE
chore(tests): remove duplicate test behavior in requests

### DIFF
--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -652,7 +652,6 @@ class BotocoreTest(TracerTestCase):
         assert len(response["Messages"]) == 1
         trace_json_message = response["Messages"][0]["MessageAttributes"]["_datadog"]["StringValue"]
         trace_data_in_message = json.loads(trace_json_message)
-        assert trace_data_in_message[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
         assert trace_data_in_message[HTTP_HEADER_PARENT_ID] == str(span.span_id)
 
     @mock_sqs
@@ -699,7 +698,6 @@ class BotocoreTest(TracerTestCase):
         assert len(response["Messages"]) == 1
         trace_json_message = response["Messages"][0]["MessageAttributes"]["_datadog"]["StringValue"]
         trace_data_in_message = json.loads(trace_json_message)
-        assert trace_data_in_message[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
         assert trace_data_in_message[HTTP_HEADER_PARENT_ID] == str(span.span_id)
 
     @mock_sqs
@@ -1571,7 +1569,6 @@ class BotocoreTest(TracerTestCase):
         detail = body_obj.get("detail")
         headers = detail.get("_datadog")
         assert headers is not None
-        assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
         assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
 
     @mock_events
@@ -1628,7 +1625,6 @@ class BotocoreTest(TracerTestCase):
         detail = body_obj.get("detail")
         headers = detail.get("_datadog")
         assert headers is not None
-        assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
         assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
 
         # the following doesn't work due to an issue in moto/localstack where
@@ -2020,7 +2016,6 @@ class BotocoreTest(TracerTestCase):
         datadog_value_decoded = base64.b64decode(msg_attr["_datadog"]["Value"])
         headers = json.loads(datadog_value_decoded.decode())
         assert headers is not None
-        assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
         assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
 
     @mock_sns
@@ -2093,7 +2088,6 @@ class BotocoreTest(TracerTestCase):
         datadog_value_decoded = base64.b64decode(msg_attr["_datadog"]["Value"])
         headers = json.loads(datadog_value_decoded.decode())
         assert headers is not None
-        assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
         assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
 
     @mock_sns
@@ -2229,7 +2223,6 @@ class BotocoreTest(TracerTestCase):
         assert msg_attr.get("_datadog") is not None
         headers = json.loads(base64.b64decode(msg_attr["_datadog"]["Value"]))
         assert headers is not None
-        assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
         assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
 
     @pytest.mark.skipif(
@@ -2304,7 +2297,6 @@ class BotocoreTest(TracerTestCase):
         assert msg_attr.get("_datadog") is not None
         headers = json.loads(base64.b64decode(msg_attr["_datadog"]["Value"]))
         assert headers is not None
-        assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
         assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
 
     @mock_sns
@@ -2434,7 +2426,6 @@ class BotocoreTest(TracerTestCase):
             decoded_record_data_json = json.loads(decoded_record_data)
             headers = decoded_record_data_json["_datadog"]
             assert headers is not None
-            assert headers[HTTP_HEADER_TRACE_ID] == str(span.trace_id)
             assert headers[HTTP_HEADER_PARENT_ID] == str(span.span_id)
         except Exception:
             # injection was not successful, so record should be exceeding 1MB in size

--- a/tests/contrib/requests/test_requests_distributed.py
+++ b/tests/contrib/requests/test_requests_distributed.py
@@ -14,7 +14,6 @@ class TestRequestsDistributed(BaseRequestTestCase, TracerTestCase):
         headers = request.headers
         assert "x-datadog-trace-id" in headers
         assert "x-datadog-parent-id" in headers
-        assert str(root_span.trace_id) == headers["x-datadog-trace-id"]
         req_span = tracer.current_span()
         assert "requests.request" == req_span.name
         assert str(req_span.span_id) == headers["x-datadog-parent-id"]


### PR DESCRIPTION
In preparation for changing the default propagation style to 128-bit trace ids: 
The checking of the trace_id with regards to what's injected duplicates the testing done in test_propagation.py. I was originally thinking to delete the entire file, but it does test distributed tracing settings at an integration level, which test_propagation.py does not.

Original thought:
"To me it seems like the requests contrib shouldn’t have to know or evaluate anything having to do with the expected headers of propagation. To make these tests work with 128 bit, I’ll need to import a specific propagation style’s methods, or copy and paste code for parsing the headers correctly. It seems like we test this kind of stuff enough in [test_propagation.py](https://github.com/DataDog/dd-trace-py/blob/2.x/tests/tracer/test_propagation.py), and that these tests were added many years ago, before we broke out testing like this."

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
