### PR TITLE
chore(internal): ignore NOP in bytecode hook injection

### DIFF
--- a/ddtrace/internal/injection.py
+++ b/ddtrace/internal/injection.py
@@ -80,7 +80,10 @@ def _inject_hook(code, hook, lineno, arg):
             if instr.lineno == last_lineno:
                 continue
             last_lineno = instr.lineno
-            if instr.lineno == lineno:
+            # Some lines might be implemented across multiple instruction
+            # offsets, and sometimes a NOP is used as a placeholder. We skip
+            # those to avoid duplicate injections.
+            if instr.lineno == lineno and instr.name != "NOP":
                 locs.appendleft(i)
         except AttributeError:
             # pseudo-instruction (e.g. label)


### PR DESCRIPTION
Some source lines might be implemented over multiple bytecode offset blocks, and in some cases some are just NOPs. We reduce the chances of double injections by ignoring these instruction offsets

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
