### PR TITLE
fix(iast): CMDi without appsec env var

### DIFF
--- a/ddtrace/appsec/_iast/_patch_modules.py
+++ b/ddtrace/appsec/_iast/_patch_modules.py
@@ -2,6 +2,7 @@ from wrapt.importer import when_imported
 
 
 IAST_PATCH = {
+    "command_injection": True,
     "path_traversal": True,
     "weak_cipher": True,
     "weak_hash": True,

--- a/ddtrace/appsec/_iast/taint_sinks/command_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/command_injection.py
@@ -1,4 +1,7 @@
+import os
 import re
+import shlex
+import subprocess
 from typing import List
 from typing import Set
 from typing import TYPE_CHECKING
@@ -6,7 +9,9 @@ from typing import Union
 
 import six
 
-from ddtrace.settings import _config
+from ddtrace import config
+from ddtrace.contrib import trace_utils
+from ddtrace.internal.logger import get_logger
 
 from .. import oce
 from .._utils import _has_to_scrub
@@ -25,7 +30,60 @@ if TYPE_CHECKING:
     from ..reporter import IastSpanReporter
     from ..reporter import Vulnerability
 
+
+log = get_logger(__name__)
+
 _INSIDE_QUOTES_REGEXP = re.compile(r"^(?:\s*(?:sudo|doas)\s+)?\b\S+\b\s*(.*)")
+
+
+def get_version():
+    # type: () -> str
+    return ""
+
+
+def patch():
+    if not config._iast_enabled:
+        return
+
+    if not getattr(os, "_datadog_cmdi_patch", False):
+        trace_utils.wrap(os, "system", _iast_cmdi_ossystem)
+
+        # all os.spawn* variants eventually use this one:
+        trace_utils.wrap(os, "_spawnvef", _iast_cmdi_osspawn)
+
+    if not getattr(subprocess, "_datadog_cmdi_patch", False):
+        trace_utils.wrap(subprocess, "Popen.__init__", _iast_cmdi_subprocess_init)
+
+        os._datadog_cmdi_patch = True
+        subprocess._datadog_cmdi_patch = True
+
+
+def unpatch():
+    # type: () -> None
+    trace_utils.unwrap(os, "system")
+    trace_utils.unwrap(os, "_spawnvef")
+    trace_utils.unwrap(subprocess.Popen, "__init__")
+    trace_utils.unwrap(subprocess.Popen, "wait")
+
+
+def _iast_cmdi_ossystem(wrapped, instance, args, kwargs):
+    _iast_report_cmdi(args[0])
+    return wrapped(*args, **kwargs)
+
+
+def _iast_cmdi_osspawn(wrapped, instance, args, kwargs):
+    mode, file, func_args, _, _ = args
+    _iast_report_cmdi(func_args)
+
+    return wrapped(*args, **kwargs)
+
+
+def _iast_cmdi_subprocess_init(wrapped, instance, args, kwargs):
+    cmd_args = args[0] if len(args) else kwargs["args"]
+    cmd_args_list = shlex.split(cmd_args) if isinstance(cmd_args, str) else cmd_args
+    _iast_report_cmdi(cmd_args_list)
+
+    return wrapped(*args, **kwargs)
 
 
 @oce.register
@@ -73,7 +131,7 @@ class CommandInjection(VulnerabilityBase):
 
     @classmethod
     def _redact_report(cls, report):  # type: (IastSpanReporter) -> IastSpanReporter
-        if not _config._iast_redaction_enabled:
+        if not config._iast_redaction_enabled:
             return report
 
         # See if there is a match on either any of the sources or value parts of the report
@@ -124,50 +182,55 @@ class CommandInjection(VulnerabilityBase):
                 source.value = None
 
         # Same for all the evidence values
-        for vuln in report.vulnerabilities:
-            # Use the initial hash directly as iteration key since the vuln itself will change
-            vuln_hash = hash(vuln)
-            if vuln.evidence.value is not None:
-                pattern, replaced = cls.replace_tokens(vuln, vulns_to_tokens, hasattr(vuln.evidence.value, "source"))
-                if replaced:
-                    vuln.evidence.pattern = pattern
-                    vuln.evidence.redacted = True
-                    vuln.evidence.value = None
-            elif vuln.evidence.valueParts is not None:
-                idx = 0
-                new_value_parts = []
-                for part in vuln.evidence.valueParts:
-                    value = part["value"]
-                    part_len = len(value)
-                    part_start = idx
-                    part_end = idx + part_len
-                    pattern_list = []
+        try:
+            for vuln in report.vulnerabilities:
+                # Use the initial hash directly as iteration key since the vuln itself will change
+                vuln_hash = hash(vuln)
+                if vuln.evidence.value is not None:
+                    pattern, replaced = cls.replace_tokens(
+                        vuln, vulns_to_tokens, hasattr(vuln.evidence.value, "source")
+                    )
+                    if replaced:
+                        vuln.evidence.pattern = pattern
+                        vuln.evidence.redacted = True
+                        vuln.evidence.value = None
+                elif vuln.evidence.valueParts is not None:
+                    idx = 0
+                    new_value_parts = []
+                    for part in vuln.evidence.valueParts:
+                        value = part["value"]
+                        part_len = len(value)
+                        part_start = idx
+                        part_end = idx + part_len
+                        pattern_list = []
 
-                    for positions in vulns_to_tokens[vuln_hash]["token_positions"]:
-                        if _check_positions_contained(positions, (part_start, part_end)):
-                            part_scrub_start = max(positions[0] - idx, 0)
-                            part_scrub_end = positions[1] - idx
-                            pattern_list.append(value[:part_scrub_start] + "" + value[part_scrub_end:])
-                            if part.get("source", False) is not False:
-                                source = report.sources[part["source"]]
-                                if source.redacted:
-                                    part["redacted"] = source.redacted
-                                    part["pattern"] = source.pattern
-                                    del part["value"]
-                                new_value_parts.append(part)
-                                break
+                        for positions in vulns_to_tokens[vuln_hash]["token_positions"]:
+                            if _check_positions_contained(positions, (part_start, part_end)):
+                                part_scrub_start = max(positions[0] - idx, 0)
+                                part_scrub_end = positions[1] - idx
+                                pattern_list.append(value[:part_scrub_start] + "" + value[part_scrub_end:])
+                                if part.get("source", False) is not False:
+                                    source = report.sources[part["source"]]
+                                    if source.redacted:
+                                        part["redacted"] = source.redacted
+                                        part["pattern"] = source.pattern
+                                        del part["value"]
+                                    new_value_parts.append(part)
+                                    break
+                                else:
+                                    part["value"] = "".join(pattern_list)
+                                    new_value_parts.append(part)
+                                    new_value_parts.append({"redacted": True})
+                                    break
                             else:
-                                part["value"] = "".join(pattern_list)
                                 new_value_parts.append(part)
-                                new_value_parts.append({"redacted": True})
+                                pattern_list.append(value[part_start:part_end])
                                 break
-                        else:
-                            new_value_parts.append(part)
-                            pattern_list.append(value[part_start:part_end])
-                            break
 
-                    idx += part_len
-                vuln.evidence.valueParts = new_value_parts
+                        idx += part_len
+                    vuln.evidence.valueParts = new_value_parts
+        except (ValueError, KeyError):
+            log.debug("an error occurred while redacting cmdi", exc_info=True)
         return report
 
 

--- a/ddtrace/contrib/subprocess/patch.py
+++ b/ddtrace/contrib/subprocess/patch.py
@@ -182,10 +182,6 @@ class SubprocessCmdLine(object):
             self._cache_entry = SubprocessCmdLine._add_new_cache_entry(
                 cache_key, self.env_vars, self.binary, self.arguments, self.truncated
             )
-        if config._iast_enabled:
-            from ddtrace.appsec._iast.taint_sinks.command_injection import _iast_report_cmdi
-
-            _iast_report_cmdi(shell_args)
 
     def scrub_env_vars(self, tokens):
         for idx, token in enumerate(tokens):

--- a/tests/appsec/iast/taint_sinks/test_command_injection.py
+++ b/tests/appsec/iast/taint_sinks/test_command_injection.py
@@ -8,9 +8,8 @@ import pytest
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast import oce
 from ddtrace.appsec._iast.constants import VULN_CMDI
-from ddtrace.contrib.subprocess.patch import SubprocessCmdLine
-from ddtrace.contrib.subprocess.patch import patch
-from ddtrace.contrib.subprocess.patch import unpatch
+from ddtrace.appsec._iast.taint_sinks.command_injection import patch
+from ddtrace.appsec._iast.taint_sinks.command_injection import unpatch
 from ddtrace.internal import core
 from tests.appsec.iast.iast_utils import get_line_and_hash
 from tests.utils import override_global_config
@@ -30,9 +29,7 @@ _PARAMS = ["/bin/ls", "-l"]
 
 @pytest.fixture(autouse=True)
 def auto_unpatch():
-    SubprocessCmdLine._clear_cache()
     yield
-    SubprocessCmdLine._clear_cache()
     try:
         unpatch()
     except AttributeError:
@@ -300,6 +297,7 @@ def test_osspawn_variants(tracer, iast_span_defaults, function, mode, arguments,
         assert vulnerability.hash == hash_value
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="Only for Linux")
 def test_multiple_cmdi(tracer, iast_span_defaults):
     with override_global_config(dict(_appsec_enabled=True, _iast_enabled=True)):
         patch()
@@ -309,9 +307,15 @@ def test_multiple_cmdi(tracer, iast_span_defaults):
             source_value="forbidden_dir/",
             source_origin=OriginType.PARAMETER,
         )
+        dir_2 = taint_pyobject(
+            pyobject="qwerty/",
+            source_name="test_run",
+            source_value="qwerty/",
+            source_origin=OriginType.PARAMETER,
+        )
         with tracer.trace("test_multiple_cmdi"):
             subprocess.run(["dir", "-l", _BAD_DIR])
-            subprocess.run(["dir", "-l", _BAD_DIR])
+            subprocess.run(["dir", "-l", dir_2])
 
         span_report = core.get_item(IAST.CONTEXT_KEY, span=iast_span_defaults)
         assert span_report


### PR DESCRIPTION
CMDi bug that needs both `DD_APPSEC_ENABLED=1` and `DD_IAST_ENABLED=1`
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
