### PR TITLE
chore(iast): slice propagation ranges error and store hash and id separately [Backport 2.1]

### DIFF
--- a/ddtrace/appsec/_iast/_ast/ast_patching.py
+++ b/ddtrace/appsec/_iast/_ast/ast_patching.py
@@ -126,7 +126,7 @@ def _remove_flask_run(text):  # type (str) -> str
 def astpatch_module(module, remove_flask_run=False):
     # type: (ModuleType, bool) -> Tuple[str, str]
     module_name = module.__name__
-    module_path = origin(module)
+    module_path = str(origin(module))
     try:
         if os.stat(module_path).st_size == 0:
             # Don't patch empty files like __init__.py

--- a/ddtrace/appsec/_iast/_stacktrace.c
+++ b/ddtrace/appsec/_iast/_stacktrace.c
@@ -17,11 +17,27 @@
 #define GET_LINENO(frame) PyFrame_GetLineNumber((PyFrameObject*)frame)
 #define GET_FRAME(tstate) PyThreadState_GetFrame(tstate)
 #define GET_PREVIOUS(frame) PyFrame_GetBack(frame)
-#define GET_FILENAME(frame) PyObject_GetAttrString(PyFrame_GetCode(frame), "co_filename")
+#define FRAME_DECREF(frame) Py_DECREF(frame)
+#define FRAME_XDECREF(frame) Py_XDECREF(frame)
+#define FILENAME_DECREF(filename) Py_DECREF(filename)
+#define FILENAME_XDECREF(filename) Py_XDECREF(filename)
+static inline PyObject*
+GET_FILENAME(PyFrameObject* frame)
+{
+    PyCodeObject* code = PyFrame_GetCode(frame);
+    if (!code) {
+        return NULL;
+    }
+    return PyObject_GetAttrString((PyObject*)code, "co_filename");
+}
 #else
 #define GET_FRAME(tstate) tstate->frame
 #define GET_PREVIOUS(frame) frame->f_back
 #define GET_FILENAME(frame) frame->f_code->co_filename
+#define FRAME_DECREF(frame)
+#define FRAME_XDECREF(frame)
+#define FILENAME_DECREF(filename)
+#define FILENAME_XDECREF(filename)
 #if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 10
 /* See: https://bugs.python.org/issue44964 */
 #define GET_LINENO(frame) PyCode_Addr2Line(frame->f_code, frame->f_lasti * 2)
@@ -39,54 +55,82 @@
  * @return Tuple, string and integer.
  **/
 static PyObject*
