### PR TITLE
fix(kafka): patch SerializingProducer and DeserializingConsumer [backport to 1.20]

### DIFF
--- a/ddtrace/contrib/kafka/patch.py
+++ b/ddtrace/contrib/kafka/patch.py
@@ -23,9 +23,15 @@ from ddtrace.pin import Pin
 
 _Producer = confluent_kafka.Producer
 _Consumer = confluent_kafka.Consumer
-_SerializingProducer = confluent_kafka.SerializingProducer if hasattr(confluent_kafka, "SerializingProducer") else None
+_SerializingProducer = (
+    confluent_kafka.SerializingProducer
+    if hasattr(confluent_kafka, "SerializingProducer")
+    else None
+)
 _DeserializingConsumer = (
-    confluent_kafka.DeserializingConsumer if hasattr(confluent_kafka, "DeserializingConsumer") else None
+    confluent_kafka.DeserializingConsumer
+    if hasattr(confluent_kafka, "DeserializingConsumer")
+    else None
 )
 
 
@@ -42,9 +48,9 @@ def get_version():
     return getattr(confluent_kafka, "__version__", "")
 
 
-class TracedProducer(confluent_kafka.Producer):
+class TracedProducerMixin:
     def __init__(self, config, *args, **kwargs):
-        super(TracedProducer, self).__init__(config, *args, **kwargs)
+        super(TracedProducerMixin, self).__init__(config, *args, **kwargs)
         self._dd_bootstrap_servers = (
             config.get("bootstrap.servers")
             if config.get("bootstrap.servers") is not None
@@ -59,11 +65,31 @@ class TracedProducer(confluent_kafka.Producer):
     __nonzero__ = __bool__
 
 
-class TracedConsumer(confluent_kafka.Consumer):
+class TracedConsumerMixin:
     def __init__(self, config, *args, **kwargs):
-        super(TracedConsumer, self).__init__(config, *args, **kwargs)
+        super(TracedConsumerMixin, self).__init__(config, *args, **kwargs)
         self._group_id = config.get("group.id", "")
         self._auto_commit = asbool(config.get("enable.auto.commit", True))
+
+
+class TracedConsumer(TracedConsumerMixin, confluent_kafka.Consumer):
+    pass
+
+
+class TracedProducer(TracedProducerMixin, confluent_kafka.Producer):
+    pass
+
+
+class TracedDeserializingConsumer(
+    TracedConsumerMixin, confluent_kafka.DeserializingConsumer
+):
+    pass
+
+
+class TracedSerializingProducer(
+    TracedProducerMixin, confluent_kafka.SerializingProducer
+):
+    pass
 
 
 def patch():
@@ -74,27 +100,33 @@ def patch():
     confluent_kafka.Producer = TracedProducer
     confluent_kafka.Consumer = TracedConsumer
     if _SerializingProducer is not None:
-        confluent_kafka.SerializingProducer = TracedProducer
+        confluent_kafka.SerializingProducer = TracedSerializingProducer
     if _DeserializingConsumer is not None:
-        confluent_kafka.DeserializingConsumer = TracedConsumer
+        confluent_kafka.DeserializingConsumer = TracedDeserializingConsumer
 
-    trace_utils.wrap(TracedProducer, "produce", traced_produce)
-    trace_utils.wrap(TracedConsumer, "poll", traced_poll)
-    trace_utils.wrap(TracedConsumer, "commit", traced_commit)
+    for producer in (TracedProducer, TracedSerializingProducer):
+        trace_utils.wrap(producer, "produce", traced_produce)
+    for consumer in (TracedConsumer, TracedDeserializingConsumer):
+        trace_utils.wrap(consumer, "poll", traced_poll)
+        trace_utils.wrap(consumer, "commit", traced_commit)
     Pin().onto(confluent_kafka.Producer)
     Pin().onto(confluent_kafka.Consumer)
+    Pin().onto(confluent_kafka.SerializingProducer)
+    Pin().onto(confluent_kafka.DeserializingConsumer)
 
 
 def unpatch():
     if getattr(confluent_kafka, "_datadog_patch", False):
         confluent_kafka._datadog_patch = False
 
-    if trace_utils.iswrapped(TracedProducer.produce):
-        trace_utils.unwrap(TracedProducer, "produce")
-    if trace_utils.iswrapped(TracedConsumer.poll):
-        trace_utils.unwrap(TracedConsumer, "poll")
-    if trace_utils.iswrapped(TracedConsumer.commit):
-        trace_utils.unwrap(TracedConsumer, "commit")
+    for producer in (TracedProducer, TracedSerializingProducer):
+        if trace_utils.iswrapped(producer.produce):
+            trace_utils.unwrap(producer, "produce")
+    for consumer in (TracedConsumer, TracedDeserializingConsumer):
+        if trace_utils.iswrapped(consumer.poll):
+            trace_utils.unwrap(consumer, "poll")
+        if trace_utils.iswrapped(consumer.commit):
+            trace_utils.unwrap(consumer, "commit")
 
     confluent_kafka.Producer = _Producer
     confluent_kafka.Consumer = _Consumer
@@ -117,10 +149,15 @@ def traced_produce(func, instance, args, kwargs):
         value = None
     message_key = kwargs.get("key", "")
     partition = kwargs.get("partition", -1)
-    core.dispatch("kafka.produce.start", [instance, args, kwargs])
+    core.dispatch(
+        "kafka.produce.start",
+        [instance, args, kwargs, isinstance(instance, _SerializingProducer)],
+    )
 
     with pin.tracer.trace(
-        schematize_messaging_operation(kafkax.PRODUCE, provider="kafka", direction=SpanDirection.OUTBOUND),
+        schematize_messaging_operation(
+            kafkax.PRODUCE, provider="kafka", direction=SpanDirection.OUTBOUND
+        ),
         service=trace_utils.ext_service(pin, config.kafka),
         span_type=SpanTypes.WORKER,
     ) as span:
@@ -146,7 +183,9 @@ def traced_poll(func, instance, args, kwargs):
         return func(*args, **kwargs)
 
     with pin.tracer.trace(
-        schematize_messaging_operation(kafkax.CONSUME, provider="kafka", direction=SpanDirection.PROCESSING),
+        schematize_messaging_operation(
+            kafkax.CONSUME, provider="kafka", direction=SpanDirection.PROCESSING
+        ),
         service=trace_utils.ext_service(pin, config.kafka),
         span_type=SpanTypes.WORKER,
     ) as span:
@@ -163,7 +202,9 @@ def traced_poll(func, instance, args, kwargs):
             message_key = message.key() or ""
             message_offset = message.offset() or -1
             span.set_tag_str(kafkax.TOPIC, message.topic())
-            span.set_tag_str(kafkax.MESSAGE_KEY, ensure_text(message_key, errors="replace"))
+            span.set_tag_str(
+                kafkax.MESSAGE_KEY, ensure_text(message_key, errors="replace")
+            )
             span.set_tag(kafkax.PARTITION, message.partition())
             span.set_tag_str(kafkax.TOMBSTONE, str(len(message) == 0))
             span.set_tag(kafkax.MESSAGE_OFFSET, message_offset)

--- a/ddtrace/internal/datastreams/kafka.py
+++ b/ddtrace/internal/datastreams/kafka.py
@@ -14,7 +14,7 @@ from ddtrace.internal.utils import set_argument_value
 INT_TYPES = six.integer_types
 
 
-def dsm_kafka_message_produce(instance, args, kwargs):
+def dsm_kafka_message_produce(instance, args, kwargs, is_serializing):
     from . import data_streams_processor as processor
 
     topic = core.get_item("kafka_topic")
@@ -30,9 +30,10 @@ def dsm_kafka_message_produce(instance, args, kwargs):
     try:
         on_delivery = get_argument_value(args, kwargs, on_delivery_arg, on_delivery_kwarg)
     except ArgumentError:
-        on_delivery_kwarg = "callback"
-        on_delivery_arg = 4
-        on_delivery = get_argument_value(args, kwargs, on_delivery_arg, on_delivery_kwarg, optional=True)
+        if not is_serializing:
+            on_delivery_kwarg = "callback"
+            on_delivery_arg = 4
+            on_delivery = get_argument_value(args, kwargs, on_delivery_arg, on_delivery_kwarg, optional=True)
 
     def wrapped_callback(err, msg):
         if err is None:

--- a/releasenotes/notes/kafka-serial-498a5b325673bfa8.yaml
+++ b/releasenotes/notes/kafka-serial-498a5b325673bfa8.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    This fix resolves an issue where ``confluent_kafka``'s ``SerializingProducer`` and ``DeserializingConsumer``
+    classes were incorrectly patched, causing crashes when these classes are in use with Datadog patching.

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -16,6 +16,7 @@ from ddtrace.contrib.kafka.patch import patch
 from ddtrace.contrib.kafka.patch import unpatch
 from ddtrace.filters import TraceFilter
 import ddtrace.internal.datastreams  # noqa: F401 - used as part of mock patching
+from ddtrace.internal.datastreams.processor import PROPAGATION_KEY
 from ddtrace.internal.datastreams.processor import ConsumerPartitionKey
 from ddtrace.internal.datastreams.processor import PartitionKey
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -16,8 +16,8 @@ from ddtrace.contrib.kafka.patch import patch
 from ddtrace.contrib.kafka.patch import unpatch
 from ddtrace.filters import TraceFilter
 import ddtrace.internal.datastreams  # noqa: F401 - used as part of mock patching
-from ddtrace.internal.datastreams.processor import PROPAGATION_KEY
 from ddtrace.internal.datastreams.processor import ConsumerPartitionKey
+from ddtrace.internal.datastreams.processor import PROPAGATION_KEY
 from ddtrace.internal.datastreams.processor import PartitionKey
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from tests.contrib.config import KAFKA_CONFIG

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -36,10 +36,7 @@ else:
 class KafkaConsumerPollFilter(TraceFilter):
     def process_trace(self, trace):
         # Filter out all poll spans that have no received message
-        if (
-            trace[0].name == "kafka.consume"
-            and trace[0].get_tag("kafka.received_message") == "False"
-        ):
+        if trace[0].name == "kafka.consume" and trace[0].get_tag("kafka.received_message") == "False":
             return None
 
         return trace
@@ -50,9 +47,7 @@ def kafka_topic(request):
     topic_name = request.node.name.replace("[", "_").replace("]", "")
 
     client = kafka_admin.AdminClient({"bootstrap.servers": BOOTSTRAP_SERVERS})
-    for _, future in client.create_topics(
-        [kafka_admin.NewTopic(topic_name, 1, 1)]
-    ).items():
+    for _, future in client.create_topics([kafka_admin.NewTopic(topic_name, 1, 1)]).items():
         try:
             future.result()
         except KafkaException:
@@ -83,9 +78,7 @@ def tracer():
 @pytest.fixture
 def dsm_processor(tracer):
     processor = tracer.data_streams_processor
-    with mock.patch(
-        "ddtrace.internal.datastreams.data_streams_processor", return_value=processor
-    ):
+    with mock.patch("ddtrace.internal.datastreams.data_streams_processor", return_value=processor):
         yield processor
 
 
@@ -198,15 +191,11 @@ def test_produce_single_server(dummy_tracer, producer, kafka_topic):
     traces = dummy_tracer.pop_traces()
     assert 1 == len(traces)
     produce_span = traces[0][0]
-    assert (
-        produce_span.get_tag("messaging.kafka.bootstrap.servers") == BOOTSTRAP_SERVERS
-    )
+    assert produce_span.get_tag("messaging.kafka.bootstrap.servers") == BOOTSTRAP_SERVERS
 
 
 def test_produce_multiple_servers(dummy_tracer, kafka_topic):
-    producer = confluent_kafka.Producer(
-        {"bootstrap.servers": ",".join([BOOTSTRAP_SERVERS] * 3)}
-    )
+    producer = confluent_kafka.Producer({"bootstrap.servers": ",".join([BOOTSTRAP_SERVERS] * 3)})
     Pin.override(producer, tracer=dummy_tracer)
     producer.produce(kafka_topic, PAYLOAD, key=KEY)
     producer.flush()
@@ -214,9 +203,7 @@ def test_produce_multiple_servers(dummy_tracer, kafka_topic):
     traces = dummy_tracer.pop_traces()
     assert 1 == len(traces)
     produce_span = traces[0][0]
-    assert produce_span.get_tag("messaging.kafka.bootstrap.servers") == ",".join(
-        [BOOTSTRAP_SERVERS] * 3
-    )
+    assert produce_span.get_tag("messaging.kafka.bootstrap.servers") == ",".join([BOOTSTRAP_SERVERS] * 3)
 
 
 @pytest.mark.parametrize("tombstone", [False, True])
@@ -277,9 +264,7 @@ def test_service_override_config(producer, consumer, kafka_topic):
 
 @pytest.mark.snapshot(ignores=["metrics.kafka.message_offset"])
 def test_analytics_with_rate(producer, consumer, kafka_topic):
-    with override_config(
-        "kafka", dict(analytics_enabled=True, analytics_sample_rate=0.5)
-    ):
+    with override_config("kafka", dict(analytics_enabled=True, analytics_sample_rate=0.5)):
         producer.produce(kafka_topic, PAYLOAD, key=KEY)
         producer.flush()
         message = None
@@ -306,15 +291,9 @@ def retry_until_not_none(factory):
     return None
 
 
-@pytest.mark.parametrize(
-    "payload_and_length", [("test", 4), ("你".encode("utf-8"), 3), (b"test2", 5)]
-)
-@pytest.mark.parametrize(
-    "key_and_length", [("test-key", 8), ("你".encode("utf-8"), 3), (b"t2", 2)]
-)
-def test_data_streams_payload_size(
-    dsm_processor, consumer, producer, kafka_topic, payload_and_length, key_and_length
-):
+@pytest.mark.parametrize("payload_and_length", [("test", 4), ("你".encode("utf-8"), 3), (b"test2", 5)])
+@pytest.mark.parametrize("key_and_length", [("test-key", 8), ("你".encode("utf-8"), 3), (b"t2", 2)])
+def test_data_streams_payload_size(dsm_processor, consumer, producer, kafka_topic, payload_and_length, key_and_length):
     payload, payload_length = payload_and_length
     key, key_length = key_and_length
     test_headers = {"1234": "5678"}
@@ -324,9 +303,7 @@ def test_data_streams_payload_size(
     expected_payload_size = float(payload_length + key_length)
     expected_payload_size += test_header_size  # to account for headers we add here
     expected_payload_size += len(PROPAGATION_KEY)  # Add in header key length
-    expected_payload_size += (
-        DSM_TEST_PATH_HEADER_SIZE  # to account for path header we add
-    )
+    expected_payload_size += DSM_TEST_PATH_HEADER_SIZE  # to account for path header we add
 
     try:
         del dsm_processor._current_context.value
@@ -346,9 +323,7 @@ def test_data_streams_payload_size(
         assert bucket.payload_size._sum == expected_payload_size
 
 
-def test_data_streams_kafka_serializing(
-    dsm_processor, deserializing_consumer, serializing_producer, kafka_topic
-):
+def test_data_streams_kafka_serializing(dsm_processor, deserializing_consumer, serializing_producer, kafka_topic):
     PAYLOAD = bytes("data streams", encoding="utf-8")
     try:
         del dsm_processor._current_context.value
@@ -364,9 +339,7 @@ def test_data_streams_kafka_serializing(
 
 
 def test_data_streams_kafka(dsm_processor, consumer, producer, kafka_topic):
-    PAYLOAD = (
-        bytes("data streams", encoding="utf-8") if six.PY3 else bytes("data streams")
-    )
+    PAYLOAD = bytes("data streams", encoding="utf-8") if six.PY3 else bytes("data streams")
     try:
         del dsm_processor._current_context.value
     except AttributeError:
@@ -430,11 +403,7 @@ def _generate_in_subprocess(random_topic):
     from ddtrace.contrib.kafka.patch import unpatch
     from ddtrace.filters import TraceFilter
 
-    PAYLOAD = (
-        bytes("hueh hueh hueh", encoding="utf-8")
-        if six.PY3
-        else bytes("hueh hueh hueh")
-    )
+    PAYLOAD = bytes("hueh hueh hueh", encoding="utf-8") if six.PY3 else bytes("hueh hueh hueh")
 
     class KafkaConsumerPollFilter(TraceFilter):
         def process_trace(self, trace):
@@ -464,17 +433,13 @@ def _generate_in_subprocess(random_topic):
     # sys.exits on connection failures, which causes the test to fail. We want to retry
     # until the connection is established. Connection failures are somewhat common.
     fibonacci_backoff_with_jitter(5)(consumer.subscribe)([random_topic])
-    fibonacci_backoff_with_jitter(5)(producer.produce)(
-        random_topic, PAYLOAD, key="test_key"
-    )
-    fibonacci_backoff_with_jitter(5, until=lambda result: isinstance(result, int))(
-        producer.flush
-    )()
+    fibonacci_backoff_with_jitter(5)(producer.produce)(random_topic, PAYLOAD, key="test_key")
+    fibonacci_backoff_with_jitter(5, until=lambda result: isinstance(result, int))(producer.flush)()
     message = None
     while message is None:
-        message = fibonacci_backoff_with_jitter(
-            5, until=lambda result: not isinstance(result, Exception)
-        )(consumer.poll)(1.0)
+        message = fibonacci_backoff_with_jitter(5, until=lambda result: not isinstance(result, Exception))(
+            consumer.poll
+        )(1.0)
 
     unpatch()
     consumer.close()
@@ -510,9 +475,7 @@ if __name__ == "__main__":
 @pytest.mark.snapshot(ignores=["metrics.kafka.message_offset"])
 @pytest.mark.parametrize("service", [None, "mysvc"])
 @pytest.mark.parametrize("schema", [None, "v0", "v1"])
-def test_schematized_span_service_and_operation(
-    ddtrace_run_python_code_in_subprocess, service, schema, kafka_topic
-):
+def test_schematized_span_service_and_operation(ddtrace_run_python_code_in_subprocess, service, schema, kafka_topic):
     code = """
 import sys
 import pytest
@@ -536,9 +499,7 @@ if __name__ == "__main__":
     assert err == b"", err.decode()
 
 
-def test_data_streams_kafka_offset_monitoring_messages(
-    dsm_processor, non_auto_commit_consumer, producer, kafka_topic
-):
+def test_data_streams_kafka_offset_monitoring_messages(dsm_processor, non_auto_commit_consumer, producer, kafka_topic):
     def _read_single_message(consumer):
         message = None
         while message is None or str(message.value()) != str(PAYLOAD):
@@ -547,9 +508,7 @@ def test_data_streams_kafka_offset_monitoring_messages(
                 consumer.commit(asynchronous=False, message=message)
                 return message
 
-    PAYLOAD = (
-        bytes("data streams", encoding="utf-8") if six.PY3 else bytes("data streams")
-    )
+    PAYLOAD = bytes("data streams", encoding="utf-8") if six.PY3 else bytes("data streams")
     consumer = non_auto_commit_consumer
     try:
         del dsm_processor._current_context.value
@@ -563,31 +522,16 @@ def test_data_streams_kafka_offset_monitoring_messages(
     _message = _read_single_message(consumer)  # noqa: F841
 
     assert len(buckets) == 1
-    assert (
-        list(buckets.values())[0].latest_produce_offsets[PartitionKey(kafka_topic, 0)]
-        > 0
-    )
+    assert list(buckets.values())[0].latest_produce_offsets[PartitionKey(kafka_topic, 0)] > 0
     assert consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset == 1
-    assert (
-        list(buckets.values())[0].latest_commit_offsets[
-            ConsumerPartitionKey("test_group", kafka_topic, 0)
-        ]
-        == 0
-    )
+    assert list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey("test_group", kafka_topic, 0)] == 0
 
     _message = _read_single_message(consumer)  # noqa: F841
     assert consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset == 2
-    assert (
-        list(buckets.values())[0].latest_commit_offsets[
-            ConsumerPartitionKey("test_group", kafka_topic, 0)
-        ]
-        == 1
-    )
+    assert list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey("test_group", kafka_topic, 0)] == 1
 
 
-def test_data_streams_kafka_offset_monitoring_offsets(
-    dsm_processor, non_auto_commit_consumer, producer, kafka_topic
-):
+def test_data_streams_kafka_offset_monitoring_offsets(dsm_processor, non_auto_commit_consumer, producer, kafka_topic):
     def _read_single_message(consumer):
         message = None
         while message is None or str(message.value()) != str(PAYLOAD):
@@ -601,9 +545,7 @@ def test_data_streams_kafka_offset_monitoring_offsets(
                 return message
 
     consumer = non_auto_commit_consumer
-    PAYLOAD = (
-        bytes("data streams", encoding="utf-8") if six.PY3 else bytes("data streams")
-    )
+    PAYLOAD = bytes("data streams", encoding="utf-8") if six.PY3 else bytes("data streams")
     try:
         del dsm_processor._current_context.value
     except AttributeError:
@@ -616,31 +558,16 @@ def test_data_streams_kafka_offset_monitoring_offsets(
 
     buckets = dsm_processor._buckets
     assert len(buckets) == 1
-    assert (
-        list(buckets.values())[0].latest_produce_offsets[PartitionKey(kafka_topic, 0)]
-        > 0
-    )
+    assert list(buckets.values())[0].latest_produce_offsets[PartitionKey(kafka_topic, 0)] > 0
     assert consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset == 1
-    assert (
-        list(buckets.values())[0].latest_commit_offsets[
-            ConsumerPartitionKey("test_group", kafka_topic, 0)
-        ]
-        == 0
-    )
+    assert list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey("test_group", kafka_topic, 0)] == 0
 
     _message = _read_single_message(consumer)  # noqa: F841
     assert consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset == 2
-    assert (
-        list(buckets.values())[0].latest_commit_offsets[
-            ConsumerPartitionKey("test_group", kafka_topic, 0)
-        ]
-        == 1
-    )
+    assert list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey("test_group", kafka_topic, 0)] == 1
 
 
-def test_data_streams_kafka_offset_monitoring_auto_commit(
-    dsm_processor, consumer, producer, kafka_topic
-):
+def test_data_streams_kafka_offset_monitoring_auto_commit(dsm_processor, consumer, producer, kafka_topic):
     def _read_single_message(consumer):
         message = None
         while message is None or str(message.value()) != str(PAYLOAD):
@@ -648,9 +575,7 @@ def test_data_streams_kafka_offset_monitoring_auto_commit(
             if message:
                 return message
 
-    PAYLOAD = (
-        bytes("data streams", encoding="utf-8") if six.PY3 else bytes("data streams")
-    )
+    PAYLOAD = bytes("data streams", encoding="utf-8") if six.PY3 else bytes("data streams")
     try:
         del dsm_processor._current_context.value
     except AttributeError:
@@ -664,24 +589,11 @@ def test_data_streams_kafka_offset_monitoring_auto_commit(
 
     buckets = dsm_processor._buckets
     assert len(buckets) == 1
-    assert (
-        list(buckets.values())[0].latest_produce_offsets[PartitionKey(kafka_topic, 0)]
-        > 0
-    )
+    assert list(buckets.values())[0].latest_produce_offsets[PartitionKey(kafka_topic, 0)] > 0
     assert consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset == 1
-    assert (
-        list(buckets.values())[0].latest_commit_offsets[
-            ConsumerPartitionKey("test_group", kafka_topic, 0)
-        ]
-        == 0
-    )
+    assert list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey("test_group", kafka_topic, 0)] == 0
 
     _message = _read_single_message(consumer)  # noqa: F841
     consumer.commit(asynchronous=False)
     assert consumer.committed([TopicPartition(kafka_topic, 0)])[0].offset == 2
-    assert (
-        list(buckets.values())[0].latest_commit_offsets[
-            ConsumerPartitionKey("test_group", kafka_topic, 0)
-        ]
-        == 1
-    )
+    assert list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey("test_group", kafka_topic, 0)] == 1


### PR DESCRIPTION
This pull request fixes
https://github.com/DataDog/dd-trace-py/issues/7174 by patching the `SerializingProducer` and `DeserializingConsumer` classes with classes that implement the appropriate functionality, rather than using `Consumer` and `Producer`. It also makes a few small changes to the Kafka integration for readability and the removal of Py2 support.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

(cherry picked from commit 621ee80ace621192aa5469eaf521e7e3d96f90c8)