### PR TITLE
fix(iast): ast patching side effect (#7638) [backport 1.20]

### DIFF
--- a/ddtrace/appsec/iast/_ast/visitor.py
+++ b/ddtrace/appsec/iast/_ast/visitor.py
@@ -393,8 +393,9 @@ class AstVisitor(ast.NodeTransformer):
                 # Send 1 as flag_added_args value
                 call_node.args.insert(0, self._int_constant(call_node, 1))
 
-                # Insert original method as first parameter (a.b.c.method)
-                call_node.args = self._add_original_function_as_arg(call_node, False)
+                # Insert None as first parameter instead of a.b.c.method
+                # to avoid unexpected side effects such as a.b.read(4).method
+                call_node.args.insert(0, self._none_constant(call_node))
 
                 # Create a new Name node for the replacement and set it as node.func
                 call_node.func = self._attr_node(call_node, aspect)

--- a/ddtrace/appsec/iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/iast/_taint_tracking/aspects.py
@@ -51,13 +51,15 @@ def add_aspect(op1, op2):
 
 
 def str_aspect(orig_function, flag_added_args, *args, **kwargs):
-    # type: (Callable, int, Any, Any) -> str
-    if orig_function != builtin_str:
-        if flag_added_args > 0:
-            args = args[flag_added_args:]
-        return orig_function(*args, **kwargs)
-
-    result = builtin_str(*args, **kwargs)
+    # type: (Optional[Callable], int, Any, Any) -> str
+    if orig_function:
+        if orig_function != builtin_str:
+            if flag_added_args > 0:
+                args = args[flag_added_args:]
+            return orig_function(*args, **kwargs)
+        result = builtin_str(*args, **kwargs)
+    else:
+        result = args[0].str(*args[1:], **kwargs)
 
     if isinstance(args[0], TEXT_TYPES) and is_pyobject_tainted(args[0]):
         try:
@@ -75,13 +77,16 @@ def str_aspect(orig_function, flag_added_args, *args, **kwargs):
 
 
 def bytes_aspect(orig_function, flag_added_args, *args, **kwargs):
-    # type: (Callable, int, Any, Any) -> bytes
-    if orig_function != builtin_bytes:
-        if flag_added_args > 0:
-            args = args[flag_added_args:]
-        return orig_function(*args, **kwargs)
+    # type: (Optional[Callable], int, Any, Any) -> bytes
+    if orig_function:
+        if orig_function != builtin_bytes:
+            if flag_added_args > 0:
+                args = args[flag_added_args:]
+            return orig_function(*args, **kwargs)
+        result = builtin_bytes(*args, **kwargs)
+    else:
+        result = args[0].bytes(*args[1:], **kwargs)
 
-    result = builtin_bytes(*args, **kwargs)
     if isinstance(args[0], TEXT_TYPES) and is_pyobject_tainted(args[0]):
         try:
             taint_pyobject_with_ranges(result, tuple(get_ranges(args[0])))
@@ -91,13 +96,16 @@ def bytes_aspect(orig_function, flag_added_args, *args, **kwargs):
 
 
 def bytearray_aspect(orig_function, flag_added_args, *args, **kwargs):
-    # type: (Callable, int, Any, Any) -> bytearray
-    if orig_function != builtin_bytearray:
-        if flag_added_args > 0:
-            args = args[flag_added_args:]
-        return orig_function(*args, **kwargs)
+    # type: (Optional[Callable], int, Any, Any) -> bytearray
+    if orig_function:
+        if orig_function != builtin_bytearray:
+            if flag_added_args > 0:
+                args = args[flag_added_args:]
+            return orig_function(*args, **kwargs)
+        result = builtin_bytearray(*args, **kwargs)
+    else:
+        result = args[0].bytearray(*args[1:], **kwargs)
 
-    result = builtin_bytearray(*args, **kwargs)
     if isinstance(args[0], TEXT_TYPES) and is_pyobject_tainted(args[0]):
         try:
             taint_pyobject_with_ranges(result, tuple(get_ranges(args[0])))
@@ -107,7 +115,9 @@ def bytearray_aspect(orig_function, flag_added_args, *args, **kwargs):
 
 
 def join_aspect(orig_function, flag_added_args, *args, **kwargs):
-    # type: (Callable, int, Any, Any) -> Any
+    # type: (Optional[Callable], int, Any, Any) -> Any
+    if not orig_function:
+        orig_function = args[0].join
     if not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
@@ -125,16 +135,22 @@ def join_aspect(orig_function, flag_added_args, *args, **kwargs):
 
 
 def bytearray_extend_aspect(orig_function, flag_added_args, *args, **kwargs):
-    # type: (Callable, int, Any, Any) -> Any
-    if not isinstance(orig_function, BuiltinFunctionType):
+    # type: (Optional[Callable], int, Any, Any) -> Any
+    if orig_function and not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
 
+    if len(args) < 2:
+        # If we're not receiving at least 2 arguments, means the call was
+        # ``x.extend()`` and not ``x.extend(y)``
+        # so either not the extend we're looking for, or no changes in taint ranges.
+        return args[0].extend(*args[1:], **kwargs)
+
     op1 = args[0]
     op2 = args[1]
     if not isinstance(op1, bytearray) or not isinstance(op2, (bytearray, bytes)):
-        return op1.extend(op2)
+        return op1.extend(*args[1:], **kwargs)
     try:
         return _extend_aspect(op1, op2)
     except Exception as e:
@@ -184,7 +200,9 @@ def build_string_aspect(*args):  # type: (List[Any]) -> str
 
 
 def ljust_aspect(orig_function, flag_added_args, *args, **kwargs):
-    # type: (Callable, int, Any, Any) -> Union[str, bytes, bytearray]
+    # type: (Optional[Callable], int, Any, Any) -> Union[str, bytes, bytearray]
+    if not orig_function:
+        orig_function = args[0].ljust
     if not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
@@ -219,8 +237,8 @@ def ljust_aspect(orig_function, flag_added_args, *args, **kwargs):
 
 
 def zfill_aspect(orig_function, flag_added_args, *args, **kwargs):
-    # type: (Callable, int, Any, Any) -> Any
-    if not isinstance(orig_function, BuiltinFunctionType):
+    # type: (Optional[Callable], int, Any, Any) -> Any
+    if orig_function and not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
@@ -261,11 +279,14 @@ def zfill_aspect(orig_function, flag_added_args, *args, **kwargs):
 
 
 def format_aspect(
-    orig_function,  # type: Callable
+    orig_function,  # type: Optional[Callable]
     flag_added_args,  # type: int
     *args,  # type: Any
     **kwargs  # type: Dict[str, Any]
 ):  # type: (...) -> str
+    if not orig_function:
+        orig_function = args[0].format
+
     if not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
@@ -312,8 +333,10 @@ def format_aspect(
     return result
 
 
-def format_map_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Callable, int, Any, Any) -> str
-    if not isinstance(orig_function, BuiltinFunctionType):
+def format_map_aspect(
+    orig_function, flag_added_args, *args, **kwargs
+):  # type: (Optional[Callable], int, Any, Any) -> str
+    if orig_function and not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
@@ -460,12 +483,14 @@ def incremental_translation(self, incr_coder, funcode, empty):
 
 
 def decode_aspect(orig_function, flag_added_args, *args, **kwargs):
-    if flag_added_args > 0:
-        self = args[0]
-        args = args[flag_added_args:]
-    else:
+    if orig_function and not flag_added_args:
+        # This patch is unexpected, so we fallback
+        # to executing the original function
         return orig_function(*args, **kwargs)
 
+    self = args[0]
+    args = args[(flag_added_args or 1) :]
+    # Assume we call decode method of the first argument
     result = self.decode(*args, **kwargs)
 
     if not is_pyobject_tainted(self) or not isinstance(self, bytes):
@@ -481,12 +506,14 @@ def decode_aspect(orig_function, flag_added_args, *args, **kwargs):
 
 
 def encode_aspect(orig_function, flag_added_args, *args, **kwargs):
-    if flag_added_args > 0:
-        self = args[0]
-        args = args[flag_added_args:]
-    else:
+    if orig_function and not flag_added_args:
+        # This patch is unexpected, so we fallback
+        # to executing the original function
         return orig_function(*args, **kwargs)
 
+    self = args[0]
+    args = args[(flag_added_args or 1) :]
+    # Assume we call encode method of the first argument
     result = self.encode(*args, **kwargs)
 
     if not is_pyobject_tainted(self) or not isinstance(self, str):
@@ -501,8 +528,10 @@ def encode_aspect(orig_function, flag_added_args, *args, **kwargs):
     return result
 
 
-def upper_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Callable, int, Any, Any) -> TEXT_TYPE
-    if not isinstance(orig_function, BuiltinFunctionType):
+def upper_aspect(
+    orig_function, flag_added_args, *args, **kwargs
+):  # type: (Optional[Callable], int, Any, Any) -> TEXT_TYPE
+    if orig_function and not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
@@ -519,8 +548,10 @@ def upper_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Cal
         return candidate_text.upper(*args, **kwargs)
 
 
