### PR TITLE
ci: add riot hash to DD_TAGS as test.configuration.riot_env_hash

### DIFF
--- a/scripts/ddtest
+++ b/scripts/ddtest
@@ -36,6 +36,7 @@ if [[ "${CIRCLECI}" = "true" ]]; then
                    -e _CI_DD_API_KEY \
                    -e _CI_DD_APP_KEY \
                    -e RIOT_RUN_RECOMPILE_REQS \
+                   -e DD_TAGS \
                    --no-TTY \
                    --quiet-pull \
                    --rm \

--- a/scripts/run-test-suite
+++ b/scripts/run-test-suite
@@ -46,7 +46,7 @@ fi
 
 for hash in ${RIOT_HASHES[@]}; do
     echo "Running riot hash: $hash"
-    if ! $DDTEST_CMD riot -P -v run --exitfirst --pass-env -s $hash $DDTRACE_FLAG $COVERAGE_FLAG; then
+    if ! $DDTEST_CMD DD_TAGS="test.configuration.riot_env_hash:$hash" riot -P -v run --exitfirst --pass-env -s $hash $DDTRACE_FLAG $COVERAGE_FLAG; then
         if [[ -v CIRCLECI ]]; then
             circleci step halt
         fi

--- a/scripts/run-test-suite
+++ b/scripts/run-test-suite
@@ -46,7 +46,7 @@ fi
 
 for hash in ${RIOT_HASHES[@]}; do
     echo "Running riot hash: $hash"
-    if ! $DDTEST_CMD DD_TAGS="test.configuration.riot_env_hash:$hash" riot -P -v run --exitfirst --pass-env -s $hash $DDTRACE_FLAG $COVERAGE_FLAG; then
+    if ! DD_TAGS="test.configuration.riot_env_hash:$hash" $DDTEST_CMD riot -P -v run --exitfirst --pass-env -s $hash $DDTRACE_FLAG $COVERAGE_FLAG; then
         if [[ -v CIRCLECI ]]; then
             circleci step halt
         fi


### PR DESCRIPTION
This adds the riot env hash to the [custom configurations](https://docs.datadoghq.com/continuous_integration/tests/#custom-configurations) for CI.

There are two major side effects:
1- tests will be considered unique per-environment, which will affect flaky test detection (eg: they'll only be seen as flaky in their environment's hash)
2- the hash will be passed to queries to the Intelligent Test Runner's skippable tests endpoint, which will improve its performance slightly, and will ensure that the coverage data is distinct to each environment (at the moment, the data is only distinct based on Python version, which means two environments with the same python version may ovewrite each other's test data)

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
