### PR TITLE
feat(openai): add request duration for llmobs payloads

### DIFF
--- a/ddtrace/contrib/openai/patch.py
+++ b/ddtrace/contrib/openai/patch.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 from typing import TYPE_CHECKING  # noqa:F401
 from typing import Any  # noqa:F401
 from typing import Dict  # noqa:F401
@@ -255,6 +256,7 @@ class _OpenAIIntegration(BaseLLMIntegration):
         choices = resp.choices
         n = kwargs.get("n", 1)
         prompt = kwargs.get("prompt", "")
+        now = time.time()
         if isinstance(prompt, str):
             prompt = [prompt]
         # Note: LLMObs ingest endpoint only accepts a 1:1 prompt-response mapping per record,
@@ -272,7 +274,10 @@ class _OpenAIIntegration(BaseLLMIntegration):
                     "temperature": kwargs.get("temperature"),
                     "max_tokens": kwargs.get("max_tokens"),
                 },
-                "output": {"completions": [{"content": choice.text} for choice in unique_choices]},
+                "output": {
+                    "completions": [{"content": choice.text} for choice in unique_choices],
+                    "durations": [(now - span.start) * 1e3 for _ in unique_choices],
+                },
             }
             self.llm_record(span, attrs_dict)
 
@@ -282,6 +287,7 @@ class _OpenAIIntegration(BaseLLMIntegration):
         if not self._config.llmobs_enabled:
             return
         choices = resp.choices
+        now = time.time()
         # Note: LLMObs ingest endpoint only accepts a 1:1 prompt-response mapping per record,
         #  so we need to send unique prompt-response records if there are multiple responses (n > 1).
         for choice in choices:
@@ -308,7 +314,8 @@ class _OpenAIIntegration(BaseLLMIntegration):
                             "content": str(content),
                             "role": choice.message.role,
                         }
-                    ]
+                    ],
+                    "durations": [(now - span.start) * 1e3],
                 },
             }
             self.llm_record(span, attrs_dict)
@@ -554,7 +561,6 @@ def _patched_convert(openai, integration):
         else:
             resp = kwargs.get("response", {})
             headers = resp.headers
-
         # This function is called for each chunk in the stream.
         # To prevent needlessly setting the same tags for each chunk, short-circuit here.
         if span.get_tag("openai.organization.name") is not None:

--- a/tests/contrib/openai/test_openai_v0.py
+++ b/tests/contrib/openai/test_openai_v0.py
@@ -2306,7 +2306,7 @@ def test_llmobs_completion(openai_vcr, openai, ddtrace_config_openai, mock_llmob
                     "model": "ada",
                     "model_provider": "openai",
                     "input": {"prompts": ["Hello world"], "temperature": 0.8, "max_tokens": 10},
-                    "output": {"completions": [{"content": ", relax!” I said to my laptop"}]},
+                    "output": {"completions": [{"content": ", relax!” I said to my laptop"}], "durations": [mock.ANY]},
                 }
             ),
             mock.call.enqueue(
@@ -2319,7 +2319,7 @@ def test_llmobs_completion(openai_vcr, openai, ddtrace_config_openai, mock_llmob
                     "model": "ada",
                     "model_provider": "openai",
                     "input": {"prompts": ["Hello world"], "temperature": 0.8, "max_tokens": 10},
-                    "output": {"completions": [{"content": " (1"}]},
+                    "output": {"completions": [{"content": " (1"}], "durations": [mock.ANY]},
                 }
             ),
         ]
@@ -2376,7 +2376,10 @@ def test_llmobs_chat_completion(openai_vcr, openai, ddtrace_config_openai, mock_
                     "model": resp.model,
                     "model_provider": "openai",
                     "input": {"messages": input_messages, "temperature": None, "max_tokens": None},
-                    "output": {"completions": [{"content": resp.choices[0].message.content, "role": "assistant"}]},
+                    "output": {
+                        "completions": [{"content": resp.choices[0].message.content, "role": "assistant"}],
+                        "durations": [mock.ANY],
+                    },
                 }
             ),
             mock.call.enqueue(
@@ -2389,7 +2392,10 @@ def test_llmobs_chat_completion(openai_vcr, openai, ddtrace_config_openai, mock_
                     "model": resp.model,
                     "model_provider": "openai",
                     "input": {"messages": input_messages, "temperature": None, "max_tokens": None},
-                    "output": {"completions": [{"content": resp.choices[1].message.content, "role": "assistant"}]},
+                    "output": {
+                        "completions": [{"content": resp.choices[1].message.content, "role": "assistant"}],
+                        "durations": [mock.ANY],
+                    },
                 }
             ),
         ]
