### PR TITLE
fix(iast): prepare aspect for unexpected args (#7491) [backport 2.0]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,7 @@ ddtrace/appsec/_iast/_taint_tracking/CMakeFiles/*
 
 # CircleCI generated config
 .circleci/config.gen.yml
+
+# Automatically generated fixtures
+tests/appsec/iast/fixtures/aspects/callers.py
+tests/appsec/iast/fixtures/aspects/unpatched_callers.py

--- a/benchmarks/appsec_iast_propagation/scenario.py
+++ b/benchmarks/appsec_iast_propagation/scenario.py
@@ -38,7 +38,7 @@ def aspect_function(internal_loop, tainted):
     value = ""
     res = value
     for _ in range(internal_loop):
-        res = add_aspect(res, join_aspect("_", (tainted, "_", tainted)))
+        res = add_aspect(res, join_aspect(str.join, 1, "_", (tainted, "_", tainted)))
         value = res
         res = add_aspect(res, tainted)
         value = res

--- a/ddtrace/appsec/_iast/_ast/visitor.py
+++ b/ddtrace/appsec/_iast/_ast/visitor.py
@@ -25,7 +25,7 @@ CODE_TYPE_FIRST_PARTY = "first_party"
 CODE_TYPE_DD = "datadog"
 CODE_TYPE_SITE_PACKAGES = "site_packages"
 CODE_TYPE_STDLIB = "stdlib"
-TAINT_SINK_FUNCTION_REPLACEMENT = "ddtrace_taint_sinks.ast_funcion"
+TAINT_SINK_FUNCTION_REPLACEMENT = "ddtrace_taint_sinks.ast_function"
 
 
 class AstVisitor(ast.NodeTransformer):
@@ -326,6 +326,16 @@ class AstVisitor(ast.NodeTransformer):
             kind=None,
         )
 
+    def _int_constant(self, from_node, value):
+        return ast.Constant(
+            lineno=from_node.lineno,
+            col_offset=from_node.col_offset,
+            end_lineno=getattr(from_node, "end_lineno", from_node.lineno),
+            end_col_offset=from_node.col_offset + 1,
+            value=value,
+            kind=None,
+        )
+
     def _call_node(self, from_node, func, args):  # type: (Any, Any, List[Any]) -> Any
         return self._node(ast.Call, from_node, func=func, args=args, keywords=[])
 
@@ -398,6 +408,11 @@ class AstVisitor(ast.NodeTransformer):
             func_name_node = func_member.id
             aspect = self._aspect_functions.get(func_name_node)
             if aspect:
+                # Send 0 as flag_added_args value
+                call_node.args.insert(0, self._int_constant(call_node, 0))
+                # Insert original function name as first parameter
+                call_node.args = self._add_original_function_as_arg(call_node, True)
+                # Substitute function call
                 call_node.func = self._attr_node(call_node, aspect)
                 self.ast_modified = call_modified = True
             else:
@@ -425,6 +440,8 @@ class AstVisitor(ast.NodeTransformer):
                 # Move the Attribute.value to 'args'
                 new_arg = func_member.value
                 call_node.args.insert(0, new_arg)
+                # Send 1 as flag_added_args value
+                call_node.args.insert(0, self._int_constant(call_node, 1))
 
                 # Create a new Name node for the replacement and set it as node.func
                 call_node.func = self._attr_node(call_node, aspect)
@@ -433,6 +450,8 @@ class AstVisitor(ast.NodeTransformer):
             elif hasattr(func_member.value, "id") or hasattr(func_member.value, "attr"):
                 aspect = self._aspect_modules.get(method_name, None)
                 if aspect:
+                    # Send 0 as flag_added_args value
+                    call_node.args.insert(0, self._int_constant(call_node, 0))
                     # Move the Function to 'args'
                     call_node.args.insert(0, call_node.func)
 
@@ -445,6 +464,8 @@ class AstVisitor(ast.NodeTransformer):
             if isinstance(call_node.func, ast.Name):
                 aspect = self._should_replace_with_taint_sink(call_node, True)
                 if aspect:
+                    # Send 0 as flag_added_args value
+                    call_node.args.insert(0, self._int_constant(call_node, 0))
                     call_node.args = self._add_original_function_as_arg(call_node, False)
                     call_node.func = self._attr_node(call_node, TAINT_SINK_FUNCTION_REPLACEMENT)
                     self.ast_modified = call_modified = True
@@ -453,6 +474,8 @@ class AstVisitor(ast.NodeTransformer):
             elif isinstance(call_node.func, ast.Attribute):
                 aspect = self._should_replace_with_taint_sink(call_node, False)
                 if aspect:
