### PR TITLE
chore: limit github release notes size

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -49,6 +49,8 @@ Generate release notes for next patch version of 2.13: `BASE=2.13 PATCH=1 python
 Generate release notes for the 2.15 release: `BASE=2.15 python release.py`
 """  # noqa
 
+MAX_GH_RELEASE_NOTES_LENGTH = 125000
+
 
 def create_release_draft(dd_repo, base, rc, patch, latest_branch):
     # make sure we're up to date
@@ -218,7 +220,12 @@ def create_draft_release(
         )
     else:
         dd_repo.create_git_release(
-            name=name, tag=tag, prerelease=prerelease, draft=True, target_commitish=base_branch, message=rn
+            name=name,
+            tag=tag,
+            prerelease=prerelease,
+            draft=True,
+            target_commitish=base_branch,
+            message=rn[:MAX_GH_RELEASE_NOTES_LENGTH],
         )
         print("\nPlease review your release notes draft here: https://github.com/DataDog/dd-trace-py/releases")
 


### PR DESCRIPTION
This change fixes a crash I encountered in `scripts/release.py` by truncating the release notes before using them in a Github API request. This is a fallback for a case that probably indicates other problems with the script and generally will not change the release notes.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
