### PR TITLE
fix(ci_visibility): fixes unittest enabling the CI VIsibility plugin

### DIFF
--- a/ddtrace/contrib/unittest/patch.py
+++ b/ddtrace/contrib/unittest/patch.py
@@ -50,6 +50,12 @@ def get_version():
     return ""
 
 
+def _enable_unittest_if_not_started():
+    if _CIVisibility.enabled:
+        return
+    _CIVisibility.enable(config=ddtrace.config.unittest)
+
+
 def _set_tracer(tracer: ddtrace.tracer):
     """Manually sets the tracer instance to `unittest.`"""
     unittest._datadog_tracer = tracer
@@ -298,8 +304,6 @@ def patch():
     """
     if getattr(unittest, "_datadog_patch", False) or _CIVisibility.enabled:
         return
-
-    _CIVisibility.enable(config=ddtrace.config.unittest)
 
     unittest._datadog_patch = True
 
@@ -613,6 +617,7 @@ def handle_cli_run(func, instance: unittest.TestProgram, args: tuple, kwargs: di
     """
     test_session_span = None
     if _is_invoked_by_cli(instance):
+        _enable_unittest_if_not_started()
         if not hasattr(_CIVisibility, "_unittest_data"):
             _CIVisibility._unittest_data = {"suites": {}, "modules": {}}
         for parent_module in instance.test._tests:
@@ -643,6 +648,7 @@ def handle_text_test_runner_wrapper(func, instance: unittest.TextTestResult, arg
     """
     if _is_invoked_by_cli(instance):
         return func(*args, **kwargs)
+    _enable_unittest_if_not_started()
     _CIVisibility._datadog_entry = "TextTestRunner"
     if not hasattr(_CIVisibility, "_datadog_session_span"):
         _CIVisibility._datadog_session_span = _start_test_session_span(instance)

--- a/releasenotes/notes/fix-unittest-git-patch-887a3963d4f58d8b.yaml
+++ b/releasenotes/notes/fix-unittest-git-patch-887a3963d4f58d8b.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    CI Visibility: Fixes `unittest` integration being patched without actually running any tests
+    CI Visibility: fixes an issue where just importing `unittest` enabled CIVisibility and potentially caused unexpected logs and API requests 

--- a/releasenotes/notes/fix-unittest-git-patch-887a3963d4f58d8b.yaml
+++ b/releasenotes/notes/fix-unittest-git-patch-887a3963d4f58d8b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    CI Visibility: Fixes `unittest` integration being patched without actually running any tests


### PR DESCRIPTION
## Motivation

This PR aims to fix [this GitHub issue](https://github.com/DataDog/dd-trace-py/issues/7257) from dd-trace-py, which was causing unexpected log messages. Related JIRA issue: [CIVIS-7652](https://datadoghq.atlassian.net/browse/CIVIS-7652?atlOrigin=eyJpIjoiM2EyMTI2YzY5YWI3NDBiMGI5OWE2ODk3MzE1Nzc2ZDUiLCJwIjoiaiJ9).

## Changes

Now, the `unittest` integration will enable `CIVisibility` only if `unittest` is running any tests. This will prevent log messages as CIVisibility won't be enabled until tests are detected.

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.


[CIVIS-7652]: https://datadoghq.atlassian.net/browse/CIVIS-7652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