### PR TITLE
refactor(writer): handle agent responses in the tracer

### DIFF
--- a/ddtrace/internal/ci_visibility/writer.py
+++ b/ddtrace/internal/ci_visibility/writer.py
@@ -28,8 +28,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Dict  # noqa:F401
     from typing import List  # noqa:F401
 
-    from ...sampler import BaseSampler  # noqa:F401
-
 
 class CIVisibilityEventClient(WriterClientBase):
     def __init__(self):
@@ -80,7 +78,6 @@ class CIVisibilityWriter(HTTPWriter):
     def __init__(
         self,
         intake_url="",  # type: str
-        sampler=None,  # type: Optional[BaseSampler]
         processing_interval=None,  # type: Optional[float]
         timeout=None,  # type: Optional[float]
         dogstatsd=None,  # type: Optional[DogStatsd]
@@ -128,7 +125,6 @@ class CIVisibilityWriter(HTTPWriter):
         super(CIVisibilityWriter, self).__init__(
             intake_url=intake_url,
             clients=clients,
-            sampler=sampler,
             processing_interval=processing_interval,
             timeout=timeout,
             dogstatsd=dogstatsd,
@@ -145,7 +141,6 @@ class CIVisibilityWriter(HTTPWriter):
         # type: () -> HTTPWriter
         return self.__class__(
             intake_url=self.intake_url,
-            sampler=self._sampler,
             processing_interval=self._interval,
             timeout=self._timeout,
             dogstatsd=self.dogstatsd,

--- a/ddtrace/internal/writer/__init__.py
+++ b/ddtrace/internal/writer/__init__.py
@@ -1,3 +1,4 @@
+from .writer import AgentResponse  # noqa: I001,F401
 from .writer import AgentWriter  # noqa:I001,F401
 from .writer import DEFAULT_SMA_WINDOW  # noqa:F401
 from .writer import HTTPWriter  # noqa:F401

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -6,6 +6,7 @@ import os
 import sys
 import threading
 from typing import TYPE_CHECKING  # noqa:F401
+from typing import Any  # noqa:F401
 from typing import Dict  # noqa:F401
 from typing import List  # noqa:F401
 from typing import Optional  # noqa:F401
@@ -24,8 +25,6 @@ from ...internal import telemetry
 from ...internal.utils.formats import parse_tags_str
 from ...internal.utils.http import Response
 from ...internal.utils.time import StopWatch
-from ...sampler import BasePrioritySampler
-from ...sampler import BaseSampler  # noqa:F401
 from .. import compat
 from .. import periodic
 from .. import service
@@ -44,6 +43,7 @@ from .writer_client import WriterClientBase  # noqa:F401
 
 
 if TYPE_CHECKING:  # pragma: no cover
+    from typing import Callable  # noqa:F401
     from typing import Tuple  # noqa:F401
 
     from ddtrace import Span  # noqa:F401
@@ -104,10 +104,8 @@ class LogWriter(TraceWriter):
     def __init__(
         self,
         out=sys.stdout,  # type: TextIO
-        sampler=None,  # type: Optional[BaseSampler]
     ):
         # type: (...) -> None
-        self._sampler = sampler
         self.encoder = JSONEncoderV2()
         self.out = out
 
@@ -118,7 +116,7 @@ class LogWriter(TraceWriter):
         :rtype: :class:`LogWriter`
         :returns: A new :class:`LogWriter` instance
         """
-        writer = self.__class__(out=self.out, sampler=self._sampler)
+        writer = self.__class__(out=self.out)
         return writer
 
     def stop(self, timeout=None):
@@ -150,7 +148,6 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
         self,
         intake_url,  # type: str
         clients,  # type: List[WriterClientBase]
-        sampler=None,  # type: Optional[BaseSampler]
         processing_interval=None,  # type: Optional[float]
         # Match the payload size since there is no functionality
         # to flush dynamically.
@@ -172,7 +169,6 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
         self.intake_url = intake_url
         self._buffer_size = buffer_size
         self._max_payload_size = max_payload_size
-        self._sampler = sampler
         self._headers = headers or {}
         self._timeout = timeout
 
@@ -286,6 +282,7 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
         return headers
 
     def _send_payload(self, payload, count, client):
+        # type: (...) -> Response
         headers = self._get_finalized_headers(count, client)
 
         self._metrics_dist("http.requests")
@@ -304,15 +301,15 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
                 self._intake_endpoint(client),
                 response.status,
                 response.reason,
-            )
+            )  # type: Tuple[Any, Any, Any]
             # Append the payload if requested
             if config._trace_writer_log_err_payload:
                 msg += ", payload %s"
                 # If the payload is bytes then hex encode the value before logging
                 if isinstance(payload, six.binary_type):
-                    log_args += (binascii.hexlify(payload).decode(),)
+                    log_args += (binascii.hexlify(payload).decode(),)  # type: ignore
                 else:
-                    log_args += (payload,)
+                    log_args += (payload,)  # type: ignore
 
             log.error(msg, *log_args)
             self._metrics_dist("http.dropped.bytes", len(payload))
@@ -429,6 +426,12 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
             self._reset_connection()
 
 
+class AgentResponse(object):
+    def __init__(self, rate_by_service):
+        # type: (Dict[str, float]) -> None
+        self.rate_by_service = rate_by_service
+
+
 class AgentWriter(HTTPWriter):
     """
     The Datadog Agent supports (at the time of writing this) receiving trace
@@ -444,7 +447,6 @@ class AgentWriter(HTTPWriter):
     def __init__(
         self,
         agent_url,  # type: str
-        sampler=None,  # type: Optional[BaseSampler]
         priority_sampling=False,  # type: bool
         processing_interval=None,  # type: Optional[float]
         # Match the payload size since there is no functionality
@@ -458,6 +460,7 @@ class AgentWriter(HTTPWriter):
         api_version=None,  # type: Optional[str]
         reuse_connections=None,  # type: Optional[bool]
         headers=None,  # type: Optional[Dict[str, str]]
+        response_callback=None,  # type: Optional[Callable[[AgentResponse], None]]
     ):
         # type: (...) -> None
         if processing_interval is None:
@@ -513,10 +516,10 @@ class AgentWriter(HTTPWriter):
         additional_header_str = os.environ.get("_DD_TRACE_WRITER_ADDITIONAL_HEADERS")
         if additional_header_str is not None:
             _headers.update(parse_tags_str(additional_header_str))
+        self._response_cb = response_callback
         super(AgentWriter, self).__init__(
             intake_url=agent_url,
             clients=[client],
-            sampler=sampler,
             processing_interval=processing_interval,
             buffer_size=buffer_size,
             max_payload_size=max_payload_size,
@@ -531,7 +534,6 @@ class AgentWriter(HTTPWriter):
         # type: () -> HTTPWriter
         return self.__class__(
             agent_url=self.agent_url,
-            sampler=self._sampler,
             processing_interval=self._interval,
             buffer_size=self._buffer_size,
             max_payload_size=self._max_payload_size,
@@ -569,6 +571,7 @@ class AgentWriter(HTTPWriter):
         raise ValueError()
 
     def _send_payload(self, payload, count, client):
+        # type: (...) -> Response
         response = super(AgentWriter, self)._send_payload(payload, count, client)
         if response.status in [404, 415]:
             log.debug("calling endpoint '%s' but received %s; downgrading API", client.ENDPOINT, response.status)
@@ -584,16 +587,15 @@ class AgentWriter(HTTPWriter):
             else:
                 if payload is not None:
                     self._send_payload(payload, count, client)
-        elif response.status < 400 and isinstance(self._sampler, BasePrioritySampler):
-            result_traces_json = response.get_json()
-            if result_traces_json and "rate_by_service" in result_traces_json:
-                try:
-                    if isinstance(self._sampler, BasePrioritySampler):
-                        self._sampler.update_rate_by_service_sample_rates(
-                            result_traces_json["rate_by_service"],
+        elif response.status < 400:
+            if self._response_cb:
+                raw_resp = response.get_json()
+                if raw_resp and "rate_by_service" in raw_resp:
+                    self._response_cb(
+                        AgentResponse(
+                            rate_by_service=raw_resp["rate_by_service"],
                         )
-                except ValueError:
-                    log.error("sample_rate is negative, cannot update the rate samplers")
+                    )
         return response
 
     def start(self):


### PR DESCRIPTION
This prevents coupling the writer to the sampling implementations. The logic is moved to the tracer, which is already coupled with the sampling implementation.

This also centralizes mutation of the samplers to the tracing class. This will simplify future updates (like dynamic configuration of sampling).

This change was previously [reverted](https://github.com/DataDog/dd-trace-py/pull/7333) due to a regression in the sampling behaviour. The regression was due to a missing callback (identified here: https://github.com/DataDog/dd-trace-py/pull/6178/files#r1416553567). To prevent this regression in the future a test case was added in https://github.com/DataDog/dd-trace-py/pull/7805. I confirmed that the test covers the regression by running it locally: 

```
(.venv) ~/d/dd-trace-py ❮❮❮ AGENT_VERSION=testagent pytest tests/integration/test_priority_sampling.py -k test_agent_sample_rate
=========================================================================================== test session starts ===========================================================================================                                                                                                                                                                                  

tests/integration/test_priority_sampling.py FEFE                                                                                                                                                    [100%]

================================================================================================= ERRORS ==================================================================================================
____________________________________________________________________________ ERROR at teardown of test_agent_sample_rate_keep _____________________________________________________________________________
At request <Request GET /test/session/snapshot >:
   At snapshot (token='tests.integration.test_priority_sampling.test_agent_sample_rate_keep'):
       - Expected span:
       {'duration': 197000,
        'meta': {'_dd.p.dm': '-0',
                 '_dd.p.tid': '656a1a2a00000000',
                 'language': 'python',
                 'runtime-id': '701521214f1f4473abe1afca4813fbec'},...
       - Received span:
       {'duration': 206000,
        'meta': {'_dd.p.dm': '-0',
                 '_dd.p.tid': '656fd77d00000000',
                 'language': 'python',
                 'runtime-id': 'f2ca8706356f479da0861200855ff847'},...
     At trace 'test' (1 spans):
      At snapshot compare of span 'test' at position 1 in trace:
       - Expected span:
       {'duration': 59000,
        'meta': {'_dd.base_service': '',
                 '_dd.p.dm': '-1',
                 '_dd.p.tid': '656a1a2b00000000',
                 'language': 'python',
                 'runtime-id': '701521214f1f4473abe1afca4813fbec'},...
   
       - Received span:
       {'duration': 59000,
        'meta': {'_dd.base_service': '',
                 '_dd.p.dm': '-0',
                 '_dd.p.tid': '656fd78100000000',
                 'language': 'python',
                 'runtime-id': 'f2ca8706356f479da0861200855ff847'},...
meta mismatch on '_dd.p.dm': got '-0' which does not match expected '-1'.

================================================================================================ FAILURES =================================================================================================
_______________________________________________________________________________________ test_agent_sample_rate_keep _______________________________________________________________________________________

    @pytest.mark.skipif(AGENT_VERSION != "testagent", reason="Tests only compatible with a testagent")
    @pytest.mark.snapshot(agent_sample_rate_by_service={"service:test,env:": 0.9999})
    def test_agent_sample_rate_keep():
        """Ensure that the agent sample rate is respected when a trace is auto sampled."""
        from ddtrace import tracer
    
        # First trace won't actually have the sample rate applied since the response has not yet been received.
        with tracer.trace(""):
            pass
        # Force a flush to get the response back.
        tracer.flush()
    
        # Subsequent traces should have the rate applied.
        with tracer.trace("test", service="test") as span:
            pass
>       assert span.get_metric("_dd.agent_psr") == pytest.approx(0.9999)
E       assert None == 0.9999 ± 1.0e-06
E         comparison failed
E         Obtained: None
E         Expected: 0.9999 ± 1.0e-06

tests/integration/test_priority_sampling.py:129: AssertionError

FAILED tests/integration/test_priority_sampling.py::test_agent_sample_rate_keep - assert None == 0.9999 ± 1.0e-06
FAILED tests/integration/test_priority_sampling.py::test_agent_sample_rate_reject - assert None == 0.0001 ± 1.0e-10
ERROR tests/integration/test_priority_sampling.py::test_agent_sample_rate_keep
ERROR tests/integration/test_priority_sampling.py::test_agent_sample_rate_reject
================================================================================= 2 failed, 2 warnings, 2 errors in 7.03s =================================================================================
```

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
