### PR TITLE
fix(internal): no lazy bytecode imports [backport #7151 to 1.20]

### DIFF
--- a/ddtrace/internal/wrapping/__init__.py
+++ b/ddtrace/internal/wrapping/__init__.py
@@ -14,8 +14,8 @@ try:
 except ImportError:
     from typing_extensions import Protocol  # type: ignore[assignment]
 
+import bytecode as bc
 from bytecode import Bytecode
-from bytecode import CompilerFlags
 from bytecode import Instr
 
 from ddtrace.internal.compat import PYTHON_VERSION_INFO as PY
@@ -38,9 +38,7 @@ Wrapper = Callable[[FunctionType, Tuple[Any], Dict[str, Any]], Any]
 
 def _add(lineno):
     if PY >= (3, 11):
-        from bytecode import BinaryOp
-
-        return Instr("BINARY_OP", BinaryOp.ADD, lineno=lineno)
+        return Instr("BINARY_OP", bc.BinaryOp.ADD, lineno=lineno)
 
     return Instr("INPLACE_ADD", lineno=lineno)
 
@@ -96,8 +94,8 @@ def wrap_bytecode(wrapper, wrapped):
 
     code = wrapped.__code__
     lineno = code.co_firstlineno + FIRSTLINENO_OFFSET
-    varargs = bool(code.co_flags & CompilerFlags.VARARGS)
-    varkwargs = bool(code.co_flags & CompilerFlags.VARKEYWORDS)
+    varargs = bool(code.co_flags & bc.CompilerFlags.VARARGS)
+    varkwargs = bool(code.co_flags & bc.CompilerFlags.VARKEYWORDS)
     nargs = code.co_argcount
     argnames = code.co_varnames[:nargs]
     try:
@@ -122,9 +120,7 @@ def wrap_bytecode(wrapper, wrapped):
         ]
 
         if code.co_cellvars:
-            from bytecode import CellVar
-
-            instrs[0:0] = [Instr("MAKE_CELL", CellVar(_), lineno=lineno) for _ in code.co_cellvars]
+            instrs[0:0] = [Instr("MAKE_CELL", bc.CellVar(_), lineno=lineno) for _ in code.co_cellvars]
 
         if code.co_freevars:
             instrs.insert(0, Instr("COPY_FREE_VARS", len(code.co_freevars), lineno=lineno))
