### PR TITLE
chore: auto-close old issues and pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,3 +21,13 @@ jobs:
           days-before-close: 180
           exempt-issue-labels: 'proposal'
           exempt-pr-labels: 'proposal'
+          close-issue-message: |
+            This issue has been automatically closed after six months of inactivity. If it's a
+            feature request, it has been added to the maintainers' internal backlog and will be
+            included in an upcoming round of feature prioritization. Please comment or reopen
+            if you think this issue was closed in error.
+          close-pr-message: |
+            This pull request has been automatically closed after six months of inactivity.
+            After this much time, it will likely be easier to open a new pull request with the
+            same changes than to update this one from the base branch. Please comment or reopen
+            if you think this pull request was closed in error.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,14 +14,10 @@ jobs:
     steps:
       - uses: actions/stale@v8
         with:
-          # Increase the total API operations from 30 to 200
           # DEV: GitHub Actions have an API rate limit of 1000 operations per hour per repository
           #      This limit is shared across all actions
           operations-per-run: 200
-          # Mark issues and PRs as stale after 30 days of no updates
-          days-before-stale: 30
-          # Do not auto-close any issues or PRs
-          days-before-close: -1
-          # Ignore issues and PRs with the following labels
-          exempt-issue-labels: 'feature-request,proposal'
-          exempt-pr-labels: 'feature-request,proposal'
+          days-before-stale: 180
+          days-before-close: 180
+          exempt-issue-labels: 'proposal'
+          exempt-pr-labels: 'proposal'


### PR DESCRIPTION
This pull request adjusts the "stale" github action to close issues and pull requests after six months of inactivity with a helpful comment. This eliminates the toilsome task of manually pruning the issue and pull request backlogs.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
