### PR TITLE
chore(core): make ddtrace-run and import ddtrace.run compatible with no side effects

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -195,6 +195,11 @@ try:
         # will be `None`.
         ddtrace_sitecustomize = sys.modules["sitecustomize"]
         del sys.modules["sitecustomize"]
+
+        # Cache this module under it's fully qualified package name
+        if "ddtrace.bootstrap.sitecustomize" not in sys.modules:
+            sys.modules["ddtrace.bootstrap.sitecustomize"] = ddtrace_sitecustomize
+
         try:
             import sitecustomize  # noqa
         except ImportError:

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -558,6 +558,8 @@ def test_ddtrace_auto_sitecustomize():
 @pytest.mark.subprocess(ddtrace_run=True, err=None)
 def test_ddtrace_run_and_auto_sitecustomize():
     """When using ddtrace-run and import ddtrace.auto we don't double import sitecustomize"""
+    import sys
+
     assert sys.modules["ddtrace.bootstrap.sitecustomize"].loaded
 
     # Setting this to false, and confirming that importing auto doesn't set it to True (sitecustomize code ran)

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -524,3 +524,45 @@ def test_ddtrace_re_module():
             (r"[\s,<>]", None),
         )
     )
+
+
+@pytest.mark.subprocess(ddtrace_run=True, err=None)
+def test_ddtrace_run_sitecustomize():
+    """When using ddtrace-run we ensure ddtrace.bootstrap.sitecustomize is in sys.module cache"""
+    import sys
+
+    assert "ddtrace.bootstrap.sitecustomize" in sys.modules
+
+    assert sys.modules["ddtrace.bootstrap.sitecustomize"].loaded
+
+
+@pytest.mark.subprocess(ddtrace_run=False, err=None)
+def test_ddtrace_auto_sitecustomize():
+    """When import ddtrace.auto we ensure ddtrace.bootstrap.sitecustomize is in sys.module cache"""
+    import sys
+
+    starting_modules = set(sys.modules.keys())
+
+    import ddtrace.auto  # noqa: F401
+
+    assert "ddtrace.bootstrap.sitecustomize" in sys.modules
+
+    assert sys.modules["ddtrace.bootstrap.sitecustomize"].loaded
+
+    # Compare the list of imported modules before/after ddtrace.auto to show it is a no-op with
+    # no additional modules imported / side-effects
+    final_modules = set(sys.modules.keys())
+    assert final_modules - starting_modules == set(["ddtrace.auto"])
+
+
+@pytest.mark.subprocess(ddtrace_run=True, err=None)
+def test_ddtrace_run_and_auto_sitecustomize():
+    """When using ddtrace-run and import ddtrace.auto we don't double import sitecustomize"""
+    assert sys.modules["ddtrace.bootstrap.sitecustomize"].loaded
+
+    # Setting this to false, and confirming that importing auto doesn't set it to True (sitecustomize code ran)
+    sys.modules["ddtrace.bootstrap.sitecustomize"].loaded = False
+
+    import ddtrace.auto  # noqa: F401
+
+    assert sys.modules["ddtrace.bootstrap.sitecustomize"].loaded is False


### PR DESCRIPTION
This change ensures that using both `ddtrace-run` and `import ddtrace.auto` does not double load the `ddtrace.bootstrap.sitecustomize` module, which has unexpected behavior.

The reason we double load `ddtrace.bootstrap.sitecustomize` today is because with `ddtrace-run` `ddtrace.bootstrap.sitecustomize` gets imported as `sitecustomize` and will get added to the `sys.modules` cache under `sitecustomize` name. Then when we go to `import ddtrace.auto`, which imports `ddtrace.bootstrap.sitecustomize` the module gets loaded again since `ddtrace.bootstrap.sitecustomize` is not in the `sys.modules` cache.

This change ensures that whenever we load `ddtrace.bootstrap.sitecustomize` we explicitly add the module to `sys.modules` cache to avoid re-loading it again when `ddtrace.auto` imports it.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
