### PR TITLE
feat(opentelemetry): datadog operation name from semantic conventions

### DIFF
--- a/ddtrace/opentelemetry/_span.py
+++ b/ddtrace/opentelemetry/_span.py
@@ -87,9 +87,6 @@ class Span(OtelSpan):
         if attributes:
             self.set_attributes(attributes)
 
-        # Used to respect https://opentelemetry.io/docs/specs/otel/trace/api/#updatename
-        self._update_name_called = False
-
     @property
     def _record_exception(self):
         # type: () -> bool
@@ -176,12 +173,7 @@ class Span(OtelSpan):
         """Updates the name of a span"""
         if not self.is_recording():
             return
-        # OpenTelemetry spans have one name while Datadog spans can have two different names (operation and resource).
-        # Ensure the resource and operation names are equal for OpenTelemetry spans
-        #
-        self._ddspan.name = name
         self._ddspan.resource = name
-        self._update_name_called = True
 
     def is_recording(self):
         # type: () -> bool
@@ -245,10 +237,6 @@ class Span(OtelSpan):
         # Adapted from https://github.com/DataDog/dd-trace-java/blob/4131e509a94db430b47104769800ec14de5f0a0d/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelConventions.java#L107
         ddspan = self._ddspan
         span_kind = self.kind
-
-        # Respect UpdateName rather than any override
-        if self._update_name_called:
-            return
 
         operation_name = ddspan.get_tag("operation.name")
         if operation_name:

--- a/releasenotes/notes/otel-operation-name-7a2bccb294aed8cd.yaml
+++ b/releasenotes/notes/otel-operation-name-7a2bccb294aed8cd.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    opentelemetry: datadog operation name from semantic conventions

--- a/tests/opentelemetry/test_span.py
+++ b/tests/opentelemetry/test_span.py
@@ -141,7 +141,7 @@ def test_otel_update_span_name(oteltracer):
     with oteltracer.start_span("otel-server") as server:
         assert server._ddspan.name == "otel-server"
         server.update_name("renamed-otel-server")
-    assert server._ddspan.name == "renamed-otel-server"
+    assert server._ddspan.resource == "renamed-otel-server"
 
 
 def test_otel_span_is_recording(oteltracer):

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_ddtrace_mixed_parenting.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_ddtrace_mixed_parenting.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "otel-top-level",
+    "name": "internal",
     "service": null,
     "resource": "otel-top-level",
     "trace_id": 0,
@@ -8,17 +8,18 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "370b7d1e226648e4b58d1faeeb4884d8"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 22384
+      "process_id": 7032
     },
-    "duration": 102104025,
-    "start": 1691164174283288366
+    "duration": 110788667,
+    "start": 1700080043282924092
   },
      {
        "name": "ddtrace-top-level",
@@ -27,8 +28,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "duration": 101975430,
-       "start": 1691164174283377785
+       "duration": 110661292,
+       "start": 1700080043283026467
      },
         {
           "name": "ddtrace-child",
@@ -37,18 +38,18 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "duration": 40291630,
-          "start": 1691164174303607026
+          "duration": 41143250,
+          "start": 1700080043303321550
         },
         {
-          "name": "otel-child",
+          "name": "internal",
           "service": null,
           "resource": "otel-child",
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
-          "duration": 41164537,
-          "start": 1691164174344146455
+          "duration": 49070375,
+          "start": 1700080043344572342
         },
            {
              "name": "ddtrace-grandchild",
@@ -57,16 +58,16 @@
              "trace_id": 0,
              "span_id": 5,
              "parent_id": 4,
-             "duration": 20721650,
-             "start": 1691164174364534600
+             "duration": 25307375,
+             "start": 1700080043368281717
            },
               {
-                "name": "otel-grandchild",
+                "name": "internal",
                 "service": null,
                 "resource": "otel-grandchild",
                 "trace_id": 0,
                 "span_id": 6,
                 "parent_id": 5,
-                "duration": 20354052,
-                "start": 1691164174364742772
+                "duration": 25177958,
+                "start": 1700080043368341134
               }]]

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_multithreading.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_multithreading.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "otel-threading-root",
+    "name": "internal",
     "service": null,
     "resource": "otel-threading-root",
     "trace_id": 0,
@@ -8,163 +8,164 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "29953bb1123f44a79c3c786defdb1bd5"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 34011
+      "process_id": 7032
     },
