### PR TITLE
ci: make black fail pre-commit rather than succeed and modify file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ ddtrace/internal/datadog/profiling/libdatadog/
 .Python
 env/
 build/
+cmake_build/
 develop-eggs/
 dist/
 downloads/

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ ddtrace/internal/datadog/profiling/libdatadog/
 .Python
 env/
 build/
-cmake_build/
 develop-eggs/
 dist/
 downloads/

--- a/hatch.toml
+++ b/hatch.toml
@@ -24,8 +24,10 @@ dependencies = [
 ]
 
 [envs.lint.scripts]
-style = [
+black_check = [
     "black --check -q {args:.}",
+]
+style = [
     "ruff check {args:.}",
     "cython-lint {args:.}",
 ]

--- a/hatch.toml
+++ b/hatch.toml
@@ -25,9 +25,10 @@ dependencies = [
 
 [envs.lint.scripts]
 black_check = [
-    "black --check -q {args:.}",
+    "black --check {args:.}",
 ]
 style = [
+    "black_check",
     "ruff check {args:.}",
     "cython-lint {args:.}",
 ]

--- a/hooks/scripts/run-black.sh
+++ b/hooks/scripts/run-black.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR | grep -E '\.py$')
 if [ -n "$staged_files" ]; then
-    hatch -v run lint:black $staged_files
+    hatch -v run lint:black_check $staged_files
 else
     echo 'hatch style check skipped: No Python files were found in `git diff --staged`'
 fi


### PR DESCRIPTION
Introduces lint:black_check as a new hatch script, and uses it during pre-commit so that pre-commit fails when black would reformat files, rather than reformat the file, succeed, and leave an uncommitted file behind.

This also tweaks .gitignore to ignore cmake_build which was introduced in 3ad6f126c0e7b97a74f58c2ea66ff368ac273b2c .

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
