### PR TITLE
fix(iast): iast leak for python 3.11

### DIFF
--- a/ddtrace/appsec/_iast/_stacktrace.c
+++ b/ddtrace/appsec/_iast/_stacktrace.c
@@ -17,10 +17,12 @@
 #define GET_LINENO(frame) PyFrame_GetLineNumber((PyFrameObject*)frame)
 #define GET_FRAME(tstate) PyThreadState_GetFrame(tstate)
 #define GET_PREVIOUS(frame) PyFrame_GetBack(frame)
-#define FRAME_DECREF(frame) Py_DECREF(frame)
+#define FRAME_DECREF(frame) Py_DecRef(frame)
 #define FRAME_XDECREF(frame) Py_XDECREF(frame)
-#define FILENAME_DECREF(filename) Py_DECREF(filename)
-#define FILENAME_XDECREF(filename) Py_XDECREF(filename)
+#define FILENAME_DECREF(filename) Py_DecRef(filename)
+#define FILENAME_XDECREF(filename)                                                                                     \
+    if (filename)                                                                                                      \
+    Py_DecRef(filename)
 static inline PyObject*
 GET_FILENAME(PyFrameObject* frame)
 {
@@ -29,7 +31,7 @@ GET_FILENAME(PyFrameObject* frame)
         return NULL;
     }
     PyObject* filename = PyObject_GetAttrString((PyObject*)code, "co_filename");
-    Py_CLEAR(code);
+    Py_DecRef(code);
     return filename;
 }
 #else
@@ -114,7 +116,7 @@ get_file_and_line(PyObject* Py_UNUSED(module), PyObject* cwd_obj)
     }
 
 exit:
-    Py_DECREF(cwd_bytes);
+    Py_DecRef(cwd_bytes);
     FRAME_XDECREF(frame);
     FILENAME_XDECREF(filename_o);
     return result;
@@ -124,10 +126,10 @@ exit_0:; // fix: "a label can only be part of a statement and a declaration is n
     PyObject* line_obj = Py_BuildValue("i", 0);
     filename_o = PyUnicode_FromString("");
     result = PyTuple_Pack(2, filename_o, line_obj);
-    Py_DECREF(cwd_bytes);
+    Py_DecRef(cwd_bytes);
     FRAME_XDECREF(frame);
     FILENAME_XDECREF(filename_o);
-    Py_DECREF(line_obj);
+    Py_DecRef(line_obj);
     return result;
 }
 

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectExtend.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectExtend.cpp
@@ -28,7 +28,7 @@ api_extend_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     // Ensure no returns are done before this method call
     auto method_name = PyUnicode_FromString("extend");
     PyObject_CallMethodObjArgs(candidate_text, method_name, to_add, nullptr);
-    Py_DECREF(method_name);
+    Py_DecRef(method_name);
 
     if (not ctx_map or ctx_map->empty() or to_result == nullptr) {
         Py_RETURN_NONE;

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
@@ -16,7 +16,7 @@ index_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* idx, TaintR
     }
 
     const auto& res_new_id = new_pyobject_id(result_o);
-    Py_DECREF(result_o);
+    Py_DecRef(result_o);
 
     if (ranges_to_set.empty()) {
         return res_new_id;

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
@@ -53,7 +53,7 @@ aspect_join_str(PyObject* sep,
 
     PyObject* new_result{ new_pyobject_id(result) };
     set_tainted_object(new_result, result_to, tx_taint_map);
-    Py_DECREF(result);
+    Py_DecRef(result);
     return new_result;
 }
 
@@ -134,7 +134,7 @@ aspect_join(PyObject* sep, PyObject* result, PyObject* iterable_elements, TaintR
 
     PyObject* new_result{ new_pyobject_id(result) };
     set_tainted_object(new_result, result_to, tx_taint_map);
-    Py_DECREF(result);
+    Py_DecRef(result);
     return new_result;
 }
 
@@ -160,7 +160,7 @@ api_join_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
                 PyList_Append(list_aux, item);
             }
             arg0 = list_aux;
-            Py_DECREF(iterator);
+            Py_DecRef(iterator);
             decref_arg0 = true;
         }
     }
@@ -181,7 +181,7 @@ api_join_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     if (get_pyobject_size(result) == 0) {
         // Empty result cannot have taint ranges
         if (decref_arg0) {
-            Py_DECREF(arg0);
+            Py_DecRef(arg0);
         }
         return result;
     }
@@ -192,7 +192,7 @@ api_join_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     }
     auto res = aspect_join(sep, result, arg0, ctx_map);
     if (decref_arg0) {
-        Py_DECREF(arg0);
+        Py_DecRef(arg0);
     }
     return res;
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
@@ -26,7 +26,7 @@ add_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* text_to_add, 
     const auto& to_candidate_text = get_tainted_object(candidate_text, tx_taint_map);
     if (to_candidate_text and to_candidate_text->get_ranges().size() >= TaintedObject::TAINT_RANGE_LIMIT) {
         const auto& res_new_id = new_pyobject_id(result_o);
-        Py_DECREF(result_o);
+        Py_DecRef(result_o);
         // If left side is already at the maximum taint ranges, we just reuse its
         // ranges, we don't need to look at left side.
         set_tainted_object(res_new_id, to_candidate_text, tx_taint_map);
@@ -39,7 +39,7 @@ add_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* text_to_add, 
     }
     if (!to_text_to_add) {
         const auto& res_new_id = new_pyobject_id(result_o);
-        Py_DECREF(result_o);
+        Py_DecRef(result_o);
         set_tainted_object(res_new_id, to_candidate_text, tx_taint_map);
         return res_new_id;
     }