+                    # Send 0 as flag_added_args value
+                    call_node.args.insert(0, self._int_constant(call_node, 0))
                     # Create a new Name node for the replacement and set it as node.func
                     call_node.args = self._add_original_function_as_arg(call_node, False)
                     call_node.func = self._attr_node(call_node, TAINT_SINK_FUNCTION_REPLACEMENT)

--- a/ddtrace/appsec/_iast/_ast/visitor.py
+++ b/ddtrace/appsec/_iast/_ast/visitor.py
@@ -443,6 +443,9 @@ class AstVisitor(ast.NodeTransformer):
                 # Send 1 as flag_added_args value
                 call_node.args.insert(0, self._int_constant(call_node, 1))
 
+                # Insert original method as first parameter (a.b.c.method)
+                call_node.args = self._add_original_function_as_arg(call_node, False)
+
                 # Create a new Name node for the replacement and set it as node.func
                 call_node.func = self._attr_node(call_node, aspect)
                 self.ast_modified = call_modified = True

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -3,6 +3,7 @@ from builtins import bytes as builtin_bytes
 from builtins import str as builtin_str
 import codecs
 import traceback
+from types import BuiltinFunctionType
 from typing import TYPE_CHECKING
 
 from ddtrace.internal.compat import iteritems
@@ -25,6 +26,7 @@ from .._taint_tracking._native import aspects  # noqa: F401
 
 if TYPE_CHECKING:
     from typing import Any
+    from typing import Callable
     from typing import Dict
     from typing import List
     from typing import Optional
@@ -49,8 +51,13 @@ def add_aspect(op1, op2):
     return _add_aspect(op1, op2)
 
 
-def str_aspect(*args, **kwargs):
-    # type: (Any, Any) -> str
+def str_aspect(orig_function, flag_added_args, *args, **kwargs):
+    # type: (Callable, int, Any, Any) -> str
+    if orig_function != builtin_str:
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(*args, **kwargs)
+
     result = builtin_str(*args, **kwargs)
     if isinstance(args[0], TEXT_TYPES) and is_pyobject_tainted(args[0]):
         try:
@@ -67,8 +74,13 @@ def str_aspect(*args, **kwargs):
     return result
 
 
-def bytes_aspect(*args, **kwargs):
-    # type: (Any, Any) -> bytes
+def bytes_aspect(orig_function, flag_added_args, *args, **kwargs):
+    # type: (Callable, int, Any, Any) -> bytes
+    if orig_function != builtin_bytes:
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(*args, **kwargs)
+
     result = builtin_bytes(*args, **kwargs)
     if isinstance(args[0], TEXT_TYPES) and is_pyobject_tainted(args[0]):
         try:
@@ -78,8 +90,13 @@ def bytes_aspect(*args, **kwargs):
     return result
 
 
-def bytearray_aspect(*args, **kwargs):
-    # type: (Any, Any) -> bytearray
+def bytearray_aspect(orig_function, flag_added_args, *args, **kwargs):
+    # type: (Callable, int, Any, Any) -> bytearray
+    if orig_function != builtin_bytearray:
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(*args, **kwargs)
+
     result = builtin_bytearray(*args, **kwargs)
     if isinstance(args[0], TEXT_TYPES) and is_pyobject_tainted(args[0]):
         try:
@@ -89,8 +106,15 @@ def bytearray_aspect(*args, **kwargs):
     return result
 
 
-def join_aspect(joiner, *args, **kwargs):
-    # type: (Any, Any, Any) -> Any
+def join_aspect(orig_function, flag_added_args, *args, **kwargs):
+    # type: (Callable, int, Any, Any) -> Any
+    if not isinstance(orig_function, BuiltinFunctionType):
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(*args, **kwargs)
+
+    joiner = args[0]
+    args = args[flag_added_args:]
     if not isinstance(joiner, TEXT_TYPES):
         return joiner.join(*args, **kwargs)
     try:
@@ -100,8 +124,15 @@ def join_aspect(joiner, *args, **kwargs):
         return joiner.join(*args, **kwargs)
 
 
-def bytearray_extend_aspect(op1, op2):
-    # type: (Any, Any) -> Any
+def bytearray_extend_aspect(orig_function, flag_added_args, *args, **kwargs):
+    # type: (Callable, int, Any, Any) -> Any
+    if not isinstance(orig_function, BuiltinFunctionType):
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(*args, **kwargs)
+
+    op1 = args[0]
+    op2 = args[1]
     if not isinstance(op1, bytearray) or not isinstance(op2, (bytearray, bytes)):
         return op1.extend(op2)
     try:
