### PR TITLE
chore(asm): tests, change telemetry service interval to 120 seconds to avoid flakyness

### DIFF
--- a/tests/appsec/conftest.py
+++ b/tests/appsec/conftest.py
@@ -8,20 +8,31 @@ from ddtrace.internal.telemetry.constants import TELEMETRY_TYPE_GENERATE_METRICS
 
 @pytest.fixture
 def mock_telemetry_lifecycle_writer():
+    previous_interval = telemetry_writer.interval
+    telemetry_writer.interval = 120
+    telemetry_writer._stop_service()
+    telemetry_writer._start_service()
     telemetry_writer.enable()
     telemetry_writer.reset_queues()
     metrics_result = telemetry_writer._namespace._metrics_data
     assert len(metrics_result[TELEMETRY_TYPE_GENERATE_METRICS][TELEMETRY_NAMESPACE_TAG_APPSEC]) == 0
     assert len(metrics_result[TELEMETRY_TYPE_DISTRIBUTION][TELEMETRY_NAMESPACE_TAG_APPSEC]) == 0
     yield telemetry_writer
+    telemetry_writer.interval = previous_interval
     telemetry_writer._namespace.flush()
 
 
 @pytest.fixture
 def mock_logs_telemetry_lifecycle_writer():
+    previous_interval = telemetry_writer.interval
+    telemetry_writer.interval = 120
+    telemetry_writer._stop_service()
+    telemetry_writer._start_service()
     telemetry_writer.enable()
     telemetry_writer.reset_queues()
     metrics_result = telemetry_writer._logs
     assert len(metrics_result) == 0
     yield telemetry_writer
     telemetry_writer.reset_queues()
+    telemetry_writer.interval = previous_interval
+    telemetry_writer._namespace.flush()


### PR DESCRIPTION
Bumping the telemetry service interval to 120 seconds from 10 for tests only.

### Motivation

`tests/appsec/iast/test_telemetry.py` can be failing as flaky on CircleCI due to threads sleeping for too long, causing the telemetry service to flush the values before the main test thread finished, creating AssertionError on telemetry content.
This would make the whole `appsec` test suite to fail.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