@@ -47,7 +47,7 @@ add_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* text_to_add, 
     auto tainted = initializer->allocate_tainted_object_copy(to_candidate_text);
     tainted->add_ranges_shifted(to_text_to_add, (RANGE_START)len_candidate_text);
     const auto& res_new_id = new_pyobject_id(result_o);
-    Py_DECREF(result_o);
+    Py_DecRef(result_o);
     set_tainted_object(res_new_id, tainted, tx_taint_map);
 
     return res_new_id;

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
@@ -90,13 +90,13 @@ api_slice_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     if (slice == nullptr) {
         PyErr_Print();
         if (start != nullptr) {
-            Py_DECREF(start);
+            Py_DecRef(start);
         }
         if (stop != nullptr) {
-            Py_DECREF(stop);
+            Py_DecRef(stop);
         }
         if (step != nullptr) {
-            Py_DECREF(step);
+            Py_DecRef(step);
         }
         return nullptr;
     }
@@ -105,14 +105,14 @@ api_slice_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     auto res = slice_aspect(result, candidate_text, start, stop, step);
 
     if (start != nullptr) {
-        Py_DECREF(start);
+        Py_DecRef(start);
     }
     if (stop != nullptr) {
-        Py_DECREF(stop);
+        Py_DecRef(stop);
     }
     if (step != nullptr) {
-        Py_DECREF(step);
+        Py_DecRef(step);
     }
-    Py_DECREF(slice);
+    Py_DecRef(slice);
     return res;
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.cpp
@@ -7,8 +7,8 @@ new_pyobject_id(PyObject* tainted_object)
         PyObject* empty_unicode = PyUnicode_New(0, 127);
         PyObject* val = Py_BuildValue("(OO)", tainted_object, empty_unicode);
         PyObject* result = PyUnicode_Join(empty_unicode, val);
-        Py_DECREF(empty_unicode);
-        Py_DECREF(val);
+        Py_DecRef(empty_unicode);
+        Py_DecRef(val);
         return result;
     }
     if (PyBytes_Check(tainted_object)) {
@@ -16,8 +16,8 @@ new_pyobject_id(PyObject* tainted_object)
         auto bytes_join_ptr = py::reinterpret_borrow<py::bytes>(empty_bytes).attr("join");
         auto val = Py_BuildValue("(OO)", tainted_object, empty_bytes);
         auto res = PyObject_CallFunctionObjArgs(bytes_join_ptr.ptr(), val, NULL);
-        Py_DECREF(val);
-        Py_DECREF(empty_bytes);
+        Py_DecRef(val);
+        Py_DecRef(empty_bytes);
         return res;
     } else if (PyByteArray_Check(tainted_object)) {
         PyObject* empty_bytes = PyBytes_FromString("");
@@ -25,9 +25,9 @@ new_pyobject_id(PyObject* tainted_object)
         auto bytearray_join_ptr = py::reinterpret_borrow<py::bytes>(empty_bytearray).attr("join");
         auto val = Py_BuildValue("(OO)", tainted_object, empty_bytearray);
         auto res = PyObject_CallFunctionObjArgs(bytearray_join_ptr.ptr(), val, NULL);
-        Py_DECREF(val);
-        Py_DECREF(empty_bytes);
-        Py_DECREF(empty_bytearray);
+        Py_DecRef(val);
+        Py_DecRef(empty_bytes);
+        Py_DecRef(empty_bytearray);
         return res;
     }
     return tainted_object;

--- a/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.cpp
@@ -70,7 +70,7 @@ copy_string_new_str_id(PyObject* source)
     // unicode_decode_utf8.
     PyObject* newobj = PyUnicode_New(length, maxchar);
     memcpy(PyUnicode_DATA(newobj), PyUnicode_DATA(source), byte_length);
-    Py_DECREF(source);
+    Py_DecRef(source);
     return newobj;
 }
 


### PR DESCRIPTION
For some reason, both Py_DECREF and Py_XDECREF Python C API functions aren't releasing PyObjects correctly. This PR replace all those calls with `Py_DecRef`

### `get_info_frame` example:
```python
# test.py
for _ in range(5):
    gc.collect()
    a = sys.gettotalrefcount()
    s.get_info_frame(CWD)
    gc.collect()
    print(sys.gettotalrefcount() - a)
```

Before:
```
 python3.11 ddtrace/appsec/_iast/test.py
10
7
7
7
7
```
After
```
 python3.11 ddtrace/appsec/_iast/test.py
4
1
1
1
1
```

### `taint_pyobject` and `_add_aspect`
```python
# test2.py
for _ in range(15):
    gc.collect()
    a = sys.gettotalrefcount()
    b = taint_pyobject(
        pyobject="abc",
        source_name="dd",
        source_value="abc",
        source_origin=OriginType.PARAMETER
    )
    c = "efg"
    res = _add_aspect(b, c)
    gc.collect()
    print(sys.gettotalrefcount() - a)
```

Before:
```
 python3.11 ddtrace/appsec/_iast/test2.py
34
9
9
9
9
```
After
```
 python3.11 ddtrace/appsec/_iast/test2.py
29
4
4
4
4
```

This PR continues researches that we did in this PRs:
https://github.com/DataDog/dd-trace-py/pull/7702
https://github.com/DataDog/dd-trace-py/pull/7630
https://github.com/DataDog/dd-trace-py/pull/7112

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