@@ -149,19 +180,29 @@ def modulo_aspect(candidate_text, candidate_tuple):
 
 
 def build_string_aspect(*args):  # type: (List[Any]) -> str
-    return join_aspect("", args)
+    return join_aspect("".join, 1, "", args)
 
 
-def ljust_aspect(candidate_text, *args, **kwargs):
-    # type: (Any, Any, Any) -> Union[str, bytes, bytearray]
+def ljust_aspect(orig_function, flag_added_args, *args, **kwargs):
+    # type: (Callable, int, Any, Any) -> Union[str, bytes, bytearray]
+    if not isinstance(orig_function, BuiltinFunctionType):
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(*args, **kwargs)
+
+    candidate_text = args[0]
+    args = args[flag_added_args:]
+
+    result = candidate_text.ljust(*args, **kwargs)
+
     if not isinstance(candidate_text, TEXT_TYPES):
-        return candidate_text.ljust(*args, **kwargs)
+        return result
     try:
         ranges_new = get_ranges(candidate_text)
         fillchar = parse_params(1, "fillchar", " ", *args, **kwargs)
         fillchar_ranges = get_ranges(fillchar)
         if ranges_new is None or (not ranges_new and not fillchar_ranges):
-            return candidate_text.ljust(*args, **kwargs)
+            return result
 
         if fillchar_ranges:
             # Can only be one char, so we create one range to cover from the start to the end
@@ -172,13 +213,23 @@ def ljust_aspect(candidate_text, *args, **kwargs):
         return res
     except Exception as e:
         _set_iast_error_metric("IAST propagation error. ljust_aspect. {}".format(e), traceback.format_exc())
-        return candidate_text.ljust(*args, **kwargs)
+    return result
 
 
-def zfill_aspect(candidate_text, *args, **kwargs):
-    # type: (Any, Any, Any) -> Any
+def zfill_aspect(orig_function, flag_added_args, *args, **kwargs):
+    # type: (Callable, int, Any, Any) -> Any
+    if not isinstance(orig_function, BuiltinFunctionType):
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(*args, **kwargs)
+
+    candidate_text = args[0]
+    args = args[flag_added_args:]
+
+    result = candidate_text.zfill(*args, **kwargs)
+
     if not isinstance(candidate_text, TEXT_TYPES):
-        return candidate_text.zfill(*args, **kwargs)
+        return result
     try:
         ranges_orig = get_ranges(candidate_text)
         if not ranges_orig:
@@ -205,16 +256,27 @@ def zfill_aspect(candidate_text, *args, **kwargs):
         return res
     except Exception as e:
         _set_iast_error_metric("IAST propagation error. format_aspect. {}".format(e), traceback.format_exc())
-        return candidate_text.zfill(*args, **kwargs)
+    return result
 
 
 def format_aspect(
-    candidate_text,  # type: str
-    *args,  # type: List[Any]
-    **kwargs  # type: Dict[str, Any]
+    orig_function,  # type: Callable
+    flag_added_args,  # type: int
+    *args,  # type: Any
+    **kwargs,  # type: Dict[str, Any]
 ):  # type: (...) -> str
+    if not isinstance(orig_function, BuiltinFunctionType):
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(*args, **kwargs)
+
+    candidate_text = args[0]  # type: str
+    args = args[flag_added_args:]
+
+    result = candidate_text.format(*args, **kwargs)
+
     if not isinstance(candidate_text, TEXT_TYPES):
-        return candidate_text.format(*args, **kwargs)
+        return result
     try:
         params = tuple(args) + tuple(kwargs.values())
         ranges_orig, candidate_text_ranges = are_all_text_all_ranges(candidate_text, params)
