### PR TITLE
chore(internal): improve the usability of the core API

### DIFF
--- a/tests/internal/test_context_events_api.py
+++ b/tests/internal/test_context_events_api.py
@@ -49,8 +49,8 @@ class TestContextEventsApi(unittest.TestCase):
         core.on(event_name, lambda magic_number: handler_return.format(magic_number))
         core.on(event_name, lambda another_magic_number: handler_return + str(another_magic_number) + "!")
         results, _ = core.dispatch(event_name, [dynamic_value])
-        assert results[0] == handler_return.format(dynamic_value)
-        assert results[1] == handler_return + str(dynamic_value) + "!"
+        assert results[1] == handler_return.format(dynamic_value)
+        assert results[0] == handler_return + str(dynamic_value) + "!"
 
     def test_core_dispatch_multiple_listeners_multiple_threads(self):
         event_name = "my.cool.event"
@@ -60,8 +60,6 @@ class TestContextEventsApi(unittest.TestCase):
                 def listener():
                     if make_target_id % 2 == 0:
                         return make_target_id * 2
-                    else:
-                        raise ValueError
 
                 core.on(event_name, listener)
 
@@ -84,11 +82,6 @@ class TestContextEventsApi(unittest.TestCase):
         expected = list(i * 2 for i in range(thread_count) if i % 2 == 0)
         assert sorted(results) == sorted(expected)
         assert len(exceptions) <= thread_count
-        for idx, exception in enumerate(exceptions):
-            if idx % 2 == 0:
-                assert exception is None
-            else:
-                assert isinstance(exception, ValueError)
 
     def test_core_dispatch_context_ended(self):
         context_id = "my.cool.context"


### PR DESCRIPTION
This pull request makes some small quality-of-life improvements to the Core API.

## Changes
* Switches the default position of new `core.on` listeners to the beginning of the list rather than the end
* Changes testing configuration to allow exceptions from `core.dispatch` handlers to bubble up during test runs
* Allow optional traversal up the tree of `ExecutionContext`s when searching for data in `get_item` calls
* Adds `core.root` attribute providing access to the root context

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
