### PR TITLE
POC ci: add optional cleanenv subprocess mark kwarg to avoid CI env leaking into test env

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -42,7 +42,6 @@ def pytest_configure(config):
                 env: the environment variables to override for the subprocess.
                 cleanenv: boolean defining whether or not the environment should
                     be cleaned first
-                usedefaultenv: use the predefined default environment
                 parametrize: whether to parametrize the test function. This is
                     similar to the `parametrize` marker, but arguments are
                     passed to the subprocess via environment variables.

--- a/conftest.py
+++ b/conftest.py
@@ -40,8 +40,8 @@ def pytest_configure(config):
                 err: the expected stderr of the subprocess, or None to ignore.
                 args: the command line arguments to pass to the subprocess.
                 env: the environment variables to override for the subprocess.
-                cleanenv: boolean defining whether or not the environment should
-                    be cleaned first
+                passenv: boolean defining whether or not the subprocess
+                    environment should inherit the original environment
                 parametrize: whether to parametrize the test function. This is
                     similar to the `parametrize` marker, but arguments are
                     passed to the subprocess via environment variables.

--- a/conftest.py
+++ b/conftest.py
@@ -40,6 +40,9 @@ def pytest_configure(config):
                 err: the expected stderr of the subprocess, or None to ignore.
                 args: the command line arguments to pass to the subprocess.
                 env: the environment variables to override for the subprocess.
+                cleanenv: boolean defining whether or not the environment should
+                    be cleaned first
+                usedefaultenv: use the predefined default environment
                 parametrize: whether to parametrize the test function. This is
                     similar to the `parametrize` marker, but arguments are
                     passed to the subprocess via environment variables.

