### PR TITLE
ci(debugging): fix exploration reporting step

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -74,8 +74,8 @@ jobs:
         # log output and it contains phony error messages.
         run: PYTHONPATH=../ddtrace/tests/debugging/exploration/ ddtrace-run pytest test --continue-on-collection-errors -v -k 'not test_simple'
       - name: Debugger exploration result
-        if: always()
-        run: cat debugger-expl.txt || true
+        if: needs.needs-run.outputs.outcome == 'success'
+        run: cat debugger-expl.txt
 
 #   sanic-testsuite-22_12:
 #     runs-on: ubuntu-20.04
@@ -194,8 +194,8 @@ jobs:
         run: DD_TRACE_REQUESTS_ENABLED=0 ddtrace-run tests/runtests.py
 
       - name: Debugger exploration results
-        if: always()
-        run: cat debugger-expl.txt || true
+        if: needs.needs-run.outputs.outcome == 'success'
+        run: cat debugger-expl.txt
 
   graphene-testsuite-3_0:
     runs-on: ubuntu-latest
@@ -241,8 +241,8 @@ jobs:
         if: needs.needs-run.outputs.outcome == 'success'
         run: ddtrace-run pytest graphene
       - name: Debugger exploration results
-        if: always()
-        run: cat debugger-expl.txt || true
+        if: needs.needs-run.outputs.outcome == 'success'
+        run: cat debugger-expl.txt
 
   fastapi-testsuite-0_92:
     runs-on: ubuntu-latest
@@ -286,8 +286,8 @@ jobs:
         if: needs.needs-run.outputs.outcome == 'success'
         run: PYTHONPATH=../ddtrace/tests/debugging/exploration/ ddtrace-run pytest -p no:warnings tests
       - name: Debugger exploration results
-        if: always()
-        run: cat debugger-expl.txt || true
+        if: needs.needs-run.outputs.outcome == 'success'
+        run: cat debugger-expl.txt
 
   flask-testsuite-1_1_4:
     runs-on: ubuntu-latest
@@ -336,8 +336,8 @@ jobs:
           pip install --upgrade MarkupSafe==2.0.1
           pytest -p no:warnings -k 'not test_exception_propagation and not test_memory_consumption' tests/
       - name: Debugger exploration results
-        if: always()
-        run: cat debugger-expl.txt || true
+        if: needs.needs-run.outputs.outcome == 'success'
+        run: cat debugger-expl.txt
 
   httpx-testsuite-0_22_0:
     runs-on: ubuntu-latest
@@ -427,8 +427,8 @@ jobs:
           pip install -e .
           pytest -p no:warnings
       - name: Debugger exploration results
-        if: always()
-        run: cat debugger-expl.txt || true
+        if: needs.needs-run.outputs.outcome == 'success'
+        run: cat debugger-expl.txt
 
   starlette-testsuite-0_17_1:
     runs-on: "ubuntu-latest"
@@ -473,8 +473,8 @@ jobs:
         if: needs.needs-run.outputs.outcome == 'success'
         run: pytest -W ignore --ddtrace-patch-all tests -k 'not test_request_headers and not test_subdomain_route and not test_websocket_headers and not test_staticfiles_with_invalid_dir_permissions_returns_401'
       - name: Debugger exploration results
-        if: always()
-        run: cat debugger-expl.txt || true
+        if: needs.needs-run.outputs.outcome == 'success'
+        run: cat debugger-expl.txt
 
   requests-testsuite-2_26_0:
     runs-on: "ubuntu-latest"
@@ -515,8 +515,8 @@ jobs:
         if: needs.needs-run.outputs.outcome == 'success'
         run: PYTHONPATH=../ddtrace/tests/debugging/exploration/ ddtrace-run pytest -p no:warnings tests
       - name: Debugger exploration results
-        if: always()
-        run: cat debugger-expl.txt || true
+        if: needs.needs-run.outputs.outcome == 'success' 
+        run: cat debugger-expl.txt
 
   asyncpg-testsuite-0_27_0:
     # https://github.com/MagicStack/asyncpg/blob/v0.25.0/.github/workflows/tests.yml#L125
@@ -649,5 +649,5 @@ jobs:
         if: needs.needs-run.outputs.outcome == 'success'
         run: ddtrace-run ./tests/gh-deadlocks.sh python39
       - name: Debugger exploration results
-        if: always()
-        run: cat debugger-expl.txt || true
+        if: needs.needs-run.outputs.outcome == 'success'
+        run: cat debugger-expl.txt


### PR DESCRIPTION
We make the reporting step conditional like the other steps in the framework test suites to avoid it failing on the missing working directory.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
