### PR TITLE
ci: fix requirements diff check crash

### DIFF
--- a/ddtrace/contrib/kafka/patch.py
+++ b/ddtrace/contrib/kafka/patch.py
@@ -9,15 +9,16 @@ from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import kafka as kafkax
 from ddtrace.internal import core
-from ddtrace.internal.compat import ensure_text
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.constants import MESSAGING_SYSTEM
+from ddtrace.internal.logger import get_logger
 from ddtrace.internal.schema import schematize_messaging_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.utils import ArgumentError
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import asbool
+from ddtrace.internal.utils.version import parse_version
 from ddtrace.pin import Pin
 
 
@@ -27,6 +28,9 @@ _SerializingProducer = confluent_kafka.SerializingProducer if hasattr(confluent_
 _DeserializingConsumer = (
     confluent_kafka.DeserializingConsumer if hasattr(confluent_kafka, "DeserializingConsumer") else None
 )
+
+
+log = get_logger(__name__)
 
 
 config._add(
@@ -40,6 +44,13 @@ config._add(
 def get_version():
     # type: () -> str
     return getattr(confluent_kafka, "__version__", "")
+
+
+KAFKA_VERSION_TUPLE = parse_version(get_version())
+
+
+_SerializationContext = confluent_kafka.serialization.SerializationContext if KAFKA_VERSION_TUPLE >= (1, 4, 0) else None
+_MessageField = confluent_kafka.serialization.MessageField if KAFKA_VERSION_TUPLE >= (1, 4, 0) else None
 
 
 class TracedProducerMixin:
@@ -139,6 +150,7 @@ def traced_produce(func, instance, args, kwargs):
         value = None
     message_key = kwargs.get("key", "") or ""
     partition = kwargs.get("partition", -1)
+    headers = get_argument_value(args, kwargs, 6, "headers", optional=True) or {}
     with pin.tracer.trace(
         schematize_messaging_operation(kafkax.PRODUCE, provider="kafka", direction=SpanDirection.OUTBOUND),
         service=trace_utils.ext_service(pin, config.kafka),
@@ -149,7 +161,14 @@ def traced_produce(func, instance, args, kwargs):
         span.set_tag_str(COMPONENT, config.kafka.integration_name)
         span.set_tag_str(SPAN_KIND, SpanKind.PRODUCER)
         span.set_tag_str(kafkax.TOPIC, topic)
-        span.set_tag_str(kafkax.MESSAGE_KEY, ensure_text(message_key, errors="replace"))
+
+        if _SerializingProducer is not None and isinstance(instance, _SerializingProducer):
+            serialized_key = serialize_key(instance, topic, message_key, headers)
+            if serialized_key is not None:
+                span.set_tag_str(kafkax.MESSAGE_KEY, serialized_key)
+        else:
+            span.set_tag_str(kafkax.MESSAGE_KEY, message_key)
+
         span.set_tag(kafkax.PARTITION, partition)
         span.set_tag_str(kafkax.TOMBSTONE, str(value is None))
         span.set_tag(SPAN_MEASURED_KEY)
@@ -184,7 +203,15 @@ def traced_poll(func, instance, args, kwargs):
             message_key = message.key() or ""
             message_offset = message.offset() or -1
             span.set_tag_str(kafkax.TOPIC, message.topic())
-            span.set_tag_str(kafkax.MESSAGE_KEY, ensure_text(message_key, errors="replace"))
+
+            # If this is a deserializing consumer, do not set the key as a tag since we
+            # do not have the serialization function
+            if (
+                (_DeserializingConsumer is not None and not isinstance(instance, _DeserializingConsumer))
+                or isinstance(message_key, str)
+                or isinstance(message_key, bytes)
+            ):
+                span.set_tag_str(kafkax.MESSAGE_KEY, message_key)
             span.set_tag(kafkax.PARTITION, message.partition())
             span.set_tag_str(kafkax.TOMBSTONE, str(len(message) == 0))
             span.set_tag(kafkax.MESSAGE_OFFSET, message_offset)
@@ -203,3 +230,18 @@ def traced_commit(func, instance, args, kwargs):
     core.dispatch("kafka.commit.start", [instance, args, kwargs])
 
     return func(*args, **kwargs)
+
+
+def serialize_key(instance, topic, key, headers):
+    if _SerializationContext is not None and _MessageField is not None:
+        ctx = _SerializationContext(topic, _MessageField.KEY, headers)
+        if hasattr(instance, "_key_serializer") and instance._key_serializer is not None:
+            try:
+                key = instance._key_serializer(key, ctx)
+                return key
+            except Exception:
+                log.debug("Failed to set Kafka Consumer key tag: %s", str(key))
+                return None
+        else:
+            log.warning("Failed to set Kafka Consumer key tag, no method available to serialize key: %s", str(key))
+            return None

--- a/releasenotes/notes/fix-bug-for-setting-message-key-span-tag-from-kafka-serialization-classes-630b09004a97063a.yaml
+++ b/releasenotes/notes/fix-bug-for-setting-message-key-span-tag-from-kafka-serialization-classes-630b09004a97063a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    kafka: Resolves ``TypeError`` raised by serializing producers and deserializing consumers when the ``message.key`` tag is set on spans.

--- a/scripts/check-diff
+++ b/scripts/check-diff
@@ -2,10 +2,10 @@
 
 directory=${1:-"."}
 message=${2:-"Files were changed or added."}
-changed_files="$(git diff -I '^#' -- ${directory})"
+changed_files="$(git diff -G'^[^#]' -- ${directory})"
 new_files="$(git ls-files -o --exclude-standard -- ${directory})"
 
-if [[ "$(git diff -I '^#' --exit-code -- ${directory})" || -n $new_files ]]
+if [[ "$(git diff -G'^[^#]'  --exit-code -- ${directory})" || -n $new_files ]]
 then
     echo "${changed_files}"
     echo "${new_files}"

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import time
@@ -734,3 +735,61 @@ def test_span_has_dsm_payload_hash(dummy_tracer, consumer, producer, kafka_topic
 
     assert consume_span.name == "kafka.consume"
     assert consume_span.get_tag("pathway.hash") is not None
+
+
+def test_tracing_with_serialization_works(dummy_tracer, kafka_topic):
+    def json_serializer(msg, s_obj):
+        return json.dumps(msg).encode("utf-8")
+
+    conf = {
+        "bootstrap.servers": BOOTSTRAP_SERVERS,
+        "key.serializer": json_serializer,
+        "value.serializer": json_serializer,
+    }
+    _producer = confluent_kafka.SerializingProducer(conf)
+
+    def json_deserializer(as_bytes, ctx):
+        try:
+            return json.loads(as_bytes)
+        except json.decoder.JSONDecodeError:
+            return as_bytes
+
+    conf = {
+        "bootstrap.servers": BOOTSTRAP_SERVERS,
+        "group.id": GROUP_ID,
+        "auto.offset.reset": "earliest",
+        "key.deserializer": json_deserializer,
+        "value.deserializer": json_deserializer,
+    }
+
+    _consumer = confluent_kafka.DeserializingConsumer(conf)
+    tp = TopicPartition(kafka_topic, 0)
+    tp.offset = 0  # we want to read the first message
+    _consumer.commit(offsets=[tp])
+    _consumer.subscribe([kafka_topic])
+
+    Pin.override(_producer, tracer=dummy_tracer)
+    Pin.override(_consumer, tracer=dummy_tracer)
+
+    test_string = "serializing_test"
+    PAYLOAD = {"val": test_string}
+
+    _producer.produce(kafka_topic, key={"name": "keykey"}, value=PAYLOAD)
+    _producer.flush()
+
+    message = None
+    while message is None or message.value() != PAYLOAD:
+        message = _consumer.poll(1.0)
+
+    # message comes back with expected test string
+    assert message.value() == PAYLOAD
+
+    traces = dummy_tracer.pop_traces()
+    produce_span = traces[0][0]
+    consume_span = traces[len(traces) - 1][0]
+
+    assert produce_span.get_tag("kafka.message_key") is not None
+
+    # consumer span will not have tag set since we can't serialize the deserialized key from the original type to
+    # a string
+    assert consume_span.get_tag("kafka.message_key") is None


### PR DESCRIPTION
This change fixes a silent failure of `scripts/check-diff` that can result in outdated riot lockfiles being committed to trunk. The failure is caused by the use of the `-I` option to `git diff` on versions of git too old to support that option, such as the version installed in the testrunner container used in CI.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
