### PR TITLE
ci(telemetry): tries to resolve RemoteDisconnected errors in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -399,7 +399,8 @@ class TelemetryTestSession(object):
 
     def create_connection(self):
         parsed = parse.urlparse(self.telemetry_writer._client._agent_url)
-        return httplib.HTTPConnection(parsed.hostname, parsed.port)
+        # A timeout of 5 seconds will hopefully prevent http.client.RemoteDisconnected errors
+        return httplib.HTTPConnection(parsed.hostname, parsed.port, timeout=5)
 
     def _request(self, method, url):
         # type: (str, str) -> Tuple[int, bytes]


### PR DESCRIPTION
A few telemetry tests are consistently failing with the following exception when getting telemetry payloads from the testagent: `http.client.RemoteDisconnected: Remote end closed connection without response`. These failures was first detected on [f86ac69](https://github.com/DataDog/dd-trace-py/commit/f86ac699ef96e9a2b7c7df511b081f292d5cda9e) ([failing tests](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/49186/workflows/3f35aef2-d79b-47f6-b16b-2cfae26f26c2/jobs/3160014)) and the root cause is still unclear. 

This PR attempts to address these connection issues by setting a 5 second timeout on tracer-testagent connections. This will hopefully reduce the rate of premature disconnection. 

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
