### PR TITLE
ci: test against the latest minor release of Mako [backport 2.3]

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -24,7 +24,7 @@ jobs:
           export PATHS=$(git diff --name-only HEAD ${{ github.event.pull_request.base.sha }})
           python -c "import os,sys,fnmatch;sys.exit(not bool([_ for pattern in {'ddtrace/*', 'setup*', 'pyproject.toml', '.github/workflows/test_frameworks.yml'} for _ in fnmatch.filter(os.environ['PATHS'].splitlines(), pattern)]))"
         continue-on-error: true
-  
+
   bottle-testsuite-0_12_19:
     runs-on: ubuntu-latest
     needs: needs-run
@@ -379,7 +379,7 @@ jobs:
         # test_pool_timeout raises RuntimeError: The connection pool was closed while 1 HTTP requests/responses were still in-flight
         run: pytest -k 'not test_pool_timeout'
 
-  mako-testsuite-1_1_4:
+  mako-testsuite-1_3_0:
     runs-on: ubuntu-latest
     needs: needs-run
     env:
@@ -401,7 +401,7 @@ jobs:
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: sqlalchemy/mako
-          ref: rel_1_1_4
+          ref: rel_1_3_0
           path: mako
       - uses: actions/setup-python@v4
         if: needs.needs-run.outputs.outcome == 'success'
@@ -515,7 +515,7 @@ jobs:
         if: needs.needs-run.outputs.outcome == 'success'
         run: PYTHONPATH=../ddtrace/tests/debugging/exploration/ ddtrace-run pytest -p no:warnings tests
       - name: Debugger exploration results
-        if: needs.needs-run.outputs.outcome == 'success' 
+        if: needs.needs-run.outputs.outcome == 'success'
         run: cat debugger-expl.txt
 
   asyncpg-testsuite-0_27_0:
@@ -589,7 +589,7 @@ jobs:
         if: needs.needs-run.outputs.outcome == 'success'
         run: |
           . ../ddtrace/.github/workflows/setup-tox.sh py39
-          
+
           pip install -e .
           pytest -p no:warnings -k "not test_import" tests/
 


### PR DESCRIPTION
This pull request fixes
[failures](https://github.com/DataDog/dd-trace-py/actions/runs/7085298702/job/19281284381?pr=7819) of the Mako framework test suite caused by the recent release of transitive dependency Chameleon==4.3.0 in
https://github.com/malthe/chameleon/commit/3f7c9044ac243af9b907b40dd4bb9d0e4c074336. Luckily, it turns out that the latest version of Mako doesn't exhibit the same issue, so upgrading the tested version is sufficient to unblock our merges.

@brettlangdon note that if we decide to merge this, someone with the permission to do so will need to update the github action requirement to reference the new framework test name.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

(cherry picked from commit f2d38250fc259c11e9b07eeb298eeef34c820404)