@@ -233,22 +295,29 @@ def format_aspect(
         new_args = list(map(fun, args))
 
         new_kwargs = {key: fun(value) for key, value in iteritems(kwargs)}
-        result = _convert_escaped_text_to_tainted_text(
+        new_result = _convert_escaped_text_to_tainted_text(
             new_template.format(*new_args, **new_kwargs),
             ranges_orig=ranges_orig,
         )
-        if result != candidate_text.format(*args):
+        if new_result != result:
             raise Exception(
                 "format_aspect result %s is different to candidate_text.format %s"
                 % (result, candidate_text.format(*args))
             )
-        return result
+        return new_result
     except Exception as e:
         _set_iast_error_metric("IAST propagation error. format_aspect. {}".format(e), traceback.format_exc())
-        return candidate_text.format(*args, **kwargs)
+    return result
 
 
-def format_map_aspect(candidate_text, *args, **kwargs):  # type: (str, Any, Any) -> str
+def format_map_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Callable, int, Any, Any) -> str
+    if not isinstance(orig_function, BuiltinFunctionType):
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(*args, **kwargs)
+
+    candidate_text = args[0]  # type: str
+    args = args[flag_added_args:]
     if not isinstance(candidate_text, TEXT_TYPES):
         return candidate_text.format_map(*args, **kwargs)
     try:
@@ -279,8 +348,15 @@ def format_map_aspect(candidate_text, *args, **kwargs):  # type: (str, Any, Any)
         return candidate_text.format_map(*args, **kwargs)
 
 
-def repr_aspect(*args, **kwargs):
-    # type: (Any, Any) -> Any
+def repr_aspect(orig_function, flag_added_args, *args, **kwargs):
+    # type: (Optional[Callable], Any, Any, Any) -> Any
+
+    # DEV: We call this function directly passing None as orig_function
+    if orig_function is not None and not isinstance(orig_function, BuiltinFunctionType):
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(*args, **kwargs)
+
     result = repr(*args, **kwargs)
     if isinstance(args[0], TEXT_TYPES) and is_pyobject_tainted(args[0]):
         try:
@@ -304,10 +380,10 @@ def format_value_aspect(
 ):  # type: (...) -> str
 
     if options == 115:
-        new_text = str_aspect(element)
+        new_text = str_aspect(str, 0, element)
     elif options == 114:
         # TODO: use our repr once we have implemented it
-        new_text = repr_aspect(element)
+        new_text = repr_aspect(repr, 0, element)
     elif options == 97:
         new_text = ascii(element)
     else:
@@ -333,7 +409,7 @@ def format_value_aspect(
             else:
                 return ("{:%s}" % format_spec).format(new_text)
         else:
-            return str_aspect(new_text)
+            return str_aspect(str, 0, new_text)
     except Exception as e:
         _set_iast_error_metric("IAST propagation error. format_value_aspect. {}".format(e), traceback.format_exc())
         return new_text
@@ -379,31 +455,54 @@ def incremental_translation(self, incr_coder, funcode, empty):
     return result
 
 
-def decode_aspect(self, *args, **kwargs):
+def decode_aspect(orig_function, flag_added_args, *args, **kwargs):
+    if flag_added_args > 0:
+        self = args[0]
+        args = args[flag_added_args:]
+    else:
+        return orig_function(*args, **kwargs)
+
+    result = self.decode(*args, **kwargs)
+
     if not is_pyobject_tainted(self) or not isinstance(self, bytes):
-        return self.decode(*args, **kwargs)
+        return result
     try:
         codec = args[0] if args else "utf-8"
         inc_dec = codecs.getincrementaldecoder(codec)(**kwargs)
         return incremental_translation(self, inc_dec, inc_dec.decode, "")
     except Exception as e:
         _set_iast_error_metric("IAST propagation error. decode_aspect. {}".format(e), traceback.format_exc())
-        return self.decode(*args, **kwargs)
+    return result
 
 
-def encode_aspect(self, *args, **kwargs):
+def encode_aspect(orig_function, flag_added_args, *args, **kwargs):
+    if flag_added_args > 0:
+        self = args[0]
+        args = args[flag_added_args:]
+    else:
+        return orig_function(*args, **kwargs)
+
+    result = self.encode(*args, **kwargs)
+
     if not is_pyobject_tainted(self) or not isinstance(self, str):
-        return self.encode(*args, **kwargs)
+        return result
     try:
         codec = args[0] if args else "utf-8"
         inc_enc = codecs.getincrementalencoder(codec)(**kwargs)
         return incremental_translation(self, inc_enc, inc_enc.encode, b"")
     except Exception as e:
         _set_iast_error_metric("IAST propagation error. encode_aspect. {}".format(e), traceback.format_exc())
-        return self.encode(*args, **kwargs)
+    return result
 
 
-def upper_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> TEXT_TYPE
+def upper_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Callable, int, Any, Any) -> TEXT_TYPE
+    if not isinstance(orig_function, BuiltinFunctionType):
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(*args, **kwargs)
+
+    candidate_text = args[0]
+    args = args[flag_added_args:]
     if not isinstance(candidate_text, TEXT_TYPES):
         return candidate_text.upper(*args, **kwargs)
 
@@ -414,8 +513,17 @@ def upper_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> T
         return candidate_text.upper(*args, **kwargs)
 
 
-def lower_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> TEXT_TYPE
+def lower_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Callable, int, Any, Any) -> TEXT_TYPE
+    if not isinstance(orig_function, BuiltinFunctionType):
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(*args, **kwargs)
+
+    candidate_text = args[0]
+    args = args[flag_added_args:]
     if not isinstance(candidate_text, TEXT_TYPES):
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
         return candidate_text.lower(*args, **kwargs)
 
     try:
