### PR TITLE
fix(iast): stacktrace leak

### DIFF
--- a/ddtrace/appsec/_iast/_stacktrace.c
+++ b/ddtrace/appsec/_iast/_stacktrace.c
@@ -26,6 +26,7 @@ GET_FILENAME(PyFrameObject* frame)
 {
     PyCodeObject* code = PyFrame_GetCode(frame);
     if (!code) {
+        Py_DECREF(code);
         return NULL;
     }
     return PyObject_GetAttrString((PyObject*)code, "co_filename");
@@ -73,13 +74,11 @@ get_file_and_line(PyObject* Py_UNUSED(module), PyObject* cwd_obj)
     }
     cwd = PyBytes_AsString(cwd_bytes);
     if (!cwd) {
-        Py_DECREF(cwd_bytes);
         goto exit_0;
     }
 
     PyFrameObject* frame = GET_FRAME(tstate);
     if (!frame) {
-        Py_DECREF(cwd_bytes);
         goto exit_0;
     }
 
@@ -124,6 +123,8 @@ exit_0:; // fix: "a label can only be part of a statement and a declaration is n
     PyObject* line_obj = Py_BuildValue("i", 0);
     filename_o = PyUnicode_FromString("");
     result = PyTuple_Pack(2, filename_o, line_obj);
+    Py_DECREF(cwd_bytes);
+    FRAME_XDECREF(frame);
     FILENAME_XDECREF(filename_o);
     Py_DECREF(line_obj);
     return result;

--- a/releasenotes/notes/iast-fix-stacktrace-leak-82032de411963780.yaml
+++ b/releasenotes/notes/iast-fix-stacktrace-leak-82032de411963780.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Vulnerability Management for Code-level (IAST): This fix eliminates some reference leaks and C-API usage when
+    IAST reports a vulnerability and calls ``get_info_frame``.


### PR DESCRIPTION
This PR contiunes the work of @pablogsal and suggestion in this PR https://github.com/DataDog/dd-trace-py/pull/7112

This PR decref a reference for Current directory variable on C file.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