-    "duration": 90569000,
-    "start": 1675884559879671000
+    "duration": 88410458,
+    "start": 1700080043405226967
   },
      {
-       "name": "s1",
+       "name": "internal",
        "service": null,
        "resource": "s1",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "meta": {
-         "runtime-id": "29953bb1123f44a79c3c786defdb1bd5"
+         "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
        },
        "metrics": {
          "_dd.top_level": 1,
-         "process_id": 34011
+         "process_id": 7032
        },
-       "duration": 90267000,
-       "start": 1675884559879895000
+       "duration": 85156542,
+       "start": 1700080043406178092
      },
         {
-          "name": "s2",
+          "name": "internal",
           "service": null,
           "resource": "s2",
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
-          "duration": 25074000,
-          "start": 1675884559879940000
+          "duration": 23362125,
+          "start": 1700080043406289967
         },
         {
-          "name": "s3",
+          "name": "internal",
           "service": null,
           "resource": "s3",
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
-          "duration": 65061000,
-          "start": 1675884559905077000
+          "duration": 61255875,
+          "start": 1700080043429745967
         },
      {
-       "name": "s1",
+       "name": "internal",
        "service": null,
        "resource": "s1",
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
        "meta": {
-         "runtime-id": "29953bb1123f44a79c3c786defdb1bd5"
+         "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
        },
        "metrics": {
          "_dd.top_level": 1,
-         "process_id": 34011
+         "process_id": 7032
        },
-       "duration": 86943000,
-       "start": 1675884559880036000
+       "duration": 85552833,
+       "start": 1700080043406687134
      },
         {
-          "name": "s2",
+          "name": "internal",
           "service": null,
           "resource": "s2",
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 3,
-          "duration": 25047000,
-          "start": 1675884559880075000
+          "duration": 23411792,
+          "start": 1700080043406774092
         },
         {
-          "name": "s3",
+          "name": "internal",
           "service": null,
           "resource": "s3",
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 3,
-          "duration": 61776000,
-          "start": 1675884559905155000
+          "duration": 61850083,
+          "start": 1700080043430265967
         },
      {
-       "name": "s1",
+       "name": "internal",
        "service": null,
        "resource": "s1",
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
        "meta": {
-         "runtime-id": "29953bb1123f44a79c3c786defdb1bd5"
+         "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
        },
        "metrics": {
          "_dd.top_level": 1,
-         "process_id": 34011
+         "process_id": 7032
        },
-       "duration": 86905000,
-       "start": 1675884559880150000
+       "duration": 85467000,
+       "start": 1700080043407120092
      },
         {
-          "name": "s2",
+          "name": "internal",
           "service": null,
           "resource": "s2",
           "trace_id": 0,
           "span_id": 10,
           "parent_id": 4,
-          "duration": 25005000,
-          "start": 1675884559880182000
+          "duration": 22181375,
+          "start": 1700080043407196592
         },
         {
-          "name": "s3",
+          "name": "internal",
           "service": null,
           "resource": "s3",
           "trace_id": 0,
           "span_id": 11,
           "parent_id": 4,
-          "duration": 61815000,
-          "start": 1675884559905219000
+          "duration": 62950666,
+          "start": 1700080043429524884
         },
      {
-       "name": "s1",
+       "name": "internal",
        "service": null,
        "resource": "s1",
        "trace_id": 0,
        "span_id": 5,
        "parent_id": 1,
        "meta": {
-         "runtime-id": "29953bb1123f44a79c3c786defdb1bd5"
+         "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
        },
        "metrics": {
          "_dd.top_level": 1,
-         "process_id": 34011
+         "process_id": 7032
        },
-       "duration": 86866000,
-       "start": 1675884559880253000
+       "duration": 85444666,
+       "start": 1700080043407564509
      },
         {
-          "name": "s2",
+          "name": "internal",
           "service": null,
           "resource": "s2",
           "trace_id": 0,
           "span_id": 12,
           "parent_id": 5,
-          "duration": 24964000,
-          "start": 1675884559880280000
+          "duration": 22272375,
+          "start": 1700080043407654425
         },
         {
-          "name": "s3",
+          "name": "internal",
           "service": null,
           "resource": "s3",
           "trace_id": 0,
           "span_id": 13,
           "parent_id": 5,
-          "duration": 61841000,
-          "start": 1675884559905263000
+          "duration": 62895166,
+          "start": 1700080043430002634
         }]]

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_span_parenting.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_span_parenting.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "otel-root",
+    "name": "internal",
     "service": null,
     "resource": "otel-root",
     "trace_id": 0,
@@ -8,79 +8,80 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529aa00000000",
       "language": "python",
-      "runtime-id": "370b7d1e226648e4b58d1faeeb4884d8"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 22384
+      "process_id": 7032
     },
