### PR TITLE
test: remove Python 2 support from injection tests

### DIFF
--- a/tests/internal/test_injection.py
+++ b/tests/internal/test_injection.py
@@ -2,9 +2,7 @@ from contextlib import contextmanager
 
 import mock
 import pytest
-from six import PY2
 
-from ddtrace.debugging._function.discovery import UnboundMethodType
 from ddtrace.internal.injection import InvalidLine
 from ddtrace.internal.injection import eject_hook
 from ddtrace.internal.injection import eject_hooks
@@ -15,9 +13,6 @@ from ddtrace.internal.utils.inspection import linenos
 
 @contextmanager
 def injected_hook(f, hook, arg, line=None):
-    if PY2 and isinstance(f, UnboundMethodType):
-        f = f.__func__
-
     code = f.__code__
 
     if line is None:
@@ -190,10 +185,7 @@ def test_inject_instance_method():
     lo = min(linenos(Stuff.instancestuff))
     hook = mock.Mock()
     old_method = Stuff.instancestuff
-    if PY2:
-        inject_hook(Stuff.instancestuff.__func__, hook, lo, 0)
-    else:
-        inject_hook(Stuff.instancestuff, hook, lo, 0)
+    inject_hook(Stuff.instancestuff, hook, lo, 0)
 
     stuff = Stuff()
     assert stuff.instancestuff(42) == 42


### PR DESCRIPTION
We remove support for Python 2 in injection tests.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
