### PR TITLE
docs: add a clarification to the documentation of DD_TRACE_METHODS [APMS-10881]

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -438,7 +438,8 @@ The following environment variables for the tracer are supported:
      default: ""
      description: |
         Specify methods to trace. For example: ``mod.submod[method1,method2];mod.submod.Class[method1]``.
-        Note that this setting is only compatible with ``ddtrace-run``.
+        Note that this setting is only compatible with ``ddtrace-run``, and that it doesn't work for methods implemented
+        by libraries for which there's an integration in ``ddtrace/contrib``.
      version_added:
        v2.1.0:
 


### PR DESCRIPTION
This pull request clarifies the documentation of `DD_TRACE_METHODS` to indicate a recently-discovered failure case when it's used to trace methods from integrated libraries.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