-    "duration": 224542605,
-    "start": 1691164174002885806
+    "duration": 261488626,
+    "start": 1700080042950720258
   },
      {
-       "name": "otel-parent1",
+       "name": "internal",
        "service": null,
        "resource": "otel-parent1",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "duration": 101305442,
-       "start": 1691164174023443313
+       "duration": 110618583,
+       "start": 1700080042974075675
      },
         {
-          "name": "otel-child1",
+          "name": "internal",
           "service": null,
           "resource": "otel-child1",
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
-          "duration": 60367898,
-          "start": 1691164174064181692
+          "duration": 65187750,
+          "start": 1700080043019322133
         },
      {
-       "name": "orphan1",
+       "name": "internal",
        "service": null,
        "resource": "orphan1",
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "duration": 102511059,
-       "start": 1691164174124877672
+       "duration": 127379917,
+       "start": 1700080043084759842
      },
      {
-       "name": "otel-parent2",
+       "name": "internal",
        "service": null,
        "resource": "otel-parent2",
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
        "meta": {
-         "runtime-id": "370b7d1e226648e4b58d1faeeb4884d8"
+         "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
        },
        "metrics": {
          "_dd.top_level": 1,
-         "process_id": 22384
+         "process_id": 7032
        },
-       "duration": 101872924,
-       "start": 1691164174125480219
+       "duration": 126974250,
+       "start": 1700080043085104425
      },
         {
-          "name": "otel-child2",
+          "name": "internal",
           "service": null,
           "resource": "otel-child2",
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 4,
           "meta": {
-            "runtime-id": "370b7d1e226648e4b58d1faeeb4884d8"
+            "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
           },
           "metrics": {
             "_dd.top_level": 1,
-            "process_id": 22384
+            "process_id": 7032
           },
-          "duration": 60462788,
-          "start": 1691164174166713523
+          "duration": 79690208,
+          "start": 1700080043132067967
         }]]

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_trace_across_fork.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_trace_across_fork.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "root",
+    "name": "internal",
     "service": null,
     "resource": "root",
     "trace_id": 0,
@@ -8,36 +8,38 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "29953bb1123f44a79c3c786defdb1bd5"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 34011
+      "process_id": 7032
     },
-    "duration": 312973000,
-    "start": 1675884560029513000
+    "duration": 45736250,
+    "start": 1700080043517030634
   },
      {
-       "name": "task",
+       "name": "internal",
        "service": null,
        "resource": "task",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "meta": {
+         "_dd.p.tid": "655529ab00000000",
          "language": "python",
-         "runtime-id": "d0c70dc4dfb240c78a993aed893ddb46",
+         "runtime-id": "9609b5511d35497e8ea3d3a71299ccd0",
          "tracestate": "dd=s:1;t.dm:-0"
        },
        "metrics": {
          "_dd.top_level": 1,
          "_dd.tracer_kr": 1.0,
          "_sampling_priority_v1": 1,
-         "process_id": 34016
+         "process_id": 7039
        },
-       "duration": 21789000,
-       "start": 1675884560245607000
+       "duration": 22333250,
+       "start": 1700080043530690050
      }]]

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_trace_multiple_coroutines.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_trace_multiple_coroutines.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "root",
+    "name": "internal",
     "service": null,
     "resource": "root",
     "trace_id": 0,
@@ -8,55 +8,56 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "370b7d1e226648e4b58d1faeeb4884d8"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 22384
+      "process_id": 7032
     },
-    "duration": 82116289,
-    "start": 1691164174559744704
+    "duration": 100303000,
+    "start": 1700080043577535550
   },
      {
-       "name": "corountine 1",
+       "name": "internal",
        "service": null,
        "resource": "corountine 1",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
-       "duration": 20236068,
-       "start": 1691164174559983603
+       "duration": 24014375,
+       "start": 1700080043577829384
      },
      {
-       "name": "corountine 2",
+       "name": "internal",
        "service": null,
        "resource": "corountine 2",
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
-       "duration": 20310665,
-       "start": 1691164174580484576
+       "duration": 25175167,
+       "start": 1700080043602012175
      },
      {
-       "name": "corountine 3",
+       "name": "internal",
        "service": null,
        "resource": "corountine 3",
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
-       "duration": 20204009,
-       "start": 1691164174600931973
+       "duration": 25196042,
+       "start": 1700080043627275592
      },
      {
-       "name": "corountine 4",
+       "name": "internal",
        "service": null,
        "resource": "corountine 4",
        "trace_id": 0,
        "span_id": 5,
        "parent_id": 1,
-       "duration": 20316636,
-       "start": 1691164174621392975
+       "duration": 25230083,
+       "start": 1700080043652546967
      }]]

--- a/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes.json
+++ b/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "otel-string-tags",
+    "name": "internal",
     "service": "moons-service-str",
     "resource": "otel-string-tags",
     "trace_id": 0,
@@ -9,9 +9,10 @@
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
       "real_string_tag": "rstr",
-      "runtime-id": "2fe461d5fb3a4eef9fe1e1517236403a",
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d",
       "tag1": "one",
       "tag2": "two",
       "tag3": "3",
@@ -21,14 +22,14 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 4171
+      "process_id": 7032
     },
