### PR TITLE
chore(setup): set OSX deployment target

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ LIBDATADOG_PROF_DOWNLOAD_DIR = os.path.join(
 
 LIBDATADOG_PROF_VERSION = "v3.0.0"
 
+# Set macOS SDK default deployment target to 10.14 for C++17 support (if unset, may default to 10.9)
 if CURRENT_OS == "Darwin":
     os.environ.setdefault("MACOSX_DEPLOYMENT_TARGET", "10.14")
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ from setuptools.command.build_ext import build_ext  # isort: skip
 from setuptools.command.build_py import build_py as BuildPyCommand  # isort: skip
 from pkg_resources import get_build_platform  # isort: skip
 from distutils.command.clean import clean as CleanCommand  # isort: skip
+from distutils import sysconfig
 
 
 try:
@@ -56,6 +57,8 @@ LIBDATADOG_PROF_DOWNLOAD_DIR = os.path.join(
 
 LIBDATADOG_PROF_VERSION = "v3.0.0"
 
+if CURRENT_OS == "Darwin":
+    os.environ.setdefault("MACOSX_DEPLOYMENT_TARGET", "10.14")
 
 def verify_checksum_from_file(sha256_filename, filename):
     # sha256 File format is ``checksum`` followed by two whitespaces, then ``filename`` then ``\n``


### PR DESCRIPTION
Manually sets the deployment target for the macOS SDK.  Previously we were letting individual extensions make their own decisions, since this environment variable wasn't set at the top-level--but the effective minimum version of the wheel is the maximum version of all of its dependencies, so there's no reason not to set this early.

Choosing a default of 10.14 in order to best support the C++17 native extensions we have.  10.14 was released Sep 24, 2018.

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
