### PR TITLE
chore: com2ann tests and ddtrace

### DIFF
--- a/ddtrace/_hooks.py
+++ b/ddtrace/_hooks.py
@@ -39,10 +39,9 @@ class Hooks(object):
 
     def register(
         self,
-        hook,  # type: Any
-        func=None,  # type: Optional[Callable]
-    ):
-        # type: (...) -> Optional[Callable[..., Any]]
+        hook: Any,
+        func: Optional[Callable] = None,
+    ) -> Optional[Callable[..., Any]]:
         """
         Function used to register a hook for the provided name.
 
@@ -86,10 +85,9 @@ class Hooks(object):
 
     def deregister(
         self,
-        hook,  # type: Any
-        func,  # type: Callable
-    ):
-        # type: (...) -> None
+        hook: Any,
+        func: Callable,
+    ) -> None:
         """
         Function to deregister a function from a hook it was registered under
 
@@ -114,11 +112,10 @@ class Hooks(object):
 
     def emit(
         self,
-        hook,  # type: Any
-        *args,  # type: Any
-        **kwargs,  # type: Any
-    ):
-        # type: (...) -> None
+        hook: Any,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         """
         Function used to call registered hook functions.
 

--- a/ddtrace/_logger.py
+++ b/ddtrace/_logger.py
@@ -13,8 +13,7 @@ DD_LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] 
 DEFAULT_FILE_SIZE_BYTES = 15 << 20  # 15 MB
 
 
-def configure_ddtrace_logger():
-    # type: () -> None
+def configure_ddtrace_logger() -> None:
     """Configures ddtrace log levels and file paths.
 
     Customization is possible with the environment variables:

--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -153,8 +153,7 @@ class ModuleNotFoundException(PatchException):
     pass
 
 
-def _on_import_factory(module, prefix="ddtrace.contrib", raise_errors=True, patch_indicator=True):
-    # type: (str, str, bool, Union[bool, List[str]]) -> Callable[[Any], None]
+def _on_import_factory(module: str, prefix: str = "ddtrace.contrib", raise_errors: bool = True, patch_indicator: Union[bool, List[str]] = True) -> Callable[[Any], None]:
     """Factory to create an import hook for the provided module name"""
 
     def on_import(hook):
@@ -191,8 +190,7 @@ def _on_import_factory(module, prefix="ddtrace.contrib", raise_errors=True, patc
     return on_import
 
 
-def patch_all(**patch_modules):
-    # type: (bool) -> None
+def patch_all(**patch_modules: bool) -> None:
     """Automatically patches all available modules.
 
     In addition to ``patch_modules``, an override can be specified via an
@@ -227,8 +225,7 @@ def patch_all(**patch_modules):
         patch_iast()
 
 
-def patch(raise_errors=True, patch_modules_prefix=DEFAULT_MODULES_PREFIX, **patch_modules):
-    # type: (bool, str, Union[List[str], bool]) -> None
+def patch(raise_errors: bool = True, patch_modules_prefix: str = DEFAULT_MODULES_PREFIX, **patch_modules: Union[List[str], bool]) -> None:
     """Patch only a set of given modules.
 
     :param bool raise_errors: Raise error if one patch fail.
@@ -263,8 +260,7 @@ def patch(raise_errors=True, patch_modules_prefix=DEFAULT_MODULES_PREFIX, **patc
     )
 
 
-def _get_patched_modules():
-    # type: () -> List[str]
+def _get_patched_modules() -> List[str]:
     """Get the list of patched modules"""
     with _LOCK:
         return sorted(_PATCHED_MODULES)

--- a/ddtrace/appsec/_api_security/api_manager.py
+++ b/ddtrace/appsec/_api_security/api_manager.py
@@ -41,13 +41,12 @@ class APIManager(Service):
         ("RESPONSE_BODY", API_SECURITY.RESPONSE_BODY, None),
     ]
 
-    _instance = None  # type: Optional[APIManager]
+    _instance: Optional[APIManager] = None
 
     SAMPLE_START_VALUE = 1.0 - sys.float_info.epsilon
 
     @classmethod
-    def enable(cls):
-        # type: () -> None
+    def enable(cls) -> None:
         if cls._instance is not None:
             log.debug("%s already enabled", cls.__name__)
             return
@@ -59,8 +58,7 @@ class APIManager(Service):
         log.debug("%s enabled", cls.__name__)
 
     @classmethod
-    def disable(cls):
-        # type: () -> None
+    def disable(cls) -> None:
         if cls._instance is None:
             log.debug("%s not enabled", cls.__name__)
             return
@@ -71,20 +69,17 @@ class APIManager(Service):
         metrics.disable()
         log.debug("%s disabled", cls.__name__)
 
-    def __init__(self):
-        # type: () -> None
+    def __init__(self) -> None:
         super(APIManager, self).__init__()
 
         self.current_sampling_value = self.SAMPLE_START_VALUE
         self._schema_meter = metrics.get_meter("schema")
         log.debug("%s initialized", self.__class__.__name__)
 
-    def _stop_service(self):
-        # type: () -> None
+    def _stop_service(self) -> None:
         remove_context_callback(self._schema_callback, global_callback=True)
 
-    def _start_service(self):
-        # type: () -> None
+    def _start_service(self) -> None:
         add_context_callback(self._schema_callback, global_callback=True)
 
     def _should_collect_schema(self, env):

--- a/ddtrace/appsec/_iast/_ast/ast_patching.py
+++ b/ddtrace/appsec/_iast/_ast/ast_patching.py
@@ -22,8 +22,8 @@ from .visitor import AstVisitor
 
 
 # Prefixes for modules where IAST patching is allowed
-IAST_ALLOWLIST = ("tests.appsec.iast",)  # type: tuple[str, ...]
-IAST_DENYLIST = ("ddtrace", "pkg_resources")  # type: tuple[str, ...]
+IAST_ALLOWLIST: tuple[str, ...] = ("tests.appsec.iast",)
+IAST_DENYLIST: tuple[str, ...] = ("ddtrace", "pkg_resources")
 
 
 if IAST.PATCH_MODULES in os.environ:
@@ -38,7 +38,7 @@ ENCODING = ""
 log = get_logger(__name__)
 
 
-def get_encoding(module_path):  # type: (str) -> str
+def get_encoding(module_path: str) -> str:
     """
     First tries to detect the encoding for the file,
     otherwise, returns global encoding default
@@ -58,7 +58,7 @@ except ImportError:
     import importlib_metadata as il_md  # type: ignore[no-redef]
 
 
-def _build_installed_package_names_list():  # type: (...) -> set[str]
+def _build_installed_package_names_list() -> set[str]:
     return {
         ilmd_d.metadata["name"] for ilmd_d in il_md.distributions() if ilmd_d is not None and ilmd_d.files is not None
     }
@@ -69,11 +69,11 @@ _NOT_PATCH_MODULE_NAMES = (
 )
 
 
-def _in_python_stdlib_or_third_party(module_name):  # type: (str) -> bool
+def _in_python_stdlib_or_third_party(module_name: str) -> bool:
     return module_name.split(".")[0].lower() in [x.lower() for x in _NOT_PATCH_MODULE_NAMES]
 
 
-def _should_iast_patch(module_name):  # type: (str) -> bool
+def _should_iast_patch(module_name: str) -> bool:
     """
     select if module_name should be patch from the longuest prefix that match in allow or deny list.
     if a prefix is in both list, deny is selected.
@@ -85,10 +85,10 @@ def _should_iast_patch(module_name):  # type: (str) -> bool
 
 
 def visit_ast(
-    source_text,  # type: str
-    module_path,  # type: str
-    module_name="",  # type: str
-):  # type: (...) -> Optional[str]
+    source_text: str,
+    module_path: str,
+    module_name: str = "",
+) -> Optional[str]:
     parsed_ast = ast.parse(source_text, module_path)
 
     visitor = AstVisitor(
@@ -123,8 +123,7 @@ def _remove_flask_run(text):  # type (str) -> str
     return new_text
 
 
-def astpatch_module(module, remove_flask_run=False):
-    # type: (ModuleType, bool) -> Tuple[str, str]
+def astpatch_module(module: ModuleType, remove_flask_run: bool = False) -> Tuple[str, str]:
     module_name = module.__name__
     module_path = str(origin(module))
     try:

--- a/ddtrace/appsec/_iast/_ast/visitor.py
+++ b/ddtrace/appsec/_iast/_ast/visitor.py
@@ -178,7 +178,7 @@ class AstVisitor(ast.NodeTransformer):
 
         return merged_set
 
-    def _is_string_node(self, node):  # type: (Any) -> bool
+    def _is_string_node(self, node: Any) -> bool:
         if PY30_37 and isinstance(node, ast.Bytes):
             return True
 
@@ -187,7 +187,7 @@ class AstVisitor(ast.NodeTransformer):
 
         return False
 
-    def _is_numeric_node(self, node):  # type: (Any) -> bool
+    def _is_numeric_node(self, node: Any) -> bool:
         if PY30_37 and isinstance(node, ast.Num):
             return True
 
@@ -196,10 +196,10 @@ class AstVisitor(ast.NodeTransformer):
 
         return False
 
-    def _is_node_constant_or_binop(self, node):  # type: (Any) -> bool
+    def _is_node_constant_or_binop(self, node: Any) -> bool:
         return self._is_string_node(node) or self._is_numeric_node(node) or isinstance(node, ast.BinOp)
 
-    def _is_call_excluded(self, func_name_node):  # type: (str) -> bool
+    def _is_call_excluded(self, func_name_node: str) -> bool:
         if not self.excluded_functions:
             return False
         excluded_for_caller = self.excluded_functions.get(func_name_node, tuple()) + self.excluded_functions.get(
@@ -207,8 +207,7 @@ class AstVisitor(ast.NodeTransformer):
         )
         return "" in excluded_for_caller or self._current_function_name in excluded_for_caller
 
-    def _is_string_format_with_literals(self, call_node):
-        # type: (ast.Call) -> bool
+    def _is_string_format_with_literals(self, call_node: ast.Call) -> bool:
         return (
             self._is_string_node(call_node.func.value)  # type: ignore[attr-defined]
             and call_node.func.attr == "format"  # type: ignore[attr-defined]
@@ -216,7 +215,7 @@ class AstVisitor(ast.NodeTransformer):
             and all(map(lambda x: self._is_node_constant_or_binop(x.value), call_node.keywords))
         )
 
-    def _get_function_name(self, call_node, is_function):  # type: (ast.Call, bool) -> str
+    def _get_function_name(self, call_node: ast.Call, is_function: bool) -> str:
         if is_function:
             return call_node.func.id  # type: ignore[attr-defined]
         # If the call is to a method
@@ -225,7 +224,7 @@ class AstVisitor(ast.NodeTransformer):
 
         return call_node.func.attr  # type: ignore[attr-defined]
 
-    def _should_replace_with_taint_sink(self, call_node, is_function):  # type: (ast.Call, bool) -> bool
+    def _should_replace_with_taint_sink(self, call_node: ast.Call, is_function: bool) -> bool:
         function_name = self._get_function_name(call_node, is_function)
 
         if function_name in self._taint_sink_replace_disabled:
@@ -233,7 +232,7 @@ class AstVisitor(ast.NodeTransformer):
 
         return any(allowed in function_name for allowed in self._taint_sink_replace_any)
 
-    def _add_original_function_as_arg(self, call_node, is_function):  # type: (ast.Call, bool) -> Any
+    def _add_original_function_as_arg(self, call_node: ast.Call, is_function: bool) -> Any:
         """
         Creates the arguments for the original function
         """
@@ -252,8 +251,7 @@ class AstVisitor(ast.NodeTransformer):
 
         return new_args
 
-    def _node(self, type_, pos_from_node, **kwargs):
-        # type: (Any, Any, Any) -> Any
+    def _node(self, type_: Any, pos_from_node: Any, **kwargs: Any) -> Any:
         """
         Abstract some basic differences in node structure between versions
         """
@@ -274,8 +272,7 @@ class AstVisitor(ast.NodeTransformer):
             lineno=lineno, end_lineno=end_lineno, col_offset=col_offset, end_col_offset=end_col_offset, **kwargs
         )
 
-    def _name_node(self, from_node, _id, ctx=ast.Load()):  # noqa: B008
-        # type: (Any, str, Any) -> ast.Name
+    def _name_node(self, from_node: Any, _id: str, ctx: Any = ast.Load()) -> ast.Name:  # noqa: B008
         return self._node(
             ast.Name,
             from_node,
@@ -283,8 +280,7 @@ class AstVisitor(ast.NodeTransformer):
             ctx=ctx,
         )
 
-    def _attr_node(self, from_node, attr, ctx=ast.Load()):  # noqa: B008
-        # type: (Any, str, Any) -> ast.Name
+    def _attr_node(self, from_node: Any, attr: str, ctx: Any = ast.Load()) -> ast.Name:  # noqa: B008
         attr_attr = ""
         name_attr = ""
         if attr:
@@ -296,7 +292,7 @@ class AstVisitor(ast.NodeTransformer):
         name_node = self._name_node(from_node, name_attr, ctx=ctx)
         return self._node(ast.Attribute, from_node, attr=attr_attr, ctx=ctx, value=name_node)
 
-    def _assign_node(self, from_node, targets, value):  # type: (Any, List[Any], Any) -> Any
+    def _assign_node(self, from_node: Any, targets: List[Any], value: Any) -> Any:
         return self._node(
             ast.Assign,
             from_node,
@@ -305,7 +301,7 @@ class AstVisitor(ast.NodeTransformer):
             type_comment=None,
         )
 
-    def find_insert_position(self, module_node):  # type: (ast.Module) -> int
+    def find_insert_position(self, module_node: ast.Module) -> int:
         insert_position = 0
         from_future_import_found = False
         import_found = False
@@ -338,8 +334,7 @@ class AstVisitor(ast.NodeTransformer):
 
         return insert_position
 
-    def _none_constant(self, from_node, ctx=ast.Load()):  # noqa: B008
-        # type: (Any, Any) -> Any
+    def _none_constant(self, from_node: Any, ctx: Any = ast.Load()) -> Any:  # noqa: B008
         if PY30_37:
             return ast.NameConstant(lineno=from_node.lineno, col_offset=from_node.col_offset, value=None)
 
@@ -353,11 +348,10 @@ class AstVisitor(ast.NodeTransformer):
             kind=None,
         )
 
-    def _call_node(self, from_node, func, args):  # type: (Any, Any, List[Any]) -> Any
+    def _call_node(self, from_node: Any, func: Any, args: List[Any]) -> Any:
         return self._node(ast.Call, from_node, func=func, args=args, keywords=[])
 
-    def visit_Module(self, module_node):
-        # type: (ast.Module) -> Any
+    def visit_Module(self, module_node: ast.Module) -> Any:
         """
         Insert the import statement for the replacements module
         """
@@ -397,8 +391,7 @@ class AstVisitor(ast.NodeTransformer):
         self.generic_visit(module_node)
         return module_node
 
-    def visit_FunctionDef(self, def_node):
-        # type: (ast.FunctionDef) -> Any
+    def visit_FunctionDef(self, def_node: ast.FunctionDef) -> Any:
         """
         Special case for some tests which would enter in a patching
         loop otherwise when visiting the check functions
@@ -410,7 +403,7 @@ class AstVisitor(ast.NodeTransformer):
 
         return def_node
 
-    def visit_Call(self, call_node):  # type: (ast.Call) -> Any
+    def visit_Call(self, call_node: ast.Call) -> Any:
         """
         Replace a call or method
         """
@@ -496,7 +489,7 @@ class AstVisitor(ast.NodeTransformer):
 
         return call_node
 
-    def visit_BinOp(self, call_node):  # type: (ast.BinOp) -> Any
+    def visit_BinOp(self, call_node: ast.BinOp) -> Any:
         """
         Replace a binary operator
         """
@@ -512,7 +505,7 @@ class AstVisitor(ast.NodeTransformer):
 
         return call_node
 
-    def visit_FormattedValue(self, fmt_value_node):  # type: (ast.FormattedValue) -> Any
+    def visit_FormattedValue(self, fmt_value_node: ast.FormattedValue) -> Any:
         """
         Visit a FormattedValue node which are the constituent atoms for the
         JoinedStr which are used to implement f-strings.
@@ -543,7 +536,7 @@ class AstVisitor(ast.NodeTransformer):
         _set_metric_iast_instrumented_propagation()
         return call_node
 
-    def visit_JoinedStr(self, joinedstr_node):  # type: (ast.JoinedStr) -> Any
+    def visit_JoinedStr(self, joinedstr_node: ast.JoinedStr) -> Any:
         """
         Replaced the JoinedStr AST node with a Call to the replacement function. Most of
         the work inside fstring is done by visit_FormattedValue above.
@@ -573,7 +566,7 @@ class AstVisitor(ast.NodeTransformer):
         _set_metric_iast_instrumented_propagation()
         return call_node
 
-    def visit_AugAssign(self, augassign_node):  # type: (ast.AugAssign) -> Any
+    def visit_AugAssign(self, augassign_node: ast.AugAssign) -> Any:
         """Replace an inplace add or multiply."""
         if isinstance(augassign_node.target, ast.Subscript):
             # Can't augassign to function call, ignore this node
@@ -584,7 +577,7 @@ class AstVisitor(ast.NodeTransformer):
         # TODO: Replace an inplace add or multiply (+= / *=)
         return augassign_node
 
-    def visit_Assign(self, assign_node):  # type: (ast.Assign) -> Any
+    def visit_Assign(self, assign_node: ast.Assign) -> Any:
         """
         Decompose multiple assignment into single ones and
         check if any item in the targets list is if type Subscript and if
@@ -636,7 +629,7 @@ class AstVisitor(ast.NodeTransformer):
 
         return ret_nodes
 
-    def visit_Delete(self, assign_node):  # type: (ast.Delete) -> Any
+    def visit_Delete(self, assign_node: ast.Delete) -> Any:
         # del replaced_index(foo, bar) would fail so avoid converting the right hand side
         # since it's going to be deleted anyway
 
@@ -647,7 +640,7 @@ class AstVisitor(ast.NodeTransformer):
         self.generic_visit(assign_node)
         return assign_node
 
-    def visit_Subscript(self, subscr_node):  # type: (ast.Subscript) -> Any
+    def visit_Subscript(self, subscr_node: ast.Subscript) -> Any:
         """
         Turn an indexes[1] and slices[0:1:2] into the replacement function call
         Optimization: dont convert if the indexes are strings

--- a/ddtrace/appsec/_iast/_metrics.py
+++ b/ddtrace/appsec/_iast/_metrics.py
@@ -56,8 +56,7 @@ def metric_verbosity(lvl):
 
 @metric_verbosity(TELEMETRY_MANDATORY_VERBOSITY)
 @deduplication
-def _set_iast_error_metric(msg):
-    # type: (str) -> None
+def _set_iast_error_metric(msg: str) -> None:
     # Due to format_exc and format_exception returns the error and the last frame
     try:
         exception_type, exception_instance, _traceback_list = sys.exc_info()

--- a/ddtrace/appsec/_iast/_patch.py
+++ b/ddtrace/appsec/_iast/_patch.py
@@ -17,13 +17,12 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Optional
 
 
-_DD_ORIGINAL_ATTRIBUTES = {}  # type: Dict[Any, Any]
+_DD_ORIGINAL_ATTRIBUTES: Dict[Any, Any] = {}
 
 log = get_logger(__name__)
 
 
-def set_and_check_module_is_patched(module_str, default_attr="_datadog_patch"):
-    # type: (str, str) -> Optional[bool]
+def set_and_check_module_is_patched(module_str: str, default_attr: str = "_datadog_patch") -> Optional[bool]:
     try:
         __import__(module_str)
         module = sys.modules[module_str]
@@ -35,8 +34,7 @@ def set_and_check_module_is_patched(module_str, default_attr="_datadog_patch"):
     return True
 
 
-def set_module_unpatched(module_str, default_attr="_datadog_patch"):
-    # type: (str, str) -> None
+def set_module_unpatched(module_str: str, default_attr: str = "_datadog_patch") -> None:
     try:
         __import__(module_str)
         module = sys.modules[module_str]
@@ -45,8 +43,7 @@ def set_module_unpatched(module_str, default_attr="_datadog_patch"):
         pass
 
 
-def try_wrap_function_wrapper(module, name, wrapper):
-    # type: (str, str, Callable) -> None
+def try_wrap_function_wrapper(module: str, name: str, wrapper: Callable) -> None:
     try:
         wrap_object(module, name, FunctionWrapper, (wrapper,))
     except (ImportError, AttributeError):

--- a/ddtrace/appsec/_iast/_patches/json_tainting.py
+++ b/ddtrace/appsec/_iast/_patches/json_tainting.py
@@ -15,21 +15,18 @@ log = get_logger(__name__)
 _DEFAULT_ATTR = "_datadog_json_tainting_patch"
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 
-def unpatch_iast():
-    # type: () -> None
+def unpatch_iast() -> None:
     set_module_unpatched("json", default_attr=_DEFAULT_ATTR)
     try_unwrap("json", "loads")
     try_unwrap("json.encoder", "JSONEncoder.default")
     try_unwrap("simplejson.encoder", "JSONEncoder.default")
 
 
-def patch():
-    # type: () -> None
+def patch() -> None:
     """Wrap functions which interact with file system."""
     if not set_and_check_module_is_patched("json", default_attr=_DEFAULT_ATTR):
         return

--- a/ddtrace/appsec/_iast/_taint_dict.py
+++ b/ddtrace/appsec/_iast/_taint_dict.py
@@ -9,13 +9,13 @@ if TYPE_CHECKING:
 
     from ._taint_tracking import Source
 
-_IAST_TAINT_DICT = {}  # type: Dict[int, Tuple[Tuple[Source, int, int],...]]
+_IAST_TAINT_DICT: Dict[int, Tuple[Tuple[Source, int, int],...]] = {}
 
 
-def get_taint_dict():  # type: () -> Dict[int, Tuple[Tuple[Source, int, int],...]]
+def get_taint_dict() -> Dict[int, Tuple[Tuple[Source, int, int],...]]:
     return _IAST_TAINT_DICT
 
 
-def clear_taint_mapping():  # type: () -> None
+def clear_taint_mapping() -> None:
     global _IAST_TAINT_DICT
     _IAST_TAINT_DICT = {}

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -80,8 +80,7 @@ __all__ = [
 ]
 
 
-def taint_pyobject(pyobject, source_name, source_value, source_origin=None):
-    # type: (Any, Any, Any, OriginType) -> Any
+def taint_pyobject(pyobject: Any, source_name: Any, source_value: Any, source_origin: OriginType = None) -> Any:
     # Request is not analyzed
     if not oce.request_has_quota:
         return pyobject
@@ -103,16 +102,15 @@ def taint_pyobject(pyobject, source_name, source_value, source_origin=None):
     return pyobject_newid
 
 
-def taint_pyobject_with_ranges(pyobject, ranges):  # type: (Any, tuple) -> None
+def taint_pyobject_with_ranges(pyobject: Any, ranges: tuple) -> None:
     set_ranges(pyobject, tuple(ranges))
 
 
-def get_tainted_ranges(pyobject):  # type: (Any) -> tuple
+def get_tainted_ranges(pyobject: Any) -> tuple:
     return get_ranges(pyobject)
 
 
-def taint_ranges_as_evidence_info(pyobject):
-    # type: (Any) -> Tuple[List[Dict[str, Union[Any, int]]], list[Source]]
+def taint_ranges_as_evidence_info(pyobject: Any) -> Tuple[List[Dict[str, Union[Any, int]]], list[Source]]:
     value_parts = []
     sources = []
     current_pos = 0

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -51,8 +51,7 @@ def add_aspect(op1, op2):
     return _add_aspect(op1, op2)
 
 
-def str_aspect(orig_function, *args, **kwargs):
-    # type: (Callable, Any, Any) -> str
+def str_aspect(orig_function: Callable, *args: Any, **kwargs: Any) -> str:
     if orig_function != builtin_str:
         return orig_function(*args, **kwargs)
 
@@ -73,8 +72,7 @@ def str_aspect(orig_function, *args, **kwargs):
     return result
 
 
-def bytes_aspect(orig_function, *args, **kwargs):
-    # type: (Callable, Any, Any) -> bytes
+def bytes_aspect(orig_function: Callable, *args: Any, **kwargs: Any) -> bytes:
     if orig_function != builtin_bytes:
         return orig_function(*args, **kwargs)
 
@@ -87,8 +85,7 @@ def bytes_aspect(orig_function, *args, **kwargs):
     return result
 
 
-def bytearray_aspect(orig_function, *args, **kwargs):
-    # type: (Callable, Any, Any) -> bytearray
+def bytearray_aspect(orig_function: Callable, *args: Any, **kwargs: Any) -> bytearray:
     if orig_function != builtin_bytearray:
         return orig_function(*args, **kwargs)
 
@@ -101,8 +98,7 @@ def bytearray_aspect(orig_function, *args, **kwargs):
     return result
 
 
-def join_aspect(orig_function, joiner, *args, **kwargs):
-    # type: (Callable, Any, Any, Any) -> Any
+def join_aspect(orig_function: Callable, joiner: Any, *args: Any, **kwargs: Any) -> Any:
     if not isinstance(orig_function, BuiltinFunctionType):
         return orig_function(*args, **kwargs)
 
@@ -147,8 +143,7 @@ def slice_aspect(candidate_text, start, stop, step) -> Any:
         return candidate_text[start:stop:step]
 
 
-def bytearray_extend_aspect(orig_function, op1, op2):
-    # type: (Callable, Any, Any) -> Any
+def bytearray_extend_aspect(orig_function: Callable, op1: Any, op2: Any) -> Any:
     if not isinstance(orig_function, BuiltinFunctionType):
         return orig_function(op1, op2)
 
@@ -161,8 +156,7 @@ def bytearray_extend_aspect(orig_function, op1, op2):
         return op1.extend(op2)
 
 
-def modulo_aspect(candidate_text, candidate_tuple):
-    # type: (Any, Any) -> Any
+def modulo_aspect(candidate_text: Any, candidate_tuple: Any) -> Any:
     if not isinstance(candidate_text, TEXT_TYPES):
         return candidate_text % candidate_tuple
 
@@ -198,12 +192,11 @@ def modulo_aspect(candidate_text, candidate_tuple):
         return candidate_text % candidate_tuple
 
 
-def build_string_aspect(*args):  # type: (List[Any]) -> str
+def build_string_aspect(*args: List[Any]) -> str:
     return join_aspect("".join, "", args)
 
 
-def ljust_aspect(orig_function, candidate_text, *args, **kwargs):
-    # type: (Callable, Any, Any, Any) -> Union[str, bytes, bytearray]
+def ljust_aspect(orig_function: Callable, candidate_text: Any, *args: Any, **kwargs: Any) -> Union[str, bytes, bytearray]:
     if not isinstance(orig_function, BuiltinFunctionType):
         return orig_function(*args, **kwargs)
 
@@ -232,8 +225,7 @@ def ljust_aspect(orig_function, candidate_text, *args, **kwargs):
     return result
 
 
-def zfill_aspect(orig_function, candidate_text, *args, **kwargs):
-    # type: (Callable, Any, Any, Any) -> Any
+def zfill_aspect(orig_function: Callable, candidate_text: Any, *args: Any, **kwargs: Any) -> Any:
     if not isinstance(orig_function, BuiltinFunctionType):
         return orig_function(*args, **kwargs)
 
@@ -249,7 +241,7 @@ def zfill_aspect(orig_function, candidate_text, *args, **kwargs):
         prefix = candidate_text[0] in ("-", "+")
 
         difflen = len(result) - len(candidate_text)
-        ranges_new = []  # type: List[TaintRange]
+        ranges_new: List[TaintRange] = []
         ranges_new_append = ranges_new.append
         ranges_new_extend = ranges_new.extend
 
@@ -271,11 +263,11 @@ def zfill_aspect(orig_function, candidate_text, *args, **kwargs):
 
 
 def format_aspect(
-    orig_function,  # type: Callable
-    candidate_text,  # type: str
-    *args,  # type: List[Any]
-    **kwargs,  # type: Dict[str, Any]
-):  # type: (...) -> str
+    orig_function: Callable,
+    candidate_text: str,
+    *args: List[Any],
+    **kwargs: Dict[str, Any],
+) -> str:
     if not isinstance(orig_function, BuiltinFunctionType):
         return orig_function(*args, **kwargs)
 
@@ -318,7 +310,7 @@ def format_aspect(
     return result
 
 
-def format_map_aspect(orig_function, candidate_text, *args, **kwargs):  # type: (Callable, str, Any, Any) -> str
+def format_map_aspect(orig_function: Callable, candidate_text: str, *args: Any, **kwargs: Any) -> str:
     if not isinstance(orig_function, BuiltinFunctionType):
         return orig_function(*args, **kwargs)
 
@@ -353,8 +345,7 @@ def format_map_aspect(orig_function, candidate_text, *args, **kwargs):  # type: 
         return candidate_text.format_map(*args, **kwargs)
 
 
-def repr_aspect(orig_function, *args, **kwargs):
-    # type: (Optional[Callable], Any, Any) -> Any
+def repr_aspect(orig_function: Optional[Callable], *args: Any, **kwargs: Any) -> Any:
 
     # DEV: We call this function directly passing None as orig_function
     if orig_function is not None and not isinstance(orig_function, BuiltinFunctionType):
@@ -378,10 +369,10 @@ def repr_aspect(orig_function, *args, **kwargs):
 
 
 def format_value_aspect(
-    element,  # type: Any
-    options=0,  # type: int
-    format_spec=None,  # type: Optional[str]
-):  # type: (...) -> str
+    element: Any,
+    options: int = 0,
+    format_spec: Optional[str] = None,
+) -> str:
     if options == 115:
         new_text = str_aspect(element)
     elif options == 114:
@@ -494,7 +485,7 @@ def encode_aspect(orig_function, self, *args, **kwargs):
     return result
 
 
-def upper_aspect(orig_function, candidate_text, *args, **kwargs):  # type: (Callable, Any, Any, Any) -> TEXT_TYPE
+def upper_aspect(orig_function: Callable, candidate_text: Any, *args: Any, **kwargs: Any) -> TEXT_TYPE:
     if not isinstance(orig_function, BuiltinFunctionType):
         return orig_function(*args, **kwargs)
 
@@ -508,7 +499,7 @@ def upper_aspect(orig_function, candidate_text, *args, **kwargs):  # type: (Call
         return candidate_text.upper(*args, **kwargs)
 
 
-def lower_aspect(orig_function, candidate_text, *args, **kwargs):  # type: (Callable, Any, Any, Any) -> TEXT_TYPE
+def lower_aspect(orig_function: Callable, candidate_text: Any, *args: Any, **kwargs: Any) -> TEXT_TYPE:
     if not isinstance(orig_function, BuiltinFunctionType):
         return orig_function(*args, **kwargs)
 
@@ -522,7 +513,7 @@ def lower_aspect(orig_function, candidate_text, *args, **kwargs):  # type: (Call
         return candidate_text.lower(*args, **kwargs)
 
 
-def swapcase_aspect(orig_function, candidate_text, *args, **kwargs):  # type: (Callable, Any, Any, Any) -> TEXT_TYPE
+def swapcase_aspect(orig_function: Callable, candidate_text: Any, *args: Any, **kwargs: Any) -> TEXT_TYPE:
     if not isinstance(orig_function, BuiltinFunctionType):
         return orig_function(*args, **kwargs)
 
@@ -535,7 +526,7 @@ def swapcase_aspect(orig_function, candidate_text, *args, **kwargs):  # type: (C
         return candidate_text.swapcase(*args, **kwargs)
 
 
-def title_aspect(orig_function, candidate_text, *args, **kwargs):  # type: (Callable, Any, Any, Any) -> TEXT_TYPE
+def title_aspect(orig_function: Callable, candidate_text: Any, *args: Any, **kwargs: Any) -> TEXT_TYPE:
     if not isinstance(orig_function, BuiltinFunctionType):
         return orig_function(*args, **kwargs)
 
@@ -548,7 +539,7 @@ def title_aspect(orig_function, candidate_text, *args, **kwargs):  # type: (Call
         return candidate_text.title(*args, **kwargs)
 
 
-def capitalize_aspect(orig_function, candidate_text, *args, **kwargs):  # type: (Callable, Any, Any, Any) -> TEXT_TYPE
+def capitalize_aspect(orig_function: Callable, candidate_text: Any, *args: Any, **kwargs: Any) -> TEXT_TYPE:
     if not isinstance(orig_function, BuiltinFunctionType):
         return orig_function(*args, **kwargs)
 
@@ -562,7 +553,7 @@ def capitalize_aspect(orig_function, candidate_text, *args, **kwargs):  # type: 
         return candidate_text.capitalize(*args, **kwargs)
 
 
-def casefold_aspect(orig_function, candidate_text, *args, **kwargs):  # type: (Callable, Any, Any, Any) -> TEXT_TYPE
+def casefold_aspect(orig_function: Callable, candidate_text: Any, *args: Any, **kwargs: Any) -> TEXT_TYPE:
     if not isinstance(orig_function, BuiltinFunctionType):
         return orig_function(*args, **kwargs)
 
@@ -578,7 +569,7 @@ def casefold_aspect(orig_function, candidate_text, *args, **kwargs):  # type: (C
         return candidate_text.casefold(*args, **kwargs)  # type: ignore[union-attr]
 
 
-def translate_aspect(orig_function, candidate_text, *args, **kwargs):  # type: (Callable, Any, Any, Any) -> TEXT_TYPE
+def translate_aspect(orig_function: Callable, candidate_text: Any, *args: Any, **kwargs: Any) -> TEXT_TYPE:
     if not isinstance(orig_function, BuiltinFunctionType):
         return orig_function(*args, **kwargs)
 

--- a/ddtrace/appsec/_iast/_utils.py
+++ b/ddtrace/appsec/_iast/_utils.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from typing import Tuple
 
 
-def _is_python_version_supported():  # type: () -> bool
+def _is_python_version_supported() -> bool:
     # IAST supports Python versions 3.6 to 3.11
     return (3, 6, 0) <= sys.version_info < (3, 12, 0)
 
@@ -39,7 +39,7 @@ _SOURCE_NAME_SCRUB = None
 _SOURCE_VALUE_SCRUB = None
 
 
-def _has_to_scrub(s):  # type: (str) -> bool
+def _has_to_scrub(s: str) -> bool:
     global _SOURCE_NAME_SCRUB
     global _SOURCE_VALUE_SCRUB
 
@@ -54,18 +54,17 @@ _REPLACEMENTS = string.ascii_letters
 _LEN_REPLACEMENTS = len(_REPLACEMENTS)
 
 
-def _scrub(s, has_range=False):  # type: (str, bool) -> str
+def _scrub(s: str, has_range: bool = False) -> str:
     if has_range:
         return "".join([_REPLACEMENTS[i % _LEN_REPLACEMENTS] for i in range(len(s))])
     return "*" * len(s)
 
 
-def _is_evidence_value_parts(value):  # type: (Any) -> bool
+def _is_evidence_value_parts(value: Any) -> bool:
     return isinstance(value, (set, list))
 
 
-def _scrub_get_tokens_positions(text, tokens):
-    # type: (str, Set[str]) -> List[Tuple[int, int]]
+def _scrub_get_tokens_positions(text: str, tokens: Set[str]) -> List[Tuple[int, int]]:
     token_positions = []
 
     for token in tokens:

--- a/ddtrace/appsec/_iast/processor.py
+++ b/ddtrace/appsec/_iast/processor.py
@@ -27,8 +27,7 @@ log = get_logger(__name__)
 
 @attr.s(eq=False)
 class AppSecIastSpanProcessor(SpanProcessor):
-    def on_span_start(self, span):
-        # type: (Span) -> None
+    def on_span_start(self, span: Span) -> None:
         if span.span_type != SpanTypes.WEB:
             return
         oce.acquire_request(span)
@@ -36,8 +35,7 @@ class AppSecIastSpanProcessor(SpanProcessor):
 
         create_context()
 
-    def on_span_finish(self, span):
-        # type: (Span) -> None
+    def on_span_finish(self, span: Span) -> None:
         """Report reported vulnerabilities.
 
         Span Tags:

--- a/ddtrace/appsec/_iast/reporter.py
+++ b/ddtrace/appsec/_iast/reporter.py
@@ -24,10 +24,10 @@ def _only_if_true(value):
 
 @attr.s(eq=False, hash=False)
 class Evidence(object):
-    value = attr.ib(type=str, default=None)  # type: Optional[str]
-    pattern = attr.ib(type=str, default=None)  # type: Optional[str]
-    valueParts = attr.ib(type=list, default=None)  # type: Optional[List[Dict[str, Any]]]
-    redacted = attr.ib(type=bool, default=False, converter=_only_if_true)  # type: bool
+    value: Optional[str] = attr.ib(type=str, default=None)
+    pattern: Optional[str] = attr.ib(type=str, default=None)
+    valueParts: Optional[List[Dict[str, Any]]] = attr.ib(type=list, default=None)
+    redacted: bool = attr.ib(type=bool, default=False, converter=_only_if_true)
 
     def _valueParts_hash(self):
         if not self.valueParts:
@@ -55,17 +55,17 @@ class Evidence(object):
 
 @attr.s(eq=True, hash=True)
 class Location(object):
-    spanId = attr.ib(type=int, eq=False, hash=False, repr=False)  # type: int
-    path = attr.ib(type=str, default=None)  # type: Optional[str]
-    line = attr.ib(type=int, default=None)  # type: Optional[int]
+    spanId: int = attr.ib(type=int, eq=False, hash=False, repr=False)
+    path: Optional[str] = attr.ib(type=str, default=None)
+    line: Optional[int] = attr.ib(type=int, default=None)
 
 
 @attr.s(eq=True, hash=True)
 class Vulnerability(object):
-    type = attr.ib(type=str)  # type: str
-    evidence = attr.ib(type=Evidence, repr=False)  # type: Evidence
-    location = attr.ib(type=Location, hash="PYTEST_CURRENT_TEST" in os.environ)  # type: Location
-    hash = attr.ib(init=False, eq=False, hash=False, repr=False)  # type: int
+    type: str = attr.ib(type=str)
+    evidence: Evidence = attr.ib(type=Evidence, repr=False)
+    location: Location = attr.ib(type=Location, hash="PYTEST_CURRENT_TEST" in os.environ)
+    hash: int = attr.ib(init=False, eq=False, hash=False, repr=False)
 
     def __attrs_post_init__(self):
         self.hash = zlib.crc32(repr(self).encode())
@@ -75,17 +75,17 @@ class Vulnerability(object):
 
 @attr.s(eq=True, hash=True)
 class Source(object):
-    origin = attr.ib(type=str)  # type: str
-    name = attr.ib(type=str)  # type: str
-    redacted = attr.ib(type=bool, default=False, converter=_only_if_true)  # type: bool
-    value = attr.ib(type=str, default=None)  # type: Optional[str]
-    pattern = attr.ib(type=str, default=None)  # type: Optional[str]
+    origin: str = attr.ib(type=str)
+    name: str = attr.ib(type=str)
+    redacted: bool = attr.ib(type=bool, default=False, converter=_only_if_true)
+    value: Optional[str] = attr.ib(type=str, default=None)
+    pattern: Optional[str] = attr.ib(type=str, default=None)
 
 
 @attr.s(eq=False, hash=False)
 class IastSpanReporter(object):
-    sources = attr.ib(type=List[Source], factory=list)  # type: List[Source]
-    vulnerabilities = attr.ib(type=Set[Vulnerability], factory=set)  # type: Set[Vulnerability]
+    sources: List[Source] = attr.ib(type=List[Source], factory=list)
+    vulnerabilities: Set[Vulnerability] = attr.ib(type=Set[Vulnerability], factory=set)
 
     def __hash__(self):
         return reduce(operator.xor, (hash(obj) for obj in set(self.sources) | self.vulnerabilities))

--- a/ddtrace/appsec/_iast/taint_sinks/_base.py
+++ b/ddtrace/appsec/_iast/taint_sinks/_base.py
@@ -66,10 +66,8 @@ class VulnerabilityBase(Operation):
         cls._redacted_report_cache.clear()
 
     @classmethod
-    def wrap(cls, func):
-        # type: (Callable) -> Callable
-        def wrapper(wrapped, instance, args, kwargs):
-            # type: (Callable, Any, Any, Any) -> Any
+    def wrap(cls, func: Callable) -> Callable:
+        def wrapper(wrapped: Callable, instance: Any, args: Any, kwargs: Any) -> Any:
             """Get the current root Span and attach it to the wrapped function. We need the span to report the
             vulnerability and update the context with the report information.
             """
@@ -82,8 +80,7 @@ class VulnerabilityBase(Operation):
         return wrapper
 
     @classmethod
-    def report(cls, evidence_value="", sources=None):
-        # type: (Union[Text|List[Dict[str, Any]]], Optional[List[Source]]) -> None
+    def report(cls, evidence_value: Union[Text|List[Dict[str, Any]]] = "", sources: Optional[List[Source]] = None) -> None:
         """Build a IastSpanReporter instance to report it in the `AppSecIastSpanProcessor` as a string JSON
 
         TODO: check deduplications if DD_IAST_DEDUPLICATION_ENABLED is true
@@ -168,8 +165,7 @@ class VulnerabilityBase(Operation):
             core.set_item(IAST.CONTEXT_KEY, redacted_report, span=span)
 
     @classmethod
-    def _extract_sensitive_tokens(cls, report):
-        # type: (Dict[Vulnerability, str]) -> Dict[int, Dict[str, Any]]
+    def _extract_sensitive_tokens(cls, report: Dict[Vulnerability, str]) -> Dict[int, Dict[str, Any]]:
         log.debug("Base class VulnerabilityBase._extract_sensitive_tokens called")
         return {}
 
@@ -205,7 +201,7 @@ class VulnerabilityBase(Operation):
         return ret, replaced
 
     @classmethod
-    def _redact_report(cls, report):  # type: (IastSpanReporter) -> IastSpanReporter
+    def _redact_report(cls, report: IastSpanReporter) -> IastSpanReporter:
         if not asm_config._iast_redaction_enabled:
             return report
 
@@ -245,7 +241,7 @@ class VulnerabilityBase(Operation):
         if not vulns_to_tokens:
             return report
 
-        all_tokens = set()  # type: Set[str]
+        all_tokens: Set[str] = set()
         for _, value_dict in six.iteritems(vulns_to_tokens):
             all_tokens.update(value_dict["tokens"])
 

--- a/ddtrace/appsec/_iast/taint_sinks/ast_taint.py
+++ b/ddtrace/appsec/_iast/taint_sinks/ast_taint.py
@@ -15,10 +15,10 @@ if TYPE_CHECKING:
 
 
 def ast_funcion(
-    func,  # type: Callable
-    *args,  # type: Any
-    **kwargs,  # type: Any
-):  # type: (...) -> Any
+    func: Callable,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
     cls = getattr(func, "__self__", None)
     func_name = getattr(func, "__name__", None)
     cls_name = ""

--- a/ddtrace/appsec/_iast/taint_sinks/command_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/command_injection.py
@@ -38,8 +38,7 @@ log = get_logger(__name__)
 _INSIDE_QUOTES_REGEXP = re.compile(r"^(?:\s*(?:sudo|doas)\s+)?\b\S+\b\s*(.*)")
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 
@@ -60,8 +59,7 @@ def patch():
         subprocess._datadog_cmdi_patch = True
 
 
-def unpatch():
-    # type: () -> None
+def unpatch() -> None:
     trace_utils.unwrap(os, "system")
     trace_utils.unwrap(os, "_spawnvef")
     trace_utils.unwrap(subprocess.Popen, "__init__")
@@ -104,10 +102,9 @@ class CommandInjection(VulnerabilityBase):
         super(CommandInjection, cls).report(evidence_value=evidence_value, sources=sources)
 
     @classmethod
-    def _extract_sensitive_tokens(cls, vulns_to_text):
-        # type: (Dict[Vulnerability, str]) -> Dict[int, Dict[str, Any]]
+    def _extract_sensitive_tokens(cls, vulns_to_text: Dict[Vulnerability, str]) -> Dict[int, Dict[str, Any]]:
 
-        ret = {}  # type: Dict[int, Dict[str, Any]]
+        ret: Dict[int, Dict[str, Any]] = {}
         for vuln, text in six.iteritems(vulns_to_text):
             vuln_hash = hash(vuln)
             ret[vuln_hash] = {
@@ -134,7 +131,7 @@ class CommandInjection(VulnerabilityBase):
         return ret, replaced
 
     @classmethod
-    def _redact_report(cls, report):  # type: (IastSpanReporter) -> IastSpanReporter
+    def _redact_report(cls, report: IastSpanReporter) -> IastSpanReporter:
         if not asm_config._iast_redaction_enabled:
             return report
 
@@ -174,7 +171,7 @@ class CommandInjection(VulnerabilityBase):
         if not vulns_to_tokens:
             return report
 
-        all_tokens = set()  # type: Set[str]
+        all_tokens: Set[str] = set()
         for _, value_dict in six.iteritems(vulns_to_tokens):
             all_tokens.update(value_dict["tokens"])
 
@@ -238,8 +235,7 @@ class CommandInjection(VulnerabilityBase):
         return report
 
 
-def _iast_report_cmdi(shell_args):
-    # type: (Union[str, List[str]]) -> None
+def _iast_report_cmdi(shell_args: Union[str, List[str]]) -> None:
     report_cmdi = ""
     from .._metrics import _set_metric_iast_executed_sink
     from .._taint_tracking import get_tainted_ranges

--- a/ddtrace/appsec/_iast/taint_sinks/insecure_cookie.py
+++ b/ddtrace/appsec/_iast/taint_sinks/insecure_cookie.py
@@ -40,7 +40,7 @@ class NoSameSite(VulnerabilityBase):
     skip_location = True
 
 
-def asm_check_cookies(cookies):  # type: (Optional[Dict[str, str]]) -> None
+def asm_check_cookies(cookies: Optional[Dict[str, str]]) -> None:
     if not cookies:
         return
 

--- a/ddtrace/appsec/_iast/taint_sinks/path_traversal.py
+++ b/ddtrace/appsec/_iast/taint_sinks/path_traversal.py
@@ -30,18 +30,15 @@ class PathTraversal(VulnerabilityBase):
         super(PathTraversal, cls).report(evidence_value=evidence_value, sources=sources)
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 
-def unpatch_iast():
-    # type: () -> None
+def unpatch_iast() -> None:
     set_module_unpatched("builtins", default_attr="_datadog_path_traversal_patch")
 
 
-def patch():
-    # type: () -> None
+def patch() -> None:
     """Wrap functions which interact with file system."""
     if not set_and_check_module_is_patched("builtins", default_attr="_datadog_path_traversal_patch"):
         return

--- a/ddtrace/appsec/_iast/taint_sinks/sql_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/sql_injection.py
@@ -33,10 +33,9 @@ class SqlInjection(VulnerabilityBase):
         super(SqlInjection, cls).report(evidence_value=evidence_value, sources=sources)
 
     @classmethod
-    def _extract_sensitive_tokens(cls, vulns_to_text):
-        # type: (Dict[Vulnerability, str]) -> Dict[int, Dict[str, Any]]
+    def _extract_sensitive_tokens(cls, vulns_to_text: Dict[Vulnerability, str]) -> Dict[int, Dict[str, Any]]:
 
-        ret = {}  # type: Dict[int, Dict[str, Any]]
+        ret: Dict[int, Dict[str, Any]] = {}
         for vuln, text in six.iteritems(vulns_to_text):
             vuln_hash = hash(vuln)
             ret[vuln_hash] = {

--- a/ddtrace/appsec/_iast/taint_sinks/ssrf.py
+++ b/ddtrace/appsec/_iast/taint_sinks/ssrf.py
@@ -42,7 +42,7 @@ class SSRF(VulnerabilityBase):
 
     @classmethod
     def _extract_sensitive_tokens(cls, vulns_to_text: Dict[Vulnerability, str]) -> VULNERABILITY_TOKEN_TYPE:
-        ret = {}  # type: VULNERABILITY_TOKEN_TYPE
+        ret: VULNERABILITY_TOKEN_TYPE = {}
         for vuln, text in vulns_to_text.items():
             vuln_hash = hash(vuln)
             authority = []
@@ -58,7 +58,7 @@ class SSRF(VulnerabilityBase):
         return ret
 
     @classmethod
-    def _redact_report(cls, report):  # type: (IastSpanReporter) -> IastSpanReporter
+    def _redact_report(cls, report: IastSpanReporter) -> IastSpanReporter:
         if not asm_config._iast_redaction_enabled:
             return report
 
@@ -98,7 +98,7 @@ class SSRF(VulnerabilityBase):
         if not vulns_to_tokens:
             return report
 
-        all_tokens = set()  # type: Set[str]
+        all_tokens: Set[str] = set()
         for _, value_dict in vulns_to_tokens.items():
             all_tokens.update(value_dict["tokens"])
 

--- a/ddtrace/appsec/_iast/taint_sinks/weak_cipher.py
+++ b/ddtrace/appsec/_iast/taint_sinks/weak_cipher.py
@@ -30,8 +30,7 @@ if TYPE_CHECKING:  # pragma: no cover
 log = get_logger(__name__)
 
 
-def get_weak_cipher_algorithms():
-    # type: () -> Set
+def get_weak_cipher_algorithms() -> Set:
     CONFIGURED_WEAK_CIPHER_ALGORITHMS = None
     DD_IAST_WEAK_CIPHER_ALGORITHMS = os.getenv("DD_IAST_WEAK_CIPHER_ALGORITHMS")
     if DD_IAST_WEAK_CIPHER_ALGORITHMS:
@@ -47,8 +46,7 @@ class WeakCipher(VulnerabilityBase):
     evidence_type = EVIDENCE_ALGORITHM_TYPE
 
 
-def unpatch_iast():
-    # type: () -> None
+def unpatch_iast() -> None:
     set_module_unpatched("Crypto", default_attr="_datadog_weak_cipher_patch")
     set_module_unpatched("cryptography", default_attr="_datadog_weak_cipher_patch")
 
@@ -62,13 +60,11 @@ def unpatch_iast():
     try_unwrap("cryptography.hazmat.primitives.ciphers", "Cipher.encryptor")
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 
-def patch():
-    # type: () -> None
+def patch() -> None:
     """Wrap hashing functions.
     Weak hashing algorithms are those that have been proven to be of high risk, or even completely broken,
     and thus are not fit for use.
@@ -129,8 +125,7 @@ def wrapped_aux_blowfish_function(wrapped, instance, args, kwargs):
 
 
 @WeakCipher.wrap
-def wrapped_rc4_function(wrapped, instance, args, kwargs):
-    # type: (Callable, Any, Any, Any) -> Any
+def wrapped_rc4_function(wrapped: Callable, instance: Any, args: Any, kwargs: Any) -> Any:
     increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, WeakCipher.vulnerability_type)
     _set_metric_iast_executed_sink(WeakCipher.vulnerability_type)
     WeakCipher.report(
@@ -140,8 +135,7 @@ def wrapped_rc4_function(wrapped, instance, args, kwargs):
 
 
 @WeakCipher.wrap
-def wrapped_function(wrapped, instance, args, kwargs):
-    # type: (Callable, Any, Any, Any) -> Any
+def wrapped_function(wrapped: Callable, instance: Any, args: Any, kwargs: Any) -> Any:
     if hasattr(instance, "_dd_weakcipher_algorithm"):
         evidence = instance._dd_weakcipher_algorithm + "_" + str(instance.__class__.__name__)
         increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, WeakCipher.vulnerability_type)
@@ -154,8 +148,7 @@ def wrapped_function(wrapped, instance, args, kwargs):
 
 
 @WeakCipher.wrap
-def wrapped_cryptography_function(wrapped, instance, args, kwargs):
-    # type: (Callable, Any, Any, Any) -> Any
+def wrapped_cryptography_function(wrapped: Callable, instance: Any, args: Any, kwargs: Any) -> Any:
     algorithm_name = instance.algorithm.name.lower()
     if algorithm_name in get_weak_cipher_algorithms():
         increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, WeakCipher.vulnerability_type)

--- a/ddtrace/appsec/_iast/taint_sinks/weak_hash.py
+++ b/ddtrace/appsec/_iast/taint_sinks/weak_hash.py
@@ -29,8 +29,7 @@ if TYPE_CHECKING:  # pragma: no cover
 log = get_logger(__name__)
 
 
-def get_weak_hash_algorithms():
-    # type: () -> Set
+def get_weak_hash_algorithms() -> Set:
     CONFIGURED_WEAK_HASH_ALGORITHMS = None
     DD_IAST_WEAK_HASH_ALGORITHMS = os.getenv("DD_IAST_WEAK_HASH_ALGORITHMS")
     if DD_IAST_WEAK_HASH_ALGORITHMS:
@@ -45,8 +44,7 @@ class WeakHash(VulnerabilityBase):
     evidence_type = EVIDENCE_ALGORITHM_TYPE
 
 
-def unpatch_iast():
-    # type: () -> None
+def unpatch_iast() -> None:
     set_module_unpatched("hashlib", default_attr="_datadog_weak_hash_patch")
     set_module_unpatched("Crypto", default_attr="_datadog_weak_hash_patch")
 
@@ -69,13 +67,11 @@ def unpatch_iast():
     try_unwrap("Crypto.Hash.SHA1", "SHA1Hash.hexdigest")
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 
-def patch():
-    # type: () -> None
+def patch() -> None:
     """Wrap hashing functions.
     Weak hashing algorithms are those that have been proven to be of high risk, or even completely broken,
     and thus are not fit for use.
@@ -126,8 +122,7 @@ def patch():
 
 
 @WeakHash.wrap
-def wrapped_digest_function(wrapped, instance, args, kwargs):
-    # type: (Callable, Any, Any, Any) -> Any
+def wrapped_digest_function(wrapped: Callable, instance: Any, args: Any, kwargs: Any) -> Any:
     if instance.name.lower() in get_weak_hash_algorithms():
         increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, WeakHash.vulnerability_type)
         _set_metric_iast_executed_sink(WeakHash.vulnerability_type)
@@ -138,20 +133,17 @@ def wrapped_digest_function(wrapped, instance, args, kwargs):
 
 
 @WeakHash.wrap
-def wrapped_md5_function(wrapped, instance, args, kwargs):
-    # type: (Callable, Any, Any, Any) -> Any
+def wrapped_md5_function(wrapped: Callable, instance: Any, args: Any, kwargs: Any) -> Any:
     return wrapped_function(wrapped, MD5_DEF, instance, args, kwargs)
 
 
 @WeakHash.wrap
-def wrapped_sha1_function(wrapped, instance, args, kwargs):
-    # type: (Callable, Any, Any, Any) -> Any
+def wrapped_sha1_function(wrapped: Callable, instance: Any, args: Any, kwargs: Any) -> Any:
     return wrapped_function(wrapped, SHA1_DEF, instance, args, kwargs)
 
 
 @WeakHash.wrap
-def wrapped_new_function(wrapped, instance, args, kwargs):
-    # type: (Callable, Any, Any, Any) -> Any
+def wrapped_new_function(wrapped: Callable, instance: Any, args: Any, kwargs: Any) -> Any:
     if args[0].lower() in get_weak_hash_algorithms():
         increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, WeakHash.vulnerability_type)
         _set_metric_iast_executed_sink(WeakHash.vulnerability_type)
@@ -161,8 +153,7 @@ def wrapped_new_function(wrapped, instance, args, kwargs):
     return wrapped(*args, **kwargs)
 
 
-def wrapped_function(wrapped, evidence, instance, args, kwargs):
-    # type: (Callable, str, Any, Any, Any) -> Any
+def wrapped_function(wrapped: Callable, evidence: str, instance: Any, args: Any, kwargs: Any) -> Any:
     increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, WeakHash.vulnerability_type)
     _set_metric_iast_executed_sink(WeakHash.vulnerability_type)
     WeakHash.report(

--- a/ddtrace/appsec/_metrics.py
+++ b/ddtrace/appsec/_metrics.py
@@ -11,8 +11,7 @@ log = get_logger(__name__)
 
 
 @deduplication
-def _set_waf_error_metric(msg, stack_trace, info):
-    # type: (str, str, DDWaf_info) -> None
+def _set_waf_error_metric(msg: str, stack_trace: str, info: DDWaf_info) -> None:
     try:
         tags = {
             "waf_version": version(),

--- a/ddtrace/appsec/_python_info/stdlib/__init__.py
+++ b/ddtrace/appsec/_python_info/stdlib/__init__.py
@@ -17,5 +17,5 @@ else:
     from .module_names_py311 import STDLIB_MODULE_NAMES
 
 
-def _stdlib_for_python_version():  # type: () -> set
+def _stdlib_for_python_version() -> set:
     return STDLIB_MODULE_NAMES

--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -108,7 +108,7 @@ def _appsec_rules_data(features: Mapping[str, Any], test_tracer: Optional[Tracer
         tracer = test_tracer
 
     if features and tracer._appsec_processor:
-        ruleset = {}  # type: dict[str, Optional[list[Any]]]
+        ruleset: dict[str, Optional[list[Any]]] = {}
         _add_rules_to_list(features, "rules_data", "rules data", ruleset)
         _add_rules_to_list(features, "custom_rules", "custom rules", ruleset)
         _add_rules_to_list(features, "rules", "Datadog rules", ruleset)

--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -52,8 +52,7 @@ def is_module_installed(module_name):
 
 
 def cleanup_loaded_modules():
-    def drop(module_name):
-        # type: (str) -> None
+    def drop(module_name: str) -> None:
         if PY2:
             # Store a reference to deleted modules to avoid them being garbage
             # collected

--- a/ddtrace/commands/ddtrace_run.py
+++ b/ddtrace/commands/ddtrace_run.py
@@ -25,9 +25,8 @@ else:
 
 
 def find_executable(
-    p,  # type: str
-):
-    # type: (...) -> typing.Optional[str]
+    p: str,
+) -> typing.Optional[str]:
     if os.path.isfile(p):
         return p
     return _which(p)

--- a/ddtrace/contrib/_trace_utils_llm.py
+++ b/ddtrace/contrib/_trace_utils_llm.py
@@ -39,30 +39,25 @@ class BaseLLMIntegration:
         self._span_pc_sampler = RateSampler(sample_rate=config.span_prompt_completion_sample_rate)
         self._log_pc_sampler = RateSampler(sample_rate=config.log_prompt_completion_sample_rate)
 
-    def is_pc_sampled_span(self, span):
-        # type: (Span) -> bool
+    def is_pc_sampled_span(self, span: Span) -> bool:
         if not span.sampled:
             return False
         return self._span_pc_sampler.sample(span)
 
-    def is_pc_sampled_log(self, span):
-        # type: (Span) -> bool
+    def is_pc_sampled_log(self, span: Span) -> bool:
         if not self._config.logs_enabled or not span.sampled:
             return False
         return self._log_pc_sampler.sample(span)
 
-    def start_log_writer(self):
-        # type: (...) -> None
+    def start_log_writer(self) -> None:
         self._log_writer.start()
 
     @abc.abstractmethod
-    def _set_base_span_tags(self, span, **kwargs):
-        # type: (Span, Dict[str, Any]) -> None
+    def _set_base_span_tags(self, span: Span, **kwargs: Dict[str, Any]) -> None:
         """Set default LLM span attributes when possible."""
         pass
 
-    def trace(self, pin, operation_id, **kwargs):
-        # type: (Pin, str, Dict[str, Any]) -> Span
+    def trace(self, pin: Pin, operation_id: str, **kwargs: Dict[str, Any]) -> Span:
         """
         Start a LLM request span.
         Reuse the service of the application since we'll tag downstream request spans with the LLM name.
@@ -78,13 +73,11 @@ class BaseLLMIntegration:
 
     @classmethod
     @abc.abstractmethod
-    def _logs_tags(cls, span):
-        # type: (Span) -> str
+    def _logs_tags(cls, span: Span) -> str:
         """Generate ddtags from the corresponding span."""
         pass
 
-    def log(self, span, level, msg, attrs):
-        # type: (Span, str, str, Dict[str, Any]) -> None
+    def log(self, span: Span, level: str, msg: str, attrs: Dict[str, Any]) -> None:
         if not self._config.logs_enabled:
             return
         tags = self._logs_tags(span)
@@ -105,13 +98,11 @@ class BaseLLMIntegration:
 
     @classmethod
     @abc.abstractmethod
-    def _metrics_tags(cls, span):
-        # type: (Span) -> list
+    def _metrics_tags(cls, span: Span) -> list:
         """Generate a list of metrics tags from a given span."""
         return []
 
-    def metric(self, span, kind, name, val, tags=None):
-        # type: (Span, str, str, Any, Optional[List[str]]) -> None
+    def metric(self, span: Span, kind: str, name: str, val: Any, tags: Optional[List[str]] = None) -> None:
         """Set a metric using the context from the given span."""
         if not self._config.metrics_enabled:
             return
@@ -127,8 +118,7 @@ class BaseLLMIntegration:
         else:
             raise ValueError("Unexpected metric type %r" % kind)
 
-    def trunc(self, text):
-        # type: (str) -> str
+    def trunc(self, text: str) -> str:
         """Truncate the given text.
 
         Use to avoid attaching too much data to spans.

--- a/ddtrace/contrib/aiobotocore/patch.py
+++ b/ddtrace/contrib/aiobotocore/patch.py
@@ -47,8 +47,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return aiobotocore_version_str
 
 

--- a/ddtrace/contrib/aiohttp/patch.py
+++ b/ddtrace/contrib/aiohttp/patch.py
@@ -44,8 +44,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return aiohttp.__version__
 
 
@@ -73,8 +72,8 @@ class _WrappedConnectorClass(wrapt.ObjectProxy):
 
 @with_traced_module
 async def _traced_clientsession_request(aiohttp, pin, func, instance, args, kwargs):
-    method = get_argument_value(args, kwargs, 0, "method")  # type: str
-    url = URL(get_argument_value(args, kwargs, 1, "url"))  # type: URL
+    method: str = get_argument_value(args, kwargs, 0, "method")
+    url: URL = URL(get_argument_value(args, kwargs, 1, "url"))
     params = kwargs.get("params")
     headers = kwargs.get("headers") or {}
 
@@ -105,7 +104,7 @@ async def _traced_clientsession_request(aiohttp, pin, func, instance, args, kwar
             query=query,
             request_headers=headers,
         )
-        resp = await func(*args, **kwargs)  # type: aiohttp.ClientResponse
+        resp: aiohttp.ClientResponse = await func(*args, **kwargs)
         set_http_meta(
             span, config.aiohttp_client, response_headers=resp.headers, status_code=resp.status, status_msg=resp.reason
         )

--- a/ddtrace/contrib/aiohttp_jinja2/patch.py
+++ b/ddtrace/contrib/aiohttp_jinja2/patch.py
@@ -17,8 +17,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(aiohttp_jinja2, "__version__", "")
 
 

--- a/ddtrace/contrib/aiomysql/patch.py
+++ b/ddtrace/contrib/aiomysql/patch.py
@@ -24,8 +24,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(aiomysql, "__version__", "")
 
 

--- a/ddtrace/contrib/aiopg/patch.py
+++ b/ddtrace/contrib/aiopg/patch.py
@@ -12,8 +12,7 @@ from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.vendor import wrapt
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(aiopg, "__version__", "")
 
 

--- a/ddtrace/contrib/aioredis/patch.py
+++ b/ddtrace/contrib/aioredis/patch.py
@@ -49,8 +49,7 @@ aioredis_version_str = getattr(aioredis, "__version__", "")
 aioredis_version = tuple([int(i) for i in aioredis_version_str.split(".")])
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return aioredis_version_str
 
 

--- a/ddtrace/contrib/algoliasearch/patch.py
+++ b/ddtrace/contrib/algoliasearch/patch.py
@@ -31,8 +31,7 @@ except ImportError:
     algoliasearch_version = (0, 0)
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return VERSION
 
 

--- a/ddtrace/contrib/aredis/patch.py
+++ b/ddtrace/contrib/aredis/patch.py
@@ -26,8 +26,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(aredis, "__version__", "")
 
 

--- a/ddtrace/contrib/asgi/middleware.py
+++ b/ddtrace/contrib/asgi/middleware.py
@@ -42,8 +42,7 @@ ASGI_VERSION = "asgi.version"
 ASGI_SPEC_VERSION = "asgi.spec_version"
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 
@@ -82,8 +81,7 @@ def _default_handle_exception_span(exc, span):
     span.set_tag(http.STATUS_CODE, 500)
 
 
-def span_from_scope(scope):
-    # type: (Mapping[str, Any]) -> Optional[Span]
+def span_from_scope(scope: Mapping[str, Any]) -> Optional[Span]:
     """Retrieve the top-level ASGI span from the scope."""
     return scope.get("datadog", {}).get("request_spans", [None])[0]
 

--- a/ddtrace/contrib/asyncio/patch.py
+++ b/ddtrace/contrib/asyncio/patch.py
@@ -8,8 +8,7 @@ from ..trace_utils import unwrap as _u
 from .wrappers import wrapped_create_task
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 

--- a/ddtrace/contrib/asyncpg/patch.py
+++ b/ddtrace/contrib/asyncpg/patch.py
@@ -45,13 +45,11 @@ config._add(
 log = get_logger(__name__)
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(asyncpg, "__version__", "")
 
 
-def _get_connection_tags(conn):
-    # type: (asyncpg.Connection) -> Dict[str, str]
+def _get_connection_tags(conn: asyncpg.Connection) -> Dict[str, str]:
     addr = conn._addr
     params = conn._params
     host = port = ""
@@ -122,20 +120,18 @@ async def _traced_query(pin, method, query, args, kwargs):
 
 @with_traced_module
 async def _traced_protocol_execute(asyncpg, pin, func, instance, args, kwargs):
-    state = get_argument_value(args, kwargs, 0, "state")  # type: Union[str, PreparedStatement]
+    state: Union[str, PreparedStatement] = get_argument_value(args, kwargs, 0, "state")
     query = state if isinstance(state, str) else state.query
     return await _traced_query(pin, func, query, args, kwargs)
 
 
-def _patch(asyncpg):
-    # type: (ModuleType) -> None
+def _patch(asyncpg: ModuleType) -> None:
     wrap(asyncpg, "connect", _traced_connect(asyncpg))
     for method in ("execute", "bind_execute", "query", "bind_execute_many"):
         wrap(asyncpg.protocol, "Protocol.%s" % method, _traced_protocol_execute(asyncpg))
 
 
-def patch():
-    # type: () -> None
+def patch() -> None:
     import asyncpg
 
     if getattr(asyncpg, "_datadog_patch", False):
@@ -147,15 +143,13 @@ def patch():
     asyncpg._datadog_patch = True
 
 
-def _unpatch(asyncpg):
-    # type: (ModuleType) -> None
+def _unpatch(asyncpg: ModuleType) -> None:
     unwrap(asyncpg, "connect")
     for method in ("execute", "bind_execute", "query", "bind_execute_many"):
         unwrap(asyncpg.protocol.Protocol, method)
 
 
-def unpatch():
-    # type: () -> None
+def unpatch() -> None:
     import asyncpg
 
     if not getattr(asyncpg, "_datadog_patch", False):

--- a/ddtrace/contrib/aws_lambda/patch.py
+++ b/ddtrace/contrib/aws_lambda/patch.py
@@ -15,8 +15,7 @@ from ._cold_start import is_cold_start
 from ._cold_start import set_cold_start
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 

--- a/ddtrace/contrib/boto/patch.py
+++ b/ddtrace/contrib/boto/patch.py
@@ -48,8 +48,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return __version__
 
 

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -47,7 +47,7 @@ from ...propagation.http import HTTPPropagator
 from ..trace_utils import unwrap
 
 
-_PATCHED_SUBMODULES = set()  # type: Set[str]
+_PATCHED_SUBMODULES: Set[str] = set()
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     from ddtrace import Span
@@ -79,8 +79,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return __version__
 
 
@@ -100,8 +99,7 @@ def _encode_data(trace_data):
     return json.dumps(trace_data)
 
 
-def inject_trace_data_to_message_attributes(trace_data, entry, endpoint_service=None):
-    # type: (Dict[str, str], Dict[str, Any], Optional[str]) -> None
+def inject_trace_data_to_message_attributes(trace_data: Dict[str, str], entry: Dict[str, Any], endpoint_service: Optional[str] = None) -> None:
     """
     :trace_data: trace headers and DSM pathway to be stored in the entry's MessageAttributes
     :entry: an SQS or SNS record
@@ -129,8 +127,7 @@ def inject_trace_data_to_message_attributes(trace_data, entry, endpoint_service=
         log.warning("skipping trace injection, max number (10) of MessageAttributes exceeded")
 
 
-def get_topic_arn(params):
-    # type: (str) -> str
+def get_topic_arn(params: str) -> str:
     """
     :params: contains the params for the current botocore action
 
@@ -140,8 +137,7 @@ def get_topic_arn(params):
     return sns_arn
 
 
-def get_queue_name(params):
-    # type: (str) -> str
+def get_queue_name(params: str) -> str:
     """
     :params: contains the params for the current botocore action
 
@@ -152,8 +148,7 @@ def get_queue_name(params):
     return url.path.rsplit("/", 1)[-1]
 
 
-def get_stream_arn(params):
-    # type: (str) -> str
+def get_stream_arn(params: str) -> str:
     """
     :params: contains the params for the current botocore action
 
@@ -163,8 +158,7 @@ def get_stream_arn(params):
     return stream_arn
 
 
-def get_pathway(pin, endpoint_service, dsm_identifier):
-    # type: (Pin, str, str) -> str
+def get_pathway(pin: Pin, endpoint_service: str, dsm_identifier: str) -> str:
     """
     :pin: patch info for the botocore client
     :endpoint_service: the name  of the service (i.e. 'sns', 'sqs', 'kinesis')
@@ -182,8 +176,7 @@ def get_pathway(pin, endpoint_service, dsm_identifier):
     return pathway.encode_b64()
 
 
-def inject_trace_to_sqs_or_sns_batch_message(params, span, endpoint_service=None, pin=None, data_streams_enabled=False):
-    # type: (Any, Span, Optional[str], Optional[Pin], Optional[bool]) -> None
+def inject_trace_to_sqs_or_sns_batch_message(params: Any, span: Span, endpoint_service: Optional[str] = None, pin: Optional[Pin] = None, data_streams_enabled: Optional[bool] = False) -> None:
     """
     :params: contains the params for the current botocore action
     :span: the span which provides the trace context to be propagated
@@ -212,8 +205,7 @@ def inject_trace_to_sqs_or_sns_batch_message(params, span, endpoint_service=None
         inject_trace_data_to_message_attributes(trace_data, entry, endpoint_service)
 
 
-def inject_trace_to_sqs_or_sns_message(params, span, endpoint_service=None, pin=None, data_streams_enabled=False):
-    # type: (Any, Span, Optional[str], Optional[Pin], Optional[bool]) -> None
+def inject_trace_to_sqs_or_sns_message(params: Any, span: Span, endpoint_service: Optional[str] = None, pin: Optional[Pin] = None, data_streams_enabled: Optional[bool] = False) -> None:
     """
     :params: contains the params for the current botocore action
     :span: the span which provides the trace context to be propagated
@@ -238,8 +230,7 @@ def inject_trace_to_sqs_or_sns_message(params, span, endpoint_service=None, pin=
     inject_trace_data_to_message_attributes(trace_data, params, endpoint_service)
 
 
-def inject_trace_to_eventbridge_detail(params, span):
-    # type: (Any, Span) -> None
+def inject_trace_to_eventbridge_detail(params: Any, span: Span) -> None:
     """
     :params: contains the params for the current botocore action
     :span: the span which provides the trace context to be propagated
@@ -273,8 +264,7 @@ def inject_trace_to_eventbridge_detail(params, span):
         entry["Detail"] = detail_json
 
 
-def get_json_from_str(data_str):
-    # type: (str) -> Tuple[str, Optional[Dict[str, Any]]]
+def get_json_from_str(data_str: str) -> Tuple[str, Optional[Dict[str, Any]]]:
     data_obj = json.loads(data_str)
 
     if data_str.endswith(LINE_BREAK):
@@ -282,8 +272,7 @@ def get_json_from_str(data_str):
     return None, data_obj
 
 
-def get_kinesis_data_object(data):
-    # type: (str) -> Tuple[str, Optional[Dict[str, Any]]]
+def get_kinesis_data_object(data: str) -> Tuple[str, Optional[Dict[str, Any]]]:
     """
     :data: the data from a kinesis stream
 
@@ -318,8 +307,7 @@ def get_kinesis_data_object(data):
     return None, None
 
 
-def inject_trace_to_kinesis_stream_data(record, span):
-    # type: (Dict[str, Any], Span) -> None
+def inject_trace_to_kinesis_stream_data(record: Dict[str, Any], span: Span) -> None:
     """
     :record: contains args for the current botocore action, Kinesis record is at index 1
     :span: the span which provides the trace context to be propagated
@@ -371,8 +359,7 @@ def record_data_streams_path_for_kinesis_stream(pin, params, results):
         )
 
 
-def inject_trace_to_kinesis_stream(params, span, pin=None, data_streams_enabled=False):
-    # type: (List[Any], Span, Optional[Pin], Optional[bool]) -> None
+def inject_trace_to_kinesis_stream(params: List[Any], span: Span, pin: Optional[Pin] = None, data_streams_enabled: Optional[bool] = False) -> None:
     """
     :params: contains the params for the current botocore action
     :span: the span which provides the trace context to be propagated
@@ -452,8 +439,7 @@ def unpatch():
         unwrap(botocore.client.BaseClient, "_make_api_call")
 
 
-def patch_submodules(submodules):
-    # type: (Union[List[str], bool]) -> None
+def patch_submodules(submodules: Union[List[str], bool]) -> None:
     if isinstance(submodules, bool) and submodules:
         _PATCHED_SUBMODULES.clear()
     elif isinstance(submodules, list):
@@ -688,8 +674,7 @@ def patched_api_call(original_func, instance, args, kwargs):
             raise
 
 
-def _set_response_metadata_tags(span, result):
-    # type: (Span, Dict[str, Any]) -> None
+def _set_response_metadata_tags(span: Span, result: Dict[str, Any]) -> None:
     if not result.get("ResponseMetadata"):
         return
     response_meta = result["ResponseMetadata"]

--- a/ddtrace/contrib/bottle/patch.py
+++ b/ddtrace/contrib/bottle/patch.py
@@ -18,8 +18,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(bottle, "__version__", "")
 
 

--- a/ddtrace/contrib/cassandra/session.py
+++ b/ddtrace/contrib/cassandra/session.py
@@ -47,8 +47,7 @@ PAGE_NUMBER = "_ddtrace_page_number"
 _connect = cassandra_cluster.Cluster.connect
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return __version__
 
 

--- a/ddtrace/contrib/celery/patch.py
+++ b/ddtrace/contrib/celery/patch.py
@@ -22,8 +22,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return str(celery.__version__)
 
 

--- a/ddtrace/contrib/celery/utils.py
+++ b/ddtrace/contrib/celery/utils.py
@@ -34,8 +34,7 @@ TAG_KEYS = frozenset(
 )
 
 
-def should_skip_context_value(key, value):
-    # type: (str, Any) -> bool
+def should_skip_context_value(key: str, value: Any) -> bool:
     # Skip this key if it is not set
     if value is None or value == "":
         return True
@@ -52,8 +51,7 @@ def should_skip_context_value(key, value):
     return False
 
 
-def set_tags_from_context(span, context):
-    # type: (Span, Dict[str, Any]) -> None
+def set_tags_from_context(span: Span, context: Dict[str, Any]) -> None:
     """Helper to extract meta values from a Celery Context"""
 
     context_tags = []

--- a/ddtrace/contrib/cherrypy/middleware.py
+++ b/ddtrace/contrib/cherrypy/middleware.py
@@ -36,8 +36,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(cherrypy, "__version__", "")
 
 

--- a/ddtrace/contrib/consul/patch.py
+++ b/ddtrace/contrib/consul/patch.py
@@ -22,8 +22,7 @@ from ...pin import Pin
 _KV_FUNCS = ["put", "get", "delete"]
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(consul, "__version__", "")
 
 

--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -39,8 +39,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 

--- a/ddtrace/contrib/dbapi_async/__init__.py
+++ b/ddtrace/contrib/dbapi_async/__init__.py
@@ -22,8 +22,7 @@ from ..trace_utils import iswrapped
 log = get_logger(__name__)
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -75,8 +75,7 @@ _NotSet = object()
 psycopg_cursor_cls = Psycopg2TracedCursor = Psycopg3TracedCursor = _NotSet
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     import django
 
     return django.__version__

--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -68,8 +68,7 @@ def resource_from_cache_prefix(resource, cache):
     return name.lower()
 
 
-def quantize_key_values(keys):
-    # type: (_quantize_param) -> Text
+def quantize_key_values(keys: _quantize_param) -> Text:
     """
     Used for Django cache key normalization.
 
@@ -79,7 +78,7 @@ def quantize_key_values(keys):
 
     If text is provided we convert to text.
     """
-    args = []  # type: List[Union[Text, bytes, Any]]
+    args: List[Union[Text, bytes, Any]] = []
 
     # Normalize input values into a List[Text, bytes]
     if isinstance(keys, dict):
@@ -287,12 +286,11 @@ def _extract_body(request):
         return req_body
 
 
-def _get_request_headers(request):
-    # type: (Any) -> Mapping[str, str]
+def _get_request_headers(request: Any) -> Mapping[str, str]:
     if DJANGO22:
-        request_headers = request.headers  # type: Mapping[str, str]
+        request_headers: Mapping[str, str] = request.headers
     else:
-        request_headers = {}  # type: Mapping[str, str]
+        request_headers: Mapping[str, str] = {}
         for header, value in request.META.items():
             name = from_wsgi_header(header)
             if name:

--- a/ddtrace/contrib/dogpile_cache/patch.py
+++ b/ddtrace/contrib/dogpile_cache/patch.py
@@ -21,8 +21,7 @@ _get_or_create_multi = dogpile_cache.region.CacheRegion.get_or_create_multi
 _lock_ctor = dogpile_lock.Lock.__init__
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(dogpile_cache, "__version__", "")
 
 

--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -63,13 +63,11 @@ def get_version_tuple(elasticsearch):
     return getattr(elasticsearch, "__version__", "")
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 
-def get_versions():
-    # type: () -> List[str]
+def get_versions() -> List[str]:
     return versions
 
 

--- a/ddtrace/contrib/falcon/patch.py
+++ b/ddtrace/contrib/falcon/patch.py
@@ -22,8 +22,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(falcon, "__version__", "")
 
 

--- a/ddtrace/contrib/fastapi/patch.py
+++ b/ddtrace/contrib/fastapi/patch.py
@@ -25,8 +25,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(fastapi, "__version__", "")
 
 

--- a/ddtrace/contrib/flask/patch.py
+++ b/ddtrace/contrib/flask/patch.py
@@ -69,8 +69,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(flask, "__version__", "")
 
 

--- a/ddtrace/contrib/flask_cache/tracers.py
+++ b/ddtrace/contrib/flask_cache/tracers.py
@@ -33,8 +33,7 @@ CACHE_BACKEND = "flask_cache.backend"
 CONTACT_POINTS = "flask_cache.contact_points"
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     try:
         import flask_caching
 
@@ -74,8 +73,7 @@ def get_traced_cache(ddtracer, service=DEFAULT_SERVICE, meta=None, cache_cls=Non
         _datadog_service = service
         _datadog_meta = meta
 
-        def __trace(self, cmd):
-            # type: (str, bool) -> Span
+        def __trace(self: str, cmd: bool) -> Span:
             """
             Start a tracing with default attributes and tags
             """

--- a/ddtrace/contrib/flask_login/patch.py
+++ b/ddtrace/contrib/flask_login/patch.py
@@ -18,8 +18,7 @@ from ..flask.wrappers import get_current_app
 log = get_logger(__name__)
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return flask_login.__version__
 
 

--- a/ddtrace/contrib/futures/patch.py
+++ b/ddtrace/contrib/futures/patch.py
@@ -7,8 +7,7 @@ from ddtrace.internal.wrapping import wrap as _w
 from .threading import _wrap_submit
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 

--- a/ddtrace/contrib/gevent/patch.py
+++ b/ddtrace/contrib/gevent/patch.py
@@ -16,8 +16,7 @@ __IMap = gevent.pool.IMap
 __IMapUnordered = gevent.pool.IMapUnordered
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(gevent, "__version__", "")
 
 

--- a/ddtrace/contrib/graphql/patch.py
+++ b/ddtrace/contrib/graphql/patch.py
@@ -53,8 +53,7 @@ else:
     from graphql.language.ast import DocumentNode as Document
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return _graphql_version_str
 
 
@@ -242,8 +241,7 @@ def _resolver_middleware(next_middleware, root, info, **args):
         return next_middleware(root, info, **args)
 
 
-def _inject_trace_middleware_to_args(trace_middleware, args, kwargs):
-    # type: (Callable, Tuple, Dict) -> Tuple[Tuple, Dict]
+def _inject_trace_middleware_to_args(trace_middleware: Callable, args: Tuple, kwargs: Dict) -> Tuple[Tuple, Dict]:
     """
     Adds a trace middleware to graphql.execute(..., middleware, ...)
     """
@@ -260,7 +258,7 @@ def _inject_trace_middleware_to_args(trace_middleware, args, kwargs):
             # trace_middleware. For the trace_middleware to be called a new MiddlewareManager will
             # need to initialized. This is handled in graphql.execute():
             # https://github.com/graphql-python/graphql-core/blob/v3.2.1/src/graphql/execution/execute.py#L254
-            middlewares = middlewares.middlewares  # type: Iterable
+            middlewares: Iterable = middlewares.middlewares
     except ArgumentError:
         middlewares = []
 
@@ -273,8 +271,7 @@ def _inject_trace_middleware_to_args(trace_middleware, args, kwargs):
     return args, kwargs
 
 
-def _get_source_str(obj):
-    # type: (Union[str, Source, Document]) -> str
+def _get_source_str(obj: Union[str, Source, Document]) -> str:
     """
     Parses graphql Documents and Source objects to retrieve
     the graphql source input for a request.
@@ -291,8 +288,7 @@ def _get_source_str(obj):
     return re.sub(r"\s+", " ", source_str).strip()
 
 
-def _set_span_errors(errors, span):
-    # type: (List[GraphQLError], Span) -> None
+def _set_span_errors(errors: List[GraphQLError], span: Span) -> None:
     if not errors:
         # do nothing if the list of graphql errors is empty
         return

--- a/ddtrace/contrib/grpc/patch.py
+++ b/ddtrace/contrib/grpc/patch.py
@@ -13,8 +13,7 @@ from .client_interceptor import intercept_channel
 from .server_interceptor import create_server_interceptor
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(grpc, "__version__", "")
 
 

--- a/ddtrace/contrib/gunicorn/__init__.py
+++ b/ddtrace/contrib/gunicorn/__init__.py
@@ -9,8 +9,7 @@ ddtrace works with Gunicorn.
 """
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 

--- a/ddtrace/contrib/httplib/patch.py
+++ b/ddtrace/contrib/httplib/patch.py
@@ -40,8 +40,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 

--- a/ddtrace/contrib/httpx/patch.py
+++ b/ddtrace/contrib/httpx/patch.py
@@ -34,8 +34,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 HTTPX_VERSION = parse_version(httpx.__version__)
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(httpx, "__version__", "")
 
 
@@ -49,8 +48,7 @@ config._add(
 )
 
 
-def _url_to_str(url):
-    # type: (httpx.URL) -> str
+def _url_to_str(url: httpx.URL) -> str:
     """
     Helper to convert the httpx.URL parts from bytes to a str
     """
@@ -76,8 +74,7 @@ def _url_to_str(url):
     return ensure_text(url)
 
 
-def _get_service_name(pin, request):
-    # type: (Pin, httpx.Request) -> typing.Text
+def _get_service_name(pin: Pin, request: httpx.Request) -> typing.Text:
     if config.httpx.split_by_domain:
         if hasattr(request.url, "netloc"):
             return ensure_text(request.url.netloc, errors="backslashreplace")
@@ -89,8 +86,7 @@ def _get_service_name(pin, request):
     return ext_service(pin, config.httpx)
 
 
-def _init_span(span, request):
-    # type: (Span, httpx.Request) -> None
+def _init_span(span: Span, request: httpx.Request) -> None:
     span.set_tag(SPAN_MEASURED_KEY)
 
     if distributed_tracing_enabled(config.httpx):
@@ -101,8 +97,7 @@ def _init_span(span, request):
         span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, sample_rate)
 
 
-def _set_span_meta(span, request, response):
-    # type: (Span, httpx.Request, httpx.Response) -> None
+def _set_span_meta(span: Span, request: httpx.Request, response: httpx.Response) -> None:
     set_http_meta(
         span,
         config.httpx,
@@ -117,12 +112,11 @@ def _set_span_meta(span, request, response):
 
 
 async def _wrapped_async_send(
-    wrapped,  # type: BoundFunctionWrapper
-    instance,  # type: httpx.AsyncClient
-    args,  # type: typing.Tuple[httpx.Request]
-    kwargs,  # type: typing.Dict[typing.Str, typing.Any]
-):
-    # type: (...) -> typing.Coroutine[None, None, httpx.Response]
+    wrapped: BoundFunctionWrapper,
+    instance: httpx.AsyncClient,
+    args: typing.Tuple[httpx.Request],
+    kwargs: typing.Dict[typing.Str, typing.Any],
+) -> typing.Coroutine[None, None, httpx.Response]:
     req = get_argument_value(args, kwargs, 0, "request")
 
     pin = Pin.get_from(instance)
@@ -146,12 +140,11 @@ async def _wrapped_async_send(
 
 
 def _wrapped_sync_send(
-    wrapped,  # type: BoundFunctionWrapper
-    instance,  # type: httpx.AsyncClient
-    args,  # type: typing.Tuple[httpx.Request]
-    kwargs,  # type: typing.Dict[typing.Str, typing.Any]
-):
-    # type: (...) -> httpx.Response
+    wrapped: BoundFunctionWrapper,
+    instance: httpx.AsyncClient,
+    args: typing.Tuple[httpx.Request],
+    kwargs: typing.Dict[typing.Str, typing.Any],
+) -> httpx.Response:
     pin = Pin.get_from(instance)
     if not pin or not pin.enabled():
         return wrapped(*args, **kwargs)
@@ -174,8 +167,7 @@ def _wrapped_sync_send(
             _set_span_meta(span, req, resp)
 
 
-def patch():
-    # type: () -> None
+def patch() -> None:
     if getattr(httpx, "_datadog_patch", False):
         return
 
@@ -195,8 +187,7 @@ def patch():
     pin.onto(httpx.Client)
 
 
-def unpatch():
-    # type: () -> None
+def unpatch() -> None:
     if not getattr(httpx, "_datadog_patch", False):
         return
 

--- a/ddtrace/contrib/jinja2/patch.py
+++ b/ddtrace/contrib/jinja2/patch.py
@@ -25,8 +25,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(jinja2, "__version__", "")
 
 

--- a/ddtrace/contrib/kafka/patch.py
+++ b/ddtrace/contrib/kafka/patch.py
@@ -37,8 +37,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(confluent_kafka, "__version__", "")
 
 

--- a/ddtrace/contrib/kombu/patch.py
+++ b/ddtrace/contrib/kombu/patch.py
@@ -31,8 +31,7 @@ from .utils import get_exchange_from_args
 from .utils import get_routing_key_from_args
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return str(kombu.__version__)
 
 

--- a/ddtrace/contrib/langchain/patch.py
+++ b/ddtrace/contrib/langchain/patch.py
@@ -41,8 +41,7 @@ if TYPE_CHECKING:
 log = get_logger(__name__)
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(langchain, "__version__", "")
 
 
@@ -65,8 +64,7 @@ class _LangChainIntegration(BaseLLMIntegration):
     def __init__(self, config, stats_url, site, api_key):
         super().__init__(config, stats_url, site, api_key)
 
-    def _set_base_span_tags(self, span, interface_type="", provider=None, model=None, api_key=None):
-        # type: (Span, str, Optional[str], Optional[str], Optional[str]) -> None
+    def _set_base_span_tags(self, span: Span, interface_type: str = "", provider: Optional[str] = None, model: Optional[str] = None, api_key: Optional[str] = None) -> None:
         """Set base level tags that should be present on all LangChain spans (if they are not None)."""
         span.set_tag_str(TYPE, interface_type)
         if provider is not None:
@@ -80,8 +78,7 @@ class _LangChainIntegration(BaseLLMIntegration):
                 span.set_tag_str(API_KEY, api_key)
 
     @classmethod
-    def _logs_tags(cls, span):
-        # type: (Span) -> str
+    def _logs_tags(cls, span: Span) -> str:
         api_key = span.get_tag(API_KEY) or ""
         tags = "env:%s,version:%s,%s:%s,%s:%s,%s:%s,%s:%s" % (  # noqa: E501
             (config.env or ""),
@@ -98,8 +95,7 @@ class _LangChainIntegration(BaseLLMIntegration):
         return tags
 
     @classmethod
-    def _metrics_tags(cls, span):
-        # type: (Span) -> list
+    def _metrics_tags(cls, span: Span) -> list:
         provider = span.get_tag(PROVIDER) or ""
         api_key = span.get_tag(API_KEY) or ""
         tags = [
@@ -117,8 +113,7 @@ class _LangChainIntegration(BaseLLMIntegration):
             tags.append("%s:%s" % (ERROR_TYPE, err_type))
         return tags
 
-    def record_usage(self, span, usage):
-        # type: (Span, Dict[str, Any]) -> None
+    def record_usage(self, span: Span, usage: Dict[str, Any]) -> None:
         if not usage or self._config.metrics_enabled is False:
             return
         for token_type in ("prompt", "completion", "total"):
@@ -131,8 +126,7 @@ class _LangChainIntegration(BaseLLMIntegration):
             self.metric(span, "incr", "tokens.total_cost", total_cost)
 
 
-def _extract_model_name(instance):
-    # type: (langchain.llm.BaseLLM) -> Optional[str]
+def _extract_model_name(instance: langchain.llm.BaseLLM) -> Optional[str]:
     """Extract model name or ID from llm instance."""
     for attr in ("model", "model_name", "model_id", "model_key", "repo_id"):
         if hasattr(instance, attr):
@@ -140,8 +134,7 @@ def _extract_model_name(instance):
     return None
 
 
-def _format_api_key(api_key):
-    # type: (str | SecretStr) -> str
+def _format_api_key(api_key: str | SecretStr) -> str:
     """Obfuscate a given LLM provider API key by returning the last four characters."""
     if hasattr(api_key, "get_secret_value"):
         api_key = api_key.get_secret_value()
@@ -151,8 +144,7 @@ def _format_api_key(api_key):
     return "...%s" % api_key[-4:]
 
 
-def _extract_api_key(instance):
-    # type: (Any) -> str
+def _extract_api_key(instance: Any) -> str:
     """
     Extract and format LLM-provider API key from instance.
     Note that langchain's LLM/ChatModel/Embeddings interfaces do not have a
@@ -167,8 +159,7 @@ def _extract_api_key(instance):
     return ""
 
 
-def _tag_openai_token_usage(span, llm_output, propagated_cost=0, propagate=False):
-    # type: (Span, Dict[str, Any], int, bool) -> None
+def _tag_openai_token_usage(span: Span, llm_output: Dict[str, Any], propagated_cost: int = 0, propagate: bool = False) -> None:
     """
     Extract token usage from llm_output, tag on span.
     Calculate the total cost for each LLM/chat_model, then propagate those values up the trace so that

--- a/ddtrace/contrib/logging/patch.py
+++ b/ddtrace/contrib/logging/patch.py
@@ -27,8 +27,7 @@ config._add(
 )  # by default, override here for custom tracer
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(logging, "__version__", "")
 
 

--- a/ddtrace/contrib/loguru/patch.py
+++ b/ddtrace/contrib/loguru/patch.py
@@ -23,8 +23,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(loguru, "__version__", "")
 
 

--- a/ddtrace/contrib/mako/patch.py
+++ b/ddtrace/contrib/mako/patch.py
@@ -15,8 +15,7 @@ from ..trace_utils import wrap as _w
 from .constants import DEFAULT_TEMPLATE_NAME
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(mako, "__version__", "")
 
 

--- a/ddtrace/contrib/mariadb/patch.py
+++ b/ddtrace/contrib/mariadb/patch.py
@@ -23,8 +23,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(mariadb, "__version__", "")
 
 

--- a/ddtrace/contrib/molten/patch.py
+++ b/ddtrace/contrib/molten/patch.py
@@ -41,8 +41,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(molten, "__version__", "")
 
 

--- a/ddtrace/contrib/mongoengine/patch.py
+++ b/ddtrace/contrib/mongoengine/patch.py
@@ -7,8 +7,7 @@ from .trace import WrappedConnect
 _connect = mongoengine.connect
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(mongoengine, "__version__", "")
 
 

--- a/ddtrace/contrib/mysql/patch.py
+++ b/ddtrace/contrib/mysql/patch.py
@@ -25,8 +25,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return mysql.connector.version.VERSION_TEXT
 
 

--- a/ddtrace/contrib/mysqldb/patch.py
+++ b/ddtrace/contrib/mysqldb/patch.py
@@ -39,8 +39,7 @@ KWPOS_BY_TAG = {
 }
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ".".join(map(str, MySQLdb.version_info[0:3]))
 
 

--- a/ddtrace/contrib/openai/patch.py
+++ b/ddtrace/contrib/openai/patch.py
@@ -80,8 +80,7 @@ _RESOURCES = {
 }
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return version.VERSION
 
 
@@ -97,16 +96,14 @@ class _OpenAIIntegration(BaseLLMIntegration):
         self._openai = openai
 
     @property
-    def _user_api_key(self):
-        # type: () -> Optional[str]
+    def _user_api_key(self) -> Optional[str]:
         """Get a representation of the user API key for tagging."""
         # Match the API key representation that OpenAI uses in their UI.
         if self._openai.api_key is None:
             return
         return "sk-...%s" % self._openai.api_key[-4:]
 
-    def _set_base_span_tags(self, span):
-        # type: (Span) -> None
+    def _set_base_span_tags(self, span: Span) -> None:
         span.set_tag_str(COMPONENT, self._config.integration_name)
         if self._user_api_key is not None:
             span.set_tag_str("openai.user.api_key", self._user_api_key)

--- a/ddtrace/contrib/openai/utils.py
+++ b/ddtrace/contrib/openai/utils.py
@@ -20,8 +20,7 @@ log = get_logger(__name__)
 _punc_regex = re.compile(r"[\w']+|[.,!?;~@#$%^&*()+/-]")
 
 
-def _compute_prompt_token_count(prompt, model):
-    # type: (Union[str, List[int]], Optional[str]) -> Tuple[bool, int]
+def _compute_prompt_token_count(prompt: Union[str, List[int]], model: Optional[str]) -> Tuple[bool, int]:
     """
     Takes in a prompt(s) and model pair, and returns a tuple of whether or not the number of prompt
     tokens was estimated, and the estimated/calculated prompt token count.
@@ -47,8 +46,7 @@ def _compute_prompt_token_count(prompt, model):
     return estimated, _est_tokens(prompt)
 
 
-def _est_tokens(prompt):
-    # type: (Union[str, List[int]]) -> int
+def _est_tokens(prompt: Union[str, List[int]]) -> int:
     """
     Provide a very rough estimate of the number of tokens in a string prompt.
     Note that if the prompt is passed in as a token array (list of ints), the token count
@@ -69,8 +67,7 @@ def _est_tokens(prompt):
     return est_tokens
 
 
-def _format_openai_api_key(openai_api_key):
-    # type: (Optional[str]) -> Optional[str]
+def _format_openai_api_key(openai_api_key: Optional[str]) -> Optional[str]:
     """
     Returns `sk-...XXXX`, where XXXX is the last 4 characters of the provided OpenAI API key.
     This mimics how OpenAI UI formats the API key.

--- a/ddtrace/contrib/psycopg/patch.py
+++ b/ddtrace/contrib/psycopg/patch.py
@@ -75,16 +75,14 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 
 PATCHED_VERSIONS = {}
 
 
-def get_versions():
-    # type: () -> List[str]
+def get_versions() -> List[str]:
     return PATCHED_VERSIONS
 
 

--- a/ddtrace/contrib/pylibmc/patch.py
+++ b/ddtrace/contrib/pylibmc/patch.py
@@ -7,8 +7,7 @@ from .client import TracedClient
 _Client = pylibmc.Client
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(pylibmc, "__version__", "")
 
 

--- a/ddtrace/contrib/pylons/middleware.py
+++ b/ddtrace/contrib/pylons/middleware.py
@@ -66,11 +66,11 @@ class PylonsTraceMiddleware(object):
     def _distributed_tracing(self, distributed_tracing):
         ddconfig.pylons["distributed_tracing"] = asbool(distributed_tracing)
 
-    def _unlist_multidict_params(self, multidict):  # type: (webob.multidict.MultiDict) -> Dict[str, Any]
+    def _unlist_multidict_params(self, multidict: webob.multidict.MultiDict) -> Dict[str, Any]:
         # Pylons multidict always return values in a list. This will convert lists with a
         # single value
         # into the un-listed value
-        new_dict = {}  # type: Dict[str, Any]
+        new_dict: Dict[str, Any] = {}
 
         for k, v in iteritems(multidict):
             if isinstance(v, list) and len(v) == 1:
@@ -80,7 +80,7 @@ class PylonsTraceMiddleware(object):
 
         return new_dict
 
-    def _parse_path_params(self, pylon_path_params):  # type: (Tuple[Any, Dict[str, Any]]) -> Dict[str, Any]
+    def _parse_path_params(self, pylon_path_params: Tuple[Any, Dict[str, Any]]) -> Dict[str, Any]:
         path_params = {}
         if len(pylon_path_params) > 0:
             path_params = {k: v for k, v in iteritems(pylon_path_params[1].copy()) if k not in ["action", "controller"]}

--- a/ddtrace/contrib/pylons/patch.py
+++ b/ddtrace/contrib/pylons/patch.py
@@ -21,8 +21,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(pylons, "__version__", "")
 
 

--- a/ddtrace/contrib/pymemcache/patch.py
+++ b/ddtrace/contrib/pymemcache/patch.py
@@ -16,8 +16,7 @@ _hash_Client = pymemcache.client.hash.Client
 _hash_HashClient = pymemcache.client.hash.Client
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(pymemcache, "__version__", "")
 
 

--- a/ddtrace/contrib/pymongo/patch.py
+++ b/ddtrace/contrib/pymongo/patch.py
@@ -25,8 +25,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(pymongo, "__version__", "")
 
 

--- a/ddtrace/contrib/pymysql/patch.py
+++ b/ddtrace/contrib/pymysql/patch.py
@@ -25,8 +25,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(pymysql, "__version__", "")
 
 

--- a/ddtrace/contrib/pynamodb/patch.py
+++ b/ddtrace/contrib/pynamodb/patch.py
@@ -35,8 +35,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(pynamodb, "__version__", "")
 
 

--- a/ddtrace/contrib/pyodbc/patch.py
+++ b/ddtrace/contrib/pyodbc/patch.py
@@ -24,8 +24,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return pyodbc.version
 
 

--- a/ddtrace/contrib/pyramid/patch.py
+++ b/ddtrace/contrib/pyramid/patch.py
@@ -25,8 +25,7 @@ config._add(
 DD_PATCH = "_datadog_patch"
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     try:
         import importlib.metadata as importlib_metadata
     except ImportError:

--- a/ddtrace/contrib/pytest/__init__.py
+++ b/ddtrace/contrib/pytest/__init__.py
@@ -76,8 +76,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     import pytest
 
     return pytest.__version__

--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -137,8 +137,7 @@ def _mark_not_skipped(item):
     item._fully_skipped = False
 
 
-def _mark_test_forced(test_item):
-    # type: (pytest.Test) -> None
+def _mark_test_forced(test_item: pytest.Test) -> None:
     test_span = _extract_span(test_item)
     test_span.set_tag_str(test.ITR_FORCED_RUN, "true")
 
@@ -152,8 +151,7 @@ def _mark_test_forced(test_item):
     session_span.set_tag_str(test.ITR_FORCED_RUN, "true")
 
 
-def _mark_test_unskippable(test_item):
-    # type: (pytest.Test) -> None
+def _mark_test_unskippable(test_item: pytest.Test) -> None:
     test_span = _extract_span(test_item)
     test_span.set_tag_str(test.ITR_UNSKIPPABLE, "true")
 
@@ -651,7 +649,7 @@ def pytest_runtest_protocol(item, nextitem):
         # Parameterized test cases will have a `callspec` attribute attached to the pytest Item object.
         # Pytest docs: https://docs.pytest.org/en/6.2.x/reference.html#pytest.Function
         if getattr(item, "callspec", None):
-            parameters = {"arguments": {}, "metadata": {}}  # type: Dict[str, Dict[str, str]]
+            parameters: Dict[str, Dict[str, str]] = {"arguments": {}, "metadata": {}}
             for param_name, param_val in item.callspec.params.items():
                 try:
                     parameters["arguments"][param_name] = encode_test_parameter(param_val)

--- a/ddtrace/contrib/pytest_bdd/__init__.py
+++ b/ddtrace/contrib/pytest_bdd/__init__.py
@@ -34,8 +34,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     try:
         import importlib.metadata as importlib_metadata
     except ImportError:

--- a/ddtrace/contrib/redis/patch.py
+++ b/ddtrace/contrib/redis/patch.py
@@ -27,8 +27,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(redis, "__version__", "")
 
 

--- a/ddtrace/contrib/rediscluster/patch.py
+++ b/ddtrace/contrib/rediscluster/patch.py
@@ -41,8 +41,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(rediscluster, "__version__", "")
 
 

--- a/ddtrace/contrib/requests/connection.py
+++ b/ddtrace/contrib/requests/connection.py
@@ -22,8 +22,7 @@ from .. import trace_utils
 log = get_logger(__name__)
 
 
-def _extract_hostname(uri):
-    # type: (str) -> str
+def _extract_hostname(uri: str) -> str:
     parsed_uri = parse.urlparse(uri)
     port = None
     try:
@@ -37,8 +36,7 @@ def _extract_hostname(uri):
     return parsed_uri.hostname
 
 
-def _extract_query_string(uri):
-    # type: (str) -> Optional[str]
+def _extract_query_string(uri: str) -> Optional[str]:
     start = uri.find("?") + 1
     if start == 0:
         return None

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -25,8 +25,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(requests, "__version__", "")
 
 

--- a/ddtrace/contrib/rq/__init__.py
+++ b/ddtrace/contrib/rq/__init__.py
@@ -114,8 +114,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     import rq
 
     return str(getattr(rq, "__version__", ""))

--- a/ddtrace/contrib/sanic/patch.py
+++ b/ddtrace/contrib/sanic/patch.py
@@ -28,8 +28,7 @@ config._add("sanic", dict(_default_service=schematize_service_name("sanic"), dis
 SANIC_VERSION = (0, 0, 0)
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(sanic, "__version__", "")
 
 

--- a/ddtrace/contrib/snowflake/patch.py
+++ b/ddtrace/contrib/snowflake/patch.py
@@ -28,8 +28,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     try:
         import snowflake.connector as c
     except AttributeError:

--- a/ddtrace/contrib/sqlalchemy/patch.py
+++ b/ddtrace/contrib/sqlalchemy/patch.py
@@ -6,8 +6,7 @@ from ..trace_utils import unwrap
 from .engine import _wrap_create_engine
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(sqlalchemy, "__version__", "")
 
 

--- a/ddtrace/contrib/sqlite3/patch.py
+++ b/ddtrace/contrib/sqlite3/patch.py
@@ -30,8 +30,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return sqlite3.sqlite_version
 
 

--- a/ddtrace/contrib/starlette/patch.py
+++ b/ddtrace/contrib/starlette/patch.py
@@ -30,8 +30,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(starlette, "__version__", "")
 
 
@@ -77,7 +76,7 @@ def unpatch():
 def traced_handler(wrapped, instance, args, kwargs):
     # Since handle can be called multiple times for one request, we take the path of each instance
     # Then combine them at the end to get the correct resource names
-    scope = get_argument_value(args, kwargs, 0, "scope")  # type: Optional[Dict[str, Any]]
+    scope: Optional[Dict[str, Any]] = get_argument_value(args, kwargs, 0, "scope")
     if not scope:
         return wrapped(*args, **kwargs)
 
@@ -94,8 +93,8 @@ def traced_handler(wrapped, instance, args, kwargs):
     else:
         scope["datadog"]["resource_paths"].append(instance.path)
 
-    request_spans = scope["datadog"].get("request_spans", [])  # type: List[Span]
-    resource_paths = scope["datadog"].get("resource_paths", [])  # type: List[str]
+    request_spans: List[Span] = scope["datadog"].get("request_spans", [])
+    resource_paths: List[str] = scope["datadog"].get("resource_paths", [])
 
     if len(request_spans) == len(resource_paths):
         # Iterate through the request_spans and assign the correct resource name to each

--- a/ddtrace/contrib/structlog/patch.py
+++ b/ddtrace/contrib/structlog/patch.py
@@ -20,8 +20,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(structlog, "__version__", "")
 
 

--- a/ddtrace/contrib/subprocess/patch.py
+++ b/ddtrace/contrib/subprocess/patch.py
@@ -35,14 +35,12 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 
-def patch():
-    # type: () -> List[str]
-    patched = []  # type: List[str]
+def patch() -> List[str]:
+    patched: List[str] = []
     if not asm_config._asm_enabled:
         return patched
 
@@ -91,8 +89,8 @@ class SubprocessCmdLineCacheEntry(object):
 
 class SubprocessCmdLine(object):
     # This catches the computed values into a SubprocessCmdLineCacheEntry object
-    _CACHE = {}  # type: Dict[str, SubprocessCmdLineCacheEntry]
-    _CACHE_DEQUE = collections.deque()  # type: Deque[str]
+    _CACHE: Dict[str, SubprocessCmdLineCacheEntry] = {}
+    _CACHE_DEQUE: Deque[str] = collections.deque()
     _CACHE_MAXSIZE = 32
     _CACHE_LOCK = RLock()
 
@@ -147,8 +145,7 @@ class SubprocessCmdLine(object):
     ]
     _COMPILED_ENV_VAR_REGEXP = re.compile(r"\b[A-Z_]+=\w+")
 
-    def __init__(self, shell_args, shell=False):
-        # type: (Union[str, List[str]], bool) -> None
+    def __init__(self, shell_args: Union[str, List[str]], shell: bool = False) -> None:
         cache_key = str(shell_args) + str(shell)
         self._cache_entry = SubprocessCmdLine._CACHE.get(cache_key)
         if self._cache_entry:
@@ -259,8 +256,7 @@ class SubprocessCmdLine(object):
 
         self.arguments = new_args
 
-    def truncate_string(self, str_):
-        # type: (str) -> str
+    def truncate_string(self, str_: str) -> str:
         oversize = len(str_) - self.TRUNCATE_LIMIT
 
         if oversize <= 0:
@@ -272,8 +268,7 @@ class SubprocessCmdLine(object):
         msg = ' "4kB argument truncated by %d characters"' % oversize
         return str_[0 : -(oversize + len(msg))] + msg
 
-    def _as_list_and_string(self):
-        # type: () -> Tuple[list[str], str]
+    def _as_list_and_string(self) -> Tuple[list[str], str]:
 
         total_list = self.env_vars + [self.binary] + self.arguments
         truncated_str = self.truncate_string(shjoin(total_list))
@@ -299,8 +294,7 @@ class SubprocessCmdLine(object):
         return str_res
 
 
-def unpatch():
-    # type: () -> None
+def unpatch() -> None:
     trace_utils.unwrap(os, "system")
     trace_utils.unwrap(os, "_spawnvef")
     trace_utils.unwrap(subprocess.Popen, "__init__")

--- a/ddtrace/contrib/tornado/patch.py
+++ b/ddtrace/contrib/tornado/patch.py
@@ -23,8 +23,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(tornado, "version", "")
 
 

--- a/ddtrace/contrib/tornado/stack_context.py
+++ b/ddtrace/contrib/tornado/stack_context.py
@@ -29,8 +29,7 @@ if _USE_STACK_CONTEXT:
         https://github.com/tornadoweb/tornado/issues/1063
         """
 
-        def __init__(self):
-            # type: (...) -> None
+        def __init__(self) -> None:
             # HACK(jd): this should be using super(), but calling DefaultContextProvider.__init__
             # sets the context to `None` which breaks this code.
             # We therefore skip DefaultContextProvider.__init__ and call only BaseContextProvider.__init__.

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -76,13 +76,11 @@ IP_PATTERNS = (
 
 
 @cached()
-def _normalized_header_name(header_name):
-    # type: (str) -> str
+def _normalized_header_name(header_name: str) -> str:
     return NORMALIZE_PATTERN.sub("_", normalize_header_name(header_name))
 
 
-def _get_header_value_case_insensitive(headers, keyname):
-    # type: (Mapping[str, str], str) -> Optional[str]
+def _get_header_value_case_insensitive(headers: Mapping[str, str], keyname: str) -> Optional[str]:
     """
     Get a header in a case insensitive way. This function is meant for frameworks
     like Django < 2.2 that don't store the headers in a case insensitive mapping.
@@ -99,8 +97,7 @@ def _get_header_value_case_insensitive(headers, keyname):
     return None
 
 
-def _normalize_tag_name(request_or_response, header_name):
-    # type: (str, str) -> str
+def _normalize_tag_name(request_or_response: str, header_name: str) -> str:
     """
     Given a tag name, e.g. 'Content-Type', returns a corresponding normalized tag name, i.e
     'http.request.headers.content_type'. Rules applied actual header name are:
@@ -124,8 +121,7 @@ def _normalize_tag_name(request_or_response, header_name):
     return "http.{}.headers.{}".format(request_or_response, normalized_name)
 
 
-def _store_headers(headers, span, integration_config, request_or_response):
-    # type: (Dict[str, str], Span, IntegrationConfig, str) -> None
+def _store_headers(headers: Dict[str, str], span: Span, integration_config: IntegrationConfig, request_or_response: str) -> None:
     """
     :param headers: A dict of http headers to be stored in the span
     :type headers: dict or list
@@ -154,8 +150,7 @@ def _store_headers(headers, span, integration_config, request_or_response):
         span.set_tag_str(tag_name or _normalize_tag_name(request_or_response, header_name), header_value)
 
 
-def _get_request_header_user_agent(headers, headers_are_case_sensitive=False):
-    # type: (Mapping[str, str], bool) -> str
+def _get_request_header_user_agent(headers: Mapping[str, str], headers_are_case_sensitive: bool = False) -> str:
     """Get user agent from request headers
     :param headers: A dict of http headers to be stored in the span
     :type headers: dict or list
@@ -177,12 +172,11 @@ def _get_request_header_user_agent(headers, headers_are_case_sensitive=False):
 _USED_IP_HEADER = ""
 
 
-def _get_request_header_client_ip(headers, peer_ip=None, headers_are_case_sensitive=False):
-    # type: (Optional[Mapping[str, str]], Optional[str], bool) -> str
+def _get_request_header_client_ip(headers: Optional[Mapping[str, str]], peer_ip: Optional[str] = None, headers_are_case_sensitive: bool = False) -> str:
 
     global _USED_IP_HEADER
 
-    def get_header_value(key):  # type: (str) -> Optional[str]
+    def get_header_value(key: str) -> Optional[str]:
         if not headers_are_case_sensitive:
             return headers.get(key)
 
@@ -255,8 +249,7 @@ def _get_request_header_client_ip(headers, peer_ip=None, headers_are_case_sensit
     return private_ip_from_headers
 
 
-def _store_request_headers(headers, span, integration_config):
-    # type: (Dict[str, str], Span, IntegrationConfig) -> None
+def _store_request_headers(headers: Dict[str, str], span: Span, integration_config: IntegrationConfig) -> None:
     """
     Store request headers as a span's tags
     :param headers: All the request's http headers, will be filtered through the whitelist
@@ -269,8 +262,7 @@ def _store_request_headers(headers, span, integration_config):
     _store_headers(headers, span, integration_config, REQUEST)
 
 
-def _store_response_headers(headers, span, integration_config):
-    # type: (Dict[str, str], Span, IntegrationConfig) -> None
+def _store_response_headers(headers: Dict[str, str], span: Span, integration_config: IntegrationConfig) -> None:
     """
     Store response headers as a span's tags
     :param headers: All the response's http headers, will be filtered through the whitelist
@@ -283,8 +275,7 @@ def _store_response_headers(headers, span, integration_config):
     _store_headers(headers, span, integration_config, RESPONSE)
 
 
-def _sanitized_url(url):
-    # type: (str) -> str
+def _sanitized_url(url: str) -> str:
     """
     Sanitize url by removing parts with potential auth info
     """
@@ -345,8 +336,7 @@ def with_traced_module(func):
     return with_mod
 
 
-def distributed_tracing_enabled(int_config, default=False):
-    # type: (IntegrationConfig, bool) -> bool
+def distributed_tracing_enabled(int_config: IntegrationConfig, default: bool = False) -> bool:
     """Returns whether distributed tracing is enabled for this integration config"""
     if "distributed_tracing_enabled" in int_config and int_config.distributed_tracing_enabled is not None:
         return int_config.distributed_tracing_enabled
@@ -355,8 +345,7 @@ def distributed_tracing_enabled(int_config, default=False):
     return default
 
 
-def int_service(pin, int_config, default=None):
-    # type: (Optional[Pin], IntegrationConfig, Optional[str]) -> Optional[str]
+def int_service(pin: Optional[Pin], int_config: IntegrationConfig, default: Optional[str] = None) -> Optional[str]:
     """Returns the service name for an integration which is internal
     to the application. Internal meaning that the work belongs to the
     user's application. Eg. Web framework, sqlalchemy, web servers.
@@ -386,8 +375,7 @@ def int_service(pin, int_config, default=None):
     return default
 
 
-def ext_service(pin, int_config, default=None):
-    # type: (Optional[Pin], IntegrationConfig, Optional[str]) -> Optional[str]
+def ext_service(pin: Optional[Pin], int_config: IntegrationConfig, default: Optional[str] = None) -> Optional[str]:
     """Returns the service name for an integration which is external
     to the application. External meaning that the integration generates
     spans wrapping code that is outside the scope of the user's application. Eg. A database, RPC, cache, etc.
@@ -407,8 +395,7 @@ def ext_service(pin, int_config, default=None):
     return default
 
 
-def _set_url_tag(integration_config, span, url, query):
-    # type: (IntegrationConfig, Span, str, str) -> None
+def _set_url_tag(integration_config: IntegrationConfig, span: Span, url: str, query: str) -> None:
 
     if integration_config.http_tag_query_string:  # Tagging query string in http.url
         if config.global_query_string_obfuscation_disabled:  # No redacting of query strings
@@ -420,28 +407,27 @@ def _set_url_tag(integration_config, span, url, query):
 
 
 def set_http_meta(
-    span,  # type: Span
-    integration_config,  # type: IntegrationConfig
-    method=None,  # type: Optional[str]
-    url=None,  # type: Optional[str]
-    target_host=None,  # type: Optional[str]
-    status_code=None,  # type: Optional[Union[int, str]]
-    status_msg=None,  # type: Optional[str]
-    query=None,  # type: Optional[str]
-    parsed_query=None,  # type: Optional[Mapping[str, str]]
-    request_headers=None,  # type: Optional[Mapping[str, str]]
-    response_headers=None,  # type: Optional[Mapping[str, str]]
-    retries_remain=None,  # type: Optional[Union[int, str]]
-    raw_uri=None,  # type: Optional[str]
-    request_cookies=None,  # type: Optional[Dict[str, str]]
-    request_path_params=None,  # type: Optional[Dict[str, str]]
-    request_body=None,  # type: Optional[Union[str, Dict[str, List[str]]]]
-    peer_ip=None,  # type: Optional[str]
-    headers_are_case_sensitive=False,  # type: bool
-    route=None,  # type: Optional[str]
-    response_cookies=None,  # type: Optional[Dict[str, str]]
-):
-    # type: (...) -> None
+    span: Span,
+    integration_config: IntegrationConfig,
+    method: Optional[str] = None,
+    url: Optional[str] = None,
+    target_host: Optional[str] = None,
+    status_code: Optional[Union[int, str]] = None,
+    status_msg: Optional[str] = None,
+    query: Optional[str] = None,
+    parsed_query: Optional[Mapping[str, str]] = None,
+    request_headers: Optional[Mapping[str, str]] = None,
+    response_headers: Optional[Mapping[str, str]] = None,
+    retries_remain: Optional[Union[int, str]] = None,
+    raw_uri: Optional[str] = None,
+    request_cookies: Optional[Dict[str, str]] = None,
+    request_path_params: Optional[Dict[str, str]] = None,
+    request_body: Optional[Union[str, Dict[str, List[str]]]] = None,
+    peer_ip: Optional[str] = None,
+    headers_are_case_sensitive: bool = False,
+    route: Optional[str] = None,
+    response_cookies: Optional[Dict[str, str]] = None,
+) -> None:
     """
     Set HTTP metas on the span
 
@@ -557,8 +543,7 @@ def set_http_meta(
         span.set_tag_str(http.ROUTE, route)
 
 
-def activate_distributed_headers(tracer, int_config=None, request_headers=None, override=None):
-    # type: (Tracer, Optional[IntegrationConfig], Optional[Dict[str, str]], Optional[bool]) -> None
+def activate_distributed_headers(tracer: Tracer, int_config: Optional[IntegrationConfig] = None, request_headers: Optional[Dict[str, str]] = None, override: Optional[bool] = None) -> None:
     """
     Helper for activating a distributed trace headers' context if enabled in integration config.
     int_config will be used to check if distributed trace headers context will be activated, but
@@ -597,12 +582,11 @@ def activate_distributed_headers(tracer, int_config=None, request_headers=None, 
 
 
 def _flatten(
-    obj,  # type: Any
-    sep=".",  # type: str
-    prefix="",  # type: str
-    exclude_policy=None,  # type: Optional[Callable[[str], bool]]
-):
-    # type: (...) -> Generator[Tuple[str, Any], None, None]
+    obj: Any,
+    sep: str = ".",
+    prefix: str = "",
+    exclude_policy: Optional[Callable[[str], bool]] = None,
+) -> Generator[Tuple[str, Any], None, None]:
     s = deque()  # type: ignore
     s.append((prefix, obj))
     while s:
@@ -616,30 +600,28 @@ def _flatten(
 
 
 def set_flattened_tags(
-    span,  # type: Span
-    items,  # type: Iterator[Tuple[str, Any]]
-    sep=".",  # type: str
-    exclude_policy=None,  # type: Optional[Callable[[str], bool]]
-    processor=None,  # type: Optional[Callable[[Any], Any]]
-):
-    # type: (...) -> None
+    span: Span,
+    items: Iterator[Tuple[str, Any]],
+    sep: str = ".",
+    exclude_policy: Optional[Callable[[str], bool]] = None,
+    processor: Optional[Callable[[Any], Any]] = None,
+) -> None:
     for prefix, value in items:
         for tag, v in _flatten(value, sep, prefix, exclude_policy):
             span.set_tag(tag, processor(v) if processor is not None else v)
 
 
 def set_user(
-    tracer,  # type: Tracer
-    user_id,  # type: str
-    name=None,  # type: Optional[str]
-    email=None,  # type: Optional[str]
-    scope=None,  # type: Optional[str]
-    role=None,  # type: Optional[str]
-    session_id=None,  # type: Optional[str]
+    tracer: Tracer,
+    user_id: str,
+    name: Optional[str] = None,
+    email: Optional[str] = None,
+    scope: Optional[str] = None,
+    role: Optional[str] = None,
+    session_id: Optional[str] = None,
     propagate=False,  # type bool
-    span=None,  # type: Optional[Span]
-):
-    # type: (...) -> None
+    span: Optional[Span] = None,
+) -> None:
     """Set user tags.
     https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#user-related-attributes
     https://docs.datadoghq.com/security_platform/application_security/setup_and_configure/?tab=set_tag&code-lang=python
@@ -677,8 +659,7 @@ def set_user(
         )
 
 
-def extract_netloc_and_query_info_from_url(url):
-    # type: (str) -> Tuple[str, str]
+def extract_netloc_and_query_info_from_url(url: str) -> Tuple[str, str]:
     parse_result = parse.urlparse(url)
     query = parse_result.query
 

--- a/ddtrace/contrib/unittest/patch.py
+++ b/ddtrace/contrib/unittest/patch.py
@@ -52,8 +52,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 

--- a/ddtrace/contrib/urllib3/patch.py
+++ b/ddtrace/contrib/urllib3/patch.py
@@ -38,8 +38,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(urllib3, "__version__", "")
 
 

--- a/ddtrace/contrib/vertica/patch.py
+++ b/ddtrace/contrib/vertica/patch.py
@@ -118,8 +118,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     import vertica_python
 
     return vertica_python.__version__

--- a/ddtrace/contrib/wsgi/wsgi.py
+++ b/ddtrace/contrib/wsgi/wsgi.py
@@ -48,8 +48,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return ""
 
 
@@ -63,8 +62,7 @@ class _DDWSGIMiddlewareBase(object):
     :param app_is_iterator: Boolean indicating whether the wrapped app is a Python iterator
     """
 
-    def __init__(self, application, tracer, int_config, pin, app_is_iterator=False):
-        # type: (Iterable, Tracer, Config, Pin, bool) -> None
+    def __init__(self, application: Iterable, tracer: Tracer, int_config: Config, pin: Pin, app_is_iterator: bool = False) -> None:
         self.app = application
         self.tracer = tracer
         self._config = int_config
@@ -72,25 +70,21 @@ class _DDWSGIMiddlewareBase(object):
         self.app_is_iterator = app_is_iterator
 
     @property
-    def _request_span_name(self):
-        # type: () -> str
+    def _request_span_name(self) -> str:
         "Returns the name of a request span. Example: `flask.request`"
         raise NotImplementedError
 
     @property
-    def _application_span_name(self):
-        # type: () -> str
+    def _application_span_name(self) -> str:
         "Returns the name of an application span. Example: `flask.application`"
         raise NotImplementedError
 
     @property
-    def _response_span_name(self):
-        # type: () -> str
+    def _response_span_name(self) -> str:
         "Returns the name of a response span. Example: `flask.response`"
         raise NotImplementedError
 
-    def __call__(self, environ, start_response):
-        # type: (Iterable, Callable) -> wrapt.ObjectProxy
+    def __call__(self, environ: Iterable, start_response: Callable) -> wrapt.ObjectProxy:
         headers = get_request_headers(environ)
         closing_iterable = ()
         not_blocked = True
@@ -136,8 +130,7 @@ class _DDWSGIMiddlewareBase(object):
 
             return core.dispatch("wsgi.request.complete", ctx, closing_iterable, self.app_is_iterator)[0][0]
 
-    def _traced_start_response(self, start_response, request_span, app_span, status, environ, exc_info=None):
-        # type: (Callable, Span, Span, str, Dict, Any) -> None
+    def _traced_start_response(self, start_response: Callable, request_span: Span, app_span: Span, status: str, environ: Dict, exc_info: Any = None) -> None:
         """sets the status code on a request span when start_response is called"""
         with core.context_with_data(
             "wsgi.response",
@@ -154,16 +147,13 @@ class _DDWSGIMiddlewareBase(object):
         ):
             return start_response(status, environ, exc_info)
 
-    def _request_span_modifier(self, req_span, environ, parsed_headers=None):
-        # type: (Span, Dict, Optional[Dict]) -> None
+    def _request_span_modifier(self, req_span: Span, environ: Dict, parsed_headers: Optional[Dict] = None) -> None:
         """Implement to modify span attributes on the request_span"""
 
-    def _application_span_modifier(self, app_span, environ, result):
-        # type: (Span, Dict, Iterable) -> None
+    def _application_span_modifier(self, app_span: Span, environ: Dict, result: Iterable) -> None:
         """Implement to modify span attributes on the application_span"""
 
-    def _response_span_modifier(self, resp_span, response):
-        # type: (Span, Dict) -> None
+    def _response_span_modifier(self, resp_span: Span, response: Dict) -> None:
         """Implement to modify span attributes on the request_span"""
 
 
@@ -193,12 +183,11 @@ def construct_url(environ):
     return url
 
 
-def get_request_headers(environ):
-    # type: (Mapping[str, str]) -> Mapping[str, str]
+def get_request_headers(environ: Mapping[str, str]) -> Mapping[str, str]:
     """
     Manually grab the request headers from the environ dictionary.
     """
-    request_headers = {}  # type: Mapping[str, str]
+    request_headers: Mapping[str, str] = {}
     for key in environ.keys():
         if key.startswith("HTTP_"):
             name = from_wsgi_header(key)
@@ -225,8 +214,7 @@ class DDWSGIMiddleware(_DDWSGIMiddlewareBase):
     _application_span_name = "wsgi.application"
     _response_span_name = "wsgi.response"
 
-    def __init__(self, application, tracer=None, span_modifier=default_wsgi_span_modifier, app_is_iterator=False):
-        # type: (Iterable, Optional[Tracer], Callable[[Span, Dict[str, str]], None], bool) -> None
+    def __init__(self, application: Iterable, tracer: Optional[Tracer] = None, span_modifier: Callable[[Span, Dict[str, str]], None] = default_wsgi_span_modifier, app_is_iterator: bool = False) -> None:
         super(DDWSGIMiddleware, self).__init__(
             application, tracer or ddtrace.tracer, config.wsgi, None, app_is_iterator=app_is_iterator
         )

--- a/ddtrace/contrib/yaaredis/patch.py
+++ b/ddtrace/contrib/yaaredis/patch.py
@@ -26,8 +26,7 @@ config._add(
 )
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return getattr(yaaredis, "__version__", "")
 
 

--- a/ddtrace/ext/aws.py
+++ b/ddtrace/ext/aws.py
@@ -7,8 +7,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from ddtrace.span import Span
 
 
-def truncate_arg_value(value, max_len=1024):
-    # type: (Any, int) -> Any
+def truncate_arg_value(value: Any, max_len: int = 1024) -> Any:
     """Truncate values which are bytes and greater than `max_len`.
     Useful for parameters like 'Body' in `put_object` operations.
     """
@@ -18,8 +17,7 @@ def truncate_arg_value(value, max_len=1024):
     return value
 
 
-def _add_api_param_span_tags(span, endpoint_name, params):
-    # type: (Span, str, Dict[str, Any]) -> None
+def _add_api_param_span_tags(span: Span, endpoint_name: str, params: Dict[str, Any]) -> None:
     # Note: Only some boto3 requests will supply these params
     # i.e. that might explain why you see these tags being set to empty strings
     if endpoint_name == "cloudwatch":

--- a/ddtrace/ext/ci.py
+++ b/ddtrace/ext/ci.py
@@ -78,8 +78,7 @@ _RE_URL = re.compile(r"(https?://|ssh://)[^/]*@")
 log = get_logger(__name__)
 
 
-def _filter_sensitive_info(url):
-    # type: (Optional[str]) -> Optional[str]
+def _filter_sensitive_info(url: Optional[str]) -> Optional[str]:
     return _RE_URL.sub("\\1", url) if url is not None else None
 
 
@@ -94,11 +93,10 @@ def _get_runtime_and_os_metadata():
     }
 
 
-def tags(env=None, cwd=None):
-    # type: (Optional[MutableMapping[str, str]], Optional[str]) -> Dict[str, str]
+def tags(env: Optional[MutableMapping[str, str]] = None, cwd: Optional[str] = None) -> Dict[str, str]:
     """Extract and set tags from provider environ, as well as git metadata."""
     env = os.environ if env is None else env
-    tags = {}  # type: Dict[str, Optional[str]]
+    tags: Dict[str, Optional[str]] = {}
     for key, extract in PROVIDERS:
         if key in env:
             tags = extract(env)
@@ -145,19 +143,18 @@ def tags(env=None, cwd=None):
     return {k: v for k, v in tags.items() if v is not None}
 
 
-def extract_appveyor(env):
-    # type: (MutableMapping[str, str]) -> Dict[str, Optional[str]]
+def extract_appveyor(env: MutableMapping[str, str]) -> Dict[str, Optional[str]]:
     """Extract CI tags from Appveyor environ."""
     url = "https://ci.appveyor.com/project/{0}/builds/{1}".format(
         env.get("APPVEYOR_REPO_NAME"), env.get("APPVEYOR_BUILD_ID")
     )
     if env.get("APPVEYOR_REPO_PROVIDER") == "github":
-        repository = "https://github.com/{0}.git".format(env.get("APPVEYOR_REPO_NAME"))  # type: Optional[str]
-        commit = env.get("APPVEYOR_REPO_COMMIT")  # type: Optional[str]
-        branch = env.get("APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH") or env.get(
+        repository: Optional[str] = "https://github.com/{0}.git".format(env.get("APPVEYOR_REPO_NAME"))
+        commit: Optional[str] = env.get("APPVEYOR_REPO_COMMIT")
+        branch: Optional[str] = env.get("APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH") or env.get(
             "APPVEYOR_REPO_BRANCH"
-        )  # type: Optional[str]
-        tag = env.get("APPVEYOR_REPO_TAG_NAME")  # type: Optional[str]
+        )
+        tag: Optional[str] = env.get("APPVEYOR_REPO_TAG_NAME")
     else:
         repository = commit = branch = tag = None
 
@@ -185,17 +182,16 @@ def extract_appveyor(env):
     }
 
 
-def extract_azure_pipelines(env):
-    # type: (MutableMapping[str, str]) -> Dict[str, Optional[str]]
+def extract_azure_pipelines(env: MutableMapping[str, str]) -> Dict[str, Optional[str]]:
     """Extract CI tags from Azure pipelines environ."""
     if env.get("SYSTEM_TEAMFOUNDATIONSERVERURI") and env.get("SYSTEM_TEAMPROJECTID") and env.get("BUILD_BUILDID"):
         base_url = "{0}{1}/_build/results?buildId={2}".format(
             env.get("SYSTEM_TEAMFOUNDATIONSERVERURI"), env.get("SYSTEM_TEAMPROJECTID"), env.get("BUILD_BUILDID")
         )
-        pipeline_url = base_url  # type: Optional[str]
-        job_url = base_url + "&view=logs&j={0}&t={1}".format(
+        pipeline_url: Optional[str] = base_url
+        job_url: Optional[str] = base_url + "&view=logs&j={0}&t={1}".format(
             env.get("SYSTEM_JOBID"), env.get("SYSTEM_TASKINSTANCEID")
-        )  # type: Optional[str]
+        )
     else:
         pipeline_url = job_url = None
 
@@ -228,8 +224,7 @@ def extract_azure_pipelines(env):
     }
 
 
-def extract_bitbucket(env):
-    # type: (MutableMapping[str, str]) -> Dict[str, Optional[str]]
+def extract_bitbucket(env: MutableMapping[str, str]) -> Dict[str, Optional[str]]:
     """Extract CI tags from Bitbucket environ."""
     url = "https://bitbucket.org/{0}/addon/pipelines/home#!/results/{1}".format(
         env.get("BITBUCKET_REPO_FULL_NAME"), env.get("BITBUCKET_BUILD_NUMBER")
@@ -249,11 +244,10 @@ def extract_bitbucket(env):
     }
 
 
-def extract_buildkite(env):
-    # type: (MutableMapping[str, str]) -> Dict[str, Optional[str]]
+def extract_buildkite(env: MutableMapping[str, str]) -> Dict[str, Optional[str]]:
     """Extract CI tags from Buildkite environ."""
     # Get all keys which start with BUILDKITE_AGENT_META_DATA_x
-    node_label_list = []  # type: List[str]
+    node_label_list: List[str] = []
     buildkite_agent_meta_data_prefix = "BUILDKITE_AGENT_META_DATA_"
     for env_variable in env:
         if env_variable.startswith(buildkite_agent_meta_data_prefix):
@@ -289,8 +283,7 @@ def extract_buildkite(env):
     }
 
 
-def extract_circle_ci(env):
-    # type: (MutableMapping[str, str]) -> Dict[str, Optional[str]]
+def extract_circle_ci(env: MutableMapping[str, str]) -> Dict[str, Optional[str]]:
     """Extract CI tags from CircleCI environ."""
     return {
         git.BRANCH: env.get("CIRCLE_BRANCH"),
@@ -315,8 +308,7 @@ def extract_circle_ci(env):
     }
 
 
-def extract_codefresh(env):
-    # type: (MutableMapping[str, str]) -> Dict[str, Optional[str]]
+def extract_codefresh(env: MutableMapping[str, str]) -> Dict[str, Optional[str]]:
     """Extract CI tags from Codefresh environ."""
     build_id = env.get("CF_BUILD_ID")
     return {
@@ -333,8 +325,7 @@ def extract_codefresh(env):
     }
 
 
-def extract_github_actions(env):
-    # type: (MutableMapping[str, str]) -> Dict[str, Optional[str]]
+def extract_github_actions(env: MutableMapping[str, str]) -> Dict[str, Optional[str]]:
     """Extract CI tags from Github environ."""
 
     pipeline_url = "{0}/{1}/actions/runs/{2}".format(
@@ -372,12 +363,11 @@ def extract_github_actions(env):
     }
 
 
-def extract_gitlab(env):
-    # type: (MutableMapping[str, str]) -> Dict[str, Optional[str]]
+def extract_gitlab(env: MutableMapping[str, str]) -> Dict[str, Optional[str]]:
     """Extract CI tags from Gitlab environ."""
     author = env.get("CI_COMMIT_AUTHOR")
-    author_name = None  # type: Optional[str]
-    author_email = None  # type: Optional[str]
+    author_name: Optional[str] = None
+    author_email: Optional[str] = None
     if author:
         # Extract name and email from `author` which is in the form "name <email>"
         author_name, author_email = author.strip("> ").split(" <")
@@ -413,8 +403,7 @@ def extract_gitlab(env):
     }
 
 
-def extract_jenkins(env):
-    # type: (MutableMapping[str, str]) -> Dict[str, Optional[str]]
+def extract_jenkins(env: MutableMapping[str, str]) -> Dict[str, Optional[str]]:
     """Extract CI tags from Jenkins environ."""
     branch = env.get("GIT_BRANCH", "")
     name = env.get("JOB_NAME")
@@ -422,8 +411,8 @@ def extract_jenkins(env):
         name = re.sub("/{0}".format(git.normalize_ref(branch)), "", name)
     if name:
         name = "/".join((v for v in name.split("/") if v and "=" not in v))
-    node_labels_list = []  # type:  List[str]
-    node_labels_env = env.get("NODE_LABELS")  # type: Optional[str]
+    node_labels_list: List[str] = []
+    node_labels_env: Optional[str] = env.get("NODE_LABELS")
     if node_labels_env:
         node_labels_list = node_labels_env.split()
     return {
@@ -447,8 +436,7 @@ def extract_jenkins(env):
     }
 
 
-def extract_teamcity(env):
-    # type: (MutableMapping[str, str]) -> Dict[str, Optional[str]]
+def extract_teamcity(env: MutableMapping[str, str]) -> Dict[str, Optional[str]]:
     """Extract CI tags from Teamcity environ."""
     return {
         JOB_URL: env.get("BUILD_URL"),
@@ -457,8 +445,7 @@ def extract_teamcity(env):
     }
 
 
-def extract_travis(env):
-    # type: (MutableMapping[str, str]) -> Dict[str, Optional[str]]
+def extract_travis(env: MutableMapping[str, str]) -> Dict[str, Optional[str]]:
     """Extract CI tags from Travis environ."""
     return {
         git.BRANCH: env.get("TRAVIS_PULL_REQUEST_BRANCH") or env.get("TRAVIS_BRANCH"),
@@ -476,13 +463,12 @@ def extract_travis(env):
     }
 
 
-def extract_bitrise(env):
-    # type: (MutableMapping[str, str]) -> Dict[str, Optional[str]]
+def extract_bitrise(env: MutableMapping[str, str]) -> Dict[str, Optional[str]]:
     """Extract CI tags from Bitrise environ."""
     commit = env.get("BITRISE_GIT_COMMIT") or env.get("GIT_CLONE_COMMIT_HASH")
     branch = env.get("BITRISEIO_GIT_BRANCH_DEST") or env.get("BITRISE_GIT_BRANCH")
     if env.get("BITRISE_GIT_MESSAGE"):
-        message = env.get("BITRISE_GIT_MESSAGE")  # type: Optional[str]
+        message: Optional[str] = env.get("BITRISE_GIT_MESSAGE")
     elif env.get("GIT_CLONE_COMMIT_MESSAGE_SUBJECT") or env.get("GIT_CLONE_COMMIT_MESSAGE_BODY"):
         message = "{0}:\n{1}".format(
             env.get("GIT_CLONE_COMMIT_MESSAGE_SUBJECT"), env.get("GIT_CLONE_COMMIT_MESSAGE_BODY")
@@ -509,8 +495,7 @@ def extract_bitrise(env):
     }
 
 
-def extract_buddy(env):
-    # type: (MutableMapping[str, str]) -> Dict[str, Optional[str]]
+def extract_buddy(env: MutableMapping[str, str]) -> Dict[str, Optional[str]]:
     """Extract CI tags from Buddy environ."""
     return {
         PROVIDER_NAME: "buddy",
@@ -528,8 +513,7 @@ def extract_buddy(env):
     }
 
 
-def extract_codebuild(env):
-    # type: (MutableMapping[str, str]) -> Dict[str, Optional[str]]
+def extract_codebuild(env: MutableMapping[str, str]) -> Dict[str, Optional[str]]:
     """Extract CI tags from codebuild environments."""
 
     tags = {}

--- a/ddtrace/ext/git.py
+++ b/ddtrace/ext/git.py
@@ -66,23 +66,20 @@ _RE_TAGS = re.compile(r"^tags/")
 log = get_logger(__name__)
 
 
-def normalize_ref(name):
-    # type: (Optional[str]) -> Optional[str]
+def normalize_ref(name: Optional[str]) -> Optional[str]:
     return _RE_TAGS.sub("", _RE_ORIGIN.sub("", _RE_REFS.sub("", name))) if name is not None else None
 
 
-def is_ref_a_tag(ref):
-    # type: (Optional[str]) -> bool
+def is_ref_a_tag(ref: Optional[str]) -> bool:
     return "tags/" in ref if ref else False
 
 
-def _git_subprocess_cmd(cmd, cwd=None, std_in=None):
-    # type: (Union[str, list[str]], Optional[str], Optional[bytes]) -> str
+def _git_subprocess_cmd(cmd: Union[str, list[str]], cwd: Optional[str] = None, std_in: Optional[bytes] = None) -> str:
     """Helper for invoking the git CLI binary."""
     if isinstance(cmd, six.string_types):
         git_cmd = cmd.split(" ")
     else:
-        git_cmd = cmd  # type: list[str]  # type: ignore[no-redef]
+        git_cmd: list[str] = cmd  # type: ignore[no-redef]
     git_cmd.insert(0, "git")
     process = subprocess.Popen(git_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE, cwd=cwd)
     stdout, stderr = process.communicate(input=std_in)
@@ -100,20 +97,17 @@ def _set_safe_directory():
         log.error("Error setting safe directory", exc_info=True)
 
 
-def _extract_clone_defaultremotename(cwd=None):
-    # type: (Optional[str]) -> str
+def _extract_clone_defaultremotename(cwd: Optional[str] = None) -> str:
     output = _git_subprocess_cmd("config --default origin --get clone.defaultRemoteName", cwd=cwd)
     return output
 
 
-def _extract_upstream_sha(cwd=None):
-    # type: (Optional[str]) -> str
+def _extract_upstream_sha(cwd: Optional[str] = None) -> str:
     output = _git_subprocess_cmd("rev-parse @{upstream}", cwd=cwd)
     return output
 
 
-def _is_shallow_repository(cwd=None):
-    # type: (Optional[str]) -> bool
+def _is_shallow_repository(cwd: Optional[str] = None) -> bool:
     output = _git_subprocess_cmd("rev-parse --is-shallow-repository", cwd=cwd)
     return output.strip() == "true"
 
@@ -136,8 +130,7 @@ def _unshallow_repository(cwd=None, repo=None, refspec=None):
     return _git_subprocess_cmd(cmd, cwd=cwd)
 
 
-def extract_user_info(cwd=None):
-    # type: (Optional[str]) -> Dict[str, Tuple[str, str, str]]
+def extract_user_info(cwd: Optional[str] = None) -> Dict[str, Tuple[str, str, str]]:
     """Extract commit author info from the git repository in the current directory or one specified by ``cwd``."""
     # Note: `git show -s --format... --date...` is supported since git 2.1.4 onwards
     stdout = _git_subprocess_cmd("show -s --format=%an,%ae,%ad,%cn,%ce,%cd --date=format:%Y-%m-%dT%H:%M:%S%z", cwd=cwd)
@@ -172,8 +165,7 @@ def get_rev_list_excluding_commits(commit_shas, cwd=None):
     return _get_rev_list(excluded_commit_shas=commit_shas, cwd=cwd)
 
 
-def _get_rev_list(excluded_commit_shas=None, included_commit_shas=None, cwd=None):
-    # type: (Optional[list[str]], Optional[list[str]], Optional[str]) -> str
+def _get_rev_list(excluded_commit_shas: Optional[list[str]] = None, included_commit_shas: Optional[list[str]] = None, cwd: Optional[str] = None) -> str:
     command = ["rev-list", "--objects", "--filter=blob:none"]
     if extract_git_version(cwd=cwd) >= (2, 23, 0):
         command.append('--since="1 month ago"')
@@ -189,47 +181,41 @@ def _get_rev_list(excluded_commit_shas=None, included_commit_shas=None, cwd=None
     return commits
 
 
-def extract_repository_url(cwd=None):
-    # type: (Optional[str]) -> str
+def extract_repository_url(cwd: Optional[str] = None) -> str:
     """Extract the repository url from the git repository in the current directory or one specified by ``cwd``."""
     # Note: `git show ls-remote --get-url` is supported since git 2.6.7 onwards
     repository_url = _git_subprocess_cmd("ls-remote --get-url", cwd=cwd)
     return repository_url
 
 
-def extract_commit_message(cwd=None):
-    # type: (Optional[str]) -> str
+def extract_commit_message(cwd: Optional[str] = None) -> str:
     """Extract git commit message from the git repository in the current directory or one specified by ``cwd``."""
     # Note: `git show -s --format... --date...` is supported since git 2.1.4 onwards
     commit_message = _git_subprocess_cmd("show -s --format=%s", cwd=cwd)
     return commit_message
 
 
-def extract_workspace_path(cwd=None):
-    # type: (Optional[str]) -> str
+def extract_workspace_path(cwd: Optional[str] = None) -> str:
     """Extract the root directory path from the git repository in the current directory or one specified by ``cwd``."""
     workspace_path = _git_subprocess_cmd("rev-parse --show-toplevel", cwd=cwd)
     return workspace_path
 
 
-def extract_branch(cwd=None):
-    # type: (Optional[str]) -> str
+def extract_branch(cwd: Optional[str] = None) -> str:
     """Extract git branch from the git repository in the current directory or one specified by ``cwd``."""
     branch = _git_subprocess_cmd("rev-parse --abbrev-ref HEAD", cwd=cwd)
     return branch
 
 
-def extract_commit_sha(cwd=None):
-    # type: (Optional[str]) -> str
+def extract_commit_sha(cwd: Optional[str] = None) -> str:
     """Extract git commit SHA from the git repository in the current directory or one specified by ``cwd``."""
     commit_sha = _git_subprocess_cmd("rev-parse HEAD", cwd=cwd)
     return commit_sha
 
 
-def extract_git_metadata(cwd=None):
-    # type: (Optional[str]) -> Dict[str, Optional[str]]
+def extract_git_metadata(cwd: Optional[str] = None) -> Dict[str, Optional[str]]:
     """Extract git commit metadata."""
-    tags = {}  # type: Dict[str, Optional[str]]
+    tags: Dict[str, Optional[str]] = {}
     _set_safe_directory()
     try:
         tags[REPOSITORY_URL] = extract_repository_url(cwd=cwd)
@@ -253,8 +239,7 @@ def extract_git_metadata(cwd=None):
     return tags
 
 
-def extract_user_git_metadata(env=None):
-    # type: (Optional[MutableMapping[str, str]]) -> Dict[str, Optional[str]]
+def extract_user_git_metadata(env: Optional[MutableMapping[str, str]] = None) -> Dict[str, Optional[str]]:
     """Extract git commit metadata from user-provided env vars."""
     env = os.environ if env is None else env
 
@@ -283,8 +268,7 @@ def extract_user_git_metadata(env=None):
 
 
 @contextlib.contextmanager
-def build_git_packfiles(revisions, cwd=None):
-    # type: (str, Optional[str]) -> Generator
+def build_git_packfiles(revisions: str, cwd: Optional[str] = None) -> Generator:
     basename = str(random.randint(1, 1000000))
     try:
         with TemporaryDirectory() as tempdir:

--- a/ddtrace/ext/sql.py
+++ b/ddtrace/ext/sql.py
@@ -10,8 +10,7 @@ log = get_logger(__name__)
 DB = "sql.db"  # the name of the database
 
 
-def normalize_vendor(vendor):
-    # type: (str) -> str
+def normalize_vendor(vendor: str) -> str:
     """Return a canonical name for a type of database."""
     if not vendor:
         return "db"  # should this ever happen?
@@ -23,8 +22,7 @@ def normalize_vendor(vendor):
         return vendor
 
 
-def _dd_parse_pg_dsn(dsn):
-    # type: (str) -> Dict[str, str]
+def _dd_parse_pg_dsn(dsn: str) -> Dict[str, str]:
     """
     Return a dictionary of the components of a postgres DSN.
     >>> parse_pg_dsn('user=dog port=1543 dbname=dogdata')

--- a/ddtrace/filters.py
+++ b/ddtrace/filters.py
@@ -14,8 +14,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 class TraceFilter(TraceProcessor):
     @abc.abstractmethod
-    def process_trace(self, trace):
-        # type: (List[Span]) -> Optional[List[Span]]
+    def process_trace(self, trace: List[Span]) -> Optional[List[Span]]:
         """Processes a trace.
 
         None can be returned to prevent the trace from being exported.
@@ -54,8 +53,7 @@ class FilterRequestsOnUrl(TraceFilter):
             regexps = [regexps]
         self._regexps = [re.compile(regexp) for regexp in regexps]
 
-    def process_trace(self, trace):
-        # type: (List[Span]) -> Optional[List[Span]]
+    def process_trace(self, trace: List[Span]) -> Optional[List[Span]]:
         """
         When the filter is registered in the tracer, process_trace is called by
         on each trace before it is sent to the agent, the returned value will

--- a/ddtrace/internal/agent.py
+++ b/ddtrace/internal/agent.py
@@ -28,8 +28,7 @@ log = get_logger(__name__)
 
 
 # This method returns if a hostname is an IPv6 address
-def is_ipv6_hostname(hostname):
-    # type: (Union[T, str]) -> bool
+def is_ipv6_hostname(hostname: Union[T, str]) -> bool:
     if not isinstance(hostname, str):
         return False
     try:
@@ -39,8 +38,7 @@ def is_ipv6_hostname(hostname):
         return False
 
 
-def get_trace_url():
-    # type: () -> str
+def get_trace_url() -> str:
     """Return the Agent URL computed from the environment.
 
     Raises a ``ValueError`` if the URL is not supported by the Agent.
@@ -65,8 +63,7 @@ def get_trace_url():
     return url
 
 
-def get_stats_url():
-    # type: () -> str
+def get_stats_url() -> str:
     user_supplied_host = ddconfig._stats_agent_hostname is not None
     user_supplied_port = ddconfig._stats_agent_port is not None
 

--- a/ddtrace/internal/atexit.py
+++ b/ddtrace/internal/atexit.py
@@ -21,10 +21,9 @@ if hasattr(atexit, "unregister"):
     unregister = atexit.unregister
 else:
     # Hello Python 2!
-    _registry = []  # type: typing.List[typing.Tuple[typing.Callable[..., None], typing.Tuple, typing.Dict]]
+    _registry: typing.List[typing.Tuple[typing.Callable[..., None], typing.Tuple, typing.Dict]] = []
 
-    def _ddtrace_atexit():
-        # type: (...) -> None
+    def _ddtrace_atexit() -> None:
         """Wrapper function that calls all registered function on normal program termination"""
         global _registry
 
@@ -38,18 +37,16 @@ else:
                 log.exception("Error in atexit hook %r", hook)
 
     def register(
-        func,  # type: typing.Callable[..., typing.Any]
-        *args,  # type: typing.Any
-        **kwargs,  # type: typing.Any
-    ):
-        # type: (...) -> typing.Callable[..., typing.Any]
+        func: typing.Callable[..., typing.Any],
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> typing.Callable[..., typing.Any]:
         """Register a function to be executed upon normal program termination"""
 
         _registry.append((func, args, kwargs))
         return func
 
-    def unregister(func):
-        # type: (typing.Callable[..., typing.Any]) -> None
+    def unregister(func: typing.Callable[..., typing.Any]) -> None:
         """
         Unregister an exit function which was previously registered using
         atexit.register.

--- a/ddtrace/internal/ci_visibility/coverage.py
+++ b/ddtrace/internal/ci_visibility/coverage.py
@@ -42,8 +42,7 @@ def _initialize_coverage(root_dir):
     return Coverage(**coverage_kwargs)
 
 
-def segments(lines):
-    # type: (Iterable[int]) -> List[Tuple[int, int, int, int, int]]
+def segments(lines: Iterable[int]) -> List[Tuple[int, int, int, int, int]]:
     """Extract the relevant report data for a single file."""
     _segments = []
     for _key, g in groupby(enumerate(sorted(lines)), lambda x: x[1] - x[0]):
@@ -55,8 +54,7 @@ def segments(lines):
     return _segments
 
 
-def _lines(coverage, context):
-    # type: (Coverage, Optional[str]) -> Dict[str, List[Tuple[int, int, int, int, int]]]
+def _lines(coverage: Coverage, context: Optional[str]) -> Dict[str, List[Tuple[int, int, int, int, int]]]:
     if not coverage._collector or not coverage._collector.data:
         return {}
 
@@ -66,8 +64,7 @@ def _lines(coverage, context):
     }
 
 
-def build_payload(coverage, root_dir, test_id=None):
-    # type: (Coverage, str, Optional[str]) -> str
+def build_payload(coverage: Coverage, root_dir: str, test_id: Optional[str] = None) -> str:
     """
     Generate a CI Visibility coverage payload, formatted as follows:
 

--- a/ddtrace/internal/ci_visibility/filters.py
+++ b/ddtrace/internal/ci_visibility/filters.py
@@ -16,13 +16,11 @@ if TYPE_CHECKING:
 
 
 class TraceCiVisibilityFilter(TraceFilter):
-    def __init__(self, tags, service):
-        # type: (Dict[Union[str, bytes], str], str) -> None
+    def __init__(self, tags: Dict[Union[str, bytes], str], service: str) -> None:
         self._tags = tags
         self._service = service
 
-    def process_trace(self, trace):
-        # type: (List[Span]) -> Optional[List[Span]]
+    def process_trace(self, trace: List[Span]) -> Optional[List[Span]]:
         if not trace:
             return trace
 

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -56,8 +56,7 @@ log = get_logger(__name__)
 DEFAULT_TIMEOUT = 15
 
 
-def _extract_repository_name_from_url(repository_url):
-    # type: (str) -> str
+def _extract_repository_name_from_url(repository_url: str) -> str:
     try:
         return parse.urlparse(repository_url).path.rstrip(".git").rpartition("/")[-1]
     except ValueError:
@@ -81,8 +80,7 @@ def _get_custom_configurations():
     return custom_configurations
 
 
-def _do_request(method, url, payload, headers):
-    # type: (str, str, str, Dict) -> Response
+def _do_request(method: str, url: str, payload: str, headers: Dict) -> Response:
     try:
         conn = get_connection(url, timeout=DEFAULT_TIMEOUT)
         log.debug("Sending request: %s %s %s %s", method, url, payload, headers)
@@ -96,13 +94,12 @@ def _do_request(method, url, payload, headers):
 
 
 class CIVisibility(Service):
-    _instance = None  # type: Optional[CIVisibility]
+    _instance: Optional[CIVisibility] = None
     enabled = False
-    _test_suites_to_skip = None  # type: Optional[List[str]]
-    _tests_to_skip = defaultdict(list)  # type: DefaultDict[str, List[str]]
+    _test_suites_to_skip: Optional[List[str]] = None
+    _tests_to_skip: DefaultDict[str, List[str]] = defaultdict(list)
 
-    def __init__(self, tracer=None, config=None, service=None):
-        # type: (Optional[Tracer], Optional[IntegrationConfig], Optional[str]) -> None
+    def __init__(self, tracer: Optional[Tracer] = None, config: Optional[IntegrationConfig] = None, service: Optional[str] = None) -> None:
         super(CIVisibility, self).__init__()
 
         if tracer:
@@ -118,8 +115,8 @@ class CIVisibility(Service):
 
         self._dd_site = os.getenv("DD_SITE", AGENTLESS_DEFAULT_SITE)
         self._suite_skipping_mode = asbool(os.getenv("_DD_CIVISIBILITY_ITR_SUITE_MODE", default=False))
-        self.config = config  # type: Optional[IntegrationConfig]
-        self._tags = ci.tags(cwd=_get_git_repo())  # type: Dict[str, str]
+        self.config: Optional[IntegrationConfig] = config
+        self._tags: Dict[str, str] = ci.tags(cwd=_get_git_repo())
         self._service = service
         self._codeowners = None
         self._root_dir = None
@@ -182,8 +179,7 @@ class CIVisibility(Service):
             return False
         return True
 
-    def _check_enabled_features(self):
-        # type: () -> Tuple[bool, bool]
+    def _check_enabled_features(self) -> Tuple[bool, bool]:
         # DEV: Remove this ``if`` once ITR is in GA
         if not ddconfig._ci_visibility_intelligent_testrunner_enabled:
             return False, False
@@ -265,8 +261,7 @@ class CIVisibility(Service):
         if writer is not None:
             self.tracer.configure(writer=writer)
 
-    def _agent_evp_proxy_is_available(self):
-        # type: () -> bool
+    def _agent_evp_proxy_is_available(self) -> bool:
         try:
             info = agent.info()
         except Exception:
@@ -378,8 +373,7 @@ class CIVisibility(Service):
         return False
 
     @classmethod
-    def enable(cls, tracer=None, config=None, service=None):
-        # type: (Optional[Tracer], Optional[Any], Optional[str]) -> None
+    def enable(cls, tracer: Optional[Tracer] = None, config: Optional[Any] = None, service: Optional[str] = None) -> None:
         log.debug("Enabling %s", cls.__name__)
 
         if ddconfig._ci_visibility_agentless_enabled:
@@ -405,8 +399,7 @@ class CIVisibility(Service):
         log.debug("%s enabled", cls.__name__)
 
     @classmethod
-    def disable(cls):
-        # type: () -> None
+    def disable(cls) -> None:
         if cls._instance is None:
             log.debug("%s not enabled", cls.__name__)
             return
@@ -419,8 +412,7 @@ class CIVisibility(Service):
 
         log.debug("%s disabled", cls.__name__)
 
-    def _start_service(self):
-        # type: () -> None
+    def _start_service(self) -> None:
         tracer_filters = self.tracer._filters
         if not any(isinstance(tracer_filter, TraceCiVisibilityFilter) for tracer_filter in tracer_filters):
             tracer_filters += [TraceCiVisibilityFilter(self._tags, self._service)]  # type: ignore[arg-type]
@@ -430,8 +422,7 @@ class CIVisibility(Service):
         if self.test_skipping_enabled() and (not self._tests_to_skip and self._test_suites_to_skip is None):
             self._fetch_tests_to_skip(SUITE if self._suite_skipping_mode else TEST)
 
-    def _stop_service(self):
-        # type: () -> None
+    def _stop_service(self) -> None:
         if self._git_client is not None:
             self._git_client.shutdown(timeout=self.tracer.SHUTDOWN_TIMEOUT)
         try:

--- a/ddtrace/internal/ci_visibility/writer.py
+++ b/ddtrace/internal/ci_visibility/writer.py
@@ -80,19 +80,19 @@ class CIVisibilityWriter(HTTPWriter):
 
     def __init__(
         self,
-        intake_url="",  # type: str
-        sampler=None,  # type: Optional[BaseSampler]
-        processing_interval=None,  # type: Optional[float]
-        timeout=None,  # type: Optional[float]
-        dogstatsd=None,  # type: Optional[DogStatsd]
-        sync_mode=False,  # type: bool
-        report_metrics=False,  # type: bool
-        api_version=None,  # type: Optional[str]
-        reuse_connections=None,  # type: Optional[bool]
-        headers=None,  # type: Optional[Dict[str, str]]
-        use_evp=False,  # type: bool
-        coverage_enabled=False,  # type: bool
-        itr_suite_skipping_mode=False,  # type: bool
+        intake_url: str = "",
+        sampler: Optional[BaseSampler] = None,
+        processing_interval: Optional[float] = None,
+        timeout: Optional[float] = None,
+        dogstatsd: Optional[DogStatsd] = None,
+        sync_mode: bool = False,
+        report_metrics: bool = False,
+        api_version: Optional[str] = None,
+        reuse_connections: Optional[bool] = None,
+        headers: Optional[Dict[str, str]] = None,
+        use_evp: bool = False,
+        coverage_enabled: bool = False,
+        itr_suite_skipping_mode: bool = False,
     ):
         if processing_interval is None:
             processing_interval = config._trace_writer_interval_seconds
@@ -108,9 +108,9 @@ class CIVisibilityWriter(HTTPWriter):
         if not intake_url:
             intake_url = "%s.%s" % (AGENTLESS_BASE_URL, os.getenv("DD_SITE", AGENTLESS_DEFAULT_SITE))
 
-        clients = (
+        clients: List[WriterClientBase] = (
             [CIVisibilityProxiedEventClient()] if use_evp else [CIVisibilityAgentlessEventClient()]
-        )  # type: List[WriterClientBase]
+        )
         if coverage_enabled:
             if not intake_cov_url:
                 intake_cov_url = "%s.%s" % (AGENTLESS_COVERAGE_BASE_URL, os.getenv("DD_SITE", AGENTLESS_DEFAULT_SITE))
@@ -142,8 +142,7 @@ class CIVisibilityWriter(HTTPWriter):
         if self.status != service.ServiceStatus.STOPPED:
             super(CIVisibilityWriter, self).stop(timeout=timeout)
 
-    def recreate(self):
-        # type: () -> HTTPWriter
+    def recreate(self) -> HTTPWriter:
         return self.__class__(
             intake_url=self.intake_url,
             sampler=self._sampler,

--- a/ddtrace/internal/codeowners.py
+++ b/ddtrace/internal/codeowners.py
@@ -5,8 +5,7 @@ from typing import Optional
 from typing import Tuple
 
 
-def path_to_regex(pattern):
-    # type: (str) -> re.Pattern
+def path_to_regex(pattern: str) -> re.Pattern:
     """
     source https://github.com/sbdchd/codeowners/blob/c95e13d384ac09cfa1c23be1a8601987f41968ea/codeowners/__init__.py
 
@@ -119,20 +118,18 @@ class Codeowners(object):
         ".gitlab/CODEOWNERS",
     )
 
-    def __init__(self, path=None, cwd=None):
-        # type: (Optional[str], Optional[str]) -> None
+    def __init__(self, path: Optional[str] = None, cwd: Optional[str] = None) -> None:
         """Initialize Codeowners object.
 
         :param path: path to CODEOWNERS file otherwise try to use any from known locations
         """
         path = path or self.location(cwd)
         if path is not None:
-            self.path = path  # type: str
-        self.patterns = []  # type: List[Tuple[re.Pattern, List[str]]]
+            self.path: str = path
+        self.patterns: List[Tuple[re.Pattern, List[str]]] = []
         self.parse()
 
-    def location(self, cwd=None):
-        # type: (Optional[str]) -> Optional[str]
+    def location(self, cwd: Optional[str] = None) -> Optional[str]:
         """Return the location of the CODEOWNERS file."""
         cwd = cwd or os.getcwd()
         for location in self.KNOWN_LOCATIONS:
@@ -141,8 +138,7 @@ class Codeowners(object):
                 return path
         raise ValueError("CODEOWNERS file not found")
 
-    def parse(self):
-        # type: () -> None
+    def parse(self) -> None:
         """Parse CODEOWNERS file and store the lines and regexes."""
         with open(self.path) as f:
             patterns = []
@@ -182,8 +178,7 @@ class Codeowners(object):
             patterns.reverse()
             self.patterns = patterns
 
-    def of(self, path):
-        # type: (str) -> List[str]
+    def of(self, path: str) -> List[str]:
         """Return code owners for a given path.
 
         :param path: path to check

--- a/ddtrace/internal/compat.py
+++ b/ddtrace/internal/compat.py
@@ -118,8 +118,7 @@ except ImportError:
         return argspec.args or argspec.varargs or argspec.keywords or argspec.defaults or isgeneratorfunction(f)
 
 
-def is_integer(obj):
-    # type: (Any) -> bool
+def is_integer(obj: Any) -> bool:
     """Helper to determine if the provided ``obj`` is an integer type or not"""
     # DEV: We have to make sure it is an integer and not a boolean
     # >>> type(True)
@@ -134,8 +133,7 @@ try:
 except ImportError:
     from time import time as _time
 
-    def time_ns():
-        # type: () -> int
+    def time_ns() -> int:
         return int(_time() * 10e5) * 1000
 
 
@@ -149,8 +147,7 @@ try:
     from time import monotonic_ns
 except ImportError:
 
-    def monotonic_ns():
-        # type: () -> int
+    def monotonic_ns() -> int:
         return int(monotonic() * 1e9)
 
 
@@ -159,8 +156,7 @@ try:
 except ImportError:
     from time import clock as _process_time  # type: ignore[attr-defined]
 
-    def process_time_ns():
-        # type: () -> int
+    def process_time_ns() -> int:
         return int(_process_time() * 1e9)
 
 
@@ -226,8 +222,7 @@ else:
 
 
 # DEV: There is `six.u()` which does something similar, but doesn't have the guard around `hasattr(s, 'decode')`
-def to_unicode(s):
-    # type: (AnyStr) -> Text
+def to_unicode(s: AnyStr) -> Text:
     """Return a unicode string for the given bytes or string instance."""
     # No reason to decode if we already have the unicode compatible object we expect
     # DEV: `six.text_type` will be a `str` for python 3 and `unicode` for python 2
@@ -247,9 +242,8 @@ def to_unicode(s):
 
 
 def get_connection_response(
-    conn,  # type: httplib.HTTPConnection
-):
-    # type: (...) -> httplib.HTTPResponse
+    conn: httplib.HTTPConnection,
+) -> httplib.HTTPResponse:
     """Returns the response for a connection.
 
     If using Python 2 enable buffering.
@@ -283,15 +277,13 @@ except ImportError:
     from collections import Iterable  # type: ignore[no-redef, attr-defined]  # noqa
 
 
-def maybe_stringify(obj):
-    # type: (Any) -> Optional[str]
+def maybe_stringify(obj: Any) -> Optional[str]:
     if obj is not None:
         return stringify(obj)
     return None
 
 
-def to_bytes_py2(n, length, byteorder):
-    # type: (int, int, str) -> Text
+def to_bytes_py2(n: int, length: int, byteorder: str) -> Text:
     """
     Convert a string to bytes in the format expected by the remote config
     capabilities string, considering the byteorder, which is needed
@@ -353,8 +345,7 @@ except ImportError:
     JSONDecodeError = ValueError  # type: ignore[misc,assignment]
 
 
-def ip_is_global(ip):
-    # type: (str) -> bool
+def ip_is_global(ip: str) -> bool:
     """
     is_global is Python 3+ only. This could raise a ValueError if the IP is not valid.
     """
@@ -453,8 +444,7 @@ except ImportError:
 
     _find_unsafe = re.compile(r"[^\w@%+=:,./-]").search
 
-    def shquote(s):
-        # type: (str) -> str
+    def shquote(s: str) -> str:
         """Return a shell-escaped version of the string *s*."""
         if not s:
             return "''"
@@ -470,8 +460,7 @@ try:
     from shlex import join as shjoin
 except ImportError:
 
-    def shjoin(args):  # type: ignore[misc]
-        # type: (Iterable[str]) -> str
+    def shjoin(args: Iterable[str]) -> str:  # type: ignore[misc]
         """Return a shell-escaped string from *args*."""
         return " ".join(shquote(arg) for arg in args)
 

--- a/ddtrace/internal/core.py
+++ b/ddtrace/internal/core.py
@@ -137,12 +137,10 @@ class EventHub:
     def __init__(self):
         self.reset()
 
-    def has_listeners(self, event_id):
-        # type: (str) -> bool
+    def has_listeners(self, event_id: str) -> bool:
         return event_id in self._listeners
 
-    def on(self, event_id, callback):
-        # type: (str, Callable) -> None
+    def on(self, event_id: str, callback: Callable) -> None:
         if callback not in self._listeners[event_id]:
             self._listeners[event_id].insert(0, callback)
 
@@ -151,8 +149,7 @@ class EventHub:
             del self._listeners
         self._listeners = defaultdict(list)
 
-    def dispatch(self, event_id, args, *other_args):
-        # type: (...) -> Tuple[List[Optional[Any]], List[Optional[Exception]]]
+    def dispatch(self, event_id, args, *other_args) -> Tuple[List[Optional[Any]], List[Optional[Exception]]]:
         if not isinstance(args, list):
             args = [args] + list(other_args)
         else:
@@ -181,23 +178,19 @@ class EventHub:
 _EVENT_HUB = contextvars.ContextVar("EventHub_var", default=EventHub())
 
 
-def has_listeners(event_id):
-    # type: (str) -> bool
+def has_listeners(event_id: str) -> bool:
     return _EVENT_HUB.get().has_listeners(event_id)  # type: ignore
 
 
-def on(event_id, callback):
-    # type: (str, Callable) -> None
+def on(event_id: str, callback: Callable) -> None:
     return _EVENT_HUB.get().on(event_id, callback)  # type: ignore
 
 
-def reset_listeners():
-    # type: () -> None
+def reset_listeners() -> None:
     _EVENT_HUB.get().reset()  # type: ignore
 
 
-def dispatch(event_id, args, *other_args):
-    # type: (...) -> Tuple[List[Optional[Any]], List[Optional[Exception]]]
+def dispatch(event_id, args, *other_args) -> Tuple[List[Optional[Any]], List[Optional[Exception]]]:
     return _EVENT_HUB.get().dispatch(event_id, args, *other_args)  # type: ignore
 
 
@@ -275,22 +268,18 @@ class ExecutionContext:
             raise KeyError
         return value
 
-    def get_items(self, data_keys):
-        # type: (List[str]) -> Optional[Any]
+    def get_items(self, data_keys: List[str]) -> Optional[Any]:
         return [self.get_item(key) for key in data_keys]
 
-    def set_item(self, data_key, data_value):
-        # type: (str, Optional[Any]) -> None
+    def set_item(self, data_key: str, data_value: Optional[Any]) -> None:
         self._data[data_key] = data_value
 
-    def set_safe(self, data_key, data_value):
-        # type: (str, Optional[Any]) -> None
+    def set_safe(self, data_key: str, data_value: Optional[Any]) -> None:
         if data_key in self._data:
             raise ValueError("Cannot overwrite ExecutionContext data key '%s'", data_key)
         return self.set_item(data_key, data_value)
 
-    def set_items(self, keys_values):
-        # type: (Dict[str, Optional[Any]]) -> None
+    def set_items(self, keys_values: Dict[str, Optional[Any]]) -> None:
         for data_key, data_value in keys_values.items():
             self.set_item(data_key, data_value)
 
@@ -317,38 +306,33 @@ def context_with_data(identifier, parent=None, **kwargs):
     return _CONTEXT_CLASS.context_with_data(identifier, parent=(parent or _CURRENT_CONTEXT.get()), **kwargs)
 
 
-def get_item(data_key, span=None):
-    # type: (str, Optional[Span]) -> Optional[Any]
+def get_item(data_key: str, span: Optional[Span] = None) -> Optional[Any]:
     if span is not None and span._local_root is not None:
         return span._local_root._get_ctx_item(data_key)
     else:
         return _CURRENT_CONTEXT.get().get_item(data_key)  # type: ignore
 
 
-def get_items(data_keys, span=None):
-    # type: (List[str], Optional[Span]) -> Optional[Any]
+def get_items(data_keys: List[str], span: Optional[Span] = None) -> Optional[Any]:
     if span is not None and span._local_root is not None:
         return [span._local_root._get_ctx_item(key) for key in data_keys]
     else:
         return _CURRENT_CONTEXT.get().get_items(data_keys)  # type: ignore
 
 
-def set_safe(data_key, data_value):
-    # type: (str, Optional[Any]) -> None
+def set_safe(data_key: str, data_value: Optional[Any]) -> None:
     _CURRENT_CONTEXT.get().set_safe(data_key, data_value)  # type: ignore
 
 
 # NB Don't call these set_* functions from `ddtrace.contrib`, only from product code!
-def set_item(data_key, data_value, span=None):
-    # type: (str, Optional[Any], Optional[Span]) -> None
+def set_item(data_key: str, data_value: Optional[Any], span: Optional[Span] = None) -> None:
     if span is not None and span._local_root is not None:
         span._local_root._set_ctx_item(data_key, data_value)
     else:
         _CURRENT_CONTEXT.get().set_item(data_key, data_value)  # type: ignore
 
 
-def set_items(keys_values, span=None):
-    # type: (Dict[str, Optional[Any]], Optional[Span]) -> None
+def set_items(keys_values: Dict[str, Optional[Any]], span: Optional[Span] = None) -> None:
     if span is not None and span._local_root is not None:
         span._local_root._set_ctx_items(keys_values)
     else:

--- a/ddtrace/internal/datadog/profiling/ddup.py
+++ b/ddtrace/internal/datadog/profiling/ddup.py
@@ -16,75 +16,75 @@ except ImportError:
 
     @not_implemented
     def init(
-        env,  # type: Optional[str]
-        service,  # type: Optional[str]
-        version,  # type: Optional[str]
-        tags,  # type: Optional[Dict[str, str]]
-        max_nframes,  # type: Optional[int]
-        url,  # type: Optional[str]
+        env: Optional[str],
+        service: Optional[str],
+        version: Optional[str],
+        tags: Optional[Dict[str, str]],
+        max_nframes: Optional[int],
+        url: Optional[str],
     ):
         pass
 
     @not_implemented
-    def start_sample(nframes):  # type: (int) -> None
+    def start_sample(nframes: int) -> None:
         pass
 
     @not_implemented
-    def push_cputime(value, count):  # type: (int, int) -> None
+    def push_cputime(value: int, count: int) -> None:
         pass
 
     @not_implemented
-    def push_walltime(value, count):  # type: (int, int) -> None
+    def push_walltime(value: int, count: int) -> None:
         pass
 
     @not_implemented
-    def push_acquire(value, count):  # type: (int, int) -> None
+    def push_acquire(value: int, count: int) -> None:
         pass
 
     @not_implemented
-    def push_release(value, count):  # type: (int, int) -> None
+    def push_release(value: int, count: int) -> None:
         pass
 
     @not_implemented
-    def push_alloc(value, count):  # type: (int, int) -> None
+    def push_alloc(value: int, count: int) -> None:
         pass
 
     @not_implemented
-    def push_heap(value):  # type: (int) -> None
+    def push_heap(value: int) -> None:
         pass
 
     @not_implemented
-    def push_lock_name(lock_name):  # type: (str) -> None
+    def push_lock_name(lock_name: str) -> None:
         pass
 
     @not_implemented
-    def push_frame(name, filename, address, line):  # type: (str, str, int, int) -> None
+    def push_frame(name: str, filename: str, address: int, line: int) -> None:
         pass
 
     @not_implemented
-    def push_threadinfo(thread_id, thread_native_id, thread_name):  # type: (int, int, Optional[str]) -> None
+    def push_threadinfo(thread_id: int, thread_native_id: int, thread_name: Optional[str]) -> None:
         pass
 
     @not_implemented
-    def push_taskinfo(task_id, task_name):  # type: (int, str) -> None
+    def push_taskinfo(task_id: int, task_name: str) -> None:
         pass
 
     @not_implemented
-    def push_exceptioninfo(exc_type, count):  # type: (type, int) -> None
+    def push_exceptioninfo(exc_type: type, count: int) -> None:
         pass
 
     @not_implemented
-    def push_class_name(class_name):  # type: (str) -> None
+    def push_class_name(class_name: str) -> None:
         pass
 
     @not_implemented
-    def push_span(span, endpoint_collection_enabled):  # type: (Optional[Span], bool) -> None
+    def push_span(span: Optional[Span], endpoint_collection_enabled: bool) -> None:
         pass
 
     @not_implemented
-    def flush_sample():  # type: () -> None
+    def flush_sample() -> None:
         pass
 
     @not_implemented
-    def upload():  # type: () -> None
+    def upload() -> None:
         pass

--- a/ddtrace/internal/datadog/profiling/utils.py
+++ b/ddtrace/internal/datadog/profiling/utils.py
@@ -8,8 +8,7 @@ LOG = get_logger(__name__)
 
 
 # 3.11 and above
-def _sanitize_string_check(value):
-    # type: (Any) -> str
+def _sanitize_string_check(value: Any) -> str:
     if isinstance(value, str):
         return value
     elif value is None:
@@ -22,8 +21,7 @@ def _sanitize_string_check(value):
 
 
 # 3.10 and below (the noop version)
-def _sanitize_string_identity(value):
-    # type: (Any) -> str
+def _sanitize_string_identity(value: Any) -> str:
     return value or ""
 
 

--- a/ddtrace/internal/datastreams/encoding.py
+++ b/ddtrace/internal/datastreams/encoding.py
@@ -7,19 +7,16 @@ from .fnv import _get_byte
 MAX_VAR_LEN_64 = 9
 
 
-def encode_var_int_64(v):
-    # type: (int) -> bytes
+def encode_var_int_64(v: int) -> bytes:
     return encode_var_uint_64(v >> (64 - 1) ^ (v << 1))
 
 
-def decode_var_int_64(b):
-    # type: (bytes) -> Tuple[int, bytes]
+def decode_var_int_64(b: bytes) -> Tuple[int, bytes]:
     v, b = decode_var_uint_64(b)
     return (v >> 1) ^ -(v & 1), b
 
 
-def encode_var_uint_64(v):
-    # type: (int) -> bytes
+def encode_var_uint_64(v: int) -> bytes:
     b = b""
     for _ in range(0, MAX_VAR_LEN_64):
         if v < 0x80:
@@ -30,8 +27,7 @@ def encode_var_uint_64(v):
     return b
 
 
-def decode_var_uint_64(b):
-    # type: (bytes) -> Tuple[int, bytes]
+def decode_var_uint_64(b: bytes) -> Tuple[int, bytes]:
     x = 0
     s = 0
     for i in range(0, MAX_VAR_LEN_64):

--- a/ddtrace/internal/datastreams/fnv.py
+++ b/ddtrace/internal/datastreams/fnv.py
@@ -19,8 +19,7 @@ else:
     _get_byte = ord
 
 
-def fnv(data, hval_init, fnv_prime, fnv_size):
-    # type: (bytes, int, int, int) -> int
+def fnv(data: bytes, hval_init: int, fnv_prime: int, fnv_size: int) -> int:
     """
     Core FNV hash algorithm used in FNV0 and FNV1.
     """
@@ -31,8 +30,7 @@ def fnv(data, hval_init, fnv_prime, fnv_size):
     return hval
 
 
-def fnv1_64(data):
-    # type: (bytes) -> int
+def fnv1_64(data: bytes) -> int:
     """
     Returns the 64 bit FNV-1 hash value for the given data.
     """

--- a/ddtrace/internal/debug.py
+++ b/ddtrace/internal/debug.py
@@ -31,8 +31,7 @@ logger = get_logger(__name__)
 architecture = callonce(lambda: platform.architecture())
 
 
-def in_venv():
-    # type: () -> bool
+def in_venv() -> bool:
     # Works with both venv and virtualenv
     # https://stackoverflow.com/a/42580137
     return (
@@ -42,14 +41,12 @@ def in_venv():
     )
 
 
-def tags_to_str(tags):
-    # type: (Dict[str, Any]) -> str
+def tags_to_str(tags: Dict[str, Any]) -> str:
     # Turn a dict of tags to a string "k1:v1,k2:v2,..."
     return ",".join(["%s:%s" % (k, v) for k, v in tags.items()])
 
 
-def collect(tracer):
-    # type: (Tracer) -> Dict[str, Any]
+def collect(tracer: Tracer) -> Dict[str, Any]:
     """Collect system and library information into a serializable dict."""
 
     from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker
@@ -78,7 +75,7 @@ def collect(tracer):
     is_venv = in_venv()
 
     packages_available = {p.name: p.version for p in get_distributions()}
-    integration_configs = {}  # type: Dict[str, Union[Dict[str, Any], str]]
+    integration_configs: Dict[str, Union[Dict[str, Any], str]] = {}
     for module, enabled in ddtrace._monkey.PATCH_MODULES.items():
         # TODO: this check doesn't work in all cases... we need a mapping
         #       between the module and the library name.

--- a/ddtrace/internal/dogstatsd.py
+++ b/ddtrace/internal/dogstatsd.py
@@ -6,8 +6,7 @@ from ddtrace.vendor.dogstatsd import DogStatsd
 from ddtrace.vendor.dogstatsd import base
 
 
-def get_dogstatsd_client(url, namespace=None, tags=None):
-    # type: (str, Optional[str], Optional[List[str]]) -> DogStatsd
+def get_dogstatsd_client(url: str, namespace: Optional[str] = None, tags: Optional[List[str]] = None) -> DogStatsd:
     # url can be either of the form `udp://<host>:<port>` or `unix://<path>`
     # also support without url scheme included
     if url.startswith("/"):

--- a/ddtrace/internal/encoding.py
+++ b/ddtrace/internal/encoding.py
@@ -29,8 +29,7 @@ class _EncoderBase(object):
     Encoder interface that provides the logic to encode traces and service.
     """
 
-    def encode_traces(self, traces):
-        # type: (List[List[Span]]) -> str
+    def encode_traces(self, traces: List[List[Span]]) -> str:
         """
         Encodes a list of traces, expecting a list of items where each items
         is a list of spans. Before dumping the string in a serialized format all
@@ -41,8 +40,7 @@ class _EncoderBase(object):
         """
         raise NotImplementedError()
 
-    def encode(self, obj):
-        # type: (List[List[Any]]) -> str
+    def encode(self, obj: List[List[Any]]) -> str:
         """
         Defines the underlying format used during traces or services encoding.
         This method must be implemented and should only be used by the internal
@@ -51,8 +49,7 @@ class _EncoderBase(object):
         raise NotImplementedError()
 
     @staticmethod
-    def _span_to_dict(span):
-        # type: (Span) -> Dict[str, Any]
+    def _span_to_dict(span: Span) -> Dict[str, Any]:
         d = {
             "trace_id": span._trace_id_64bits,
             "parent_id": span.parent_id,
@@ -126,14 +123,12 @@ class JSONEncoderV2(JSONEncoder):
 
     content_type = "application/json"
 
-    def encode_traces(self, traces):
-        # type: (List[List[Span]]) -> str
+    def encode_traces(self, traces: List[List[Span]]) -> str:
         normalized_traces = [[JSONEncoderV2._convert_span(span) for span in trace] for trace in traces]
         return self.encode({"traces": normalized_traces})
 
     @staticmethod
-    def _convert_span(span):
-        # type: (Span) -> Dict[str, Any]
+    def _convert_span(span: Span) -> Dict[str, Any]:
         sp = JSONEncoderV2._span_to_dict(span)
         sp = JSONEncoderV2._normalize_span(sp)
         sp["trace_id"] = JSONEncoderV2._encode_id_to_hex(sp.get("trace_id"))
@@ -142,15 +137,13 @@ class JSONEncoderV2(JSONEncoder):
         return sp
 
     @staticmethod
-    def _encode_id_to_hex(dd_id):
-        # type: (Optional[int]) -> str
+    def _encode_id_to_hex(dd_id: Optional[int]) -> str:
         if not dd_id:
             return "0000000000000000"
         return "%0.16X" % int(dd_id)
 
     @staticmethod
-    def _decode_id_to_hex(hex_id):
-        # type: (Optional[str]) -> int
+    def _decode_id_to_hex(hex_id: Optional[str]) -> int:
         if not hex_id:
             return 0
         return int(hex_id, 16)

--- a/ddtrace/internal/gitmetadata.py
+++ b/ddtrace/internal/gitmetadata.py
@@ -9,7 +9,7 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import formats
 
 
-_GITMETADATA_TAGS = None  # type: typing.Optional[typing.Tuple[str, str]]
+_GITMETADATA_TAGS: typing.Optional[typing.Tuple[str, str]] = None
 
 log = get_logger(__name__)
 
@@ -33,8 +33,7 @@ class GitMetadataConfig(Env):
     tags = Env.var(str, "tags", default="")
 
 
-def _get_tags_from_env(config):
-    # type: (GitMetadataConfig) -> typing.Tuple[str, str]
+def _get_tags_from_env(config: GitMetadataConfig) -> typing.Tuple[str, str]:
     """
     Get git metadata from environment variables.
     Returns tuple (repository_url, commit_sha)
@@ -53,8 +52,7 @@ def _get_tags_from_env(config):
     return filtered_git_url, commit_sha
 
 
-def _get_tags_from_package(config):
-    # type: (GitMetadataConfig) -> typing.Tuple[str, str]
+def _get_tags_from_package(config: GitMetadataConfig) -> typing.Tuple[str, str]:
     """
     Extracts git metadata from python package's medatada field Project-URL:
     e.g: Project-URL: source_code_link, https://github.com/user/repo#gitcommitsha&someoptions
@@ -87,8 +85,7 @@ def _get_tags_from_package(config):
         return "", ""
 
 
-def get_git_tags():
-    # type: () -> typing.Tuple[str, str]
+def get_git_tags() -> typing.Tuple[str, str]:
     """
     Returns git metadata tags tuple (repository_url, commit_sha)
     """
@@ -121,8 +118,7 @@ def get_git_tags():
         return "", ""
 
 
-def clean_tags(tags):
-    # type: (typing.Dict[str, str]) -> typing.Dict[str, str]
+def clean_tags(tags: typing.Dict[str, str]) -> typing.Dict[str, str]:
     """
     Cleanup tags from git metadata
     """

--- a/ddtrace/internal/glob_matching.py
+++ b/ddtrace/internal/glob_matching.py
@@ -8,13 +8,11 @@ class GlobMatcher(object):
     The match method will be cached for quicker matching and is in a class to keep it from being global.
     """
 
-    def __init__(self, pattern):
-        # type: (str) -> None
+    def __init__(self, pattern: str) -> None:
         self.pattern = pattern
 
     @cachedmethod()
-    def match(self, subject):
-        # type: (str) -> bool
+    def match(self, subject: str) -> bool:
         pattern = self.pattern
         px = 0  # [p]attern inde[x]
         sx = 0  # [s]ubject inde[x]

--- a/ddtrace/internal/hostname.py
+++ b/ddtrace/internal/hostname.py
@@ -2,11 +2,10 @@ import os
 import socket
 
 
-_hostname = os.getenv("DD_HOSTNAME", "")  # type: str
+_hostname: str = os.getenv("DD_HOSTNAME", "")
 
 
-def get_hostname():
-    # type: () -> str
+def get_hostname() -> str:
     global _hostname
     if not _hostname:
         _hostname = socket.gethostname()

--- a/ddtrace/internal/http.py
+++ b/ddtrace/internal/http.py
@@ -7,10 +7,9 @@ class BasePathMixin(httplib.HTTPConnection, object):
     Mixin for HTTPConnection to insert a base path to requested URLs
     """
 
-    _base_path = "/"  # type: str
+    _base_path: str = "/"
 
-    def putrequest(self, method, url, skip_host=False, skip_accept_encoding=False):
-        # type: (str, str, bool, bool) -> None
+    def putrequest(self, method: str, url: str, skip_host: bool = False, skip_accept_encoding: bool = False) -> None:
         url = parse.urljoin(self._base_path, url)
         return super(BasePathMixin, self).putrequest(
             method, url, skip_host=skip_host, skip_accept_encoding=skip_accept_encoding

--- a/ddtrace/internal/injection.py
+++ b/ddtrace/internal/injection.py
@@ -60,8 +60,7 @@ else:
 _INJECT_HOOK_OPCODES = [_.name for _ in INJECTION_ASSEMBLY]
 
 
-def _inject_hook(code, hook, lineno, arg):
-    # type: (Bytecode, HookType, int, Any) -> None
+def _inject_hook(code: Bytecode, hook: HookType, lineno: int, arg: Any) -> None:
     """Inject a hook at the given line number inside an abstract code object.
 
     The hook is called with the given argument, which is also used as an
@@ -73,7 +72,7 @@ def _inject_hook(code, hook, lineno, arg):
     # occurrences and inject the hook at each of them. An example of when this
     # happens is with finally blocks, which are duplicated at the end of the
     # bytecode.
-    locs = deque()  # type: Deque[int]
+    locs: Deque[int] = deque()
     last_lineno = None
     for i, instr in enumerate(code):
         try:
@@ -104,14 +103,13 @@ _INJECT_HOOK_OPCODE_POS = 0 if PY < (3, 11) else 1
 _INJECT_ARG_OPCODE_POS = 1 if PY < (3, 11) else 2
 
 
-def _eject_hook(code, hook, line, arg):
-    # type: (Bytecode, HookType, int, Any) -> None
+def _eject_hook(code: Bytecode, hook: HookType, line: int, arg: Any) -> None:
     """Eject a hook from the abstract code object at the given line number.
 
     The hook is identified by its argument. This ensures that only the right
     hook is ejected.
     """
-    locs = deque()  # type: Deque[int]
+    locs: Deque[int] = deque()
     for i, instr in enumerate(code):
         try:
             # DEV: We look at the expected opcode pattern to match the injected
@@ -141,8 +139,7 @@ def _function_with_new_code(f, abstract_code):
     return f
 
 
-def inject_hooks(f, hooks):
-    # type: (FunctionType, List[HookInfoType]) -> List[HookInfoType]
+def inject_hooks(f: FunctionType, hooks: List[HookInfoType]) -> List[HookInfoType]:
     """Bulk-inject a list of hooks into a function.
 
     Hooks are specified via a list of tuples, where each tuple contains the hook
@@ -165,8 +162,7 @@ def inject_hooks(f, hooks):
     return failed
 
 
-def eject_hooks(f, hooks):
-    # type: (FunctionType, List[HookInfoType]) -> List[HookInfoType]
+def eject_hooks(f: FunctionType, hooks: List[HookInfoType]) -> List[HookInfoType]:
     """Bulk-eject a list of hooks from a function.
 
     The hooks are specified via a list of tuples, where each tuple contains the
@@ -189,8 +185,7 @@ def eject_hooks(f, hooks):
     return failed
 
 
-def inject_hook(f, hook, line, arg):
-    # type: (FunctionType, HookType, int, Any) -> FunctionType
+def inject_hook(f: FunctionType, hook: HookType, line: int, arg: Any) -> FunctionType:
     """Inject a hook into a function.
 
     The hook is injected at the given line number and called with the given
@@ -204,8 +199,7 @@ def inject_hook(f, hook, line, arg):
     return _function_with_new_code(f, abstract_code)
 
 
-def eject_hook(f, hook, line, arg):
-    # type: (FunctionType, HookType, int, Any) -> FunctionType
+def eject_hook(f: FunctionType, hook: HookType, line: int, arg: Any) -> FunctionType:
     """Eject a hook from a function.
 
     The hook is identified by its line number and the argument passed to the

--- a/ddtrace/internal/log_writer.py
+++ b/ddtrace/internal/log_writer.py
@@ -47,18 +47,17 @@ class V2LogWriter(PeriodicService):
         - https://docs.datadoghq.com/api/v2/logs/#send-logs
     """
 
-    def __init__(self, site, api_key, interval, timeout):
-        # type: (str, str, float, float) -> None
+    def __init__(self, site: str, api_key: str, interval: float, timeout: float) -> None:
         super(V2LogWriter, self).__init__(interval=interval)
         self._lock = forksafe.RLock()
-        self._buffer = []  # type: List[V2LogEvent]
+        self._buffer: List[V2LogEvent] = []
         # match the API limit
         self._buffer_limit = 1000
-        self._timeout = timeout  # type: float
-        self._api_key = api_key  # type: str
-        self._endpoint = "/api/v2/logs"  # type: str
-        self._site = site  # type: str
-        self._intake = "http-intake.logs.%s" % self._site  # type: str
+        self._timeout: float = timeout
+        self._api_key: str = api_key
+        self._endpoint: str = "/api/v2/logs"
+        self._site: str = site
+        self._intake: str = "http-intake.logs.%s" % self._site
         self._headers = {
             "DD-API-KEY": self._api_key,
             "Content-Type": "application/json",
@@ -69,8 +68,7 @@ class V2LogWriter(PeriodicService):
         super(V2LogWriter, self).start()
         atexit.register(self.on_shutdown)
 
-    def enqueue(self, log):
-        # type: (V2LogEvent) -> None
+    def enqueue(self, log: V2LogEvent) -> None:
         with self._lock:
             if len(self._buffer) >= self._buffer_limit:
                 logger.warning("log buffer full (limit is %d), dropping log", self._buffer_limit)
@@ -81,12 +79,10 @@ class V2LogWriter(PeriodicService):
         self.periodic()
 
     @property
-    def _url(self):
-        # type: () -> str
+    def _url(self) -> str:
         return "https://%s%s" % (self._intake, self._endpoint)
 
-    def periodic(self):
-        # type: () -> None
+    def periodic(self) -> None:
         with self._lock:
             if not self._buffer:
                 return

--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -11,8 +11,7 @@ if typing.TYPE_CHECKING:
     from typing import Tuple
 
 
-def get_logger(name):
-    # type: (str) -> DDLogger
+def get_logger(name: str) -> DDLogger:
     """
     Retrieve or create a ``DDLogger`` instance.
 
@@ -63,8 +62,7 @@ def get_logger(name):
     return cast(DDLogger, logger)
 
 
-def hasHandlers(self):
-    # type: (DDLogger) -> bool
+def hasHandlers(self: DDLogger) -> bool:
     """
     See if this logger has any handlers configured.
     Loop through all handlers for this logger and its parents in the
@@ -99,15 +97,14 @@ class DDLogger(logging.Logger):
     # Named tuple used for keeping track of a log lines current time bucket and the number of log lines skipped
     LoggingBucket = collections.namedtuple("LoggingBucket", ("bucket", "skipped"))
 
-    def __init__(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Constructor for ``DDLogger``"""
         super(DDLogger, self).__init__(*args, **kwargs)
 
         # Dict to keep track of the current time bucket per name/level/pathname/lineno
-        self.buckets = collections.defaultdict(
+        self.buckets: DefaultDict[Tuple[str, int, str, int], DDLogger.LoggingBucket] = collections.defaultdict(
             lambda: DDLogger.LoggingBucket(0, 0)
-        )  # type: DefaultDict[Tuple[str, int, str, int], DDLogger.LoggingBucket]
+        )
 
         # Allow 1 log record per name/level/pathname/lineno every 60 seconds by default
         # Allow configuring via `DD_TRACE_LOGGING_RATE`
@@ -119,8 +116,7 @@ class DDLogger(logging.Logger):
         else:
             self.rate_limit = 60
 
-    def handle(self, record):
-        # type: (logging.LogRecord) -> None
+    def handle(self, record: logging.LogRecord) -> None:
         """
         Function used to call the handlers for a log line.
 

--- a/ddtrace/internal/metrics.py
+++ b/ddtrace/internal/metrics.py
@@ -24,8 +24,7 @@ class Metrics(object):
             >>> writer_meter.increment('success')  # won't be emitted
     """
 
-    def __init__(self, dogstats_url=None, namespace=None):
-        # type: (Optional[str], Optional[str]) -> None
+    def __init__(self, dogstats_url: Optional[str] = None, namespace: Optional[str] = None) -> None:
         self.dogstats_url = dogstats_url
         self.namespace = namespace
         self.enabled = False
@@ -33,13 +32,11 @@ class Metrics(object):
         self._client = get_dogstatsd_client(dogstats_url or agent.get_stats_url(), namespace=namespace)
 
     class Meter(object):
-        def __init__(self, metrics, name):
-            # type: (Metrics, str) -> None
+        def __init__(self, metrics: Metrics, name: str) -> None:
             self.metrics = metrics
             self.name = name
 
-        def increment(self, name, value=1.0, tags=None):
-            # type: (str, float, Optional[Dict[str, str]]) -> None
+        def increment(self, name: str, value: float = 1.0, tags: Optional[Dict[str, str]] = None) -> None:
             if not self.metrics.enabled:
                 return None
 
@@ -47,8 +44,7 @@ class Metrics(object):
                 ".".join((self.name, name)), value, [":".join(_) for _ in tags.items()] if tags else None
             )
 
-        def gauge(self, name, value=1.0, tags=None):
-            # type: (str, float, Optional[Dict[str, str]]) -> None
+        def gauge(self, name: str, value: float = 1.0, tags: Optional[Dict[str, str]] = None) -> None:
             if not self.metrics.enabled:
                 return None
 
@@ -56,8 +52,7 @@ class Metrics(object):
                 ".".join((self.name, name)), value, [":".join(_) for _ in tags.items()] if tags else None
             )
 
-        def histogram(self, name, value=1.0, tags=None):
-            # type: (str, float, Optional[Dict[str, str]]) -> None
+        def histogram(self, name: str, value: float = 1.0, tags: Optional[Dict[str, str]] = None) -> None:
             if not self.metrics.enabled:
                 return None
 
@@ -65,8 +60,7 @@ class Metrics(object):
                 ".".join((self.name, name)), value, [":".join(_) for _ in tags.items()] if tags else None
             )
 
-        def distribution(self, name, value=1.0, tags=None):
-            # type: (str, float, Optional[Dict[str, str]]) -> None
+        def distribution(self, name: str, value: float = 1.0, tags: Optional[Dict[str, str]] = None) -> None:
             if not self.metrics.enabled:
                 return None
 
@@ -74,14 +68,11 @@ class Metrics(object):
                 ".".join((self.name, name)), value, [":".join(_) for _ in tags.items()] if tags else None
             )
 
-    def enable(self):
-        # type: () -> None
+    def enable(self) -> None:
         self.enabled = True
 
-    def disable(self):
-        # type: () -> None
+    def disable(self) -> None:
         self.enabled = False
 
-    def get_meter(self, name):
-        # type: (str) -> Metrics.Meter
+    def get_meter(self, name: str) -> Metrics.Meter:
         return self.Meter(self, name)

--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -63,8 +63,7 @@ Distribution = t.NamedTuple("Distribution", [("name", str), ("version", str), ("
 
 
 @callonce
-def get_distributions():
-    # type: () -> t.Set[Distribution]
+def get_distributions() -> t.Set[Distribution]:
     """returns the name and version of all distributions in a python path"""
     try:
         import importlib.metadata as importlib_metadata
@@ -86,14 +85,12 @@ def get_distributions():
     return pkgs
 
 
-def _is_python_source_file(path):
-    # type: (pathlib.PurePath) -> bool
+def _is_python_source_file(path: pathlib.PurePath) -> bool:
     return os.path.splitext(path.name)[-1].lower() in SUPPORTED_EXTENSIONS
 
 
 @callonce
-def _package_file_mapping():
-    # type: (...) -> t.Optional[t.Dict[str, Distribution]]
+def _package_file_mapping() -> t.Optional[t.Dict[str, Distribution]]:
     try:
         import importlib.metadata as il_md
     except ImportError:
@@ -120,8 +117,7 @@ def _package_file_mapping():
         return None
 
 
-def filename_to_package(filename):
-    # type: (str) -> t.Optional[Distribution]
+def filename_to_package(filename: str) -> t.Optional[Distribution]:
     mapping = _package_file_mapping()
     if mapping is None:
         return None
@@ -133,6 +129,5 @@ def filename_to_package(filename):
     return mapping.get(filename)
 
 
-def is_third_party(filename):
-    # type: (str) -> bool
+def is_third_party(filename: str) -> bool:
     return filename_to_package(filename) is not None

--- a/ddtrace/internal/periodic.py
+++ b/ddtrace/internal/periodic.py
@@ -21,12 +21,11 @@ class PeriodicThread(threading.Thread):
 
     def __init__(
         self,
-        interval,  # type: float
-        target,  # type: typing.Callable[[], typing.Any]
-        name=None,  # type: typing.Optional[str]
-        on_shutdown=None,  # type: typing.Optional[typing.Callable[[], typing.Any]]
-    ):
-        # type: (...) -> None
+        interval: float,
+        target: typing.Callable[[], typing.Any],
+        name: typing.Optional[str] = None,
+        on_shutdown: typing.Optional[typing.Callable[[], typing.Any]] = None,
+    ) -> None:
         """Create a periodic thread.
 
         :param interval: The interval in seconds to wait between execution of the periodic function.
@@ -67,12 +66,11 @@ class AwakeablePeriodicThread(PeriodicThread):
 
     def __init__(
         self,
-        interval,  # type: float
-        target,  # type: typing.Callable[[], typing.Any]
-        name=None,  # type: typing.Optional[str]
-        on_shutdown=None,  # type: typing.Optional[typing.Callable[[], typing.Any]]
-    ):
-        # type: (...) -> None
+        interval: float,
+        target: typing.Callable[[], typing.Any],
+        name: typing.Optional[str] = None,
+        on_shutdown: typing.Optional[typing.Callable[[], typing.Any]] = None,
+    ) -> None:
         """Create a periodic thread that can be awakened on demand."""
         super(AwakeablePeriodicThread, self).__init__(interval, target, name, on_shutdown)
         self.request = forksafe.Event()
@@ -115,23 +113,20 @@ class PeriodicService(service.Service):
     __thread_class__ = PeriodicThread
 
     @property
-    def interval(self):
-        # type: (...) -> float
+    def interval(self) -> float:
         return self._interval
 
     @interval.setter
     def interval(
         self,
-        value,  # type: float
-    ):
-        # type: (...) -> None
+        value: float,
+    ) -> None:
         self._interval = value
         # Update the interval of the PeriodicThread based on ours
         if self._worker:
             self._worker.interval = value
 
-    def _start_service(self, *args, **kwargs):
-        # type: (typing.Any, typing.Any) -> None
+    def _start_service(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         """Start the periodic service."""
         self._worker = self.__thread_class__(
             self.interval,
@@ -141,17 +136,15 @@ class PeriodicService(service.Service):
         )
         self._worker.start()
 
-    def _stop_service(self, *args, **kwargs):
-        # type: (typing.Any, typing.Any) -> None
+    def _stop_service(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         """Stop the periodic collector."""
         self._worker.stop()
         super(PeriodicService, self)._stop_service(*args, **kwargs)
 
     def join(
         self,
-        timeout=None,  # type: typing.Optional[float]
-    ):
-        # type: (...) -> None
+        timeout: typing.Optional[float] = None,
+    ) -> None:
         if self._worker:
             self._worker.join(timeout)
 
@@ -159,8 +152,7 @@ class PeriodicService(service.Service):
     def on_shutdown():
         pass
 
-    def periodic(self):
-        # type: (...) -> None
+    def periodic(self) -> None:
         pass
 
 
@@ -169,6 +161,5 @@ class AwakeablePeriodicService(PeriodicService):
 
     __thread_class__ = AwakeablePeriodicThread
 
-    def awake(self):
-        # type: (...) -> None
+    def awake(self) -> None:
         self._worker.awake()

--- a/ddtrace/internal/processor/__init__.py
+++ b/ddtrace/internal/processor/__init__.py
@@ -16,10 +16,9 @@ log = get_logger(__name__)
 class SpanProcessor(six.with_metaclass(abc.ABCMeta)):
     """A Processor is used to process spans as they are created and finished by a tracer."""
 
-    __processors__ = []  # type: List["SpanProcessor"]
+    __processors__: List["SpanProcessor"] = []
 
-    def __attrs_post_init__(self):
-        # type: () -> None
+    def __attrs_post_init__(self) -> None:
         """Default post initializer which logs the representation of the
         Processor at the ``logging.DEBUG`` level.
 
@@ -34,8 +33,7 @@ class SpanProcessor(six.with_metaclass(abc.ABCMeta)):
         log.debug("initialized processor %r", self)
 
     @abc.abstractmethod
-    def on_span_start(self, span):
-        # type: (Span) -> None
+    def on_span_start(self, span: Span) -> None:
         """Called when a span is started.
 
         This method is useful for making upfront decisions on spans.
@@ -46,8 +44,7 @@ class SpanProcessor(six.with_metaclass(abc.ABCMeta)):
         pass
 
     @abc.abstractmethod
-    def on_span_finish(self, span):
-        # type: (Span) -> None
+    def on_span_finish(self, span: Span) -> None:
         """Called with the result of any previous processors or initially with
         the finishing span when a span finishes.
 
@@ -56,21 +53,18 @@ class SpanProcessor(six.with_metaclass(abc.ABCMeta)):
         """
         pass
 
-    def shutdown(self, timeout):
-        # type: (Optional[float]) -> None
+    def shutdown(self, timeout: Optional[float]) -> None:
         """Called when the processor is done being used.
 
         Any clean-up or flushing should be performed with this method.
         """
         pass
 
-    def register(self):
-        # type: () -> None
+    def register(self) -> None:
         """Register the processor with the global list of processors."""
         SpanProcessor.__processors__.append(self)
 
-    def unregister(self):
-        # type: () -> None
+    def unregister(self) -> None:
         """Unregister the processor from the global list of processors."""
         try:
             SpanProcessor.__processors__.remove(self)

--- a/ddtrace/internal/processor/endpoint_call_counter.py
+++ b/ddtrace/internal/processor/endpoint_call_counter.py
@@ -18,16 +18,13 @@ class EndpointCallCounterProcessor(SpanProcessor):
     _endpoint_counts_lock = attr.ib(init=False, repr=False, factory=forksafe.Lock, eq=False)
     _enabled = attr.ib(default=False, repr=False, eq=False)
 
-    def enable(self):
-        # type: () -> None
+    def enable(self) -> None:
         self._enabled = True
 
-    def on_span_start(self, span):
-        # type: (Span) -> None
+    def on_span_start(self, span: Span) -> None:
         pass
 
-    def on_span_finish(self, span):
-        # type: (Span) -> None
+    def on_span_finish(self, span: Span) -> None:
         if not self._enabled:
             return
         if span._local_root == span and span.span_type == SpanTypes.WEB:
@@ -35,8 +32,7 @@ class EndpointCallCounterProcessor(SpanProcessor):
             with self._endpoint_counts_lock:
                 self.endpoint_counts[resource] = self.endpoint_counts.get(resource, 0) + 1
 
-    def reset(self):
-        # type: () -> EndpointCountsType
+    def reset(self) -> EndpointCountsType:
         with self._endpoint_counts_lock:
             counts = self.endpoint_counts
             self.endpoint_counts = {}

--- a/ddtrace/internal/rate_limiter.py
+++ b/ddtrace/internal/rate_limiter.py
@@ -29,8 +29,7 @@ class RateLimiter(object):
         "tokens_total",
     )
 
-    def __init__(self, rate_limit):
-        # type: (int) -> None
+    def __init__(self, rate_limit: int) -> None:
         """
         Constructor for RateLimiter
 
@@ -41,15 +40,15 @@ class RateLimiter(object):
         :type rate_limit: :obj:`int`
         """
         self.rate_limit = rate_limit
-        self.tokens = rate_limit  # type: float
+        self.tokens: float = rate_limit
         self.max_tokens = rate_limit
 
         self.last_update_ns = compat.monotonic_ns()
 
-        self.current_window_ns = 0  # type: float
+        self.current_window_ns: float = 0
         self.tokens_allowed = 0
         self.tokens_total = 0
-        self.prev_window_rate = None  # type: Optional[float]
+        self.prev_window_rate: Optional[float] = None
 
         self._lock = threading.Lock()
 
@@ -57,8 +56,7 @@ class RateLimiter(object):
     def _has_been_configured(self):
         return self.rate_limit != DEFAULT_SAMPLING_RATE_LIMIT
 
-    def is_allowed(self, timestamp_ns):
-        # type: (int) -> bool
+    def is_allowed(self, timestamp_ns: int) -> bool:
         """
         Check whether the current request is allowed or not
 
@@ -74,8 +72,7 @@ class RateLimiter(object):
         self._update_rate_counts(allowed, timestamp_ns)
         return allowed
 
-    def _update_rate_counts(self, allowed, timestamp_ns):
-        # type: (bool, int) -> None
+    def _update_rate_counts(self, allowed: bool, timestamp_ns: int) -> None:
         # No tokens have been seen yet, start a new window
         if not self.current_window_ns:
             self.current_window_ns = timestamp_ns
@@ -94,8 +91,7 @@ class RateLimiter(object):
             self.tokens_allowed += 1
         self.tokens_total += 1
 
-    def _is_allowed(self, timestamp_ns):
-        # type: (int) -> bool
+    def _is_allowed(self, timestamp_ns: int) -> bool:
         # Rate limit of 0 blocks everything
         if self.rate_limit == 0:
             return False
@@ -114,8 +110,7 @@ class RateLimiter(object):
 
             return False
 
-    def _replenish(self, timestamp_ns):
-        # type: (int) -> None
+    def _replenish(self, timestamp_ns: int) -> None:
         try:
             # If we are at the max, we do not need to add any more
             if self.tokens == self.max_tokens:
@@ -136,8 +131,7 @@ class RateLimiter(object):
             self.tokens + (elapsed * self.rate_limit),
         )
 
-    def _current_window_rate(self):
-        # type: () -> float
+    def _current_window_rate(self) -> float:
         # No tokens have been seen, effectively 100% sample rate
         # DEV: This is to avoid division by zero error
         if not self.tokens_total:
@@ -147,8 +141,7 @@ class RateLimiter(object):
         return self.tokens_allowed / self.tokens_total
 
     @property
-    def effective_rate(self):
-        # type: () -> float
+    def effective_rate(self) -> float:
         """
         Return the effective sample rate of this rate limiter
 
@@ -220,8 +213,7 @@ class BudgetRateLimiterWithJitter(object):
             self.budget = self.max_budget = 1.0
         self._on_exceed_called = False
 
-    def limit(self, f=None, *args, **kwargs):
-        # type: (Optional[Callable[..., Any]], *Any, **Any) -> Any
+    def limit(self, f: Optional[Callable[..., Any]] = None, *args: Any, **kwargs: Any) -> Any:
         """Make rate-limited calls to a function with the given arguments."""
         should_call = False
         with self._lock:
@@ -249,8 +241,7 @@ class BudgetRateLimiterWithJitter(object):
         else:
             return RateLimitExceeded
 
-    def __call__(self, f):
-        # type: (Callable[..., Any]) -> Callable[..., Any]
+    def __call__(self, f: Callable[..., Any]) -> Callable[..., Any]:
         def limited_f(*args, **kwargs):
             return self.limit(f, *args, **kwargs)
 

--- a/ddtrace/internal/remoteconfig/_connectors.py
+++ b/ddtrace/internal/remoteconfig/_connectors.py
@@ -24,8 +24,7 @@ SharedDataType = Mapping[str, Any]
 
 
 class UUIDEncoder(json.JSONEncoder):
-    def default(self, obj):
-        # type: (Any) -> Any
+    def default(self, obj: Any) -> Any:
         if isinstance(obj, UUID):
             # if the obj is uuid, we simply return the value of uuid
             return obj.hex
@@ -46,12 +45,10 @@ class PublisherSubscriberConnector(object):
         self.shared_data_counter = 0
 
     @staticmethod
-    def _hash_config(config_raw, metadata_raw):
-        # type: (Any, Any) -> int
+    def _hash_config(config_raw: Any, metadata_raw: Any) -> int:
         return hash(str(config_raw) + str(metadata_raw))
 
-    def read(self):
-        # type: () -> SharedDataType
+    def read(self) -> SharedDataType:
         config_raw = to_unicode(self.data.value)
         config = json.loads(config_raw) if config_raw else {}
         if config:
@@ -61,8 +58,7 @@ class PublisherSubscriberConnector(object):
                 return config
         return {}
 
-    def write(self, metadata, config_raw):
-        # type: (Any, Any) -> None
+    def write(self, metadata: Any, config_raw: Any) -> None:
         last_checksum = self._hash_config(config_raw, metadata)
         if last_checksum != self.checksum:
             data_len = len(self.data.value)
@@ -80,8 +76,7 @@ class PublisherSubscriberConnector(object):
             self.checksum = last_checksum
 
     @staticmethod
-    def serialize(metadata, config_raw, shared_data_counter):
-        # type: (Any, Dict[str, Any], int) -> bytes
+    def serialize(metadata: Any, config_raw: Dict[str, Any], shared_data_counter: int) -> bytes:
         if PY2:
             data = bytes(
                 json.dumps(

--- a/ddtrace/internal/remoteconfig/_publishers.py
+++ b/ddtrace/internal/remoteconfig/_publishers.py
@@ -25,19 +25,16 @@ log = get_logger(__name__)
 
 
 class RemoteConfigPublisherBase(six.with_metaclass(abc.ABCMeta)):
-    _preprocess_results_func = None  # type: Optional[PreprocessFunc]
+    _preprocess_results_func: Optional[PreprocessFunc] = None
 
-    def __init__(self, data_connector, preprocess_func=None):
-        # type: (PublisherSubscriberConnector, Optional[PreprocessFunc]) -> None
+    def __init__(self, data_connector: PublisherSubscriberConnector, preprocess_func: Optional[PreprocessFunc] = None) -> None:
         self._data_connector = data_connector
         self._preprocess_results_func = preprocess_func
 
-    def dispatch(self, pubsub_instance=None):
-        # type: (Optional[Any]) -> None
+    def dispatch(self, pubsub_instance: Optional[Any] = None) -> None:
         raise NotImplementedError
 
-    def append(self, config_content, target, config_metadata):
-        # type: (Optional[Any], str, Optional[Any]) -> None
+    def append(self, config_content: Optional[Any], target: str, config_metadata: Optional[Any]) -> None:
         raise NotImplementedError
 
 
@@ -46,17 +43,14 @@ class RemoteConfigPublisher(RemoteConfigPublisherBase):
     shared them to all process. Dynamic Instrumentation uses this class
     """
 
-    def __init__(self, data_connector, preprocess_func=None):
-        # type: (PublisherSubscriberConnector, Optional[PreprocessFunc]) -> None
+    def __init__(self, data_connector: PublisherSubscriberConnector, preprocess_func: Optional[PreprocessFunc] = None) -> None:
         super(RemoteConfigPublisher, self).__init__(data_connector, preprocess_func)
-        self._config_and_metadata = []  # type: List[Tuple[Optional[Any], Optional[Any]]]
+        self._config_and_metadata: List[Tuple[Optional[Any], Optional[Any]]] = []
 
-    def append(self, config_content, target="", config_metadata=None):
-        # type: (Optional[Any], str, Optional[Any]) -> None
+    def append(self, config_content: Optional[Any], target: str = "", config_metadata: Optional[Any] = None) -> None:
         self._config_and_metadata.append((config_content, config_metadata))
 
-    def dispatch(self, pubsub_instance=None):
-        # type: (Optional[Any]) -> None
+    def dispatch(self, pubsub_instance: Optional[Any] = None) -> None:
         from attr import asdict
 
         # TODO: RemoteConfigPublisher doesn't need _preprocess_results_func callback at this moment. Uncomment those
@@ -79,13 +73,11 @@ class RemoteConfigPublisherMergeDicts(RemoteConfigPublisherBase):
     payloads and send it to the subscriber. ASM uses this class
     """
 
-    def __init__(self, data_connector, preprocess_func):
-        # type: (PublisherSubscriberConnector, PreprocessFunc) -> None
+    def __init__(self, data_connector: PublisherSubscriberConnector, preprocess_func: PreprocessFunc) -> None:
         super(RemoteConfigPublisherMergeDicts, self).__init__(data_connector, preprocess_func)
-        self._configs = {}  # type: Dict[str, Any]
+        self._configs: Dict[str, Any] = {}
 
-    def append(self, config_content, target, config_metadata=None):
-        # type: (Optional[Any], str, Optional[Any]) -> None
+    def append(self, config_content: Optional[Any], target: str, config_metadata: Optional[Any] = None) -> None:
         if not self._configs.get(target):
             self._configs[target] = {}
 
@@ -101,9 +93,8 @@ class RemoteConfigPublisherMergeDicts(RemoteConfigPublisherBase):
             else:
                 raise ValueError("target %s config %s has type of %s" % (target, config_content, type(config_content)))
 
-    def dispatch(self, pubsub_instance=None):
-        # type: (Optional[Any]) -> None
-        config_result = {}  # type: Dict[str, Any]
+    def dispatch(self, pubsub_instance: Optional[Any] = None) -> None:
+        config_result: Dict[str, Any] = {}
         try:
             for _target, config_item in self._configs.items():
                 for key, value in config_item.items():

--- a/ddtrace/internal/remoteconfig/_pubsub.py
+++ b/ddtrace/internal/remoteconfig/_pubsub.py
@@ -80,9 +80,9 @@ log = get_logger(__name__)
 
 
 class PubSub(object):
-    _shared_data = None  # type: PublisherSubscriberConnector
-    _publisher = None  # type: RemoteConfigPublisherBase
-    _subscriber = None  # type: RemoteConfigSubscriber
+    _shared_data: PublisherSubscriberConnector = None
+    _publisher: RemoteConfigPublisherBase = None
+    _subscriber: RemoteConfigSubscriber = None
 
     def start_subscriber(self):
         self._subscriber.start()
@@ -90,24 +90,19 @@ class PubSub(object):
     def restart_subscriber(self, join=False):
         self._subscriber.force_restart(join)
 
-    def _poll_data(self, test_tracer=None):
-        # type: (Optional[Tracer]) -> None
+    def _poll_data(self, test_tracer: Optional[Tracer] = None) -> None:
         self._subscriber._get_data_from_connector_and_exec(test_tracer=test_tracer)
 
-    def stop(self, join=False):
-        # type: (bool) -> None
+    def stop(self, join: bool = False) -> None:
         self._subscriber.stop(join=join)
 
-    def publish(self):
-        # type: () -> None
+    def publish(self) -> None:
         self._publisher.dispatch(self)
 
-    def append_and_publish(self, config_content=None, target="", config_metadata=None):
-        # type: (Optional[Any], str, Optional[Any]) -> None
+    def append_and_publish(self, config_content: Optional[Any] = None, target: str = "", config_metadata: Optional[Any] = None) -> None:
         """Append data to publisher and send the data to subscriber. It's a shortcut for testing purposes"""
         self.append(config_content, target, config_metadata)
         self.publish()
 
-    def append(self, config_content, target, config_metadata):
-        # type: (Optional[Any], str, Optional[Any]) -> None
+    def append(self, config_content: Optional[Any], target: str, config_metadata: Optional[Any]) -> None:
         self._publisher.append(config_content, target, config_metadata)

--- a/ddtrace/internal/remoteconfig/_subscribers.py
+++ b/ddtrace/internal/remoteconfig/_subscribers.py
@@ -22,8 +22,7 @@ log = get_logger(__name__)
 class RemoteConfigSubscriber(object):
     _th_worker = None
 
-    def __init__(self, data_connector, callback, name):
-        # type: (PublisherSubscriberConnector, Callable, str) -> None
+    def __init__(self, data_connector: PublisherSubscriberConnector, callback: Callable, name: str) -> None:
         self._data_connector = data_connector
         self.is_running = False
         self._callback = callback
@@ -31,14 +30,12 @@ class RemoteConfigSubscriber(object):
         log.debug("[%s] Subscriber %s init", os.getpid(), self._name)
         self.interval = get_poll_interval_seconds() / 2
 
-    def _exec_callback(self, data, test_tracer=None):
-        # type: (SharedDataType, Optional[Tracer]) -> None
+    def _exec_callback(self, data: SharedDataType, test_tracer: Optional[Tracer] = None) -> None:
         if data:
             log.debug("[%s] Subscriber %s _exec_callback: %s", os.getpid(), self._name, str(data)[:50])
             self._callback(data, test_tracer=test_tracer)
 
-    def _get_data_from_connector_and_exec(self, test_tracer=None):
-        # type: (Optional[Tracer]) -> None
+    def _get_data_from_connector_and_exec(self, test_tracer: Optional[Tracer] = None) -> None:
         data = self._data_connector.read()
         self._exec_callback(data, test_tracer=test_tracer)
 
@@ -87,8 +84,7 @@ class RemoteConfigSubscriber(object):
         )
         self.start()
 
-    def stop(self, join=False):
-        # type: (bool) -> None
+    def stop(self, join: bool = False) -> None:
         if self._th_worker:
             self.is_running = False
             self._th_worker.stop()

--- a/ddtrace/internal/remoteconfig/utils.py
+++ b/ddtrace/internal/remoteconfig/utils.py
@@ -1,6 +1,5 @@
 from ddtrace import config
 
 
-def get_poll_interval_seconds():
-    # type:() -> float
+def get_poll_interval_seconds() -> float:
     return config._remote_config_poll_interval

--- a/ddtrace/internal/runtime/collector.py
+++ b/ddtrace/internal/runtime/collector.py
@@ -24,12 +24,11 @@ class ValueCollector(object):
 
     enabled = True
     periodic = False
-    required_modules = []  # type: List[str]
-    value = None  # type: Optional[List[Tuple[str, str]]]
+    required_modules: List[str] = []
+    value: Optional[List[Tuple[str, str]]] = None
     value_loaded = False
 
-    def __init__(self, enabled=None, periodic=None, required_modules=None):
-        # type: (Optional[bool], Optional[bool], Optional[List[str]]) -> None
+    def __init__(self, enabled: Optional[bool] = None, periodic: Optional[bool] = None, required_modules: Optional[List[str]] = None) -> None:
         self.enabled = self.enabled if enabled is None else enabled
         self.periodic = self.periodic if periodic is None else periodic
         self.required_modules = self.required_modules if required_modules is None else required_modules
@@ -55,8 +54,7 @@ class ValueCollector(object):
             return None
         return modules
 
-    def collect(self, keys=None):
-        # type: (Optional[Set[str]]) -> Optional[List[Tuple[str, str]]]
+    def collect(self, keys: Optional[Set[str]] = None) -> Optional[List[Tuple[str, str]]]:
         """Returns metrics as collected by `collect_fn`.
 
         :param keys: The keys of the metrics to collect.

--- a/ddtrace/internal/runtime/container.py
+++ b/ddtrace/internal/runtime/container.py
@@ -38,8 +38,7 @@ class CGroupInfo(object):
     )
 
     @classmethod
-    def from_line(cls, line):
-        # type: (str) -> Optional[CGroupInfo]
+    def from_line(cls, line: str) -> Optional[CGroupInfo]:
         """
         Parse a new :class:`CGroupInfo` from the provided line
 
@@ -84,8 +83,7 @@ class CGroupInfo(object):
         return cls(id=id_, groups=groups, path=path, container_id=container_id, controllers=controllers, pod_id=pod_id)
 
 
-def get_container_info(pid="self"):
-    # type: (str) -> Optional[CGroupInfo]
+def get_container_info(pid: str = "self") -> Optional[CGroupInfo]:
     """
     Helper to fetch the current container id, if we are running in a container
 

--- a/ddtrace/internal/runtime/metric_collectors.py
+++ b/ddtrace/internal/runtime/metric_collectors.py
@@ -16,7 +16,7 @@ from .constants import THREAD_COUNT
 
 
 class RuntimeMetricCollector(ValueCollector):
-    value = []  # type: List[Tuple[str, str]]
+    value: List[Tuple[str, str]] = []
     periodic = True
 
 

--- a/ddtrace/internal/runtime/runtime_metrics.py
+++ b/ddtrace/internal/runtime/runtime_metrics.py
@@ -77,17 +77,15 @@ class RuntimeWorker(periodic.PeriodicService):
     _services = attr.ib(type=Set[str], init=False, factory=set)
 
     enabled = False
-    _instance = None  # type: ClassVar[Optional[RuntimeWorker]]
+    _instance: ClassVar[Optional[RuntimeWorker]] = None
     _lock = forksafe.Lock()
 
-    def __attrs_post_init__(self):
-        # type: () -> None
+    def __attrs_post_init__(self) -> None:
         self._dogstatsd_client = get_dogstatsd_client(self.dogstatsd_url or ddtrace.internal.agent.get_stats_url())
         self.tracer = self.tracer or ddtrace.tracer
 
     @classmethod
-    def disable(cls):
-        # type: () -> None
+    def disable(cls) -> None:
         with cls._lock:
             if cls._instance is None:
                 return
@@ -116,8 +114,7 @@ class RuntimeWorker(periodic.PeriodicService):
         cls.enable()
 
     @classmethod
-    def enable(cls, flush_interval=None, tracer=None, dogstatsd_url=None):
-        # type: (Optional[float], Optional[ddtrace.Tracer], Optional[str]) -> None
+    def enable(cls, flush_interval: Optional[float] = None, tracer: Optional[ddtrace.Tracer] = None, dogstatsd_url: Optional[str] = None) -> None:
         with cls._lock:
             if cls._instance is not None:
                 return
@@ -137,8 +134,7 @@ class RuntimeWorker(periodic.PeriodicService):
         # Report status to telemetry
         telemetry.telemetry_writer.add_configuration(TELEMETRY_RUNTIMEMETRICS_ENABLED, True, origin="unknown")
 
-    def flush(self):
-        # type: () -> None
+    def flush(self) -> None:
         # The constant tags for the dogstatsd client needs to updated with any new
         # service(s) that may have been added.
         if self._services != self.tracer._services:
@@ -150,13 +146,11 @@ class RuntimeWorker(periodic.PeriodicService):
                 log.debug("Writing metric %s:%s", key, value)
                 self._dogstatsd_client.distribution(key, value)
 
-    def _stop_service(self):
-        # type: (...) -> None
+    def _stop_service(self) -> None:
         # De-register span hook
         super(RuntimeWorker, self)._stop_service()
 
-    def update_runtime_tags(self):
-        # type: () -> None
+    def update_runtime_tags(self) -> None:
         # DEV: ddstatsd expects tags in the form ['key1:value1', 'key2:value2', ...]
         tags = ["{}:{}".format(k, v) for k, v in RuntimeTags()]
         log.debug("Updating constant tags %s", tags)

--- a/ddtrace/internal/runtime/tag_collectors.py
+++ b/ddtrace/internal/runtime/tag_collectors.py
@@ -13,7 +13,7 @@ from .constants import TRACER_VERSION
 
 class RuntimeTagCollector(ValueCollector):
     periodic = False
-    value = []  # type: List[Tuple[str, str]]
+    value: List[Tuple[str, str]] = []
 
 
 class TracerTagCollector(RuntimeTagCollector):

--- a/ddtrace/internal/safety.py
+++ b/ddtrace/internal/safety.py
@@ -21,8 +21,7 @@ if PY3:
     long = int
 
 
-def _maybe_slots(obj):
-    # type: (Any) -> Union[Tuple[str], List[str]]
+def _maybe_slots(obj: Any) -> Union[Tuple[str], List[str]]:
     try:
         slots = object.__getattribute__(obj, "__slots__")
         if isinstance(slots, str):
@@ -33,19 +32,16 @@ def _maybe_slots(obj):
 
 
 @cached()
-def _slots(_type):
-    # type: (Type) -> Set[str]
+def _slots(_type: Type) -> Set[str]:
     return {_ for cls in object.__getattribute__(_type, "__mro__") for _ in _maybe_slots(cls)}
 
 
-def get_slots(obj):
-    # type: (Any) -> Set[str]
+def get_slots(obj: Any) -> Set[str]:
     """Get the object's slots."""
     return _slots(type(obj))
 
 
-def _isinstance(obj, types):
-    # type: (Any, Union[Type, Tuple[Union[Type, Tuple[Any, ...]], ...]]) -> bool
+def _isinstance(obj: Any, types: Union[Type, Tuple[Union[Type, Tuple[Any, ...]], ...]]) -> bool:
     # DEV: isinstance falls back to calling __getattribute__ which could cause
     # side effects.
     return issubclass(type(obj), types)
@@ -63,33 +59,27 @@ class SafeObjectProxy(wrapt.ObjectProxy):
     calls that can also trigger side-effects.
     """
 
-    def __call__(self, *args, **kwargs):
-        # type: (Any, Any) -> Optional[Any]
+    def __call__(self, *args: Any, **kwargs: Any) -> Optional[Any]:
         raise RuntimeError("Cannot call safe object")
 
-    def __getattribute__(self, name):
-        # type: (str) -> Any
+    def __getattribute__(self, name: str) -> Any:
         if name == "__wrapped__" and not IS_312_OR_NEWER:
             raise AttributeError("Access denied")
 
         return super(SafeObjectProxy, self).__getattribute__(name)
 
-    def __getattr__(self, name):
-        # type: (str) -> Any
+    def __getattr__(self, name: str) -> Any:
         if name == "__wrapped__" and IS_312_OR_NEWER:
             raise AttributeError("Access denied")
         return type(self).safe(super(SafeObjectProxy, self).__getattr__(name))
 
-    def __getitem__(self, item):
-        # type: (Any) -> Any
+    def __getitem__(self, item: Any) -> Any:
         return type(self).safe(super(SafeObjectProxy, self).__getitem__(item))
 
-    def __iter__(self):
-        # type: () -> Any
+    def __iter__(self) -> Any:
         return iter(type(self).safe(_) for _ in super(SafeObjectProxy, self).__iter__())
 
-    def items(self):
-        # type: () -> Iterator[Tuple[Any, Any]]
+    def items(self) -> Iterator[Tuple[Any, Any]]:
         return (
             (type(self).safe(k), type(self).safe(v)) for k, v in super(SafeObjectProxy, self).__getattr__("items")()
         )
@@ -101,8 +91,7 @@ class SafeObjectProxy(wrapt.ObjectProxy):
     __repr__ = __str__
 
     @classmethod
-    def safe(cls, obj):
-        # type: (Any) -> Optional[Any]
+    def safe(cls, obj: Any) -> Optional[Any]:
         """Turn an object into a safe proxy."""
         _type = type(obj)
 

--- a/ddtrace/internal/serverless/__init__.py
+++ b/ddtrace/internal/serverless/__init__.py
@@ -3,8 +3,7 @@ from os import environ
 from os import path
 
 
-def in_aws_lambda():
-    # type: () -> bool
+def in_aws_lambda() -> bool:
     """Returns whether the environment is an AWS Lambda.
     This is accomplished by checking if the AWS_LAMBDA_FUNCTION_NAME environment
     variable is defined.
@@ -12,16 +11,14 @@ def in_aws_lambda():
     return bool(environ.get("AWS_LAMBDA_FUNCTION_NAME", False))
 
 
-def has_aws_lambda_agent_extension():
-    # type: () -> bool
+def has_aws_lambda_agent_extension() -> bool:
     """Returns whether the environment has the AWS Lambda Datadog Agent
     extension available.
     """
     return path.exists("/opt/extensions/datadog-agent")
 
 
-def in_gcp_function():
-    # type: () -> bool
+def in_gcp_function() -> bool:
     """Returns whether the environment is a GCP Function.
     This is accomplished by checking for the presence of one of two pairs of environment variables,
     with one pair being set by deprecated GCP Function runtimes, and the other set by newer runtimes.
@@ -31,8 +28,7 @@ def in_gcp_function():
     return is_deprecated_gcp_function or is_newer_gcp_function
 
 
-def in_azure_function_consumption_plan():
-    # type: () -> bool
+def in_azure_function_consumption_plan() -> bool:
     """Returns whether the environment is an Azure Consumption Plan Function.
     This is accomplished by checking the presence of two Azure Function env vars,
     as well as a third SKU variable indicating consumption plans.

--- a/ddtrace/internal/service.py
+++ b/ddtrace/internal/service.py
@@ -18,10 +18,9 @@ class ServiceStatus(enum.Enum):
 class ServiceStatusError(RuntimeError):
     def __init__(
         self,
-        service_cls,  # type: typing.Type[Service]
-        current_status,  # type: ServiceStatus
-    ):
-        # type: (...) -> None
+        service_cls: typing.Type[Service],
+        current_status: ServiceStatus,
+    ) -> None:
         self.current_status = current_status
         super(ServiceStatusError, self).__init__(
             "%s is already in status %s" % (service_cls.__name__, current_status.value)
@@ -45,10 +44,9 @@ class Service(six.with_metaclass(abc.ABCMeta)):
 
     def start(
         self,
-        *args,  # type: typing.Any
-        **kwargs,  # type: typing.Any
-    ):
-        # type: (...) -> None
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> None:
         """Start the service."""
         # Use a lock so we're sure that if 2 threads try to start the service at the same time, one of them will raise
         # an error.
@@ -61,10 +59,9 @@ class Service(six.with_metaclass(abc.ABCMeta)):
     @abc.abstractmethod
     def _start_service(
         self,
-        *args,  # type: typing.Any
-        **kwargs,  # type: typing.Any
-    ):
-        # type: (...) -> None
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> None:
         """Start the service for real.
 
         This method uses the internal lock to be sure there's no race conditions and that the service is really started
@@ -74,10 +71,9 @@ class Service(six.with_metaclass(abc.ABCMeta)):
 
     def stop(
         self,
-        *args,  # type: typing.Any
-        **kwargs,  # type: typing.Any
-    ):
-        # type: (...) -> None
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> None:
         """Stop the service."""
         with self._service_lock:
             if self.status == ServiceStatus.STOPPED:
@@ -88,10 +84,9 @@ class Service(six.with_metaclass(abc.ABCMeta)):
     @abc.abstractmethod
     def _stop_service(
         self,
-        *args,  # type: typing.Any
-        **kwargs,  # type: typing.Any
-    ):
-        # type: (...) -> None
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> None:
         """Stop the service for real.
 
         This method uses the internal lock to be sure there's no race conditions and that the service is really stopped
@@ -100,7 +95,6 @@ class Service(six.with_metaclass(abc.ABCMeta)):
         """
 
     def join(
-        self, timeout=None  # type: typing.Optional[float]
-    ):
-        # type: (...) -> None
+        self, timeout: typing.Optional[float] = None
+    ) -> None:
         """Join the service once stopped."""

--- a/ddtrace/internal/sma.py
+++ b/ddtrace/internal/sma.py
@@ -15,8 +15,7 @@ class SimpleMovingAverage(object):
         "sum_total",
     )
 
-    def __init__(self, size):
-        # type: (int) -> None
+    def __init__(self, size: int) -> None:
         """
         Constructor for SimpleMovingAverage.
 
@@ -35,8 +34,7 @@ class SimpleMovingAverage(object):
         self.counts = [0] * self.size
         self.totals = [0] * self.size
 
-    def get(self):
-        # type: () -> float
+    def get(self) -> float:
         """
         Get the current SMA value.
         """
@@ -45,8 +43,7 @@ class SimpleMovingAverage(object):
 
         return float(self.sum_count) / self.sum_total
 
-    def set(self, count, total):
-        # type: (int, int) -> None
+    def set(self, count: int, total: int) -> None:
         """
         Set the value of the next bucket and update the SMA value.
 

--- a/ddtrace/internal/telemetry/__init__.py
+++ b/ddtrace/internal/telemetry/__init__.py
@@ -12,7 +12,7 @@ import sys
 from .writer import TelemetryWriter
 
 
-telemetry_writer = TelemetryWriter()  # type: TelemetryWriter
+telemetry_writer: TelemetryWriter = TelemetryWriter()
 
 __all__ = ["telemetry_writer"]
 

--- a/ddtrace/internal/telemetry/data.py
+++ b/ddtrace/internal/telemetry/data.py
@@ -16,14 +16,12 @@ from ...settings.asm import config as asm_config
 from ..hostname import get_hostname
 
 
-def _format_version_info(vi):
-    # type: (sys._version_info) -> str
+def _format_version_info(vi: sys._version_info) -> str:
     """Converts sys.version_info into a string with the format x.x.x"""
     return "%d.%d.%d" % (vi.major, vi.minor, vi.micro)
 
 
-def _get_container_id():
-    # type: () -> str
+def _get_container_id() -> str:
     """Get ID from docker container"""
     container_info = get_container_info()
     if container_info:
@@ -31,8 +29,7 @@ def _get_container_id():
     return ""
 
 
-def _get_os_version():
-    # type: () -> str
+def _get_os_version() -> str:
     """Returns the os version for applications running on Mac or Windows 32-bit"""
     try:
         mver, _, _ = platform.mac_ver()
@@ -50,8 +47,7 @@ def _get_os_version():
 
 
 @cached()
-def _get_application(key):
-    # type: (Tuple[str, str, str]) -> Dict
+def _get_application(key: Tuple[str, str, str]) -> Dict:
     """
     This helper packs and unpacks get_application arguments to support caching.
     Cached() annotation only supports functions with one argument
@@ -71,23 +67,20 @@ def _get_application(key):
     }
 
 
-def get_dependencies():
-    # type: () -> List[Dict[str, str]]
+def get_dependencies() -> List[Dict[str, str]]:
     """Returns a unique list of the names and versions of all installed packages"""
     dependencies = {(dist.name, dist.version) for dist in get_distributions()}
     return [{"name": name, "version": version} for name, version in dependencies]
 
 
-def get_application(service, version, env):
-    # type: (str, str, str) -> Dict
+def get_application(service: str, version: str, env: str) -> Dict:
     """Creates a dictionary to store application data using ddtrace configurations and the System-Specific module"""
     # We cache the application dict to reduce overhead since service, version, or env configurations
     # can change during runtime
     return _get_application((service, version, env))
 
 
-def _get_products():
-    # type: () -> Dict
+def _get_products() -> Dict:
     return {
         "appsec": {"version": get_version(), "enabled": asm_config._asm_enabled},
     }
@@ -96,8 +89,7 @@ def _get_products():
 _host_info = None
 
 
-def get_host_info():
-    # type: () -> Dict
+def get_host_info() -> Dict:
     """Creates a dictionary to store host data using the platform module"""
     global _host_info
     if _host_info is None:

--- a/ddtrace/internal/telemetry/metrics.py
+++ b/ddtrace/internal/telemetry/metrics.py
@@ -20,8 +20,7 @@ class Metric(six.with_metaclass(abc.ABCMeta)):
     metric_type = ""
     __slots__ = ["namespace", "name", "_tags", "is_common_to_all_tracers", "interval", "_points", "_count"]
 
-    def __init__(self, namespace, name, tags, common, interval=None):
-        # type: (str, str, MetricTagType, bool, Optional[float]) -> None
+    def __init__(self, namespace: str, name: str, tags: MetricTagType, common: bool, interval: Optional[float] = None) -> None:
         """
         namespace: the scope of the metric: tracer, appsec, etc.
         name: string
@@ -35,11 +34,10 @@ class Metric(six.with_metaclass(abc.ABCMeta)):
         self.namespace = namespace
         self._tags = tags
         self._count = 0.0
-        self._points = []  # type: List
+        self._points: List = []
 
     @classmethod
-    def get_id(cls, name, namespace, tags, metric_type):
-        # type: (str, str, MetricTagType, str) -> int
+    def get_id(cls, name: str, namespace: str, tags: MetricTagType, metric_type: str) -> int:
         """
         https://www.datadoghq.com/blog/the-power-of-tagged-metrics/#whats-a-metric-tag
         """
@@ -49,13 +47,11 @@ class Metric(six.with_metaclass(abc.ABCMeta)):
         return self.get_id(self.name, self.namespace, self._tags, self.metric_type)
 
     @abc.abstractmethod
-    def add_point(self, value=1.0):
-        # type: (float) -> None
+    def add_point(self, value: float = 1.0) -> None:
         """adds timestamped data point associated with a metric"""
         pass
 
-    def to_dict(self):
-        # type: () -> Dict
+    def to_dict(self) -> Dict:
         """returns a dictionary containing the metrics fields expected by the telemetry intake service"""
         data = {
             "metric": self.name,
@@ -77,8 +73,7 @@ class CountMetric(Metric):
 
     metric_type = "count"
 
-    def add_point(self, value=1.0):
-        # type: (float) -> None
+    def add_point(self, value: float = 1.0) -> None:
         """adds timestamped data point associated with a metric"""
         if self._points:
             self._points[0][1] += value
@@ -96,8 +91,7 @@ class GaugeMetric(Metric):
 
     metric_type = "gauge"
 
-    def add_point(self, value=1.0):
-        # type: (float) -> None
+    def add_point(self, value: float = 1.0) -> None:
         """adds timestamped data point associated with a metric"""
         self._points = [(time.time(), value)]
 
@@ -110,8 +104,7 @@ class RateMetric(Metric):
 
     metric_type = "rate"
 
-    def add_point(self, value=1.0):
-        # type: (float) -> None
+    def add_point(self, value: float = 1.0) -> None:
         """Example:
         https://github.com/DataDog/datadogpy/blob/ee5ac16744407dcbd7a3640ee7b4456536460065/datadog/threadstats/metrics.py#L181
         """
@@ -128,15 +121,13 @@ class DistributionMetric(Metric):
 
     metric_type = "distributions"
 
-    def add_point(self, value=1.0):
-        # type: (float) -> None
+    def add_point(self, value: float = 1.0) -> None:
         """Example:
         https://github.com/DataDog/datadogpy/blob/ee5ac16744407dcbd7a3640ee7b4456536460065/datadog/threadstats/metrics.py#L181
         """
         self._points.append(value)
 
-    def to_dict(self):
-        # type: () -> Dict
+    def to_dict(self) -> Dict:
         """returns a dictionary containing the metrics fields expected by the telemetry intake service"""
         data = {
             "metric": self.name,

--- a/ddtrace/internal/telemetry/metrics_namespaces.py
+++ b/ddtrace/internal/telemetry/metrics_namespaces.py
@@ -16,16 +16,14 @@ NamespaceMetricType = Dict[str, Dict[str, Dict[str, Any]]]
 
 
 class MetricNamespace:
-    def __init__(self):
-        # type: () -> None
-        self._lock = forksafe.Lock()  # type: forksafe.ResetObject
-        self._metrics_data = {
+    def __init__(self) -> None:
+        self._lock: forksafe.ResetObject = forksafe.Lock()
+        self._metrics_data: Dict[str, Dict[str, Dict[int, Metric]]] = {
             TELEMETRY_TYPE_GENERATE_METRICS: defaultdict(dict),
             TELEMETRY_TYPE_DISTRIBUTION: defaultdict(dict),
-        }  # type: Dict[str, Dict[str, Dict[int, Metric]]]
+        }
 
-    def flush(self):
-        # type: () -> Dict
+    def flush(self) -> Dict:
         with self._lock:
             namespace_metrics = self._metrics_data
             self._metrics_data = {
@@ -34,8 +32,7 @@ class MetricNamespace:
             }
             return namespace_metrics
 
-    def add_metric(self, metric_class, namespace, name, value=1.0, tags=None, interval=None):
-        # type: (Type[Metric], str, str, float, MetricTagType, Optional[float]) -> None
+    def add_metric(self, metric_class: Type[Metric], namespace: str, name: str, value: float = 1.0, tags: MetricTagType = None, interval: Optional[float] = None) -> None:
         """
         Telemetry Metrics are stored in DD dashboards, check the metrics in datadoghq.com/metric/explorer.
         The metric will store in dashboard as "dd.instrumentation_telemetry_data." + namespace + "." + name

--- a/ddtrace/internal/tracemethods.py
+++ b/ddtrace/internal/tracemethods.py
@@ -3,8 +3,7 @@ import typing
 import wrapt
 
 
-def _parse_trace_methods(raw_dd_trace_methods):
-    # type: (str) -> typing.List[str]
+def _parse_trace_methods(raw_dd_trace_methods: str) -> typing.List[str]:
     """Return the methods to trace based on the specification of DD_TRACE_METHODS.
 
     DD_TRACE_METHODS is specified to be FullyQualifiedClassOrModuleName[comma-separated-methods]
@@ -60,8 +59,7 @@ def _parse_trace_methods(raw_dd_trace_methods):
     return dd_trace_methods
 
 
-def _install_trace_methods(raw_dd_trace_methods):
-    # type: (str) -> None
+def _install_trace_methods(raw_dd_trace_methods: str) -> None:
     """Install tracing on the given methods."""
     for qualified_method in _parse_trace_methods(raw_dd_trace_methods):
         # We don't know if the method is a class method or a module method, so we need to assume it's a module
@@ -86,8 +84,7 @@ def _install_trace_methods(raw_dd_trace_methods):
         trace_method(base_module_guess, method_name)
 
 
-def trace_method(module, method_name):
-    # type: (str, str) -> None
+def trace_method(module: str, method_name: str) -> None:
 
     @wrapt.importer.when_imported(module)
     def _(m):

--- a/ddtrace/internal/uds.py
+++ b/ddtrace/internal/uds.py
@@ -12,16 +12,14 @@ class UDSHTTPConnection(BasePathMixin, httplib.HTTPConnection):
     # mechanism, they are actually used as HTTP headers such as `Host`.
     def __init__(
         self,
-        path,  # type: str
-        *args,  # type: Any
-        **kwargs,  # type: Any
-    ):
-        # type: (...) -> None
+        path: str,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         super(UDSHTTPConnection, self).__init__(*args, **kwargs)
         self.path = path
 
-    def connect(self):
-        # type: () -> None
+    def connect(self) -> None:
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.connect(self.path)
         self.sock = sock

--- a/ddtrace/internal/utils/__init__.py
+++ b/ddtrace/internal/utils/__init__.py
@@ -15,13 +15,12 @@ class ArgumentError(Exception):
 
 
 def get_argument_value(
-    args,  # type: List[Any]
-    kwargs,  # type: Dict[str, Any]
-    pos,  # type: int
-    kw,  # type: str
-    optional=False,  # type: bool
-):
-    # type: (...) -> Optional[Any]
+    args: List[Any],
+    kwargs: Dict[str, Any],
+    pos: int,
+    kw: str,
+    optional: bool = False,
+) -> Optional[Any]:
     """
     This function parses the value of a target function argument that may have been
     passed in as a positional argument or a keyword argument. Because monkey-patched
@@ -48,13 +47,12 @@ def get_argument_value(
 
 
 def set_argument_value(
-    args,  # type: Tuple[Any, ...]
-    kwargs,  # type: Dict[str, Any]
-    pos,  # type: int
-    kw,  # type: str
-    value,  # type: Any
-):
-    # type: (...) -> Tuple[Tuple[Any, ...], Dict[str, Any]]
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
+    pos: int,
+    kw: str,
+    value: Any,
+) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
     """
     Returns a new args, kwargs with the given value updated
     :param args: Positional arguments
@@ -74,8 +72,7 @@ def set_argument_value(
     return args, kwargs
 
 
-def _get_metas_to_propagate(context):
-    # type: (Any) -> List[Tuple[str, str]]
+def _get_metas_to_propagate(context: Any) -> List[Tuple[str, str]]:
     metas_to_propagate = []
     for k, v in context._meta.items():
         if isinstance(k, six.string_types) and k.startswith("_dd.p."):

--- a/ddtrace/internal/utils/attr.py
+++ b/ddtrace/internal/utils/attr.py
@@ -8,8 +8,7 @@ from typing import Union
 T = TypeVar("T")
 
 
-def from_env(name, default, value_type):
-    # type: (str, T, Union[Callable[[Union[str, T, None]], T], Type[T]]) -> Callable[[], T]
+def from_env(name: str, default: T, value_type: Union[Callable[[Union[str, T, None]], T], Type[T]]) -> Callable[[], T]:
     def _():
         return value_type(os.environ.get(name, default))
 

--- a/ddtrace/internal/utils/attrdict.py
+++ b/ddtrace/internal/utils/attrdict.py
@@ -20,14 +20,12 @@ class AttrDict(dict):
        print(data.key)
     """
 
-    def __getattr__(self, key):
-        # type: (str) -> Any
+    def __getattr__(self, key: str) -> Any:
         if key in self:
             return self[key]
         return object.__getattribute__(self, key)
 
-    def __setattr__(self, key, value):
-        # type: (str, Any) -> None
+    def __setattr__(self, key: str, value: Any) -> None:
         # 1) Ensure if the key exists from a dict key we always prefer that
         # 2) If we do not have an existing key but we do have an attr, set that
         # 3) No existing key or attr exists, so set a key

--- a/ddtrace/internal/utils/cache.py
+++ b/ddtrace/internal/utils/cache.py
@@ -25,13 +25,11 @@ class LFUCache(dict):
     cache when it grows beyond the requested size is O(log(size)).
     """
 
-    def __init__(self, maxsize=256):
-        # type: (int) -> None
+    def __init__(self, maxsize: int = 256) -> None:
         self.maxsize = maxsize
         self.lock = RLock()
 
-    def get(self, key, f):  # type: ignore[override]
-        # type: (T, F) -> Any
+    def get(self, key: T, f: F) -> Any:  # type: ignore[override]
         """Get a value from the cache.
 
         If the value with the given key is not in the cache, the expensive
@@ -62,16 +60,13 @@ class LFUCache(dict):
             return value
 
 
-def cached(maxsize=256):
-    # type: (int) -> Callable[[F], F]
+def cached(maxsize: int = 256) -> Callable[[F], F]:
     """Decorator for memoizing functions of a single argument (LFU policy)."""
 
-    def cached_wrapper(f):
-        # type: (F) -> F
+    def cached_wrapper(f: F) -> F:
         cache = LFUCache(maxsize)
 
-        def cached_f(key):
-            # type: (T) -> Any
+        def cached_f(key: T) -> Any:
             return cache.get(key, f)
 
         cached_f.invalidate = cache.clear  # type: ignore[attr-defined]
@@ -82,38 +77,32 @@ def cached(maxsize=256):
 
 
 class CachedMethodDescriptor(object):
-    def __init__(self, method, maxsize):
-        # type: (M, int) -> None
+    def __init__(self, method: M, maxsize: int) -> None:
         self._method = method
         self._maxsize = maxsize
 
-    def __get__(self, obj, objtype=None):
-        # type: (Any, Optional[Type]) -> F
+    def __get__(self, obj: Any, objtype: Optional[Type] = None) -> F:
         cached_method = cached(self._maxsize)(self._method.__get__(obj, objtype))
         setattr(obj, self._method.__name__, cached_method)
         return cached_method
 
 
-def cachedmethod(maxsize=256):
-    # type: (int) -> Callable[[M], CachedMethodDescriptor]
+def cachedmethod(maxsize: int = 256) -> Callable[[M], CachedMethodDescriptor]:
     """Decorator for memoizing methods of a single argument (LFU policy)."""
 
-    def cached_wrapper(f):
-        # type: (M) -> CachedMethodDescriptor
+    def cached_wrapper(f: M) -> CachedMethodDescriptor:
         return CachedMethodDescriptor(f, maxsize)
 
     return cached_wrapper
 
 
-def callonce(f):
-    # type: (Callable[[], Any]) -> Callable[[], Any]
+def callonce(f: Callable[[], Any]) -> Callable[[], Any]:
     """Decorator for executing a function only the first time."""
     argspec = getfullargspec(f)
     if is_not_void_function(f, argspec):
         raise ValueError("The callonce decorator can only be applied to functions with no arguments")
 
-    def _():
-        # type: () -> Any
+    def _() -> Any:
         try:
             retval, exc = f.__callonce_result__  # type: ignore[attr-defined]
         except AttributeError:

--- a/ddtrace/internal/utils/config.py
+++ b/ddtrace/internal/utils/config.py
@@ -3,8 +3,7 @@ import sys
 import typing
 
 
-def get_application_name():
-    # type: () -> typing.Optional[str]
+def get_application_name() -> typing.Optional[str]:
     """Attempts to find the application name using system arguments."""
     try:
         import __main__

--- a/ddtrace/internal/utils/formats.py
+++ b/ddtrace/internal/utils/formats.py
@@ -25,8 +25,7 @@ T = TypeVar("T")
 log = logging.getLogger(__name__)
 
 
-def deep_getattr(obj, attr_string, default=None):
-    # type: (Any, str, Optional[Any]) -> Optional[Any]
+def deep_getattr(obj: Any, attr_string: str, default: Optional[Any] = None) -> Optional[Any]:
     """
     Returns the attribute of `obj` at the dotted path given by `attr_string`
     If no such attribute is reachable, returns `default`
@@ -50,8 +49,7 @@ def deep_getattr(obj, attr_string, default=None):
     return obj
 
 
-def asbool(value):
-    # type: (Union[str, bool, None]) -> bool
+def asbool(value: Union[str, bool, None]) -> bool:
     """Convert the given String to a boolean object.
 
     Accepted values are `True` and `1`.
@@ -65,8 +63,7 @@ def asbool(value):
     return value.lower() in ("true", "1")
 
 
-def parse_tags_str(tags_str):
-    # type: (Optional[str]) -> Dict[str, str]
+def parse_tags_str(tags_str: Optional[str]) -> Dict[str, str]:
     """Parse a string of tags typically provided via environment variables.
 
     The expected string is of the form::
@@ -81,8 +78,7 @@ def parse_tags_str(tags_str):
 
     TAGSEP = ", "
 
-    def parse_tags(tags):
-        # type: (List[str]) -> Tuple[List[Tuple[str, str]], List[str]]
+    def parse_tags(tags: List[str]) -> Tuple[List[Tuple[str, str]], List[str]]:
         parsed_tags = []
         invalids = []
 
@@ -98,7 +94,7 @@ def parse_tags_str(tags_str):
     tags_str = tags_str.strip(TAGSEP)
 
     # Take the maximal set of tags that can be parsed correctly for a given separator
-    tag_list = []  # type: List[Tuple[str, str]]
+    tag_list: List[Tuple[str, str]] = []
     invalids = []
     for sep in TAGSEP:
         ts = tags_str.split(sep)
@@ -129,15 +125,14 @@ def parse_tags_str(tags_str):
     return dict(tag_list)
 
 
-def stringify_cache_args(args, value_max_len=VALUE_MAX_LEN, cmd_max_len=CMD_MAX_LEN):
-    # type: (List[Any], int, int) -> Text
+def stringify_cache_args(args: List[Any], value_max_len: int = VALUE_MAX_LEN, cmd_max_len: int = CMD_MAX_LEN) -> Text:
     """Convert a list of arguments into a space concatenated string
 
     This function is useful to convert a list of cache keys
     into a resource name or tag value with a max size limit.
     """
     length = 0
-    out = []  # type: List[Text]
+    out: List[Text] = []
     for arg in args:
         try:
             if isinstance(arg, (binary_type, text_type)):

--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -44,8 +44,7 @@ log = logging.getLogger(__name__)
 
 
 @cached()
-def normalize_header_name(header_name):
-    # type: (Optional[str]) -> Optional[str]
+def normalize_header_name(header_name: Optional[str]) -> Optional[str]:
     """
     Normalizes an header name to lower case, stripping all its leading and trailing white spaces.
     :param header_name: the header name to normalize
@@ -56,8 +55,7 @@ def normalize_header_name(header_name):
     return header_name.strip().lower() if header_name is not None else None
 
 
-def strip_query_string(url):
-    # type: (str) -> str
+def strip_query_string(url: str) -> str:
     """
     Strips the query string from a URL for use as tag in spans.
     :param url: The URL to be stripped
@@ -70,8 +68,7 @@ def strip_query_string(url):
     return h + fs + f
 
 
-def redact_query_string(query_string, query_string_obfuscation_pattern):
-    # type: (str, Optional[re.Pattern]) -> Union[bytes, str]
+def redact_query_string(query_string: str, query_string_obfuscation_pattern: Optional[re.Pattern]) -> Union[bytes, str]:
     if query_string_obfuscation_pattern is None:
         return query_string
 
@@ -79,8 +76,7 @@ def redact_query_string(query_string, query_string_obfuscation_pattern):
     return query_string_obfuscation_pattern.sub(b"<redacted>", bytes_query)
 
 
-def redact_url(url, query_string_obfuscation_pattern, query_string=None):
-    # type: (str, re.Pattern, Optional[str]) -> Union[str,bytes]
+def redact_url(url: str, query_string_obfuscation_pattern: re.Pattern, query_string: Optional[str] = None) -> Union[str,bytes]:
 
     # Avoid further processing if obfuscation is disabled
     if query_string_obfuscation_pattern is None:
@@ -95,7 +91,7 @@ def redact_url(url, query_string_obfuscation_pattern, query_string=None):
         redacted_query = redact_query_string(parts.query, query_string_obfuscation_pattern)
 
     if redacted_query is not None and len(parts) >= 5:
-        redacted_parts = parts[:4] + (redacted_query,) + parts[5:]  # type: Tuple[Union[str, bytes], ...]
+        redacted_parts: Tuple[Union[str, bytes], ...] = parts[:4] + (redacted_query,) + parts[5:]
         bytes_redacted_parts = tuple(x if isinstance(x, bytes) else x.encode("utf-8") for x in redacted_parts)
         return urlunsplit(bytes_redacted_parts, url)
 
@@ -103,8 +99,7 @@ def redact_url(url, query_string_obfuscation_pattern, query_string=None):
     return url
 
 
-def urlunsplit(components, original_url):
-    # type: (Tuple[bytes, ...], str) -> bytes
+def urlunsplit(components: Tuple[bytes, ...], original_url: str) -> bytes:
     """
     Adaptation from urlunsplit and urlunparse, using bytes components
     """
@@ -124,8 +119,7 @@ def urlunsplit(components, original_url):
     return url
 
 
-def connector(url, **kwargs):
-    # type: (str, Any) -> Connector
+def connector(url: str, **kwargs: Any) -> Connector:
     """Create a connector context manager for the given URL.
 
     This function returns a context manager that wraps a connection object to
@@ -140,8 +134,7 @@ def connector(url, **kwargs):
     """
 
     @contextmanager
-    def _connector_context():
-        # type: () -> Generator[Union[compat.httplib.HTTPConnection, compat.httplib.HTTPSConnection], None, None]
+    def _connector_context() -> Generator[Union[compat.httplib.HTTPConnection, compat.httplib.HTTPSConnection], None, None]:
         connection = get_connection(url, **kwargs)
         yield connection
         connection.close()
@@ -194,8 +187,7 @@ def w3c_get_dd_list_member(context):
 
 
 @cached()
-def w3c_encode_tag(args):
-    # type: (Tuple[Pattern, str, str]) -> str
+def w3c_encode_tag(args: Tuple[Pattern, str, str]) -> str:
     pattern, replacement, tag_val = args
     tag_val = pattern.sub(replacement, tag_val)
     # replace = with ~ if it wasn't already replaced by the regex
@@ -273,8 +265,7 @@ class Response(object):
         )
 
 
-def get_connection(url, timeout=DEFAULT_TIMEOUT):
-    # type: (str, float) -> ConnectionType
+def get_connection(url: str, timeout: float = DEFAULT_TIMEOUT) -> ConnectionType:
     """Return an HTTP connection to the given URL."""
     parsed = verify_url(url)
     hostname = parsed.hostname or ""
@@ -290,8 +281,7 @@ def get_connection(url, timeout=DEFAULT_TIMEOUT):
     raise ValueError("Unsupported protocol '%s'" % parsed.scheme)
 
 
-def verify_url(url):
-    # type: (str) -> parse.ParseResult
+def verify_url(url: str) -> parse.ParseResult:
     """Validates that the given URL can be used as an intake
     Returns a parse.ParseResult.
     Raises a ``ValueError`` if the URL cannot be used as an intake
@@ -311,12 +301,11 @@ def verify_url(url):
     return parsed
 
 
-_HTML_BLOCKED_TEMPLATE_CACHE = None  # type: Optional[str]
-_JSON_BLOCKED_TEMPLATE_CACHE = None  # type: Optional[str]
+_HTML_BLOCKED_TEMPLATE_CACHE: Optional[str] = None
+_JSON_BLOCKED_TEMPLATE_CACHE: Optional[str] = None
 
 
-def _get_blocked_template(accept_header_value):
-    # type: (str) -> str
+def _get_blocked_template(accept_header_value: str) -> str:
 
     global _HTML_BLOCKED_TEMPLATE_CACHE
     global _JSON_BLOCKED_TEMPLATE_CACHE

--- a/ddtrace/internal/utils/importlib.py
+++ b/ddtrace/internal/utils/importlib.py
@@ -12,8 +12,7 @@ from typing import Type
 class require_modules(object):
     """Context manager to check the availability of required modules."""
 
-    def __init__(self, modules):
-        # type: (List[str]) -> None
+    def __init__(self, modules: List[str]) -> None:
         self._missing_modules = []
         for module in modules:
             try:
@@ -21,24 +20,20 @@ class require_modules(object):
             except ImportError:
                 self._missing_modules.append(module)
 
-    def __enter__(self):
-        # type: () -> List[str]
+    def __enter__(self) -> List[str]:
         return self._missing_modules
 
-    def __exit__(self, exc_type, exc_value, traceback):
-        # type: (Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]) -> None
+    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_value: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
         return
 
 
-def func_name(f):
-    # type: (Callable[..., Any]) -> str
+def func_name(f: Callable[..., Any]) -> str:
     """Return a human readable version of the function's name."""
     if hasattr(f, "__module__"):
         return "%s.%s" % (f.__module__, getattr(f, "__name__", f.__class__.__name__))
     return getattr(f, "__name__", f.__class__.__name__)
 
 
-def module_name(instance):
-    # type: (Any) -> str
+def module_name(instance: Any) -> str:
     """Return the instance module name."""
     return instance.__class__.__module__.split(".")[0]

--- a/ddtrace/internal/utils/inspection.py
+++ b/ddtrace/internal/utils/inspection.py
@@ -6,8 +6,7 @@ from bytecode import Bytecode
 from ddtrace.internal.compat import PYTHON_VERSION_INFO as PY
 
 
-def linenos(f):
-    # type: (FunctionType) -> Set[int]
+def linenos(f: FunctionType) -> Set[int]:
     """Get the line numbers of a function."""
     ls = {
         _

--- a/ddtrace/internal/utils/retry.py
+++ b/ddtrace/internal/utils/retry.py
@@ -14,8 +14,7 @@ class RetryError(Exception):
     pass
 
 
-def retry(after, until=lambda result: result is None, initial_wait=0):
-    # type: (t.Union[int, float, t.Iterable[t.Union[int, float]]], t.Callable[[t.Any], bool], float) -> t.Callable
+def retry(after: t.Union[int, float, t.Iterable[t.Union[int, float]]], until: t.Callable[[t.Any], bool] = lambda result: result is None, initial_wait: float = 0) -> t.Callable:
     def retry_decorator(f):
         @wraps(f)
         def retry_wrapped(*args, **kwargs):
@@ -55,8 +54,7 @@ def retry(after, until=lambda result: result is None, initial_wait=0):
     return retry_decorator
 
 
-def fibonacci_backoff_with_jitter(attempts, initial_wait=1.0, until=lambda result: result is None):
-    # type: (int, float, t.Callable[[t.Any], bool]) -> t.Callable
+def fibonacci_backoff_with_jitter(attempts: int, initial_wait: float = 1.0, until: t.Callable[[t.Any], bool] = lambda result: result is None) -> t.Callable:
     return retry(
         after=[random.uniform(0, initial_wait * (1.618**i)) for i in range(attempts - 1)],  # nosec
         until=until,

--- a/ddtrace/internal/utils/time.py
+++ b/ddtrace/internal/utils/time.py
@@ -11,8 +11,7 @@ from ddtrace.internal.logger import get_logger
 log = get_logger(__name__)
 
 
-def fromisoformat_py2(t):
-    # type: (str) -> datetime
+def fromisoformat_py2(t: str) -> datetime:
     """Alternative function to datetime.fromisoformat that does not exist in python 2. This function parses dates with
     this format: 2022-09-01T01:00:00+02:00
     """
@@ -24,8 +23,7 @@ def fromisoformat_py2(t):
     return ret
 
 
-def parse_isoformat(date):
-    # type: (str) -> Optional[datetime]
+def parse_isoformat(date: str) -> Optional[datetime]:
     if date.endswith("Z"):
         try:
             return datetime.strptime(date, "%Y-%m-%dT%H:%M:%S.%fZ")
@@ -56,19 +54,16 @@ class StopWatch(object):
     .. _monotonic: https://pypi.python.org/pypi/monotonic/
     """
 
-    def __init__(self):
-        # type: () -> None
-        self._started_at = None  # type: Optional[float]
-        self._stopped_at = None  # type: Optional[float]
+    def __init__(self) -> None:
+        self._started_at: Optional[float] = None
+        self._stopped_at: Optional[float] = None
 
-    def start(self):
-        # type: () -> StopWatch
+    def start(self) -> StopWatch:
         """Starts the watch."""
         self._started_at = compat.monotonic()
         return self
 
-    def elapsed(self):
-        # type: () -> float
+    def elapsed(self) -> float:
         """Get how many seconds have elapsed.
 
         :return: Number of seconds elapsed
@@ -83,19 +78,16 @@ class StopWatch(object):
             now = self._stopped_at
         return now - self._started_at
 
-    def __enter__(self):
-        # type: () -> StopWatch
+    def __enter__(self) -> StopWatch:
         """Starts the watch."""
         self.start()
         return self
 
-    def __exit__(self, tp, value, traceback):
-        # type: (Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]) -> None
+    def __exit__(self, tp: Optional[Type[BaseException]], value: Optional[BaseException], traceback: Optional[TracebackType]) -> None:
         """Stops the watch."""
         self.stop()
 
-    def stop(self):
-        # type: () -> StopWatch
+    def stop(self) -> StopWatch:
         """Stops the watch."""
         if self._started_at is None:
             raise RuntimeError("Can not stop a stopwatch that has not been" " started")
@@ -106,8 +98,7 @@ class StopWatch(object):
 class HourGlass(object):
     """An implementation of an hourglass."""
 
-    def __init__(self, duration):
-        # type: (float) -> None
+    def __init__(self, duration: float) -> None:
         t = compat.monotonic()
 
         self._duration = duration
@@ -116,8 +107,7 @@ class HourGlass(object):
 
         self.trickling = self._trickled  # type: ignore[assignment]
 
-    def turn(self):
-        # type: () -> None
+    def turn(self) -> None:
         """Turn the hourglass."""
         t = compat.monotonic()
         top_0 = self._end_at - self._started_at
@@ -128,17 +118,14 @@ class HourGlass(object):
 
         self.trickling = self._trickling  # type: ignore[assignment]
 
-    def trickling(self):
-        # type: () -> bool
+    def trickling(self) -> bool:
         """Check if sand is still trickling."""
         return False
 
-    def _trickled(self):
-        # type: () -> bool
+    def _trickled(self) -> bool:
         return False
 
-    def _trickling(self):
-        # type: () -> bool
+    def _trickling(self) -> bool:
         if compat.monotonic() < self._end_at:
             return True
 
@@ -147,8 +134,7 @@ class HourGlass(object):
 
         return False
 
-    def __enter__(self):
-        # type: () -> HourGlass
+    def __enter__(self) -> HourGlass:
         self.turn()
         return self
 

--- a/ddtrace/internal/utils/version.py
+++ b/ddtrace/internal/utils/version.py
@@ -5,8 +5,7 @@ import ddtrace.vendor.packaging.version as packaging_version
 from ddtrace.version import get_version
 
 
-def parse_version(version):
-    # type: (str) -> typing.Tuple[int, int, int]
+def parse_version(version: str) -> typing.Tuple[int, int, int]:
     """Convert a version string to a tuple of (major, minor, micro)
 
     Examples::
@@ -51,8 +50,7 @@ def parse_version(version):
     )
 
 
-def _pep440_to_semver(version=None):
-    # type: (Optional[str]) -> str
+def _pep440_to_semver(version: Optional[str] = None) -> str:
     # The library uses a PEP 440-compliant (https://peps.python.org/pep-0440/) versioning
     # scheme, but the Agent spec requires that we use a SemVer-compliant version.
     #

--- a/ddtrace/internal/utils/wrappers.py
+++ b/ddtrace/internal/utils/wrappers.py
@@ -9,15 +9,13 @@ from ddtrace.vendor import wrapt
 F = TypeVar("F", bound=Callable[..., Any])
 
 
-def iswrapped(obj, attr=None):
-    # type: (Any, Optional[str]) -> bool
+def iswrapped(obj: Any, attr: Optional[str] = None) -> bool:
     """Returns whether an attribute is wrapped or not."""
     if attr is not None:
         obj = getattr(obj, attr, None)
     return hasattr(obj, "__wrapped__") and isinstance(obj, wrapt.ObjectProxy)
 
 
-def unwrap(obj, attr):
-    # type: (Any, str) -> None
+def unwrap(obj: Any, attr: str) -> None:
     f = getattr(obj, attr)
     setattr(obj, attr, f.__wrapped__)

--- a/ddtrace/internal/uwsgi.py
+++ b/ddtrace/internal/uwsgi.py
@@ -15,8 +15,7 @@ class uWSGIMasterProcess(Exception):
     """The process is uWSGI master process."""
 
 
-def check_uwsgi(worker_callback=None, atexit=None):
-    # type: (Optional[Callable], Optional[Callable]) -> None
+def check_uwsgi(worker_callback: Optional[Callable] = None, atexit: Optional[Callable] = None) -> None:
     """Check whetever uwsgi is running and what needs to be done.
 
     :param worker_callback: Callback function to call in uWSGI worker processes.

--- a/ddtrace/internal/wrapping/__init__.py
+++ b/ddtrace/internal/wrapping/__init__.py
@@ -26,8 +26,8 @@ from ddtrace.internal.wrapping.generators import wrap_generator
 class WrappedFunction(Protocol):
     """A wrapped function."""
 
-    __dd_wrapped__ = None  # type: Optional[FunctionType]
-    __dd_wrappers__ = None  # type: Optional[Dict[Any, Any]]
+    __dd_wrapped__: Optional[FunctionType] = None
+    __dd_wrappers__: Optional[Dict[Any, Any]] = None
 
     def __call__(self, *args, **kwargs):
         pass
@@ -108,8 +108,7 @@ else:
 FIRSTLINENO_OFFSET = int(PY >= (3, 11))
 
 
-def wrap_bytecode(wrapper, wrapped):
-    # type: (Wrapper, FunctionType) -> bc.Bytecode
+def wrap_bytecode(wrapper: Wrapper, wrapped: FunctionType) -> bc.Bytecode:
     """Wrap a function with a wrapper function.
 
     The wrapper function expects the wrapped function as the first argument,
@@ -209,8 +208,7 @@ def wrap_bytecode(wrapper, wrapped):
     return bc.Bytecode(instrs)
 
 
-def wrap(f, wrapper):
-    # type: (FunctionType, Wrapper) -> WrappedFunction
+def wrap(f: FunctionType, wrapper: Wrapper) -> WrappedFunction:
     """Wrap a function with a wrapper.
 
     The wrapper expects the function as first argument, followed by the tuple
@@ -267,8 +265,7 @@ def wrap(f, wrapper):
     return wf
 
 
-def unwrap(wf, wrapper):
-    # type: (WrappedFunction, Wrapper) -> FunctionType
+def unwrap(wf: WrappedFunction, wrapper: Wrapper) -> FunctionType:
     """Unwrap a wrapped function.
 
     This is the reverse of :func:`wrap`. In case of multiple wrapping layers,

--- a/ddtrace/internal/writer/writer_client.py
+++ b/ddtrace/internal/writer/writer_client.py
@@ -9,7 +9,7 @@ class WriterClientBase(object):
 
     def __init__(
         self,
-        encoder,  # type: BufferedEncoder
+        encoder: BufferedEncoder,
     ):
         self.encoder = encoder
 

--- a/ddtrace/opentelemetry/_context.py
+++ b/ddtrace/opentelemetry/_context.py
@@ -21,8 +21,7 @@ log = get_logger(__name__)
 
 
 class DDRuntimeContext:
-    def attach(self, otel_context):
-        # type: (OtelContext) -> object
+    def attach(self, otel_context: OtelContext) -> object:
         """
         Converts an OpenTelemetry Span to a Datadog Span/Context then stores the
         Datadog representation in the Global DDtrace Trace Context Provider.
@@ -46,8 +45,7 @@ class DDRuntimeContext:
         # Since manually deactivating spans is not supported by ddtrace this object will never be used.
         return object()
 
-    def get_current(self):
-        # type: (...) -> OtelContext
+    def get_current(self) -> OtelContext:
         """
         Converts the active datadog span to an Opentelemetry Span and then stores it
         in a format that can be parsed by the OpenTelemetry API.
@@ -63,8 +61,7 @@ class DDRuntimeContext:
             context = set_span_in_context(span, context)
         return context
 
-    def detach(self, token):
-        # type: (object) -> None
+    def detach(self, token: object) -> None:
         """
         NOP, The otel api uses this method to deactivate spans but this operation is not supported by
         the datadog context provider.
@@ -72,8 +69,7 @@ class DDRuntimeContext:
         pass
 
     @property
-    def _ddcontext_provider(self):
-        # type: () -> DDBaseContextProvider
+    def _ddcontext_provider(self) -> DDBaseContextProvider:
         """
         Get the ddtrace context provider from the global Datadog tracer.
         This can reterive a default, gevent, or asyncio context provider.

--- a/ddtrace/opentelemetry/_span.py
+++ b/ddtrace/opentelemetry/_span.py
@@ -37,14 +37,13 @@ class Span(OtelSpan):
 
     def __init__(
         self,
-        datadog_span,  # type: DDSpan
-        kind=SpanKind.INTERNAL,  # type: SpanKind
-        attributes=None,  # type: Optional[Mapping[str, AttributeValue]]
-        start_time=None,  # type: Optional[int]
-        record_exception=None,  # type: Optional[bool]
-        set_status_on_exception=None,  # type: Optional[bool]
-    ):
-        # type: (...) -> None
+        datadog_span: DDSpan,
+        kind: SpanKind = SpanKind.INTERNAL,
+        attributes: Optional[Mapping[str, AttributeValue]] = None,
+        start_time: Optional[int] = None,
+        record_exception: Optional[bool] = None,
+        set_status_on_exception: Optional[bool] = None,
+    ) -> None:
         if start_time is not None:
             # start_time should be set in nanoseconds
             datadog_span.start_ns = start_time
@@ -63,29 +62,24 @@ class Span(OtelSpan):
             self.set_attributes(attributes)
 
     @property
-    def _record_exception(self):
-        # type: () -> bool
+    def _record_exception(self) -> bool:
         # default value is True, if record exception key is not set return True
         return core.get_item(self._RECORD_EXCEPTION_KEY, span=self._ddspan) is not False
 
     @_record_exception.setter
-    def _record_exception(self, value):
-        # type: (bool) -> None
+    def _record_exception(self, value: bool) -> None:
         core.set_item(self._RECORD_EXCEPTION_KEY, value, span=self._ddspan)
 
     @property
-    def _set_status_on_exception(self):
-        # type: () -> bool
+    def _set_status_on_exception(self) -> bool:
         # default value is True, if set status on exception key is not set return True
         return core.get_item(self._SET_EXCEPTION_STATUS_KEY, span=self._ddspan) is not False
 
     @_set_status_on_exception.setter
-    def _set_status_on_exception(self, value):
-        # type: (bool) -> None
+    def _set_status_on_exception(self, value: bool) -> None:
         core.set_item(self._SET_EXCEPTION_STATUS_KEY, value, span=self._ddspan)
 
-    def end(self, end_time=None):
-        # type: (Optional[int]) -> None
+    def end(self, end_time: Optional[int] = None) -> None:
         """
         Marks the end time of a span. This method should be called once.
 
@@ -103,8 +97,7 @@ class Span(OtelSpan):
         # TODO: Propose a fix in opentelemetry-python-contrib project
         return self._ddspan._meta.get(SPAN_KIND, SpanKind.INTERNAL.name.lower())
 
-    def get_span_context(self):
-        # type: () -> SpanContext
+    def get_span_context(self) -> SpanContext:
         """Returns an OpenTelemetry SpanContext"""
         ts = None
         tf = TraceFlags.DEFAULT
@@ -115,14 +108,12 @@ class Span(OtelSpan):
 
         return SpanContext(self._ddspan.trace_id, self._ddspan.span_id, False, tf, ts)
 
-    def set_attributes(self, attributes):
-        # type: (Mapping[str, AttributeValue]) -> None
+    def set_attributes(self, attributes: Mapping[str, AttributeValue]) -> None:
         """Sets attributes/tags"""
         for k, v in attributes.items():
             self.set_attribute(k, v)
 
-    def set_attribute(self, key, value):
-        # type: (str, AttributeValue) -> None
+    def set_attribute(self, key: str, value: AttributeValue) -> None:
         """Sets an attribute or service name on a tag"""
         if not self.is_recording():
             return
@@ -130,13 +121,11 @@ class Span(OtelSpan):
         # `service.version` attributes. This functionality is supported by Span.set_tag and NOT Span.set_tag_str().
         self._ddspan.set_tag(key, value)
 
-    def add_event(self, name, attributes=None, timestamp=None):
-        # type: (str, Optional[Attributes], Optional[int]) -> None
+    def add_event(self, name: str, attributes: Optional[Attributes] = None, timestamp: Optional[int] = None) -> None:
         """NOOP - events are not yet supported"""
         return
 
-    def update_name(self, name):
-        # type: (str) -> None
+    def update_name(self, name: str) -> None:
         """Updates the name of a span"""
         if not self.is_recording():
             return
@@ -145,13 +134,11 @@ class Span(OtelSpan):
         self._ddspan.name = name
         self._ddspan.resource = name
 
-    def is_recording(self):
-        # type: () -> bool
+    def is_recording(self) -> bool:
         """Returns False if Span.end() is called."""
         return not self._ddspan.finished
 
-    def set_status(self, status, description=None):
-        # type: (Union[Status, StatusCode], Optional[str]) -> None
+    def set_status(self, status: Union[Status, StatusCode], description: Optional[str] = None) -> None:
         """
         Updates a Span from StatusCode.OK to StatusCode.ERROR.
         Note - The default status is OK. Setting the status to StatusCode.UNSET or updating the
@@ -173,8 +160,7 @@ class Span(OtelSpan):
             if message:
                 self.set_attribute(ERROR_MSG, message)
 
-    def record_exception(self, exception, attributes=None, timestamp=None, escaped=False):
-        # type: (BaseException, Optional[Attributes], Optional[int], bool) -> None
+    def record_exception(self, exception: BaseException, attributes: Optional[Attributes] = None, timestamp: Optional[int] = None, escaped: bool = False) -> None:
         """
         Records the type, message, and traceback of an exception as Span attributes.
         Note - Span Events are not yet supported.
@@ -185,8 +171,7 @@ class Span(OtelSpan):
         if attributes:
             self.set_attributes(attributes)
 
-    def __enter__(self):
-        # type: () -> Span
+    def __enter__(self) -> Span:
         """Invoked when `Span` is used as a context manager.
         Returns the `Span` itself.
         """

--- a/ddtrace/opentracer/helpers.py
+++ b/ddtrace/opentracer/helpers.py
@@ -14,8 +14,7 @@ Helper routines for Datadog OpenTracing.
 """
 
 
-def set_global_tracer(tracer):
-    # type: (Tracer) -> None
+def set_global_tracer(tracer: Tracer) -> None:
     """Sets the global tracers to the given tracer."""
 
     # overwrite the opentracer reference

--- a/ddtrace/opentracer/propagation/http.py
+++ b/ddtrace/opentracer/propagation/http.py
@@ -24,8 +24,7 @@ class HTTPPropagator(Propagator):
     """
 
     @staticmethod
-    def inject(span_context, carrier):
-        # type: (SpanContext, Dict[str, str]) -> None
+    def inject(span_context: SpanContext, carrier: Dict[str, str]) -> None:
         """Inject a span context into a carrier.
 
         *span_context* is injected into the carrier by first using an
@@ -49,8 +48,7 @@ class HTTPPropagator(Propagator):
                 carrier[HTTP_BAGGAGE_PREFIX + key] = span_context.baggage[key]
 
     @staticmethod
-    def extract(carrier):
-        # type: (Dict[str, str]) -> SpanContext
+    def extract(carrier: Dict[str, str]) -> SpanContext:
         """Extract a span context from a carrier.
 
         :class:`ddtrace.propagation.http.HTTPPropagator` is used to extract

--- a/ddtrace/opentracer/settings.py
+++ b/ddtrace/opentracer/settings.py
@@ -35,7 +35,6 @@ ConfigKeys = ConfigKeyNames(
 )
 
 
-def config_invalid_keys(config):
-    # type: (Dict[str, Any]) -> List[str]
+def config_invalid_keys(config: Dict[str, Any]) -> List[str]:
     """Returns a list of keys that exist in *config* and not in KEYS."""
     return [key for key in config.keys() if key not in ConfigKeys]

--- a/ddtrace/opentracer/span.py
+++ b/ddtrace/opentracer/span.py
@@ -31,8 +31,7 @@ _TagNameType = Union[Text, bytes]
 class Span(OpenTracingSpan):
     """Datadog implementation of :class:`opentracing.Span`"""
 
-    def __init__(self, tracer, context, operation_name):
-        # type: (Tracer, Optional[SpanContext], str) -> None
+    def __init__(self, tracer: Tracer, context: Optional[SpanContext], operation_name: str) -> None:
         if context is not None:
             context = SpanContext(ddcontext=context._dd_context, baggage=context.baggage)
         else:
@@ -45,8 +44,7 @@ class Span(OpenTracingSpan):
         # use a datadog span
         self._dd_span = DatadogSpan(operation_name, context=context._dd_context, span_api=SPAN_API_OPENTRACING)
 
-    def finish(self, finish_time=None):
-        # type: (Optional[float]) -> None
+    def finish(self, finish_time: Optional[float] = None) -> None:
         """Finish the span.
 
         This calls finish on the ddspan.
@@ -62,8 +60,7 @@ class Span(OpenTracingSpan):
         self._dd_span.finish(finish_time)
         self.finished = True
 
-    def set_baggage_item(self, key, value):
-        # type: (str, Any) -> Span
+    def set_baggage_item(self, key: str, value: Any) -> Span:
         """Sets a baggage item in the span context of this span.
 
         Baggage is used to propagate state between spans.
@@ -82,8 +79,7 @@ class Span(OpenTracingSpan):
             self._context = new_ctx
         return self
 
-    def get_baggage_item(self, key):
-        # type: (str) -> Optional[str]
+    def get_baggage_item(self, key: str) -> Optional[str]:
         """Gets a baggage item from the span context of this span.
 
         :param key: baggage item key
@@ -94,14 +90,12 @@ class Span(OpenTracingSpan):
         """
         return self.context.get_baggage_item(key)
 
-    def set_operation_name(self, operation_name):
-        # type: (str) -> Span
+    def set_operation_name(self, operation_name: str) -> Span:
         """Set the operation name."""
         self._dd_span.name = operation_name
         return self
 
-    def log_kv(self, key_values, timestamp=None):
-        # type: (Dict[_TagNameType, Any], Optional[float]) -> Span
+    def log_kv(self, key_values: Dict[_TagNameType, Any], timestamp: Optional[float] = None) -> Span:
         """Add a log record to this span.
 
         Passes on relevant opentracing key values onto the datadog span.
@@ -134,8 +128,7 @@ class Span(OpenTracingSpan):
 
         return self
 
-    def set_tag(self, key, value):
-        # type: (_TagNameType, Any) -> Span
+    def set_tag(self, key: _TagNameType, value: Any) -> Span:
         """Set a tag on the span.
 
         This sets the tag on the underlying datadog span.
@@ -156,16 +149,14 @@ class Span(OpenTracingSpan):
             self._dd_span.set_tag(key, value)
         return self
 
-    def _get_tag(self, key):
-        # type: (_TagNameType) -> Optional[Text]
+    def _get_tag(self, key: _TagNameType) -> Optional[Text]:
         """Gets a tag from the span.
 
         This method retrieves the tag from the underlying datadog span.
         """
         return self._dd_span.get_tag(key)
 
-    def _get_metric(self, key):
-        # type: (_TagNameType) -> Optional[NumericType]
+    def _get_metric(self, key: _TagNameType) -> Optional[NumericType]:
         """Gets a metric from the span.
 
         This method retrieves the metric from the underlying datadog span.
@@ -184,14 +175,12 @@ class Span(OpenTracingSpan):
         self._dd_span.__exit__(exc_type, exc_val, exc_tb)
         self.finish()
 
-    def _associate_dd_span(self, ddspan):
-        # type: (DatadogSpan) -> None
+    def _associate_dd_span(self, ddspan: DatadogSpan) -> None:
         """Associates a DD span with this span."""
         # get the datadog span context
         self._dd_span = ddspan
         self.context._dd_context = ddspan.context
 
     @property
-    def _dd_context(self):
-        # type: () -> DatadogContext
+    def _dd_context(self) -> DatadogContext:
         return self._dd_span.context

--- a/ddtrace/opentracer/span_context.py
+++ b/ddtrace/opentracer/span_context.py
@@ -13,13 +13,12 @@ class SpanContext(OpenTracingSpanContext):
 
     def __init__(
         self,
-        trace_id=None,  # type: Optional[int]
-        span_id=None,  # type: Optional[int]
-        sampling_priority=None,  # type: Optional[NumericType]
-        baggage=None,  # type: Optional[Dict[str, Any]]
-        ddcontext=None,  # type: Optional[DatadogContext]
-    ):
-        # type: (...) -> None
+        trace_id: Optional[int] = None,
+        span_id: Optional[int] = None,
+        sampling_priority: Optional[NumericType] = None,
+        baggage: Optional[Dict[str, Any]] = None,
+        ddcontext: Optional[DatadogContext] = None,
+    ) -> None:
         # create a new dict for the baggage if it is not provided
         # NOTE: it would be preferable to use opentracing.SpanContext.EMPTY_BAGGAGE
         #       but it is mutable.
@@ -38,20 +37,17 @@ class SpanContext(OpenTracingSpanContext):
         self._baggage = dict(baggage)
 
     @property
-    def baggage(self):
-        # type: () -> Dict[str, Any]
+    def baggage(self) -> Dict[str, Any]:
         return self._baggage
 
-    def set_baggage_item(self, key, value):
-        # type: (str, Any) -> None
+    def set_baggage_item(self, key: str, value: Any) -> None:
         """Sets a baggage item in this span context.
 
         Note that this operation mutates the baggage of this span context
         """
         self.baggage[key] = value
 
-    def with_baggage_item(self, key, value):
-        # type: (str, Any) -> SpanContext
+    def with_baggage_item(self, key: str, value: Any) -> SpanContext:
         """Returns a copy of this span with a new baggage item.
 
         Useful for instantiating new child span contexts.
@@ -60,7 +56,6 @@ class SpanContext(OpenTracingSpanContext):
         baggage[key] = value
         return SpanContext(ddcontext=self._dd_context, baggage=baggage)
 
-    def get_baggage_item(self, key):
-        # type: (str) -> Optional[Any]
+    def get_baggage_item(self, key: str) -> Optional[Any]:
         """Gets a baggage item in this span context."""
         return self.baggage.get(key, None)

--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -29,7 +29,7 @@ from .utils import get_context_provider_for_scope_manager
 
 log = get_logger(__name__)
 
-DEFAULT_CONFIG = {
+DEFAULT_CONFIG: Dict[str, Any] = {
     keys.AGENT_HOSTNAME: None,
     keys.AGENT_HTTPS: None,
     keys.AGENT_PORT: None,
@@ -42,7 +42,7 @@ DEFAULT_CONFIG = {
     keys.SETTINGS: {
         "FILTERS": [],
     },
-}  # type: Dict[str, Any]
+}
 
 
 class Tracer(opentracing.Tracer):
@@ -50,12 +50,11 @@ class Tracer(opentracing.Tracer):
 
     def __init__(
         self,
-        service_name=None,  # type: Optional[str]
-        config=None,  # type: Optional[Dict[str, Any]]
-        scope_manager=None,  # type: Optional[ScopeManager]
-        dd_tracer=None,  # type: Optional[DatadogTracer]
-    ):
-        # type: (...) -> None
+        service_name: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+        scope_manager: Optional[ScopeManager] = None,
+        dd_tracer: Optional[DatadogTracer] = None,
+    ) -> None:
         """Initialize a new Datadog opentracer.
 
         :param service_name: (optional) the name of the service that this
@@ -118,22 +117,20 @@ class Tracer(opentracing.Tracer):
         }
 
     @property
-    def scope_manager(self):
-        # type: () -> ScopeManager
+    def scope_manager(self) -> ScopeManager:
         """Returns the scope manager being used by this tracer."""
         return self._scope_manager
 
     def start_active_span(
         self,
-        operation_name,  # type: str
-        child_of=None,  # type: Optional[Union[Span, SpanContext]]
-        references=None,  # type: Optional[List[Any]]
-        tags=None,  # type: Optional[Dict[str, str]]
-        start_time=None,  # type: Optional[int]
-        ignore_active_span=False,  # type: bool
-        finish_on_close=True,  # type: bool
-    ):
-        # type: (...) -> Scope
+        operation_name: str,
+        child_of: Optional[Union[Span, SpanContext]] = None,
+        references: Optional[List[Any]] = None,
+        tags: Optional[Dict[str, str]] = None,
+        start_time: Optional[int] = None,
+        ignore_active_span: bool = False,
+        finish_on_close: bool = True,
+    ) -> Scope:
         """Returns a newly started and activated `Scope`.
         The returned `Scope` supports with-statement contexts. For example::
 
@@ -188,14 +185,13 @@ class Tracer(opentracing.Tracer):
 
     def start_span(
         self,
-        operation_name=None,  # type: Optional[str]
-        child_of=None,  # type: Optional[Union[Span, SpanContext]]
-        references=None,  # type: Optional[List[Any]]
-        tags=None,  # type: Optional[Dict[str, str]]
-        start_time=None,  # type: Optional[int]
-        ignore_active_span=False,  # type: bool
-    ):
-        # type: (...) -> Span
+        operation_name: Optional[str] = None,
+        child_of: Optional[Union[Span, SpanContext]] = None,
+        references: Optional[List[Any]] = None,
+        tags: Optional[Dict[str, str]] = None,
+        start_time: Optional[int] = None,
+        ignore_active_span: bool = False,
+    ) -> Span:
         """Starts and returns a new Span representing a unit of work.
 
         Starting a root Span (a Span with no causal references)::
@@ -242,7 +238,7 @@ class Tracer(opentracing.Tracer):
         ot_parent = None  # 'ot_parent' is more readable than 'child_of'
         ot_parent_context = None  # the parent span's context
         # dd_parent: the child_of to pass to the ddtracer
-        dd_parent = None  # type: Optional[Union[DatadogSpan, DatadogContext]]
+        dd_parent: Optional[Union[DatadogSpan, DatadogContext]] = None
 
         if child_of is not None:
             ot_parent = child_of  # 'ot_parent' is more readable than 'child_of'
@@ -314,8 +310,7 @@ class Tracer(opentracing.Tracer):
         return otspan
 
     @property
-    def active_span(self):
-        # type: () -> Optional[Span]
+    def active_span(self) -> Optional[Span]:
         """Retrieves the active span from the opentracing scope manager
 
         Falls back to using the datadog active span if one is not found. This
@@ -326,14 +321,13 @@ class Tracer(opentracing.Tracer):
             return scope.span
         else:
             dd_span = self._dd_tracer.current_span()
-            ot_span = None  # type: Optional[Span]
+            ot_span: Optional[Span] = None
             if dd_span:
                 ot_span = Span(self, None, dd_span.name)
                 ot_span._associate_dd_span(dd_span)
             return ot_span
 
-    def inject(self, span_context, format, carrier):  # noqa: A002
-        # type: (SpanContext, str, Dict[str, str]) -> None
+    def inject(self, span_context: SpanContext, format: str, carrier: Dict[str, str]) -> None:  # noqa: A002
         """Injects a span context into a carrier.
 
         :param span_context: span context to inject.
@@ -347,8 +341,7 @@ class Tracer(opentracing.Tracer):
 
         propagator.inject(span_context, carrier)
 
-    def extract(self, format, carrier):  # noqa: A002
-        # type: (str, Dict[str, str]) -> SpanContext
+    def extract(self, format: str, carrier: Dict[str, str]) -> SpanContext:  # noqa: A002
         """Extracts a span context from a carrier.
 
         :param format: format that the carrier is encoded with.
@@ -366,8 +359,7 @@ class Tracer(opentracing.Tracer):
         self._dd_tracer.context_provider.activate(dd_span_ctx)
         return ot_span_ctx
 
-    def get_log_correlation_context(self):
-        # type: () -> Dict[str, str]
+    def get_log_correlation_context(self) -> Dict[str, str]:
         """Retrieves the data used to correlate a log with the current active trace.
         Generates a dictionary for custom logging instrumentation including the trace id and
         span id of the current active span, as well as the configured service, version, and environment names.

--- a/ddtrace/opentracer/utils.py
+++ b/ddtrace/opentracer/utils.py
@@ -7,8 +7,7 @@ from ddtrace.provider import BaseContextProvider
 #    `context_provider` will just not be set and we'll get an `AttributeError` instead
 
 
-def get_context_provider_for_scope_manager(scope_manager):
-    # type: (ScopeManager) -> BaseContextProvider
+def get_context_provider_for_scope_manager(scope_manager: ScopeManager) -> BaseContextProvider:
     """Returns the context_provider to use with a given scope_manager."""
 
     scope_manager_type = type(scope_manager).__name__
@@ -18,7 +17,7 @@ def get_context_provider_for_scope_manager(scope_manager):
     if scope_manager_type == "AsyncioScopeManager":
         import ddtrace.contrib.asyncio
 
-        dd_context_provider = ddtrace.contrib.asyncio.context_provider  # type: BaseContextProvider
+        dd_context_provider: BaseContextProvider = ddtrace.contrib.asyncio.context_provider
     elif scope_manager_type == "GeventScopeManager":
         import ddtrace.contrib.gevent
 
@@ -33,8 +32,7 @@ def get_context_provider_for_scope_manager(scope_manager):
     return dd_context_provider
 
 
-def _patch_scope_manager(scope_manager, context_provider):
-    # type: (ScopeManager, BaseContextProvider) -> None
+def _patch_scope_manager(scope_manager: ScopeManager, context_provider: BaseContextProvider) -> None:
     """
     Patches a scope manager so that any time a span is activated
     it'll also activate the underlying ddcontext with the underlying

--- a/ddtrace/pin.py
+++ b/ddtrace/pin.py
@@ -34,26 +34,24 @@ class Pin(object):
 
     def __init__(
         self,
-        service=None,  # type: Optional[str]
-        tags=None,  # type: Optional[Dict[str, str]]
+        service: Optional[str] = None,
+        tags: Optional[Dict[str, str]] = None,
         tracer=None,
-        _config=None,  # type: Optional[Dict[str, Any]]
-    ):
-        # type: (...) -> None
+        _config: Optional[Dict[str, Any]] = None,
+    ) -> None:
         tracer = tracer or ddtrace.tracer
         self.tags = tags
         self.tracer = tracer
-        self._target = None  # type: Optional[int]
+        self._target: Optional[int] = None
         # keep the configuration attribute internal because the
         # public API to access it is not the Pin class
-        self._config = _config or {}  # type: Dict[str, Any]
+        self._config: Dict[str, Any] = _config or {}
         # [Backward compatibility]: service argument updates the `Pin` config
         self._config["service_name"] = service
         self._initialized = True
 
     @property
-    def service(self):
-        # type: () -> str
+    def service(self) -> str:
         """Backward compatibility: accessing to `pin.service` returns the underlying
         configuration value.
         """
@@ -68,8 +66,7 @@ class Pin(object):
         return "Pin(service=%s, tags=%s, tracer=%s)" % (self.service, self.tags, self.tracer)
 
     @staticmethod
-    def _find(*objs):
-        # type: (Any) -> Optional[Pin]
+    def _find(*objs: Any) -> Optional[Pin]:
         """
         Return the first :class:`ddtrace.pin.Pin` found on any of the provided objects or `None` if none were found
 
@@ -88,8 +85,7 @@ class Pin(object):
         return None
 
     @staticmethod
-    def get_from(obj):
-        # type: (Any) -> Optional[Pin]
+    def get_from(obj: Any) -> Optional[Pin]:
         """Return the pin associated with the given object. If a pin is attached to
         `obj` but the instance is not the owner of the pin, a new pin is cloned and
         attached. This ensures that a pin inherited from a class is a copy for the new
@@ -116,12 +112,11 @@ class Pin(object):
     @classmethod
     def override(
         cls,
-        obj,  # type: Any
-        service=None,  # type: Optional[str]
-        tags=None,  # type: Optional[Dict[str, str]]
+        obj: Any,
+        service: Optional[str] = None,
+        tags: Optional[Dict[str, str]] = None,
         tracer=None,
-    ):
-        # type: (...) -> None
+    ) -> None:
         """Override an object with the given attributes.
 
         That's the recommended way to customize an already instrumented client, without
@@ -140,13 +135,11 @@ class Pin(object):
         else:
             pin.clone(service=service, tags=tags, tracer=tracer).onto(obj)
 
-    def enabled(self):
-        # type: () -> bool
+    def enabled(self) -> bool:
         """Return true if this pin's tracer is enabled."""
         return bool(self.tracer) and self.tracer.enabled
 
-    def onto(self, obj, send=True):
-        # type: (Any, bool) -> None
+    def onto(self, obj: Any, send: bool = True) -> None:
         """Patch this pin onto the given object. If send is true, it will also
         queue the metadata to be sent to the server.
         """
@@ -165,8 +158,7 @@ class Pin(object):
         except AttributeError:
             log.debug("can't pin onto object. skipping", exc_info=True)
 
-    def remove_from(self, obj):
-        # type: (Any) -> None
+    def remove_from(self, obj: Any) -> None:
         # Remove pin from the object.
         try:
             pin_name = _DD_PIN_PROXY_NAME if isinstance(obj, wrapt.ObjectProxy) else _DD_PIN_NAME
@@ -179,11 +171,10 @@ class Pin(object):
 
     def clone(
         self,
-        service=None,  # type: Optional[str]
-        tags=None,  # type: Optional[Dict[str, str]]
+        service: Optional[str] = None,
+        tags: Optional[Dict[str, str]] = None,
         tracer=None,
-    ):
-        # type: (...) -> Pin
+    ) -> Pin:
         """Return a clone of the pin with the given attributes replaced."""
         # do a shallow copy of Pin dicts
         if not tags and self.tags:

--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -13,7 +13,7 @@ from ddtrace.internal.wrapping import wrap
 from . import _threading
 
 
-THREAD_LINK = None  # type: typing.Optional[_threading._ThreadLink]
+THREAD_LINK: typing.Optional[_threading._ThreadLink] = None
 
 
 def current_task(loop=None):
@@ -29,8 +29,7 @@ def _task_get_name(task):
 
 
 @ModuleWatchdog.after_module_imported("asyncio")
-def _(asyncio):
-    # type: (ModuleType) -> None
+def _(asyncio: ModuleType) -> None:
     global THREAD_LINK
 
     if hasattr(asyncio, "current_task"):

--- a/ddtrace/profiling/collector/__init__.py
+++ b/ddtrace/profiling/collector/__init__.py
@@ -36,14 +36,12 @@ class Collector(service.Service):
 class PeriodicCollector(Collector, periodic.PeriodicService):
     """A collector that needs to run periodically."""
 
-    def periodic(self):
-        # type: (...) -> None
+    def periodic(self) -> None:
         """Collect events and push them into the recorder."""
         for events in self.collect():
             self.recorder.push_events(events)
 
-    def collect(self):
-        # type: (...) -> typing.Iterable[typing.Iterable[event.Event]]
+    def collect(self) -> typing.Iterable[typing.Iterable[event.Event]]:
         """Collect the actual data.
 
         :return: A list of event list to push in the recorder.

--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -40,8 +40,7 @@ class LockReleaseEvent(LockEventBase):
     locked_for_ns = attr.ib(default=0, type=int)
 
 
-def _current_thread():
-    # type: (...) -> typing.Tuple[int, str]
+def _current_thread() -> typing.Tuple[int, str]:
     thread_id = _thread.get_ident()
     return thread_id, _threading.get_thread_name(thread_id)
 
@@ -185,31 +184,26 @@ class LockCollector(collector.CaptureSamplerCollector):
     _original = attr.ib(init=False, repr=False, type=typing.Any, cmp=False)
 
     @abc.abstractmethod
-    def _get_original(self):
-        # type: (...) -> typing.Any
+    def _get_original(self) -> typing.Any:
         pass
 
     @abc.abstractmethod
     def _set_original(
-        self, value  # type: typing.Any
-    ):
-        # type: (...) -> None
+        self, value: typing.Any
+    ) -> None:
         pass
 
-    def _start_service(self):
-        # type: (...) -> None
+    def _start_service(self) -> None:
         """Start collecting lock usage."""
         self.patch()
         super(LockCollector, self)._start_service()
 
-    def _stop_service(self):
-        # type: (...) -> None
+    def _stop_service(self) -> None:
         """Stop collecting lock usage."""
         super(LockCollector, self)._stop_service()
         self.unpatch()
 
-    def patch(self):
-        # type: (...) -> None
+    def patch(self) -> None:
         """Patch the module for tracking lock allocation."""
         # We only patch the lock from the `threading` module.
         # Nobody should use locks from `_thread`; if they do so, then it's deliberate and we don't profile.
@@ -223,7 +217,6 @@ class LockCollector(collector.CaptureSamplerCollector):
 
         self._set_original(FunctionWrapper(self.original, _allocate_lock))
 
-    def unpatch(self):
-        # type: (...) -> None
+    def unpatch(self) -> None:
         """Unpatch the threading module for tracking lock allocation."""
         self._set_original(self.original)

--- a/ddtrace/profiling/collector/asyncio.py
+++ b/ddtrace/profiling/collector/asyncio.py
@@ -28,8 +28,7 @@ class AsyncioLockCollector(_lock.LockCollector):
 
     PROFILED_LOCK_CLASS = _ProfiledAsyncioLock
 
-    def _start_service(self):
-        # type: (...) -> None
+    def _start_service(self) -> None:
         """Start collecting lock usage."""
         try:
             import asyncio
@@ -38,12 +37,10 @@ class AsyncioLockCollector(_lock.LockCollector):
         self._asyncio_module = asyncio
         return super(AsyncioLockCollector, self)._start_service()
 
-    def _get_original(self):
-        # type: (...) -> typing.Any
+    def _get_original(self) -> typing.Any:
         return self._asyncio_module.Lock
 
     def _set_original(
-        self, value  # type: typing.Any
-    ):
-        # type: (...) -> None
+        self, value: typing.Any
+    ) -> None:
         self._asyncio_module.Lock = value  # type: ignore[misc]

--- a/ddtrace/profiling/collector/memalloc.py
+++ b/ddtrace/profiling/collector/memalloc.py
@@ -66,8 +66,7 @@ class MemoryCollector(collector.PeriodicCollector):
     _export_libdd_enabled = attr.ib(type=bool, default=config.export.libdd_enabled)
     _export_py_enabled = attr.ib(type=bool, default=config.export.py_enabled)
 
-    def _start_service(self):
-        # type: (...) -> None
+    def _start_service(self) -> None:
         """Start collecting memory profiles."""
         if _memalloc is None:
             raise collector.CollectorUnavailable
@@ -84,16 +83,14 @@ class MemoryCollector(collector.PeriodicCollector):
         super(MemoryCollector, self)._start_service()
 
     @staticmethod
-    def on_shutdown():
-        # type: () -> None
+    def on_shutdown() -> None:
         if _memalloc is not None:
             try:
                 _memalloc.stop()
             except RuntimeError:
                 pass
 
-    def _get_thread_id_ignore_set(self):
-        # type: () -> typing.Set[int]
+    def _get_thread_id_ignore_set(self) -> typing.Set[int]:
         # This method is not perfect and prone to race condition in theory, but very little in practice.
         # Anyhow it's not a big deal — it's a best effort feature.
         return {

--- a/ddtrace/profiling/collector/threading.py
+++ b/ddtrace/profiling/collector/threading.py
@@ -30,12 +30,10 @@ class ThreadingLockCollector(_lock.LockCollector):
 
     PROFILED_LOCK_CLASS = _ProfiledThreadingLock
 
-    def _get_original(self):
-        # type: (...) -> typing.Any
+    def _get_original(self) -> typing.Any:
         return threading.Lock
 
     def _set_original(
-        self, value  # type: typing.Any
-    ):
-        # type: (...) -> None
+        self, value: typing.Any
+    ) -> None:
         threading.Lock = value  # type: ignore[misc]

--- a/ddtrace/profiling/event.py
+++ b/ddtrace/profiling/event.py
@@ -14,9 +14,8 @@ StackTraceType = typing.List[DDFrame]
 
 
 def event_class(
-    klass,  # type: typing.Type[_T]
-):
-    # type: (...) -> typing.Type[_T]
+    klass: typing.Type[_T],
+) -> typing.Type[_T]:
     return attr.s(slots=True)(klass)
 
 
@@ -27,8 +26,7 @@ class Event(object):
     timestamp = attr.ib(factory=compat.time_ns)
 
     @property
-    def name(self):
-        # type: (...) -> str
+    def name(self) -> str:
         """Name of the event."""
         return self.__class__.__name__
 
@@ -63,10 +61,9 @@ class StackBasedEvent(SampleEvent):
 
     def set_trace_info(
         self,
-        span,  # type: typing.Optional[ddspan.Span]
-        endpoint_collection_enabled,  # type: bool
-    ):
-        # type: (...) -> None
+        span: typing.Optional[ddspan.Span],
+        endpoint_collection_enabled: bool,
+    ) -> None:
         if span:
             self.span_id = span.span_id
             if span._local_root is not None:

--- a/ddtrace/profiling/exporter/__init__.py
+++ b/ddtrace/profiling/exporter/__init__.py
@@ -17,11 +17,10 @@ class Exporter(object):
 
     def export(
         self,
-        events,  # type: recorder.EventsType
-        start_time_ns,  # type: int
-        end_time_ns,  # type: int
-    ):
-        # type: (...) -> typing.Any
+        events: recorder.EventsType,
+        start_time_ns: int,
+        end_time_ns: int,
+    ) -> typing.Any:
         """Export events.
 
         :param events: List of events to export.
@@ -37,10 +36,9 @@ class NullExporter(Exporter):
 
     def export(
         self,
-        events,  # type: recorder.EventsType
-        start_time_ns,  # type: int
-        end_time_ns,  # type: int
-    ):
-        # type: (...) -> None
+        events: recorder.EventsType,
+        start_time_ns: int,
+        end_time_ns: int,
+    ) -> None:
         """Discard events."""
         pass

--- a/ddtrace/profiling/exporter/file.py
+++ b/ddtrace/profiling/exporter/file.py
@@ -18,11 +18,10 @@ class PprofFileExporter(pprof.PprofExporter):
 
     def export(
         self,
-        events,  # type: recorder.EventsType
-        start_time_ns,  # type: int
-        end_time_ns,  # type: int
-    ):
-        # type: (...) -> typing.Tuple[pprof.pprof_ProfileType, typing.List[pprof.Package]]
+        events: recorder.EventsType,
+        start_time_ns: int,
+        end_time_ns: int,
+    ) -> typing.Tuple[pprof.pprof_ProfileType, typing.List[pprof.Package]]:
         """Export events to pprof file.
 
         The file name is based on the prefix passed to init. The process ID number and type of export is then added as a

--- a/ddtrace/profiling/exporter/http.py
+++ b/ddtrace/profiling/exporter/http.py
@@ -108,10 +108,9 @@ class PprofHTTPExporter(pprof.PprofExporter):
 
     @staticmethod
     def _encode_multipart_formdata(
-        event,  # type: bytes
-        data,  # type: typing.List[typing.Dict[str, bytes]]
-    ):
-        # type: (...) -> typing.Tuple[bytes, bytes]
+        event: bytes,
+        data: typing.List[typing.Dict[str, bytes]],
+    ) -> typing.Tuple[bytes, bytes]:
         boundary = binascii.hexlify(os.urandom(16))
 
         # The body that is generated is very sensitive and must perfectly match what the server expects.
@@ -137,9 +136,8 @@ class PprofHTTPExporter(pprof.PprofExporter):
         return content_type, body
 
     def _get_tags(
-        self, service  # type: str
-    ):
-        # type: (...) -> str
+        self, service: str
+    ) -> str:
         tags = {
             "service": service,
             "runtime-id": runtime.get_runtime_id(),
@@ -151,11 +149,10 @@ class PprofHTTPExporter(pprof.PprofExporter):
 
     def export(
         self,
-        events,  # type: recorder.EventsType
-        start_time_ns,  # type: int
-        end_time_ns,  # type: int
-    ):
-        # type: (...) -> typing.Tuple[pprof.pprof_ProfileType, typing.List[pprof.Package]]
+        events: recorder.EventsType,
+        start_time_ns: int,
+        end_time_ns: int,
+    ) -> typing.Tuple[pprof.pprof_ProfileType, typing.List[pprof.Package]]:
         """Export events to an HTTP endpoint.
 
         :param events: The event dictionary from a `ddtrace.profiling.recorder.Recorder`.
@@ -206,14 +203,14 @@ class PprofHTTPExporter(pprof.PprofExporter):
             )
 
         service = self.service or os.path.basename(profile.string_table[profile.mapping[0].filename])
-        event = {
+        event: Dict[str, Any] = {
             "version": "4",
             "family": "python",
             "attachments": [item["filename"].decode("utf-8") for item in data],
             "tags_profiler": self._get_tags(service),
             "start": (datetime.datetime.utcfromtimestamp(start_time_ns / 1e9).replace(microsecond=0).isoformat() + "Z"),
             "end": (datetime.datetime.utcfromtimestamp(end_time_ns / 1e9).replace(microsecond=0).isoformat() + "Z"),
-        }  # type: Dict[str, Any]
+        }
 
         if self.endpoint_call_counter_span_processor is not None:
             event["endpoint_counts"] = self.endpoint_call_counter_span_processor.reset()

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -92,9 +92,8 @@ class Profiler(object):
         self._profiler.start()
 
     def __getattr__(
-        self, key  # type: str
-    ):
-        # type: (...) -> typing.Any
+        self, key: str
+    ) -> typing.Any:
         return getattr(self._profiler, key)
 
 
@@ -132,8 +131,7 @@ class _ProfilerInstance(service.Service):
 
     ENDPOINT_TEMPLATE = "https://intake.profile.{}"
 
-    def _build_default_exporters(self):
-        # type: (...) -> List[exporter.Exporter]
+    def _build_default_exporters(self) -> List[exporter.Exporter]:
         _OUTPUT_PPROF = config.output_pprof
         if _OUTPUT_PPROF:
             # DEV: Import this only if needed to avoid importing protobuf
@@ -208,8 +206,7 @@ class _ProfilerInstance(service.Service):
             ]
         return []
 
-    def __attrs_post_init__(self):
-        # type: (...) -> None
+    def __attrs_post_init__(self) -> None:
         # Allow to store up to 10 threads for 60 seconds at 50 Hz
         max_stack_events = 10 * 60 * 50
         r = self._recorder = recorder.Recorder(
@@ -266,9 +263,9 @@ class _ProfilerInstance(service.Service):
         exporters = self._build_default_exporters()
 
         if exporters or self._export_libdd_enabled:
-            scheduler_class = (
+            scheduler_class: (Type[Union[scheduler.Scheduler, scheduler.ServerlessScheduler]]) = (
                 scheduler.ServerlessScheduler if self._lambda_function_name else scheduler.Scheduler
-            )  # type: (Type[Union[scheduler.Scheduler, scheduler.ServerlessScheduler]])
+            )
 
             self._scheduler = scheduler_class(
                 recorder=r,
@@ -297,8 +294,7 @@ class _ProfilerInstance(service.Service):
             }
         )
 
-    def _start_service(self):
-        # type: (...) -> None
+    def _start_service(self) -> None:
         """Start the profiler."""
         collectors = []
         for col in self._collectors:
@@ -315,8 +311,7 @@ class _ProfilerInstance(service.Service):
         if self._scheduler is not None:
             self._scheduler.start()
 
-    def _stop_service(self, flush=True, join=True):
-        # type: (bool, bool) -> None
+    def _stop_service(self, flush: bool = True, join: bool = True) -> None:
         """Stop the profiler.
 
         :param flush: Flush a last profile.

--- a/ddtrace/profiling/recorder.py
+++ b/ddtrace/profiling/recorder.py
@@ -40,13 +40,11 @@ class Recorder(object):
     events = attr.ib(init=False, repr=False, eq=False, type=EventsType)
     _events_lock = attr.ib(init=False, repr=False, factory=threading.RLock, eq=False)
 
-    def __attrs_post_init__(self):
-        # type: (...) -> None
+    def __attrs_post_init__(self) -> None:
         self._reset_events()
         forksafe.register(self._after_fork)
 
-    def _after_fork(self):
-        # type: (...) -> None
+    def _after_fork(self) -> None:
         # NOTE: do not try to push events if the process forked
         # This means we don't know the state of _events_lock and it might be unusable — we'd deadlock
         self.push_events = self._push_events_noop  # type: ignore[assignment]

--- a/ddtrace/profiling/scheduler.py
+++ b/ddtrace/profiling/scheduler.py
@@ -31,8 +31,7 @@ class Scheduler(periodic.PeriodicService):
         # Copy the value to use it later since we're going to adjust the real interval
         self._configured_interval = self.interval
 
-    def _start_service(self):
-        # type: (...) -> None
+    def _start_service(self) -> None:
         """Start the scheduler."""
         LOG.debug("Starting scheduler")
         super(Scheduler, self)._start_service()

--- a/ddtrace/propagation/_database_monitoring.py
+++ b/ddtrace/propagation/_database_monitoring.py
@@ -28,8 +28,7 @@ DBM_TRACE_INJECTED_TAG = "_dd.dbm_trace_injected"
 log = get_logger(__name__)
 
 
-def default_sql_injector(dbm_comment, sql_statement):
-    # type: (str, Union[str, bytes]) -> Union[str, bytes]
+def default_sql_injector(dbm_comment: str, sql_statement: Union[str, bytes]) -> Union[str, bytes]:
     try:
         if isinstance(sql_statement, bytes):
             return dbm_comment.encode("utf-8", errors="strict") + sql_statement
@@ -63,8 +62,7 @@ class _DBM_Propagator(object):
         args, kwargs = set_argument_value(args, kwargs, self.sql_pos, self.sql_kw, sql_with_dbm_tags)
         return args, kwargs
 
-    def _get_dbm_comment(self, db_span):
-        # type: (Span) -> Optional[str]
+    def _get_dbm_comment(self, db_span: Span) -> Optional[str]:
         """Generate DBM trace injection comment and updates span tags
         This method will set the ``_dd.dbm_trace_injected: "true"`` tag
         on ``db_span`` if the configured injection mode is ``"full"``.

--- a/ddtrace/propagation/_utils.py
+++ b/ddtrace/propagation/_utils.py
@@ -4,8 +4,7 @@ from ddtrace.internal.utils.cache import cached
 
 
 @cached()
-def get_wsgi_header(header):
-    # type: (str) -> str
+def get_wsgi_header(header: str) -> str:
     """Returns a WSGI compliant HTTP header.
     See https://www.python.org/dev/peps/pep-3333/#environ-variables for
     information from the spec.
@@ -14,8 +13,7 @@ def get_wsgi_header(header):
 
 
 @cached()
-def from_wsgi_header(header):
-    # type: (str) -> Optional[str]
+def from_wsgi_header(header: str) -> Optional[str]:
     """Convert a WSGI compliant HTTP header into the original header.
     See https://www.python.org/dev/peps/pep-3333/#environ-variables for
     information from the spec.

--- a/ddtrace/runtime/__init__.py
+++ b/ddtrace/runtime/__init__.py
@@ -7,8 +7,7 @@ import ddtrace.internal.runtime.runtime_metrics
 
 class _RuntimeMetricsStatus(type):
     @property
-    def _enabled(_):
-        # type: () -> bool
+    def _enabled(_) -> bool:
         """Runtime metrics enabled status."""
         return ddtrace.internal.runtime.runtime_metrics.RuntimeWorker.enabled
 
@@ -27,8 +26,7 @@ class RuntimeMetrics(six.with_metaclass(_RuntimeMetricsStatus)):
     """
 
     @staticmethod
-    def enable(tracer=None, dogstatsd_url=None, flush_interval=None):
-        # type: (Optional[ddtrace.Tracer], Optional[str], Optional[float]) -> None
+    def enable(tracer: Optional[ddtrace.Tracer] = None, dogstatsd_url: Optional[str] = None, flush_interval: Optional[float] = None) -> None:
         """
         Enable the runtime metrics collection service.
 
@@ -46,8 +44,7 @@ class RuntimeMetrics(six.with_metaclass(_RuntimeMetricsStatus)):
         )
 
     @staticmethod
-    def disable():
-        # type: () -> None
+    def disable() -> None:
         """
         Disable the runtime metrics collection service.
 

--- a/ddtrace/sampling_rule.py
+++ b/ddtrace/sampling_rule.py
@@ -27,13 +27,12 @@ class SamplingRule(object):
 
     def __init__(
         self,
-        sample_rate,  # type: float
-        service=NO_RULE,  # type: Any
-        name=NO_RULE,  # type: Any
-        resource=NO_RULE,  # type: Any
-        tags=NO_RULE,  # type: Any
-    ):
-        # type: (...) -> None
+        sample_rate: float,
+        service: Any = NO_RULE,
+        name: Any = NO_RULE,
+        resource: Any = NO_RULE,
+        tags: Any = NO_RULE,
+    ) -> None:
         """
         Configure a new :class:`SamplingRule`
 
@@ -81,13 +80,11 @@ class SamplingRule(object):
         self.tags = tags
 
     @property
-    def sample_rate(self):
-        # type: () -> float
+    def sample_rate(self) -> float:
         return self._sample_rate
 
     @sample_rate.setter
-    def sample_rate(self, sample_rate):
-        # type: (float) -> None
+    def sample_rate(self, sample_rate: float) -> None:
         self._sample_rate = sample_rate
         self._sampling_id_threshold = sample_rate * _MAX_UINT_64BITS
 
@@ -121,8 +118,7 @@ class SamplingRule(object):
         return prop == pattern
 
     @cachedmethod()
-    def _matches(self, key):
-        # type: (Tuple[Optional[str], str, Optional[str]]) -> bool
+    def _matches(self, key: Tuple[Optional[str], str, Optional[str]]) -> bool:
         # self._matches exists to maintain legacy pattern values such as regex and functions
         service, name, resource = key
         for prop, pattern in [(service, self.service), (name, self.name), (resource, self.resource)]:
@@ -131,8 +127,7 @@ class SamplingRule(object):
         else:
             return True
 
-    def matches(self, span):
-        # type: (Span) -> bool
+    def matches(self, span: Span) -> bool:
         """
         Return if this span matches this rule
 
@@ -144,8 +139,7 @@ class SamplingRule(object):
         glob_match = self.glob_matches(span)
         return glob_match and self._matches((span.service, span.name, span.resource))
 
-    def glob_matches(self, span):
-        # type: (Span) -> bool
+    def glob_matches(self, span: Span) -> bool:
         tag_match = True
         if self._tag_value_matchers:
             tag_match = self.tag_match(span.get_tags())
@@ -165,8 +159,7 @@ class SamplingRule(object):
                 return False
         return tag_match
 
-    def sample(self, span, allow_false=True):
-        # type: (Span, bool) -> bool
+    def sample(self, span: Span, allow_false: bool = True) -> bool:
         """
         Return if this rule chooses to sample the span
 
@@ -200,8 +193,7 @@ class SamplingRule(object):
 
     __str__ = __repr__
 
-    def __eq__(self, other):
-        # type: (Any) -> bool
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, SamplingRule):
             raise TypeError("Cannot compare SamplingRule to {}".format(type(other)))
 

--- a/ddtrace/settings/dynamic_instrumentation.py
+++ b/ddtrace/settings/dynamic_instrumentation.py
@@ -15,8 +15,7 @@ DEFAULT_MAX_PROBES = 100
 DEFAULT_GLOBAL_RATE_LIMIT = 100.0
 
 
-def _derive_tags(c):
-    # type: (En) -> str
+def _derive_tags(c: En) -> str:
     _tags = dict(env=ddconfig.env, version=ddconfig.version, debugger_version=get_version())
     _tags.update(ddconfig.tags)
 

--- a/ddtrace/settings/http.py
+++ b/ddtrace/settings/http.py
@@ -19,8 +19,7 @@ class HttpConfig(object):
     related to the http context.
     """
 
-    def __init__(self, header_tags=None):
-        # type: (Optional[Mapping[str, str]]) -> None
+    def __init__(self, header_tags: Optional[Mapping[str, str]] = None) -> None:
         self._header_tags = {normalize_header_name(k): v for k, v in header_tags.items()} if header_tags else {}
         self.trace_query_string = None
 
@@ -29,8 +28,7 @@ class HttpConfig(object):
         self._header_tag_name.invalidate()
 
     @cachedmethod()
-    def _header_tag_name(self, header_name):
-        # type: (str) -> Optional[str]
+    def _header_tag_name(self, header_name: str) -> Optional[str]:
         if not self._header_tags:
             return None
 
@@ -41,12 +39,10 @@ class HttpConfig(object):
         return self._header_tags.get(normalized_header_name)
 
     @property
-    def is_header_tracing_configured(self):
-        # type: () -> bool
+    def is_header_tracing_configured(self) -> bool:
         return len(self._header_tags) > 0
 
-    def trace_headers(self, whitelist):
-        # type: (Union[List[str], str]) -> Optional[HttpConfig]
+    def trace_headers(self, whitelist: Union[List[str], str]) -> Optional[HttpConfig]:
         """
         Registers a set of headers to be traced at global level or integration level.
         :param whitelist: the case-insensitive list of traced headers
@@ -71,8 +67,7 @@ class HttpConfig(object):
 
         return self
 
-    def header_is_traced(self, header_name):
-        # type: (str) -> bool
+    def header_is_traced(self, header_name: str) -> bool:
         """
         Returns whether or not the current header should be traced.
         :param header_name: the header name

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -62,8 +62,7 @@ class IntegrationConfig(AttrDict):
             self.get_http_tag_query_string(getattr(self, "default_http_tag_query_string", None)),
         )
 
-    def _get_analytics_settings(self):
-        # type: () -> Tuple[Optional[bool], float]
+    def _get_analytics_settings(self) -> Tuple[Optional[bool], float]:
         # Set default analytics configuration, default is disabled
         # DEV: Default to `None` which means do not set this key
         # Inject environment variables for integration
@@ -96,8 +95,7 @@ class IntegrationConfig(AttrDict):
         return self.global_config.http.trace_query_string
 
     @property
-    def is_header_tracing_configured(self):
-        # type: (...) -> bool
+    def is_header_tracing_configured(self) -> bool:
         """Returns whether header tracing is enabled for this integration.
 
         Will return true if traced headers are configured for this integration
@@ -105,8 +103,7 @@ class IntegrationConfig(AttrDict):
         """
         return self.http.is_header_tracing_configured or self.global_config.http.is_header_tracing_configured
 
-    def header_is_traced(self, header_name):
-        # type: (str) -> bool
+    def header_is_traced(self, header_name: str) -> bool:
         """
         Returns whether or not the current header should be traced.
         :param header_name: the header name
@@ -115,8 +112,7 @@ class IntegrationConfig(AttrDict):
         """
         return self._header_tag_name(header_name) is not None
 
-    def _header_tag_name(self, header_name):
-        # type: (str) -> Optional[str]
+    def _header_tag_name(self, header_name: str) -> Optional[str]:
         tag_name = self.http._header_tag_name(header_name)
         if tag_name is None:
             return self.global_config._header_tag_name(header_name)

--- a/ddtrace/settings/profiling.py
+++ b/ddtrace/settings/profiling.py
@@ -11,8 +11,7 @@ from ddtrace.internal.utils.formats import parse_tags_str
 logger = get_logger(__name__)
 
 
-def _derive_default_heap_sample_size(heap_config, default_heap_sample_size=1024 * 1024):
-    # type: (ProfilingConfig.Heap, int) -> int
+def _derive_default_heap_sample_size(heap_config: ProfilingConfig.Heap, default_heap_sample_size: int = 1024 * 1024) -> int:
     heap_sample_size = heap_config._sample_size
     if heap_sample_size is not None:
         return heap_sample_size
@@ -38,8 +37,7 @@ def _derive_default_heap_sample_size(heap_config, default_heap_sample_size=1024 
     return int(max(math.ceil(total_mem / max_samples), default_heap_sample_size))
 
 
-def _is_valid_libdatadog():
-    # type: () -> bool
+def _is_valid_libdatadog() -> bool:
     return platform.machine() in ["x86_64", "aarch64"] and "glibc" in platform.libc_ver()[0]
 
 

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -85,8 +85,7 @@ _INTERNAL_APPLICATION_SPAN_TYPES = {"custom", "template", "web", "worker"}
 AnyCallable = TypeVar("AnyCallable", bound=Callable)
 
 
-def _start_appsec_processor():
-    # type: () -> Optional[Any]
+def _start_appsec_processor() -> Optional[Any]:
     # FIXME: type should be AppsecSpanProcessor but we have a cyclic import here
     try:
         from .appsec._processor import AppSecSpanProcessor
@@ -108,26 +107,25 @@ def _start_appsec_processor():
 
 
 def _default_span_processors_factory(
-    trace_filters,  # type: List[TraceFilter]
-    trace_writer,  # type: TraceWriter
-    partial_flush_enabled,  # type: bool
-    partial_flush_min_spans,  # type: int
-    appsec_enabled,  # type: bool
-    iast_enabled,  # type: bool
-    compute_stats_enabled,  # type: bool
-    single_span_sampling_rules,  # type: List[SpanSamplingRule]
-    agent_url,  # type: str
-    profiling_span_processor,  # type: EndpointCallCounterProcessor
-):
-    # type: (...) -> Tuple[List[SpanProcessor], Optional[Any], List[SpanProcessor]]
+    trace_filters: List[TraceFilter],
+    trace_writer: TraceWriter,
+    partial_flush_enabled: bool,
+    partial_flush_min_spans: int,
+    appsec_enabled: bool,
+    iast_enabled: bool,
+    compute_stats_enabled: bool,
+    single_span_sampling_rules: List[SpanSamplingRule],
+    agent_url: str,
+    profiling_span_processor: EndpointCallCounterProcessor,
+) -> Tuple[List[SpanProcessor], Optional[Any], List[SpanProcessor]]:
     # FIXME: type should be AppsecSpanProcessor but we have a cyclic import here
     """Construct the default list of span processors to use."""
-    trace_processors = []  # type: List[TraceProcessor]
+    trace_processors: List[TraceProcessor] = []
     trace_processors += [TraceTagsProcessor(), PeerServiceProcessor(_ps_config), BaseServiceProcessor()]
     trace_processors += [TraceSamplingProcessor(compute_stats_enabled)]
     trace_processors += trace_filters
 
-    span_processors = []  # type: List[SpanProcessor]
+    span_processors: List[SpanProcessor] = []
     span_processors += [TopLevelSpanProcessor()]
 
     if appsec_enabled:
@@ -169,14 +167,14 @@ def _default_span_processors_factory(
         span_processors.append(SpanSamplingProcessor(single_span_sampling_rules))
 
     # These need to run after all the other processors
-    deferred_processors = [
+    deferred_processors: List[SpanProcessor] = [
         SpanAggregator(
             partial_flush_enabled=partial_flush_enabled,
             partial_flush_min_spans=partial_flush_min_spans,
             trace_processors=trace_processors,
             writer=trace_writer,
         )
-    ]  # type: List[SpanProcessor]
+    ]
     return span_processors, appsec_processor, deferred_processors
 
 
@@ -196,11 +194,10 @@ class Tracer(object):
 
     def __init__(
         self,
-        url=None,  # type: Optional[str]
-        dogstatsd_url=None,  # type: Optional[str]
-        context_provider=None,  # type: Optional[DefaultContextProvider]
-    ):
-        # type: (...) -> None
+        url: Optional[str] = None,
+        dogstatsd_url: Optional[str] = None,
+        context_provider: Optional[DefaultContextProvider] = None,
+    ) -> None:
         """
         Create a new ``Tracer`` instance. A global tracer is already initialized
         for common usage, so there is no need to initialize your own ``Tracer``.
@@ -211,14 +208,14 @@ class Tracer(object):
 
         maybe_start_serverless_mini_agent()
 
-        self._filters = []  # type: List[TraceFilter]
+        self._filters: List[TraceFilter] = []
 
         # globally set tags
         self._tags = config.tags.copy()
 
         # collection of services seen, used for runtime metrics tags
         # a buffer for service info so we don't perpetually send the same things
-        self._services = set()  # type: Set[str]
+        self._services: Set[str] = set()
         if config.service:
             self._services.add(config.service)
 
@@ -228,14 +225,14 @@ class Tracer(object):
 
         self.enabled = config._tracing_enabled
         self.context_provider = context_provider or DefaultContextProvider()
-        self._sampler = DatadogSampler()  # type: BaseSampler
+        self._sampler: BaseSampler = DatadogSampler()
         self._dogstatsd_url = agent.get_stats_url() if dogstatsd_url is None else dogstatsd_url
         self._compute_stats = config._trace_compute_stats
-        self._agent_url = agent.get_trace_url() if url is None else url  # type: str
+        self._agent_url: str = agent.get_trace_url() if url is None else url
         verify_url(self._agent_url)
 
         if self._use_log_writer() and url is None:
-            writer = LogWriter()  # type: TraceWriter
+            writer: TraceWriter = LogWriter()
         else:
             writer = AgentWriter(
                 agent_url=self._agent_url,
@@ -245,8 +242,8 @@ class Tracer(object):
                 sync_mode=self._use_sync_mode(),
                 headers={"Datadog-Client-Computed-Stats": "yes"} if self._compute_stats else {},
             )
-        self._single_span_sampling_rules = get_span_sampling_rules()  # type: List[SpanSamplingRule]
-        self._writer = writer  # type: TraceWriter
+        self._single_span_sampling_rules: List[SpanSamplingRule] = get_span_sampling_rules()
+        self._writer: TraceWriter = writer
         self._partial_flush_enabled = config._partial_flush_enabled
         self._partial_flush_min_spans = config._partial_flush_min_spans
         self._asm_enabled = asm_config._asm_enabled
@@ -282,8 +279,7 @@ class Tracer(object):
 
         self._new_process = False
 
-    def _atexit(self):
-        # type: () -> None
+    def _atexit(self) -> None:
         key = "ctrl-break" if os.name == "nt" else "ctrl-c"
         log.debug(
             "Waiting %d seconds for tracer to finish. Hit %s to quit.",
@@ -292,8 +288,7 @@ class Tracer(object):
         )
         self.shutdown(timeout=self.SHUTDOWN_TIMEOUT)
 
-    def on_start_span(self, func):
-        # type: (Callable) -> Callable
+    def on_start_span(self, func: Callable) -> Callable:
         """Register a function to execute when a span start.
 
         Can be used as a decorator.
@@ -304,8 +299,7 @@ class Tracer(object):
         self._hooks.register(self.__class__.start_span, func)
         return func
 
-    def deregister_on_start_span(self, func):
-        # type: (Callable) -> Callable
+    def deregister_on_start_span(self, func: Callable) -> Callable:
         """Unregister a function registered to execute when a span starts.
 
         Can be used as a decorator.
@@ -320,8 +314,7 @@ class Tracer(object):
     def debug_logging(self):
         return log.isEnabledFor(logging.DEBUG)
 
-    def current_trace_context(self, *args, **kwargs):
-        # type: (...) -> Optional[Context]
+    def current_trace_context(self, *args, **kwargs) -> Optional[Context]:
         """Return the context for the current trace.
 
         If there is no active trace then None is returned.
@@ -333,14 +326,13 @@ class Tracer(object):
             return active.context
         return None
 
-    def get_log_correlation_context(self):
-        # type: () -> Dict[str, str]
+    def get_log_correlation_context(self) -> Dict[str, str]:
         """Retrieves the data used to correlate a log with the current active trace.
         Generates a dictionary for custom logging instrumentation including the trace id and
         span id of the current active span, as well as the configured service, version, and environment names.
         If there is no active span, a dictionary with an empty string for each value will be returned.
         """
-        active = None  # type: Optional[Union[Context, Span]]
+        active: Optional[Union[Context, Span]] = None
         if self.enabled:
             active = self.context_provider.active()
 
@@ -360,26 +352,25 @@ class Tracer(object):
     # TODO: deprecate this method and make sure users create a new tracer if they need different parameters
     def configure(
         self,
-        enabled=None,  # type: Optional[bool]
-        hostname=None,  # type: Optional[str]
-        port=None,  # type: Optional[int]
-        uds_path=None,  # type: Optional[str]
-        https=None,  # type: Optional[bool]
-        sampler=None,  # type: Optional[BaseSampler]
-        context_provider=None,  # type: Optional[DefaultContextProvider]
-        wrap_executor=None,  # type: Optional[Callable]
-        priority_sampling=None,  # type: Optional[bool]
-        settings=None,  # type: Optional[Dict[str, Any]]
-        dogstatsd_url=None,  # type: Optional[str]
-        writer=None,  # type: Optional[TraceWriter]
-        partial_flush_enabled=None,  # type: Optional[bool]
-        partial_flush_min_spans=None,  # type: Optional[int]
-        api_version=None,  # type: Optional[str]
-        compute_stats_enabled=None,  # type: Optional[bool]
-        appsec_enabled=None,  # type: Optional[bool]
-        iast_enabled=None,  # type: Optional[bool]
-    ):
-        # type: (...) -> None
+        enabled: Optional[bool] = None,
+        hostname: Optional[str] = None,
+        port: Optional[int] = None,
+        uds_path: Optional[str] = None,
+        https: Optional[bool] = None,
+        sampler: Optional[BaseSampler] = None,
+        context_provider: Optional[DefaultContextProvider] = None,
+        wrap_executor: Optional[Callable] = None,
+        priority_sampling: Optional[bool] = None,
+        settings: Optional[Dict[str, Any]] = None,
+        dogstatsd_url: Optional[str] = None,
+        writer: Optional[TraceWriter] = None,
+        partial_flush_enabled: Optional[bool] = None,
+        partial_flush_min_spans: Optional[int] = None,
+        api_version: Optional[str] = None,
+        compute_stats_enabled: Optional[bool] = None,
+        appsec_enabled: Optional[bool] = None,
+        iast_enabled: Optional[bool] = None,
+    ) -> None:
         """Configure a Tracer.
 
         :param bool enabled: If True, finished traces will be submitted to the API, else they'll be dropped.
@@ -558,29 +549,27 @@ class Tracer(object):
 
     def _start_span_after_shutdown(
         self,
-        name,  # type: str
-        child_of=None,  # type: Optional[Union[Span, Context]]
-        service=None,  # type: Optional[str]
-        resource=None,  # type: Optional[str]
-        span_type=None,  # type: Optional[str]
-        activate=False,  # type: bool
-        span_api=SPAN_API_DATADOG,  # type: str
-    ):
-        # type: (...) -> Span
+        name: str,
+        child_of: Optional[Union[Span, Context]] = None,
+        service: Optional[str] = None,
+        resource: Optional[str] = None,
+        span_type: Optional[str] = None,
+        activate: bool = False,
+        span_api: str = SPAN_API_DATADOG,
+    ) -> Span:
         log.warning("Spans started after the tracer has been shut down will not be sent to the Datadog Agent.")
         return self._start_span(name, child_of, service, resource, span_type, activate, span_api)
 
     def _start_span(
         self,
-        name,  # type: str
-        child_of=None,  # type: Optional[Union[Span, Context]]
-        service=None,  # type: Optional[str]
-        resource=None,  # type: Optional[str]
-        span_type=None,  # type: Optional[str]
-        activate=False,  # type: bool
-        span_api=SPAN_API_DATADOG,  # type: str
-    ):
-        # type: (...) -> Span
+        name: str,
+        child_of: Optional[Union[Span, Context]] = None,
+        service: Optional[str] = None,
+        resource: Optional[str] = None,
+        span_type: Optional[str] = None,
+        activate: bool = False,
+        span_api: str = SPAN_API_DATADOG,
+    ) -> Span:
         """Return a span that represents an operation called ``name``.
 
         Note that the :meth:`.trace` method will almost always be preferred
@@ -637,7 +626,7 @@ class Tracer(object):
                     self.context_provider.activate(new_ctx)
                 child_of = new_ctx
 
-        parent = None  # type: Optional[Span]
+        parent: Optional[Span] = None
         if child_of is not None:
             if isinstance(child_of, Context):
                 context = child_of
@@ -748,8 +737,7 @@ class Tracer(object):
 
     start_span = _start_span
 
-    def _on_span_finish(self, span):
-        # type: (Span) -> None
+    def _on_span_finish(self, span: Span) -> None:
         active = self.current_span()
         # Debug check: if the finishing span has a parent and its parent
         # is not the next active span then this is an error in synchronous tracing.
@@ -781,8 +769,7 @@ class Tracer(object):
         else:
             log.log(level, msg)
 
-    def trace(self, name, service=None, resource=None, span_type=None, span_api=SPAN_API_DATADOG):
-        # type: (str, Optional[str], Optional[str], Optional[str], str) -> Span
+    def trace(self, name: str, service: Optional[str] = None, resource: Optional[str] = None, span_type: Optional[str] = None, span_api: str = SPAN_API_DATADOG) -> Span:
         """Activate and return a new span that inherits from the current active span.
 
         :param str name: the name of the operation being traced
@@ -833,8 +820,7 @@ class Tracer(object):
             span_api=span_api,
         )
 
-    def current_root_span(self):
-        # type: () -> Optional[Span]
+    def current_root_span(self) -> Optional[Span]:
         """Returns the root span of the current execution.
 
         This is useful for attaching information related to the trace as a
@@ -853,8 +839,7 @@ class Tracer(object):
             return None
         return span._local_root
 
-    def current_span(self):
-        # type: () -> Optional[Span]
+    def current_span(self) -> Optional[Span]:
         """Return the active span in the current execution context.
 
         Note that there may be an active span represented by a context object
@@ -865,8 +850,7 @@ class Tracer(object):
         return active if isinstance(active, Span) else None
 
     @property
-    def agent_trace_url(self):
-        # type: () -> Optional[str]
+    def agent_trace_url(self) -> Optional[str]:
         """Trace agent url"""
         if isinstance(self._writer, AgentWriter):
             return self._writer.agent_url
@@ -879,12 +863,11 @@ class Tracer(object):
 
     def wrap(
         self,
-        name=None,  # type: Optional[str]
-        service=None,  # type: Optional[str]
-        resource=None,  # type: Optional[str]
-        span_type=None,  # type: Optional[str]
-    ):
-        # type: (...) -> Callable[[AnyCallable], AnyCallable]
+        name: Optional[str] = None,
+        service: Optional[str] = None,
+        resource: Optional[str] = None,
+        span_type: Optional[str] = None,
+    ) -> Callable[[AnyCallable], AnyCallable]:
         """
         A decorator used to trace an entire function. If the traced function
         is a coroutine, it traces the coroutine execution when is awaited.
@@ -927,8 +910,7 @@ class Tracer(object):
                 span.set_tag('a', 'b')
         """
 
-        def wrap_decorator(f):
-            # type: (AnyCallable) -> AnyCallable
+        def wrap_decorator(f: AnyCallable) -> AnyCallable:
             # FIXME[matt] include the class name for methods.
             span_name = name if name else "%s.%s" % (f.__module__, f.__name__)
 
@@ -974,8 +956,7 @@ class Tracer(object):
 
         return wrap_decorator
 
-    def set_tags(self, tags):
-        # type: (Dict[str, str]) -> None
+    def set_tags(self, tags: Dict[str, str]) -> None:
         """Set some tags at the tracer level.
         This will append those tags to each span created by the tracer.
 
@@ -983,8 +964,7 @@ class Tracer(object):
         """
         self._tags.update(tags)
 
-    def shutdown(self, timeout=None):
-        # type: (Optional[float]) -> None
+    def shutdown(self, timeout: Optional[float] = None) -> None:
         """Shutdown the tracer and flush finished traces. Avoid calling shutdown multiple times.
 
         :param timeout: How long in seconds to wait for the background worker to flush traces
@@ -1007,8 +987,7 @@ class Tracer(object):
         self.start_span = self._start_span_after_shutdown  # type: ignore[assignment]
 
     @staticmethod
-    def _use_log_writer():
-        # type: () -> bool
+    def _use_log_writer() -> bool:
         """Returns whether the LogWriter should be used in the environment by
         default.
 
@@ -1031,8 +1010,7 @@ class Tracer(object):
             return in_aws_lambda()
 
     @staticmethod
-    def _use_sync_mode():
-        # type: () -> bool
+    def _use_sync_mode() -> bool:
         """Returns, if an `AgentWriter` is to be used, whether it should be run
          in synchronous mode by default.
 

--- a/ddtrace/version.py
+++ b/ddtrace/version.py
@@ -1,5 +1,4 @@
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     try:
         from ._version import version
 

--- a/tests/appsec/iast/aspects/aspect_utils.py
+++ b/tests/appsec/iast/aspects/aspect_utils.py
@@ -26,18 +26,18 @@ TAINT_FORMAT_CAPTURE_BYTES = rb"\:\+-(?:\<(?P<inputid>[0-9a-zA-Z\-]+)\>)?(.+?)(?
 TAINT_FORMAT_PATTERN_BYTES = re.compile(TAINT_FORMAT_CAPTURE_BYTES, re.MULTILINE | re.DOTALL)
 
 
-def create_taint_range_with_format(text_input, fn_origin=""):  # type: (Any, str) -> Any
+def create_taint_range_with_format(text_input: Any, fn_origin: str = "") -> Any:
     is_bytes = isinstance(text_input, (bytes, bytearray))
     taint_format_capture = TAINT_FORMAT_CAPTURE_BYTES if is_bytes else TAINT_FORMAT_CAPTURE
     taint_format_pattern = TAINT_FORMAT_PATTERN_BYTES if is_bytes else TAINT_FORMAT_PATTERN
 
-    text_output = re.sub(  # type: ignore
+    text_output: Any = re.sub(  # type: ignore
         taint_format_capture, r"\2", text_input, flags=re.MULTILINE | re.DOTALL
-    )  # type: Any
+    )
     if isinstance(text_input, bytearray):
         text_output = bytearray(text_output)  # type: ignore
 
-    ranges_ = []  # type: List[TaintRange]
+    ranges_: List[TaintRange] = []
     acc_input_id = 0
     for i, match in enumerate(taint_format_pattern.finditer(text_input)):  # type: ignore[attr-defined]
         match_start = match.start() - (i * 6) - acc_input_id
@@ -69,18 +69,17 @@ def create_taint_range_with_format(text_input, fn_origin=""):  # type: (Any, str
 
 
 class BaseReplacement(object):
-    def _to_tainted_string_with_origin(self, text):
-        # type: (Text) -> Text
+    def _to_tainted_string_with_origin(self, text: Text) -> Text:
         if not isinstance(text, (str, bytes, bytearray)):
             return text
 
         # CAVEAT: the sequences ":+-" and "-+:" can be escaped with  "::++--" and "--+*::"
         elements = re.split(r"(\:\+-<[0-9a-zA-Z\-]+>|<[0-9a-zA-Z\-]+>-\+\:)", text)
 
-        ranges = []  # type: List[TaintRange]
+        ranges: List[TaintRange] = []
         ranges_append = ranges.append
         new_text = text.__class__()
-        context = None  # type: Optional[EscapeContext]
+        context: Optional[EscapeContext] = None
         for index, element in enumerate(elements):
             if index % 2 == 0:
                 element = element.replace("::++--", ":+-")
@@ -112,11 +111,11 @@ class BaseReplacement(object):
 
     def _assert_format_result(
         self,
-        taint_escaped_template,  # type: Text
-        taint_escaped_parameter,  # type: Any
-        expected_result,  # type: Text
-        escaped_expected_result,  # type: Text
-    ):  # type: (...) -> None
+        taint_escaped_template: Text,
+        taint_escaped_parameter: Any,
+        expected_result: Text,
+        escaped_expected_result: Text,
+    ) -> None:
         template = self._to_tainted_string_with_origin(taint_escaped_template)
         parameter = self._to_tainted_string_with_origin(taint_escaped_parameter)
         result = mod.do_format_with_positional_parameter(template, parameter)

--- a/tests/appsec/iast/aspects/test_add_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_add_aspect_fixtures.py
@@ -16,11 +16,10 @@ mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.str_methods")
 
 
 class TestOperatorAddReplacement(unittest.TestCase):
-    def test_nostring_operator_add(self):
-        # type: () -> None
+    def test_nostring_operator_add(self) -> None:
         assert mod.do_operator_add_params(2, 3) == 5
 
-    def test_regression_operator_add_re_compile(self):  # type: () -> None
+    def test_regression_operator_add_re_compile(self) -> None:
         try:
             mod.do_add_re_compile()
         except Exception as e:
@@ -28,7 +27,7 @@ class TestOperatorAddReplacement(unittest.TestCase):
 
     def test_string_operator_add_none_tainted(
         self,
-    ):  # type: () -> None
+    ) -> None:
         string_input = "foo"
         bar = "bar"
         result = mod.do_operator_add_params(string_input, bar)
@@ -36,14 +35,14 @@ class TestOperatorAddReplacement(unittest.TestCase):
 
     def test_operator_add_dis(
         self,
-    ):  # type: () -> None
+    ) -> None:
         import dis
 
         bytecode = dis.Bytecode(mod.do_operator_add_params)
         dis.dis(mod.do_operator_add_params)
         assert bytecode.codeobj.co_names == ("ddtrace_aspects", "add_aspect")
 
-    def test_string_operator_add_one_tainted(self):  # type: () -> None
+    def test_string_operator_add_one_tainted(self) -> None:
         string_input = taint_pyobject(
             pyobject="foo",
             source_name="test_add_aspect_tainting_left_hand",
@@ -55,7 +54,7 @@ class TestOperatorAddReplacement(unittest.TestCase):
         result = mod.do_operator_add_params(string_input, bar)
         assert len(get_tainted_ranges(result)) == 1
 
-    def test_string_operator_add_two(self):  # type: () -> None
+    def test_string_operator_add_two(self) -> None:
         string_input = taint_pyobject(
             pyobject="foo",
             source_name="test_string_operator_add_two",
@@ -74,7 +73,7 @@ class TestOperatorAddReplacement(unittest.TestCase):
 
     def test_decoration_when_function_and_decorator_modify_texts_then_tainted(
         self,
-    ):  # type: () -> None
+    ) -> None:
         prefix = taint_pyobject(pyobject="a", source_name="a", source_value="a", source_origin=OriginType.PARAMETER)
         suffix = taint_pyobject(pyobject="b", source_name="b", source_value="b", source_origin=OriginType.PARAMETER)
 
@@ -84,7 +83,7 @@ class TestOperatorAddReplacement(unittest.TestCase):
         # TODO: migrate aspect title
         assert len(get_tainted_ranges(result)) == 2
 
-    def test_string_operator_add_one_tainted_mixed_bytearray_bytes(self):  # type: () -> None
+    def test_string_operator_add_one_tainted_mixed_bytearray_bytes(self) -> None:
         string_input = taint_pyobject(
             pyobject=b"foo", source_name="foo", source_value="foo", source_origin=OriginType.PARAMETER
         )
@@ -100,7 +99,7 @@ class TestOperatorAddReplacement(unittest.TestCase):
         # E       SystemError: <method 'join' of 'bytes' objects> returned a result with an exception set
         # assert len(get_tainted_ranges(result)) == 2
 
-    def test_string_operator_add_two_mixed_bytearray_bytes(self):  # type: () -> None
+    def test_string_operator_add_two_mixed_bytearray_bytes(self) -> None:
         string_input = taint_pyobject(
             pyobject=bytearray(b"foo"), source_name="foo", source_value="foo", source_origin=OriginType.PARAMETER
         )

--- a/tests/appsec/iast/aspects/test_aspect_helpers.py
+++ b/tests/appsec/iast/aspects/test_aspect_helpers.py
@@ -73,11 +73,11 @@ def test_common_replace_tainted_bytearray():
     assert get_ranges(s2) == [_RANGE1, _RANGE2]
 
 
-def _build_sample_range(start, end, name):  # type: (int, int) -> TaintRange
+def _build_sample_range(start, end: int, name: int) -> TaintRange:
     return TaintRange(start, end, Source(name, "sample_value", OriginType.PARAMETER))
 
 
-def test_as_formatted_evidence():  # type: () -> None
+def test_as_formatted_evidence() -> None:
     s = "abcdefgh"
     set_ranges(s, (_build_sample_range(0, 5, "first"),))
     assert as_formatted_evidence(s) == ":+-<first>abcde<first>-+:fgh"
@@ -99,7 +99,7 @@ def test_as_formatted_evidence():  # type: () -> None
     assert as_formatted_evidence(s) == ":+-<first>ab<first>-+:c:+-<second>de<second>-+:fgh"
 
 
-def test_as_formatted_evidence_convert_escaped_text_to_tainted_text():  # type: () -> None
+def test_as_formatted_evidence_convert_escaped_text_to_tainted_text() -> None:
     from ddtrace.appsec._iast._taint_tracking import TagMappingMode
 
     s = "abcdefgh"

--- a/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
@@ -24,25 +24,25 @@ EscapeContext = NamedTuple("EscapeContext", [("id", Any), ("position", int)])
 
 
 class TestOperatorFormatReplacement(BaseReplacement):
-    def test_format_when_template_is_none_then_raises_attribute_error(self):  # type: () -> None
+    def test_format_when_template_is_none_then_raises_attribute_error(self) -> None:
         with pytest.raises(AttributeError):
             mod.do_format_with_positional_parameter(None, "")
 
-    def test_format_when_parameter_is_none_then_does_not_break(self):  # type: () -> None
+    def test_format_when_parameter_is_none_then_does_not_break(self) -> None:
         assert mod.do_format_with_positional_parameter("{}", None) == "None"
 
-    def test_format_when_parameter_dict_none_then_does_not_break(self):  # type: () -> None
+    def test_format_when_parameter_dict_none_then_does_not_break(self) -> None:
         assert mod.do_format_with_named_parameter("{key}", None) == "None"
 
-    def test_format_when_positional_no_tainted_then_no_tainted_result(self):  # type: () -> None
+    def test_format_when_positional_no_tainted_then_no_tainted_result(self) -> None:
         result = mod.do_format_with_positional_parameter("template {}", "parameter")
         assert as_formatted_evidence(result) == "template parameter"
 
-    def test_format_when_named_no_tainted_then_no_tainted_result(self):  # type: () -> None
+    def test_format_when_named_no_tainted_then_no_tainted_result(self) -> None:
         result = mod.do_format_with_named_parameter("template {key}", "parameter")
         assert as_formatted_evidence(result) == "template parameter"
 
-    def test_format_when_tainted_parameter_then_tainted_result(self):  # type: () -> None
+    def test_format_when_tainted_parameter_then_tainted_result(self) -> None:
         self._assert_format_result(
             taint_escaped_template="template {}",
             taint_escaped_parameter=":+-<input1>parameter<input1>-+:",
@@ -50,7 +50,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
             escaped_expected_result="template :+-<input1>parameter<input1>-+:",
         )
 
-    def test_format_when_tainted_template_range_no_brackets_then_tainted_result(self):  # type: () -> None
+    def test_format_when_tainted_template_range_no_brackets_then_tainted_result(self) -> None:
         self._assert_format_result(
             taint_escaped_template=":+-<input1>template<input1>-+: {}",
             taint_escaped_parameter="parameter",
@@ -58,8 +58,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template<input1>-+: parameter",
         )
 
-    def test_format_when_tainted_template_range_with_brackets_then_tainted_result(self):
-        # type: () -> None
+    def test_format_when_tainted_template_range_with_brackets_then_tainted_result(self) -> None:
         self._assert_format_result(
             taint_escaped_template="template :+-<input1>{}<input1>-+:",
             taint_escaped_parameter="parameter",
@@ -69,8 +68,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
 
     def test_format_when_tainted_template_range_no_brackets_and_tainted_param_then_tainted(
         self,
-    ):
-        # type: () -> None
+    ) -> None:
         self._assert_format_result(
             taint_escaped_template=":+-<input1>template<input1>-+: {}",
             taint_escaped_parameter=":+-<input2>parameter<input2>-+:",
@@ -78,8 +76,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template<input1>-+: " ":+-<input2>parameter<input2>-+:",
         )
 
-    def test_format_when_tainted_template_range_with_brackets_and_tainted_param_then_tainted(self):
-        # type: () -> None
+    def test_format_when_tainted_template_range_with_brackets_and_tainted_param_then_tainted(self) -> None:
         self._assert_format_result(
             taint_escaped_template=":+-<input1>template {}<input1>-+:",
             taint_escaped_parameter=":+-<input1>parameter<input2>-+:",
@@ -87,8 +84,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template <input1>-+:" ":+-<input2>parameter<input2>-+:",
         )
 
-    def test_format_when_ranges_overlap_then_give_preference_to_ranges_from_parameter(self):
-        # type: () -> None
+    def test_format_when_ranges_overlap_then_give_preference_to_ranges_from_parameter(self) -> None:
         self._assert_format_result(
             taint_escaped_template=":+-<input1>template {} range overlapping<input1>-+:",
             taint_escaped_parameter=":+-<input2>parameter<input2>-+:",
@@ -98,8 +94,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
             ":+-<input1> range overlapping<input1>-+:",
         )
 
-    def test_format_when_tainted_str_emoji_strings_then_tainted_result(self):
-        # type: () -> None
+    def test_format_when_tainted_str_emoji_strings_then_tainted_result(self) -> None:
         self._assert_format_result(
             taint_escaped_template=":+-<input1>template⚠️<input1>-+: {}",
             taint_escaped_parameter=":+-<input2>parameter⚠️<input2>-+:",
@@ -107,8 +102,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template⚠️<input1>-+: " ":+-<input2>parameter⚠️<input2>-+:",
         )
 
-    def test_format_when_tainted_unicode_emoji_strings_then_tainted_result(self):
-        # type: () -> None
+    def test_format_when_tainted_unicode_emoji_strings_then_tainted_result(self) -> None:
         self._assert_format_result(
             taint_escaped_template=":+-<input1>template⚠️<input1>-+: {}",
             taint_escaped_parameter=":+-<input2>parameter⚠️<input2>-+:",
@@ -116,8 +110,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template⚠️<input1>-+: " ":+-<input2>parameter⚠️<input2>-+:",
         )
 
-    def test_format_when_tainted_template_range_no_brackets_and_param_not_str_then_tainted(self):
-        # type: () -> None
+    def test_format_when_tainted_template_range_no_brackets_and_param_not_str_then_tainted(self) -> None:
         self._assert_format_result(
             taint_escaped_template=":+-<input1>template<input1>-+: {:.2f}",
             taint_escaped_parameter=math.pi,
@@ -125,8 +118,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template<input1>-+: 3.14",
         )
 
-    def test_format_when_tainted_template_range_with_brackets_and_param_not_str_then_tainted(self):
-        # type: () -> None
+    def test_format_when_tainted_template_range_with_brackets_and_param_not_str_then_tainted(self) -> None:
         self._assert_format_result(
             taint_escaped_template=":+-<input1>template {:.2f}<input1>-+:",
             taint_escaped_parameter=math.pi,
@@ -134,8 +126,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template 3.14<input1>-+:",
         )
 
-    def test_format_when_texts_tainted_and_contain_escape_sequences_then_result_uncorrupted(self):
-        # type: () -> None
+    def test_format_when_texts_tainted_and_contain_escape_sequences_then_result_uncorrupted(self) -> None:
         self._assert_format_result(
             taint_escaped_template=":+-<input1>template ::++--<0>my_code<0>--++::" "<input1>-+: {}",
             taint_escaped_parameter=":+-<input2>parameter<input2>-+: " "::++--<0>my_code<0>--++::",
@@ -145,8 +136,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
             ":+-<0>my_code<0>-+:",
         )
 
-    def test_format_when_parameter_value_already_present_in_template_then_range_is_correct(self):
-        # type: () -> None
+    def test_format_when_parameter_value_already_present_in_template_then_range_is_correct(self) -> None:
         self._assert_format_result(
             taint_escaped_template="aaaaaa{}aaa",
             taint_escaped_parameter="a:+-<input1>a<input1>-+:a",
@@ -154,7 +144,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
             escaped_expected_result="aaaaaaa:+-<input1>a<input1>-+:aaaa",
         )
 
-    def test_format_with_args_and_kwargs(self):  # type: () -> None
+    def test_format_with_args_and_kwargs(self) -> None:
         string_input = "-1234 {} {test_var}"
         res = mod.do_args_kwargs_1(string_input, *[6], **{"test_var": 1})  # pylint: disable=no-member
         assert as_formatted_evidence(res) == "-1234 6 1"
@@ -168,7 +158,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
         # TODO format with params doesn't work correctly
         #  assert as_formatted_evidence(res) == ":+--12-+:34 6 1"
 
-    def test_format_with_one_argument_args_and_kwargs(self):  # type: () -> None
+    def test_format_with_one_argument_args_and_kwargs(self) -> None:
         string_input = "-1234 {} {} {test_var}"
         res = mod.do_args_kwargs_2(string_input, *[6], **{"test_var": 1})  # pylint: disable=no-member
         assert as_formatted_evidence(res) == "-1234 1 6 1"
@@ -182,7 +172,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
         # TODO format with params doesn't work correctly
         #  as_formatted_evidence(res) == ":+--12-+:34 1 6 1"
 
-    def test_format_with_two_argument_args_and_kwargs(self):  # type: () -> None
+    def test_format_with_two_argument_args_and_kwargs(self) -> None:
         string_input = "-1234 {} {} {} {test_var}"
         res = mod.do_args_kwargs_3(string_input, *[6], **{"test_var": 1})  # pylint: disable=no-member
         assert as_formatted_evidence(res) == "-1234 1 2 6 1"
@@ -196,7 +186,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
         # TODO format with params doesn't work correctly
         #  as_formatted_evidence(res) == ":+--12-+:34 1 2 6 1"
 
-    def test_format_with_two_argument_two_keywordargument_args_kwargs(self):  # type: () -> None
+    def test_format_with_two_argument_two_keywordargument_args_kwargs(self) -> None:
         string_input = "-1234 {} {} {} {test_kwarg} {test_var}"
         res = mod.do_args_kwargs_4(string_input, *[6], **{"test_var": 1})  # pylint: disable=no-member
         assert as_formatted_evidence(res) == "-1234 1 2 6 3 1"
@@ -210,7 +200,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
         # TODO format with params doesn't work correctly
         #  as_formatted_evidence(res) == ":+--12-+:34 1 2 6 3 1"
 
-    def test_format_when_tainted_template_range_special_then_tainted_result(self):  # type: () -> None
+    def test_format_when_tainted_template_range_special_then_tainted_result(self) -> None:
         self._assert_format_result(
             taint_escaped_template=":+-<input1>{:<15s}<input1>-+: parameter",
             taint_escaped_parameter="parameter",
@@ -218,7 +208,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>parameter      <input1>-+: parameter",
         )
 
-    def test_format_when_tainted_template_range_special_template_then_tainted_result(self):  # type: () -> None
+    def test_format_when_tainted_template_range_special_template_then_tainted_result(self) -> None:
         # TODO format with params doesn't work correctly
         # self._assert_format_result(
         #     taint_escaped_template="{:<25s} parameter",

--- a/tests/appsec/iast/aspects/test_format_map_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_format_map_aspect_fixtures.py
@@ -21,11 +21,11 @@ mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.str_methods")
 class TestOperatorFormatMapReplacement(BaseReplacement):
     def _assert_format_map_result(
         self,
-        taint_escaped_template,  # type: str
-        taint_escaped_mapping,  # type: Dict[str, Any]
-        expected_result,  # type: str
-        escaped_expected_result,  # type: str
-    ):  # type: (...) -> None
+        taint_escaped_template: str,
+        taint_escaped_mapping: Dict[str, Any],
+        expected_result: str,
+        escaped_expected_result: str,
+    ) -> None:
         template = self._to_tainted_string_with_origin(taint_escaped_template)
         mapping = {key: self._to_tainted_string_with_origin(value) for key, value in iteritems(taint_escaped_mapping)}
 
@@ -37,23 +37,23 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
         assert as_formatted_evidence(result, tag_mapping_function=None) == escaped_expected_result
 
     @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
-    def test_format_map_when_template_is_none_then_raises_attribute_error(self):  # type: () -> None
+    def test_format_map_when_template_is_none_then_raises_attribute_error(self) -> None:
         with pytest.raises(AttributeError):
             mod.do_format_map(None, {})
 
     @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
-    def test_format_map_when_parameter_is_none_then_raises_type_error(self):  # type: () -> None
+    def test_format_map_when_parameter_is_none_then_raises_type_error(self) -> None:
         with pytest.raises(TypeError):
             assert mod.do_format_map("{key}", None) == "None"
 
     @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
-    def test_format_map_when_no_tainted_strings_then_no_tainted_result(self):  # type: () -> None
+    def test_format_map_when_no_tainted_strings_then_no_tainted_result(self) -> None:
         result = mod.do_format_map("template {key}", {"key": "parameter"})
         assert result, "template parameter"
         assert not get_ranges(result)
 
     @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
-    def test_format_map_when_tainted_parameter_then_tainted_result(self):  # type: () -> None
+    def test_format_map_when_tainted_parameter_then_tainted_result(self) -> None:
         self._assert_format_map_result(
             taint_escaped_template="template {key}",
             taint_escaped_mapping={"key": ":+-<input1>parameter<input1>-+:"},
@@ -62,7 +62,7 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
         )
 
     @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
-    def test_format_map_when_tainted_template_range_no_brackets_then_tainted_result(self):  # type: () -> None
+    def test_format_map_when_tainted_template_range_no_brackets_then_tainted_result(self) -> None:
         self._assert_format_map_result(
             taint_escaped_template=":+-<input1>template<input1>-+: {key}",
             taint_escaped_mapping={"key": "parameter"},
@@ -71,7 +71,7 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
         )
 
     @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
-    def test_format_map_when_tainted_template_range_with_brackets_then_tainted_result(self):  # type: () -> None
+    def test_format_map_when_tainted_template_range_with_brackets_then_tainted_result(self) -> None:
         self._assert_format_map_result(
             taint_escaped_template="template :+-<input1>{key}<input1>-+:",
             taint_escaped_mapping={"key": "parameter"},
@@ -82,7 +82,7 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
     @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_tainted_template_range_no_brackets_and_tainted_param_then_tainted(
         self,
-    ):  # type: () -> None
+    ) -> None:
         self._assert_format_map_result(
             taint_escaped_template=":+-<input1>template<input1>-+: {key}",
             taint_escaped_mapping={"key": ":+-<input2>parameter<input2>-+:"},
@@ -93,7 +93,7 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
     @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_tainted_template_range_with_brackets_and_tainted_param_then_tainted(
         self,
-    ):  # type: () -> None
+    ) -> None:
         self._assert_format_map_result(
             taint_escaped_template=":+-<input1>template {key}<input1>-+:",
             taint_escaped_mapping={"key": ":+-<input1>parameter<input2>-+:"},
@@ -102,7 +102,7 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
         )
 
     @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
-    def test_format_map_when_ranges_overlap_then_give_preference_to_ranges_from_parameter(self):  # type: () -> None
+    def test_format_map_when_ranges_overlap_then_give_preference_to_ranges_from_parameter(self) -> None:
         self._assert_format_map_result(
             taint_escaped_template=":+-<input1>template {key} range overlapping<input1>-+:",
             taint_escaped_mapping={"key": ":+-<input2>parameter<input2>-+:"},
@@ -113,7 +113,7 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
         )
 
     @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
-    def test_format_map_when_tainted_str_emoji_strings_then_tainted_result(self):  # type: () -> None
+    def test_format_map_when_tainted_str_emoji_strings_then_tainted_result(self) -> None:
         self._assert_format_map_result(
             taint_escaped_template=":+-<input1>template⚠️<input1>-+: {key}",
             taint_escaped_mapping={"key": ":+-<input2>parameter⚠️<input2>-+:"},
@@ -124,7 +124,7 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
     @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_tainted_template_range_no_brackets_and_param_not_str_then_tainted(
         self,
-    ):  # type: () -> None
+    ) -> None:
         self._assert_format_map_result(
             taint_escaped_template=":+-<input1>template<input1>-+: {key:.2f}",
             taint_escaped_mapping={"key": math.pi},
@@ -135,7 +135,7 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
     @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_tainted_template_range_with_brackets_and_param_not_str_then_tainted(
         self,
-    ):  # type: () -> None
+    ) -> None:
         self._assert_format_map_result(
             taint_escaped_template=":+-<input1>template {key:.2f}<input1>-+:",
             taint_escaped_mapping={"key": math.pi},
@@ -146,7 +146,7 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
     @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_texts_tainted_and_contain_escape_sequences_then_result_uncorrupted(
         self,
-    ):  # type: () -> None
+    ) -> None:
         self._assert_format_map_result(
             taint_escaped_template=":+-<input1>template ::++--<0>my_code<0>--++::" "<input1>-+: {key}",
             taint_escaped_mapping={"key": ":+-<input2>parameter<input2>-+: " "::++--<0>my_code<0>--++::"},
@@ -159,7 +159,7 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
     @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_parameter_value_already_present_in_template_then_range_is_correct(
         self,
-    ):  # type: () -> None
+    ) -> None:
         self._assert_format_map_result(
             taint_escaped_template="aaaaaa{key}aaa",
             taint_escaped_mapping={"key": "a:+-<input1>a<input1>-+:a"},

--- a/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
@@ -15,7 +15,7 @@ mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.str_methods")
 
 
 class TestOperatorJoinReplacement(object):
-    def test_string_join_tainted_joiner(self):  # type: () -> None
+    def test_string_join_tainted_joiner(self) -> None:
         # taint "joi" from "-joiner-"
         string_input = taint_pyobject(
             pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
@@ -28,7 +28,7 @@ class TestOperatorJoinReplacement(object):
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "-joiner-"
         assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "-joiner-"
 
-    def test_string_join_tainted_joiner_bytes(self):  # type: () -> None
+    def test_string_join_tainted_joiner_bytes(self) -> None:
         # taint "joi" from "-joiner-"
         string_input = taint_pyobject(
             pyobject=b"-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
@@ -40,7 +40,7 @@ class TestOperatorJoinReplacement(object):
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == b"-joiner-"
         assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == b"-joiner-"
 
-    def test_string_join_tainted_joiner_bytes_bytearray(self):  # type: () -> None
+    def test_string_join_tainted_joiner_bytes_bytearray(self) -> None:
         # taint "joi" from "-joiner-"
         string_input = taint_pyobject(
             pyobject=b"-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
@@ -52,7 +52,7 @@ class TestOperatorJoinReplacement(object):
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == b"-joiner-"
         assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == b"-joiner-"
 
-    def test_string_join_tainted_joiner_bytearray(self):  # type: () -> None
+    def test_string_join_tainted_joiner_bytearray(self) -> None:
         # taint "joi" from "-joiner-"
         string_input = taint_pyobject(
             pyobject=bytearray(b"-joiner-"),
@@ -68,7 +68,7 @@ class TestOperatorJoinReplacement(object):
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == bytearray(b"-joiner-")
         assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == bytearray(b"-joiner-")
 
-    def test_string_join_tainted_joiner_bytearray_bytes(self):  # type: () -> None
+    def test_string_join_tainted_joiner_bytearray_bytes(self) -> None:
         # taint "joi" from "-joiner-"
         string_input = taint_pyobject(
             pyobject=bytearray(b"-joiner-"),
@@ -84,7 +84,7 @@ class TestOperatorJoinReplacement(object):
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == bytearray(b"-joiner-")
         assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == bytearray(b"-joiner-")
 
-    def test_string_join_tainted_joined(self):  # type: () -> None
+    def test_string_join_tainted_joined(self) -> None:
         string_input = "-joiner-"
         it = [
             taint_pyobject(
@@ -102,7 +102,7 @@ class TestOperatorJoinReplacement(object):
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "aaaa"
         assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "cccc"
 
-    def test_string_join_tainted_all(self):  # type: () -> None
+    def test_string_join_tainted_all(self) -> None:
         string_input = taint_pyobject(
             pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
         )
@@ -167,7 +167,7 @@ class TestOperatorJoinReplacement(object):
             assert result[ranges[pos].start : (ranges[pos].start + ranges[pos].length)] == results
             pos += 1
 
-    def test_string_join_tuple(self):  # type: () -> None
+    def test_string_join_tuple(self) -> None:
         # Not tainted
         base_string = "abcde"
         result = mod.do_join_tuple(base_string)
@@ -189,7 +189,7 @@ class TestOperatorJoinReplacement(object):
         assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "abcde"
         assert result[ranges[2].start : (ranges[2].start + ranges[2].length)] == "abcde"
 
-    def test_string_join_set(self):  # type: () -> None
+    def test_string_join_set(self) -> None:
         # Not tainted
         base_string = "abcde"
         result = mod.do_join_set(base_string)
@@ -209,8 +209,7 @@ class TestOperatorJoinReplacement(object):
         assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "abcde"
         assert result[ranges[2].start : (ranges[2].start + ranges[2].length)] == "abcde"
 
-    def test_string_join_generator(self):
-        # type: () -> None
+    def test_string_join_generator(self) -> None:
         # Not tainted
         base_string = "abcde"
         result = mod.do_join_generator(base_string)
@@ -232,8 +231,7 @@ class TestOperatorJoinReplacement(object):
         assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "abcde"
         assert result[ranges[2].start : (ranges[2].start + ranges[2].length)] == "abcde"
 
-    def test_string_join_args_kwargs(self):
-        # type: () -> None
+    def test_string_join_args_kwargs(self) -> None:
         # Not tainted
         base_string = "-abcde-"
         result = mod.do_join_args_kwargs(base_string, ("f", "g"))
@@ -253,8 +251,7 @@ class TestOperatorJoinReplacement(object):
         assert len(ranges) == 1
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "-abcde-"
 
-    def test_string_join_empty_iterable_joiner_tainted(self):
-        # type: () -> None
+    def test_string_join_empty_iterable_joiner_tainted(self) -> None:
         # Not tainted
         base_string = "+abcde-"
         result = mod.do_join_args_kwargs(base_string, "")
@@ -273,8 +270,7 @@ class TestOperatorJoinReplacement(object):
         ranges = get_tainted_ranges(result)
         assert len(ranges) == 0
 
-    def test_string_join_empty_joiner_arg_tainted(self):
-        # type: () -> None
+    def test_string_join_empty_joiner_arg_tainted(self) -> None:
         # Not tainted
         base_string = ""
         result = mod.do_join_args_kwargs(base_string, "fghi")
@@ -294,8 +290,7 @@ class TestOperatorJoinReplacement(object):
         assert len(ranges) == 1
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "fghi"
 
-    def test_string_join_iterable_tainted(self):
-        # type: () -> None
+    def test_string_join_iterable_tainted(self) -> None:
         # Not tainted
         base_string = "+abcde-"
         result = mod.do_join_args_kwargs(base_string, "fg")
@@ -316,8 +311,7 @@ class TestOperatorJoinReplacement(object):
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "f"
         assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "g"
 
-    def test_string_join_iterable_first_half_tainted(self):
-        # type: () -> None
+    def test_string_join_iterable_first_half_tainted(self) -> None:
         # Not tainted
         base_string = "-abcde-"
         result = mod.do_join_args_kwargs(base_string, "fg")
@@ -337,8 +331,7 @@ class TestOperatorJoinReplacement(object):
         assert len(ranges) == 2
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "f"
 
-    def test_string_join_iterable_second_half_tainted(self):
-        # type: () -> None
+    def test_string_join_iterable_second_half_tainted(self) -> None:
         # Not tainted
         base_string = "-abcde-"
         result = mod.do_join_args_kwargs(base_string, "fg")
@@ -358,8 +351,7 @@ class TestOperatorJoinReplacement(object):
         assert len(ranges) == 2
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "f"
 
-    def test_string_join_iterable_middle_tainted(self):
-        # type: () -> None
+    def test_string_join_iterable_middle_tainted(self) -> None:
         # Not tainted
         base_string = "+abcde-"
         result = mod.do_join_args_kwargs(base_string, "fgh")
@@ -379,8 +371,7 @@ class TestOperatorJoinReplacement(object):
         assert len(ranges) == 3
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "f"
 
-    def test_string_join_joiner_tainted(self):
-        # type: () -> None
+    def test_string_join_joiner_tainted(self) -> None:
         # Tainted joiner
         tainted_base_string = taint_pyobject(
             pyobject="-abcde-",
@@ -394,8 +385,7 @@ class TestOperatorJoinReplacement(object):
         ranges = get_tainted_ranges(result)
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "-abcde-"
 
-    def test_string_join_all_tainted(self):
-        # type: () -> None
+    def test_string_join_all_tainted(self) -> None:
         # Tainted joiner
         tainted_base_string = taint_pyobject(
             pyobject="+abcde-",

--- a/tests/appsec/iast/aspects/test_modulo_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_modulo_aspect_fixtures.py
@@ -21,14 +21,14 @@ mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.str_methods")
 class TestOperatorModuloReplacement(BaseReplacement):
     def _assert_modulo_result(
         self,
-        taint_escaped_template,  # type: Text
-        taint_escaped_parameter,  # type: Any
-        expected_result,  # type: Text
-        escaped_expected_result,  # type: Text
-    ):  # type: (...) -> None
+        taint_escaped_template: Text,
+        taint_escaped_parameter: Any,
+        expected_result: Text,
+        escaped_expected_result: Text,
+    ) -> None:
         template = self._to_tainted_string_with_origin(taint_escaped_template)
 
-        parameter = tuple()  # type: Any
+        parameter: Any = tuple()
         if isinstance(taint_escaped_parameter, (tuple, List)):
             parameter = tuple([self._to_tainted_string_with_origin(item) for item in taint_escaped_parameter])
         else:
@@ -39,19 +39,19 @@ class TestOperatorModuloReplacement(BaseReplacement):
         assert result == expected_result
         assert as_formatted_evidence(result, tag_mapping_function=None) == escaped_expected_result
 
-    def test_modulo_when_template_is_none_then_raises_attribute_error(self):  # type: () -> None
+    def test_modulo_when_template_is_none_then_raises_attribute_error(self) -> None:
         with pytest.raises(TypeError):
             mod.do_modulo(None, "")
 
-    def test_modulo_when_parameter_is_none_then_does_not_break(self):  # type: () -> None
+    def test_modulo_when_parameter_is_none_then_does_not_break(self) -> None:
         assert mod.do_modulo("%s", None) == "None"
 
-    def test_modulo_when_positional_no_tainted_then_no_tainted_result(self):  # type: () -> None
+    def test_modulo_when_positional_no_tainted_then_no_tainted_result(self) -> None:
         result = mod.do_modulo("template %s", "parameter")
         assert result, "template parameter"
         assert not get_ranges(result)
 
-    def test_modulo_when_tainted_parameter_then_tainted_result(self):  # type: () -> None
+    def test_modulo_when_tainted_parameter_then_tainted_result(self) -> None:
         self._assert_modulo_result(
             taint_escaped_template="template %s",
             taint_escaped_parameter=":+-<input1>parameter<input1>-+:",
@@ -59,7 +59,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
             escaped_expected_result="template :+-<input1>parameter<input1>-+:",
         )
 
-    def test_modulo_when_tainted_template_range_no_percent_then_tainted_result(self):  # type: () -> None
+    def test_modulo_when_tainted_template_range_no_percent_then_tainted_result(self) -> None:
         self._assert_modulo_result(
             taint_escaped_template=":+-<input1>template<input1>-+: %s",
             taint_escaped_parameter="parameter",
@@ -67,7 +67,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template<input1>-+: parameter",
         )
 
-    def test_modulo_when_tainted_template_range_with_percent_then_tainted_result(self):  # type: () -> None
+    def test_modulo_when_tainted_template_range_with_percent_then_tainted_result(self) -> None:
         self._assert_modulo_result(
             taint_escaped_template="template :+-<input1>%s<input1>-+:",
             taint_escaped_parameter="parameter",
@@ -75,7 +75,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
             escaped_expected_result="template :+-<input1>parameter<input1>-+:",
         )
 
-    def test_modulo_when_multiple_tainted_parameter_then_tainted_result(self):  # type: () -> None
+    def test_modulo_when_multiple_tainted_parameter_then_tainted_result(self) -> None:
         self._assert_modulo_result(
             taint_escaped_template="template %s %s",
             taint_escaped_parameter=[":+-<input1>p1<input1>-+:", ":+-<input2>p2<input2>-+:"],
@@ -83,7 +83,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
             escaped_expected_result="template :+-<input1>p1<input1>-+: :+-<input2>p2<input2>-+:",
         )
 
-    def test_modulo_when_parameters_and_tainted_template_range_no_percent_then_tainted_result(self):  # type: () -> None
+    def test_modulo_when_parameters_and_tainted_template_range_no_percent_then_tainted_result(self) -> None:
         self._assert_modulo_result(
             taint_escaped_template=":+-<input1>template<input1>-+: %s %s",
             taint_escaped_parameter=["p1", "p2"],
@@ -93,7 +93,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
 
     def test_modulo_when_parameters_and_tainted_template_range_with_percent_then_tainted_result(
         self,
-    ):  # type: () -> None
+    ) -> None:
         self._assert_modulo_result(
             taint_escaped_template="template :+-<input1>%s %s<input1>-+:",
             taint_escaped_parameter=["p1", "p2"],
@@ -101,7 +101,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
             escaped_expected_result="template :+-<input1>p1 p2<input1>-+:",
         )
 
-    def test_modulo_when_tainted_template_range_no_percent_and_tainted_param_then_tainted(self):  # type: () -> None
+    def test_modulo_when_tainted_template_range_no_percent_and_tainted_param_then_tainted(self) -> None:
         self._assert_modulo_result(
             taint_escaped_template=":+-<input1>template<input1>-+: %s",
             taint_escaped_parameter=":+-<input2>parameter<input2>-+:",
@@ -109,7 +109,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template<input1>-+: " ":+-<input2>parameter<input2>-+:",
         )
 
-    def test_modulo_when_tainted_template_range_with_percent_and_tainted_param_then_tainted(self):  # type: () -> None
+    def test_modulo_when_tainted_template_range_with_percent_and_tainted_param_then_tainted(self) -> None:
         self._assert_modulo_result(
             taint_escaped_template=":+-<input1>template %s<input1>-+:",
             taint_escaped_parameter=":+-<input1>parameter<input2>-+:",
@@ -117,7 +117,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template <input1>-+:" ":+-<input2>parameter<input2>-+:",
         )
 
-    def test_modulo_when_ranges_overlap_then_give_preference_to_ranges_from_parameter(self):  # type: () -> None
+    def test_modulo_when_ranges_overlap_then_give_preference_to_ranges_from_parameter(self) -> None:
         self._assert_modulo_result(
             taint_escaped_template=":+-<input1>template %s range overlapping<input1>-+:",
             taint_escaped_parameter=":+-<input2>parameter<input2>-+:",
@@ -127,7 +127,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
             ":+-<input1> range overlapping<input1>-+:",
         )
 
-    def test_modulo_when_tainted_str_emoji_strings_then_tainted_result(self):  # type: () -> None
+    def test_modulo_when_tainted_str_emoji_strings_then_tainted_result(self) -> None:
         self._assert_modulo_result(
             taint_escaped_template=":+-<input1>template⚠️<input1>-+: %s",
             taint_escaped_parameter=":+-<input2>parameter⚠️<input2>-+:",
@@ -135,7 +135,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template⚠️<input1>-+: " ":+-<input2>parameter⚠️<input2>-+:",
         )
 
-    def test_modulo_when_tainted_unicode_emoji_strings_then_tainted_result(self):  # type: () -> None
+    def test_modulo_when_tainted_unicode_emoji_strings_then_tainted_result(self) -> None:
         self._assert_modulo_result(
             taint_escaped_template=":+-<input1>template⚠️<input1>-+: %s",
             taint_escaped_parameter=":+-<input2>parameter⚠️<input2>-+:",
@@ -143,7 +143,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template⚠️<input1>-+: " ":+-<input2>parameter⚠️<input2>-+:",
         )
 
-    def test_modulo_when_tainted_template_range_no_percent_and_param_not_str_then_tainted(self):  # type: () -> None
+    def test_modulo_when_tainted_template_range_no_percent_and_param_not_str_then_tainted(self) -> None:
         self._assert_modulo_result(
             taint_escaped_template=":+-<input1>template<input1>-+: %0.2f",
             taint_escaped_parameter=math.pi,
@@ -151,7 +151,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template<input1>-+: 3.14",
         )
 
-    def test_modulo_when_tainted_template_range_with_percent_and_param_not_str_then_tainted(self):  # type: () -> None
+    def test_modulo_when_tainted_template_range_with_percent_and_param_not_str_then_tainted(self) -> None:
         self._assert_modulo_result(
             taint_escaped_template=":+-<input1>template %0.2f<input1>-+:",
             taint_escaped_parameter=math.pi,
@@ -161,7 +161,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
 
     def test_modulo_when_texts_tainted_and_contain_escape_sequences_then_result_uncorrupted(
         self,
-    ):  # type: () -> None
+    ) -> None:
         self._assert_modulo_result(
             taint_escaped_template=":+-<input1>template ::++--<0>my_code<0>--++::" "<input1>-+: %s",
             taint_escaped_parameter=":+-<input2>parameter<input2>-+: " "::++--<0>my_code<0>--++::",
@@ -171,7 +171,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
             ":+-<0>my_code<0>-+:",
         )
 
-    def test_modulo_when_parameter_value_already_present_in_template_then_range_is_correct(self):  # type: () -> None
+    def test_modulo_when_parameter_value_already_present_in_template_then_range_is_correct(self) -> None:
         self._assert_modulo_result(
             taint_escaped_template="aaaaaa%saaa",
             taint_escaped_parameter="a:+-<input1>a<input1>-+:a",

--- a/tests/appsec/iast/aspects/test_str_aspect.py
+++ b/tests/appsec/iast/aspects/test_str_aspect.py
@@ -99,8 +99,7 @@ def test_repr_aspect_tainting(obj, expected_result):
 
 
 class TestOperatorsReplacement(BaseReplacement):
-    def test_aspect_ljust_str_tainted(self):
-        # type: () -> None
+    def test_aspect_ljust_str_tainted(self) -> None:
         string_input = "foo"
 
         # Not tainted
@@ -147,8 +146,7 @@ class TestOperatorsReplacement(BaseReplacement):
         list_metrics_logs = list(telemetry_writer._logs)
         assert len(list_metrics_logs) == 0
 
-    def test_format(self):
-        # type: () -> None
+    def test_format(self) -> None:
         string_input = "foo"
         result = mod.do_format_fill(string_input)
         assert result == "foo       "

--- a/tests/appsec/iast/aspects/test_str_py3.py
+++ b/tests/appsec/iast/aspects/test_str_py3.py
@@ -16,14 +16,14 @@ mod_py3 = _iast_patched_module("tests.appsec.iast.fixtures.aspects.str_methods_p
 
 class TestOperatorsReplacement(BaseReplacement):
     @staticmethod
-    def test_taint():  # type: () -> None
+    def test_taint() -> None:
         string_input = "foo"
         assert as_formatted_evidence(string_input) == "foo"
 
         string_input = create_taint_range_with_format(":+-foo-+:")
         assert as_formatted_evidence(string_input) == ":+-foo-+:"
 
-    def test_string_build_string_tainted(self):  # type: () -> None
+    def test_string_build_string_tainted(self) -> None:
         string_input = "foo"
         result = mod_py3.do_fmt_value(string_input)  # pylint: disable=no-member
         assert result == "foo     bar"
@@ -33,8 +33,7 @@ class TestOperatorsReplacement(BaseReplacement):
         assert result == "foo     bar"
         assert as_formatted_evidence(result) == ":+-foo-+:     bar"
 
-    def test_string_fstring_tainted(self):
-        # type: () -> None
+    def test_string_fstring_tainted(self) -> None:
         string_input = "foo"
         result = mod_py3.do_repr_fstring(string_input)
         assert result == "'foo'"
@@ -44,8 +43,7 @@ class TestOperatorsReplacement(BaseReplacement):
         result = mod_py3.do_repr_fstring(string_input)  # pylint: disable=no-member
         assert as_formatted_evidence(result) == "':+-foo-+:'"
 
-    def test_string_fstring_with_format_tainted(self):
-        # type: () -> None
+    def test_string_fstring_with_format_tainted(self) -> None:
         string_input = "foo"
         result = mod_py3.do_repr_fstring_with_format(string_input)
         assert result == "'foo'     "
@@ -55,8 +53,7 @@ class TestOperatorsReplacement(BaseReplacement):
         result = mod_py3.do_repr_fstring_with_format(string_input)  # pylint: disable=no-member
         assert as_formatted_evidence(result) == "':+-foo-+:'     "
 
-    def test_string_fstring_repr_str_twice_tainted(self):
-        # type: () -> None
+    def test_string_fstring_repr_str_twice_tainted(self) -> None:
         string_input = "foo"
 
         result = mod_py3.do_repr_fstring_twice(string_input)  # pylint: disable=no-member
@@ -68,8 +65,7 @@ class TestOperatorsReplacement(BaseReplacement):
         assert result == "'foo' 'foo'"
         assert as_formatted_evidence(result) == "':+-foo-+:' ':+-foo-+:'"
 
-    def test_string_fstring_repr_object_twice_tainted(self):
-        # type: () -> None
+    def test_string_fstring_repr_object_twice_tainted(self) -> None:
         string_input = "foo"
         result = mod.MyObject(string_input)
         assert repr(result) == "foo a"
@@ -84,7 +80,7 @@ class TestOperatorsReplacement(BaseReplacement):
         assert result == "foo a foo a"
         assert as_formatted_evidence(result) == ":+-foo-+: a :+-foo-+: a"
 
-    def test_string_fstring_twice_different_objects_tainted(self):  # type: () -> None
+    def test_string_fstring_twice_different_objects_tainted(self) -> None:
         string_input = create_taint_range_with_format(":+-foo-+:")
         obj = mod.MyObject(string_input)  # pylint: disable=no-member
         obj2 = mod.MyObject(string_input)  # pylint: disable=no-member
@@ -93,7 +89,7 @@ class TestOperatorsReplacement(BaseReplacement):
         assert result == "foo a foo a"
         assert as_formatted_evidence(result) == ":+-foo-+: a :+-foo-+: a"
 
-    def test_string_fstring_twice_different_objects_tainted_twice(self):  # type: () -> None
+    def test_string_fstring_twice_different_objects_tainted_twice(self) -> None:
         string_input = create_taint_range_with_format(":+-foo-+:")
         obj = mod.MyObject(string_input)  # pylint: disable=no-member
 
@@ -111,6 +107,6 @@ class TestOperatorsReplacement(BaseReplacement):
             mod_py3.do_repr_fstring_with_expression5,
         ],
     )
-    def test_string_fstring_non_string(self, function):  # type: () -> None
+    def test_string_fstring_non_string(self, function) -> None:
         result = function()  # pylint: disable=no-member
         assert result == "Hello world, True!"

--- a/tests/appsec/iast/fixtures/aspects/str_methods.py
+++ b/tests/appsec/iast/fixtures/aspects/str_methods.py
@@ -33,7 +33,7 @@ def methodcaller(*args, **kwargs):
 
 
 class WebServerHandler(SimpleHTTPRequestHandler):
-    def do_GET(self):  # type: () -> None
+    def do_GET(self) -> None:
         self.send_response(200)
         self.send_header("Content-type", "text/html")
         self.end_headers()
@@ -42,7 +42,7 @@ class WebServerHandler(SimpleHTTPRequestHandler):
 
 
 class StoppableHTTPServer(HTTPServer):
-    def run(self):  # type: () -> None
+    def run(self) -> None:
         try:
             self.serve_forever()
         finally:
@@ -54,8 +54,8 @@ def do_operator_add_params(a, b):
     return a + b
 
 
-def uppercase_decorator(function):  # type: (Callable) -> Callable
-    def wrapper(a, b):  # type: (str, str) -> str
+def uppercase_decorator(function: Callable) -> Callable:
+    def wrapper(a: str, b: str) -> str:
         func = function(a, b)
         return func.upper()
 
@@ -63,7 +63,7 @@ def uppercase_decorator(function):  # type: (Callable) -> Callable
 
 
 @uppercase_decorator
-def do_add_and_uppercase(a, b):  # type: (str, str) -> str
+def do_add_and_uppercase(a: str, b: str) -> str:
     return a + b
 
 
@@ -88,74 +88,73 @@ def get_full_path_methods(path, META, force_append_slash=False):
     )
 
 
-def do_upper_not_str(s):  # type: (str) -> str
+def do_upper_not_str(s: str) -> str:
     class MyStr(object):
         @staticmethod
-        def upper(string):  # type: (str) -> str
+        def upper(string: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.upper(s)
 
 
-def do_lower_not_str(s):  # type: (str) -> str
+def do_lower_not_str(s: str) -> str:
     class MyStr(object):
         @staticmethod
-        def lower(string):  # type: (str) -> str
+        def lower(string: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.lower(s)
 
 
-def do_swapcase(s):  # type: (str) -> str
+def do_swapcase(s: str) -> str:
     return s.swapcase()
 
 
-def do_swapcase_not_str(s):  # type: (str) -> str
+def do_swapcase_not_str(s: str) -> str:
     class MyStr(object):
         @staticmethod
-        def swapcase(string):  # type: (str) -> str
+        def swapcase(string: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.swapcase(s)
 
 
-def do_title(s):  # type: (str) -> str
+def do_title(s: str) -> str:
     return s.title()
 
 
-def do_title_not_str(s):  # type: (str) -> str
+def do_title_not_str(s: str) -> str:
     class MyStr(object):
         @staticmethod
-        def title(string):  # type: (str) -> str
+        def title(string: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.title(s)
 
 
-def do_capitalize(s):  # type: (str) -> str
+def do_capitalize(s: str) -> str:
     return s.capitalize()
 
 
-def do_capitalize_not_str(s):  # type: (str) -> str
+def do_capitalize_not_str(s: str) -> str:
     class MyStr(object):
         @staticmethod
-        def capitalize(string):  # type: (str) -> str
+        def capitalize(string: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.capitalize(s)
 
 
-def do_decode(s, encoding="utf-8", errors="strict"):  # type: (bytes, str, str) -> str
+def do_decode(s: bytes, encoding: str = "utf-8", errors: str = "strict") -> str:
     return s.decode(encoding, errors)
 
 
-def do_translate(s, translate_dict):
-    # type: (str, dict) -> str
+def do_translate(s: str, translate_dict: dict) -> str:
     return s.translate(translate_dict)
 
 
@@ -163,256 +162,254 @@ def do_decode_simple(s: bytes) -> str:
     return s.decode()
 
 
-def do_encode(s, encoding="utf-8", errors="strict"):
-    # type: (str, str, str) -> bytes
+def do_encode(s: str, encoding: str = "utf-8", errors: str = "strict") -> bytes:
     return s.encode(encoding, errors)
 
 
-def do_encode_from_dict(s, encoding="utf-8", errors="strict"):
-    # type: (str, str, str) -> bytes
+def do_encode_from_dict(s: str, encoding: str = "utf-8", errors: str = "strict") -> bytes:
     my_dictionary = {}
     my_dictionary["test"] = s
     return my_dictionary.get("test", "").encode(encoding, errors)
 
 
-def do_str_to_bytes(s):  # type: (str) -> bytes
+def do_str_to_bytes(s: str) -> bytes:
     if sys.version_info[0] >= 3:
         return bytes(s, encoding="utf-8")
     return bytes(s)
 
 
-def do_str_to_bytearray(s):  # type: (str) -> bytearray
+def do_str_to_bytearray(s: str) -> bytearray:
     if sys.version_info[0] >= 3:
         return bytearray(s, encoding="utf-8")
     return bytearray(s)
 
 
-def do_str_to_bytes_to_bytearray(s):  # type: (str) -> bytearray
+def do_str_to_bytes_to_bytearray(s: str) -> bytearray:
     if sys.version_info[0] >= 3:
         return bytearray(bytes(s, encoding="utf-8"))
     return bytearray(bytes(s))
 
 
-def do_str_to_bytes_to_bytearray_to_str(s):  # type: (str) -> str
+def do_str_to_bytes_to_bytearray_to_str(s: str) -> str:
     if sys.version_info[0] >= 3:
         return str(bytearray(bytes(s, encoding="utf-8")), encoding="utf-8")
     return str(bytearray(bytes(s)))
 
 
-def do_bytearray_to_bytes(s):  # type: (bytearray) -> bytes
+def do_bytearray_to_bytes(s: bytearray) -> bytes:
     return bytes(s)
 
 
-def do_bytearray_append(ba):  # type: (bytearray) -> bytes
+def do_bytearray_append(ba: bytearray) -> bytes:
     ba.append(37)
     return ba
 
 
-def do_bytearray_extend(ba, b):  # type: (bytearray, bytearray) -> None
+def do_bytearray_extend(ba: bytearray, b: bytearray) -> None:
     ba.extend(b)
     return ba
 
 
-def do_bytes_to_str(b):  # type: (bytes) -> str
+def do_bytes_to_str(b: bytes) -> str:
     if sys.version_info[0] >= 3:
         return str(b, encoding="utf-8")
     return str(b)
 
 
-def do_bytearray_to_str(b):  # type: (bytearray) -> str
+def do_bytearray_to_str(b: bytearray) -> str:
     if sys.version_info[0] >= 3:
         return str(b, encoding="utf-8")
     return str(b)
 
 
-def do_bytes_to_bytearray(s):  # type: (bytes) -> bytearray
+def do_bytes_to_bytearray(s: bytes) -> bytearray:
     return bytearray(s)
 
 
-def do_bytes_to_iter_bytearray(b):  # type: (bytes) -> bytearray
+def do_bytes_to_iter_bytearray(b: bytes) -> bytearray:
     groups = iter(b.split(b"%"))
     result = bytearray(next(groups, b""))
     return result
 
 
-def do_encode_not_str(s):  # type: (str) -> str
+def do_encode_not_str(s: str) -> str:
     class MyStr(object):
         @staticmethod
-        def encode(string):  # type: (str) -> str
+        def encode(string: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.encode(s)
 
 
-def do_expandtabs(s):  # type: (str) -> str
+def do_expandtabs(s: str) -> str:
     return s.expandtabs()
 
 
-def do_expandtabs_not_str(s):  # type: (str) -> str
+def do_expandtabs_not_str(s: str) -> str:
     class MyStr(object):
         @staticmethod
-        def expandtabs(string):  # type: (str) -> str
+        def expandtabs(string: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.expandtabs(s)
 
 
-def do_casefold(s):  # type: (str) -> str
+def do_casefold(s: str) -> str:
     return s.casefold()
 
 
-def do_casefold_not_str(s):  # type: (str) -> str
+def do_casefold_not_str(s: str) -> str:
     class MyStr(object):
         @staticmethod
-        def casefold(string):  # type: (str) -> str
+        def casefold(string: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.casefold(s)
 
 
-def do_center(c, i):  # type: (str, int) -> str
+def do_center(c: str, i: int) -> str:
     return c.center(i)
 
 
-def do_center_not_str(c):  # type: (str) -> str
+def do_center_not_str(c: str) -> str:
     class MyStr(object):
         @staticmethod
-        def center(string):  # type: (str) -> str
+        def center(string: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.center(c)
 
 
-def do_ljust_not_str(c):  # type: (str) -> str
+def do_ljust_not_str(c: str) -> str:
     class MyStr(object):
         @staticmethod
-        def ljust(string1, string2):  # type: (str, str) -> str
+        def ljust(string1: str, string2: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.ljust(c, c)
 
 
-def do_ljust(s, width):  # type: (str, int) -> str
+def do_ljust(s: str, width: int) -> str:
     return s.ljust(width)
 
 
-def do_ljust_2(s, width, fill_char):  # type: (str, int, str) -> str
+def do_ljust_2(s: str, width: int, fill_char: str) -> str:
     return s.ljust(width, fill_char)
 
 
-def do_lstrip_not_str(c):  # type: (str) -> str
+def do_lstrip_not_str(c: str) -> str:
     class MyStr(object):
         @staticmethod
-        def lstrip(string1, string2):  # type: (str, str) -> str
+        def lstrip(string1: str, string2: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.lstrip(c, c)
 
 
-def do_lstrip(s):  # type: (str) -> str
+def do_lstrip(s: str) -> str:
     return s.lstrip()
 
 
-def do_rstrip_not_str(c):  # type: (str) -> str
+def do_rstrip_not_str(c: str) -> str:
     class MyStr(object):
         @staticmethod
-        def rstrip(string1, string2):  # type: (str, str) -> str
+        def rstrip(string1: str, string2: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.rstrip(c, c)
 
 
-def do_split_not_str(c):  # type: (str) -> str
+def do_split_not_str(c: str) -> str:
     class MyStr(object):
         @staticmethod
-        def split(string1, string2, string3):  # type: (str, str, str) -> str
+        def split(string1: str, string2: str, string3: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.split(c, c, c)
 
 
-def do_rsplit_not_str(c):  # type: (str) -> str
+def do_rsplit_not_str(c: str) -> str:
     class MyStr(object):
         @staticmethod
-        def rsplit(string1, string2, string3):  # type: (str, str, str) -> str
+        def rsplit(string1: str, string2: str, string3: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.rsplit(c, c, c)
 
 
-def do_splitlines_not_str(c):  # type: (str) -> str
+def do_splitlines_not_str(c: str) -> str:
     class MyStr(object):
         @staticmethod
-        def splitlines(string1, string2, string3):  # type: (str, str, str) -> str
+        def splitlines(string1: str, string2: str, string3: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.splitlines(c, c, c)
 
 
-def do_partition_not_str(c):  # type: (str) -> str
+def do_partition_not_str(c: str) -> str:
     class MyStr(object):
         @staticmethod
-        def partition(string1, string2, string3):  # type: (str, str, str) -> str
+        def partition(string1: str, string2: str, string3: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.partition(c, c, c)
 
 
-def do_rpartition_not_str(c):  # type: (str) -> str
+def do_rpartition_not_str(c: str) -> str:
     class MyStr(object):
         @staticmethod
-        def rpartition(string1, string2, string3):  # type: (str, str, str) -> str
+        def rpartition(string1: str, string2: str, string3: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.rpartition(c, c, c)
 
 
-def do_replace_not_str(c):  # type: (str) -> str
+def do_replace_not_str(c: str) -> str:
     class MyStr(object):
         @staticmethod
-        def replace(string1):  # type: (str) -> str
+        def replace(string1: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.replace(c)
 
 
-def do_format_not_str(c):  # type: (str) -> str
+def do_format_not_str(c: str) -> str:
     class MyStr(object):
         @staticmethod
-        def format(string1):  # type: (str) -> str
+        def format(string1: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.format(c)
 
 
-def do_format_map_not_str(c):  # type: (str) -> str
+def do_format_map_not_str(c: str) -> str:
     class MyStr(object):
         @staticmethod
-        def format_map(string1):  # type: (str) -> str
+        def format_map(string1: str) -> str:
             return "output"
 
     my_str = MyStr()
     return my_str.format_map(c)
 
 
-def do_zfill_not_str(c):  # type: (str) -> str
+def do_zfill_not_str(c: str) -> str:
     class MyStr(object):
         @staticmethod
-        def zfill(string1):  # type: (str) -> str
+        def zfill(string1: str) -> str:
             return "output"
 
     my_str = MyStr()
@@ -581,7 +578,7 @@ class AutoIncrementWithSubSubclassClass:
         self.dummy.dummy.creation_counter += 1
 
 
-def someother_function():  # type: () -> None
+def someother_function() -> None:
     print("Im some other function that should not be replaced")
 
 
@@ -647,11 +644,11 @@ def do_decorated_function():
     return "decorated function"
 
 
-def do_join_tuple_unpack_with_call_for_mock():  # type: () -> Text
+def do_join_tuple_unpack_with_call_for_mock() -> Text:
     return os.path.join("UTC", *("A", "B"))
 
 
-def do_join_tuple_unpack_with_call():  # type: () -> Text
+def do_join_tuple_unpack_with_call() -> Text:
     return os.path.join("UTC", *("A", "B"))
 
 
@@ -659,26 +656,26 @@ class SampleClass(object):
     TIME_ZONE = "UTC/UTM"
 
     @staticmethod
-    def commonprefix(first, *args):  # type: (Text, List[Any]) -> Sequence
+    def commonprefix(first: Text, *args: List[Any]) -> Sequence:
         return os.path.commonprefix(list([first]) + list(args))
 
 
-def do_join_tuple_unpack_with_call_no_replace():  # type: () -> Sequence
+def do_join_tuple_unpack_with_call_no_replace() -> Sequence:
     return SampleClass.commonprefix("/usr/bin", *("/usr/local/lib", "/usr/lib"))
 
 
-def do_join_tuple_unpack_with_call_with_methods(zoneinfo_root):  # type: (str) -> bool
+def do_join_tuple_unpack_with_call_with_methods(zoneinfo_root: str) -> bool:
     simple = SampleClass()
     return os.path.exists(os.path.join(zoneinfo_root, *(simple.TIME_ZONE.split("/"))))
 
 
 class MapJoin(object):
     @staticmethod
-    def join(arg0, foo="a", baz="x"):  # type: (Text, Text, Text) -> Text
+    def join(arg0: Text, foo: Text = "a", baz: Text = "x") -> Text:
         return os.path.join(arg0, foo, baz)
 
 
-def do_join_map_unpack_with_call():  # type: () -> Text
+def do_join_map_unpack_with_call() -> Text:
     return MapJoin.join(arg0="/", **{"foo": "bar", "baz": "qux"})
 
 
@@ -697,32 +694,32 @@ def no_effect_using_wraps(func):
     return wrapper
 
 
-def do_upper(s):  # type: (str) -> str
+def do_upper(s: str) -> str:
     return s.upper()
 
 
-def do_lower(s):  # type: (str) -> str
+def do_lower(s: str) -> str:
     return s.lower()
 
 
 class MockIssue:
-    def __init__(self, value):  # type: (str) -> None
+    def __init__(self, value: str) -> None:
         self.value = value
 
-    def __repr__(self):  # type: () -> str
+    def __repr__(self) -> str:
         return self.value
 
-    def __str__(self):  # type: () -> str
+    def __str__(self) -> str:
         return self.value
 
     @property
-    def level(self):  # type: () -> int
+    def level(self) -> int:
         return 1
 
-    def is_silenced(self):  # type: () -> bool
+    def is_silenced(self) -> bool:
         return False
 
-    def is_serious(self):  # type: () -> bool
+    def is_serious(self) -> bool:
         return False
 
 
@@ -731,7 +728,7 @@ class MyIter:
     _leftover = "my_string"
     _producer = (i for i in ["a", "b", "c"])
 
-    def function_next(self):  # type: () -> str
+    def function_next(self) -> str:
         """
         Used when the exact number of bytes to read is unimportant.
 
@@ -748,25 +745,25 @@ class MyIter:
         return output
 
 
-def func_iter_sum(a):  # type: (str) -> List
-    out = []  # type: List[str]
+def func_iter_sum(a: str) -> List:
+    out: List[str] = []
     out += a, a
     return out
 
 
-def get_random_string_module_encode(allowed_chars):  # type: (str) -> List[str]
+def get_random_string_module_encode(allowed_chars: str) -> List[str]:
     result = ("%s%s%s" % ("a", "b", "c")).encode("utf-8")
     return [allowed_chars for i in result]
 
 
-def get_random_string_join(mystring):  # type: (str) -> str
+def get_random_string_join(mystring: str) -> str:
     return "".join(mystring for i in ["1", "2"])
 
 
 def get_random_string_seed(
-    length=12,
-    allowed_chars="abcdefghijklmnopqrstuvwxyz" "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
-):  # type: (int, str) -> str
+    length: int = 12,
+    allowed_chars: str = "abcdefghijklmnopqrstuvwxyz" "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+) -> str:
     """
     Returns a securely generated random string.
 
@@ -777,19 +774,19 @@ def get_random_string_seed(
     return "".join(random.choice(allowed_chars) for i in range(length))
 
 
-def mark_safe(a):  # type: (str) -> str
+def mark_safe(a: str) -> str:
     return a
 
 
-def conditional_escape(a):  # type: (str) -> str
+def conditional_escape(a: str) -> str:
     return a
 
 
-def format_html(a, args):  # type: (str, *Tuple) -> str
+def format_html(a: str, args: Tuple) -> str:
     return a.join(args)
 
 
-def format_html_join(attrs, args_generator=None):  # type: (str, List[str]) -> str
+def format_html_join(attrs: str, args_generator: List[str] = None) -> str:
     if args_generator is None:
         args_generator = ["a", "b", "c"]
 
@@ -797,9 +794,9 @@ def format_html_join(attrs, args_generator=None):  # type: (str, List[str]) -> s
     return result
 
 
-def get_wrapped_repeat_text_with_join(wrapper):  # type: (Callable) -> Callable
+def get_wrapped_repeat_text_with_join(wrapper: Callable) -> Callable:
     @wrapper
-    def repeat_text_with_join(text, times=2):  # type: (str, int) -> str
+    def repeat_text_with_join(text: str, times: int = 2) -> str:
         # Use the join to confirm that we use a string-propagation method
         return "_".join([text for i in range(0, times)])
 
@@ -807,40 +804,40 @@ def get_wrapped_repeat_text_with_join(wrapper):  # type: (Callable) -> Callable
 
 
 def do_format_with_positional_parameter(
-    template,  # type: Text
-    parameter,  # type: Any
-):  # type: (...) -> Text
+    template: Text,
+    parameter: Any,
+) -> Text:
     return template.format(parameter)
 
 
 def do_format_with_named_parameter(
-    template,  # type: Text
-    value,  # type: Any
-):  # type: (...) -> Text
+    template: Text,
+    value: Any,
+) -> Text:
     return template.format(key=value)
 
 
-def mapper(taint_range):  # type: (Any) -> Text
+def mapper(taint_range: Any) -> Text:
     return taint_range.origin.parameter_name
 
 
-def do_args_kwargs_1(format_string, *args_safe, **kwargs_safe):  # type: (str, Any, Any) -> str
+def do_args_kwargs_1(format_string: str, *args_safe: Any, **kwargs_safe: Any) -> str:
     return format_string.format(*args_safe, **kwargs_safe)
 
 
-def do_args_kwargs_2(format_string, *args_safe, **kwargs_safe):  # type: (str, Any, Any) -> str
+def do_args_kwargs_2(format_string: str, *args_safe: Any, **kwargs_safe: Any) -> str:
     return format_string.format("1", *args_safe, **kwargs_safe)
 
 
-def do_args_kwargs_3(format_string, *args_safe, **kwargs_safe):  # type: (str, Any, Any) -> str
+def do_args_kwargs_3(format_string: str, *args_safe: Any, **kwargs_safe: Any) -> str:
     return format_string.format("1", "2", *args_safe, **kwargs_safe)
 
 
-def do_args_kwargs_4(format_string, *args_safe, **kwargs_safe):  # type: (str, Any, Any) -> str
+def do_args_kwargs_4(format_string: str, *args_safe: Any, **kwargs_safe: Any) -> str:
     return format_string.format("1", "2", test_kwarg=3, *args_safe, **kwargs_safe)
 
 
-def do_format_map(template, mapping):  # type: (str, Dict[str, Any]) -> str
+def do_format_map(template: str, mapping: Dict[str, Any]) -> str:
     return template.format_map(mapping)
 
 
@@ -848,62 +845,60 @@ def do_format_key_error(param1):  # type: (str, Dict[str, Any]) -> str
     return "Test {param1}, {param2}".format(param1=param1)
 
 
-def do_join(s, iterable):
-    # type: (str, Iterable) -> str
+def do_join(s: str, iterable: Iterable) -> str:
     return s.join(iterable)
 
 
-def do_join_args_kwargs(s, *args, **kwargs):
-    # type: (str, Iterable) -> str
+def do_join_args_kwargs(s, *args: str, **kwargs: Iterable) -> str:
     return s.join(*args, **kwargs)
 
 
-def do_join_tuple(mystring):  # type: (str) -> str
+def do_join_tuple(mystring: str) -> str:
     mystring = mystring
     gen = tuple(mystring + _ for _ in ["1", "2", "3"])
     return "".join(gen)
 
 
-def do_join_set(mystring):  # type: (str) -> str
+def do_join_set(mystring: str) -> str:
     mystring = mystring
     gen = {mystring + _ for _ in ["1", "2", "3"]}
     return "".join(gen)
 
 
-def do_join_generator(mystring):  # type: (str) -> str
+def do_join_generator(mystring: str) -> str:
     mystring = mystring
     gen = (mystring for _ in ["1", "2", "3"])
     return "".join(gen)
 
 
-def do_join_generator_2(mystring):  # type: (str) -> str
-    def parts():  # type: () -> Generator
+def do_join_generator_2(mystring: str) -> str:
+    def parts() -> Generator:
         for i in ["x", "y", "z"]:
             yield i
 
     return mystring.join(parts())
 
 
-def do_join_generator_and_title(mystring):  # type: (str) -> str
+def do_join_generator_and_title(mystring: str) -> str:
     mystring = mystring.title()
     gen = (mystring for _ in ["1", "2", "3"])
     return "".join(gen)
 
 
-def do_modulo(template, parameter):  # type: (Text, Any) -> Text
+def do_modulo(template: Text, parameter: Any) -> Text:
     return template % parameter
 
 
-def do_replace(text, old, new, count=-1):  # type: (Text, Text, Text, int) -> Text
+def do_replace(text: Text, old: Text, new: Text, count: int = -1) -> Text:
     return text.replace(old, new, count)
 
 
 def do_slice(
-    text,  # type: str
-    first,  # type: Optional[int]
-    second,  # type: Optional[int]
-    third,  # type: Optional[int]
-):  # type: (...) -> str
+    text: str,
+    first: Optional[int],
+    second: Optional[int],
+    third: Optional[int],
+) -> str:
     # CAVEAT: the following code is duplicate on purpose (also present in production code),
     # because it needs to expose the slicing in order to be patched correctly.
 
@@ -925,7 +920,7 @@ def do_slice(
     return key_lambda_map[cases_key](text)
 
 
-def mult_two(a, b):  # type: (Any, Any) -> Any
+def mult_two(a: Any, b: Any) -> Any:
     return a * b
 
 
@@ -935,14 +930,14 @@ def inplace_mult(a, b):
 
 
 class MyObject(object):
-    def __init__(self, str_param):  # type: (str) -> None
+    def __init__(self, str_param: str) -> None:
         self.str_param = str_param
 
-    def __repr__(self):  # type: () -> str
+    def __repr__(self) -> str:
         return self.str_param + " a"
 
 
-def do_format_fill(a):  # type: (Any) -> str
+def do_format_fill(a: Any) -> str:
     return "{:10}".format(a)
 
 
@@ -966,36 +961,36 @@ def do_namedtuple(s: Text) -> Any:
     return my_string
 
 
-def do_split_no_args(s):  # type: (str) -> List[str]
+def do_split_no_args(s: str) -> List[str]:
     return s.split()
 
 
-def do_rsplit_no_args(s):  # type: (str) -> List[str]
+def do_rsplit_no_args(s: str) -> List[str]:
     return s.rsplit()
 
 
-def do_split(s, sep, maxsplit=-1):  # type: (str, str, int) -> List[str]
+def do_split(s: str, sep: str, maxsplit: int = -1) -> List[str]:
     return s.split(sep, maxsplit)
 
 
 # foosep is just needed so it has the signature expected by _test_somesplit_impl
-def do_splitlines(s, foosep):  # type: (str, str) -> List[str]
+def do_splitlines(s: str, foosep: str) -> List[str]:
     return s.splitlines()
 
 
-def do_partition(s, sep):  # type: (str, str) -> Tuple[str, str, str]
+def do_partition(s: str, sep: str) -> Tuple[str, str, str]:
     return s.partition(sep)
 
 
-def do_zfill(s, width):  # type: (str, int) -> str
+def do_zfill(s: str, width: int) -> str:
     return s.zfill(width)
 
 
-def do_rsplit(s, sep, maxsplit=-1):  # type: (str, str, int) -> List[str]
+def do_rsplit(s: str, sep: str, maxsplit: int = -1) -> List[str]:
     return s.rsplit(sep, maxsplit)
 
 
-def do_rstrip_2(s):  # type: (str) -> str
+def do_rstrip_2(s: str) -> str:
     return s.rstrip()
 
 
@@ -1003,12 +998,12 @@ def do_index(c: str, i: int) -> str:
     return c[i]
 
 
-def do_methodcaller(s, func, *args):  # type: (str, str, Any) -> str
+def do_methodcaller(s: str, func: str, *args: Any) -> str:
     func_method = operator.methodcaller(func, *args)
     return func_method(s)
 
 
-def get_http_headers(header_key):  # type: (str) -> bytes
+def get_http_headers(header_key: str) -> bytes:
     RANDOM_PORT = 0
     server = StoppableHTTPServer(("127.0.0.1", RANDOM_PORT), WebServerHandler)
     thread = threading.Thread(None, server.run)
@@ -1021,18 +1016,18 @@ def get_http_headers(header_key):  # type: (str) -> bytes
     return conn._buffer[2]
 
 
-def urlunsplit_1(data):  # type: (List[str]) -> str
+def urlunsplit_1(data: List[str]) -> str:
     scheme, netloc, url, query, fragment = data
     return scheme + "://" + netloc + url + "?" + query + "#" + fragment
 
 
-def urlunsplit_2(data):  # type: (List[str]) -> str
+def urlunsplit_2(data: List[str]) -> str:
     netloc, url = data
     url = "//" + (netloc or "")
     return url
 
 
-def urljoin(bpath, path):  # type: (str, str) -> List[str]
+def urljoin(bpath: str, path: str) -> List[str]:
     return bpath.split("/")[:-1] + path.split("/")
 
 

--- a/tests/appsec/iast/fixtures/aspects/str_methods_py3.py
+++ b/tests/appsec/iast/fixtures/aspects/str_methods_py3.py
@@ -9,27 +9,27 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Tuple
 
 
-def do_fmt_value(a):  # type: (str) -> str
+def do_fmt_value(a: str) -> str:
     return f"{a:<8s}bar"
 
 
-def do_repr_fstring(a):  # type: (Any) -> str
+def do_repr_fstring(a: Any) -> str:
     return f"{a!r}"
 
 
-def do_repr_fstring_twice(a):  # type: (Any) -> str
+def do_repr_fstring_twice(a: Any) -> str:
     return f"{a!r} {a!r}"
 
 
-def do_repr_fstring_twice_different_objects(a, b):  # type: (Any, Any) -> str
+def do_repr_fstring_twice_different_objects(a: Any, b: Any) -> str:
     return f"{a!r} {b!r}"
 
 
-def do_repr_fstring_with_format(a):  # type: (Any) -> str
+def do_repr_fstring_with_format(a: Any) -> str:
     return f"{a!r:10}"
 
 
-def do_repr_fstring_with_format_twice(a):  # type: (Any) -> str
+def do_repr_fstring_with_format_twice(a: Any) -> str:
     return f"{a!r:10} {a!r:11}"
 
 
@@ -60,7 +60,7 @@ class Resolver404(Exception):
 
 
 class ResolverMatch:
-    def __init__(self, *args, **kwargs):  # type: (List[Any], List[Any]) -> None
+    def __init__(self, *args: List[Any], **kwargs: List[Any]) -> None:
         pass
 
 
@@ -74,21 +74,21 @@ class URLPattern:
     app_name = None
     namespace = None
 
-    def __init__(self, pattern=None):  # type: (URLPattern) -> None
+    def __init__(self, pattern: URLPattern = None) -> None:
         self.pattern = pattern
         self.url_patterns = [self.pattern]
 
     def _join_route(self, current_route, sub_match_route):
         return "".join([current_route, sub_match_route])
 
-    def match(self, path):  # type: (str) -> Optional[Tuple[str, str, str], bool]
+    def match(self, path: str) -> Optional[Tuple[str, str, str], bool]:
         global COUNTER
         COUNTER = COUNTER + 1
         if COUNTER > 4:
             return False
         return path, path, path
 
-    def resolve(self, path):  # type: (str) -> Optional[ResolverMatch, None]
+    def resolve(self, path: str) -> Optional[ResolverMatch, None]:
         path = str(path)  # path may be a reverse_lazy object
         tried = []
         match = self.pattern.match(path) if self.pattern else False

--- a/tests/appsec/iast/test_env_var.py
+++ b/tests/appsec/iast/test_env_var.py
@@ -24,8 +24,7 @@ def _run_python_file(*args, **kwargs):
 
 
 @pytest.mark.skipif(not _is_python_version_supported(), reason="IAST compatible versions")
-def test_env_var_iast_enabled(capfd):
-    # type: (...) -> None
+def test_env_var_iast_enabled(capfd) -> None:
     env = os.environ.copy()
     env["DD_IAST_ENABLED"] = "true"
     _run_python_file(env=env)
@@ -35,8 +34,7 @@ def test_env_var_iast_enabled(capfd):
 
 
 @pytest.mark.skipif(PY2, reason="Not testing Python 2")
-def test_env_var_iast_disabled(monkeypatch, capfd):
-    # type: (...) -> None
+def test_env_var_iast_disabled(monkeypatch, capfd) -> None:
     env = os.environ.copy()
     env["DD_IAST_ENABLED"] = "false"
     _run_python_file(env=env)
@@ -46,8 +44,7 @@ def test_env_var_iast_disabled(monkeypatch, capfd):
 
 
 @pytest.mark.skipif(PY2, reason="Not testing Python 2")
-def test_env_var_iast_unset(monkeypatch, capfd):
-    # type: (...) -> None
+def test_env_var_iast_unset(monkeypatch, capfd) -> None:
     _run_python_file()
     captured = capfd.readouterr()
     assert "hi" in captured.out
@@ -56,8 +53,7 @@ def test_env_var_iast_unset(monkeypatch, capfd):
 
 @pytest.mark.skipif(not _is_python_version_supported(), reason="IAST compatible versions")
 @pytest.mark.xfail(reason="IAST now working with Gevent yet")
-def test_env_var_iast_enabled_gevent_unload_modules_true(capfd):
-    # type: (...) -> None
+def test_env_var_iast_enabled_gevent_unload_modules_true(capfd) -> None:
     env = os.environ.copy()
     env["DD_IAST_ENABLED"] = "true"
     env["DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE"] = "true"
@@ -69,8 +65,7 @@ def test_env_var_iast_enabled_gevent_unload_modules_true(capfd):
 
 @pytest.mark.skipif(not _is_python_version_supported(), reason="IAST compatible versions")
 @pytest.mark.xfail(reason="IAST now working with Gevent yet")
-def test_env_var_iast_enabled_gevent_unload_modules_false(capfd):
-    # type: (...) -> None
+def test_env_var_iast_enabled_gevent_unload_modules_false(capfd) -> None:
     env = os.environ.copy()
     env["DD_IAST_ENABLED"] = "true"
     env["DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE"] = "false"
@@ -82,8 +77,7 @@ def test_env_var_iast_enabled_gevent_unload_modules_false(capfd):
 
 @pytest.mark.skipif(not _is_python_version_supported(), reason="IAST compatible versions")
 @pytest.mark.xfail(reason="IAST now working with Gevent yet")
-def test_env_var_iast_enabled_gevent_patch_all_true(capfd):
-    # type: (...) -> None
+def test_env_var_iast_enabled_gevent_patch_all_true(capfd) -> None:
     env = os.environ.copy()
     env["DD_IAST_ENABLED"] = "true"
     _run_python_file(filename="main_gevent.py", env=env)
@@ -93,8 +87,7 @@ def test_env_var_iast_enabled_gevent_patch_all_true(capfd):
 
 
 @pytest.mark.skipif(not _is_python_version_supported(), reason="IAST compatible versions")
-def test_A_env_var_iast_modules_to_patch(capfd):
-    # type: (...) -> None
+def test_A_env_var_iast_modules_to_patch(capfd) -> None:
     import gc
     import sys
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -404,8 +404,7 @@ class TelemetryTestSession(object):
         parsed = parse.urlparse(self.telemetry_writer._client._agent_url)
         return httplib.HTTPConnection(parsed.hostname, parsed.port)
 
-    def _request(self, method, url):
-        # type: (str, str) -> Tuple[int, bytes]
+    def _request(self, method: str, url: str) -> Tuple[int, bytes]:
         conn = self.create_connection()
         try:
             conn.request(method, url)
@@ -448,8 +447,7 @@ class TelemetryTestSession(object):
 
 
 @pytest.fixture
-def test_agent_session(telemetry_writer, request):
-    # type: (TelemetryWriter, Any) -> Generator[TelemetryTestSession, None, None]
+def test_agent_session(telemetry_writer: TelemetryWriter, request: Any) -> Generator[TelemetryTestSession, None, None]:
     token = request_token(request)
     telemetry_writer._restart_sequence()
     telemetry_writer._client._headers["X-Datadog-Test-Session-Token"] = token

--- a/tests/contrib/asyncpg/test_asyncpg.py
+++ b/tests/contrib/asyncpg/test_asyncpg.py
@@ -13,16 +13,14 @@ from tests.contrib.config import POSTGRES_CONFIG
 
 
 @pytest.fixture(autouse=True)
-def patch_asyncpg():
-    # type: () -> Generator[None, None, None]
+def patch_asyncpg() -> Generator[None, None, None]:
     patch()
     yield
     unpatch()
 
 
 @pytest.fixture
-async def patched_conn():
-    # type: () -> Generator[asyncpg.Connection, None, None]
+async def patched_conn() -> Generator[asyncpg.Connection, None, None]:
     conn = await asyncpg.connect(
         host=POSTGRES_CONFIG["host"],
         port=POSTGRES_CONFIG["port"],

--- a/tests/contrib/dbapi/test_dbapi.py
+++ b/tests/contrib/dbapi/test_dbapi.py
@@ -182,7 +182,7 @@ class TestTracedCursor(TracerTestCase):
             pass
 
         traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         # Only measure if the name passed matches the default name (e.g. `sql.query` and not `sql.query.fetchall`)
         assert_is_not_measured(span)
         assert span.get_tag("pin1") == "value_pin1", "Pin tags are preserved"
@@ -208,7 +208,7 @@ class TestTracedCursor(TracerTestCase):
             pass
 
         traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         assert span.service == "cfg-service"
 
     def test_default_service(self):
@@ -223,7 +223,7 @@ class TestTracedCursor(TracerTestCase):
             pass
 
         traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         assert span.service == "db"
 
     def test_default_service_cfg(self):
@@ -238,7 +238,7 @@ class TestTracedCursor(TracerTestCase):
             pass
 
         traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         assert span.service == "default-svc"
 
     def test_service_cfg_and_pin(self):
@@ -253,7 +253,7 @@ class TestTracedCursor(TracerTestCase):
             pass
 
         traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         assert span.service == "pin-svc"
 
     def test_django_traced_cursor_backward_compatibility(self):
@@ -271,7 +271,7 @@ class TestTracedCursor(TracerTestCase):
             pass
 
         traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         # Row count
         assert span.get_metric("db.row_count") == 123, "Row count is set as a metric"
 
@@ -417,7 +417,7 @@ class TestFetchTracedCursor(TracerTestCase):
             pass
 
         traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         assert span.get_tag("pin1") == "value_pin1", "Pin tags are preserved"
         assert span.get_tag("extra1") == "value_extra1", "Extra tags are merged into pin tags"
         assert span.name == "my_name", "Span name is respected"
@@ -443,7 +443,7 @@ class TestFetchTracedCursor(TracerTestCase):
             pass
 
         traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         # Row count
         assert span.get_metric("db.row_count") == 123, "Row count is set as a metric"
 
@@ -494,7 +494,7 @@ class TestFetchTracedCursor(TracerTestCase):
             pass
 
         traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         assert span.get_metric("db.row_count") is None
 
     def test_callproc_can_handle_arbitrary_args(self):

--- a/tests/contrib/dbapi_async/test_dbapi_async.py
+++ b/tests/contrib/dbapi_async/test_dbapi_async.py
@@ -193,7 +193,7 @@ class TestTracedAsyncCursor(AsyncioTestCase):
             pass
 
         await traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         # Only measure if the name passed matches the default name (e.g. `sql.query` and not `sql.query.fetchall`)
         assert_is_not_measured(span)
         assert span.get_tag("pin1") == "value_pin1", "Pin tags are preserved"
@@ -220,7 +220,7 @@ class TestTracedAsyncCursor(AsyncioTestCase):
             pass
 
         await traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         assert span.service == "cfg-service"
 
     @mark_asyncio
@@ -236,7 +236,7 @@ class TestTracedAsyncCursor(AsyncioTestCase):
             pass
 
         await traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         assert span.service == "db"
 
     @mark_asyncio
@@ -252,7 +252,7 @@ class TestTracedAsyncCursor(AsyncioTestCase):
             pass
 
         await traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         assert span.service == "default-svc"
 
     @mark_asyncio
@@ -268,7 +268,7 @@ class TestTracedAsyncCursor(AsyncioTestCase):
             pass
 
         await traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         assert span.service == "pin-svc"
 
     @mark_asyncio
@@ -287,7 +287,7 @@ class TestTracedAsyncCursor(AsyncioTestCase):
             pass
 
         await traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         # Row count
         assert span.get_metric("db.row_count") == 123, "Row count is set as a metric"
 
@@ -442,7 +442,7 @@ class TestFetchTracedAsyncCursor(AsyncioTestCase):
             pass
 
         await traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         assert span.get_tag("pin1") == "value_pin1", "Pin tags are preserved"
         assert span.get_tag("extra1") == "value_extra1", "Extra tags are merged into pin tags"
         assert span.name == "my_name", "Span name is respected"
@@ -469,7 +469,7 @@ class TestFetchTracedAsyncCursor(AsyncioTestCase):
             pass
 
         await traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         # Row count
         assert span.get_metric("db.row_count") == 123, "Row count is set as a metric"
 
@@ -522,7 +522,7 @@ class TestFetchTracedAsyncCursor(AsyncioTestCase):
             pass
 
         await traced_cursor._trace_method(method, "my_name", "my_resource", {"extra1": "value_extra1"}, False)
-        span = tracer.pop()[0]  # type: Span
+        span: Span = tracer.pop()[0]
         assert span.get_metric("db.row_count") is None
 
     @mark_asyncio

--- a/tests/contrib/django/django_app/appsec_urls.py
+++ b/tests/contrib/django/django_app/appsec_urls.py
@@ -121,17 +121,17 @@ def taint_checking_enabled_view(request):
         from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
         from ddtrace.appsec._iast._taint_tracking import taint_ranges_as_evidence_info
 
-        def assert_origin_path(path):  # type: (Any) -> None
+        def assert_origin_path(path: Any) -> None:
             assert is_pyobject_tainted(path)
             result = taint_ranges_as_evidence_info(path)
             assert result[1][0].origin == OriginType.PATH
 
     else:
 
-        def assert_origin_path(pyobject):  # type: (Any) -> bool
+        def assert_origin_path(pyobject: Any) -> bool:
             return True
 
-        def is_pyobject_tainted(pyobject):  # type: (Any) -> bool
+        def is_pyobject_tainted(pyobject: Any) -> bool:
             return True
 
     # TODO: Taint request body
@@ -152,7 +152,7 @@ def taint_checking_disabled_view(request):
         from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
     else:
 
-        def is_pyobject_tainted(pyobject):  # type: (Any) -> bool
+        def is_pyobject_tainted(pyobject: Any) -> bool:
             return False
 
     assert not is_pyobject_tainted(request.body)

--- a/tests/contrib/flask/test_appsec_flask_snapshot.py
+++ b/tests/contrib/flask/test_appsec_flask_snapshot.py
@@ -29,26 +29,22 @@ DEFAULT_HEADERS = {
 
 
 @pytest.fixture
-def flask_port():
-    # type: () -> str
+def flask_port() -> str:
     return "8000"
 
 
 @pytest.fixture
-def flask_wsgi_application():
-    # type: () -> str
+def flask_wsgi_application() -> str:
     return "tests.contrib.flask.app:app"
 
 
 @pytest.fixture
-def flask_command(flask_wsgi_application, flask_port):
-    # type: (str, str) -> List[str]
+def flask_command(flask_wsgi_application: str, flask_port: str) -> List[str]:
     cmd = "ddtrace-run flask run -h 0.0.0.0 -p %s" % (flask_port,)
     return cmd.split()
 
 
-def flask_appsec_good_rules_env(flask_wsgi_application):
-    # type: (str) -> Dict[str, str]
+def flask_appsec_good_rules_env(flask_wsgi_application: str) -> Dict[str, str]:
     env = os.environ.copy()
     env.update(
         {
@@ -63,8 +59,7 @@ def flask_appsec_good_rules_env(flask_wsgi_application):
 
 
 @pytest.fixture
-def flask_client(flask_command, flask_port, flask_wsgi_application, flask_env_arg):
-    # type: (List[str], Dict[str, str], str, Callable) -> Generator[Client, None, None]
+def flask_client(flask_command: List[str], flask_port: Dict[str, str], flask_wsgi_application: str, flask_env_arg: Callable) -> Generator[Client, None, None]:
     # Copy the env to get the correct PYTHONPATH and such
     # from the virtualenv.
     # webservers might exec or fork into another process, so we need to os.setsid() to create a process group

--- a/tests/contrib/flask/test_flask_snapshot.py
+++ b/tests/contrib/flask/test_flask_snapshot.py
@@ -21,26 +21,22 @@ DEFAULT_HEADERS = {
 
 
 @pytest.fixture
-def flask_port():
-    # type: () -> str
+def flask_port() -> str:
     return "8000"
 
 
 @pytest.fixture
-def flask_wsgi_application():
-    # type: () -> str
+def flask_wsgi_application() -> str:
     return "tests.contrib.flask.app:app"
 
 
 @pytest.fixture
-def flask_command(flask_wsgi_application, flask_port):
-    # type: (str, str) -> List[str]
+def flask_command(flask_wsgi_application: str, flask_port: str) -> List[str]:
     cmd = "ddtrace-run flask run -h 0.0.0.0 -p %s" % (flask_port,)
     return cmd.split()
 
 
-def flask_default_env(flask_wsgi_application):
-    # type: (str) -> Dict[str, str]
+def flask_default_env(flask_wsgi_application: str) -> Dict[str, str]:
     env = os.environ.copy()
     env.update(
         {
@@ -53,8 +49,7 @@ def flask_default_env(flask_wsgi_application):
 
 
 @pytest.fixture
-def flask_client(flask_command, flask_port, flask_wsgi_application, flask_env_arg):
-    # type: (List[str], Dict[str, str], str, Callable) -> Generator[Client, None, None]
+def flask_client(flask_command: List[str], flask_port: Dict[str, str], flask_wsgi_application: str, flask_env_arg: Callable) -> Generator[Client, None, None]:
     # Copy the env to get the correct PYTHONPATH and such
     # from the virtualenv.
     # webservers might exec or fork into another process, so we need to os.setsid() to create a process group
@@ -99,8 +94,7 @@ def flask_client(flask_command, flask_port, flask_wsgi_application, flask_env_ar
     ignores=["meta.flask.version"], variants={"220": flask_version >= (2, 2, 0), "": flask_version < (2, 2, 0)}
 )
 @pytest.mark.parametrize("flask_env_arg", (flask_default_env,))
-def test_flask_200(flask_client):
-    # type: (Client) -> None
+def test_flask_200(flask_client: Client) -> None:
     assert flask_client.get("/", headers=DEFAULT_HEADERS).status_code == 200
 
 
@@ -109,8 +103,7 @@ def test_flask_200(flask_client):
     variants={"220": flask_version >= (2, 2, 0), "": flask_version < (2, 2, 0)},
 )
 @pytest.mark.parametrize("flask_env_arg", (flask_default_env,))
-def test_flask_stream(flask_client):
-    # type: (Client) -> None
+def test_flask_stream(flask_client: Client) -> None:
     resp = flask_client.get("/stream", headers=DEFAULT_HEADERS, stream=True)
     # read streamed reasponse, this will close the flask.response span
     assert list(resp.iter_lines()) == [b"0123456789"]
@@ -123,6 +116,5 @@ def test_flask_stream(flask_client):
     variants={"220": flask_version >= (2, 2, 0), "": flask_version < (2, 2, 0)},
 )
 @pytest.mark.parametrize("flask_env_arg", (flask_default_env,))
-def test_flask_get_user(flask_client):
-    # type: (Client) -> None
+def test_flask_get_user(flask_client: Client) -> None:
     assert flask_client.get("/identify").status_code == 200

--- a/tests/contrib/gunicorn/test_gunicorn.py
+++ b/tests/contrib/gunicorn/test_gunicorn.py
@@ -46,22 +46,21 @@ def parse_payload(data):
 
 
 def _gunicorn_settings_factory(
-    env=None,  # type: Dict[str, str]
-    directory=None,  # type: str
-    app_path="tests.contrib.gunicorn.wsgi_mw_app:app",  # type: str
-    num_workers="4",  # type: str
-    worker_class="sync",  # type: str
-    bind="0.0.0.0:8080",  # type: str
-    use_ddtracerun=True,  # type: bool
-    import_auto_in_postworkerinit=False,  # type: bool
-    import_auto_in_app=None,  # type: Optional[bool]
-    enable_module_cloning=False,  # type: bool
-    debug_mode=False,  # type: bool
-    dd_service=None,  # type: Optional[str]
-    schema_version=None,  # type: Optional[str]
-    rlock=True,  # type: bool
-):
-    # type: (...) -> GunicornServerSettings
+    env: Dict[str, str] = None,
+    directory: str = None,
+    app_path: str = "tests.contrib.gunicorn.wsgi_mw_app:app",
+    num_workers: str = "4",
+    worker_class: str = "sync",
+    bind: str = "0.0.0.0:8080",
+    use_ddtracerun: bool = True,
+    import_auto_in_postworkerinit: bool = False,
+    import_auto_in_app: Optional[bool] = None,
+    enable_module_cloning: bool = False,
+    debug_mode: bool = False,
+    dd_service: Optional[str] = None,
+    schema_version: Optional[str] = None,
+    rlock: bool = True,
+) -> GunicornServerSettings:
     """Factory for creating gunicorn settings with simple defaults if settings are not defined."""
     if directory is None:
         directory = os.getcwd()

--- a/tests/contrib/httplib/test_httplib.py
+++ b/tests/contrib/httplib/test_httplib.py
@@ -408,7 +408,7 @@ class HTTPLibTestCase(HTTPLibBaseMixin, TracerTestCase):
         with self.override_config("httplib", {}):
             from ddtrace.settings import IntegrationConfig
 
-            integration_config = config.httplib  # type: IntegrationConfig
+            integration_config: IntegrationConfig = config.httplib
             integration_config.http.trace_headers(["my-header", "access-control-allow-origin"])
             conn = self.get_http_connection(SOCKET)
             with contextlib.closing(conn):

--- a/tests/contrib/httpx/test_httpx.py
+++ b/tests/contrib/httpx/test_httpx.py
@@ -24,8 +24,7 @@ DEFAULT_HEADERS = {
 pytestmark = pytest.mark.skipif(HTTPX_VERSION < (0, 11), reason="httpx<=0.10 Client is asynchronous")
 
 
-def get_url(path):
-    # type: (str) -> str
+def get_url(path: str) -> str:
     return "http://{}:{}{}".format(HOST, PORT, path)
 
 

--- a/tests/contrib/httpx/test_httpx_pre_0_11.py
+++ b/tests/contrib/httpx/test_httpx_pre_0_11.py
@@ -25,8 +25,7 @@ DEFAULT_HEADERS = {
 pytestmark = pytest.mark.skipif(HTTPX_VERSION >= (0, 11), reason="httpx<=0.10 Client is asynchronous")
 
 
-def get_url(path):
-    # type: (str) -> str
+def get_url(path: str) -> str:
     return "http://{}:{}{}".format(HOST, PORT, path)
 
 

--- a/tests/contrib/mariadb/test_mariadb.py
+++ b/tests/contrib/mariadb/test_mariadb.py
@@ -16,7 +16,7 @@ from tests.utils import override_config
 from tests.utils import snapshot
 
 
-MARIADB_VERSION = mariadb.__version_info__  # type: Tuple[int, int, int, str, int]
+MARIADB_VERSION: Tuple[int, int, int, str, int] = mariadb.__version_info__
 SNAPSHOT_VARIANTS = {
     "pre_1_1": MARIADB_VERSION < (1, 1, 0),
     "post_1_1": MARIADB_VERSION

--- a/tests/contrib/openai/test_openai.py
+++ b/tests/contrib/openai/test_openai.py
@@ -110,8 +110,7 @@ def azure_openai(openai):
 class FilterOrg(TraceFilter):
     """Replace the organization tag on spans with fake data."""
 
-    def process_trace(self, trace):
-        # type: (List[Span]) -> Optional[List[Span]]
+    def process_trace(self, trace: List[Span]) -> Optional[List[Span]]:
         for span in trace:
             if span.get_tag("organization"):
                 span.set_tag_str("organization", "not-a-real-org")

--- a/tests/contrib/rediscluster/test.py
+++ b/tests/contrib/rediscluster/test.py
@@ -25,8 +25,7 @@ def redis_client():
         unpatch()
 
 
-def _get_test_client():
-    # type: () -> rediscluster.StrictRedisCluster
+def _get_test_client() -> rediscluster.StrictRedisCluster:
     host = REDISCLUSTER_CONFIG["host"]
     ports = REDISCLUSTER_CONFIG["ports"]
 

--- a/tests/contrib/sqlite3/test_sqlite3.py
+++ b/tests/contrib/sqlite3/test_sqlite3.py
@@ -26,8 +26,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 @pytest.fixture
-def patched_conn():
-    # type: () -> Generator[sqlite3.Cursor, None, None]
+def patched_conn() -> Generator[sqlite3.Cursor, None, None]:
     patch()
     conn = sqlite3.connect(":memory:")
     yield conn

--- a/tests/debugging/mocking.py
+++ b/tests/debugging/mocking.py
@@ -194,8 +194,7 @@ def debugger(**config_overrides: Any) -> Generator[TestDebugger, None, None]:
 
 
 @contextmanager
-def exception_debugging(**config_overrides):
-    # type: (Any) -> Generator[TestDebugger, None, None]
+def exception_debugging(**config_overrides: Any) -> Generator[TestDebugger, None, None]:
     config_overrides.setdefault("enabled", True)
 
     with _debugger(ed_config, config_overrides) as ed:

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -316,20 +316,16 @@ def test_custom_writer():
     tracer = ddtrace.Tracer()
 
     class CustomWriter(TraceWriter):
-        def recreate(self):
-            # type: () -> TraceWriter
+        def recreate(self) -> TraceWriter:
             return self
 
-        def stop(self, timeout=None):
-            # type: (Optional[float]) -> None
+        def stop(self, timeout: Optional[float] = None) -> None:
             pass
 
-        def write(self, spans=None):
-            # type: (Optional[List[Span]]) -> None
+        def write(self, spans: Optional[List[Span]] = None) -> None:
             pass
 
-        def flush_queue(self):
-            # type: () -> None
+        def flush_queue(self) -> None:
             pass
 
     tracer._writer = CustomWriter()

--- a/tests/integration/test_propagation.py
+++ b/tests/integration/test_propagation.py
@@ -37,8 +37,7 @@ def tracer(request):
 
 
 @pytest.mark.snapshot()
-def test_trace_tags_multispan(tracer):
-    # type: (Tracer) -> None
+def test_trace_tags_multispan(tracer: Tracer) -> None:
     headers = {
         "x-datadog-trace-id": "1234",
         "x-datadog-parent-id": "5678",

--- a/tests/integration/test_trace_stats.py
+++ b/tests/integration/test_trace_stats.py
@@ -19,15 +19,13 @@ pytestmark = pytest.mark.skipif(AGENT_VERSION != "testagent", reason="Tests only
 
 
 @pytest.fixture
-def sample_rate():
-    # type: () -> Generator[float, None, None]
+def sample_rate() -> Generator[float, None, None]:
     # Default the sample rate to 0 so no traces are sent for requests.
     yield 0.0
 
 
 @pytest.fixture
-def stats_tracer(sample_rate):
-    # type: (float) -> Generator[Tracer, None, None]
+def stats_tracer(sample_rate: float) -> Generator[Tracer, None, None]:
     with override_global_config(dict(_trace_compute_stats=True)):
         tracer = Tracer()
         tracer.configure(

--- a/tests/internal/test_forksafe.py
+++ b/tests/internal/test_forksafe.py
@@ -150,8 +150,7 @@ else:
     lock_release_exc_type = RuntimeError
 
 
-def test_lock_basic():
-    # type: (...) -> None
+def test_lock_basic() -> None:
     """Check that a forksafe.Lock implements the correct threading.Lock interface"""
     lock = forksafe.Lock()
     assert lock.acquire()
@@ -185,8 +184,7 @@ def test_lock_fork():
     assert exit_code == 12
 
 
-def test_rlock_basic():
-    # type: (...) -> None
+def test_rlock_basic() -> None:
     """Check that a forksafe.RLock implements the correct threading.RLock interface"""
     lock = forksafe.RLock()
     assert lock.acquire()
@@ -227,8 +225,7 @@ def test_rlock_fork():
     assert exit_code == 12
 
 
-def test_event_basic():
-    # type: (...) -> None
+def test_event_basic() -> None:
     """Check that a forksafe.Event implements the correct threading.Event interface"""
     event = forksafe.Event()
     assert event.is_set() is False

--- a/tests/internal/test_utils_time.py
+++ b/tests/internal/test_utils_time.py
@@ -19,8 +19,7 @@ from ddtrace.internal.utils.time import parse_isoformat
     ],
 )
 @pytest.mark.skipif(sys.version_info > (3, 0, 0), reason="Python 2 tests")
-def test_parse_isoformat_py2(date_str, expected):
-    # type: (str, datetime.datetime) -> None
+def test_parse_isoformat_py2(date_str: str, expected: datetime.datetime) -> None:
     result = parse_isoformat(date_str)
     assert result == expected
 
@@ -37,15 +36,13 @@ def test_parse_isoformat_py2(date_str, expected):
     ],
 )
 @pytest.mark.skipif(sys.version_info < (3, 5, 0) or sys.version_info >= (3, 7, 0), reason="Python 3.5 and 3.6 tests")
-def test_parse_isoformat_py36(date_str, expected):
-    # type: (str, datetime.datetime) -> None
+def test_parse_isoformat_py36(date_str: str, expected: datetime.datetime) -> None:
     result = parse_isoformat(date_str)
     assert result == expected
 
 
 @pytest.mark.skipif(sys.version_info < (3, 5, 0) or sys.version_info >= (3, 7, 0), reason="Python 3.5 and 3.6 tests")
-def test_parse_isoformat_py36_with_timezone():
-    # type: () -> None
+def test_parse_isoformat_py36_with_timezone() -> None:
     result = parse_isoformat("2022-09-01T01:00:00+02:00")
     assert result == datetime.datetime(2022, 8, 31, 23, 0)
 
@@ -62,14 +59,12 @@ def test_parse_isoformat_py36_with_timezone():
     ],
 )
 @pytest.mark.skipif(sys.version_info < (3, 7, 0), reason="Python 3 tests")
-def test_parse_isoformat_py3(date_str, expected):
-    # type: (str, datetime.datetime) -> None
+def test_parse_isoformat_py3(date_str: str, expected: datetime.datetime) -> None:
     result = parse_isoformat(date_str)
     assert result == expected
 
 
 @pytest.mark.skipif(sys.version_info < (3, 7, 0), reason="Python 3 tests")
-def test_parse_isoformat_py3_with_timezone():
-    # type: () -> None
+def test_parse_isoformat_py3_with_timezone() -> None:
     result = parse_isoformat("2022-09-01T01:00:00+02:00")
     assert result == datetime.datetime(2022, 9, 1, 1, 0, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200)))

--- a/tests/internal/test_utils_version.py
+++ b/tests/internal/test_utils_version.py
@@ -33,8 +33,7 @@ def _assert_and_get_version_agent_format(version_agent_format):
         ("", (0, 0, 0)),
     ],
 )
-def test_parse_version(version_str, expected):
-    # type: (str, typing.Tuple[int, int, int]) -> None
+def test_parse_version(version_str: str, expected: typing.Tuple[int, int, int]) -> None:
     """Ensure parse_version helper properly parses versions"""
     assert parse_version(version_str) == expected
 
@@ -58,8 +57,7 @@ def test_default_version_agent_format():
         ("2.0.0.dev", "2.0.0-dev"),
     ],
 )
-def test_version_agent_format(version_str, expected):
-    # type: (str, typing.Tuple[int, int, int]) -> None
+def test_version_agent_format(version_str: str, expected: typing.Tuple[int, int, int]) -> None:
     version_agent_format = _pep440_to_semver(version_str)
     assert version_agent_format == expected
     _assert_and_get_version_agent_format(version_agent_format)

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -186,9 +186,8 @@ def test_memory_collector():
     (True, False),
 )
 def test_memory_collector_ignore_profiler(
-    ignore_profiler,  # type: bool
-):
-    # type: (...) -> None
+    ignore_profiler: bool,
+) -> None:
     r = recorder.Recorder()
     mc = memalloc.MemoryCollector(r, ignore_profiler=ignore_profiler)
     quit_thread = threading.Event()

--- a/tests/profiling/collector/test_task.py
+++ b/tests/profiling/collector/test_task.py
@@ -9,8 +9,7 @@ from ddtrace.profiling.collector import _task
 TESTING_GEVENT = os.getenv("DD_PROFILE_TEST_GEVENT", False)
 
 
-def test_get_task_main():
-    # type: (...) -> None
+def test_get_task_main() -> None:
     if _task._gevent_tracer is None:
         assert _task.get_task(compat.main_thread.ident) == (None, None, None)
 

--- a/tests/profiling/test_gunicorn.py
+++ b/tests/profiling/test_gunicorn.py
@@ -35,13 +35,11 @@ def gunicorn(monkeypatch):
     yield _run_gunicorn
 
 
-def _get_worker_pids(stdout):
-    # type: (str) -> list[int]
+def _get_worker_pids(stdout: str) -> list[int]:
     return [int(_) for _ in re.findall(r"Booting worker with pid: (\d+)", stdout)]
 
 
-def _test_gunicorn(gunicorn, tmp_path, monkeypatch, *args):
-    # type: (...) -> None
+def _test_gunicorn(gunicorn, tmp_path, monkeypatch, *args) -> None:
     filename = str(tmp_path / "gunicorn.pprof")
     monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)
 
@@ -60,7 +58,6 @@ def _test_gunicorn(gunicorn, tmp_path, monkeypatch, *args):
         utils.check_pprof_file("%s.%d.1" % (filename, pid))
 
 
-def test_gunicorn(gunicorn, tmp_path, monkeypatch):
-    # type: (...) -> None
+def test_gunicorn(gunicorn, tmp_path, monkeypatch) -> None:
     args = ("-k", "gevent") if TESTING_GEVENT else tuple()
     _test_gunicorn(gunicorn, tmp_path, monkeypatch, *args)

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -405,8 +405,7 @@ def test_default_collectors():
     p.stop(flush=False)
 
 
-def test_profiler_serverless(monkeypatch):
-    # type: (...) -> None
+def test_profiler_serverless(monkeypatch) -> None:
     monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "foobar")
     p = profiler.Profiler()
     assert isinstance(p._scheduler, scheduler.ServerlessScheduler)

--- a/tests/profiling/utils.py
+++ b/tests/profiling/utils.py
@@ -4,9 +4,8 @@ from ddtrace.profiling.exporter import pprof
 
 
 def check_pprof_file(
-    filename,  # type: str
-):
-    # type: (...) -> None
+    filename: str,
+) -> None:
     with gzip.open(filename, "rb") as f:
         content = f.read()
     p = pprof.pprof_pb2.Profile()

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -396,8 +396,7 @@ def test_telemetry_graceful_shutdown(telemetry_writer, test_agent_session, mock_
 
 
 @flaky(1704067200)
-def test_app_heartbeat_event_periodic(mock_time, telemetry_writer, test_agent_session):
-    # type: (mock.Mock, Any, TelemetryWriter) -> None
+def test_app_heartbeat_event_periodic(mock_time: mock.Mock, telemetry_writer: Any, test_agent_session: TelemetryWriter) -> None:
     """asserts that we queue/send app-heartbeat when periodc() is called"""
 
     # Ensure telemetry writer is initialized to send periodic events
@@ -420,8 +419,7 @@ def test_app_heartbeat_event_periodic(mock_time, telemetry_writer, test_agent_se
 
 
 @flaky(1704067200)
-def test_app_heartbeat_event(mock_time, telemetry_writer, test_agent_session):
-    # type: (mock.Mock, Any, TelemetryWriter) -> None
+def test_app_heartbeat_event(mock_time: mock.Mock, telemetry_writer: Any, test_agent_session: TelemetryWriter) -> None:
     """asserts that we queue/send app-heartbeat event every 60 seconds when app_heartbeat_event() is called"""
 
     # Assert clean slate
@@ -435,8 +433,7 @@ def test_app_heartbeat_event(mock_time, telemetry_writer, test_agent_session):
     assert len(events) == 1
 
 
-def _get_request_body(payload, payload_type, seq_id=1):
-    # type: (Dict, str, int) -> Dict
+def _get_request_body(payload: Dict, payload_type: str, seq_id: int = 1) -> Dict:
     """used to test the body of requests received by the testagent"""
     return {
         "tracer_time": time.time(),

--- a/tests/tracer/test_context.py
+++ b/tests/tracer/test_context.py
@@ -90,8 +90,7 @@ def test_traceparent_basic():
         Context(trace_id=123, span_id=321, meta={"meta": "value"}, metrics={"metric": 4.556}),
     ],
 )
-def test_context_serializable(context):
-    # type: (Context) -> None
+def test_context_serializable(context: Context) -> None:
     state = pickle.dumps(context)
     restored = pickle.loads(state)
     assert context == restored
@@ -190,8 +189,7 @@ def test_context_serializable(context):
         "no_span_id_or_tp",
     ],
 )
-def test_traceparent(context, expected_traceparent):
-    # type: (Context,str) -> None
+def test_traceparent(context: Context, expected_traceparent: str) -> None:
     assert context._traceparent == expected_traceparent
 
 
@@ -324,8 +322,7 @@ def test_traceparent(context, expected_traceparent):
         "test_origin_specific_replacement",
     ],
 )
-def test_tracestate(context, expected_tracestate):
-    # type: (Context,str) -> None
+def test_tracestate(context: Context, expected_tracestate: str) -> None:
     assert context._tracestate == expected_tracestate
 
 
@@ -341,6 +338,5 @@ def test_tracestate(context, expected_tracestate):
         (Context(dd_origin="§¢À"), None),
     ],
 )
-def test_dd_origin_character_set(ctx, expected_dd_origin):
-    # type: (Context,Optional[str]) -> None
+def test_dd_origin_character_set(ctx: Context, expected_dd_origin: Optional[str]) -> None:
     assert ctx.dd_origin == expected_dd_origin

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -40,8 +40,7 @@ from tests.utils import DummyTracer
 _ORIGIN_KEY = ORIGIN_KEY.encode()
 
 
-def span_to_tuple(span):
-    # type: (Span) -> tuple
+def span_to_tuple(span: Span) -> tuple:
     return (
         span.service,
         span.name,

--- a/tests/tracer/test_memory_leak.py
+++ b/tests/tracer/test_memory_leak.py
@@ -17,8 +17,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 @pytest.fixture
-def tracer():
-    # type: (...) -> Tracer
+def tracer() -> Tracer:
     return Tracer()
 
 

--- a/tests/tracer/test_processors.py
+++ b/tests/tracer/test_processors.py
@@ -52,10 +52,10 @@ def test_no_impl():
 def test_default_post_init():
     @attr.s
     class MyProcessor(SpanProcessor):
-        def on_span_start(self, span):  # type: (Span) -> None
+        def on_span_start(self, span: Span) -> None:
             pass
 
-        def on_span_finish(self, data):  # type: (Any) -> Any
+        def on_span_finish(self, data: Any) -> Any:
             pass
 
     with mock.patch("ddtrace.internal.processor.log") as log:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -259,10 +259,9 @@ class BaseTestCase(SubprocessTestCase):
 
 
 def _build_tree(
-    spans,  # type: List[Span]
-    root,  # type: Span
-):
-    # type: (...) -> TestSpanNode
+    spans: List[Span],
+    root: Span,
+) -> TestSpanNode:
     """helper to build a tree structure for the provided root span"""
     children = []
     for span in spans:
@@ -273,9 +272,8 @@ def _build_tree(
 
 
 def get_root_span(
-    spans,  # type: List[Span]
-):
-    # type: (...) -> TestSpanNode
+    spans: List[Span],
+) -> TestSpanNode:
     """
     Helper to get the root span from the list of spans in this container
 
@@ -337,8 +335,7 @@ class TestSpanContainer(object):
         """subclass required property"""
         raise NotImplementedError
 
-    def get_root_span(self):
-        # type: (...) -> TestSpanNode
+    def get_root_span(self) -> TestSpanNode:
         """
         Helper to get the root span from the list of spans in this container
 
@@ -348,8 +345,7 @@ class TestSpanContainer(object):
         """
         return get_root_span(self.spans)
 
-    def get_root_spans(self):
-        # type: (...) -> List[Span]
+    def get_root_spans(self) -> List[Span]:
         """
         Helper to get all root spans from the list of spans in this container
 
@@ -443,12 +439,10 @@ class TracerTestCase(TestSpanContainer, BaseTestCase):
         """Required subclass method for TestSpanContainer"""
         return self.tracer.get_spans()
 
-    def pop_spans(self):
-        # type: () -> List[Span]
+    def pop_spans(self) -> List[Span]:
         return self.tracer.pop()
 
-    def pop_traces(self):
-        # type: () -> List[List[Span]]
+    def pop_traces(self) -> List[List[Span]]:
         return self.tracer.pop_traces()
 
     def reset(self):
@@ -493,14 +487,12 @@ class DummyWriterMixin:
             self.spans += spans
             self.traces += traces
 
-    def pop(self):
-        # type: () -> List[Span]
+    def pop(self) -> List[Span]:
         s = self.spans
         self.spans = []
         return s
 
-    def pop_traces(self):
-        # type: () -> List[List[Span]]
+    def pop_traces(self) -> List[List[Span]]:
         traces = self.traces
         self.traces = []
         return traces
@@ -565,29 +557,24 @@ class DummyTracer(Tracer):
         self.configure(*args, **kwargs)
 
     @property
-    def agent_url(self):
-        # type: () -> str
+    def agent_url(self) -> str:
         return self._writer.agent_url
 
     @property
-    def encoder(self):
-        # type: () -> Encoder
+    def encoder(self) -> Encoder:
         return self._writer.msgpack_encoder
 
-    def get_spans(self):
-        # type: () -> List[List[Span]]
+    def get_spans(self) -> List[List[Span]]:
         spans = self._writer.spans
         if self._trace_flush_enabled:
             flush_test_tracer_spans(self._writer)
         return spans
 
-    def pop(self):
-        # type: () -> List[Span]
+    def pop(self) -> List[Span]:
         spans = self._writer.pop()
         return spans
 
-    def pop_traces(self):
-        # type: () -> List[List[Span]]
+    def pop_traces(self) -> List[List[Span]]:
         traces = self._writer.pop_traces()
         if self._trace_flush_enabled:
             flush_test_tracer_spans(self._writer)
@@ -1141,8 +1128,7 @@ def call_program(*args, **kwargs):
     return stdout, stderr, subp.wait(), subp.pid
 
 
-def request_token(request):
-    # type: (pytest.FixtureRequest) -> str
+def request_token(request: pytest.FixtureRequest) -> str:
     token = ""
     token += request.module.__name__
     token += ".%s" % request.cls.__name__ if request.cls else ""

--- a/tests/webclient.py
+++ b/tests/webclient.py
@@ -10,8 +10,7 @@ from ddtrace.propagation.http import HTTPPropagator
 class Client(object):
     """HTTP Client for making requests to a local http server."""
 
-    def __init__(self, base_url):
-        # type: (str) -> None
+    def __init__(self, base_url: str) -> None:
         self._base_url = base_url
         self._session = requests.Session()
         # Propagate traces with trace_id = 1 for the ping trace so we can filter them out.
@@ -19,8 +18,7 @@ class Client(object):
         HTTPPropagator.inject(c, d)
         self._ignore_headers = d
 
-    def _url(self, path):
-        # type: (str) -> str
+    def _url(self, path: str) -> str:
         return six.moves.urllib.parse.urljoin(self._base_url, path)
 
     def get(self, path, **kwargs):


### PR DESCRIPTION
`find ddtrace -type f -name "*.py" -exec com2ann {} \;`
`find tests -type f -name "*.py" -exec com2ann {} \;`

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
