### PR TITLE
fix(langchain): avoid direct root imports from langchain

### DIFF
--- a/ddtrace/contrib/langchain/constants.py
+++ b/ddtrace/contrib/langchain/constants.py
@@ -27,7 +27,7 @@ text_embedding_models = (
     "EmbaasEmbeddings",
 )
 
-vectorstores = (
+vectorstore_classes = (
     "AzureSearch",
     "Redis",
     "ElasticVectorSearch",

--- a/ddtrace/contrib/langchain/patch.py
+++ b/ddtrace/contrib/langchain/patch.py
@@ -20,7 +20,7 @@ from ddtrace.contrib.langchain.constants import PROVIDER
 from ddtrace.contrib.langchain.constants import TOTAL_COST
 from ddtrace.contrib.langchain.constants import TYPE
 from ddtrace.contrib.langchain.constants import text_embedding_models
-from ddtrace.contrib.langchain.constants import vectorstores
+from ddtrace.contrib.langchain.constants import vectorstore_classes
 from ddtrace.contrib.trace_utils import unwrap
 from ddtrace.contrib.trace_utils import with_traced_module
 from ddtrace.contrib.trace_utils import wrap
@@ -756,6 +756,14 @@ def patch():
             )
         integration.start_log_writer()
 
+    # Langchain doesn't allow wrapping directly from root, so we have to import the base classes first before wrapping.
+    # ref: https://github.com/DataDog/dd-trace-py/issues/7123
+    from langchain import embeddings  # noqa
+    from langchain import vectorstores  # noqa
+    from langchain.chains.base import Chain  # noqa
+    from langchain.chat_models.base import BaseChatModel  # noqa
+    from langchain.llms.base import BaseLLM  # noqa
+
     wrap("langchain", "llms.base.BaseLLM.generate", traced_llm_generate(langchain))
     wrap("langchain", "llms.base.BaseLLM.agenerate", traced_llm_agenerate(langchain))
     wrap("langchain", "chat_models.base.BaseChatModel.generate", traced_chat_model_generate(langchain))
@@ -777,7 +785,7 @@ def patch():
                 wrap("langchain", "embeddings.%s.embed_documents" % text_embedding_model, traced_embedding(langchain))
                 # TODO: langchain >= 0.0.209 includes async embedding implementation (only for OpenAI)
     # We need to do the same with Vectorstores.
-    for vectorstore in vectorstores:
+    for vectorstore in vectorstore_classes:
         if hasattr(langchain.vectorstores, vectorstore):
             # Ensure not double patched, as some Embeddings interfaces are pointers to other Embeddings.
             if not isinstance(
@@ -809,7 +817,7 @@ def unpatch():
                 deep_getattr(langchain.embeddings, "%s.embed_documents" % text_embedding_model), wrapt.ObjectProxy
             ):
                 unwrap(getattr(langchain.embeddings, text_embedding_model), "embed_documents")
-    for vectorstore in vectorstores:
+    for vectorstore in vectorstore_classes:
         if hasattr(langchain.vectorstores, vectorstore):
             if isinstance(
                 deep_getattr(langchain.vectorstores, "%s.similarity_search" % vectorstore), wrapt.ObjectProxy

--- a/releasenotes/notes/langchain-fix-imports-dddd44cd581e6baa.yaml
+++ b/releasenotes/notes/langchain-fix-imports-dddd44cd581e6baa.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    langchain: This fix resolves an import error with patching langchain versions newer than 0.0.300 due to
+    langchain dropping support for wrapping or importing directly from root. 

--- a/tests/contrib/langchain/test_langchain_patch.py
+++ b/tests/contrib/langchain/test_langchain_patch.py
@@ -2,7 +2,7 @@ from ddtrace.contrib.langchain import get_version
 from ddtrace.contrib.langchain import patch
 from ddtrace.contrib.langchain import unpatch
 from ddtrace.contrib.langchain.constants import text_embedding_models
-from ddtrace.contrib.langchain.constants import vectorstores
+from ddtrace.contrib.langchain.constants import vectorstore_classes
 from tests.contrib.patch import PatchTestCase
 
 
@@ -24,7 +24,7 @@ class TestLangchainPatch(PatchTestCase.Base):
             if embedding_model:
                 self.assert_wrapped(embedding_model.embed_query)
                 self.assert_wrapped(embedding_model.embed_documents)
-        for vectorstore in vectorstores:
+        for vectorstore in vectorstore_classes:
             vectorstore_interface = getattr(langchain.vectorstores, vectorstore, None)
             if vectorstore_interface:
                 self.assert_wrapped(vectorstore_interface.similarity_search)
@@ -41,7 +41,7 @@ class TestLangchainPatch(PatchTestCase.Base):
             if embedding_model:
                 self.assert_not_wrapped(embedding_model.embed_query)
                 self.assert_not_wrapped(embedding_model.embed_documents)
-        for vectorstore in vectorstores:
+        for vectorstore in vectorstore_classes:
             vectorstore_interface = getattr(langchain.vectorstores, vectorstore, None)
             if vectorstore_interface:
                 self.assert_not_wrapped(vectorstore_interface.similarity_search)
@@ -58,7 +58,7 @@ class TestLangchainPatch(PatchTestCase.Base):
             if embedding_model:
                 self.assert_not_double_wrapped(embedding_model.embed_query)
                 self.assert_not_double_wrapped(embedding_model.embed_documents)
-        for vectorstore in vectorstores:
+        for vectorstore in vectorstore_classes:
             vectorstore_interface = getattr(langchain.vectorstores, vectorstore, None)
             if vectorstore_interface:
                 self.assert_not_double_wrapped(vectorstore_interface.similarity_search)


### PR DESCRIPTION
Fixes #7123.

This PR fixes an issue brought up with `langchain>=0.0.300` where directly importing from langchain root is not supported anymore, which was previously not an issue in our patch wrapping code. The fix was to import the base modules containing the functions this integration wraps around before wrapping to get around the import error from trying to access directly from langchain root.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
