### PR TITLE
fix(setuptools): update deprecated license format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ddtrace"
 dynamic = ["version"]
 description = "Datadog APM client library"
 readme = "README.md"
-# license-files = { paths = ["LICENSE.BSD3"] }
+license = { text = "LICENSE.BSD3" }
 requires-python = ">=3.7"
 authors = [
     { name = "Datadog, Inc.", email = "dev@datadoghq.com" },

--- a/releasenotes/notes/fix-setuptools-license-c061c22889799c6c.yaml
+++ b/releasenotes/notes/fix-setuptools-license-c061c22889799c6c.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fixes an issue where ddtrace could not be installed from source when using `setuptools>=69` due to a change in the license field.
+    Fixes an issue where ddtrace could not be installed from source when using ``setuptools>=69`` due to a change in the license field.

--- a/releasenotes/notes/fix-setuptools-license-c061c22889799c6c.yaml
+++ b/releasenotes/notes/fix-setuptools-license-c061c22889799c6c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes an issue where ddtrace could not be installed from source when using `setuptools>=69` due to a change in the license field.


### PR DESCRIPTION
Resolves: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/50959/workflows/fc3694ee-c64a-4a56-bd74-94ef0a9d0552/jobs/3258065

This error prevents ddtrace from being installed from source.

This issue was introduced by setuptools v69: https://setuptools.pypa.io/en/stable/history.html#deprecations-and-removals

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
