### PR TITLE
fix(wsgi): handle django wsgi app being an iterator (#6858)

### DIFF
--- a/ddtrace/tracing/trace_handlers.py
+++ b/ddtrace/tracing/trace_handlers.py
@@ -28,8 +28,13 @@ log = get_logger(__name__)
 
 
 class _TracedIterable(wrapt.ObjectProxy):
-    def __init__(self, wrapped, span, parent_span):
-        super(_TracedIterable, self).__init__(wrapped)
+    def __init__(self, wrapped, span, parent_span, wrapped_is_iterator=False):
+        self._self_wrapped_is_iterator = wrapped_is_iterator
+        if self._self_wrapped_is_iterator:
+            super(_TracedIterable, self).__init__(wrapped)
+            self._wrapped_iterator = iter(wrapped)
+        else:
+            super(_TracedIterable, self).__init__(iter(wrapped))
         self._self_span = span
         self._self_parent_span = parent_span
         self._self_span_finished = False
@@ -39,7 +44,10 @@ class _TracedIterable(wrapt.ObjectProxy):
 
     def __next__(self):
         try:
-            return next(self.__wrapped__)
+            if self._self_wrapped_is_iterator:
+                return next(self._wrapped_iterator)
+            else:
+                return next(self.__wrapped__)
         except StopIteration:
             self._finish_spans()
             raise
@@ -158,7 +166,7 @@ def _on_request_prepare(ctx, start_response):
     ctx.set_item("intercept_start_response", intercept_start_response)
 
 
-def _on_app_success(ctx, closing_iterator):
+def _on_app_success(ctx, closing_iterable):
     app_span = ctx.get_item("app_span")
     middleware = ctx.get_item("middleware")
     modifier = (
@@ -166,7 +174,7 @@ def _on_app_success(ctx, closing_iterator):
         if hasattr(middleware, "_application_call_modifier")
         else middleware._application_span_modifier
     )
-    modifier(app_span, ctx.get_item("environ"), closing_iterator)
+    modifier(app_span, ctx.get_item("environ"), closing_iterable)
     app_span.finish()
 
 
@@ -179,7 +187,7 @@ def _on_app_exception(ctx):
     req_span.finish()
 
 
-def _on_request_complete(ctx, closing_iterator):
+def _on_request_complete(ctx, closing_iterable, app_is_iterator):
     middleware = ctx.get_item("middleware")
     req_span = ctx.get_item("req_span")
     # start flask.response span. This span will be finished after iter(result) is closed.
@@ -199,9 +207,9 @@ def _on_request_complete(ctx, closing_iterator):
         if hasattr(middleware, "_response_call_modifier")
         else middleware._response_span_modifier
     )
-    modifier(resp_span, closing_iterator)
+    modifier(resp_span, closing_iterable)
 
-    return _TracedIterable(iter(closing_iterator), resp_span, req_span)
+    return _TracedIterable(closing_iterable, resp_span, req_span, wrapped_is_iterator=app_is_iterator)
 
 
 def _on_response_context_started(ctx):

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -78,6 +78,7 @@ doctest
 dogpile
 dogpile.cache
 dogstatsd
+dunder
 dsn
 dunder
 elasticsearch

--- a/releasenotes/notes/wsgi-iter-cca70a8d4429e925.yaml
+++ b/releasenotes/notes/wsgi-iter-cca70a8d4429e925.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    wsgi: This change introduces the keyword argument app_is_iterator to the DDWSGIMiddleware constructor.
+    It's provided as a workaround for an issue where the Datadog WSGI middleware would fail to handle WSGI
+    apps that are not their own iterators. This condition can arise when a Django app attempts to send its
+    "request finished" signal, in which case it may cause connection leaks. Standard methods of distinguishing
+    an iterable from its iterator, such as checking for the presence of iter and next dunder methods, don't
+    work in this case for unknown reasons. Instead of adding brittle special-case detection logic to the
+    middleware, this new argument allows users to indicate when this is the case.