-    "duration": 1216333,
-    "start": 1699977005889436597
+    "duration": 907417,
+    "start": 1700080043692314967
   }],
 [
   {
-    "name": "otel-numerical-tags",
+    "name": "internal",
     "service": "moons-service-num",
     "resource": "otel-numerical-tags",
     "trace_id": 1,
@@ -37,8 +38,9 @@
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "2fe461d5fb3a4eef9fe1e1517236403a"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
@@ -46,11 +48,11 @@
       "_sampling_priority_v1": 1,
       "float_tag": 2.111,
       "int_tag": 1,
-      "process_id": 4171,
+      "process_id": 7032,
       "tag1": 1,
       "tag2": 2,
       "tag3": 3.1415
     },
-    "duration": 186125,
-    "start": 1699977005890878222
+    "duration": 118958,
+    "start": 1700080043693385092
   }]]

--- a/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override0].json
+++ b/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override0].json
@@ -8,15 +8,17 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "1c857ba7ed0a49508c60687b4a8cf74f"
+      "operation.name": "operation-override",
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 4394
+      "process_id": 7032
     },
-    "duration": 174084,
-    "start": 1699977766014929420
+    "duration": 150625,
+    "start": 1700080043703585842
   }]]

--- a/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override1].json
+++ b/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override1].json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "set-service.name",
+    "name": "internal",
     "service": "service-override",
     "resource": "set-service.name",
     "trace_id": 0,
@@ -9,15 +9,16 @@
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "1c857ba7ed0a49508c60687b4a8cf74f"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 4394
+      "process_id": 7032
     },
-    "duration": 104667,
-    "start": 1699977766024527420
+    "duration": 109333,
+    "start": 1700080043711463967
   }]]

--- a/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override2].json
+++ b/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override2].json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "set-resource.name",
+    "name": "internal",
     "service": null,
     "resource": "resource-override",
     "trace_id": 0,
@@ -8,15 +8,16 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "1c857ba7ed0a49508c60687b4a8cf74f"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 4394
+      "process_id": 7032
     },
-    "duration": 109292,
-    "start": 1699977766032865670
+    "duration": 231375,
+    "start": 1700080043717985509
   }]]

--- a/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override3].json
+++ b/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override3].json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "set-span.type",
+    "name": "internal",
     "service": null,
     "resource": "set-span.type",
     "trace_id": 0,
@@ -9,15 +9,16 @@
     "type": "type-override",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "1c857ba7ed0a49508c60687b4a8cf74f"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 4394
+      "process_id": 7032
     },
-    "duration": 73834,
-    "start": 1699977766040078795
+    "duration": 70000,
+    "start": 1700080043724267050
   }]]

--- a/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override4].json
+++ b/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override4].json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "set-analytics.event",
+    "name": "internal",
     "service": null,
     "resource": "set-analytics.event",
     "trace_id": 0,
@@ -8,16 +8,17 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "1c857ba7ed0a49508c60687b4a8cf74f"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_dd1.sr.eausr": 0.5,
       "_sampling_priority_v1": 1,
-      "process_id": 4394
+      "process_id": 7032
     },
-    "duration": 77542,
-    "start": 1699977766045192087
+    "duration": 73625,
+    "start": 1700080043729772259
   }]]

--- a/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_kind.json
+++ b/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_kind.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "otel-client",
+    "name": "client",
     "service": null,
     "resource": "otel-client",
     "trace_id": 0,
@@ -8,22 +8,23 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "86d94e107de5452e80709b37ac12b380",
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d",
       "span.kind": "client"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 32782
+      "process_id": 7032
     },
-    "duration": 60000,
-    "start": 1675884475200541000
+    "duration": 64708,
+    "start": 1700080043734273717
   }],
 [
   {
-    "name": "otel-server",
+    "name": "server",
     "service": null,
     "resource": "otel-server",
     "trace_id": 1,
@@ -31,22 +32,23 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "86d94e107de5452e80709b37ac12b380",
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d",
       "span.kind": "server"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 32782
+      "process_id": 7032
     },
-    "duration": 30000,
-    "start": 1675884475200657000
+    "duration": 45833,
+    "start": 1700080043734405217
   }],
 [
   {
-    "name": "otel-producer",
+    "name": "producer",
     "service": null,
     "resource": "otel-producer",
     "trace_id": 2,
@@ -54,22 +56,23 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "86d94e107de5452e80709b37ac12b380",
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d",
       "span.kind": "producer"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 32782
+      "process_id": 7032
     },
-    "duration": 22000,
-    "start": 1675884475200716000
+    "duration": 39000,
+    "start": 1700080043734499134
   }],
 [
   {
-    "name": "otel-consumer",
+    "name": "consumer",
     "service": null,
     "resource": "otel-consumer",
     "trace_id": 3,
@@ -77,22 +80,23 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "86d94e107de5452e80709b37ac12b380",
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d",
       "span.kind": "consumer"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 32782
+      "process_id": 7032
     },
-    "duration": 21000,
-    "start": 1675884475200766000
+    "duration": 46542,
+    "start": 1700080043734588300
   }],
 [
   {
-    "name": "otel-internal",
+    "name": "internal",
     "service": null,
     "resource": "otel-internal",
     "trace_id": 4,
@@ -100,15 +104,16 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "86d94e107de5452e80709b37ac12b380"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 32782
+      "process_id": 7032
     },
-    "duration": 17000,
-    "start": 1675884475200814000
+    "duration": 29917,
+    "start": 1700080043734681342
   }]]

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_ddtrace_run].json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_ddtrace_run].json
@@ -8,18 +8,18 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "655529ac00000000",
+      "_dd.p.tid": "655535db00000000",
       "language": "python",