--- a/riotfile.py
+++ b/riotfile.py
@@ -105,6 +105,7 @@ venv = Venv(
         "DD_CIVISIBILITY_ITR_ENABLED": "1",
         "DD_PATCH_MODULES": "unittest:false",
         "CMAKE_BUILD_PARALLEL_LEVEL": "12",
+        "DD_ENV": "circleci",
     },
     venvs=[
         Venv(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,9 @@ from tests.utils import request_token
 from tests.utils import snapshot_context as _snapshot_context
 
 
+DEFAULT_SUBPROCESS_ENV = {}
+
+
 def pytest_configure(config):
     config.addinivalue_line(
         "markers", "snapshot(*args, **kwargs): mark test to run as a snapshot test which sends traces to the test agent"
@@ -205,7 +208,14 @@ def run_function_from_file(item, params=None):
         args.append("-m")
 
     # Override environment variables for the subprocess
-    env = os.environ.copy()
+    if marker.kwargs.get("cleanenv", False):
+        env = {}
+    else:
+        env = os.environ.copy()
+
+    if marker.kwargs.get("usedefaultenv", False):
+        env.update(DEFAULT_SUBPROCESS_ENV)
+
     pythonpath = os.getenv("PYTHONPATH", None)
     base_path = os.path.dirname(os.path.dirname(__file__))
     env["PYTHONPATH"] = os.pathsep.join((base_path, pythonpath)) if pythonpath is not None else base_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,9 +25,6 @@ from tests.utils import request_token
 from tests.utils import snapshot_context as _snapshot_context
 
 
-DEFAULT_SUBPROCESS_ENV = {}
-
-
 def pytest_configure(config):
     config.addinivalue_line(
         "markers", "snapshot(*args, **kwargs): mark test to run as a snapshot test which sends traces to the test agent"
@@ -212,9 +209,6 @@ def run_function_from_file(item, params=None):
         env = {}
     else:
         env = os.environ.copy()
-
-    if marker.kwargs.get("usedefaultenv", False):
-        env.update(DEFAULT_SUBPROCESS_ENV)
 
     pythonpath = os.getenv("PYTHONPATH", None)
     base_path = os.path.dirname(os.path.dirname(__file__))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,11 +204,11 @@ def run_function_from_file(item, params=None):
     if run_module:
         args.append("-m")
 
+    env = {}
+
     # Override environment variables for the subprocess
-    if marker.kwargs.get("cleanenv", False):
-        env = {}
-    else:
-        env = os.environ.copy()
+    if marker.kwargs.get("passenv", False):
+        env.update(os.environ)
 
     pythonpath = os.getenv("PYTHONPATH", None)
     base_path = os.path.dirname(os.path.dirname(__file__))

--- a/tests/tracer/runtime/test_runtime_metrics.py
+++ b/tests/tracer/runtime/test_runtime_metrics.py
@@ -70,7 +70,7 @@ class TestRuntimeTags(TracerTestCase):
                 assert tags == [("env", "staging.dog")]
 
 
-@pytest.mark.subprocess(cleanenv=True)
+@pytest.mark.subprocess()
 def test_runtime_tags_empty():
     from ddtrace.internal.runtime.runtime_metrics import RuntimeTags
 
@@ -81,7 +81,7 @@ def test_runtime_tags_empty():
     assert set(tags.keys()) == set(["lang", "lang_interpreter", "lang_version", "tracer_version"])
 
 
-@pytest.mark.subprocess(env={"DD_SERVICE": "my-service", "DD_ENV": "test-env", "DD_VERSION": "1.2.3"}, cleanenv=True)
+@pytest.mark.subprocess(env={"DD_SERVICE": "my-service", "DD_ENV": "test-env", "DD_VERSION": "1.2.3"})
 def test_runtime_tags_usm():
     from ddtrace.internal.runtime.runtime_metrics import RuntimeTags
 
@@ -97,7 +97,7 @@ def test_runtime_tags_usm():
     assert tags["version"] == "1.2.3"
 
 
-@pytest.mark.subprocess(env={"DD_TAGS": "version:1.2.3,custom:tag,test:key", "DD_VERSION": "4.5.6"}, cleanenv=True)
+@pytest.mark.subprocess(env={"DD_TAGS": "version:1.2.3,custom:tag,test:key", "DD_VERSION": "4.5.6"})
 def test_runtime_tags_dd_tags():
     from ddtrace.internal.runtime.runtime_metrics import RuntimeTags
 
@@ -113,7 +113,7 @@ def test_runtime_tags_dd_tags():
     assert tags["version"] == "4.5.6"
 
 
-@pytest.mark.subprocess(cleanenv=True)
+@pytest.mark.subprocess()
 def test_runtime_tags_manual_tracer_tags():
     from ddtrace import tracer
     from ddtrace.internal.runtime.runtime_metrics import RuntimeTags

--- a/tests/tracer/runtime/test_runtime_metrics.py
+++ b/tests/tracer/runtime/test_runtime_metrics.py
@@ -70,7 +70,7 @@ class TestRuntimeTags(TracerTestCase):
                 assert tags == [("env", "staging.dog")]
 
 
-@pytest.mark.subprocess(env={})
+@pytest.mark.subprocess(cleanenv=True)
 def test_runtime_tags_empty():
     from ddtrace.internal.runtime.runtime_metrics import RuntimeTags
 
@@ -81,7 +81,7 @@ def test_runtime_tags_empty():
     assert set(tags.keys()) == set(["lang", "lang_interpreter", "lang_version", "tracer_version"])
 
 
-@pytest.mark.subprocess(env={"DD_SERVICE": "my-service", "DD_ENV": "test-env", "DD_VERSION": "1.2.3"})
+@pytest.mark.subprocess(env={"DD_SERVICE": "my-service", "DD_ENV": "test-env", "DD_VERSION": "1.2.3"}, cleanenv=True)
 def test_runtime_tags_usm():
     from ddtrace.internal.runtime.runtime_metrics import RuntimeTags
 
@@ -97,7 +97,7 @@ def test_runtime_tags_usm():
     assert tags["version"] == "1.2.3"
 
 
-@pytest.mark.subprocess(env={"DD_TAGS": "version:1.2.3,custom:tag,test:key", "DD_VERSION": "4.5.6"})
+@pytest.mark.subprocess(env={"DD_TAGS": "version:1.2.3,custom:tag,test:key", "DD_VERSION": "4.5.6"}, cleanenv=True)
 def test_runtime_tags_dd_tags():
     from ddtrace.internal.runtime.runtime_metrics import RuntimeTags
 
@@ -113,7 +113,7 @@ def test_runtime_tags_dd_tags():
     assert tags["version"] == "4.5.6"
 
 
-@pytest.mark.subprocess()
+@pytest.mark.subprocess(cleanenv=True)
 def test_runtime_tags_manual_tracer_tags():
     from ddtrace import tracer
     from ddtrace.internal.runtime.runtime_metrics import RuntimeTags

--- a/tests/tracer/runtime/test_tag_collectors.py
+++ b/tests/tracer/runtime/test_tag_collectors.py
@@ -71,7 +71,7 @@ def test_tracer_tags_config():
     )
 
 
-@pytest.mark.subprocess()
+@pytest.mark.subprocess(cleanenv=True)
 def test_tracer_tags_service_from_code():
     """Ensure we collect the expected tags for the TracerTagCollector"""
     import ddtrace

--- a/tests/tracer/test_logger.py
+++ b/tests/tracer/test_logger.py
@@ -410,6 +410,7 @@ class DDLoggerTestCase(BaseTestCase):
 @pytest.mark.subprocess(
     ddtrace_run=True,
     env={"DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE": "true"},
+    passenv=True,
     out=lambda _: "MyThread - ERROR - Hello from thread" in _ and "Dummy" not in _,
 )
 def test_logger_no_dummy_thread_name_after_module_cleanup():


### PR DESCRIPTION
This introduces a `cleanenv` kwargs to the `subprocess` mark that avoids coping `os.environ`, and prevents things like adding a new environment variable in CircleCI from breaking unit tests.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