--- a/tests/.suitespec.json
+++ b/tests/.suitespec.json
@@ -611,6 +611,7 @@
             "@contrib",
             "@appsec",
             "@asgi",
+            "@wsgi",
             "@django",
             "@dbapi",
             "@pg",
@@ -1057,6 +1058,7 @@
             "@tracing",
             "@wsgi",
             "tests/contrib/wsgi/*",
+            "tests/contrib/django/test_django_wsgi.py",
             "tests/contrib/uwsgi/__init__.py",
             "tests/snapshots/tests.contrib.wsgi.*"
         ],

--- a/tests/contrib/django/test_django_wsgi.py
+++ b/tests/contrib/django/test_django_wsgi.py
@@ -1,0 +1,77 @@
+import logging
+import os
+import subprocess
+
+import django
+from django.core.signals import request_finished
+from django.core.wsgi import get_wsgi_application
+from django.dispatch import receiver
+from django.http import HttpResponse
+import pytest
+
+from ddtrace.contrib.wsgi import DDWSGIMiddleware
+from ddtrace.internal.compat import PY2
+from ddtrace.internal.compat import PY3
+from tests.webclient import Client
+
+
+filepath, extension = os.path.splitext(__file__)
+ROOT_URLCONF = os.path.basename(filepath)
+WSGI_APPLICATION = os.path.basename(filepath) + ".app"
+DEBUG = True
+SERVER_PORT = 8000
+SENTINEL_LOG = "request finished signal received"
+
+log = logging.getLogger(__name__)
+
+
+@receiver(request_finished)
+def log_request_finished(*_, **__):
+    log.warning(SENTINEL_LOG)
+
+
+def handler(_):
+    return HttpResponse("Hello!")
+
+
+if PY3:
+    from django.urls import path
+
+    urlpatterns = [path("", handler)]
+    # it would be better to check for app_is_iterator programmatically, but Django WSGI apps behave like
+    # iterators for the purpose of DDWSGIMiddleware despite not having both "__next__" and "__iter__" methods
+    app = DDWSGIMiddleware(get_wsgi_application(), app_is_iterator=True)
+
+
+@pytest.mark.skipif(
+    django.VERSION < (3, 0, 0) or PY2, reason="Older Django versions don't work with this use of django-admin"
+)
+def test_django_app_receives_request_finished_signal_when_app_is_ddwsgimiddleware():
+    env = os.environ.copy()
+    env.update(
+        {
+            "PYTHONPATH": os.path.dirname(os.path.abspath(__file__)) + ":" + env["PYTHONPATH"],
+            "DJANGO_SETTINGS_MODULE": "test_django_wsgi",
+        }
+    )
+    cmd = ["django-admin", "runserver", "--noreload", str(SERVER_PORT)]
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        close_fds=True,
+        env=env,
+    )
+
+    client = Client("http://localhost:%d" % SERVER_PORT)
+    client.wait()
+    output = ""
+    try:
+        assert client.get("/").status_code == 200
+    finally:
+        try:
+            _, output = proc.communicate(timeout=1)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            _, output = proc.communicate()
+    assert SENTINEL_LOG in str(output)


### PR DESCRIPTION
This change fixes https://github.com/DataDog/dd-trace-py/issues/5325 by having the WSGI middleware handle cases when the wrapped iterable object is an iterator. This condition can arise when a Django app attempts to send its "request finished" signal, in which case it may cause connection leaks. Standard methods of distinguishing an iterable from its iterator, such as checking for the presence of __iter__ and __next__ methods, don't work in this case for unknown reasons. Instead of adding brittle special-case detection logic to the middleware, this new argument allows users to indicate when this is the case.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

---------

Co-authored-by: Peter Salas <peter@fixie.ai>
(cherry picked from commit 229378aa883e8bdc7d4939f8d466413e5f485f42)

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
