### PR TITLE
Fix `RuntimeError: dictionary changed size during iteration` (`1.x`)

### DIFF
--- a/ddtrace/internal/utils/__init__.py
+++ b/ddtrace/internal/utils/__init__.py
@@ -74,7 +74,8 @@ def set_argument_value(
 def _get_metas_to_propagate(context):
     # type: (Any) -> List[Tuple[str, str]]
     metas_to_propagate = []
-    for k, v in context._meta.items():
+    # copying context._meta.items() to avoid RuntimeError: dictionary changed size during iteration
+    for k, v in list(context._meta.items()):
         if isinstance(k, six.string_types) and k.startswith("_dd.p."):
             metas_to_propagate.append((k, v))
     return metas_to_propagate

--- a/releasenotes/notes/fix-runtimeerror-on-get-metas-to-propagate-0e88d788181562ae.yaml
+++ b/releasenotes/notes/fix-runtimeerror-on-get-metas-to-propagate-0e88d788181562ae.yaml
@@ -1,0 +1,30 @@
+---
+#instructions:
+#    The style guide below provides explanations, instructions, and templates to write your own release note.
+#    Once finished, all irrelevant sections (including this instruction section) should be removed,
+#    and the release note should be committed with the rest of the changes.
+#
+#    The main goal of a release note is to provide a brief overview of a change and provide actionable steps to the user.
+#    The release note should clearly communicate what the change is, why the change was made, and how a user can migrate their code.
+#
+#    The release note should also clearly distinguish between announcements and user instructions. Use:
+#    * Past tense for previous/existing behavior (ex: ``resulted, caused, failed``)
+#    * Third person present tense for the change itself (ex: ``adds, fixes, upgrades``)
+#    * Active present infinitive for user instructions (ex: ``set, use, add``)
+#
+#    Release notes should:
+#    * Use plain language
+#    * Be concise
+#    * Include actionable steps with the necessary code changes
+#    * Include relevant links (bug issues, upstream issues or release notes, documentation pages)
+#    * Use full sentences with sentence-casing and punctuation.
+#    * Before using Datadog specific acronyms/terminology, a release note must first introduce them with a definition.
+#
+#    Release notes should not:
+#    * Be vague. Example: ``fixes an issue in tracing``.
+#    * Use overly technical language
+#    * Use dynamic links (``stable/latest/1.x`` URLs). Instead, use static links (specific version, commit hash) whenever possible so that they don't break in the future.
+fixes:
+  - |
+    ddtrace.internal.utils: This fix resolves an issue where concurrent mutations to the `context._meta` dict
+    caused `RuntimeError: dictionary changed size during iteration`.

--- a/releasenotes/notes/fix-runtimeerror-on-get-metas-to-propagate-0e88d788181562ae.yaml
+++ b/releasenotes/notes/fix-runtimeerror-on-get-metas-to-propagate-0e88d788181562ae.yaml
@@ -1,29 +1,4 @@
 ---
-#instructions:
-#    The style guide below provides explanations, instructions, and templates to write your own release note.
-#    Once finished, all irrelevant sections (including this instruction section) should be removed,
-#    and the release note should be committed with the rest of the changes.
-#
-#    The main goal of a release note is to provide a brief overview of a change and provide actionable steps to the user.
-#    The release note should clearly communicate what the change is, why the change was made, and how a user can migrate their code.
-#
-#    The release note should also clearly distinguish between announcements and user instructions. Use:
-#    * Past tense for previous/existing behavior (ex: ``resulted, caused, failed``)
-#    * Third person present tense for the change itself (ex: ``adds, fixes, upgrades``)
-#    * Active present infinitive for user instructions (ex: ``set, use, add``)
-#
-#    Release notes should:
-#    * Use plain language
-#    * Be concise
-#    * Include actionable steps with the necessary code changes
-#    * Include relevant links (bug issues, upstream issues or release notes, documentation pages)
-#    * Use full sentences with sentence-casing and punctuation.
-#    * Before using Datadog specific acronyms/terminology, a release note must first introduce them with a definition.
-#
-#    Release notes should not:
-#    * Be vague. Example: ``fixes an issue in tracing``.
-#    * Use overly technical language
-#    * Use dynamic links (``stable/latest/1.x`` URLs). Instead, use static links (specific version, commit hash) whenever possible so that they don't break in the future.
 fixes:
   - |
     ddtrace.internal.utils: This fix resolves an issue where concurrent mutations to the `context._meta` dict


### PR DESCRIPTION
We've been seeing this infrequently in a FastAPI app and decided to dig in.

Looks like `context._meta` is changing size during iteration.

Saw a similar issue [here](https://github.com/DataDog/dd-trace-py/pull/1745) so implementing a similar fix.

---

`2.x` PR: https://github.com/DataDog/dd-trace-py/pull/7427

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.