### PR TITLE
feat(tracer): add remote config support of sample rate

### DIFF
--- a/ddtrace/appsec/_capabilities.py
+++ b/ddtrace/appsec/_capabilities.py
@@ -13,7 +13,7 @@ def _appsec_rc_file_is_not_static():
 
 
 def _asm_feature_is_required():
-    flags = _appsec_rc_flags()
+    flags = _rc_capabilities()
     return Flags.ASM_ACTIVATION in flags or Flags.ASM_API_SECURITY_SAMPLE_RATE in flags
 
 
@@ -44,7 +44,7 @@ _ALL_ASM_BLOCKING = (
 )
 
 
-def _appsec_rc_flags(test_tracer: Optional[ddtrace.Tracer] = None) -> Flags:
+def _rc_capabilities(test_tracer: Optional[ddtrace.Tracer] = None) -> Flags:
     tracer = ddtrace.tracer if test_tracer is None else test_tracer
     value = Flags(0)
     if ddtrace.config._remote_config_enabled:
@@ -73,5 +73,5 @@ def _appsec_rc_capabilities(test_tracer: Optional[ddtrace.Tracer] = None) -> str
     ...
     256         -> 100000000        -> b'\x01\x00'          -> b'AQA='
     """
-    value = _appsec_rc_flags(test_tracer=test_tracer)
+    value = _rc_capabilities(test_tracer=test_tracer)
     return base64.b64encode(value.to_bytes((value.bit_length() + 7) // 8, "big")).decode()

--- a/ddtrace/appsec/_capabilities.py
+++ b/ddtrace/appsec/_capabilities.py
@@ -29,6 +29,7 @@ class Flags(enum.IntFlag):
     ASM_CUSTOM_BLOCKING_RESPONSE = 1 << 9
     ASM_TRUSTED_IPS = 1 << 10
     ASM_API_SECURITY_SAMPLE_RATE = 1 << 11
+    APM_TRACING_SAMPLE_RATE = 1 << 12
 
 
 _ALL_ASM_BLOCKING = (
@@ -54,6 +55,7 @@ def _appsec_rc_flags(test_tracer: Optional[ddtrace.Tracer] = None) -> Flags:
             value |= _ALL_ASM_BLOCKING
         if asm_config._api_security_enabled:
             value |= Flags.ASM_API_SECURITY_SAMPLE_RATE
+    value |= Flags.APM_TRACING_SAMPLE_RATE
     return value
 
 

--- a/ddtrace/appsec/_capabilities.py
+++ b/ddtrace/appsec/_capabilities.py
@@ -29,7 +29,6 @@ class Flags(enum.IntFlag):
     ASM_CUSTOM_BLOCKING_RESPONSE = 1 << 9
     ASM_TRUSTED_IPS = 1 << 10
     ASM_API_SECURITY_SAMPLE_RATE = 1 << 11
-    APM_TRACING_SAMPLE_RATE = 1 << 12
 
 
 _ALL_ASM_BLOCKING = (
@@ -55,7 +54,6 @@ def _appsec_rc_flags(test_tracer: Optional[ddtrace.Tracer] = None) -> Flags:
             value |= _ALL_ASM_BLOCKING
         if asm_config._api_security_enabled:
             value |= Flags.ASM_API_SECURITY_SAMPLE_RATE
-    value |= Flags.APM_TRACING_SAMPLE_RATE
     return value
 
 

--- a/ddtrace/bootstrap/preload.py
+++ b/ddtrace/bootstrap/preload.py
@@ -66,6 +66,7 @@ if config._remote_config_enabled:
     from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
 
     remoteconfig_poller.enable()
+    config.enable_remote_configuration()
 
 if asm_config._asm_enabled or config._remote_config_enabled:
     from ddtrace.appsec._remoteconfiguration import enable_appsec_rc

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -1,5 +1,6 @@
 import base64
 from datetime import datetime
+import enum
 import hashlib
 import json
 import os
@@ -17,11 +18,10 @@ import uuid
 import attr
 import cattr
 from envier import En
-import enum
 import six
 
 import ddtrace
-from ddtrace.appsec._capabilities import _appsec_rc_capabilities
+from ddtrace.appsec._capabilities import _rc_capabilities as appsec_rc_capabilities
 from ddtrace.internal import agent
 from ddtrace.internal import gitmetadata
 from ddtrace.internal import runtime
@@ -237,6 +237,9 @@ class RemoteConfigClient(object):
         self._last_error = None  # type: Optional[str]
         self._backend_state = None  # type: Optional[str]
 
+    def _encode_capabilities(self, capabilities: enum.IntFlag) -> str:
+        return base64.b64encode(capabilities.to_bytes((capabilities.bit_length() + 7) // 8, "big")).decode()
+
     def renew_id(self):
         # called after the process is forked to declare a new id
         self.id = str(uuid.uuid4())
@@ -363,9 +366,7 @@ class RemoteConfigClient(object):
     def _build_payload(self, state):
         # type: (Mapping[str, Any]) -> Mapping[str, Any]
         self._client_tracer["extra_services"] = list(ddtrace.config._get_extra_services())
-        capabilities = _appsec_rc_capabilities()
-        capabilities |= Capabilities.APM_TRACING_SAMPLE_RATE
-
+        capabilities = appsec_rc_capabilities() | Capabilities.APM_TRACING_SAMPLE_RATE
         return dict(
             client=dict(
                 id=self.id,
@@ -373,7 +374,7 @@ class RemoteConfigClient(object):
                 is_tracer=True,
                 client_tracer=self._client_tracer,
                 state=state,
-                capabilities=capabilities,
+                capabilities=self._encode_capabilities(capabilities),
             ),
             cached_target_files=self.cached_target_files,
         )

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -9,6 +9,7 @@ from typing import Dict  # noqa:F401
 from typing import List  # noqa:F401
 from typing import Optional  # noqa:F401
 from typing import Tuple  # noqa:F401
+from typing import Union  # noqa:F401
 
 from ddtrace.internal.serverless import in_azure_function_consumption_plan
 from ddtrace.internal.serverless import in_gcp_function
@@ -217,9 +218,11 @@ class _ConfigItem:
             self._code_value = value
         elif source == "remote_config":
             self._rc_value = value
+        else:
+            raise ValueError("Invalid source: {}".format(source))
 
     def set_code(self, value):
-        # type: (Any) -> None
+        # type: (Union[int, float, str, bool]) -> None
         self._code_value = value
 
     def unset_rc(self):
@@ -227,7 +230,7 @@ class _ConfigItem:
         self._rc_value = None
 
     def value(self):
-        # type: () -> Any
+        # type: () -> Union[int, float, str, bool]
         if self._rc_value is not None:
             return self._rc_value
         if self._code_value is not None:

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -194,18 +194,19 @@ def get_error_ranges(error_range_str):
 
 
 _ConfigSource = Literal["default", "env", "code", "remote_config"]
+_JSONType = Union[None, int, float, str, bool, List["_JSONType"], Dict[str, "_JSONType"]]
 
 
 class _ConfigItem:
     """Configuration item that tracks the value of a setting, and where it came from."""
 
     def __init__(self, name, default, envs):
-        # type: (str, Any, List[Tuple[str, Callable[[str], Any]]]) -> None
+        # type: (str, _JSONType, List[Tuple[str, Callable[[str], Any]]]) -> None
         self._name = name
         self._default_value = default
-        self._env_value = None
-        self._code_value = None
-        self._rc_value = None
+        self._env_value: _JSONType = None
+        self._code_value: _JSONType = None
+        self._rc_value: _JSONType = None
         self._envs = envs
         for env_var, parser in envs:
             if env_var in os.environ:
@@ -222,7 +223,7 @@ class _ConfigItem:
             raise ValueError("Invalid source: {}".format(source))
 
     def set_code(self, value):
-        # type: (Union[int, float, str, bool]) -> None
+        # type: (_JSONType) -> None
         self._code_value = value
 
     def unset_rc(self):
@@ -230,7 +231,7 @@ class _ConfigItem:
         self._rc_value = None
 
     def value(self):
-        # type: () -> Union[int, float, str, bool]
+        # type: () -> _JSONType
         if self._rc_value is not None:
             return self._rc_value
         if self._code_value is not None:

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -192,27 +192,44 @@ def get_error_ranges(error_range_str):
     return error_ranges  # type: ignore[return-value]
 
 
-ConfigSource = Literal["default", "env", "code"]
+_ConfigSource = Literal["default", "env", "code", "remote_config"]
 
 
 class _ConfigItem:
     """Configuration item that tracks the value of a setting, and where it came from."""
 
     def __init__(self, name, default, envs):
+        # type: (str, Any, List[Tuple[str, Callable[[str], Any]]]) -> None
         self._name = name
         self._default_value = default
         self._env_value = None
         self._code_value = None
+        self._rc_value = None
         self._envs = envs
         for env_var, parser in envs:
             if env_var in os.environ:
                 self._env_value = parser(os.environ[env_var])
                 break
 
+    def set_value_source(self, value, source):
+        # type: (Any, _ConfigSource) -> None
+        if source == "code":
+            self._code_value = value
+        elif source == "remote_config":
+            self._rc_value = value
+
     def set_code(self, value):
+        # type: (Any) -> None
         self._code_value = value
 
+    def unset_rc(self):
+        # type: () -> None
+        self._rc_value = None
+
     def value(self):
+        # type: () -> Any
+        if self._rc_value is not None:
+            return self._rc_value
         if self._code_value is not None:
             return self._code_value
         if self._env_value is not None:
@@ -220,7 +237,9 @@ class _ConfigItem:
         return self._default_value
 
     def source(self):
-        # type: () -> ConfigSource
+        # type: () -> _ConfigSource
+        if self._rc_value is not None:
+            return "remote_config"
         if self._code_value is not None:
             return "code"
         if self._env_value is not None:
@@ -228,12 +247,13 @@ class _ConfigItem:
         return "default"
 
     def __repr__(self):
-        return "<{} name={} default={} env_value={} user_value={}>".format(
+        return "<{} name={} default={} env_value={} user_value={} remote_config_value={}>".format(
             self.__class__.__name__,
             self._name,
             self._default_value,
             self._env_value,
             self._code_value,
+            self._rc_value,
         )
 
 
@@ -618,11 +638,21 @@ class Config(object):
         if key == "_config":
             return super(self.__class__, self).__setattr__(key, value)
         elif key in self._config:
-            self._config[key].set_code(value)
-            self._notify_subscribers([key])
+            self._set_config_items([(key, value, "code")])
             return None
         else:
             return super(self.__class__, self).__setattr__(key, value)
+
+    def _set_config_items(self, items):
+        # type: (List[Tuple[str, Any, _ConfigSource]]) -> None
+        for key, value, origin in items:
+            self._config[key].set_value_source(value, origin)
+
+        from ..internal.telemetry import telemetry_writer
+
+        cs = [{"name": k, "value": self._config[k].value(), "origin": self._get_source(k)} for k, _, _ in items]
+        telemetry_writer.add_event({"configuration": cs}, "app-client-configuration-change")
+        self._notify_subscribers([i[0] for i in items])
 
     def _reset(self):
         # type: () -> None
@@ -631,3 +661,49 @@ class Config(object):
     def _get_source(self, item):
         # type: (str) -> str
         return self._config[item].source()
+
+    def _remoteconfigPubSub(self):
+        from ddtrace.internal.remoteconfig._connectors import PublisherSubscriberConnector
+        from ddtrace.internal.remoteconfig._publishers import RemoteConfigPublisher
+        from ddtrace.internal.remoteconfig._pubsub import PubSub
+        from ddtrace.internal.remoteconfig._pubsub import RemoteConfigSubscriber
+
+        class _GlobalConfigPubSub(PubSub):
+            __publisher_class__ = RemoteConfigPublisher
+            __subscriber_class__ = RemoteConfigSubscriber
+            __shared_data__ = PublisherSubscriberConnector()
+
+            def __init__(self, callback):
+                self._publisher = self.__publisher_class__(self.__shared_data__, None)
+                self._subscriber = self.__subscriber_class__(self.__shared_data__, callback, "GlobalConfig")
+
+        return _GlobalConfigPubSub
+
+    def _handle_remoteconfig(self, data, test_tracer=None):
+        # type: (Any, Any) -> None
+
+        # If no data is submitted then the RC config has been deleted. Revert the settings.
+        if not data:
+            for item in self._config.values():
+                item.unset_rc()
+            return
+
+        config = data["config"][0]
+        if "lib_config" not in config:
+            log.warning("unexpected RC payload %r", config)
+            return
+
+        lib_config = config["lib_config"]
+        updated_items = []  # type: List[Tuple[str, Any]]
+
+        if "tracing_sampling_rate" in lib_config:
+            updated_items.append(("_trace_sample_rate", lib_config["tracing_sampling_rate"]))
+
+        self._set_config_items([(k, v, "remote_config") for k, v in updated_items])
+
+    def enable_remote_configuration(self):
+        # type: () -> None
+        """Enable fetching configuration from Datadog."""
+        from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
+
+        remoteconfig_poller.register("APM_TRACING", self._remoteconfigPubSub()(self._handle_remoteconfig))

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -692,6 +692,10 @@ class Config(object):
                 item.unset_rc()
             return
 
+        if len(data["config"]) == 0:
+            log.warning("unexpected number of RC payloads %r", data)
+            return
+
         config = data["config"][0]
         if "lib_config" not in config:
             log.warning("unexpected RC payload %r", config)

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -22,7 +22,6 @@ from ddtrace.internal.processor.endpoint_call_counter import EndpointCallCounter
 from ddtrace.internal.sampling import SpanSamplingRule
 from ddtrace.internal.sampling import get_span_sampling_rules
 from ddtrace.internal.utils import _get_metas_to_propagate
-from ddtrace.settings import Config
 from ddtrace.settings.asm import config as asm_config
 from ddtrace.settings.peer_service import _ps_config
 
@@ -72,6 +71,8 @@ from .span import Span
 
 
 if TYPE_CHECKING:
+    from ddtrace.settings import Config  # noqa: F401
+
     from .internal.writer import AgentResponse  # noqa: F401
 
 

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -410,7 +410,7 @@ class Tracer(object):
 
         if sampler is not None:
             self._sampler = sampler
-            self._user_sampler = sampler
+            self._user_sampler = self._sampler
 
         self._dogstatsd_url = dogstatsd_url or self._dogstatsd_url
 
@@ -1061,9 +1061,11 @@ class Tracer(object):
                 self.configure(sampler=self._user_sampler)
                 return
 
-            sample_rate = None
             if cfg._get_source("_trace_sample_rate") != "default":
                 sample_rate = cfg._trace_sample_rate
+            else:
+                sample_rate = None
             sampler = DatadogSampler(default_sample_rate=sample_rate)
             self._sampler = sampler
+            # Hack to reconfigure the agent with the new sample rate
             self.configure()

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -1058,7 +1058,7 @@ class Tracer(object):
         if "_trace_sample_rate" in items:
             # Reset the user sampler if one exists
             if cfg._get_source("_trace_sample_rate") != "remote_config" and self._user_sampler:
-                self.configure(sampler=self._user_sampler)
+                self._sampler = self._user_sampler
                 return
 
             if cfg._get_source("_trace_sample_rate") != "default":
@@ -1067,5 +1067,3 @@ class Tracer(object):
                 sample_rate = None
             sampler = DatadogSampler(default_sample_rate=sample_rate)
             self._sampler = sampler
-            # Hack to reconfigure the agent with the new sample rate
-            self.configure()

--- a/releasenotes/notes/sample-rate-rc-13119efdf34bc462.yaml
+++ b/releasenotes/notes/sample-rate-rc-13119efdf34bc462.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    tracer: Add support for remotely setting the trace sample rate from the Datadog UI. This functionality is enabled by default when using ``ddtrace-run`` and library injection. To enable it when using the library manually, use ``ddtrace.config.enable_remote_config()``.

--- a/tests/appsec/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/appsec/test_remoteconfiguration.py
@@ -117,12 +117,12 @@ def test_rc_activation_states_off(tracer, appsec_enabled, rc_value, remote_confi
 @pytest.mark.parametrize(
     "rc_enabled, appsec_enabled, capability",
     [
-        (True, "true", "E/w="),  # All capabilities except ASM_ACTIVATION
-        (False, "true", "EAA="),
-        (True, "false", "EAA="),
-        (False, "false", "EAA="),
-        (True, "", "EAI="),  # ASM_ACTIVATION
-        (False, "", "EAA="),
+        (True, "true", "A/w="),  # All capabilities except ASM_ACTIVATION
+        (False, "true", ""),
+        (True, "false", ""),
+        (False, "false", ""),
+        (True, "", "Ag=="),  # ASM_ACTIVATION
+        (False, "", ""),
     ],
 )
 def test_rc_capabilities(rc_enabled, appsec_enabled, capability, tracer):
@@ -142,8 +142,8 @@ def test_rc_capabilities(rc_enabled, appsec_enabled, capability, tracer):
 @pytest.mark.parametrize(
     "env_rules, expected",
     [
-        ({}, "E/4="),  # All capabilities
-        ({"DD_APPSEC_RULES": DEFAULT.RULES}, "EAI="),  # Only ASM_FEATURES
+        ({}, "A/4="),  # All capabilities
+        ({"DD_APPSEC_RULES": DEFAULT.RULES}, "Ag=="),  # Only ASM_FEATURES
     ],
 )
 def test_rc_activation_capabilities(tracer, remote_config_worker, env_rules, expected):

--- a/tests/appsec/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/appsec/test_remoteconfiguration.py
@@ -117,12 +117,12 @@ def test_rc_activation_states_off(tracer, appsec_enabled, rc_value, remote_confi
 @pytest.mark.parametrize(
     "rc_enabled, appsec_enabled, capability",
     [
-        (True, "true", "A/w="),  # All capabilities except ASM_ACTIVATION
-        (False, "true", ""),
-        (True, "false", ""),
-        (False, "false", ""),
-        (True, "", "Ag=="),  # ASM_ACTIVATION
-        (False, "", ""),
+        (True, "true", "E/w="),  # All capabilities except ASM_ACTIVATION
+        (False, "true", "EAA="),
+        (True, "false", "EAA="),
+        (False, "false", "EAA="),
+        (True, "", "EAI="),  # ASM_ACTIVATION
+        (False, "", "EAA="),
     ],
 )
 def test_rc_capabilities(rc_enabled, appsec_enabled, capability, tracer):
@@ -142,8 +142,8 @@ def test_rc_capabilities(rc_enabled, appsec_enabled, capability, tracer):
 @pytest.mark.parametrize(
     "env_rules, expected",
     [
-        ({}, "A/4="),  # All capabilities
-        ({"DD_APPSEC_RULES": DEFAULT.RULES}, "Ag=="),  # Only ASM_FEATURES
+        ({}, "E/4="),  # All capabilities
+        ({"DD_APPSEC_RULES": DEFAULT.RULES}, "EAI="),  # Only ASM_FEATURES
     ],
 )
 def test_rc_activation_capabilities(tracer, remote_config_worker, env_rules, expected):

--- a/tests/integration/test_settings.py
+++ b/tests/integration/test_settings.py
@@ -1,0 +1,76 @@
+import pytest
+
+from .test_integration import AGENT_VERSION
+
+
+def _get_latest_telemetry_config_item(events, item_name):
+    for event in reversed(sorted(events, key=lambda e: (e["tracer_time"], e["seq_id"]))):
+        for item in reversed(event.get("payload", {}).get("configuration", [])):
+            if item_name == item["name"]:
+                return item
+    return None
+
+
+@pytest.mark.skipif(AGENT_VERSION != "testagent", reason="Tests only compatible with a testagent")
+def test_remoteconfig_sampling_rate_default(test_agent_session, run_python_code_in_subprocess):
+    out, err, status, _ = run_python_code_in_subprocess(
+        """
+from ddtrace import config, tracer
+from tests.internal.test_settings import _base_rc_config
+
+with tracer.trace("test") as span:
+    pass
+assert span.get_metric("_dd.rule_psr") is None
+
+config._handle_remoteconfig(_base_rc_config({"tracing_sampling_rate": 0.5}))
+with tracer.trace("test") as span:
+    pass
+assert span.get_metric("_dd.rule_psr") == 0.5
+
+config._handle_remoteconfig(_base_rc_config({"tracing_sampling_rate": None}))
+with tracer.trace("test") as span:
+    pass
+assert span.get_metric("_dd.rule_psr") is None, "Unsetting remote config trace sample rate"
+
+config._handle_remoteconfig(_base_rc_config({"tracing_sampling_rate": 0.8}))
+with tracer.trace("test") as span:
+    pass
+assert span.get_metric("_dd.rule_psr") == 0.8
+
+config._handle_remoteconfig(_base_rc_config({"tracing_sampling_rate": None}))
+with tracer.trace("test") as span:
+    pass
+assert span.get_metric("_dd.rule_psr") is None, "(second time) unsetting remote config trace sample rate"
+        """,
+    )
+    assert status == 0, err
+
+    events = test_agent_session.get_events()
+    assert _get_latest_telemetry_config_item(events, "_trace_sample_rate") == {
+        "name": "_trace_sample_rate",
+        "value": 1.0,
+        "origin": "default",
+    }
+
+
+@pytest.mark.skipif(AGENT_VERSION != "testagent", reason="Tests only compatible with a testagent")
+def test_remoteconfig_sampling_rate_telemetry(test_agent_session, run_python_code_in_subprocess):
+    out, err, status, _ = run_python_code_in_subprocess(
+        """
+from ddtrace import config, tracer
+from tests.internal.test_settings import _base_rc_config
+
+config._handle_remoteconfig(_base_rc_config({"tracing_sampling_rate": 0.5}))
+with tracer.trace("test") as span:
+    pass
+assert span.get_metric("_dd.rule_psr") == 0.5
+        """,
+    )
+    assert status == 0, err
+
+    events = test_agent_session.get_events()
+    assert _get_latest_telemetry_config_item(events, "_trace_sample_rate") == {
+        "name": "_trace_sample_rate",
+        "value": 0.5,
+        "origin": "remote_config",
+    }

--- a/tests/internal/remoteconfig/test_remoteconfig_client_e2e.py
+++ b/tests/internal/remoteconfig/test_remoteconfig_client_e2e.py
@@ -18,6 +18,7 @@ from tests.utils import override_global_config
 
 def _expected_payload(
     rc_client,
+    capabilities="EAA=",
     has_errors=False,
     targets_version=0,
     backend_client_state=None,
@@ -50,7 +51,7 @@ def _expected_payload(
                 "config_states": config_states,
                 "has_error": has_errors,
             },
-            "capabilities": "EAA=",
+            "capabilities": capabilities,
         },
         "cached_target_files": cached_target_files,
     }
@@ -113,7 +114,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     # 0.
     mock_send_request.return_value = MOCK_AGENT_RESPONSES[0]
     rc_client.request()
-    expected_response = _expected_payload(rc_client)
+    expected_response = _expected_payload(rc_client, capabilities="EAI=")
 
     assert rc_client._last_error is None
     _assert_response(mock_send_request, expected_response)
@@ -131,7 +132,9 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     # The tracer is supposed to process this update and store that the latest TUF Targets version is 1.
     mock_send_request.return_value = MOCK_AGENT_RESPONSES[1]
     rc_client.request()
-    expected_response = _expected_payload(rc_client, targets_version=1, backend_client_state="eyJmb28iOiAiYmFyIn0=")
+    expected_response = _expected_payload(
+        rc_client, capabilities="EAI=", targets_version=1, backend_client_state="eyJmb28iOiAiYmFyIn0="
+    )
 
     assert rc_client._last_error is None
     _assert_response(mock_send_request, expected_response)
@@ -150,6 +153,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
+        capabilities="EAI=",
         targets_version=2,
         config_states=[{"id": "ASM_FEATURES-base", "version": 1, "product": "ASM_FEATURES", "apply_state": 2}],
         backend_client_state="eyJmb28iOiAiYmFyIn0=",
@@ -184,6 +188,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
+        capabilities="EAI=",
         targets_version=3,
         config_states=[{"id": "ASM_FEATURES-base", "version": 2, "product": "ASM_FEATURES", "apply_state": 2}],
         backend_client_state="eyJmb28iOiAiYmFyIn0=",
@@ -218,6 +223,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
+        capabilities="EAI=",
         targets_version=4,
         config_states=[],
         backend_client_state="eyJmb28iOiAiYmFyIn0=",
@@ -241,6 +247,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
+        capabilities="EAI=",
         targets_version=5,
         config_states=[
             {"id": "ASM_FEATURES-base", "version": 1, "product": "ASM_FEATURES", "apply_state": 2},
@@ -288,6 +295,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
+        capabilities="EAI=",
         targets_version=6,
         config_states=[
             {"id": "ASM_FEATURES-base", "version": 1, "product": "ASM_FEATURES", "apply_state": 2},
@@ -335,6 +343,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
+        capabilities="EAI=",
         targets_version=7,
         config_states=[
             {"id": "ASM_FEATURES-third", "version": 1, "product": "ASM_FEATURES", "apply_state": 2},
@@ -393,6 +402,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
+        capabilities="EAI=",
         targets_version=8,
         config_states=[
             {"id": "ASM_FEATURES-second", "version": 1, "product": "ASM_FEATURES", "apply_state": 2},
@@ -442,6 +452,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
+        capabilities="EAI=",
         targets_version=9,
         config_states=[
             {"id": "ASM_FEATURES-second", "version": 1, "product": "ASM_FEATURES", "apply_state": 2},
@@ -490,6 +501,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
+        capabilities="EAI=",
         targets_version=10,
         config_states=[
             {"id": "ASM_FEATURES-second", "version": 1, "product": "ASM_FEATURES", "apply_state": 2},
@@ -538,6 +550,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
+        capabilities="EAI=",
         targets_version=11,
         config_states=[
             {"id": "ASM_FEATURES-second", "version": 1, "product": "ASM_FEATURES", "apply_state": 2},
@@ -603,6 +616,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
+        capabilities="EAI=",
         targets_version=12,
         config_states=[
             {"id": "ASM_FEATURES-second", "version": 1, "product": "ASM_FEATURES", "apply_state": 2},
@@ -664,6 +678,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
+        capabilities="EAI=",
         targets_version=12,
         has_errors=True,
         error_msg="Not all client configurations have target files",
@@ -727,6 +742,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
+        capabilities="EAI=",
         targets_version=12,
         has_errors=True,
         error_msg=(
@@ -790,7 +806,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
 
 
 @mock.patch.object(RemoteConfigClient, "_send_request")
-@mock.patch("ddtrace.internal.remoteconfig.client.appsec_rc_capabilities")
+@mock.patch("ddtrace.appsec._capabilities._appsec_rc_capabilities")
 def test_remote_config_client_callback_error(
     mock_appsec_rc_capabilities,
     mock_send_request,

--- a/tests/internal/remoteconfig/test_remoteconfig_client_e2e.py
+++ b/tests/internal/remoteconfig/test_remoteconfig_client_e2e.py
@@ -50,7 +50,7 @@ def _expected_payload(
                 "config_states": config_states,
                 "has_error": has_errors,
             },
-            "capabilities": "Ag==",
+            "capabilities": "EAA=",
         },
         "cached_target_files": cached_target_files,
     }
@@ -790,7 +790,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
 
 
 @mock.patch.object(RemoteConfigClient, "_send_request")
-@mock.patch("ddtrace.internal.remoteconfig.client._appsec_rc_capabilities")
+@mock.patch("ddtrace.internal.remoteconfig.client.appsec_rc_capabilities")
 def test_remote_config_client_callback_error(
     mock_appsec_rc_capabilities,
     mock_send_request,

--- a/tests/internal/remoteconfig/test_remoteconfig_client_e2e.py
+++ b/tests/internal/remoteconfig/test_remoteconfig_client_e2e.py
@@ -114,7 +114,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     # 0.
     mock_send_request.return_value = MOCK_AGENT_RESPONSES[0]
     rc_client.request()
-    expected_response = _expected_payload(rc_client, capabilities="EAI=")
+    expected_response = _expected_payload(rc_client)
 
     assert rc_client._last_error is None
     _assert_response(mock_send_request, expected_response)
@@ -132,9 +132,7 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     # The tracer is supposed to process this update and store that the latest TUF Targets version is 1.
     mock_send_request.return_value = MOCK_AGENT_RESPONSES[1]
     rc_client.request()
-    expected_response = _expected_payload(
-        rc_client, capabilities="EAI=", targets_version=1, backend_client_state="eyJmb28iOiAiYmFyIn0="
-    )
+    expected_response = _expected_payload(rc_client, targets_version=1, backend_client_state="eyJmb28iOiAiYmFyIn0=")
 
     assert rc_client._last_error is None
     _assert_response(mock_send_request, expected_response)
@@ -153,7 +151,6 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
-        capabilities="EAI=",
         targets_version=2,
         config_states=[{"id": "ASM_FEATURES-base", "version": 1, "product": "ASM_FEATURES", "apply_state": 2}],
         backend_client_state="eyJmb28iOiAiYmFyIn0=",
@@ -188,7 +185,6 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
-        capabilities="EAI=",
         targets_version=3,
         config_states=[{"id": "ASM_FEATURES-base", "version": 2, "product": "ASM_FEATURES", "apply_state": 2}],
         backend_client_state="eyJmb28iOiAiYmFyIn0=",
@@ -223,7 +219,6 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
-        capabilities="EAI=",
         targets_version=4,
         config_states=[],
         backend_client_state="eyJmb28iOiAiYmFyIn0=",
@@ -247,7 +242,6 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
-        capabilities="EAI=",
         targets_version=5,
         config_states=[
             {"id": "ASM_FEATURES-base", "version": 1, "product": "ASM_FEATURES", "apply_state": 2},
@@ -295,7 +289,6 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
-        capabilities="EAI=",
         targets_version=6,
         config_states=[
             {"id": "ASM_FEATURES-base", "version": 1, "product": "ASM_FEATURES", "apply_state": 2},
@@ -343,7 +336,6 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
-        capabilities="EAI=",
         targets_version=7,
         config_states=[
             {"id": "ASM_FEATURES-third", "version": 1, "product": "ASM_FEATURES", "apply_state": 2},
@@ -402,7 +394,6 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
-        capabilities="EAI=",
         targets_version=8,
         config_states=[
             {"id": "ASM_FEATURES-second", "version": 1, "product": "ASM_FEATURES", "apply_state": 2},
@@ -452,7 +443,6 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
-        capabilities="EAI=",
         targets_version=9,
         config_states=[
             {"id": "ASM_FEATURES-second", "version": 1, "product": "ASM_FEATURES", "apply_state": 2},
@@ -501,7 +491,6 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
-        capabilities="EAI=",
         targets_version=10,
         config_states=[
             {"id": "ASM_FEATURES-second", "version": 1, "product": "ASM_FEATURES", "apply_state": 2},
@@ -550,7 +539,6 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
-        capabilities="EAI=",
         targets_version=11,
         config_states=[
             {"id": "ASM_FEATURES-second", "version": 1, "product": "ASM_FEATURES", "apply_state": 2},
@@ -616,7 +604,6 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
-        capabilities="EAI=",
         targets_version=12,
         config_states=[
             {"id": "ASM_FEATURES-second", "version": 1, "product": "ASM_FEATURES", "apply_state": 2},
@@ -678,7 +665,6 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
-        capabilities="EAI=",
         targets_version=12,
         has_errors=True,
         error_msg="Not all client configurations have target files",
@@ -742,7 +728,6 @@ def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_reque
     rc_client.request()
     expected_response = _expected_payload(
         rc_client,
-        capabilities="EAI=",
         targets_version=12,
         has_errors=True,
         error_msg=(

--- a/tests/internal/remoteconfig/test_remoteconfig_client_e2e.py
+++ b/tests/internal/remoteconfig/test_remoteconfig_client_e2e.py
@@ -79,7 +79,7 @@ def _assert_response(mock_send_request, expected_response):
 
 
 @mock.patch.object(RemoteConfigClient, "_send_request")
-@mock.patch("ddtrace.internal.remoteconfig.client._appsec_rc_capabilities")
+@mock.patch("ddtrace.appsec._capabilities._appsec_rc_capabilities")
 def test_remote_config_client_steps(mock_appsec_rc_capabilities, mock_send_request):
     remoteconfig_poller.disable()
     assert remoteconfig_poller.status == ServiceStatus.STOPPED

--- a/tests/internal/test_settings.py
+++ b/tests/internal/test_settings.py
@@ -1,3 +1,5 @@
+import os
+
 import mock
 import pytest
 
@@ -7,6 +9,27 @@ from ddtrace.settings import Config
 @pytest.fixture
 def config():
     yield Config()
+
+
+def _base_rc_config(cfg):
+    lib_config = {
+        "tracing_sampling_rate": None,
+        "log_injection_enabled": None,
+        "tracing_header_tags": None,
+        "data_streams_enabled": None,
+    }
+    lib_config.update(cfg)
+
+    return {
+        "metadata": [],
+        "config": [
+            {
+                "action": "enable",
+                "service_target": {"service": None, "env": None},
+                "lib_config": lib_config,
+            }
+        ],
+    }
 
 
 @pytest.mark.parametrize(
@@ -34,6 +57,13 @@ def config():
             "code": {"_trace_sample_rate": 0.8},
             "expected": {"_trace_sample_rate": 0.8},
             "expected_source": {"_trace_sample_rate": "code"},
+        },
+        {
+            "env": {"DD_TRACE_SAMPLE_RATE": "0.9"},
+            "code": {"_trace_sample_rate": 0.8},
+            "rc": {"tracing_sampling_rate": 0.7},
+            "expected": {"_trace_sample_rate": 0.7},
+            "expected_source": {"_trace_sample_rate": "remote_config"},
         },
         {
             "env": {"DD_LOGS_INJECTION": "true"},
@@ -69,6 +99,10 @@ def test_settings(testcase, config, monkeypatch):
     for code_name, code_value in testcase.get("code", {}).items():
         setattr(config, code_name, code_value)
 
+    rc_items = testcase.get("rc", {}).items()
+    if rc_items:
+        config._handle_remoteconfig(_base_rc_config(rc_items), None)
+
     for expected_name, expected_value in testcase["expected"].items():
         assert getattr(config, expected_name) == expected_value
 
@@ -82,3 +116,47 @@ def test_config_subscription(config):
         config._subscribe([s], _handler)
         setattr(config, s, "1")
         _handler.assert_called_once_with(config, [s])
+
+
+def test_remoteconfig_sampling_rate_user(run_python_code_in_subprocess):
+    env = os.environ.copy()
+    env.update({"DD_TRACE_SAMPLE_RATE": "0.1"})
+    out, err, status, _ = run_python_code_in_subprocess(
+        """
+from ddtrace import config, tracer
+from ddtrace.sampler import DatadogSampler
+from tests.internal.test_settings import _base_rc_config
+
+with tracer.trace("test") as span:
+    pass
+assert span.get_metric("_dd.rule_psr") == 0.1
+
+config._handle_remoteconfig(_base_rc_config({"tracing_sampling_rate": 0.2}))
+with tracer.trace("test") as span:
+    pass
+assert span.get_metric("_dd.rule_psr") == 0.2
+
+config._handle_remoteconfig(_base_rc_config({"tracing_sampling_rate": None}))
+with tracer.trace("test") as span:
+    pass
+assert span.get_metric("_dd.rule_psr") == 0.1
+
+custom_sampler = DatadogSampler(default_sample_rate=0.3)
+tracer.configure(sampler=custom_sampler)
+with tracer.trace("test") as span:
+    pass
+assert span.get_metric("_dd.rule_psr") == 0.3
+
+config._handle_remoteconfig(_base_rc_config({"tracing_sampling_rate": 0.4}))
+with tracer.trace("test") as span:
+    pass
+assert span.get_metric("_dd.rule_psr") == 0.4
+
+config._handle_remoteconfig(_base_rc_config({"tracing_sampling_rate": None}))
+with tracer.trace("test") as span:
+    pass
+assert span.get_metric("_dd.rule_psr") == 0.3
+        """,
+        env=env,
+    )
+    assert status == 0, err.decode("utf-8")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -124,9 +124,9 @@ def override_global_config(values):
         "_remote_config_poll_interval",
         "_sampling_rules",
         "_sampling_rules_file",
-        "_trace_sample_rate",
         "_trace_rate_limit",
         "_trace_sampling_rules",
+        "_trace_sample_rate",
         "_trace_api",
         "_trace_writer_buffer_size",
         "_trace_writer_payload_size",
@@ -150,6 +150,8 @@ def override_global_config(values):
         "_user_model_name_field",
     ]
 
+    subscriptions = ddtrace.config._subscriptions
+    ddtrace.config._subscriptions = []
     # Grab the current values of all keys
     originals = dict((key, getattr(ddtrace.config, key)) for key in global_config_keys)
     asm_originals = dict((key, getattr(ddtrace.settings.asm.config, key)) for key in asm_config_keys)
@@ -169,6 +171,7 @@ def override_global_config(values):
         for key, value in asm_originals.items():
             setattr(ddtrace.settings.asm.config, key, value)
         ddtrace.config._reset()
+        ddtrace.config._subscriptions = subscriptions
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Add support for remotely configuring the trace sample rate via the Remote Config platform. This enables the trace sample rate to be configured through the Datadog UI, enabling users to easily configure it for their service without requiring a deploy. 

The feature is enabled by default when using `ddtrace-run` or the various injection methods but is not enabled by default for manual usage of the library to avoid unnecessary overhead. Instead, `ddtrace.config.enable_remote_configuration()` is provided for advanced users to enable the functionality.

This extends on #6192 to add a remote config source to configuration items.


## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