-      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
+      "runtime-id": "b4ffa244c11343de919ca20a7e8eebcf"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 7032
+      "process_id": 7703
     },
-    "duration": 15415375,
-    "start": 1700080044520766759
+    "duration": 17414000,
+    "start": 1700083163139832175
   },
      {
        "name": "flask.request",
@@ -32,7 +32,7 @@
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
-         "_dd.p.tid": "655529ac00000000",
+         "_dd.p.tid": "655535db00000000",
          "component": "flask",
          "flask.endpoint": "otel",
          "flask.url_rule": "/otel",
@@ -43,9 +43,9 @@
          "http.url": "http://0.0.0.0:8000/otel",
          "http.useragent": "python-requests/2.28.1",
          "language": "python",
-         "runtime-id": "a8aaa573d8ef4043a8fcfcbeeb55d356",
+         "runtime-id": "a29fc1c052394690a557d5d7a5207798",
          "span.kind": "server",
-         "traceparent": "00-655529ac00000000295c17dbc34c50f8-59365c74e01f16dc-01",
+         "traceparent": "00-655535db000000001e5a01526309382a-a6d82d11c8b9f104-01",
          "tracestate": "dd=s:1;t.dm:-0"
        },
        "metrics": {
@@ -53,10 +53,10 @@
          "_dd.top_level": 1,
          "_dd.tracer_kr": 1.0,
          "_sampling_priority_v1": 1,
-         "process_id": 7042
+         "process_id": 7713
        },
-       "duration": 13032542,
-       "start": 1700080044522790134
+       "duration": 14813125,
+       "start": 1700083163141821300
      },
         {
           "name": "flask.application",
@@ -71,8 +71,8 @@
             "flask.endpoint": "otel",
             "flask.url_rule": "/otel"
           },
-          "duration": 12537167,
-          "start": 1700080044523044176
+          "duration": 14243208,
+          "start": 1700083163142061300
         },
            {
              "name": "flask.try_trigger_before_first_request_functions",
@@ -85,8 +85,8 @@
                "_dd.base_service": "",
                "component": "flask"
              },
-             "duration": 12458,
-             "start": 1700080044523188676
+             "duration": 14625,
+             "start": 1700083163142217383
            },
            {
              "name": "flask.preprocess_request",
@@ -99,8 +99,8 @@
                "_dd.base_service": "",
                "component": "flask"
              },
-             "duration": 18166,
-             "start": 1700080044523289093
+             "duration": 20125,
+             "start": 1700083163142331717
            },
            {
              "name": "flask.dispatch_request",
@@ -113,8 +113,8 @@
                "_dd.base_service": "",
                "component": "flask"
              },
-             "duration": 11887875,
-             "start": 1700080044523362968
+             "duration": 13437750,
+             "start": 1700083163142415633
            },
               {
                 "name": "tests.opentelemetry.flask_app.otel",
@@ -127,8 +127,8 @@
                   "_dd.base_service": "",
                   "component": "flask"
                 },
-                "duration": 11811209,
-                "start": 1700080044523430384
+                "duration": 13354542,
+                "start": 1700083163142480508
               },
                  {
                    "name": "internal",
@@ -140,8 +140,8 @@
                    "meta": {
                      "_dd.base_service": ""
                    },
-                   "duration": 33042,
-                   "start": 1700080044535191301
+                   "duration": 52875,
+                   "start": 1700083163155755800
                  },
            {
              "name": "flask.process_response",
@@ -154,8 +154,8 @@
                "_dd.base_service": "",
                "component": "flask"
              },
-             "duration": 23000,
-             "start": 1700080044535362634
+             "duration": 32375,
+             "start": 1700083163156004175
            },
            {
              "name": "flask.do_teardown_request",
@@ -168,8 +168,8 @@
                "_dd.base_service": "",
                "component": "flask"
              },
-             "duration": 14333,
-             "start": 1700080044535497593
+             "duration": 31625,
+             "start": 1700083163156192133
            },
            {
              "name": "flask.do_teardown_appcontext",
@@ -182,8 +182,8 @@
                "_dd.base_service": "",
                "component": "flask"
              },
-             "duration": 8250,
-             "start": 1700080044535560343
+             "duration": 9292,
+             "start": 1700083163156278258
            },
         {
           "name": "flask.response",
@@ -196,6 +196,6 @@
             "_dd.base_service": "",
             "component": "flask"
           },
