### PR TITLE
fix(asm): fix manual keep for user event

### DIFF
--- a/ddtrace/appsec/trace_utils.py
+++ b/ddtrace/appsec/trace_utils.py
@@ -61,7 +61,7 @@ def _track_user_login_common(
         if name:
             span.set_tag_str("%s.username" % tag_prefix, name)
 
-        span.set_tag_str(constants.MANUAL_KEEP_KEY, "true")
+        span.set_tag(constants.MANUAL_KEEP_KEY)
         return span
     else:
         log.warning(
@@ -133,7 +133,7 @@ def track_user_signup_event(tracer, user_id, success, login_events_mode=LOGIN_EV
         success_str = "true" if success else "false"
         span.set_tag_str(APPSEC.USER_SIGNUP_EVENT, success_str)
         span.set_tag_str(user.ID, user_id)
-        span.set_tag_str(constants.MANUAL_KEEP_KEY, "true")
+        span.set_tag(constants.MANUAL_KEEP_KEY)
 
         # This is used to mark if the call was done from the SDK of the automatic login events
         if login_events_mode == LOGIN_EVENTS_MODE.SDK:
@@ -182,7 +182,7 @@ def track_custom_event(tracer, event_name, metadata):
 
     for k, v in six.iteritems(metadata):
         span.set_tag_str("%s.%s.%s" % (APPSEC.CUSTOM_EVENT_PREFIX, event_name, k), str(v))
-        span.set_tag_str(constants.MANUAL_KEEP_KEY, "true")
+        span.set_tag(constants.MANUAL_KEEP_KEY)
 
 
 def should_block_user(tracer, userid):  # type: (Tracer, str) -> bool

--- a/releasenotes/notes/fix_manual_keep_for_users_events-3b4b37a9ef9e50ea.yaml
+++ b/releasenotes/notes/fix_manual_keep_for_users_events-3b4b37a9ef9e50ea.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ASM: This fix resolves an issue where user events spans could be sampled erroneously.

--- a/tests/appsec/test_appsec_trace_utils.py
+++ b/tests/appsec/test_appsec_trace_utils.py
@@ -173,7 +173,7 @@ class EventsSDKTestCase(TracerTestCase):
             assert root_span.get_tag("%s.%s" % (failure_prefix, user.ID)) == "1234"
             assert root_span.get_tag("%s.%s" % (failure_prefix, user.EXISTS)) == "true"
             assert root_span.get_tag("%s.foo" % failure_prefix) == "bar"
-            assert root_span.get_tag(constants.MANUAL_KEEP_KEY) == "true"
+            assert root_span.context.sampling_priority == constants.USER_KEEP
             # set_user tags: shouldn't have been called
             assert not root_span.get_tag(user.ID)
             assert not root_span.get_tag(user.NAME)

--- a/tests/appsec/test_appsec_trace_utils.py
+++ b/tests/appsec/test_appsec_trace_utils.py
@@ -51,7 +51,7 @@ class EventsSDKTestCase(TracerTestCase):
             assert root_span.get_tag("%s.sdk" % success_prefix) == "true"
             assert not root_span.get_tag("%s.auto.mode" % success_prefix)
             assert not root_span.get_tag("%s.track" % failure_prefix)
-            assert root_span.get_tag(constants.MANUAL_KEEP_KEY) == "true"
+            assert root_span.context.sampling_priority == constants.USER_KEEP
             # set_user tags
             assert root_span.get_tag(user.ID) == "1234"
             assert root_span.get_tag(user.NAME) == "John"
@@ -109,7 +109,7 @@ class EventsSDKTestCase(TracerTestCase):
 
             root_span = self.tracer.current_root_span()
             success_prefix = "%s.success" % APPSEC.USER_LOGIN_EVENT_PREFIX
-            assert root_span.get_tag("%s.track" % success_prefix) == "true"
+            assert root_span.context.sampling_priority == constants.USER_KEEP
             assert not root_span.get_tag("%s.sdk" % success_prefix)
             assert root_span.get_tag("%s.auto.mode" % success_prefix) == str(LOGIN_EVENTS_MODE.SAFE)
 
@@ -142,7 +142,7 @@ class EventsSDKTestCase(TracerTestCase):
             assert root_span.get_tag("%s.sdk" % success_prefix) == "true"
             assert not root_span.get_tag("%s.auto.mode" % success_prefix)
             assert root_span.get_tag("%s.foo" % success_prefix) == "bar"
-            assert root_span.get_tag(constants.MANUAL_KEEP_KEY) == "true"
+            assert root_span.context.sampling_priority == constants.USER_KEEP
             # set_user tags
             assert root_span.get_tag(user.ID) == "1234"
             assert not root_span.get_tag(user.NAME)


### PR DESCRIPTION
Partial backport of https://github.com/DataDog/dd-trace-py/pull/6633 to fix user events being dropped by the tracer

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
