### PR TITLE
ci: pin testrunner to test py<3.7 [targets 1.20]

### DIFF
--- a/.github/workflows/requirements-locks.yml
+++ b/.github/workflows/requirements-locks.yml
@@ -9,7 +9,7 @@ jobs:
   validate:
     name: Check requirements lockfiles
     runs-on: ubuntu-latest
-    container: ghcr.io/datadog/dd-trace-py/testrunner:latest
+    container: ghcr.io/datadog/dd-trace-py/testrunner:0f49c377e3568020d82e8fa2b4f314900deb8f8d
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/testrunner.yml
+++ b/.github/workflows/testrunner.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-publish:
     uses: ./.github/workflows/build-and-publish-image.yml
     with:
-      tags: 'ghcr.io/datadog/dd-trace-py/testrunner:${{ github.sha }},ghcr.io/datadog/dd-trace-py/testrunner:latest'
+      tags: 'ghcr.io/datadog/dd-trace-py/testrunner:${{ github.sha }},ghcr.io/datadog/dd-trace-py/testrunner:0f49c377e3568020d82e8fa2b4f314900deb8f8d'
       platforms: 'linux/amd64,linux/arm64/v8'
       build-args: ''
       context: ./docker

--- a/.github/workflows/testrunner.yml
+++ b/.github/workflows/testrunner.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-publish:
     uses: ./.github/workflows/build-and-publish-image.yml
     with:
-      tags: 'ghcr.io/datadog/dd-trace-py/testrunner:${{ github.sha }},ghcr.io/datadog/dd-trace-py/testrunner:0f49c377e3568020d82e8fa2b4f314900deb8f8d'
+      tags: 'ghcr.io/datadog/dd-trace-py/testrunner:${{ github.sha }}'
       platforms: 'linux/amd64,linux/arm64/v8'
       build-args: ''
       context: ./docker

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -1072,6 +1072,7 @@ class Tracer(object):
 
     @staticmethod
     def _is_span_internal(span):
+        # comment to run tests
         return not span.span_type or span.span_type in _INTERNAL_APPLICATION_SPAN_TYPES
 
 

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -1072,7 +1072,6 @@ class Tracer(object):
 
     @staticmethod
     def _is_span_internal(span):
-        # comment to run tests
         return not span.span_type or span.span_type in _INTERNAL_APPLICATION_SPAN_TYPES
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,7 +152,7 @@ services:
           - "127.0.0.1:5433:5433"
 
     testrunner:
-        image: ghcr.io/datadog/dd-trace-py/testrunner:latest
+        image: ghcr.io/datadog/dd-trace-py/testrunner:0f49c377e3568020d82e8fa2b4f314900deb8f8d
         command: bash
         environment:
             - TOX_SKIP_DIST=True


### PR DESCRIPTION
## Description

This PR pins the version of testrunner used in the 1.20 branch. This will allow us to run tests with `python<=3.6`.

## Motivation

The latest testrunner image does not support python<3.7 ([image](https://github.com/datadog/dd-trace-py/pkgs/container/dd-trace-py%2Ftestrunner/150490464?tag=253febbef2d235970f1c71ced77df6fe4fbeb449)):

`command`: `docker run -it ghcr.io/datadog/dd-trace-py/testrunner:latest cat root/.python-version`
`output`:  `3.10.11  3.7.16  3.8.16  3.9.16  3.11.3  3.12-dev`

The second most recent version of testrunner supports `py<3.7` ([image](https://github.com/datadog/dd-trace-py/pkgs/container/dd-trace-py%2Ftestrunner/141140913?tag=0f49c377e3568020d82e8fa2b4f314900deb8f8d)):
 
`command`: `docker run -it ghcr.io/datadog/dd-trace-py/testrunner:0f49c377e3568020d82e8fa2b4f314900deb8f8d cat root/.python-version`
`output`: `3.10.11 2.7.18 3.5.10 3.6.15 3.7.16 3.8.16 3.9.16 3.11.3 3.12-dev`


## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