@@ -425,7 +533,14 @@ def lower_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> T
         return candidate_text.lower(*args, **kwargs)
 
 
-def swapcase_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> TEXT_TYPE
+def swapcase_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Callable, int, Any, Any) -> TEXT_TYPE
+    if not isinstance(orig_function, BuiltinFunctionType):
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(*args, **kwargs)
+
+    candidate_text = args[0]
+    args = args[flag_added_args:]
     if not isinstance(candidate_text, TEXT_TYPES):
         return candidate_text.swapcase(*args, **kwargs)
     try:
@@ -435,7 +550,14 @@ def swapcase_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -
         return candidate_text.swapcase(*args, **kwargs)
 
 
-def title_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> TEXT_TYPE
+def title_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Callable, int, Any, Any) -> TEXT_TYPE
+    if not isinstance(orig_function, BuiltinFunctionType):
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(*args, **kwargs)
+
+    candidate_text = args[0]
+    args = args[flag_added_args:]
     if not isinstance(candidate_text, TEXT_TYPES):
         return candidate_text.title(*args, **kwargs)
     try:
@@ -445,7 +567,14 @@ def title_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> T
         return candidate_text.title(*args, **kwargs)
 
 
-def capitalize_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> TEXT_TYPE
+def capitalize_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Callable, int, Any, Any) -> TEXT_TYPE
+    if not isinstance(orig_function, BuiltinFunctionType):
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(*args, **kwargs)
+
+    candidate_text = args[0]
+    args = args[flag_added_args:]
     if not isinstance(candidate_text, TEXT_TYPES):
         return candidate_text.capitalize(*args, **kwargs)
 
@@ -456,8 +585,22 @@ def capitalize_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any)
         return candidate_text.capitalize(*args, **kwargs)
 
 
-def casefold_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> TEXT_TYPE
+def casefold_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Callable, int, Any, Any) -> TEXT_TYPE
+    if not isinstance(orig_function, BuiltinFunctionType):
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(*args, **kwargs)
+
+    if orig_function.__qualname__ not in ("str.casefold", "bytes.casefold", "bytearray.casefold"):
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(args, **kwargs)
+
+    candidate_text = args[0]
+    args = args[flag_added_args:]
     if not isinstance(candidate_text, TEXT_TYPES):
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
         return candidate_text.casefold(*args, **kwargs)
     try:
         return common_replace("casefold", candidate_text, *args, **kwargs)
@@ -466,7 +609,14 @@ def casefold_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -
         return candidate_text.casefold(*args, **kwargs)  # type: ignore[union-attr]
 
 
-def translate_aspect(candidate_text, *args, **kwargs):  # type: (Any, Any, Any) -> TEXT_TYPE
+def translate_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Callable, int, Any, Any) -> TEXT_TYPE
+    if not isinstance(orig_function, BuiltinFunctionType):
+        if flag_added_args > 0:
+            args = args[flag_added_args:]
+        return orig_function(*args, **kwargs)
+
+    candidate_text = args[0]
+    args = args[flag_added_args:]
     if not isinstance(candidate_text, TEXT_TYPES):
         return candidate_text.translate(*args, **kwargs)
     try:

--- a/ddtrace/appsec/_iast/taint_sinks/__init__.py
+++ b/ddtrace/appsec/_iast/taint_sinks/__init__.py
@@ -1,8 +1,8 @@
-from .ast_taint import ast_funcion
+from .ast_taint import ast_function
 from .path_traversal import open_path_traversal
 
 
 __all__ = [
     "open_path_traversal",
-    "ast_funcion",
+    "ast_function",
 ]

--- a/ddtrace/appsec/_iast/taint_sinks/ast_taint.py
+++ b/ddtrace/appsec/_iast/taint_sinks/ast_taint.py
@@ -10,8 +10,9 @@ if TYPE_CHECKING:
     from typing import Callable
 
 
