### PR TITLE
chore(ci): pin the library version being built

### DIFF
--- a/.gitlab/build-deb-rpm.sh
+++ b/.gitlab/build-deb-rpm.sh
@@ -23,7 +23,7 @@ echo `pwd`
     --python-version=3.9 \
     --python-version=3.8 \
     --python-version=3.7 \
-    --ddtrace-version=$PYTHON_PACKAGE_VERSION  \
+    --ddtrace-version=1.20.4 \
     --arch x86_64 \
     --arch aarch64 \
     --platform musllinux_1_1 \

--- a/lib-injection/Dockerfile
+++ b/lib-injection/Dockerfile
@@ -15,7 +15,7 @@ RUN python3 dl_wheels.py \
         --python-version=3.9 \
         --python-version=3.8 \
         --python-version=3.7 \
-        --ddtrace-version=${DDTRACE_PYTHON_VERSION} \
+        --ddtrace-version=1.20.4 \
         --arch x86_64 \
         --arch aarch64 \
         --platform musllinux_1_1 \

--- a/releasenotes/notes/lib-inject-version-9236836076cc3c79.yaml
+++ b/releasenotes/notes/lib-inject-version-9236836076cc3c79.yaml
@@ -1,0 +1,5 @@
+---
+issues:
+  - |
+    lib-injection: The v1.20.5 release version has no library code changes and
+      will install the v1.20.4 version of `ddtrace``.


### PR DESCRIPTION
There are no code changes in `1.20.5` only packaging updates so we can safely use the previous tracer version. This allows us to rapidly get fix `1.20.5` out without waiting for the corresponding PyPI build to finish which takes 4+ hours.

The risk is that users who are confused when manually specifying version `1.20.5` in their K8s chart or deb/rpm install will see ``ddtrace`` version [`1.20.4`](https://pypi.org/project/ddtrace/1.20.4/) installed instead. There is no harm as the 1.20.5 release is only fixing a packaging issue for the library injection packages.

This change will be reverted as soon as `1.20.5` is released to ensure subsequent `1.20` releases include the code changes to the library.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] ~Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).~
- [x] ~Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))~

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] ~If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.~
- [x] This PR doesn't touch any of that.
