### PR TITLE
fix(openai): change llmobs request duration from milliseconds to seconds

### DIFF
--- a/ddtrace/contrib/openai/patch.py
+++ b/ddtrace/contrib/openai/patch.py
@@ -276,7 +276,7 @@ class _OpenAIIntegration(BaseLLMIntegration):
                 },
                 "output": {
                     "completions": [{"content": choice.text} for choice in unique_choices],
-                    "durations": [(now - span.start) * 1e3 for _ in unique_choices],
+                    "durations": [now - span.start for _ in unique_choices],
                 },
             }
             self.llm_record(span, attrs_dict)
@@ -315,7 +315,7 @@ class _OpenAIIntegration(BaseLLMIntegration):
                             "role": choice.message.role,
                         }
                     ],
-                    "durations": [(now - span.start) * 1e3],
+                    "durations": [now - span.start],
                 },
             }
             self.llm_record(span, attrs_dict)

--- a/tests/contrib/openai/test_openai_v0.py
+++ b/tests/contrib/openai/test_openai_v0.py
@@ -2326,6 +2326,8 @@ def test_llmobs_completion(openai_vcr, openai, ddtrace_config_openai, mock_llmob
             ),
         ]
     )
+    for record in mock_llmobs_writer.enqueue.call_args_list:
+        assert span.duration >= record[0][0]["output"]["durations"][0]
 
 
 @pytest.mark.parametrize(
@@ -2402,6 +2404,8 @@ def test_llmobs_chat_completion(openai_vcr, openai, ddtrace_config_openai, mock_
             ),
         ]
     )
+    for record in mock_llmobs_writer.enqueue.call_args_list:
+        assert span.duration >= record[0][0]["output"]["durations"][0]
 
 
 @pytest.mark.parametrize(
@@ -2461,3 +2465,5 @@ def test_llmobs_chat_completion_function_call(
             ),
         ]
     )
+    for record in mock_llmobs_writer.enqueue.call_args_list:
+        assert span.duration >= record[0][0]["output"]["durations"][0]

--- a/tests/contrib/openai/test_openai_v1.py
+++ b/tests/contrib/openai/test_openai_v1.py
@@ -1974,6 +1974,8 @@ def test_llmobs_completion(openai_vcr, openai, ddtrace_config_openai, mock_llmob
             ),
         ]
     )
+    for record in mock_llmobs_writer.enqueue.call_args_list:
+        assert span.duration >= record[0][0]["output"]["durations"][0]
 
 
 @pytest.mark.parametrize(
@@ -2049,6 +2051,8 @@ def test_llmobs_chat_completion(openai_vcr, openai, ddtrace_config_openai, mock_
             ),
         ]
     )
+    for record in mock_llmobs_writer.enqueue.call_args_list:
+        assert span.duration >= record[0][0]["output"]["durations"][0]
 
 
 @pytest.mark.parametrize(
@@ -2107,3 +2111,5 @@ def test_llmobs_chat_completion_function_call(
             ),
         ]
     )
+    for record in mock_llmobs_writer.enqueue.call_args_list:
+        assert span.duration >= record[0][0]["output"]["durations"][0]

--- a/tests/internal/test_llmobs.py
+++ b/tests/internal/test_llmobs.py
@@ -59,7 +59,8 @@ def _completion_record():
                     "content": "\n\nThe Enigma code was broken by a team of codebreakers at Bletchley Park, "
                     "led by mathematician Alan Turing."
                 }
-            ]
+            ],
+            "durations": [1.234],
         },
     }
 
@@ -87,7 +88,8 @@ def _chat_completion_record():
                     "and your quest will not go unnoticed",
                     "role": "assistant",
                 }
-            ]
+            ],
+            "durations": [2.345],
         },
     }
 


### PR DESCRIPTION
This PR changes the request durations metric on the llmobs payloads generated by the openai integration to be in seconds rather than milliseconds as initially written in #7840. This metric should now conform to the documented API for LLMObs payloads.

Note: this PR does not need a release note as sending LLMObs payloads is still in private beta.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
