### PR TITLE
fix(structlog): appends to `default_processors` via list to avoid TypingError (backport 7679) 

### DIFF
--- a/ddtrace/contrib/structlog/patch.py
+++ b/ddtrace/contrib/structlog/patch.py
@@ -48,8 +48,18 @@ def _tracer_injection(_, __, event_dict):
 
 
 def _w_get_logger(func, instance, args, kwargs):
+    """
+    Append the tracer injection processor to the ``default_processors`` list used by the logger
+    The ``default_processors`` list has built in defaults which protects against a user configured ``None`` value.
+    The argument to configure ``default_processors`` accepts an iterable type:
+        - List: default use case which has been accounted for
+        - Tuple: patched via list conversion
+        - Set: ignored because structlog processors care about order notably the last value to be a Renderer
+        - Dict: because keys are ignored, this essentially becomes a List
+    """
+
     dd_processor = [_tracer_injection]
-    structlog._config._CONFIG.default_processors = dd_processor + structlog._config._CONFIG.default_processors
+    structlog._config._CONFIG.default_processors = dd_processor + list(structlog._config._CONFIG.default_processors)
     return func(*args, **kwargs)
 
 

--- a/releasenotes/notes/fix_structlog_processor_list-037c90b391dbfbc2.yaml
+++ b/releasenotes/notes/fix_structlog_processor_list-037c90b391dbfbc2.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    structlog: Fixes ``TypeError`` raised when ddtrace log processor is configured with a tuple


### PR DESCRIPTION
…eError (#7679)

Fixes #7665 by changing `default_processors` to list accounting for all types of iterables before appending

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

