### PR TITLE
fix(iast): report cookies

### DIFF
--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -515,43 +515,42 @@ def set_http_meta(
     if retries_remain is not None:
         span.set_tag_str(http.RETRIES_REMAIN, str(retries_remain))
 
-    if asm_config._asm_enabled:
-        from ddtrace.appsec._iast._utils import _is_iast_enabled
+    from ddtrace.appsec._iast._utils import _is_iast_enabled
 
-        if _is_iast_enabled():
-            from ddtrace.appsec._iast.taint_sinks.insecure_cookie import asm_check_cookies
+    if _is_iast_enabled():
+        from ddtrace.appsec._iast.taint_sinks.insecure_cookie import asm_check_cookies
 
-            if request_cookies:
-                asm_check_cookies(request_cookies)
+        if request_cookies:
+            asm_check_cookies(request_cookies)
 
-            if response_cookies:
-                asm_check_cookies(response_cookies)
+        if response_cookies:
+            asm_check_cookies(response_cookies)
 
-        if span.span_type == SpanTypes.WEB:
-            from ddtrace.appsec._asm_request_context import set_waf_address
-            from ddtrace.appsec._constants import SPAN_DATA_NAMES
+    if asm_config._asm_enabled and span.span_type == SpanTypes.WEB:
+        from ddtrace.appsec._asm_request_context import set_waf_address
+        from ddtrace.appsec._constants import SPAN_DATA_NAMES
 
-            status_code = str(status_code) if status_code is not None else None
+        status_code = str(status_code) if status_code is not None else None
 
-            addresses = {
-                k: v
-                for k, v in [
-                    (SPAN_DATA_NAMES.REQUEST_URI_RAW, raw_uri),
-                    (SPAN_DATA_NAMES.REQUEST_METHOD, method),
-                    (SPAN_DATA_NAMES.REQUEST_COOKIES, request_cookies),
-                    (SPAN_DATA_NAMES.REQUEST_QUERY, parsed_query),
-                    (SPAN_DATA_NAMES.REQUEST_HEADERS_NO_COOKIES, request_headers),
-                    (SPAN_DATA_NAMES.RESPONSE_HEADERS_NO_COOKIES, response_headers),
-                    (SPAN_DATA_NAMES.RESPONSE_STATUS, status_code),
-                    (SPAN_DATA_NAMES.REQUEST_PATH_PARAMS, request_path_params),
-                    (SPAN_DATA_NAMES.REQUEST_BODY, request_body),
-                    (SPAN_DATA_NAMES.REQUEST_HTTP_IP, request_ip),
-                    (SPAN_DATA_NAMES.REQUEST_ROUTE, route),
-                ]
-                if v is not None
-            }
-            for k, v in addresses.items():
-                set_waf_address(k, v, span)
+        addresses = {
+            k: v
+            for k, v in [
+                (SPAN_DATA_NAMES.REQUEST_URI_RAW, raw_uri),
+                (SPAN_DATA_NAMES.REQUEST_METHOD, method),
+                (SPAN_DATA_NAMES.REQUEST_COOKIES, request_cookies),
+                (SPAN_DATA_NAMES.REQUEST_QUERY, parsed_query),
+                (SPAN_DATA_NAMES.REQUEST_HEADERS_NO_COOKIES, request_headers),
+                (SPAN_DATA_NAMES.RESPONSE_HEADERS_NO_COOKIES, response_headers),
+                (SPAN_DATA_NAMES.RESPONSE_STATUS, status_code),
+                (SPAN_DATA_NAMES.REQUEST_PATH_PARAMS, request_path_params),
+                (SPAN_DATA_NAMES.REQUEST_BODY, request_body),
+                (SPAN_DATA_NAMES.REQUEST_HTTP_IP, request_ip),
+                (SPAN_DATA_NAMES.REQUEST_ROUTE, route),
+            ]
+            if v is not None
+        }
+        for k, v in addresses.items():
+            set_waf_address(k, v, span)
 
     if route is not None:
         span.set_tag_str(http.ROUTE, route)

--- a/releasenotes/notes/iast-fix-cookie-report-573f444827a1f3f5.yaml
+++ b/releasenotes/notes/iast-fix-cookie-report-573f444827a1f3f5.yaml
@@ -2,4 +2,4 @@
 fixes:
   - |
     Vulnerability Management for Code-level (IAST): Generates cookies vulnerabilities report if IAST is enabled. 
-    Before this fix, Cookies vulnerabilities need both IAST enabled and Appsec enable.
+    Before this fix, Cookies vulnerabilities were only generated if both IAST and Appsec were enabled.

--- a/releasenotes/notes/iast-fix-cookie-report-573f444827a1f3f5.yaml
+++ b/releasenotes/notes/iast-fix-cookie-report-573f444827a1f3f5.yaml
@@ -1,6 +1,5 @@
 ---
 fixes:
   - |
-    Vulnerability Management for Code-level (IAST): IAST is independent of Appsec; ``DD_IAST_ENABLED`` doesn't require 
-    ``DD_APPSEC_ENABLED``. With that, this fix introduces a small refactor when both IAST and ASM check the 
-    request cookies.
+    Vulnerability Management for Code-level (IAST): Generates cookies vulnerabilities report if IAST is enabled. 
+    Before this fix, Cookies vulnerabilities need both IAST enabled and Appsec enable.

--- a/releasenotes/notes/iast-fix-cookie-report-573f444827a1f3f5.yaml
+++ b/releasenotes/notes/iast-fix-cookie-report-573f444827a1f3f5.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Vulnerability Management for Code-level (IAST): IAST is independent of Appsec; ``DD_IAST_ENABLED`` doesn't require 
+    ``DD_APPSEC_ENABLED``. With that, this fix introduces a small refactor when both IAST and ASM check the 
+    request cookies.

--- a/tests/contrib/flask/test_flask_appsec_iast.py
+++ b/tests/contrib/flask/test_flask_appsec_iast.py
@@ -371,7 +371,12 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
                 VULN_SQL_INJECTION,
                 filename=TEST_FILE_PATH,
             )
-            vulnerability = loaded["vulnerabilities"][0]
+            vulnerability = False
+            for vuln in loaded["vulnerabilities"]:
+                if vuln["type"] == VULN_SQL_INJECTION:
+                    vulnerability = vuln
+
+            assert vulnerability, "No {} reported".format(VULN_SQL_INJECTION)
             assert vulnerability["type"] == VULN_SQL_INJECTION
             assert vulnerability["evidence"] == {
                 "valueParts": [{"value": "SELECT 1 FROM "}, {"value": "sqlite_master", "source": 0}]


### PR DESCRIPTION
IAST is independent of Appsec; `iast_enabled` doesn't require `asm_enabled`. With that, this PR introduces a small refactor when both IAST and ASM check the request cookies.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