@@ -133,7 +129,7 @@ def wrap_bytecode(wrapper, wrapped):
     if nargs:
         instrs.extend(
             [
-                Instr("LOAD_DEREF", CellVar(argname), lineno=lineno)
+                Instr("LOAD_DEREF", bc.CellVar(argname), lineno=lineno)
                 if PY >= (3, 11) and argname in code.co_cellvars
                 else Instr("LOAD_FAST", argname, lineno=lineno)
                 for argname in argnames
@@ -177,7 +173,7 @@ def wrap_bytecode(wrapper, wrapped):
 
     # If the function has special flags set, like the generator, async generator
     # or coroutine, inject unraveling code before the return opcode.
-    if CompilerFlags.GENERATOR & code.co_flags and not (CompilerFlags.COROUTINE & code.co_flags):
+    if bc.CompilerFlags.GENERATOR & code.co_flags and not (bc.CompilerFlags.COROUTINE & code.co_flags):
         wrap_generator(instrs, code, lineno)
     elif PY3:
         wrap_async(instrs, code, lineno)
@@ -230,7 +226,7 @@ def wrap(f, wrapper):
         nargs += code.kwonlyargcount
     except AttributeError:
         pass
-    nargs += bool(code.flags & CompilerFlags.VARARGS) + bool(code.flags & CompilerFlags.VARKEYWORDS)
+    nargs += bool(code.flags & bc.CompilerFlags.VARARGS) + bool(code.flags & bc.CompilerFlags.VARKEYWORDS)
     code.argnames = f.__code__.co_varnames[:nargs]
 
     f.__code__ = code.to_code()

--- a/ddtrace/internal/wrapping/asyncs.py
+++ b/ddtrace/internal/wrapping/asyncs.py
@@ -1,9 +1,7 @@
 import sys
 
-from bytecode import Compare
-from bytecode import CompilerFlags
+import bytecode as bc
 from bytecode import Instr
-from bytecode import Label
 
 from ddtrace.internal.compat import PYTHON_VERSION_INFO as PY
 
@@ -33,7 +31,7 @@ from ddtrace.internal.compat import PYTHON_VERSION_INFO as PY
 if PY >= (3, 11):
 
     def wrap_async(instrs, code, lineno):
-        if CompilerFlags.COROUTINE & code.co_flags:
+        if bc.CompilerFlags.COROUTINE & code.co_flags:
             # DEV: This is just
             # >>> return await wrapper(wrapped, args, kwargs)
             instrs[0:0] = [
@@ -41,8 +39,8 @@ if PY >= (3, 11):
                 Instr("POP_TOP", lineno=lineno),
             ]
 
-            send = Label()
-            send_jb = Label()
+            send = bc.Label()
+            send_jb = bc.Label()
 
             instrs[-1:-1] = [
                 Instr("GET_AWAITABLE", 0, lineno=lineno),
@@ -55,28 +53,25 @@ if PY >= (3, 11):
                 send,
             ]
 
-        elif CompilerFlags.ASYNC_GENERATOR & code.co_flags:
-            from bytecode import TryBegin
-            from bytecode import TryEnd
-
+        elif bc.CompilerFlags.ASYNC_GENERATOR & code.co_flags:
             instrs[0:0] = [
                 Instr("RETURN_GENERATOR", lineno=lineno),
                 Instr("POP_TOP", lineno=lineno),
             ]
 
-            stopiter = Label()
-            loop = Label()
-            genexit = Label()
-            exc = Label()
-            propagate = Label()
-            _yield = Label()
+            stopiter = bc.Label()
+            loop = bc.Label()
+            genexit = bc.Label()
+            exc = bc.Label()
+            propagate = bc.Label()
+            _yield = bc.Label()
 
-            try_stopiter = TryBegin(stopiter, push_lasti=False)
-            try_stopiter_2 = TryBegin(stopiter, push_lasti=False)
-            try_except = TryBegin(genexit, push_lasti=True)
+            try_stopiter = bc.TryBegin(stopiter, push_lasti=False)
+            try_stopiter_2 = bc.TryBegin(stopiter, push_lasti=False)
+            try_except = bc.TryBegin(genexit, push_lasti=True)
 
-            send = [Label() for _ in range(3)]
-            send_jb = [Label() for _ in range(3)]
+            send = [bc.Label() for _ in range(3)]
+            send_jb = [bc.Label() for _ in range(3)]
 
             instrs[-1:] = [
                 try_stopiter,
@@ -93,7 +88,7 @@ if PY >= (3, 11):
                 Instr("LOAD_CONST", None, lineno=lineno),
                 send_jb[0],
                 Instr("SEND", send[0], lineno=lineno),
-                TryEnd(try_stopiter),
+                bc.TryEnd(try_stopiter),
                 try_except,
                 Instr("YIELD_VALUE", lineno=lineno),
                 Instr("RESUME", 3, lineno=lineno),
@@ -110,7 +105,7 @@ if PY >= (3, 11):
                 Instr("PRECALL", 1, lineno=lineno),
                 Instr("CALL", 1, lineno=lineno),
                 Instr("JUMP_BACKWARD", loop, lineno=lineno),
-                TryEnd(try_except),
+                bc.TryEnd(try_except),
                 try_stopiter_2,
                 genexit,  # except GeneratorExit:
                 Instr("PUSH_EXC_INFO", lineno=lineno),
@@ -155,7 +150,7 @@ if PY >= (3, 11):
                 Instr("SWAP", 2, lineno=lineno),
                 Instr("POP_EXCEPT", lineno=lineno),
                 Instr("JUMP_BACKWARD", _yield, lineno=lineno),
-                TryEnd(try_stopiter_2),
+                bc.TryEnd(try_stopiter_2),
                 stopiter,  # except StopAsyncIteration:
                 Instr("PUSH_EXC_INFO", lineno=lineno),
                 Instr("LOAD_CONST", StopAsyncIteration, lineno=lineno),
@@ -175,7 +170,7 @@ else:
     def _compare_exc(label, lineno):
         """Compat helper for comparing exceptions."""
         if PY < (3, 9):
-            return Instr("COMPARE_OP", Compare.EXC_MATCH, lineno=lineno)
+            return Instr("COMPARE_OP", bc.Compare.EXC_MATCH, lineno=lineno)
         return Instr("JUMP_IF_NOT_EXC_MATCH", label, lineno=lineno)
 
     def _jump_if_false(label, lineno):
@@ -198,7 +193,7 @@ else:
         return Instr("SETUP_FINALLY", label, lineno=lineno)
 
     def wrap_async(instrs, code, lineno):
-        if CompilerFlags.COROUTINE & code.co_flags:
+        if bc.CompilerFlags.COROUTINE & code.co_flags:
             # DEV: This is just
             # >>> return await wrapper(wrapped, args, kwargs)
             instrs[-1:-1] = [
@@ -206,13 +201,13 @@ else:
                 Instr("LOAD_CONST", None, lineno=lineno),
                 Instr("YIELD_FROM", lineno=lineno),
             ]
-        elif CompilerFlags.ASYNC_GENERATOR & code.co_flags:
-            stopiter = Label()
-            loop = Label()
-            genexit = Label()
-            exc = Label()
-            propagate = Label()
-            _yield = Label()
+        elif bc.CompilerFlags.ASYNC_GENERATOR & code.co_flags:
+            stopiter = bc.Label()
+            loop = bc.Label()
+            genexit = bc.Label()
+            exc = bc.Label()
+            propagate = bc.Label()
+            _yield = bc.Label()
 
             instrs[-1:] = [
                 _setup_block(stopiter, lineno=lineno),

--- a/ddtrace/internal/wrapping/generators.py
+++ b/ddtrace/internal/wrapping/generators.py
@@ -1,8 +1,7 @@
 import sys
 
-from bytecode import Compare
+import bytecode as bc
 from bytecode import Instr
-from bytecode import Label
 
 from ddtrace.internal.compat import PYTHON_VERSION_INFO as PY
 
@@ -31,24 +30,21 @@ from ddtrace.internal.compat import PYTHON_VERSION_INFO as PY
 if PY >= (3, 11):
 
     def wrap_generator(instrs, code, lineno):
-        from bytecode import TryBegin
-        from bytecode import TryEnd
-
         instrs[0:0] = [
             Instr("RETURN_GENERATOR", lineno=lineno),
             Instr("POP_TOP", lineno=lineno),
         ]
 
-        stopiter = Label()
-        loop = Label()
-        genexit = Label()
-        exc = Label()
-        propagate = Label()
-        _yield = Label()
+        stopiter = bc.Label()
+        loop = bc.Label()
+        genexit = bc.Label()
+        exc = bc.Label()
+        propagate = bc.Label()
+        _yield = bc.Label()
 
-        try_stopiter = TryBegin(stopiter, push_lasti=False)
-        try_stopiter_2 = TryBegin(stopiter, push_lasti=False)
-        try_except = TryBegin(genexit, push_lasti=True)
+        try_stopiter = bc.TryBegin(stopiter, push_lasti=False)
+        try_stopiter_2 = bc.TryBegin(stopiter, push_lasti=False)
+        try_except = bc.TryBegin(genexit, push_lasti=True)
 
         instrs[-1:] = [
             try_stopiter,
@@ -62,7 +58,7 @@ if PY >= (3, 11):
             loop,
             Instr("PRECALL", 1, lineno=lineno),
             Instr("CALL", 1, lineno=lineno),
-            TryEnd(try_stopiter),
+            bc.TryEnd(try_stopiter),
             _yield,
             try_except,
             Instr("YIELD_VALUE", lineno=lineno),
@@ -72,7 +68,7 @@ if PY >= (3, 11):
             Instr("LOAD_FAST", "__ddgensend", lineno=lineno),
             Instr("SWAP", 2, lineno=lineno),
             Instr("JUMP_BACKWARD", loop, lineno=lineno),
-            TryEnd(try_except),
+            bc.TryEnd(try_except),
             try_stopiter_2,
             genexit,  # except GeneratorExit:
             Instr("PUSH_EXC_INFO", lineno=lineno),
@@ -100,7 +96,7 @@ if PY >= (3, 11):
             Instr("SWAP", 2, lineno=lineno),
             Instr("POP_EXCEPT", lineno=lineno),
             Instr("JUMP_BACKWARD", _yield, lineno=lineno),
-            TryEnd(try_stopiter_2),
+            bc.TryEnd(try_stopiter_2),
             stopiter,  # except StopIteration:
             Instr("PUSH_EXC_INFO", lineno=lineno),
             Instr("LOAD_CONST", StopIteration, lineno=lineno),
@@ -120,7 +116,7 @@ else:
     def _compare_exc(label, lineno):
         """Compat helper for comparing exceptions."""
         if PY < (3, 9):
-            return Instr("COMPARE_OP", Compare.EXC_MATCH, lineno=lineno)
+            return Instr("COMPARE_OP", bc.Compare.EXC_MATCH, lineno=lineno)
         return Instr("JUMP_IF_NOT_EXC_MATCH", label, lineno=lineno)
 
     def _jump_if_false(label, lineno):
@@ -154,12 +150,12 @@ else:
         return Instr("CALL_FUNCTION_EX", 0, lineno=lineno)
 
     def wrap_generator(instrs, code, lineno):
-        stopiter = Label()
-        loop = Label()
-        genexit = Label()
-        exc = Label()
-        propagate = Label()
-        _yield = Label()
+        stopiter = bc.Label()
+        loop = bc.Label()
+        genexit = bc.Label()
+        exc = bc.Label()
+        propagate = bc.Label()
+        _yield = bc.Label()
 
         instrs[-1:] = [
             _setup_block(stopiter, lineno),

--- a/releasenotes/notes/fix-bytecode-no-lazy-imports-fc229b23e60fca53.yaml
+++ b/releasenotes/notes/fix-bytecode-no-lazy-imports-fc229b23e60fca53.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    tracing: Fix an issue with some integrations, such as OpenAI, that caused an
+    exception on start-up when using gevent.


### PR DESCRIPTION
Backport of #7151 to 1.20

Remove any lazy bytecode imports that can cause incompatibilities with the module cloning mechanism.

Fixes #7144.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