-          "duration": 225292,
-          "start": 1700080044535589301
+          "duration": 311541,
+          "start": 1700083163156314342
         }]]

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_ddtrace_run].json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_ddtrace_run].json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "test-otel-distributed-trace",
+    "name": "internal",
     "service": null,
     "resource": "test-otel-distributed-trace",
     "trace_id": 0,
@@ -8,17 +8,18 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ac00000000",
       "language": "python",
-      "runtime-id": "8d35d684fb45476e9eefce2af7928f52"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 500
+      "process_id": 7032
     },
-    "duration": 22783125,
-    "start": 1692985768049390669
+    "duration": 15415375,
+    "start": 1700080044520766759
   },
      {
        "name": "flask.request",
@@ -31,19 +32,20 @@
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
+         "_dd.p.tid": "655529ac00000000",
          "component": "flask",
          "flask.endpoint": "otel",
          "flask.url_rule": "/otel",
-         "flask.version": "1.1.4",
+         "flask.version": "2.1.3",
          "http.method": "GET",
          "http.route": "/otel",
          "http.status_code": "200",
          "http.url": "http://0.0.0.0:8000/otel",
          "http.useragent": "python-requests/2.28.1",
          "language": "python",
-         "runtime-id": "c9c1831139db432cb96bec4f13de02f4",
+         "runtime-id": "a8aaa573d8ef4043a8fcfcbeeb55d356",
          "span.kind": "server",
-         "traceparent": "00-0000000000000000b90d8e59817784be-94120f4149690bb5-01",
+         "traceparent": "00-655529ac00000000295c17dbc34c50f8-59365c74e01f16dc-01",
          "tracestate": "dd=s:1;t.dm:-0"
        },
        "metrics": {
@@ -51,10 +53,10 @@
          "_dd.top_level": 1,
          "_dd.tracer_kr": 1.0,
          "_sampling_priority_v1": 1,
-         "process_id": 510
+         "process_id": 7042
        },
-       "duration": 20940459,
-       "start": 1692985768050919460
+       "duration": 13032542,
+       "start": 1700080044522790134
      },
         {
           "name": "flask.application",
@@ -69,8 +71,8 @@
             "flask.endpoint": "otel",
             "flask.url_rule": "/otel"
           },
-          "duration": 20517875,
-          "start": 1692985768051128919
+          "duration": 12537167,
+          "start": 1700080044523044176
         },
            {
              "name": "flask.try_trigger_before_first_request_functions",
@@ -83,8 +85,8 @@
                "_dd.base_service": "",
                "component": "flask"
              },
-             "duration": 10959,
-             "start": 1692985768051207710
+             "duration": 12458,
+             "start": 1700080044523188676
            },
            {
              "name": "flask.preprocess_request",
@@ -97,8 +99,8 @@
                "_dd.base_service": "",
                "component": "flask"
              },
-             "duration": 13333,
-             "start": 1692985768051270544
+             "duration": 18166,
+             "start": 1700080044523289093
            },
            {
              "name": "flask.dispatch_request",
@@ -111,8 +113,8 @@
                "_dd.base_service": "",
                "component": "flask"
              },
-             "duration": 20136125,
-             "start": 1692985768051315752
+             "duration": 11887875,
+             "start": 1700080044523362968
            },
               {
                 "name": "tests.opentelemetry.flask_app.otel",
@@ -125,11 +127,11 @@
                   "_dd.base_service": "",
                   "component": "flask"
                 },
-                "duration": 20106916,
-                "start": 1692985768051335919
+                "duration": 11811209,
+                "start": 1700080044523430384
               },
                  {
-                   "name": "otel-flask-manual-span",
+                   "name": "internal",
                    "service": "flask",
                    "resource": "otel-flask-manual-span",
                    "trace_id": 0,
@@ -138,8 +140,8 @@
                    "meta": {
                      "_dd.base_service": ""
                    },
-                   "duration": 39500,
-                   "start": 1692985768071392002
+                   "duration": 33042,
+                   "start": 1700080044535191301
                  },
            {
              "name": "flask.process_response",
@@ -152,8 +154,8 @@
                "_dd.base_service": "",
                "component": "flask"
              },
-             "duration": 17250,
-             "start": 1692985768071503002
+             "duration": 23000,
+             "start": 1700080044535362634
            },
            {
              "name": "flask.do_teardown_request",
@@ -166,8 +168,8 @@
                "_dd.base_service": "",
                "component": "flask"
              },
-             "duration": 11958,
-             "start": 1692985768071595252
+             "duration": 14333,
+             "start": 1700080044535497593
            },
            {
              "name": "flask.do_teardown_appcontext",
@@ -180,8 +182,8 @@
                "_dd.base_service": "",
                "component": "flask"
              },