-get_file_and_line(PyObject* Py_UNUSED(module), PyObject* args)
+get_file_and_line(PyObject* Py_UNUSED(module), PyObject* cwd_obj)
 {
-    PyThreadState* tstate = PyThreadState_GET();
-    PyFrameObject* frame;
-    PyObject* filename_o;
+    PyThreadState* tstate = PyThreadState_Get();
+    if (!tstate) {
+        goto exit_0;
+    }
+
     int line;
+    PyObject* filename_o = NULL;
+    PyObject* result = NULL;
+    PyObject* cwd_bytes = NULL;
+    char* cwd = NULL;
 
-    PyObject *cwd_obj = Py_None, *cwd_bytes;
-    char* cwd;
-    if (!PyArg_ParseTuple(args, "O", &cwd_obj))
-        return NULL;
-    if (cwd_obj != Py_None) {
-        if (!PyUnicode_FSConverter(cwd_obj, &cwd_bytes))
-            return NULL;
-        cwd = PyBytes_AsString(cwd_bytes);
-    } else {
-        return NULL;
+    if (!PyUnicode_FSConverter(cwd_obj, &cwd_bytes)) {
+        goto exit_0;
+    }
+    cwd = PyBytes_AsString(cwd_bytes);
+    if (!cwd) {
+        Py_DECREF(cwd_bytes);
+        goto exit_0;
     }
 
-    if (NULL != tstate && NULL != GET_FRAME(tstate)) {
-        frame = GET_FRAME(tstate);
-        while (NULL != frame) {
-            filename_o = GET_FILENAME(frame);
-            const char* filename = PyUnicode_AsUTF8(filename_o);
-            if (((strstr(filename, DD_TRACE_INSTALLED_PREFIX) != NULL && strstr(filename, TESTS_PREFIX) == NULL)) ||
-                (strstr(filename, SITE_PACKAGES_PREFIX) != NULL || strstr(filename, cwd) == NULL)) {
+    PyFrameObject* frame = GET_FRAME(tstate);
+    if (!frame) {
+        Py_DECREF(cwd_bytes);
+        goto exit_0;
+    }
 
-                frame = GET_PREVIOUS(frame);
-                continue;
-            }
-            /*
-             frame->f_lineno will not always return the correct line number
-             you need to call PyCode_Addr2Line().
-            */
-            line = GET_LINENO(frame);
-            return PyTuple_Pack(2, filename_o, Py_BuildValue("i", line));
+    while (NULL != frame) {
+        filename_o = GET_FILENAME(frame);
+        if (!filename_o) {
+            goto exit;
         }
+        const char* filename = PyUnicode_AsUTF8(filename_o);
+        if (((strstr(filename, DD_TRACE_INSTALLED_PREFIX) != NULL && strstr(filename, TESTS_PREFIX) == NULL)) ||
+            (strstr(filename, SITE_PACKAGES_PREFIX) != NULL || strstr(filename, cwd) == NULL)) {
+            PyFrameObject* prev_frame = GET_PREVIOUS(frame);
+            FRAME_DECREF(frame);
+            FILENAME_DECREF(filename_o);
+            frame = prev_frame;
+            continue;
+        }
+        /*
+         frame->f_lineno will not always return the correct line number
+         you need to call PyCode_Addr2Line().
+        */
+        line = GET_LINENO(frame);
+        PyObject* line_obj = Py_BuildValue("i", line);
+        if (!line_obj) {
+            goto exit;
+        }
+        result = PyTuple_Pack(2, filename_o, line_obj);
+        break;
     }
-#if PY_MAJOR_VERSION > 3 || PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 10
-    return Py_NewRef(Py_None);
-#else
-    Py_INCREF(Py_None);
-    return Py_None;
-#endif
+    if (result == NULL) {
+        goto exit_0;
+    }
+
+exit:
+    Py_DECREF(cwd_bytes);
+    FRAME_XDECREF(frame);
+    FILENAME_XDECREF(filename_o);
+    return result;
+
+exit_0:; // fix: "a label can only be part of a statement and a declaration is not a statement" error
+    // Return "", 0
+    PyObject* line_obj = Py_BuildValue("i", 0);
+    filename_o = PyUnicode_FromString("");
+    result = PyTuple_Pack(2, filename_o, line_obj);
+    FILENAME_XDECREF(filename_o);
+    Py_DECREF(line_obj);
+    return result;
 }
 
 static PyMethodDef StacktraceMethods[] = {
-    { "get_info_frame", (PyCFunction)get_file_and_line, METH_VARARGS, "stacktrace functions" },
+    { "get_info_frame", (PyCFunction)get_file_and_line, METH_O, "stacktrace functions" },
     { NULL, NULL, 0, NULL }
 };
 
@@ -99,8 +143,7 @@ static struct PyModuleDef stacktrace = { PyModuleDef_HEAD_INIT,
 PyMODINIT_FUNC
 PyInit__stacktrace(void)
 {
-    PyObject* m;
-    m = PyModule_Create(&stacktrace);
+    PyObject* m = PyModule_Create(&stacktrace);
     if (m == NULL)
         return NULL;
     return m;

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
@@ -12,14 +12,16 @@ reduce_ranges_from_index_range_map(TaintRangeRefs index_range_map)
         auto taint_range{ index_range_map.at(index) };
         if (taint_range != current_range) {
             if (current_range) {
-                new_ranges.emplace_back(initializer->allocate_taint_range(current_start, index, current_range->source));
+                new_ranges.emplace_back(
+                  initializer->allocate_taint_range(current_start, index - current_start, current_range->source));
             }
             current_range = taint_range;
             current_start = index;
         }
     }
     if (current_range != nullptr) {
-        new_ranges.emplace_back(initializer->allocate_taint_range(current_start, index, current_range->source));
+        new_ranges.emplace_back(
+          initializer->allocate_taint_range(current_start, index - current_start, current_range->source));
     }
     return new_ranges;
 }
@@ -99,6 +101,7 @@ api_slice_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
         return nullptr;
     }
     PyObject* result = PyObject_GetItem(candidate_text, slice);
+
     auto res = slice_aspect(result, candidate_text, start, stop, step);
 
     if (start != nullptr) {

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.cpp
@@ -97,7 +97,7 @@ range_sort(const TaintRangePtr& t1, const TaintRangePtr& t2)
 // TODO OPTIMIZATION: Remove py::types once this isn't used in Python
 template<class StrType>
 StrType
-as_formatted_evidence(const StrType& text,
+as_formatted_evidence(StrType& text,
                       optional<TaintRangeRefs>& text_ranges,
                       const optional<TagMappingMode>& tag_mapping_mode,
                       const optional<const py::dict>& new_ranges)

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
@@ -24,7 +24,7 @@ common_replace(const py::str& string_method,
 
 template<class StrType>
 StrType
-as_formatted_evidence(const StrType& text,
+as_formatted_evidence(StrType& text,
                       optional<TaintRangeRefs>& text_ranges,
                       const optional<TagMappingMode>& tag_mapping_mode,
                       const optional<const py::dict>& new_ranges);

--- a/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
@@ -44,7 +44,7 @@ Initializer::free_tainting_map(TaintRangeMapType* tx_map)
     }
 
     for (auto& kv_taint_map : *tx_map) {
-        kv_taint_map.second->decref();
+        kv_taint_map.second.second->decref();
     }
 
     tx_map->clear();
@@ -78,6 +78,25 @@ Initializer::num_objects_tainted()
         return ctx_map->size();
     }
     return 0;
+}
+
+string
+Initializer::debug_taint_map()
+{
+    auto ctx_map = initializer->get_tainting_map();
+    if (!ctx_map) {
+        return ("[]");
+    }
+
+    std::stringstream output;
+    output << "[";
+    for (const auto& item : *ctx_map) {
+        output << "{ 'Id-Key': " << item.first << ",";
+        output << "'Value': { 'Hash': " << item.second.first << ", 'TaintedObject': '" << item.second.second->toString()
+               << "'}},";
+    }
+    output << "]";
+    return output.str();
 }
 
 int
@@ -231,6 +250,7 @@ void
 pyexport_initializer(py::module& m)
 {
     m.def("clear_tainting_maps", [] { initializer->clear_tainting_maps(); });
+    m.def("debug_taint_map", [] { return initializer->debug_taint_map(); });
 
     m.def("num_objects_tainted", [] { return initializer->num_objects_tainted(); });
     m.def("initializer_size", [] { return initializer->initializer_size(); });

--- a/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.h
@@ -63,6 +63,8 @@ class Initializer
      */
     static int num_objects_tainted();
 
+    string debug_taint_map();
+
     /**
      * Gets the size of the Initializer object.
      *

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
@@ -23,23 +23,19 @@ using TaintedObjectPtr = TaintedObject*;
 #ifdef NDEBUG // Decide wether to use abseil
 
 #include "absl/container/node_hash_map.h"
-using TaintRangeMapType = absl::node_hash_map<uintptr_t, TaintedObjectPtr>;
+using TaintRangeMapType = absl::node_hash_map<uintptr_t, std::pair<Py_hash_t, TaintedObjectPtr>>;
 
 #else
 
 #include <unordered_map>
-using TaintRangeMapType = std::map<uintptr_t, TaintedObjectPtr>;
+using TaintRangeMapType = std::map<uintptr_t, std::pair<Py_hash_t, TaintedObjectPtr>>;
 
 #endif // NDEBUG
 
 inline static uintptr_t
-get_unique_id(PyObject* str)
+get_unique_id(const PyObject* str)
 {
-    if ((((PyASCIIObject*)str)->hash) == -1) {
-        Py_hash_t result = PyObject_Hash(str);
-    }
-    auto res = uintptr_t(str) + ((PyASCIIObject*)str)->hash;
-    return hash<uintptr_t>{}(res);
+    return uintptr_t(str);
 }
 
 struct TaintRange
@@ -82,37 +78,37 @@ TaintRangeRefs
 api_shift_taint_ranges(const TaintRangeRefs&, RANGE_START offset);
 
 TaintRangeRefs
-get_ranges(const PyObject* string_input, TaintRangeMapType* tx_map);
+get_ranges(PyObject* string_input, TaintRangeMapType* tx_map);
 inline TaintRangeRefs
-get_ranges(const PyObject* string_input)
+get_ranges(PyObject* string_input)
 {
     return get_ranges(string_input, nullptr);
 }
 inline TaintRangeRefs
-api_get_ranges(const py::object& string_input)
+api_get_ranges(py::object& string_input)
 {
     return get_ranges(string_input.ptr());
 }
 
 void
-set_ranges(const PyObject* str, const TaintRangeRefs& ranges, TaintRangeMapType* tx_map);
+set_ranges(PyObject* str, const TaintRangeRefs& ranges, TaintRangeMapType* tx_map);
 
 inline void
-set_ranges(const PyObject* str, const TaintRangeRefs& ranges)
+set_ranges(PyObject* str, const TaintRangeRefs& ranges)
 {
     set_ranges(str, ranges, nullptr);
 }
 inline void
-api_set_ranges(const py::object& str, const TaintRangeRefs& ranges)
+api_set_ranges(py::object& str, const TaintRangeRefs& ranges)
 {
     set_ranges(str.ptr(), ranges);
 }
 
 // Returns a tuple with (all ranges, ranges of candidate_text)
 std::tuple<TaintRangeRefs, TaintRangeRefs>
-are_all_text_all_ranges(const PyObject* candidate_text, const py::tuple& parameter_list);
+are_all_text_all_ranges(PyObject* candidate_text, const py::tuple& parameter_list);
 inline std::tuple<TaintRangeRefs, TaintRangeRefs>
-api_are_all_text_all_ranges(const py::object& candidate_text, const py::tuple& parameter_list)
+api_are_all_text_all_ranges(py::object& candidate_text, const py::tuple& parameter_list)
 {
     return are_all_text_all_ranges(candidate_text.ptr(), parameter_list);
 }
@@ -121,7 +117,7 @@ TaintRangePtr
 get_range_by_hash(size_t range_hash, optional<TaintRangeRefs>& taint_ranges);
 
 void
-set_fast_tainted_if_notinterned_unicode(const PyObject* objptr);
+set_fast_tainted_if_notinterned_unicode(PyObject* objptr);
 inline void
 api_set_fast_tainted_if_unicode(const py::object& obj)
 {
@@ -137,7 +133,13 @@ api_is_unicode_and_not_fast_tainted(const py::object str)
 }
 
 TaintedObject*
-get_tainted_object(const PyObject* str, TaintRangeMapType* tx_taint_map);
+get_tainted_object(PyObject* str, TaintRangeMapType* tx_taint_map);
+
+Py_hash_t
+bytearray_hash(PyObject* bytearray);
+
+Py_hash_t
+get_internal_hash(PyObject* obj);
 
 void
 set_tainted_object(PyObject* str, TaintedObjectPtr tainted_object, TaintRangeMapType* tx_taint_map);

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.cpp
@@ -72,7 +72,8 @@ TaintedObject::add_ranges_shifted(TaintRangeRefs ranges,
     }
 }
 
-TaintedObject::operator string()
+std::string
+TaintedObject::toString()
 {
     stringstream ss;
 
@@ -80,13 +81,18 @@ TaintedObject::operator string()
     if (not ranges_.empty()) {
         ss << ", ranges=[";
         for (const auto& range : ranges_) {
-            ss << range << ", ";
+            ss << range->toString() << ", ";
         }
         ss << "]";
     }
     ss << "]";
 
     return ss.str();
+}
+
+TaintedObject::operator string()
+{
+    return toString();
 }
 
 void

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.h
@@ -46,6 +46,8 @@ class TaintedObject
                             RANGE_LENGTH max_length = -1,
                             RANGE_START orig_offset = -1);
 
+    std::string toString();
+
     explicit operator string();
 
     void move_ranges_to_stack();

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -15,6 +15,7 @@ if _is_python_version_supported():
     from ._native.aspect_helpers import parse_params
     from ._native.initializer import active_map_addreses_size
     from ._native.initializer import create_context
+    from ._native.initializer import debug_taint_map
     from ._native.initializer import destroy_context
     from ._native.initializer import initializer_size
     from ._native.initializer import num_objects_tainted
@@ -75,6 +76,7 @@ __all__ = [
     "as_formatted_evidence",
     "parse_params",
     "num_objects_tainted",
+    "debug_taint_map",
 ]
 
 

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -137,7 +137,11 @@ def slice_aspect(candidate_text, start, stop, step) -> Any:
     ):
         return candidate_text[start:stop:step]
     try:
-        return _slice_aspect(candidate_text, start, stop, step)
+        result = _slice_aspect(candidate_text, start, stop, step)
+        expected_result = candidate_text[start:stop:step]
+        if result != expected_result:
+            return expected_result
+        return result
     except Exception as e:
         _set_iast_error_metric("IAST propagation error. slice_aspect. {}".format(e))
         return candidate_text[start:stop:step]
@@ -270,7 +274,7 @@ def format_aspect(
     orig_function,  # type: Callable
     candidate_text,  # type: str
     *args,  # type: List[Any]
-    **kwargs  # type: Dict[str, Any]
+    **kwargs,  # type: Dict[str, Any]
 ):  # type: (...) -> str
     if not isinstance(orig_function, BuiltinFunctionType):
         return orig_function(*args, **kwargs)
@@ -289,7 +293,7 @@ def format_aspect(
         new_template = as_formatted_evidence(
             candidate_text, candidate_text_ranges, tag_mapping_function=TagMappingMode.Mapper
         )
-        fun = (
+        fun = (  # noqa: E731
             lambda arg: as_formatted_evidence(arg, tag_mapping_function=TagMappingMode.Mapper)
             if isinstance(arg, TEXT_TYPES)
             else arg
@@ -378,7 +382,6 @@ def format_value_aspect(
     options=0,  # type: int
     format_spec=None,  # type: Optional[str]
 ):  # type: (...) -> str
-
     if options == 115:
         new_text = str_aspect(element)
     elif options == 114:


### PR DESCRIPTION
Backport IAST refactors and fixes from 2.x to 2.1:
https://github.com/DataDog/dd-trace-py/pull/7485: Remove NULL returns from get_file_and_line native function
https://github.com/DataDog/dd-trace-py/pull/7340: Store hash and id separately in tx_taint_map
https://github.com/DataDog/dd-trace-py/pull/7192: Slice propagation ranges error

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
