### PR TITLE
feat(iast): vulnerability deduplication

### DIFF
--- a/ddtrace/appsec/_iast/_overhead_control_engine.py
+++ b/ddtrace/appsec/_iast/_overhead_control_engine.py
@@ -56,6 +56,17 @@ class Operation(object):
         return result
 
     @classmethod
+    def increment_quota(cls):
+        # type: () -> bool
+        cls._lock.acquire()
+        result = False
+        if cls._vulnerability_quota < MAX_VULNERABILITIES_PER_REQUEST:
+            cls._vulnerability_quota += 1
+            result = True
+        cls._lock.release()
+        return result
+
+    @classmethod
     def has_quota(cls):
         # type: () -> bool
         cls._lock.acquire()

--- a/riotfile.py
+++ b/riotfile.py
@@ -147,6 +147,7 @@ venv = Venv(
             },
             env={
                 "DD_IAST_REQUEST_SAMPLING": "100",  # Override default 30% to analyze all IAST requests
+                "_DD_APPSEC_DEDUPLICATION_ENABLED": "false",
             },
         ),
         Venv(

--- a/tests/appsec/iast/taint_sinks/test_path_traversal.py
+++ b/tests/appsec/iast/taint_sinks/test_path_traversal.py
@@ -9,6 +9,7 @@ from ddtrace.appsec._iast.constants import VULN_PATH_TRAVERSAL
 from ddtrace.internal import core
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
 from tests.appsec.iast.iast_utils import get_line_and_hash
+from tests.utils import override_env
 
 
 FIXTURES_PATH = "tests/appsec/iast/fixtures/taint_sinks/path_traversal.py"
@@ -106,3 +107,30 @@ def test_path_traversal(module, function, iast_span_defaults):
     assert vulnerability.evidence.value is None
     assert vulnerability.evidence.pattern is None
     assert vulnerability.evidence.redacted is None
+
+
+@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+@pytest.mark.parametrize("num_vuln_expected", [1, 0, 0])
+def test_path_traversal_deduplication(num_vuln_expected, iast_span_defaults):
+    from ddtrace.appsec._iast._taint_tracking import OriginType
+    from ddtrace.appsec._iast._taint_tracking import taint_pyobject
+
+    mod = _iast_patched_module("tests.appsec.iast.fixtures.taint_sinks.path_traversal")
+    file_path = os.path.join(ROOT_DIR, "../fixtures", "taint_sinks", "not_exists.txt")
+
+    with override_env(dict(_DD_APPSEC_DEDUPLICATION_ENABLED="true")):
+        tainted_string = taint_pyobject(
+            file_path, source_name="path", source_value=file_path, source_origin=OriginType.PATH
+        )
+
+        for _ in range(0, 5):
+            mod.pt_open(tainted_string)
+
+        span_report = core.get_item(IAST.CONTEXT_KEY, span=iast_span_defaults)
+
+        if num_vuln_expected == 0:
+            assert span_report is None
+        else:
+            assert span_report
+
+            assert len(span_report.vulnerabilities) == num_vuln_expected

--- a/tests/appsec/iast/taint_sinks/test_sql_injection.py
+++ b/tests/appsec/iast/taint_sinks/test_sql_injection.py
@@ -6,6 +6,7 @@ from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.internal import core
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
 from tests.appsec.iast.iast_utils import get_line_and_hash
+from tests.utils import override_env
 
 
 try:
@@ -34,6 +35,7 @@ def test_sql_injection(iast_span_defaults):
     span_report = core.get_item(IAST.CONTEXT_KEY, span=iast_span_defaults)
     assert span_report
 
+    assert len(span_report.vulnerabilities) == 1
     vulnerability = list(span_report.vulnerabilities)[0]
     source = span_report.sources[0]
     assert vulnerability.type == VULN_SQL_INJECTION
@@ -49,3 +51,28 @@ def test_sql_injection(iast_span_defaults):
     assert vulnerability.location.line == line
     assert vulnerability.location.path == FIXTURES_PATH
     assert vulnerability.hash == hash_value
+
+
+@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+@pytest.mark.parametrize("num_vuln_expected", [1, 0, 0])
+def test_sql_injection_deduplication(num_vuln_expected, iast_span_defaults):
+    mod = _iast_patched_module("tests.appsec.iast.fixtures.taint_sinks.sql_injection")
+    with override_env(dict(_DD_APPSEC_DEDUPLICATION_ENABLED="true")):
+        table = taint_pyobject(
+            pyobject="students",
+            source_name="test_ossystem",
+            source_value="students",
+            source_origin=OriginType.PARAMETER,
+        )
+        assert is_pyobject_tainted(table)
+        for _ in range(0, 5):
+            mod.sqli_simple(table)
+
+        span_report = core.get_item(IAST.CONTEXT_KEY, span=iast_span_defaults)
+
+        if num_vuln_expected == 0:
+            assert span_report is None
+        else:
+            assert span_report
+
+            assert len(span_report.vulnerabilities) == num_vuln_expected

--- a/tests/appsec/iast/taint_sinks/test_weak_cipher.py
+++ b/tests/appsec/iast/taint_sinks/test_weak_cipher.py
@@ -1,6 +1,5 @@
 import pytest
 
-from benchmarks.bm.utils import override_env
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast.constants import VULN_WEAK_CIPHER_TYPE
 from ddtrace.appsec._iast.taint_sinks.weak_cipher import unpatch_iast
@@ -11,6 +10,7 @@ from tests.appsec.iast.fixtures.taint_sinks.weak_algorithms import cipher_blowfi
 from tests.appsec.iast.fixtures.taint_sinks.weak_algorithms import cipher_des
 from tests.appsec.iast.fixtures.taint_sinks.weak_algorithms import cryptography_algorithm
 from tests.appsec.iast.iast_utils import get_line_and_hash
+from tests.utils import override_env
 
 
 FIXTURES_PATH = "tests/appsec/iast/fixtures/taint_sinks/weak_algorithms.py"

--- a/tests/appsec/iast/taint_sinks/test_weak_hash.py
+++ b/tests/appsec/iast/taint_sinks/test_weak_hash.py
@@ -258,7 +258,7 @@ def test_weak_check_repeated(iast_span_defaults):
     assert len(span_report.vulnerabilities) == 1
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10, 0), reason="hmac has a weak hash vulnerability until Python 3.10")
+@pytest.mark.skipif(sys.version_info > (3, 10, 0), reason="hmac has a weak hash vulnerability until Python 3.10")
 def test_weak_hash_check_hmac(iast_span_defaults):
     import hashlib
     import hmac

