### PR TITLE
docs: add instructions documentation on how to update venv locks to latest

### DIFF
--- a/docs/contributing-testing.rst
+++ b/docs/contributing-testing.rst
@@ -170,3 +170,23 @@ Lastly, we will register it as a suite in the same file under ``"suites":``:
     ],
 
 Once you've completed these steps, CircleCI will run the new test suite.
+
+How do I update a Riot environment to use the latest version of a package?
+--------------------------------------------------------------------------
+
+Reading through the above example and others in ``riotfile.py``, you may notice that some package versions are specified
+as the variable ``latest``. When the Riotfile is compiled into the ``.txt`` files in the ``.riot`` directory, ``latest`` tells
+the compiler to pin the newest version of the package available on PyPI according to semantic versioning.
+
+Because this version resolution happens during Riotfile compilation, ``latest`` doesn't always mean "latest" once the compiled
+requirements files are checked into source control. In order to stay current, these requirements files need to be recompiled
+periodically.
+
+Assume you have a ``Venv`` instance in the Riotfile that uses the ``latest`` variable. Note the ``name`` field of this
+environment object.
+
+1. Run ``scripts/ddtest`` to enter a shell in the testrunner container
+2. ``export VENV_NAME=<name_you_noted_above>``
+3. Delete all of the requirements lockfiles for the chosen environment, then regenerate them:
+   ``for h in `riot list --hash-only "^${VENV_NAME}$"`; do rm .riot/requirements/${h}.txt; done; scripts/compile-and-prune-test-requirements``
+4. Commit the resulting changes to the ``.riot`` directory, and open a pull request against the trunk branch.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -128,6 +128,7 @@ LLM
 langchain
 lifecycle
 linters
+lockfiles
 logbook
 loguru
 lookups
@@ -229,6 +230,7 @@ submodules
 substring
 testagent
 TestCase
+testrunner
 timestamp
 tokenizer
 tracecontext


### PR DESCRIPTION
This change documents the process of updating the lockfiles for a riot venv that uses the `latest` version specifier.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