-def lower_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Callable, int, Any, Any) -> TEXT_TYPE
-    if not isinstance(orig_function, BuiltinFunctionType):
+def lower_aspect(
+    orig_function, flag_added_args, *args, **kwargs
+):  # type: (Optional[Callable], int, Any, Any) -> TEXT_TYPE
+    if orig_function and not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
@@ -528,8 +559,6 @@ def lower_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Cal
     candidate_text = args[0]
     args = args[flag_added_args:]
     if not isinstance(candidate_text, TEXT_TYPES):
-        if flag_added_args > 0:
-            args = args[flag_added_args:]
         return candidate_text.lower(*args, **kwargs)
 
     try:
@@ -539,8 +568,10 @@ def lower_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Cal
         return candidate_text.lower(*args, **kwargs)
 
 
-def swapcase_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Callable, int, Any, Any) -> TEXT_TYPE
-    if not isinstance(orig_function, BuiltinFunctionType):
+def swapcase_aspect(
+    orig_function, flag_added_args, *args, **kwargs
+):  # type: (Optional[Callable], int, Any, Any) -> TEXT_TYPE
+    if orig_function and not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
@@ -556,8 +587,10 @@ def swapcase_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (
         return candidate_text.swapcase(*args, **kwargs)
 
 
-def title_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Callable, int, Any, Any) -> TEXT_TYPE
-    if not isinstance(orig_function, BuiltinFunctionType):
+def title_aspect(
+    orig_function, flag_added_args, *args, **kwargs
+):  # type: (Optional[Callable], int, Any, Any) -> TEXT_TYPE
+    if orig_function and not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
@@ -573,8 +606,10 @@ def title_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Cal
         return candidate_text.title(*args, **kwargs)
 
 
