### PR TITLE
ci: do not fail on missing exploration data

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -75,7 +75,7 @@ jobs:
         run: PYTHONPATH=../ddtrace/tests/debugging/exploration/ ddtrace-run pytest test --continue-on-collection-errors -v -k 'not test_simple'
       - name: Debugger exploration result
         if: always()
-        run: cat debugger-expl.txt
+        run: cat debugger-expl.txt || true
 
 #   sanic-testsuite-22_12:
 #     runs-on: ubuntu-20.04
@@ -195,7 +195,7 @@ jobs:
 
       - name: Debugger exploration results
         if: always()
-        run: cat debugger-expl.txt
+        run: cat debugger-expl.txt || true
 
   graphene-testsuite-3_0:
     runs-on: ubuntu-latest
@@ -242,7 +242,7 @@ jobs:
         run: ddtrace-run pytest graphene
       - name: Debugger exploration results
         if: always()
-        run: cat debugger-expl.txt
+        run: cat debugger-expl.txt || true
 
   fastapi-testsuite-0_92:
     runs-on: ubuntu-latest
@@ -287,7 +287,7 @@ jobs:
         run: PYTHONPATH=../ddtrace/tests/debugging/exploration/ ddtrace-run pytest -p no:warnings tests
       - name: Debugger exploration results
         if: always()
-        run: cat debugger-expl.txt
+        run: cat debugger-expl.txt || true
 
   flask-testsuite-1_1_4:
     runs-on: ubuntu-latest
@@ -337,7 +337,7 @@ jobs:
           pytest -p no:warnings -k 'not test_exception_propagation and not test_memory_consumption' tests/
       - name: Debugger exploration results
         if: always()
-        run: cat debugger-expl.txt
+        run: cat debugger-expl.txt || true
 
   httpx-testsuite-0_22_0:
     runs-on: ubuntu-latest
@@ -428,7 +428,7 @@ jobs:
           pytest -p no:warnings
       - name: Debugger exploration results
         if: always()
-        run: cat debugger-expl.txt
+        run: cat debugger-expl.txt || true
 
   starlette-testsuite-0_17_1:
     runs-on: "ubuntu-latest"
@@ -474,7 +474,7 @@ jobs:
         run: pytest -W ignore --ddtrace-patch-all tests -k 'not test_request_headers and not test_subdomain_route and not test_websocket_headers and not test_staticfiles_with_invalid_dir_permissions_returns_401'
       - name: Debugger exploration results
         if: always()
-        run: cat debugger-expl.txt
+        run: cat debugger-expl.txt || true
 
   requests-testsuite-2_26_0:
     runs-on: "ubuntu-latest"
@@ -516,7 +516,7 @@ jobs:
         run: PYTHONPATH=../ddtrace/tests/debugging/exploration/ ddtrace-run pytest -p no:warnings tests
       - name: Debugger exploration results
         if: always()
-        run: cat debugger-expl.txt
+        run: cat debugger-expl.txt || true
 
   asyncpg-testsuite-0_27_0:
     # https://github.com/MagicStack/asyncpg/blob/v0.25.0/.github/workflows/tests.yml#L125
@@ -650,4 +650,4 @@ jobs:
         run: ddtrace-run ./tests/gh-deadlocks.sh python39
       - name: Debugger exploration results
         if: always()
-        run: cat debugger-expl.txt
+        run: cat debugger-expl.txt || true


### PR DESCRIPTION
We make sure that the framework tests don't fail when they are actually skipped on a PR, and no exploration data is generated.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
