### PR TITLE
ci: add missing requirement for starlette

### DIFF
--- a/.riot/requirements/d764cf7.txt
+++ b/.riot/requirements/d764cf7.txt
@@ -13,6 +13,7 @@ charset-normalizer==3.1.0
 coverage[toml]==7.2.2
 databases==0.7.0
 exceptiongroup==1.1.1
+greenlet==3.0.1
 h11==0.14.0
 httpcore==0.16.3
 httpx==0.23.3


### PR DESCRIPTION
Address a CI failure due to requirements mismatch in starlette that happens in nightly tests, example failures:

- https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/51155/workflows/089be621-f17a-4a20-ba69-b5b037489160/jobs/3268257
- https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/51046/workflows/611217fe-f8d6-4fd5-9d30-0d81a7980291/jobs/3262107

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