-def capitalize_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Callable, int, Any, Any) -> TEXT_TYPE
-    if not isinstance(orig_function, BuiltinFunctionType):
+def capitalize_aspect(
+    orig_function, flag_added_args, *args, **kwargs
+):  # type: (Optional[Callable], int, Any, Any) -> TEXT_TYPE
+    if orig_function and not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
@@ -591,16 +626,21 @@ def capitalize_aspect(orig_function, flag_added_args, *args, **kwargs):  # type:
         return candidate_text.capitalize(*args, **kwargs)
 
 
-def casefold_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Callable, int, Any, Any) -> TEXT_TYPE
-    if not isinstance(orig_function, BuiltinFunctionType):
+def casefold_aspect(
+    orig_function, flag_added_args, *args, **kwargs
+):  # type: (Optional[Callable], int, Any, Any) -> TEXT_TYPE
+    if orig_function:
+        if not isinstance(orig_function, BuiltinFunctionType):
+            if flag_added_args > 0:
+                args = args[flag_added_args:]
+            return orig_function(*args, **kwargs)
+    else:
+        orig_function = getattr(args[0], "casefold", None)
+
+    if orig_function and orig_function.__qualname__ not in ("str.casefold", "bytes.casefold", "bytearray.casefold"):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
-
-    if orig_function.__qualname__ not in ("str.casefold", "bytes.casefold", "bytearray.casefold"):
-        if flag_added_args > 0:
-            args = args[flag_added_args:]
-        return orig_function(args, **kwargs)
 
     candidate_text = args[0]
     args = args[flag_added_args:]
@@ -615,8 +655,10 @@ def casefold_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (
         return candidate_text.casefold(*args, **kwargs)  # type: ignore[union-attr]
 
 
-def translate_aspect(orig_function, flag_added_args, *args, **kwargs):  # type: (Callable, int, Any, Any) -> TEXT_TYPE
-    if not isinstance(orig_function, BuiltinFunctionType):
+def translate_aspect(
+    orig_function, flag_added_args, *args, **kwargs
+):  # type: (Optional[Callable], int, Any, Any) -> TEXT_TYPE
+    if orig_function and not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)