-def ast_funcion(
+def ast_function(
     func,  # type: Callable
+    flag_added_args,  # type: Any
     *args,  # type: Any
     **kwargs  # type: Any
 ):  # type: (...) -> Any
@@ -24,6 +25,9 @@ def ast_funcion(
             cls_name = cls.__class__.__name__
         except AttributeError:
             pass
+
+    if flag_added_args > 0:
+        args = args[flag_added_args:]
 
     if cls.__class__.__module__ == "random" and cls_name == "Random" and func_name in DEFAULT_WEAK_RANDOMNESS_FUNCTIONS:
         # Weak, run the analyzer

--- a/ddtrace/appsec/_iast/taint_sinks/command_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/command_injection.py
@@ -179,7 +179,7 @@ def _iast_report_cmdi(shell_args):
     if isinstance(shell_args, (list, tuple)):
         for arg in shell_args:
             if get_tainted_ranges(arg):
-                report_cmdi = join_aspect(" ", shell_args)
+                report_cmdi = join_aspect(" ".join, 1, " ", shell_args)
                 break
     elif get_tainted_ranges(shell_args):
         report_cmdi = shell_args

--- a/releasenotes/notes/iast-fix-ast-patching-arguments-67b838a27a6c01f8.yaml
+++ b/releasenotes/notes/iast-fix-ast-patching-arguments-67b838a27a6c01f8.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Vulnerability Management for Code-level (IAST): This fix addresses AST patching issues where custom functions or methods could be replaced by aspects with differing argument numbers, causing runtime errors as a result. Furthermore, it addresses a case during patching where the module is inadvertently passed as the first argument to the aspect.

--- a/tests/appsec/iast/aspects/test_common_aspects.py
+++ b/tests/appsec/iast/aspects/test_common_aspects.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""
+Common tests to aspects, like ensuring that they don't break when receiving extra arguments.
+"""
+import os
+
+import pytest
+
+
+try:
+    # Disable unused import warning pylint: disable=W0611
+    from ddtrace.appsec._iast._taint_tracking import TagMappingMode  # noqa: F401
+except (ImportError, AttributeError):
+    pytest.skip("IAST not supported for this Python version", allow_module_level=True)
+
+
+from tests.appsec.iast.aspects.conftest import _iast_patched_module
+import tests.appsec.iast.fixtures.aspects.callees
+
+
+def generate_callers_from_callees(callees_module, callers_file="", callees_module_str=""):
+    """
+    Generate a callers module from a callees module, calling all it's functions.
+    """
+    module_functions = [x for x in dir(callees_module) if not x.startswith(("_", "@"))]
+
+    with open(callers_file, "w", encoding="utf-8") as callers:
+        callers.write(f"from {callees_module_str} import *\n")
+        callers.write(f"import {callees_module_str} as _original_callees\n")
+
+        for function in module_functions:
+            callers.write(
+                f"""
+def callee_{function}(*args, **kwargs):
+    return _original_callees.{function}(*args, **kwargs)
+
+def callee_{function}_direct(*args, **kwargs):
+    return {function}(*args, **kwargs)\n
+            """
+            )
+
+
+PATCHED_CALLERS_FILE = "tests/appsec/iast/fixtures/aspects/callers.py"
+UNPATCHED_CALLERS_FILE = "tests/appsec/iast/fixtures/aspects/unpatched_callers.py"
+
+for _file in (PATCHED_CALLERS_FILE, UNPATCHED_CALLERS_FILE):
+    generate_callers_from_callees(
+        callers_file=_file,
+        callees_module=tests.appsec.iast.fixtures.aspects.callees,
+        callees_module_str="tests.appsec.iast.fixtures.aspects.callees",
+    )
+
+patched_callers = _iast_patched_module(PATCHED_CALLERS_FILE.replace("/", ".")[0:-3])
+# This import needs to be done after the file is created (previous line)
+# pylint: disable=[wrong-import-position],[no-name-in-module]
+from tests.appsec.iast.fixtures.aspects import unpatched_callers  # type: ignore[attr-defined] # noqa: E402
+
+
+@pytest.mark.parametrize("aspect", [x for x in dir(unpatched_callers) if not x.startswith(("_", "@"))])
+@pytest.mark.parametrize("args", [(), ("a"), ("a", "b")])
+@pytest.mark.parametrize("kwargs", [{}, {"dry_run": False}, {"dry_run": True}])
+def test_aspect_patched_result(aspect, args, kwargs):
+    """
+    Test that the result of the patched aspect call is the same as the unpatched one.
+    """
+    assert getattr(patched_callers, aspect)(*args, **kwargs) == getattr(unpatched_callers, aspect)(*args, **kwargs)
+
+
+def teardown():
+    """
+    Remove the callers file after the tests are done.
+    """
+    for _file in (PATCHED_CALLERS_FILE, UNPATCHED_CALLERS_FILE):
+        os.remove(_file)
+        assert not os.path.exists(_file)

--- a/tests/appsec/iast/aspects/test_common_aspects.py
+++ b/tests/appsec/iast/aspects/test_common_aspects.py
@@ -66,7 +66,7 @@ def test_aspect_patched_result(aspect, args, kwargs):
     assert getattr(patched_callers, aspect)(*args, **kwargs) == getattr(unpatched_callers, aspect)(*args, **kwargs)
 
 
-def teardown():
+def teardown_module(_):
     """
     Remove the callers file after the tests are done.
     """

--- a/tests/appsec/iast/aspects/test_encode_decode_aspect.py
+++ b/tests/appsec/iast/aspects/test_encode_decode_aspect.py
@@ -54,8 +54,21 @@ def test_decode_and_add_aspect(infix, args, kwargs, should_be_tainted, prefix, s
     main_string = ddtrace_aspects.add_aspect(main_string, suffix)
     if should_be_tainted:
         assert len(get_tainted_ranges(main_string))
-    ok, res = catch_all(ddtrace_aspects.decode_aspect, (main_string,) + args, kwargs)
-    assert (ok, res) == catch_all(main_string.__class__.decode, (main_string,) + args, kwargs)
+    ok, res = catch_all(
+        ddtrace_aspects.decode_aspect,
+        (
+            main_string.__class__.decode,
+            1,
+            main_string,
+        )
+        + args,
+        kwargs,
+    )
+    assert (ok, res) == catch_all(
+        main_string.__class__.decode,
+        (main_string,) + args,
+        kwargs,
+    )
     if should_be_tainted and ok:
         list_tr = get_tainted_ranges(res)
         assert len(list_tr) == 1
@@ -99,7 +112,16 @@ def test_encode_and_add_aspect(infix, args, kwargs, should_be_tainted, prefix, s
     main_string = ddtrace_aspects.add_aspect(main_string, suffix)
     if should_be_tainted:
         assert len(get_tainted_ranges(main_string))
-    ok, res = catch_all(ddtrace_aspects.encode_aspect, (main_string,) + args, kwargs)
+    ok, res = catch_all(
+        ddtrace_aspects.encode_aspect,
+        (
+            main_string.__class__.encode,
+            1,
+            main_string,
+        )
+        + args,
+        kwargs,
+    )
 
     assert (ok, res) == catch_all(main_string.__class__.encode, (main_string,) + args, kwargs)
     if should_be_tainted and ok:

--- a/tests/appsec/iast/aspects/test_str_aspect.py
+++ b/tests/appsec/iast/aspects/test_str_aspect.py
@@ -36,7 +36,7 @@ def setup():
 def test_str_aspect(obj, kwargs):
     import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
 
-    assert ddtrace_aspects.str_aspect(obj, **kwargs) == str(obj, **kwargs)
+    assert ddtrace_aspects.str_aspect(str, 0, obj, **kwargs) == str(obj, **kwargs)
 
 
 @pytest.mark.parametrize(
@@ -66,7 +66,7 @@ def test_str_aspect_tainting(obj, kwargs, should_be_tainted):
             obj, source_name="test_str_aspect_tainting", source_value=obj, source_origin=OriginType.PARAMETER
         )
 
-    result = ddtrace_aspects.str_aspect(obj, **kwargs)
+    result = ddtrace_aspects.str_aspect(str, 0, obj, **kwargs)
     assert is_pyobject_tainted(result) == should_be_tainted
 
     assert result == str(obj, **kwargs)
@@ -94,7 +94,7 @@ def test_repr_aspect_tainting(obj, expected_result):
         obj, source_name="test_repr_aspect_tainting", source_value=obj, source_origin=OriginType.PARAMETER
     )
 
-    result = ddtrace_aspects.repr_aspect(obj)
+    result = ddtrace_aspects.repr_aspect(repr, 0, obj)
     assert is_pyobject_tainted(result) is True
 
 

--- a/tests/appsec/iast/fixtures/aspects/callees.py
+++ b/tests/appsec/iast/fixtures/aspects/callees.py
@@ -1,0 +1,73 @@
+import builtins as _builtins
+
+
+def extend(*args, **kwargs):
+    return "--".join(("extend", _builtins.str(args), _builtins.str(kwargs)))
+
+
+def encode(*args, **kwargs):
+    return "--".join(("encode", _builtins.str(args), _builtins.str(kwargs)))
+
+
+def decode(*args, **kwargs):
+    return "--".join(("decode", _builtins.str(args), _builtins.str(kwargs)))
+
+
+def str(*args, **kwargs):  # noqa: A001
+    return "--".join(("_builtins.str", _builtins.str(args), _builtins.str(kwargs)))
+
+
+def bytes(*args, **kwargs):  # noqa: A001
+    return "--".join(("bytes", _builtins.str(args), _builtins.str(kwargs)))
+
+
+def bytearray(*args, **kwargs):  # noqa: A001
+    return "--".join(("bytearray", _builtins.str(args), _builtins.str(kwargs)))
+
+
+def join(*args, **kwargs):
+    return "--".join(("join", _builtins.str(args), _builtins.str(kwargs)))
+
+
+def ljust(*args, **kwargs):
+    return "--".join(("ljust", _builtins.str(args), _builtins.str(kwargs)))
+
+
+def zfill(*args, **kwargs):
+    return "--".join(("zfill", _builtins.str(args), _builtins.str(kwargs)))
+
+
+def format_map(*args, **kwargs):
+    return "--".join(("format_map", _builtins.str(args), _builtins.str(kwargs)))
+
+
+def repr(*args, **kwargs):  # noqa: A001
+    return "--".join(("repr", _builtins.str(args), _builtins.str(kwargs)))
+
+
+def upper(*args, **kwargs):
+    return "--".join(("upper", _builtins.str(args), _builtins.str(kwargs)))
+
+
+def lower(*args, **kwargs):
+    return "--".join(("lower", _builtins.str(args), _builtins.str(kwargs)))
+
+
+def swapcase(*args, **kwargs):
+    return "--".join(("swapcase", _builtins.str(args), _builtins.str(kwargs)))
+
+
+def title(*args, **kwargs):
+    return "--".join(("title", _builtins.str(args), _builtins.str(kwargs)))
+
+
+def capitalize(*args, **kwargs):
+    return "--".join(("capitalize", _builtins.str(args), _builtins.str(kwargs)))
+
+
+def casefold(*args, **kwargs):
+    return "--".join(("casefold", _builtins.str(args), _builtins.str(kwargs)))
+
+
+def translate(*args, **kwargs):
+    return "--".join(("translate", _builtins.str(args), _builtins.str(kwargs)))

--- a/tests/appsec/iast/fixtures/aspects/str_methods.py
+++ b/tests/appsec/iast/fixtures/aspects/str_methods.py
@@ -698,8 +698,8 @@ def no_effect_using_wraps(func):
     return wrapper
 
 
-def do_upper(s):  # type: (str) -> str
-    return s.upper()
+def do_upper(sss):  # type: (str) -> str
+    return sss.upper()
 
 
 def do_lower(s):  # type: (str) -> str

--- a/tests/appsec/iast/taint_tracking/test_native_taint_range.py
+++ b/tests/appsec/iast/taint_tracking/test_native_taint_range.py
@@ -124,10 +124,10 @@ def test_collisions():
         t4 = random.choice(tainted)
         mixed_tainted_ids.append(id(t4))
 
-        t5 = format_aspect(n1, t4)
+        t5 = format_aspect(n1.format, 1, n1, t4)
         mixed_tainted_ids.append(id(t5))
 
-        t6 = join_aspect(t5, [t2, n3])
+        t6 = join_aspect(t5.join, 1, t5, [t2, n3])
         mixed_tainted_ids.append(id(t6))
 
     for t in mixed_tainted_and_nottainted:
@@ -143,9 +143,9 @@ def test_collisions():
 
         n4 = random.choice(not_tainted)
 
-        n5 = format_aspect(n1, [n4])
+        n5 = format_aspect(n1.format, 1, n1, [n4])
 
-        n6 = join_aspect(n5, [n2, n3])
+        n6 = join_aspect(n5.join, 1, n5, [n2, n3])
 
         mixed_nottainted.append(n6)
 

--- a/tests/contrib/django/django_app/appsec_urls.py
+++ b/tests/contrib/django/django_app/appsec_urls.py
@@ -196,7 +196,7 @@ def sqli_http_request_body(request):
     if key in request.POST:
         value = request.POST[key]
     else:
-        value = decode_aspect(request.body)
+        value = decode_aspect(bytes.decode, 1, request.body)
     with connection.cursor() as cursor:
         # label iast_enabled_sqli_http_body
         cursor.execute(add_aspect("SELECT 1 FROM sqlite_", value))


### PR DESCRIPTION
IAST: This PR addresses two interconnected issues in the AST patching process that replaces code with aspects:

1. Resolves a bug that occurs during AST patching, where a custom function or method call could be replaced by one of our aspects. In situations where the function has a different number of arguments than our aspects, a runtime ``TypeError`` occurs. This is fixed by ensuring that all aspects now receive ``(*args, **kwargs)`` and pass them appropriately to the original custom function or method.

2. Fixes another bug in the AST patching process, where the module of a function is incorrectly passed as the first argument to the aspect. In cases where it's a custom function, our logic inadvertently passes the module received as the first argument to the original function. The solution involves introducing a flag to the aspect's arguments, indicating the additional arguments added during patching. This allows us to remove them before calling the original function or method.

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

---------

Co-authored-by: Alberto Vara <alberto.vara@datadoghq.com>
(cherry picked from commit d5caa6c16b3ba9e9f7ca4c63a434ae4734ebd5b0)