### PR TITLE
ci: upgrade black now that 2.7 support is no longer a requirement

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -2,9 +2,8 @@
 detached = true
 python = "3.10"
 dependencies = [
-    "black==21.4b2",
-    # See https://github.com/psf/black/issues/2964 for incompatibility with click==8.1.0
-    "click<8.1.0",
+    "black==23.10.1",
+    "click==8.1.7",
     "cython-lint==0.15.0",
     "codespell==2.1.0",
     "bandit==1.7.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ exclude = '''
 
 [tool.black]
 line-length = 120
-target_version = ['py27', 'py35', 'py36', 'py37', 'py38']
+target_version = ['py37', 'py38', 'py39', 'py310', 'py311']
 include = '''\.py[ix]?$'''
 exclude = '''
 (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ exclude = '''
 
 [tool.black]
 line-length = 120
-target_version = ['py37', 'py38', 'py39', 'py310', 'py311']
+target_version = ['py37', 'py38', 'py39', 'py310', 'py311', 'py312']
 include = '''\.py[ix]?$'''
 exclude = '''
 (


### PR DESCRIPTION
This change fixes https://github.com/DataDog/dd-trace-py/issues/4664 by upgrading `black` and `click` to the current latest versions.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