--- a/releasenotes/notes/iast-fix-patching-side-effect-56d0b168e74839fc.yaml
+++ b/releasenotes/notes/iast-fix-patching-side-effect-56d0b168e74839fc.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Vulnerability Management for Code-level (IAST): This fix resolves an issue where, at AST patching to replace code with IAST aspects, passing the original function/method as an extra parameter for accurate patching unintentionally triggers side effects in methods obtained from an expression (like ``decode`` in ``file.read(n).decode()``), resulting in unexpected multiple calls to the expression (``file.read(n)`` in the example).

--- a/tests/appsec/iast/_ast/fixtures/misleading_methods.py
+++ b/tests/appsec/iast/_ast/fixtures/misleading_methods.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import tests.appsec.iast.fixtures.aspects.callees as callees_module
+
+
+class FakeStr(str):
+    def __init__(self, *args, **kwargs):
+        for i in [x for x in dir(callees_module) if not x.startswith(("_", "@"))]:
+            setattr(self, i, getattr(callees_module, i))
+
+    def call_ljust(self, *args, **kwargs):
+        return self.ljust(*args, **kwargs)
+
+    def call_join(self, *args, **kwargs):
+        return self.join(*args, **kwargs)
+
+    def call_zfill(self, *args, **kwargs):
+        return self.zfill(*args, **kwargs)
+
+    def call_format(self, *args, **kwargs):
+        return self.format(*args, **kwargs)
+
+    def call_format_map(self, *args, **kwargs):
+        return self.format_map(*args, **kwargs)
+
+    def call_repr(self, *args, **kwargs):
+        return self.repr(*args, **kwargs)
+
+    def call_upper(self, *args, **kwargs):
+        return self.upper(*args, **kwargs)
+
+    def call_lower(self, *args, **kwargs):
+        return self.lower(*args, **kwargs)
+
+    def call_casefold(self, *args, **kwargs):
+        return self.casefold(*args, **kwargs)
+
+    def call_capitalize(self, *args, **kwargs):
+        return self.capitalize(*args, **kwargs)
+
+    def call_title(self, *args, **kwargs):
+        return self.title(*args, **kwargs)
+
+    def call_swapcase(self, *args, **kwargs):
+        return self.swapcase(*args, **kwargs)
+
+    def call_translate(self, *args, **kwargs):
+        return self.translate(*args, **kwargs)
+
+    def call_extend(self, *args, **kwargs):
+        return self.extend(*args, **kwargs)
+
+    def call_encode(self, *args, **kwargs):
+        return self.encode(*args, **kwargs)
+
+    def call_decode(self, *args, **kwargs):
+        return self.decode(*args, **kwargs)
+
+    def call_str(self, *args, **kwargs):
+        return self.str(*args, **kwargs)
+
+    def call_bytes(self, *args, **kwargs):
+        return self.bytes(*args, **kwargs)
+
+    def call_bytearray(self, *args, **kwargs):
+        return self.bytearray(*args, **kwargs)

--- a/tests/appsec/iast/_ast/test_proper_patching.py
+++ b/tests/appsec/iast/_ast/test_proper_patching.py
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+import pytest
+
+
+try:
+    from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
+    from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
+    from tests.appsec.iast.aspects.aspect_utils import create_taint_range_with_format
+    from tests.appsec.iast.aspects.conftest import _iast_patched_module
+except (ImportError, AttributeError):
+    pytest.skip("IAST not supported for this Python version", allow_module_level=True)
+
+mod = _iast_patched_module("tests.appsec.iast._ast.fixtures.misleading_methods")
+
+
+class TestProperMethodsReplacement(BaseReplacement):
+    @pytest.mark.parametrize("method", [x for x in dir(mod.FakeStr()) if x.startswith("call_")])
+    def test_string_proper_method_called(self, method):
+        """
+        Methods should not be replaced by the aspect since it's not the builtin method
+        """
+        input_str = "foo"
+
+        string_argument1 = create_taint_range_with_format(":+-b-+:")
+
+        result = getattr(mod.FakeStr(input_str), method)(input_str, string_argument1)
+
+        as_formatted_evidence_result = as_formatted_evidence(result)
+        assert ":+-" not in as_formatted_evidence_result
+        assert "--" in as_formatted_evidence_result
+        assert "foo" in as_formatted_evidence_result
+        assert "b" in as_formatted_evidence_result