--- a/tests/appsec/iast/taint_sinks/test_weak_hash.py
+++ b/tests/appsec/iast/taint_sinks/test_weak_hash.py
@@ -1,15 +1,18 @@
 import sys
 
+from mock import mock
 import pytest
 
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._utils import _is_python_version_supported as python_supported_by_iast
 from ddtrace.appsec._iast.constants import VULN_INSECURE_HASHING_TYPE
+from ddtrace.appsec._iast.taint_sinks._base import taint_sink_deduplication
 from ddtrace.appsec._iast.taint_sinks.weak_hash import unpatch_iast
 from ddtrace.internal import core
 from tests.appsec.iast.fixtures.taint_sinks.weak_algorithms import hashlib_new
 from tests.appsec.iast.fixtures.taint_sinks.weak_algorithms import parametrized_week_hash
 from tests.appsec.iast.iast_utils import get_line_and_hash
+from tests.utils import override_env
 
 
 WEAK_ALGOS_FIXTURES_PATH = "tests/appsec/iast/fixtures/taint_sinks/weak_algorithms.py"
@@ -255,8 +258,8 @@ def test_weak_check_repeated(iast_span_defaults):
     assert len(span_report.vulnerabilities) == 1
 
 
-@pytest.mark.skip(reason="FIXME: does not work with Python 3.10+")
-def test_weak_check_hmac(iast_span_defaults):
+@pytest.mark.skipif(sys.version_info < (3, 10, 0), reason="hmac has a weak hash vulnerability until Python 3.10")
+def test_weak_hash_check_hmac(iast_span_defaults):
     import hashlib
     import hmac
 
@@ -274,3 +277,56 @@ def test_weak_check_hmac_secure(iast_span_defaults):
     mac.digest()
     span_report = core.get_item(IAST.CONTEXT_KEY, span=iast_span_defaults)
     assert span_report is None
