### PR TITLE
Revert "chore(iast): adjust tests as tainted objects may be lost"

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
@@ -33,9 +33,13 @@ using TaintRangeMapType = std::map<uintptr_t, TaintedObjectPtr>;
 #endif // NDEBUG
 
 inline static uintptr_t
-get_unique_id(const PyObject* str)
+get_unique_id(PyObject* str)
 {
-    return uintptr_t(str);
+    if ((((PyASCIIObject*)str)->hash) == -1) {
+        Py_hash_t result = PyObject_Hash(str);
+    }
+    auto res = uintptr_t(str) + ((PyASCIIObject*)str)->hash;
+    return hash<uintptr_t>{}(res);
 }
 
 struct TaintRange

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
@@ -32,14 +32,23 @@ using TaintRangeMapType = std::map<uintptr_t, TaintedObjectPtr>;
 
 #endif // NDEBUG
 
+inline uintptr_t
+hash_combine(uintptr_t first, const uintptr_t second)
+{
+    uintptr_t res = second;
+    std::hash<uintptr_t> hasher;
+    res ^= hasher(first) + 0x9e3779b9 + (second << 6) + (second >> 2);
+    return res;
+}
+
 inline static uintptr_t
 get_unique_id(PyObject* str)
 {
     if ((((PyASCIIObject*)str)->hash) == -1) {
         Py_hash_t result = PyObject_Hash(str);
     }
-    auto res = uintptr_t(str) + ((PyASCIIObject*)str)->hash;
-    return hash<uintptr_t>{}(res);
+    // auto res = uintptr_t(str) + ((PyASCIIObject*)str)->hash;
+    return hash_combine(uintptr_t(str), ((PyASCIIObject*)str)->hash);
 }
 
 struct TaintRange

--- a/releasenotes/notes/iast-fix-id-collisions-87da1c4229876398.yaml
+++ b/releasenotes/notes/iast-fix-id-collisions-87da1c4229876398.yaml
@@ -1,5 +1,5 @@
 ---
-issues:
+fixes:
   - |
     Vulnerability Management for Code-level (IAST): Fix potential string id collisions that could cause false 
     positives with non tainted objects being marked as tainted.

--- a/releasenotes/notes/iast-fix-id-collisions-87da1c4229876398.yaml
+++ b/releasenotes/notes/iast-fix-id-collisions-87da1c4229876398.yaml
@@ -1,0 +1,5 @@
+---
+issues:
+  - |
+    Vulnerability Management for Code-level (IAST): Fix potential string id collisions that could cause false 
+    positives with non tainted objects being marked as tainted.

--- a/tests/appsec/iast/aspects/test_bytearray_extend_aspect.py
+++ b/tests/appsec/iast/aspects/test_bytearray_extend_aspect.py
@@ -42,9 +42,9 @@ class TestByteArrayExtendAspect(object):
         assert result == bytearray(b"123456")
         assert ba1 == bytearray(b"123456")
         ranges = get_tainted_ranges(result)
+        assert ranges == [TaintRange(0, 3, Source("test", "foo", OriginType.PARAMETER))]
         assert get_tainted_ranges(ba1) == [TaintRange(0, 3, Source("test", "foo", OriginType.PARAMETER))]
         assert not get_tainted_ranges(ba2)