--- a/tests/appsec/iast/aspects/test_common_aspects_generator.py
+++ b/tests/appsec/iast/aspects/test_common_aspects_generator.py
@@ -16,57 +16,68 @@ except (ImportError, AttributeError):
 
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
 import tests.appsec.iast.fixtures.aspects.callees
+import tests.appsec.iast.fixtures.aspects.obj_callees
 
 
-def generate_callers_from_callees(callees_module, callers_file="", callees_module_str=""):
+def generate_callers_from_callees(functions_module, callees_module, callers_file="", callees_module_str=""):
     """
     Generate a callers module from a callees module, calling all it's functions.
     """
-    module_functions = [x for x in dir(callees_module) if not x.startswith(("_", "@"))]
+    module_functions = [x for x in dir(functions_module) if not x.startswith(("_", "@", "join"))]
 
     with open(callers_file, "w", encoding="utf-8") as callers:
         callers.write(f"from {callees_module_str} import *\n")
-        callers.write(f"import {callees_module_str} as _original_callees\n")
+        callers.write(f"from {callees_module_str} import _number_generator\n")
+        callers.write("_ng = _number_generator()\n")
 
         for function in module_functions:
             callers.write(
                 f"""
-def callee_{function}(*args, **kwargs):
-    return _original_callees.{function}(*args, **kwargs)
 
-def callee_{function}_direct(*args, **kwargs):
-    return {function}(*args, **kwargs)\n
+def generator_call_{function}(*args, **kwargs):
+    return next(_ng).{function}(*args, **kwargs)
             """
             )
 
 
-PATCHED_CALLERS_FILE = "tests/appsec/iast/fixtures/aspects/callers.py"
-UNPATCHED_CALLERS_FILE = "tests/appsec/iast/fixtures/aspects/unpatched_callers.py"
+PATCHED_CALLERS_FILE = "tests/appsec/iast/fixtures/aspects/obj_callers.py"
+UNPATCHED_CALLERS_FILE = "tests/appsec/iast/fixtures/aspects/unpatched_obj_callers.py"
+FUNCTIONS_MODULE = tests.appsec.iast.fixtures.aspects.callees
+CALLEES_MODULE = "tests.appsec.iast.fixtures.aspects.obj_callees"
+
 
 for _file in (PATCHED_CALLERS_FILE, UNPATCHED_CALLERS_FILE):
     generate_callers_from_callees(
+        functions_module=FUNCTIONS_MODULE,
         callers_file=_file,
-        callees_module=tests.appsec.iast.fixtures.aspects.callees,
-        callees_module_str="tests.appsec.iast.fixtures.aspects.callees",
+        callees_module=tests.appsec.iast.fixtures.aspects.obj_callees,
+        callees_module_str=CALLEES_MODULE,
     )
 
 patched_callers = _iast_patched_module(PATCHED_CALLERS_FILE.replace("/", ".")[0:-3])
 # This import needs to be done after the file is created (previous line)
 # pylint: disable=[wrong-import-position],[no-name-in-module]
-from tests.appsec.iast.fixtures.aspects import unpatched_callers  # type: ignore[attr-defined] # noqa: E402
+from tests.appsec.iast.fixtures.aspects import unpatched_obj_callers  # type: ignore[attr-defined] # noqa: E402
 
 
-@pytest.mark.parametrize("aspect", [x for x in dir(unpatched_callers) if not x.startswith(("_", "@"))])
-@pytest.mark.parametrize("args", [(), ("a"), ("a", "b")])
+@pytest.mark.parametrize("aspect", [x for x in dir(unpatched_obj_callers) if not x.startswith(("@", "_", "FakeStr"))])
+@pytest.mark.parametrize(
+    "args",
+    [
+        (),
+        ("a"),
+        ("a", "b"),
+    ],
+)
 @pytest.mark.parametrize("kwargs", [{}, {"dry_run": False}, {"dry_run": True}])
 def test_aspect_patched_result(aspect, args, kwargs):
     """
     Test that the result of the patched aspect call is the same as the unpatched one.
     """
-    assert getattr(patched_callers, aspect)(*args, **kwargs) == getattr(unpatched_callers, aspect)(*args, **kwargs)
+    assert getattr(patched_callers, aspect)(*args, **kwargs) == getattr(unpatched_obj_callers, aspect)(*args, **kwargs)
 
 
-def teardown():
+def teardown_module(_):
     """
     Remove the callers file after the tests are done.
     """

