### PR TITLE
fix(lib-inject): set correct permissions on package files

### DIFF
--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -88,8 +88,10 @@ jobs:
            cd lib-injection
            # Ensure /datadog-lib/ddtrace_pkgs is a valid directory that is not empty
            docker-compose run lib_inject find /datadog-init/ddtrace_pkgs -maxdepth 0 -empty | wc -l && if [ $? -ne 0 ]; then exit 1; fi
-           # Ensure non-datadog users have read and write permissions to files stored in /datadog-lib/ddtrace_pkgs
-           docker-compose run lib_inject find /datadog-init/ddtrace_pkgs ! -perm -a=rw | wc -l && if [ $? -ne 0 ]; then exit 1; fi
+           # Ensure files are not world writeable
+           docker-compose run lib_inject find /datadog-init/ddtrace_pkgs ! -perm /o+w | wc -l && if [ $? -ne 0 ]; then exit 1; fi
+           # Ensure non-datadog users have read  permissions to files stored in /datadog-lib/ddtrace_pkgs
+           docker-compose run lib_inject find /datadog-init/ddtrace_pkgs ! -perm -a=r | wc -l && if [ $? -ne 0 ]; then exit 1; fi
       - name: Test the app
         run: |
           curl http://localhost:18080

--- a/.gitlab/build-deb-rpm.sh
+++ b/.gitlab/build-deb-rpm.sh
@@ -33,6 +33,9 @@ echo `pwd`
 
 cp ../lib-injection/sitecustomize.py dd-trace.dir/lib/
 
+chmod -R o-w dd-trace.dir/lib
+chmod -R g-w dd-trace.dir/lib
+
 cp auto_inject-python.version dd-trace.dir/lib/version
 
 fpm_wrapper "datadog-apm-library-python" "$PYTHON_PACKAGE_VERSION" \

--- a/lib-injection/Dockerfile
+++ b/lib-injection/Dockerfile
@@ -29,7 +29,8 @@ ARG UID=10000
 RUN addgroup -g 10000 -S datadog && \
     adduser -u ${UID} -S datadog -G datadog
 RUN chown -R datadog:datadog /datadog-init/ddtrace_pkgs
-RUN chmod -R a+rw /datadog-init/ddtrace_pkgs
+RUN chmod -R o-w /datadog-init/ddtrace_pkgs
+RUN chmod -R g-w /datadog-init/ddtrace_pkgs
 USER ${UID}
 WORKDIR /datadog-init
 ADD sitecustomize.py /datadog-init/sitecustomize.py

--- a/releasenotes/notes/lib-inject-permissions-8222a09585eb5350.yaml
+++ b/releasenotes/notes/lib-inject-permissions-8222a09585eb5350.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    lib-injection: Update package files to not be world-writable.


### PR DESCRIPTION
Package files should not be world-writable. Users noticed injected ddtrace package files being flagged by security scanners.

In particular the `bytecode` package in Python 3.7 includes world-writable sources files.

## Testing

The existing tests should cover that the feature still works in the K8s library injection. The existing assertion for the permissions on the files is updated to assert that the permission is correctly applied to all package files.

For the deb/rpm I manually tested the commands that the build runs and validated that the files are not world-writable.

## Risk

There may be unknown situations where Python packages require these permissions. In the worst-case with these situations the application may crash due to an unexpected exception at runtime.


## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