-             "duration": 7917,
-             "start": 1692985768071627585
+             "duration": 8250,
+             "start": 1700080044535560343
            },
         {
           "name": "flask.response",
@@ -194,6 +196,6 @@
             "_dd.base_service": "",
             "component": "flask"
           },
-          "duration": 196500,
-          "start": 1692985768071656294
+          "duration": 225292,
+          "start": 1700080044535589301
         }]]

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_opentelemetry_instrument].json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_opentelemetry_instrument].json
@@ -8,18 +8,18 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "655529ad00000000",
+      "_dd.p.tid": "655535dc00000000",
       "language": "python",
-      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
+      "runtime-id": "b4ffa244c11343de919ca20a7e8eebcf"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 7032
+      "process_id": 7703
     },
-    "duration": 22901500,
-    "start": 1700080045337399676
+    "duration": 24467250,
+    "start": 1700083164080082009
   },
      {
        "name": "server",
@@ -29,7 +29,7 @@
        "span_id": 2,
        "parent_id": 1,
        "meta": {
-         "_dd.p.tid": "655529ad00000000",
+         "_dd.p.tid": "655535dc00000000",
          "http.flavor": "1.1",
          "http.host": "0.0.0.0:8001",
          "http.method": "GET",
@@ -41,7 +41,7 @@
          "http.user_agent": "python-requests/2.28.1",
          "language": "python",
          "net.peer.ip": "127.0.0.1",
-         "runtime-id": "6cb5712ee8324f649ce3857faab3dc67",
+         "runtime-id": "f90fe90fc53a4388b02210639d156981",
          "span.kind": "server",
          "tracestate": "dd=s:1;t.dm:-0"
        },
@@ -50,11 +50,11 @@
          "_dd.tracer_kr": 1.0,
          "_sampling_priority_v1": 0,
          "net.host.port": 8001,
-         "net.peer.port": 59704,
-         "process_id": 7050
+         "net.peer.port": 65508,
+         "process_id": 7721
        },
-       "duration": 341625,
-       "start": 1700080045338622343
+       "duration": 413250,
+       "start": 1700083164081574592
      },
         {
           "name": "internal",
@@ -63,6 +63,6 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "duration": 15583,
-          "start": 1700080045338866510
+          "duration": 18250,
+          "start": 1700083164081867259
         }]]

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_opentelemetry_instrument].json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_opentelemetry_instrument].json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "test-otel-distributed-trace",
+    "name": "internal",
     "service": null,
     "resource": "test-otel-distributed-trace",
     "trace_id": 0,
@@ -8,26 +8,28 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ad00000000",
       "language": "python",
-      "runtime-id": "29953bb1123f44a79c3c786defdb1bd5"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 34011
+      "process_id": 7032
     },
-    "duration": 17919000,
-    "start": 1675884561931051000
+    "duration": 22901500,
+    "start": 1700080045337399676
   },
      {
-       "name": "/otel",
+       "name": "server",
        "service": null,
        "resource": "/otel",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "meta": {
+         "_dd.p.tid": "655529ad00000000",
          "http.flavor": "1.1",
          "http.host": "0.0.0.0:8001",
          "http.method": "GET",
@@ -39,7 +41,7 @@
          "http.user_agent": "python-requests/2.28.1",
          "language": "python",
          "net.peer.ip": "127.0.0.1",
-         "runtime-id": "c6467d51b30d46e0960922cfeddda2a4",
+         "runtime-id": "6cb5712ee8324f649ce3857faab3dc67",
          "span.kind": "server",
          "tracestate": "dd=s:1;t.dm:-0"
        },
@@ -48,19 +50,19 @@
          "_dd.tracer_kr": 1.0,
          "_sampling_priority_v1": 0,
          "net.host.port": 8001,
-         "net.peer.port": 50782,
-         "process_id": 34028
+         "net.peer.port": 59704,
+         "process_id": 7050
        },
-       "duration": 354944,
-       "start": 1675884561932909056
+       "duration": 341625,
+       "start": 1700080045338622343
      },
         {
-          "name": "otel-flask-manual-span",
+          "name": "internal",
           "service": null,
           "resource": "otel-flask-manual-span",
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
-          "duration": 15000,
-          "start": 1675884561933174000
+          "duration": 15583,
+          "start": 1700080045338866510
         }]]

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_with_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_with_default_args.json
@@ -8,15 +8,16 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "86d94e107de5452e80709b37ac12b380"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 32782
+      "process_id": 7032
     },
-    "duration": 60000,
-    "start": 1675884475365464000
+    "duration": 80000,
+    "start": 1700080043775697967
   }]]

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_with_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_with_default_args.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "rename-start-current-span",
+    "name": "internal",
     "service": null,
     "resource": "rename-start-current-span",
     "trace_id": 0,
@@ -8,16 +8,16 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "655529ab00000000",
+      "_dd.p.tid": "655535da00000000",
       "language": "python",