--- a/tests/appsec/iast/fixtures/aspects/callees.py
+++ b/tests/appsec/iast/fixtures/aspects/callees.py
@@ -37,6 +37,10 @@ def zfill(*args, **kwargs):
     return "--".join(("zfill", _builtins.str(args), _builtins.str(kwargs)))
 
 
+def format(*args, **kwargs):  # noqa: A001
+    return "--".join(("format", _builtins.str(args), _builtins.str(kwargs)))
+
+
 def format_map(*args, **kwargs):
     return "--".join(("format_map", _builtins.str(args), _builtins.str(kwargs)))
 

--- a/tests/appsec/iast/fixtures/aspects/obj_callees.py
+++ b/tests/appsec/iast/fixtures/aspects/obj_callees.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import builtins as _builtins
+
+
+def _number_generator():
+    number = 0
+    while True:
+        number += 1
+        yield FakeStr(_builtins.str(number))
+
+
+class FakeStr(str):
+    # Yeah, we want the join of the str to work as self.join, so we're not overriding
+    # join or doing this aspect tests in this case
+    #
+    # def join(self, *args, **kwargs):
+    #     return self.join(("join", _builtins.str(args), _builtins.str(kwargs)))
+
+    def extend(self, *args, **kwargs):
+        return self.join(("extend", _builtins.str(args), _builtins.str(kwargs)))
+
+    def encode(self, *args, **kwargs):
+        return self.join(("encode", _builtins.str(args), _builtins.str(kwargs)))
+
+    def decode(self, *args, **kwargs):
+        return self.join(("decode", _builtins.str(args), _builtins.str(kwargs)))
+
+    def str(self, *args, **kwargs):  # noqa: A001
+        return self.join(("_builtins.str", _builtins.str(args), _builtins.str(kwargs)))
+
+    def bytes(self, *args, **kwargs):  # noqa: A001
+        return self.join(("bytes", _builtins.str(args), _builtins.str(kwargs)))
+
+    def bytearray(self, *args, **kwargs):  # noqa: A001
+        return self.join(("bytearray", _builtins.str(args), _builtins.str(kwargs)))
+
+    def ljust(self, *args, **kwargs):
+        return self.join(("ljust", _builtins.str(args), _builtins.str(kwargs)))
+
+    def zfill(self, *args, **kwargs):
+        return self.join(("zfill", _builtins.str(args), _builtins.str(kwargs)))
+
+    def format(self, *args, **kwargs):  # noqa: A001
+        return self.join(("format", _builtins.str(args), _builtins.str(kwargs)))
+
+    def format_map(self, *args, **kwargs):
+        return self.join(("format_map", _builtins.str(args), _builtins.str(kwargs)))
+
+    def repr(self, *args, **kwargs):  # noqa: A001
+        return self.join(("repr", _builtins.str(args), _builtins.str(kwargs)))
+
+    def upper(self, *args, **kwargs):
+        return self.join(("upper", _builtins.str(args), _builtins.str(kwargs)))
+
+    def lower(self, *args, **kwargs):
+        return self.join(("lower", _builtins.str(args), _builtins.str(kwargs)))
+
+    def swapcase(self, *args, **kwargs):
+        return self.join(("swapcase", _builtins.str(args), _builtins.str(kwargs)))
+
+    def title(self, *args, **kwargs):
+        return self.join(("title", _builtins.str(args), _builtins.str(kwargs)))
+
+    def capitalize(self, *args, **kwargs):
+        return self.join(("capitalize", _builtins.str(args), _builtins.str(kwargs)))
+
+    def casefold(self, *args, **kwargs):
+        return self.join(("casefold", _builtins.str(args), _builtins.str(kwargs)))
+
+    def translate(self, *args, **kwargs):
+        return self.join(("translate", _builtins.str(args), _builtins.str(kwargs)))


### PR DESCRIPTION
IAST: This fix resolves an issue where, at AST patching to replace code with IAST aspects, the original function/method was passed as an extra parameter for accurate patching (i.e. check the function inside the aspect), and this strategy lead to unintentionally triggers side effects in methods obtained from an expression (like ``decode`` in ``file.read(n).decode()``), resulting in unexpected multiple calls to the expression (``file.read(n)`` in the example).

# Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

# Reviewer
- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

---------

Co-authored-by: Alberto Vara <alberto.vara@datadoghq.com>
(cherry picked from commit 601fd6ab7f1eef11134ece39f0d8fd9fa4386f9c)