### PR TITLE
chore(tracer): add agent sample rate regression test

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -16,7 +16,7 @@ mongo_image: &mongo_image mongo:3.6@sha256:19c11a8f1064fd2bb713ef1270f79a742a184
 httpbin_image: &httpbin_image kennethreitz/httpbin@sha256:2c7abc4803080c22928265744410173b6fea3b898872c01c5fd0f0f9df4a59fb
 vertica_image: &vertica_image sumitchawla/vertica:latest
 rabbitmq_image: &rabbitmq_image rabbitmq:3.7-alpine
-testagent_image: &testagent_image ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.15.0
+testagent_image: &testagent_image ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.16.0
 
 parameters:
   coverage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
         volumes:
           - ddagent:/tmp/ddagent:rw
     testagent:
-        image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.15.0
+        image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.16.0
         ports:
             - "127.0.0.1:9126:8126"
         volumes:

--- a/tests/integration/test_priority_sampling.py
+++ b/tests/integration/test_priority_sampling.py
@@ -1,6 +1,9 @@
 import time
 
+import pytest
+
 from ddtrace.constants import AUTO_KEEP
+from ddtrace.constants import AUTO_REJECT
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.internal.encoding import JSONEncoder
 from ddtrace.internal.encoding import MsgpackEncoderV03 as Encoder
@@ -8,6 +11,8 @@ from ddtrace.internal.writer import AgentWriter
 from tests.integration.utils import parametrize_with_all_encodings
 from tests.integration.utils import skip_if_testagent
 from tests.utils import override_global_config
+
+from .test_integration import AGENT_VERSION
 
 
 def _turn_tracer_into_dummy(tracer):
@@ -104,3 +109,44 @@ def test_priority_sampling_response():
             sampler_key in t._writer._sampler._by_service_samplers
         ), "after fetching priority sample rates from the agent, the tracer should hold those rates"
         t.shutdown()
+
+
+@pytest.mark.skipif(AGENT_VERSION != "testagent", reason="Tests only compatible with a testagent")
+@pytest.mark.snapshot(agent_sample_rate_by_service={"service:test,env:": 0.9999})
+def test_agent_sample_rate_keep():
+    """Ensure that the agent sample rate is respected when a trace is auto sampled."""
+    from ddtrace import tracer
+
+    # First trace won't actually have the sample rate applied since the response has not yet been received.
+    with tracer.trace(""):
+        pass
+    # Force a flush to get the response back.
+    tracer.flush()
+
+    # Subsequent traces should have the rate applied.
+    with tracer.trace("test", service="test") as span:
+        pass
+    # TODO this metric should be set
+    assert span.get_metric("_dd.agent_psr") != pytest.approx(0.9999)
+    assert span.get_metric("_sampling_priority_v1") == AUTO_KEEP
+
+
+@pytest.mark.skipif(AGENT_VERSION != "testagent", reason="Tests only compatible with a testagent")
+@pytest.mark.snapshot(agent_sample_rate_by_service={"service:test,env:": 0.0001})
+def test_agent_sample_rate_reject():
+    """Ensure that the agent sample rate is respected when a trace is auto rejected."""
+    from ddtrace import tracer
+
+    # First trace won't actually have the sample rate applied since the response has not yet been received.
+    with tracer.trace(""):
+        pass
+
+    # Force a flush to get the response back.
+    tracer.flush()
+
+    # Subsequent traces should have the rate applied.
+    with tracer.trace("test", service="test") as span:
+        pass
+    # TODO this metric should be set
+    assert span.get_metric("_dd.agent_psr") != pytest.approx(0.0001)
+    assert span.get_metric("_sampling_priority_v1") == AUTO_REJECT

--- a/tests/snapshots/tests.integration.test_priority_sampling.test_agent_sample_rate_keep.json
+++ b/tests/snapshots/tests.integration.test_priority_sampling.test_agent_sample_rate_keep.json
@@ -1,0 +1,47 @@
+[[
+  {
+    "name": "test",
+    "service": "test",
+    "resource": "test",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "meta": {
+      "_dd.base_service": "",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "656a1a2b00000000",
+      "language": "python",
+      "runtime-id": "701521214f1f4473abe1afca4813fbec"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 86402
+    },
+    "duration": 59000,
+    "start": 1701452331028235000
+  }],
+[
+  {
+    "name": "",
+    "service": null,
+    "resource": "",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "656a1a2a00000000",
+      "language": "python",
+      "runtime-id": "701521214f1f4473abe1afca4813fbec"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 86402
+    },
+    "duration": 197000,
+    "start": 1701452330966062000
+  }]]

--- a/tests/snapshots/tests.integration.test_priority_sampling.test_agent_sample_rate_reject.json
+++ b/tests/snapshots/tests.integration.test_priority_sampling.test_agent_sample_rate_reject.json
@@ -1,0 +1,47 @@
+[[
+  {
+    "name": "test",
+    "service": "test",
+    "resource": "test",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "meta": {
+      "_dd.base_service": "",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "656a1a2b00000000",
+      "language": "python",
+      "runtime-id": "701521214f1f4473abe1afca4813fbec"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 0,
+      "process_id": 86402
+    },
+    "duration": 30000,
+    "start": 1701452331042592000
+  }],
+[
+  {
+    "name": "",
+    "service": null,
+    "resource": "",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "656a1a2b00000000",
+      "language": "python",
+      "runtime-id": "701521214f1f4473abe1afca4813fbec"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 86402
+    },
+    "duration": 43000,
+    "start": 1701452331041315000
+  }]]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import time
 from typing import List  # noqa:F401
+import urllib.parse
 
 import attr
 import pkg_resources
@@ -959,7 +960,15 @@ class SnapshotTest(object):
 
 
 @contextmanager
-def snapshot_context(token, ignores=None, tracer=None, async_mode=True, variants=None, wait_for_num_traces=None):
+def snapshot_context(
+    token,
+    agent_sample_rate_by_service=None,
+    ignores=None,
+    tracer=None,
+    async_mode=True,
+    variants=None,
+    wait_for_num_traces=None,
+):
     # Use variant that applies to update test token. One must apply. If none
     # apply, the test should have been marked as skipped.
     if variants:
@@ -992,9 +1001,14 @@ def snapshot_context(token, ignores=None, tracer=None, async_mode=True, variants
             os.environ["_DD_TRACE_WRITER_ADDITIONAL_HEADERS"] = ",".join(
                 ["%s:%s" % (k, v) for k, v in existing_headers.items()]
             )
-
         try:
-            conn.request("GET", "/test/session/start?test_session_token=%s" % token)
+            query = urllib.parse.urlencode(
+                {
+                    "test_session_token": token,
+                    "agent_sample_rate_by_service": json.dumps(agent_sample_rate_by_service or {}),
+                }
+            )
+            conn.request("GET", "/test/session/start?" + query)
         except Exception as e:
             pytest.fail("Could not connect to test agent: %s" % str(e), pytrace=False)
         else:


### PR DESCRIPTION
To avoid [regressions](https://github.com/DataDog/dd-trace-py/pull/7333) like #6178 a test case is added to assert that agent sample rates are respected by the tracer.

In order to do this, a new functionality is used in the test agent to customize the sample rates returned by the agent (https://github.com/DataDog/dd-apm-test-agent/pull/149)

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
