### PR TITLE
fix(tracer): fix multiprocessing queue on aws lambda (backport 7612)

### DIFF
--- a/scripts/releasenotes/notes/do-not-use-multiprocessing-queue-in-aws-lambda-99fd75820125906f.yaml
+++ b/scripts/releasenotes/notes/do-not-use-multiprocessing-queue-in-aws-lambda-99fd75820125906f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    lambda: This change disables the use of ``multiprocessing.queue`` in Lambda, because it is not supported in Lambda


### PR DESCRIPTION
## Checklist

- [x] Change(s) are motivated and described in the PR description.

## Reviewer Checklist

- [x] Title is accurate.