-      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
+      "runtime-id": "b4ffa244c11343de919ca20a7e8eebcf"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 7032
+      "process_id": 7703
     },
-    "duration": 80000,
-    "start": 1700080043775697967
+    "duration": 70875,
+    "start": 1700083162387024633
   }]]

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_without_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_without_default_args.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "root-span",
+    "name": "internal",
     "service": null,
     "resource": "root-span",
     "trace_id": 0,
@@ -8,17 +8,18 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "370b7d1e226648e4b58d1faeeb4884d8"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 22384
+      "process_id": 7032
     },
-    "duration": 176928,
-    "start": 1691164174708472479
+    "duration": 445750,
+    "start": 1700080043780180259
   },
      {
        "name": "rename-start-current-span",

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_without_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_without_default_args.json
@@ -8,21 +8,21 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "655529ab00000000",
+      "_dd.p.tid": "655535da00000000",
       "language": "python",
-      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
+      "runtime-id": "b4ffa244c11343de919ca20a7e8eebcf"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 7032
+      "process_id": 7703
     },
-    "duration": 445750,
-    "start": 1700080043780180259
+    "duration": 472708,
+    "start": 1700083162392162508
   },
      {
-       "name": "rename-start-current-span",
+       "name": "server",
        "service": null,
        "resource": "rename-start-current-span",
        "trace_id": 0,

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_ignore_exceptions.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_ignore_exceptions.json
@@ -8,16 +8,16 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "655529ab00000000",
+      "_dd.p.tid": "655535da00000000",
       "language": "python",
-      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
+      "runtime-id": "b4ffa244c11343de919ca20a7e8eebcf"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 7032
+      "process_id": 7703
     },
-    "duration": 49917,
-    "start": 1700080043771332550
+    "duration": 57583,
+    "start": 1700083162382901633
   }]]

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_ignore_exceptions.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_ignore_exceptions.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "otel-error-span",
+    "name": "internal",
     "service": null,
     "resource": "otel-error-span",
     "trace_id": 0,
@@ -8,15 +8,16 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "86d94e107de5452e80709b37ac12b380"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 32782
+      "process_id": 7032
     },
-    "duration": 294000,
-    "start": 1675884475345037000
+    "duration": 49917,
+    "start": 1700080043771332550
   }]]

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_with_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_with_default_args.json
@@ -8,15 +8,16 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "86d94e107de5452e80709b37ac12b380"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 32782
+      "process_id": 7032
     },
-    "duration": 61728000,
-    "start": 1675884475239846000
+    "duration": 226292,
+    "start": 1700080043759483300
   }]]

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_with_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_with_default_args.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "rename-start-span",
+    "name": "internal",
     "service": null,
     "resource": "rename-start-span",
     "trace_id": 0,
@@ -8,16 +8,16 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "655529ab00000000",
+      "_dd.p.tid": "655535da00000000",
       "language": "python",
-      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
+      "runtime-id": "b4ffa244c11343de919ca20a7e8eebcf"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 7032
+      "process_id": 7703
     },
-    "duration": 226292,
-    "start": 1700080043759483300
+    "duration": 200166,
+    "start": 1700083162370926925
   }]]

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_without_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_without_default_args.json
@@ -1,6 +1,6 @@
 [[
   {
-    "name": "root-span",
+    "name": "internal",
     "service": null,
     "resource": "root-span",
     "trace_id": 0,
@@ -8,17 +8,18 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "655529ab00000000",
       "language": "python",
-      "runtime-id": "370b7d1e226648e4b58d1faeeb4884d8"
+      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 22384
+      "process_id": 7032
     },
-    "duration": 161681,
-    "start": 1691164174693725216
+    "duration": 170666,
+    "start": 1700080043764516509
   },
      {
        "name": "rename-start-span",

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_without_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_without_default_args.json
@@ -8,21 +8,21 @@
     "parent_id": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "655529ab00000000",
+      "_dd.p.tid": "655535da00000000",
       "language": "python",
-      "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
+      "runtime-id": "b4ffa244c11343de919ca20a7e8eebcf"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 7032
+      "process_id": 7703
     },
-    "duration": 170666,
-    "start": 1700080043764516509
+    "duration": 181041,
+    "start": 1700083162375734175
   },
      {
-       "name": "rename-start-span",
+       "name": "client",
        "service": null,
        "resource": "rename-start-span",
        "trace_id": 0,


### PR DESCRIPTION
Resolves: https://github.com/DataDog/dd-trace-py/issues/7543

This changes the mapping of OpenTelemetry semantics to Datadog operation names. 

We are adopting the mapping implemented in [dd-trace-java](https://github.com/DataDog/dd-trace-java/blob/4131e509a94db430b47104769800ec14de5f0a0d/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelConventions.java#L107). 

Testing is covered by system-tests.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
