### PR TITLE
fix(docs): update contributing autohooks

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -68,6 +68,17 @@ minor version branches according to the :ref:`version support policy<versioning_
 If your pull request is a ``fix`` or ``ci`` change, apply the backport labels corresponding to the minor
 versions that need the change.
 
+Commit Hooks
+------------
+
+The tracer library uses formatting/linting tools including black, flake8, and mypy.
+While these are run in each CI pipeline for pull requests, they are automated to run
+when you call `git commit` as pre-commit hooks to catch any formatting errors before
+you commit.
+
+To initialize the pre-commit hook script to run in your development
+branch, run ``$hooks/autohook.sh install``.
+
 Implementation Guidelines
 =========================
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -77,7 +77,7 @@ when you call `git commit` as pre-commit hooks to catch any formatting errors be
 you commit.
 
 To initialize the pre-commit hook script to run in your development
-branch, run ``$hooks/autohook.sh install``.
+branch, run ``$ hooks/autohook.sh install``.
 
 Implementation Guidelines
 =========================


### PR DESCRIPTION
## What does this PR do?

This PR aims to update the `CONTRIBUTING` page from the docs to add the installation steps for `autohooks`, easing the onboarding process for new contributors.

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