@@ -2446,7 +2452,8 @@ def test_llmobs_chat_completion_function_call(
                     "output": {
                         "completions": [
                             {"content": resp.choices[0].message.function_call.arguments, "role": "assistant"}
-                        ]
+                        ],
+                        "durations": [mock.ANY],
                     },
                 }
             ),

--- a/tests/contrib/openai/test_openai_v1.py
+++ b/tests/contrib/openai/test_openai_v1.py
@@ -1950,7 +1950,10 @@ def test_llmobs_completion(openai_vcr, openai, ddtrace_config_openai, mock_llmob
                     "model": "ada",
                     "model_provider": "openai",
                     "input": {"prompts": ["Hello world"], "temperature": 0.8, "max_tokens": 10},
-                    "output": {"completions": [{"content": ", relax!” I said to my laptop"}]},
+                    "output": {
+                        "completions": [{"content": ", relax!” I said to my laptop"}],
+                        "durations": [mock.ANY],
+                    },
                 }
             ),
             mock.call.enqueue(
@@ -1963,7 +1966,10 @@ def test_llmobs_completion(openai_vcr, openai, ddtrace_config_openai, mock_llmob
                     "model": "ada",
                     "model_provider": "openai",
                     "input": {"prompts": ["Hello world"], "temperature": 0.8, "max_tokens": 10},
-                    "output": {"completions": [{"content": " (1"}]},
+                    "output": {
+                        "completions": [{"content": " (1"}],
+                        "durations": [mock.ANY],
+                    },
                 }
             ),
         ]
@@ -2019,7 +2025,10 @@ def test_llmobs_chat_completion(openai_vcr, openai, ddtrace_config_openai, mock_
                     "model": resp.model,
                     "model_provider": "openai",
                     "input": {"messages": input_messages, "temperature": None, "max_tokens": None},
-                    "output": {"completions": [{"content": resp.choices[0].message.content, "role": "assistant"}]},
+                    "output": {
+                        "completions": [{"content": resp.choices[0].message.content, "role": "assistant"}],
+                        "durations": [mock.ANY],
+                    },
                 }
             ),
             mock.call.enqueue(
@@ -2032,7 +2041,10 @@ def test_llmobs_chat_completion(openai_vcr, openai, ddtrace_config_openai, mock_
                     "model": resp.model,
                     "model_provider": "openai",
                     "input": {"messages": input_messages, "temperature": None, "max_tokens": None},
-                    "output": {"completions": [{"content": resp.choices[1].message.content, "role": "assistant"}]},
+                    "output": {
+                        "completions": [{"content": resp.choices[1].message.content, "role": "assistant"}],
+                        "durations": [mock.ANY],
+                    },
                 }
             ),
         ]
@@ -2088,7 +2100,8 @@ def test_llmobs_chat_completion_function_call(
                     "output": {
                         "completions": [
                             {"content": resp.choices[0].message.function_call.arguments, "role": "assistant"}
-                        ]
+                        ],
+                        "durations": [mock.ANY],
                     },
                 }
             ),


### PR DESCRIPTION
This PR follows up on #7663 by adding the request duration metric of the OpenAI Completion/ChatCompletion call to payloads being sent to the LLMObs backend. 

Because of the fact that the `openai.request` span has not been finished before we can calculate the request duration, we calculate the request duration roughly as the difference between the span start time and the timestamp for when we start generating the llmobs record payload. Note that this is not exactly accurate (off by approximately ~15-20ms for a ~1-2s request) compared to using the underlying `http.request` span. The reason this approach was taken is that the `http.request` span is not always guaranteed (requires the http requests integration to be enabled). 

### Next Steps

To allow a more accurate calculation of the request duration in the future, we will need to compute the timestamp at the earliest possible timestamp after receiving the response (in `_EndpointHook.handle_request()`) and passing that timestamp all the way to the `generate_llm_*completion()` function. This is not trivial which is why we're choosing the simplest option in this PR for now.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
