### PR TITLE
revert: chore(ci): pin the library version being built

### DIFF
--- a/.gitlab/build-deb-rpm.sh
+++ b/.gitlab/build-deb-rpm.sh
@@ -23,7 +23,7 @@ echo `pwd`
     --python-version=3.9 \
     --python-version=3.8 \
     --python-version=3.7 \
-    --ddtrace-version=1.20.4 \
+    --ddtrace-version=$PYTHON_PACKAGE_VERSION  \
     --arch x86_64 \
     --arch aarch64 \
     --platform musllinux_1_1 \

--- a/lib-injection/Dockerfile
+++ b/lib-injection/Dockerfile
@@ -15,7 +15,7 @@ RUN python3 dl_wheels.py \
         --python-version=3.9 \
         --python-version=3.8 \
         --python-version=3.7 \
-        --ddtrace-version=1.20.4 \
+        --ddtrace-version=${DDTRACE_PYTHON_VERSION} \
         --arch x86_64 \
         --arch aarch64 \
         --platform musllinux_1_1 \

--- a/releasenotes/notes/lib-inject-version-9236836076cc3c79.yaml
+++ b/releasenotes/notes/lib-inject-version-9236836076cc3c79.yaml
@@ -1,5 +1,0 @@
----
-issues:
-  - |
-    lib-injection: The v1.20.5 release version has no library code changes and
-      will install the v1.20.4 version of `ddtrace``.


### PR DESCRIPTION
In reviewing the 1.20.5 release it was noticed that a [fix](https://github.com/DataDog/dd-trace-py/pull/7230) got merged and but not released to the 1.20 branch.

This makes #7255 semantically incorrect and we have to release a 1.20.5 version.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
