### PR TITLE
test(profiling): collector log tests

### DIFF
--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -377,14 +377,18 @@ def test_failed_start_collector(caplog, monkeypatch):
     err_collector = mock.MagicMock(wraps=ErrCollect(p._recorder))
     p._collectors = [err_collector]
     p.start()
-    assert caplog.record_tuples == [
-        (("ddtrace.profiling.profiler", logging.ERROR, "Failed to start collector %r, disabling." % err_collector))
+
+    def profiling_tuples(tuples):
+        return [t for t in tuples if t[0].startswith("ddtrace.profiling")]
+
+    assert profiling_tuples(caplog.record_tuples) == [
+        ("ddtrace.profiling.profiler", logging.ERROR, "Failed to start collector %r, disabling." % err_collector)
     ]
     time.sleep(2)
     p.stop()
     assert err_collector.snapshot.call_count == 0
-    assert caplog.record_tuples == [
-        (("ddtrace.profiling.profiler", logging.ERROR, "Failed to start collector %r, disabling." % err_collector))
+    assert profiling_tuples(caplog.record_tuples) == [
+        ("ddtrace.profiling.profiler", logging.ERROR, "Failed to start collector %r, disabling." % err_collector)
     ]
 
 


### PR DESCRIPTION
We improve the logic around log call testing in a profiling collector test to ensure that we ignore non-profiling-related log calls. This fixes recent flakiness probably caused by some extra logging done by other products that would show up in the fixed profiling test.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
