### PR TITLE
ci(sanic): disable sanic framework test

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -74,40 +74,40 @@ jobs:
         # log output and it contains phony error messages.
         run: PYTHONPATH=../ddtrace/tests/debugging/exploration/ ddtrace-run pytest test --continue-on-collection-errors -v -k 'not test_simple'
 
-  sanic-testsuite-22_12:
-    runs-on: ubuntu-20.04
-    needs: needs-run
-    env:
-      # Regression test for DataDog/dd-trace-py/issues/5722
-      DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE: true
-      CMAKE_BUILD_PARALLEL_LEVEL: 12
-    defaults:
-      run:
-        working-directory: sanic
-    steps:
-      - uses: actions/checkout@v3
-        if: needs.needs-run.outputs.outcome == 'success'
-        with:
-          path: ddtrace
-      - uses: actions/checkout@v3
-        if: needs.needs-run.outputs.outcome == 'success'
-        with:
-          repository: sanic-org/sanic
-          ref: v22.12.0
-          path: sanic
-      - uses: actions/setup-python@v4
-        if: needs.needs-run.outputs.outcome == 'success'
-        with:
-          python-version: "3.11"
-      - name: Install sanic and dependencies required to run tests
-        if: needs.needs-run.outputs.outcome == 'success'
-        run: pip3 install '.[test]' aioquic
-      - name: Install ddtrace
-        if: needs.needs-run.outputs.outcome == 'success'
-        run: pip3 install ../ddtrace
-      - name: Run tests
-        if: needs.needs-run.outputs.outcome == 'success'
-        run: ddtrace-run pytest -k "not test_add_signal and not test_ode_removes and not test_skip_touchup and not test_dispatch_signal_triggers and not test_keep_alive_connection_context and not test_redirect_with_params"
+#   sanic-testsuite-22_12:
+#     runs-on: ubuntu-20.04
+#     needs: needs-run
+#     env:
+#       # Regression test for DataDog/dd-trace-py/issues/5722
+#       DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE: true
+#       CMAKE_BUILD_PARALLEL_LEVEL: 12
+#     defaults:
+#       run:
+#         working-directory: sanic
+#     steps:
+#       - uses: actions/checkout@v3
+#         if: needs.needs-run.outputs.outcome == 'success'
+#         with:
+#           path: ddtrace
+#       - uses: actions/checkout@v3
+#         if: needs.needs-run.outputs.outcome == 'success'
+#         with:
+#           repository: sanic-org/sanic
+#           ref: v22.12.0
+#           path: sanic
+#       - uses: actions/setup-python@v4
+#         if: needs.needs-run.outputs.outcome == 'success'
+#         with:
+#           python-version: "3.11"
+#       - name: Install sanic and dependencies required to run tests
+#         if: needs.needs-run.outputs.outcome == 'success'
+#         run: pip3 install '.[test]' aioquic
+#       - name: Install ddtrace
+#         if: needs.needs-run.outputs.outcome == 'success'
+#         run: pip3 install ../ddtrace
+#       - name: Run tests
+#         if: needs.needs-run.outputs.outcome == 'success'
+#         run: ddtrace-run pytest -k "not test_add_signal and not test_ode_removes and not test_skip_touchup and not test_dispatch_signal_triggers and not test_keep_alive_connection_context and not test_redirect_with_params"
 
   django-testsuite-3_1:
     strategy:


### PR DESCRIPTION
I made a PR before for Sanic failing/timing out always on 1.20 and 1.19 and it seemed that this wasn't the case for 2.x at the time. However, after looking at more PRs it seems that this test_suite is actually super flakey for 2.x as well, so skipping for now.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
