### PR TITLE
ci(logging): update tests to reflect new 128 bit trace_id standard

### DIFF
--- a/tests/.suitespec.json
+++ b/tests/.suitespec.json
@@ -506,10 +506,16 @@
             "tests/contrib/logging/*"
         ],
         "logbook": [
+            "@core",
+            "@contrib",
+            "@tracing",
             "@logbook",
             "tests/contrib/logbook/*"
         ],
         "loguru": [
+            "@core",
+            "@contrib",
+            "@tracing",
             "@loguru",
             "tests/contrib/loguru/*"
         ],
@@ -953,6 +959,9 @@
             "tests/contrib/starlette/*"
         ],
         "structlog": [
+            "@core",
+            "@contrib",
+            "@tracing",
             "@structlog",
             "tests/contrib/structlog/*"
         ],

--- a/tests/contrib/structlog/test_structlog_logging.py
+++ b/tests/contrib/structlog/test_structlog_logging.py
@@ -19,7 +19,7 @@ cf = structlog.testing.CapturingLoggerFactory()
 def _test_logging(output, span, env, service, version):
     dd_trace_id, dd_span_id = (span.trace_id, span.span_id) if span else (0, 0)
 
-    if dd_trace_id != 0 and config._128_bit_trace_id_enabled and not config._128_bit_trace_id_logging_enabled:
+    if dd_trace_id != 0 and not config._128_bit_trace_id_logging_enabled:
         dd_trace_id = span._trace_id_64bits
 
     assert json.loads(output[0].args[0])["event"] == "Hello!"
@@ -28,8 +28,6 @@ def _test_logging(output, span, env, service, version):
     assert json.loads(output[0].args[0])["dd.env"] == env or ""
     assert json.loads(output[0].args[0])["dd.service"] == service or ""
     assert json.loads(output[0].args[0])["dd.version"] == version or ""
-
-    cf.logger.calls.clear()
 
 
 @pytest.fixture(autouse=True)
@@ -49,15 +47,13 @@ def patch_structlog():
 def global_config():
     with override_global_config({"service": "logging", "env": "global.env", "version": "global.version"}):
         yield
+    cf.logger.calls.clear()
 
 
 def test_log_trace_global_values():
     """
     Check trace info includes global values over local span values
     """
-
-    cf.logger.calls.clear()
-
     span = tracer.trace("test.logging")
     span.set_tag(ENV_KEY, "local-env")
     span.set_tag(SERVICE_KEY, "local-service")
@@ -72,8 +68,6 @@ def test_log_trace_global_values():
 
 
 def test_log_no_trace():
-    cf.logger.calls.clear()
-
     structlog.get_logger().info("Hello!")
     output = cf.logger.calls
 

--- a/tests/contrib/structlog/test_structlog_logging.py
+++ b/tests/contrib/structlog/test_structlog_logging.py
@@ -19,6 +19,9 @@ cf = structlog.testing.CapturingLoggerFactory()
 def _test_logging(output, span, env, service, version):
     dd_trace_id, dd_span_id = (span.trace_id, span.span_id) if span else (0, 0)
 
+    if dd_trace_id != 0 and config._128_bit_trace_id_enabled and not config._128_bit_trace_id_logging_enabled:
+        dd_trace_id = span._trace_id_64bits
+
     assert json.loads(output[0].args[0])["event"] == "Hello!"
     assert json.loads(output[0].args[0])["dd.trace_id"] == str(dd_trace_id)
     assert json.loads(output[0].args[0])["dd.span_id"] == str(dd_span_id)
@@ -53,6 +56,8 @@ def test_log_trace_global_values():
     Check trace info includes global values over local span values
     """
 
+    cf.logger.calls.clear()
+
     span = tracer.trace("test.logging")
     span.set_tag(ENV_KEY, "local-env")
     span.set_tag(SERVICE_KEY, "local-service")
@@ -67,6 +72,8 @@ def test_log_trace_global_values():
 
 
 def test_log_no_trace():
+    cf.logger.calls.clear()
+
     structlog.get_logger().info("Hello!")
     output = cf.logger.calls
 
@@ -251,7 +258,7 @@ def test_log_DD_TAGS():
     output = cf.logger.calls
 
     assert json.loads(output[0].args[0])["event"] == "Hello!"
-    assert json.loads(output[0].args[0])["dd.trace_id"] == str(span.trace_id)
+    assert json.loads(output[0].args[0])["dd.trace_id"] == str(span._trace_id_64bits)
     assert json.loads(output[0].args[0])["dd.span_id"] == str(span.span_id)
     assert json.loads(output[0].args[0])["dd.env"] == "ddenv"
     assert json.loads(output[0].args[0])["dd.service"] == "ddtagservice"


### PR DESCRIPTION
Updates tests in new logging libraries to reflect new 128 bit trace_id standard. 
The logic remains untouched that 128bit trace_ids continue to only be logged iff `_128_bit_trace_id_logging_enabled` is `True`

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
