### PR TITLE
fix(asm): fix asgi core dispatch call

### DIFF
--- a/ddtrace/contrib/asgi/middleware.py
+++ b/ddtrace/contrib/asgi/middleware.py
@@ -193,9 +193,9 @@ class TraceMiddleware:
                     url = f"{url}?{query_string}"
             if not self.integration_config.trace_query_string:
                 query_string = None
-            parse_body_result = await core.dispatch("asgi.request.parse.body", receive, headers)[0]
+            parse_body_result = core.dispatch("asgi.request.parse.body", receive, headers)[0]
             if len(parse_body_result) == 1:
-                receive, body = parse_body_result[0]
+                receive, body = await parse_body_result[0]
             else:
                 body = None
 

--- a/ddtrace/contrib/asgi/middleware.py
+++ b/ddtrace/contrib/asgi/middleware.py
@@ -193,7 +193,11 @@ class TraceMiddleware:
                     url = f"{url}?{query_string}"
             if not self.integration_config.trace_query_string:
                 query_string = None
-            receive, body = await core.dispatch("asgi.request.parse.body", receive, headers)[0][0]
+            parse_body_result = await core.dispatch("asgi.request.parse.body", receive, headers)[0]
+            if len(parse_body_result) == 1:
+                receive, body = parse_body_result[0]
+            else:
+                body = None
 
             client = scope.get("client")
             if isinstance(client, list) and len(client):

--- a/ddtrace/contrib/asgi/middleware.py
+++ b/ddtrace/contrib/asgi/middleware.py
@@ -193,11 +193,10 @@ class TraceMiddleware:
                     url = f"{url}?{query_string}"
             if not self.integration_config.trace_query_string:
                 query_string = None
+            body = None
             parse_body_result = core.dispatch("asgi.request.parse.body", receive, headers)[0]
             if len(parse_body_result) == 1:
                 receive, body = await parse_body_result[0]
-            else:
-                body = None
 
             client = scope.get("client")
             if isinstance(client, list) and len(client):


### PR DESCRIPTION
https://github.com/DataDog/dd-trace-py/pull/7220 introduced a bug in the asgi middleware if for some reason, the related asm dispatch function was not registered.
This fix this.

As PR 7220 was not released yet, no release note is necessary for this fix.

Also: add regression test with locally unregistering core callback mechanism

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
