### PR TITLE
chore(perf): add microbenchmarks for the internal core api

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,7 @@ deploy_to_di_backend:automatic:
     UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID
     UPSTREAM_TAG: $CI_COMMIT_TAG
     UPSTREAM_PACKAGE_JOB: build
-    
+
 deploy_to_di_backend:manual:
   stage: deploy
   rules:

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -79,6 +79,11 @@ benchmark-flask-sqli:
   extends: .benchmarks
   variables:
     SCENARIO: "flask_sqli"
+    
+benchmark-core-api:
+  extends: .benchmarks
+  variables:
+    SCENARIO: "core_api"
 
 benchmark-otel-span:
   extends: .benchmarks

--- a/benchmarks/core_api/config.yaml
+++ b/benchmarks/core_api/config.yaml
@@ -1,0 +1,28 @@
+core_dispatch_no_listeners:
+  listeners: 0
+  set_item_count: 0
+  get_item_exists: false
+core_dispatch_listeners:
+  listeners: 10
+  set_item_count: 0
+  get_item_exists: false
+context_with_data_no_listeners:
+  listeners: 0
+  set_item_count: 0
+  get_item_exists: false
+context_with_data_listeners:
+  listeners: 10
+  set_item_count: 0
+  get_item_exists: false
+set_item:
+  listeners: 0
+  set_item_count: 100
+  get_item_exists: false
+get_item_missing:
+  listeners: 0
+  set_item_count: 0
+  get_item_exists: false
+get_item_exists:
+  listeners: 0
+  set_item_count: 0
+  get_item_exists: true

--- a/benchmarks/core_api/scenario.py
+++ b/benchmarks/core_api/scenario.py
@@ -1,0 +1,60 @@
+import bm
+
+from ddtrace.internal import core
+
+
+class CoreAPIScenario(bm.Scenario):
+    CUSTOM_EVENT_NAME = "CoreAPIScenario.event"
+
+    listeners = bm.var(type=int, default=0)
+    set_item_count = bm.var(type=int, default=100)
+    get_item_exists = bm.var_bool(default=False)
+
+    def run(self):
+        # Activate a number of no-op listeners for known events
+        for _ in range(self.listeners):
+
+            def listener(_):
+                pass
+
+            core.on(self.CUSTOM_EVENT_NAME, listener)
+            core.on("context.started.with_data", listener)
+            core.on("context.ended.with_data", listener)
+
+        if self.get_item_exists:
+            core.set_item("key", "value")
+
+        def core_dispatch(loops):
+            """Measure the cost to dispatch an event on the hub"""
+            for _ in range(loops):
+                core.dispatch(self.CUSTOM_EVENT_NAME, (5, 6, 7, 8))
+
+        def context_with_data(loops):
+            """Measure the cost of creating and ending a new context"""
+            for _ in range(loops):
+                with core.context_with_data("with_data"):
+                    pass
+
+        def set_item(loops):
+            """Measure the overhead of setting keys on a context"""
+            for i in range(loops):
+                with core.context_with_data("with_data") as ctx:
+                    key = f"key-{i}"
+                    for _ in range(self.set_item_count):
+                        ctx.set_item(key, "value")
+
+        def get_item(loops):
+            """Measure the cost to fetch an item from the root context"""
+            for _ in range(loops):
+                core.get_item("key")
+
+        if "core_dispatch" in self.scenario_name:
+            yield core_dispatch
+        elif "context_with_data" in self.scenario_name:
+            yield context_with_data
+        elif "set_item" in self.scenario_name:
+            yield set_item
+        elif "get_item" in self.scenario_name:
+            yield get_item
+        else:
+            raise RuntimeError(f"Unknown scenario_name {self.scenario_name}")


### PR DESCRIPTION
The following adds some basic microbenchmarks for the internal core api.

We are trying to measure the following scenarios:

- Calling `core.dispatch`
  - When there are no listeners registered for the event
  - When there are 10 no-op listeners registered
- Using the `core.context_with_data` context manager
  - When there are no listeners registered for the event
  - When there are 10 no-op listeners registered
- Creating a context via `core.context_with_data` and then setting 100 keys on it
- Calling `core.get_item` on the root context
  - When the key does not exist
  - When the key does exist


## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
