### PR TITLE
docs: correct dogstatsd example configuration

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -178,9 +178,9 @@ The following environment variables for the tracer are supported:
          ``udp://`` to connect using UDP or with ``unix://`` to use a Unix
          Domain Socket.
 
-         Example for UDP url: ``DD_TRACE_AGENT_URL=udp://localhost:8125``
+         Example for UDP url: ``DD_DOGSTATSD_URL=udp://localhost:8125``
 
-         Example for UDS: ``DD_TRACE_AGENT_URL=unix:///var/run/datadog/dsd.socket``
+         Example for UDS: ``DD_DOGSTATSD_URL=unix:///var/run/datadog/dsd.socket``
 
    DD_TRACE_AGENT_TIMEOUT_SECONDS:
      type: Float


### PR DESCRIPTION
The example for Dogstatsd configuration was incorrect.

<img width="761" alt="image" src="https://github.com/DataDog/dd-trace-py/assets/155673/1359fc1c-0b50-4e2a-85c5-b2dde1147bf5">

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