-        assert set(ranges) <= set([TaintRange(0, 3, Source("test", "foo", OriginType.PARAMETER))])
 
     def test_extend_first_tainted_second_bytes(self):
         ba1 = taint_pyobject(
@@ -55,9 +55,9 @@ class TestByteArrayExtendAspect(object):
         result = mod.do_bytearray_extend(ba1, ba2)
         assert result == bytearray(b"123456")
         ranges = get_tainted_ranges(result)
+        assert ranges == [TaintRange(0, 3, Source("test", "foo", OriginType.PARAMETER))]
         assert get_tainted_ranges(ba1) == [TaintRange(0, 3, Source("test", "foo", OriginType.PARAMETER))]
         assert not get_tainted_ranges(ba2)
-        assert set(ranges) <= set([TaintRange(0, 3, Source("test", "foo", OriginType.PARAMETER))])
 
     def test_extend_second_tainted(self):
         ba1 = bytearray(b"123")
@@ -91,12 +91,10 @@ class TestByteArrayExtendAspect(object):
         result = mod.do_bytearray_extend(ba1, ba2)
         assert result == bytearray(b"123456")
         ranges = get_tainted_ranges(result)
+        assert len(ranges) == 2
+        assert ranges == [
+            TaintRange(0, 3, Source("test1", "foo", OriginType.PARAMETER)),
+            TaintRange(3, 3, Source("test2", "bar", OriginType.BODY)),
+        ]
         assert get_tainted_ranges(ba1) == ranges
         assert get_tainted_ranges(ba2) == [TaintRange(0, 3, Source("test2", "bar", OriginType.BODY))]
-        assert len(ranges) <= 2
-        assert set(ranges) <= set(
-            [
-                TaintRange(0, 3, Source("test1", "foo", OriginType.PARAMETER)),
-                TaintRange(3, 3, Source("test2", "bar", OriginType.BODY)),
-            ]
-        )

--- a/tests/appsec/iast/aspects/test_bytearray_extend_aspect.py
+++ b/tests/appsec/iast/aspects/test_bytearray_extend_aspect.py
@@ -42,9 +42,9 @@ class TestByteArrayExtendAspect(object):
         assert result == bytearray(b"123456")
         assert ba1 == bytearray(b"123456")
         ranges = get_tainted_ranges(result)
-        assert ranges == [TaintRange(0, 3, Source("test", "foo", OriginType.PARAMETER))]
         assert get_tainted_ranges(ba1) == [TaintRange(0, 3, Source("test", "foo", OriginType.PARAMETER))]
         assert not get_tainted_ranges(ba2)
+        assert set(ranges) <= set([TaintRange(0, 3, Source("test", "foo", OriginType.PARAMETER))])
 
     def test_extend_first_tainted_second_bytes(self):
         ba1 = taint_pyobject(
@@ -55,9 +55,9 @@ class TestByteArrayExtendAspect(object):
         result = mod.do_bytearray_extend(ba1, ba2)
         assert result == bytearray(b"123456")
         ranges = get_tainted_ranges(result)
-        assert ranges == [TaintRange(0, 3, Source("test", "foo", OriginType.PARAMETER))]
         assert get_tainted_ranges(ba1) == [TaintRange(0, 3, Source("test", "foo", OriginType.PARAMETER))]
         assert not get_tainted_ranges(ba2)
+        assert set(ranges) <= set([TaintRange(0, 3, Source("test", "foo", OriginType.PARAMETER))])
 
     def test_extend_second_tainted(self):
         ba1 = bytearray(b"123")
@@ -91,10 +91,12 @@ class TestByteArrayExtendAspect(object):
         result = mod.do_bytearray_extend(ba1, ba2)
         assert result == bytearray(b"123456")
         ranges = get_tainted_ranges(result)
-        assert len(ranges) == 2
-        assert ranges == [
-            TaintRange(0, 3, Source("test1", "foo", OriginType.PARAMETER)),
-            TaintRange(3, 3, Source("test2", "bar", OriginType.BODY)),
-        ]
         assert get_tainted_ranges(ba1) == ranges
         assert get_tainted_ranges(ba2) == [TaintRange(0, 3, Source("test2", "bar", OriginType.BODY))]
+        assert len(ranges) <= 2
+        assert set(ranges) <= set(
+            [
+                TaintRange(0, 3, Source("test1", "foo", OriginType.PARAMETER)),
+                TaintRange(3, 3, Source("test2", "bar", OriginType.BODY)),
+            ]
+        )

--- a/tests/appsec/iast/taint_tracking/test_native_taint_range.py
+++ b/tests/appsec/iast/taint_tracking/test_native_taint_range.py
@@ -23,6 +23,9 @@ try:
     from ddtrace.appsec._iast._taint_tracking import shift_taint_range
     from ddtrace.appsec._iast._taint_tracking import shift_taint_ranges
     from ddtrace.appsec._iast._taint_tracking import taint_pyobject
+    from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect
+    from ddtrace.appsec._iast._taint_tracking.aspects import format_aspect
+    from ddtrace.appsec._iast._taint_tracking.aspects import join_aspect
 except (ImportError, AttributeError):
     pytest.skip("IAST not supported for this Python version", allow_module_level=True)
 
@@ -84,6 +87,70 @@ def test_unicode_fast_tainting():
         assert not is_notinterned_notfasttainted_unicode(c)
         set_fast_tainted_if_notinterned_unicode(c)
         assert not is_notinterned_notfasttainted_unicode(c)
+
+
+def test_collisions():
+    not_tainted = []
+    tainted = []
+    mixed_tainted_ids = []
+    mixed_nottainted = []
+    mixed_tainted_and_nottainted = []
+
+    # Generate untainted strings
+    for i in range(10):
+        not_tainted.append("N%04d" % i)
+
+    # Generate tainted strings
+    for i in range(10000):
+        t = taint_pyobject(
+            "T%04d" % i, source_name="request_body", source_value="hello", source_origin=OriginType.PARAMETER
+        )
+        tainted.append(t)
+
+    for t in tainted:
+        assert len(get_ranges(t)) > 0
+
+    for n in not_tainted:
+        assert get_ranges(n) == []
+
+    # Do join and format operations mixing tainted and untainted strings, store in mixed_tainted_and_nottainted
+    for _ in range(10000):
+        n1 = add_aspect(add_aspect("_", random.choice(not_tainted)), "{}_")
+
+        t2 = random.choice(tainted)
+
+        n3 = random.choice(not_tainted)
+
+        t4 = random.choice(tainted)
+        mixed_tainted_ids.append(id(t4))
+
+        t5 = format_aspect(n1.format, n1, t4)
+        mixed_tainted_ids.append(id(t5))
+
+        t6 = join_aspect(t5.join, t5, [t2, n3])
+        mixed_tainted_ids.append(id(t6))
+
+    for t in mixed_tainted_and_nottainted:
+        assert len(get_ranges(t)) == 2
+
+    # Do join and format operations with only untainted strings, store in mixed_nottainted
+    for i in range(10):
+        n1 = add_aspect("===", not_tainted[i])
+
+        n2 = random.choice(not_tainted)
+
+        n3 = random.choice(not_tainted)
+
+        n4 = random.choice(not_tainted)
+
+        n5 = format_aspect(n1.format, n1, [n4])
+
+        n6 = join_aspect(n5.join, n5, [n2, n3])
+
+        mixed_nottainted.append(n6)
+
+    for n in mixed_nottainted:
+        assert len(get_ranges(n)) == 0, f"id {id(n)} in {(id(n) in mixed_tainted_ids)}"
 
 
 def test_set_get_ranges_str():


### PR DESCRIPTION
This reverts commit d91ce9cbd3e809a9fad5e263635793d7c87e62db.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
