### PR TITLE
fix(asm): fix segfault in IAST for f-string formatting of non-text values

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -378,7 +378,7 @@ def format_value_aspect(
     else:
         new_text = element
     if not isinstance(new_text, TEXT_TYPES):
-        return new_text
+        return format(new_text)
 
     try:
         if format_spec:

--- a/releasenotes/notes/iast-fix-fstring-format-d8f0fc1533c75cdb.yaml
+++ b/releasenotes/notes/iast-fix-fstring-format-d8f0fc1533c75cdb.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ASM: This fix resolves an issue where an f-string expression would not be formatted properly causing a segfault if IAST is enabled.

--- a/tests/appsec/iast/aspects/test_str_py3.py
+++ b/tests/appsec/iast/aspects/test_str_py3.py
@@ -100,3 +100,17 @@ class TestOperatorsReplacement(BaseReplacement):
         result = mod_py3.do_repr_fstring_with_format_twice(obj)  # pylint: disable=no-member
         assert result == "foo a      foo a      "
         assert as_formatted_evidence(result) == ":+-foo-+: a      :+-foo-+: a      "
+
+    @pytest.mark.parametrize(
+        "function",
+        [
+            mod_py3.do_repr_fstring_with_expression1,
+            mod_py3.do_repr_fstring_with_expression2,
+            mod_py3.do_repr_fstring_with_expression3,
+            mod_py3.do_repr_fstring_with_expression4,
+            mod_py3.do_repr_fstring_with_expression5,
+        ],
+    )
+    def test_string_fstring_non_string(self, function):  # type: () -> None
+        result = function()  # pylint: disable=no-member
+        assert result == "Hello world, True!"

--- a/tests/appsec/iast/fixtures/aspects/str_methods_py3.py
+++ b/tests/appsec/iast/fixtures/aspects/str_methods_py3.py
@@ -33,6 +33,28 @@ def do_repr_fstring_with_format_twice(a):  # type: (Any) -> str
     return f"{a!r:10} {a!r:11}"
 
 
+def do_repr_fstring_with_expression1():  # type: (Any) -> str
+    return f"Hello world, {False or True}!"
+
+
+def do_repr_fstring_with_expression2():  # type: (Any) -> str
+    return f"Hello world, {'True' * 1}!"
+
+
+def do_repr_fstring_with_expression3():  # type: (Any) -> str
+    return f"Hello world, {'true'.capitalize()}!"
+
+
+def do_repr_fstring_with_expression4():  # type: (Any) -> str
+    import math
+
+    return f"Hello world, {math.sin(5.5) <= 0}!"
+
+
+def do_repr_fstring_with_expression5():  # type: (Any) -> str
+    return f"Hello world, {str([False, False, True, False][400 % 199]).lower().capitalize()}!"
+
+
 class Resolver404(Exception):
     pass
 


### PR DESCRIPTION
IAST: There was a missing step in the construction of f-strings replacements for IAST patching, where non-string values should be formatted. This was causing a segfault in those cases, and this PR should fix them. 

As you can see in the PEP 498, in the code equivalence section, a format call is performed: https://peps.python.org/pep-0498/#code-equivalence

Also add unit tests as regression tests.

## Checklist
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
