### PR TITLE
fix(bootstrap): do not load new modules after module cleanup [backport #7649 to 2.1]

### DIFF
--- a/ddtrace/bootstrap/preload.py
+++ b/ddtrace/bootstrap/preload.py
@@ -1,0 +1,109 @@
+"""
+Bootstrapping code that is run when using the `ddtrace-run` Python entrypoint
+Add all monkey-patching that needs to run by default here
+"""
+import os  # noqa
+
+from ddtrace import config  # noqa
+from ddtrace.debugging._config import di_config  # noqa
+from ddtrace.debugging._config import ed_config  # noqa
+from ddtrace.settings.profiling import config as profiling_config  # noqa
+from ddtrace.internal.logger import get_logger  # noqa
+from ddtrace.internal.module import ModuleWatchdog  # noqa
+from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker  # noqa
+from ddtrace.internal.tracemethods import _install_trace_methods  # noqa
+from ddtrace.internal.utils.formats import asbool  # noqa
+from ddtrace.internal.utils.formats import parse_tags_str  # noqa
+from ddtrace.settings.asm import config as asm_config  # noqa
+from ddtrace import tracer
+
+
+import typing as t
+
+# Register operations to be performned after the preload is complete. In
+# general, we might need to perform some cleanup operations after the
+# initialisation of the library, while also execute some more code after that.
+#  _____ ___  _________  _____ ______  _____   ___   _   _  _____
+# |_   _||  \/  || ___ \|  _  || ___ \|_   _| / _ \ | \ | ||_   _|
+#   | |  | .  . || |_/ /| | | || |_/ /  | |  / /_\ \|  \| |  | |
+#   | |  | |\/| ||  __/ | | | ||    /   | |  |  _  || . ` |  | |
+#  _| |_ | |  | || |    \ \_/ /| |\ \   | |  | | | || |\  |  | |
+#  \___/ \_|  |_/\_|     \___/ \_| \_|  \_/  \_| |_/\_| \_/  \_/
+# Do not register any functions that import ddtrace modules that have not been
+# imported yet.
+post_preload = []
+
+
+def register_post_preload(func: t.Callable) -> None:
+    post_preload.append(func)
+
+
+log = get_logger(__name__)
+
+
+if profiling_config.enabled:
+    log.debug("profiler enabled via environment variable")
+    import ddtrace.profiling.auto  # noqa: F401
+
+if di_config.enabled or ed_config.enabled:
+    from ddtrace.debugging import DynamicInstrumentation
+
+    DynamicInstrumentation.enable()
+
+if config._runtime_metrics_enabled:
+    RuntimeWorker.enable()
+
+if asbool(os.getenv("DD_IAST_ENABLED", False)):
+    from ddtrace.appsec._iast._utils import _is_python_version_supported
+
+    if _is_python_version_supported():
+        from ddtrace.appsec._iast._ast.ast_patching import _should_iast_patch
+        from ddtrace.appsec._iast._loader import _exec_iast_patched_module
+
+        ModuleWatchdog.register_pre_exec_module_hook(_should_iast_patch, _exec_iast_patched_module)
+
+if config._remote_config_enabled:
+    from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
+
+    remoteconfig_poller.enable()
+
+if asm_config._asm_enabled or config._remote_config_enabled:
+    from ddtrace.appsec._remoteconfiguration import enable_appsec_rc
+
+    enable_appsec_rc()
+
+if config._otel_enabled:
+
+    @ModuleWatchdog.after_module_imported("opentelemetry.trace")
+    def _(_):
+        from opentelemetry.trace import set_tracer_provider
+
+        from ddtrace.opentelemetry import TracerProvider
+
+        set_tracer_provider(TracerProvider())
+
+
+if asbool(os.getenv("DD_TRACE_ENABLED", default=True)):
+    from ddtrace import patch_all
+
+    @register_post_preload
+    def _():
+        # We need to clean up after we have imported everything we need from
+        # ddtrace, but before we register the patch-on-import hooks for the
+        # integrations.
+        modules_to_patch = os.getenv("DD_PATCH_MODULES")
+        modules_to_str = parse_tags_str(modules_to_patch)
+        modules_to_bool = {k: asbool(v) for k, v in modules_to_str.items()}
+        patch_all(**modules_to_bool)
+
+    if config.trace_methods:
+        _install_trace_methods(config.trace_methods)
+
+if "DD_TRACE_GLOBAL_TAGS" in os.environ:
+    env_tags = os.getenv("DD_TRACE_GLOBAL_TAGS")
+    tracer.set_tags(parse_tags_str(env_tags))
+
+
+@register_post_preload
+def _():
+    tracer._generate_diagnostic_logs()

--- a/ddtrace/bootstrap/preload.py
+++ b/ddtrace/bootstrap/preload.py
@@ -67,7 +67,7 @@ if config._remote_config_enabled:
 
     remoteconfig_poller.enable()
 
-if asm_config._asm_enabled or config._remote_config_enabled:
+if config._appsec_enabled or config._remote_config_enabled:
     from ddtrace.appsec._remoteconfiguration import enable_appsec_rc
 
     enable_appsec_rc()

--- a/ddtrace/bootstrap/preload.py
+++ b/ddtrace/bootstrap/preload.py
@@ -14,7 +14,6 @@ from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker  # noqa
 from ddtrace.internal.tracemethods import _install_trace_methods  # noqa
 from ddtrace.internal.utils.formats import asbool  # noqa
 from ddtrace.internal.utils.formats import parse_tags_str  # noqa
-from ddtrace.settings.asm import config as asm_config  # noqa
 from ddtrace import tracer
 
 

--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -2,6 +2,17 @@
 Bootstrapping code that is run when using the `ddtrace-run` Python entrypoint
 Add all monkey-patching that needs to run by default here
 """
+#  _____ ___  _________  _____ ______  _____   ___   _   _  _____
+# |_   _||  \/  || ___ \|  _  || ___ \|_   _| / _ \ | \ | ||_   _|
+#   | |  | .  . || |_/ /| | | || |_/ /  | |  / /_\ \|  \| |  | |
+#   | |  | |\/| ||  __/ | | | ||    /   | |  |  _  || . ` |  | |
+#  _| |_ | |  | || |    \ \_/ /| |\ \   | |  | | | || |\  |  | |
+#  \___/ \_|  |_/\_|     \___/ \_| \_|  \_/  \_| |_/\_| \_/  \_/
+# DO NOT MODIFY THIS FILE!
+# Only do so if you know what you're doing. This file contains boilerplate code
+# to allow injecting a custom sitecustomize.py file into the Python process to
+# perform the correct initialisation for the library. All the actual
+# initialisation logic should be placed in preload.py.
 from ddtrace import LOADED_MODULES  # isort:skip
 
 import logging  # noqa
@@ -11,16 +22,10 @@ import warnings  # noqa
 
 from ddtrace import config  # noqa
 from ddtrace._logger import _configure_log_injection
-from ddtrace.debugging._config import di_config  # noqa
-from ddtrace.debugging._config import ed_config  # noqa
-from ddtrace.internal.compat import PY2  # noqa
 from ddtrace.internal.logger import get_logger  # noqa
 from ddtrace.internal.module import ModuleWatchdog  # noqa
 from ddtrace.internal.module import find_loader  # noqa
-from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker  # noqa
-from ddtrace.internal.tracemethods import _install_trace_methods  # noqa
 from ddtrace.internal.utils.formats import asbool  # noqa
-from ddtrace.internal.utils.formats import parse_tags_str  # noqa
 
 
 # Debug mode from the tracer will do the same here, so only need to do this otherwise.
@@ -43,10 +48,6 @@ if "gevent" in sys.modules or "gevent.monkey" in sys.modules:
         )
 
 
-if PY2:
-    _unloaded_modules = []
-
-
 def is_module_installed(module_name):
     return find_loader(module_name) is not None
 
@@ -54,10 +55,6 @@ def is_module_installed(module_name):
 def cleanup_loaded_modules():
     def drop(module_name):
         # type: (str) -> None
-        if PY2:
-            # Store a reference to deleted modules to avoid them being garbage
-            # collected
-            _unloaded_modules.append(sys.modules[module_name])
         del sys.modules[module_name]
 
     MODULES_REQUIRING_CLEANUP = ("gevent",)
@@ -88,15 +85,9 @@ def cleanup_loaded_modules():
             "google.protobuf",  # the upb backend in >= 4.21 does not like being unloaded
         ]
     )
-    if PY2:
-        KEEP_MODULES_PY2 = frozenset(["encodings", "codecs", "copy_reg"])
     for m in list(_ for _ in sys.modules if _ not in LOADED_MODULES):
         if any(m == _ or m.startswith(_ + ".") for _ in KEEP_MODULES):
             continue
-
-        if PY2:
-            if any(m == _ or m.startswith(_ + ".") for _ in KEEP_MODULES_PY2):
-                continue
 
         drop(m)
 
@@ -127,61 +118,9 @@ def cleanup_loaded_modules():
 
 
 try:
-    from ddtrace import tracer
+    import ddtrace.bootstrap.preload as preload  # Perform the actual initialisation
 
-    profiling = asbool(os.getenv("DD_PROFILING_ENABLED", False))
-
-    if profiling:
-        log.debug("profiler enabled via environment variable")
-        import ddtrace.profiling.auto  # noqa: F401
-
-    if di_config.enabled or ed_config.enabled:
-        from ddtrace.debugging import DynamicInstrumentation
-
-        DynamicInstrumentation.enable()
-
-    if config._runtime_metrics_enabled:
-        RuntimeWorker.enable()
-
-    if asbool(os.getenv("DD_IAST_ENABLED", False)):
-        from ddtrace.appsec._iast._utils import _is_python_version_supported
-
-        if _is_python_version_supported():
-            from ddtrace.appsec._iast._ast.ast_patching import _should_iast_patch
-            from ddtrace.appsec._iast._loader import _exec_iast_patched_module
-
-            ModuleWatchdog.register_pre_exec_module_hook(_should_iast_patch, _exec_iast_patched_module)
-
-    if asbool(os.getenv("DD_TRACE_ENABLED", default=True)):
-        from ddtrace import patch_all
-
-        # We need to clean up after we have imported everything we need from
-        # ddtrace, but before we register the patch-on-import hooks for the
-        # integrations.
-        cleanup_loaded_modules()
-        modules_to_patch = os.getenv("DD_PATCH_MODULES")
-        modules_to_str = parse_tags_str(modules_to_patch)
-        modules_to_bool = {k: asbool(v) for k, v in modules_to_str.items()}
-        patch_all(**modules_to_bool)
-
-        if config.trace_methods:
-            _install_trace_methods(config.trace_methods)
-    else:
-        cleanup_loaded_modules()
-
-    # Only the import of the original sitecustomize.py is allowed after this
-    # point.
-
-    if "DD_TRACE_GLOBAL_TAGS" in os.environ:
-        env_tags = os.getenv("DD_TRACE_GLOBAL_TAGS")
-        tracer.set_tags(parse_tags_str(env_tags))
-
-    if sys.version_info >= (3, 7) and config._otel_enabled:
-        from opentelemetry.trace import set_tracer_provider
-
-        from ddtrace.opentelemetry import TracerProvider
-
-        set_tracer_provider(TracerProvider())
+    cleanup_loaded_modules()
 
     # Check for and import any sitecustomize that would have normally been used
     # had ddtrace-run not been used.
@@ -218,22 +157,15 @@ try:
         else:
             log.debug("additional sitecustomize found in: %s", sys.path)
 
-    if config._remote_config_enabled:
-        from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
-
-        remoteconfig_poller.enable()
-
-    if config._appsec_enabled or config._remote_config_enabled:
-        from ddtrace.appsec._remoteconfiguration import enable_appsec_rc
-
-        enable_appsec_rc()
-
     config._ddtrace_bootstrapped = True
     # Loading status used in tests to detect if the `sitecustomize` has been
     # properly loaded without exceptions. This must be the last action in the module
     # when the execution ends with a success.
     loaded = True
-    tracer._generate_diagnostic_logs()
+
+    for f in preload.post_preload:
+        f()
+
 except Exception:
     loaded = False
     log.warning("error configuring Datadog tracing", exc_info=True)

--- a/releasenotes/notes/fix-bootstrap-no-imports-after-module-cleanup-8592af3c81df0576.yaml
+++ b/releasenotes/notes/fix-bootstrap-no-imports-after-module-cleanup-8592af3c81df0576.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a regression with the support for gevent that could have occurred if
+    some products, like ASM, telemetry, were enabled.

--- a/tests/internal/test_auto.py
+++ b/tests/internal/test_auto.py
@@ -1,7 +1,12 @@
 import pytest
 
 
-@pytest.mark.subprocess(env=dict(DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE="true"))
+@pytest.mark.subprocess(
+    env=dict(
+        DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE="true",
+        DD_REMOTE_CONFIGURATION_ENABLED="1",
+    )
+)
 def test_auto():
     import sys
 

--- a/tests/telemetry/test_telemetry_metrics_e2e.py
+++ b/tests/telemetry/test_telemetry_metrics_e2e.py
@@ -122,7 +122,7 @@ for _ in range(10):
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="OpenTelemetry dropped support for python<=3.6")
 def test_span_creation_and_finished_metrics_otel(test_agent_session, ddtrace_run_python_code_in_subprocess):
     code = """
-import opentelemetry
+import opentelemetry.trace
 
 ot = opentelemetry.trace.get_tracer(__name__)
 for _ in range(9):
@@ -172,7 +172,7 @@ for _ in range(9):
 def test_span_creation_no_finish(test_agent_session, ddtrace_run_python_code_in_subprocess):
     code = """
 import ddtrace
-import opentelemetry
+import opentelemetry.trace
 from ddtrace import opentracer
 
 ddtracer = ddtrace.tracer


### PR DESCRIPTION
Backport of #7649 to 2.1

We refactor the logic of the sitecustomize bootstrap script to make it harder to introduce new initialisation logic that can break some of the boilerplate bootstrapping logic, such as the module cleanup mechanism for the support of frameworks like gevent. We move all the logic into a dedicated module, preload, and expose post_preload hooks in case that some code needs to be run after the module cleanup. However, the problem is now slightly shifted towards these hooks. Care must be taken not to register any hooks that import modules that are not already imported during the execution of the preload script.

## Testing Strategy

The test that was supposed to catch the presence of the `threading` module after initialisation when cleaning up the imported modules failed because RC was disabled globally in tests with `DD_REMOTE_CONFIGURATION_ENABLED=1` in the `riotfile.py` script. We have modified the test to ensure that RC is enabled.

## Further Details

Because the changes in this PR include a refactor, we summarise the part of the old coding that actually caused the issue in the first place. The `sitecustomize.py` source included the following coding

```python
    # Only the import of the original sitecustomize.py is allowed after this
    # point.

    if sys.version_info >= (3, 7) and config._otel_enabled:
        from opentelemetry.trace import set_tracer_provider

        from ddtrace.opentelemetry import TracerProvider

        set_tracer_provider(TracerProvider())

    ...

    if config._remote_config_enabled:
        from ddtrace.internal.remoteconfig.worker import remoteconfig_poller

        remoteconfig_poller.enable()

    if asm_config._asm_enabled or config._remote_config_enabled:
        from ddtrace.appsec._remoteconfiguration import enable_appsec_rc

        enable_appsec_rc()
```

The first `if` block introduces two problems:
- it force-loads the `opentelemetry` module
- it imports more modules from `ddtrace` _after_ the comment that instructs not to add imports beyond that point

Note that the current implementation of the `opentelemetry` intergration also force-loads the `opentelemetry` module when `TracerProvider` is imported. Therefore, the whole logic should be registered as a module import hook.

The other `if` blocks further down in the `sitecustomize.py` source also import from `ddtrace`. In fact, they import features that require threading support, which ultimately forces the gevent-crucial `threading` module to be re-loaded too early after the loaded module clean-up.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
