### PR TITLE
fix(debugging): function probes on same lazy module

### DIFF
--- a/ddtrace/debugging/_debugger.py
+++ b/ddtrace/debugging/_debugger.py
@@ -131,7 +131,7 @@ class DebuggerModuleWatchdog(ModuleWatchdog):
         if module_name in cls._locations:
             # We already have a hook for this origin, don't register a new one
             # but invoke it directly instead, if the module was already loaded.
-            module = sys.modules[module_name]
+            module = sys.modules.get(module_name)
             if module is not None:
                 hook(module)
 

--- a/releasenotes/notes/fix-debugger-same-module-wrapping-5fa0653ca015874c.yaml
+++ b/releasenotes/notes/fix-debugger-same-module-wrapping-5fa0653ca015874c.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: fix an issue that caused function probes on the
+    same module to fail to instrument and be reported in the ``ERROR`` status
+    in the UI if the module was not yet imported.

--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -512,6 +512,28 @@ def test_debugger_multiple_function_probes_on_same_function():
             Stuff.instancestuff.__dd_wrappers__
 
 
+def test_debugger_multiple_function_probes_on_same_lazy_module():
+    sys.modules.pop("tests.submod.stuff", None)
+
+    probes = [
+        create_snapshot_function_probe(
+            probe_id="probe-instance-method-%d" % i,
+            module="tests.submod.stuff",
+            func_qname="Stuff.instancestuff",
+            rate=float("inf"),
+        )
+        for i in range(3)
+    ]
+
+    with debugger() as d:
+        d.add_probes(*probes)
+
+        import tests.submod.stuff  # noqa
+
+        assert len(d._probe_registry) == len(probes)
+        assert all(_.error_type is None for _ in d._probe_registry.values())
+
+
 # DEV: The following tests are to ensure compatibility with the tracer
 import wrapt as wrapt  # noqa
 
@@ -861,7 +883,7 @@ def test_debugger_log_live_probe_generate_messages():
                     " ",
                     {"dsl": "bar", "json": {"ref": "bar"}},
                     "!",
-                )
+                ),
             ),
         )
 
@@ -999,7 +1021,7 @@ def test_debugger_modified_probe():
                 version=1,
                 source_file="tests/submod/stuff.py",
                 line=36,
-                **compile_template("hello world")
+                **compile_template("hello world"),
             )
         )
 
@@ -1015,7 +1037,7 @@ def test_debugger_modified_probe():
                 version=2,
                 source_file="tests/submod/stuff.py",
                 line=36,
-                **compile_template("hello brave new world")
+                **compile_template("hello brave new world"),
             )
         )
 


### PR DESCRIPTION
Fix a typo that caused a module lookup to fail with a KeyError exception, even though it was followed by a check against None.

This caused function probes on the same module that was not yet loaded to fail to instrument and be reported in the ``ERROR`` status in the UI.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
