### PR TITLE
fix(iast): remove logs metrics noise

### DIFF
--- a/tests/appsec/iast/aspects/test_encode_decode_aspect.py
+++ b/tests/appsec/iast/aspects/test_encode_decode_aspect.py
@@ -3,12 +3,15 @@
 import pytest
 
 from ddtrace.appsec._iast._utils import _is_python_version_supported as python_supported_by_iast
+from tests.appsec.iast.aspects.conftest import _iast_patched_module
 
 
-try:
+if python_supported_by_iast():
     from ddtrace.appsec._iast._taint_tracking import OriginType
-except (ImportError, AttributeError):
-    pytest.skip("IAST not supported for this Python version", allow_module_level=True)
+    from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+    from ddtrace.appsec._iast._taint_tracking import taint_pyobject
+
+    mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.str_methods")
 
 
 def catch_all(fun, args, kwargs):
@@ -125,3 +128,31 @@ def test_encode_and_add_aspect(infix, args, kwargs, should_be_tainted, prefix, s
         assert list_ranges[0].start == len(prefix.encode(*args, **kwargs))
         len_infix = len(infix.encode(*args, **kwargs))
         assert list_ranges[0].length == len_infix
+
+
+def test_encode_error_and_no_log_metric(telemetry_writer):
+    string_input = taint_pyobject(
+        pyobject="abcde",
+        source_name="test_add_aspect_tainting_left_hand",
+        source_value="abcde",
+        source_origin=OriginType.PARAMETER,
+    )
+    with pytest.raises(LookupError):
+        mod.do_encode(string_input, "encoding-not-exists")
+
+    list_metrics_logs = list(telemetry_writer._logs)
+    assert len(list_metrics_logs) == 0
+
+
+def test_dencode_error_and_no_log_metric(telemetry_writer):
+    string_input = taint_pyobject(
+        pyobject=b"abcde",
+        source_name="test_add_aspect_tainting_left_hand",
+        source_value="abcde",
+        source_origin=OriginType.PARAMETER,
+    )
+    with pytest.raises(LookupError):
+        mod.do_decode(string_input, "decoding-not-exists")
+
+    list_metrics_logs = list(telemetry_writer._logs)
+    assert len(list_metrics_logs) == 0

--- a/tests/appsec/iast/aspects/test_encode_decode_aspect.py
+++ b/tests/appsec/iast/aspects/test_encode_decode_aspect.py
@@ -130,6 +130,7 @@ def test_encode_and_add_aspect(infix, args, kwargs, should_be_tainted, prefix, s
         assert list_ranges[0].length == len_infix
 
 
+@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
 def test_encode_error_and_no_log_metric(telemetry_writer):
     string_input = taint_pyobject(
         pyobject="abcde",
@@ -144,6 +145,7 @@ def test_encode_error_and_no_log_metric(telemetry_writer):
     assert len(list_metrics_logs) == 0
 
 
+@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
 def test_dencode_error_and_no_log_metric(telemetry_writer):
     string_input = taint_pyobject(
         pyobject=b"abcde",

--- a/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
@@ -5,6 +5,9 @@ from typing import NamedTuple
 
 import pytest
 
+from tests.utils import override_env
+from tests.utils import override_global_config
+
 
 try:
     from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
@@ -224,3 +227,10 @@ class TestOperatorFormatReplacement(BaseReplacement):
         #     escaped_expected_result="a:+-<input2>aaaa<input2>-+:a parameter",
         # )
         pass
+
+    def test_format_key_error_and_no_log_metric(self, telemetry_writer):
+        with pytest.raises(KeyError):
+            mod.do_format_key_error("test1")
+
+        list_metrics_logs = list(telemetry_writer._logs)
+        assert len(list_metrics_logs) == 0

--- a/tests/appsec/iast/aspects/test_index_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_index_aspect_fixtures.py
@@ -64,3 +64,17 @@ def test_string_index(input_str, index_pos, expected_result, tainted):
         assert len(tainted_ranges) == 1
         assert tainted_ranges[0].start == 0
         assert tainted_ranges[0].length == 1
+
+
+def test_index_error_and_no_log_metric(telemetry_writer):
+    string_input = taint_pyobject(
+        pyobject="abcde",
+        source_name="test_add_aspect_tainting_left_hand",
+        source_value="abcde",
+        source_origin=OriginType.PARAMETER,
+    )
+    with pytest.raises(IndexError):
+        mod.do_index(string_input, 100)
+
+    list_metrics_logs = list(telemetry_writer._logs)
+    assert len(list_metrics_logs) == 0

--- a/tests/appsec/iast/aspects/test_index_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_index_aspect_fixtures.py
@@ -66,6 +66,9 @@ def test_string_index(input_str, index_pos, expected_result, tainted):
         assert tainted_ranges[0].length == 1
 
 
+@pytest.mark.skipif(
+    not python_supported_by_iast() or sys.version_info < (3, 9, 0), reason="Python version not supported by IAST"
+)
 def test_index_error_and_no_log_metric(telemetry_writer):
     string_input = taint_pyobject(
         pyobject="abcde",

--- a/tests/appsec/iast/aspects/test_str_aspect.py
+++ b/tests/appsec/iast/aspects/test_str_aspect.py
@@ -112,6 +112,14 @@ class TestOperatorsReplacement(BaseReplacement):
         ljusted = mod.do_ljust(string_input, 4)  # pylint: disable=no-member
         assert as_formatted_evidence(ljusted) == ":+-foo-+: "
 
+    def test_aspect_ljust_error_and_no_log_metric(self, telemetry_writer):
+        string_input = create_taint_range_with_format(":+-foo-+:")
+        with pytest.raises(TypeError):
+            mod.do_ljust(string_input, "aaaaa")
+
+        list_metrics_logs = list(telemetry_writer._logs)
+        assert len(list_metrics_logs) == 0
+
     def test_zfill(self):
         # Not tainted
         string_input = "-1234"
@@ -130,6 +138,14 @@ class TestOperatorsReplacement(BaseReplacement):
         string_input = create_taint_range_with_format(":+-012-+:34")
         res = mod.do_zfill(string_input, 7)  # pylint: disable=no-member
         assert as_formatted_evidence(res) == "00:+-012-+:34"
+
+    def test_aspect_zfill_error_and_no_log_metric(self, telemetry_writer):
+        string_input = create_taint_range_with_format(":+-foo-+:")
+        with pytest.raises(TypeError):
+            mod.do_zfill(string_input, "aaaaa")
+
+        list_metrics_logs = list(telemetry_writer._logs)
+        assert len(list_metrics_logs) == 0
 
     def test_format(self):
         # type: () -> None

--- a/tests/appsec/iast/fixtures/aspects/str_methods.py
+++ b/tests/appsec/iast/fixtures/aspects/str_methods.py
@@ -844,6 +844,10 @@ def do_format_map(template, mapping):  # type: (str, Dict[str, Any]) -> str
     return template.format_map(mapping)
 
 
+def do_format_key_error(param1):  # type: (str, Dict[str, Any]) -> str
+    return "Test {param1}, {param2}".format(param1=param1)
+
+
 def do_join(s, iterable):
     # type: (str, Iterable) -> str
     return s.join(iterable)


### PR DESCRIPTION
IAST Aspects report a log metric each time an exception is raised. We noticed an application that wants to raise and control exceptions, such as in this dummy example:

```python
my_data = {"element1": 1}
is_element2_in_my_data = False
try:
    my_data["element1"]
    is_element2_in_my_data = True
except KeyError:
    pass
```

Those operations should not log a metric.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