+
+
+@pytest.mark.parametrize("num_vuln_expected", [1, 0, 0])
+def test_weak_hash_deduplication(num_vuln_expected, iast_span_defaults):
+    import hashlib
+
+    with override_env(dict(_DD_APPSEC_DEDUPLICATION_ENABLED="true")):
+        for _ in range(0, 5):
+            m = hashlib.new("md5")
+            m.digest()
+
+        span_report = core.get_item(IAST.CONTEXT_KEY, span=iast_span_defaults)
+
+        if num_vuln_expected == 0:
+            assert span_report is None
+        else:
+            assert span_report
+
+            assert len(span_report.vulnerabilities) == num_vuln_expected
+
+
+@mock.patch.object(taint_sink_deduplication, "get_last_time_reported")
+def test_weak_hash_deduplication_expired_cache(mock_get_last_time_reported, iast_span_defaults):
+    """CAVEAT: this test will fail at Wednesday, July 20, 5127"""
+    import hashlib
+
+    with override_env(dict(_DD_APPSEC_DEDUPLICATION_ENABLED="true")):
+        mock_get_last_time_reported.return_value = 0.0
+        m = hashlib.new("md5")
+        m.digest()
+
+        span_report = core.get_item(IAST.CONTEXT_KEY, span=iast_span_defaults)
+        assert len(span_report.vulnerabilities) == 1
+
+        mock_get_last_time_reported.return_value = 99642544540.0
+        m = hashlib.new("md5")
+        m.digest()
+
+        span_report = core.get_item(IAST.CONTEXT_KEY, span=iast_span_defaults)
+        assert len(span_report.vulnerabilities) == 1
+
+        m = hashlib.new("md5")
+        m.digest()
+
+        span_report = core.get_item(IAST.CONTEXT_KEY, span=iast_span_defaults)
+        assert len(span_report.vulnerabilities) == 1
+
+        mock_get_last_time_reported.return_value = 1142544540.0
+        m = hashlib.new("md5")
+        m.digest()
+
+        span_report = core.get_item(IAST.CONTEXT_KEY, span=iast_span_defaults)
+        assert len(span_report.vulnerabilities) == 2

--- a/tests/contrib/django/test_django_appsec_iast.py
+++ b/tests/contrib/django/test_django_appsec_iast.py
@@ -11,6 +11,7 @@ from ddtrace.appsec._iast._utils import _is_python_version_supported as python_s
 from ddtrace.internal.compat import urlencode
 from ddtrace.settings.asm import config as asm_config
 from tests.appsec.iast.iast_utils import get_line_and_hash
+from tests.utils import override_env
 from tests.utils import override_global_config
 
 
@@ -435,9 +436,9 @@ def test_django_tainted_iast_disabled_sqli_http_cookies_value(client, test_spans
 @pytest.mark.django_db()
 @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
 def test_django_tainted_user_agent_iast_enabled_sqli_http_body(client, test_spans, tracer, payload, content_type):
-    with override_global_config(dict(_iast_enabled=True)), mock.patch(
-        "ddtrace.contrib.dbapi._is_iast_enabled", return_value=True
-    ):
+    with override_global_config(dict(_iast_enabled=True)), override_env(
+        dict(_DD_APPSEC_DEDUPLICATION_ENABLED="true")
+    ), mock.patch("ddtrace.contrib.dbapi._is_iast_enabled", return_value=True):
         root_span, response = _aux_appsec_get_root_span(
             client,
             test_spans,

--- a/tests/contrib/django/test_django_appsec_iast.py
+++ b/tests/contrib/django/test_django_appsec_iast.py
@@ -437,7 +437,7 @@ def test_django_tainted_iast_disabled_sqli_http_cookies_value(client, test_spans
 @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
 def test_django_tainted_user_agent_iast_enabled_sqli_http_body(client, test_spans, tracer, payload, content_type):
     with override_global_config(dict(_iast_enabled=True)), override_env(
-        dict(_DD_APPSEC_DEDUPLICATION_ENABLED="true")
+        dict(_DD_APPSEC_DEDUPLICATION_ENABLED="false")
     ), mock.patch("ddtrace.contrib.dbapi._is_iast_enabled", return_value=True):
         root_span, response = _aux_appsec_get_root_span(
             client,


### PR DESCRIPTION
IAST vulnerability deduplication: If we report and attach a vulnerability to a span, we don't report it again until 1 hour later to reduce the number of spans marked as "manually keep."


Example of this feature on Java Tracer: https://github.com/DataDog/dd-trace-java/pull/4855
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
