### PR TITLE
chore(tracing): remove 512 char limit on X_DATADOG_TAGS_MAX_LENGTH

### DIFF
--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -423,11 +423,11 @@ class Config(object):
 
         # Datadog tracer tags propagation
         x_datadog_tags_max_length = int(os.getenv("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH", default=512))
-        if x_datadog_tags_max_length < 0 or x_datadog_tags_max_length > 512:
+        if x_datadog_tags_max_length < 0:
             raise ValueError(
                 (
                     "Invalid value {!r} provided for DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH, "
-                    "only non-negative values less than or equal to 512 allowed"
+                    "only non-negative values allowed"
                 ).format(x_datadog_tags_max_length)
             )
         self._x_datadog_tags_max_length = x_datadog_tags_max_length

--- a/releasenotes/notes/lift_max_tag_length_setting-366b3b60d458355b.yaml
+++ b/releasenotes/notes/lift_max_tag_length_setting-366b3b60d458355b.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    tags: Previously ``DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH`` had a max limit setting of 512 characters.
+    This change removes that limit but keeps the default at 512.

--- a/tests/tracer/test_settings.py
+++ b/tests/tracer/test_settings.py
@@ -327,7 +327,7 @@ def test_environment_header_tags():
     (
         (dict(), (512, True)),
         (dict(DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH="0"), (0, False)),
-        (dict(DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH="513"), (ValueError, "Invalid value 513")),
+        (dict(DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH="1024"), (1024, True)),
         (dict(DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH="-1"), (ValueError, "Invalid value -1")),
     ),
 )


### PR DESCRIPTION
Previously the limit was 512 characters (still the default). However, a user reached out saying they wanted to send larger tags than this, and we aren't aware of a version to limit it to strictly 512 characters.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
