### PR TITLE
fix(kafka): fix deserializing consumer patching

### DIFF
--- a/ddtrace/contrib/kafka/patch.py
+++ b/ddtrace/contrib/kafka/patch.py
@@ -77,6 +77,9 @@ class TracedSerializingProducer(_SerializingProducer):
             else config.get("metadata.broker.list")
         )
 
+    def produce(self, topic, value=None, *args, **kwargs):
+        super(TracedProducer, self).produce(topic, value, *args, **kwargs)
+
     # in older versions of confluent_kafka, bool(Producer()) evaluates to False,
     # which makes the Pin functionality ignore it.
     def __bool__(self):
@@ -103,6 +106,12 @@ class TracedDeserializingConsumer(_DeserializingConsumer):
         super(TracedDeserializingConsumer, self).__init__(config, *args, **kwargs)
         self._group_id = config.get("group.id", "")
         self._auto_commit = asbool(config.get("enable.auto.commit", True))
+
+    def poll(self, timeout=None):
+        return super(TracedConsumer, self).poll(timeout)
+
+    def commit(self, message=None, *args, **kwargs):
+        return super(TracedConsumer, self).commit(message, args, kwargs)
 
 
 def patch():

--- a/tests/contrib/kafka/test_kafka_patch.py
+++ b/tests/contrib/kafka/test_kafka_patch.py
@@ -14,19 +14,25 @@ class TestKafkaPatch(PatchTestCase.Base):
         self.assert_wrapped(confluent_kafka.Producer({}).produce)
         self.assert_wrapped(confluent_kafka.Consumer({"group.id": "group_id"}).poll)
         self.assert_wrapped(confluent_kafka.SerializingProducer({}).produce)
-        self.assert_wrapped(confluent_kafka.DeserializingConsumer({"group.id": "group_id"}).poll)
+        self.assert_wrapped(
+            confluent_kafka.DeserializingConsumer({"group.id": "group_id", "value.deserializer": bool}).poll
+        )
 
     def assert_not_module_patched(self, confluent_kafka):
         self.assert_not_wrapped(confluent_kafka.Producer({}).produce)
         self.assert_not_wrapped(confluent_kafka.Consumer({"group.id": "group_id"}).poll)
         self.assert_not_wrapped(confluent_kafka.SerializingProducer({}).produce)
-        self.assert_not_wrapped(confluent_kafka.DeserializingConsumer({"group.id": "group_id"}).poll)
+        self.assert_not_wrapped(
+            confluent_kafka.DeserializingConsumer({"group.id": "group_id", "value.deserializer": bool}).poll
+        )
 
     def assert_not_module_double_patched(self, confluent_kafka):
         self.assert_not_double_wrapped(confluent_kafka.Producer({}).produce)
         self.assert_not_double_wrapped(confluent_kafka.Consumer({"group.id": "group_id"}).poll)
         self.assert_not_double_wrapped(confluent_kafka.SerializingProducer({}).produce)
-        self.assert_not_double_wrapped(confluent_kafka.DeserializingConsumer({"group.id": "group_id"}).poll)
+        self.assert_not_double_wrapped(
+            confluent_kafka.DeserializingConsumer({"group.id": "group_id", "value.deserializer": bool}).poll
+        )
 
     def assert_module_implements_get_version(self):
         version = get_version()


### PR DESCRIPTION
Fix support of DeserializingConsumer and SerializingConsumer. Existing tracing support for these classes is overriding them to be the base Consumer/Producer classes.

Link to issue https://github.com/DataDog/dd-trace-py/issues/7339
Link to original PR where this was introduced https://github.com/DataDog/dd-trace-py/pull/6711

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
