### PR TITLE
chore: fix dependencie-reporting performance issue

### DIFF
--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -102,11 +102,13 @@ def _package_file_mapping():
                 d = Distribution(name=ilmd_d.metadata["name"], version=ilmd_d.version, path=None)
                 for f in ilmd_d.files:
                     if _is_python_source_file(f):
-                        _path = fspath(f.locate())
-                        mapping[_path] = d
-                        _realp = os.path.realpath(_path)
-                        if _realp != _path:
-                            mapping[_realp] = d
+                        mapping[fspath(f.locate())] = d
+                        # JJJ
+                        # _path = fspath(f.locate())
+                        # mapping[_path] = d
+                        # _realp = os.path.realpath(_path)
+                        # if _realp != _path:
+                        #     mapping[_realp] = d
 
         return mapping
 

--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -102,13 +102,12 @@ def _package_file_mapping():
                 d = Distribution(name=ilmd_d.metadata["name"], version=ilmd_d.version, path=None)
                 for f in ilmd_d.files:
                     if _is_python_source_file(f):
-                        mapping[fspath(f.locate())] = d
-                        # JJJ
-                        # _path = fspath(f.locate())
-                        # mapping[_path] = d
-                        # _realp = os.path.realpath(_path)
-                        # if _realp != _path:
-                        #     mapping[_realp] = d
+                        # mapping[fspath(f.locate())] = d
+                        _path = fspath(f.locate())
+                        mapping[_path] = d
+                        _realp = os.path.realpath(_path)
+                        if _realp != _path:
+                            mapping[_realp] = d
 
         return mapping
 

--- a/ddtrace/internal/telemetry/__init__.py
+++ b/ddtrace/internal/telemetry/__init__.py
@@ -53,7 +53,6 @@ def _excepthook(tp, value, root_traceback):
 
         if config._telemetry_enabled and not telemetry_writer.started:
             telemetry_writer._app_started_event(False)
-            telemetry_writer._app_dependencies_loaded_event()
 
         telemetry_writer.app_shutdown()
 

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -629,10 +629,11 @@ class TelemetryWriter(PeriodicService):
         if configurations:
             self._app_client_configuration_changed_event(configurations)
 
-        if config._telemetry_dependency_collection:
-            newly_imported_deps = self._flush_new_imported_dependencies()
-            if newly_imported_deps:
-                self._update_dependencies_event(newly_imported_deps)
+        # JJJ
+        # if config._telemetry_dependency_collection:
+        #     newly_imported_deps = self._flush_new_imported_dependencies()
+        #     if newly_imported_deps:
+        #         self._update_dependencies_event(newly_imported_deps)
 
         if not self._events_queue:
             # Optimization: only queue heartbeat if no other events are queued

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -601,9 +601,10 @@ class AgentWriter(HTTPWriter):
     def start(self):
         super(AgentWriter, self).start()
         try:
-            if config._telemetry_enabled and not telemetry.telemetry_writer.started:
-                telemetry.telemetry_writer._app_started_event()
-                telemetry.telemetry_writer._app_dependencies_loaded_event()
+            # JJJ
+            # if config._telemetry_enabled and not telemetry.telemetry_writer.started:
+            #     telemetry.telemetry_writer._app_started_event()
+            #     telemetry.telemetry_writer._app_dependencies_loaded_event()
 
             # appsec remote config should be enabled/started after the global tracer and configs
             # are initialized

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -601,10 +601,8 @@ class AgentWriter(HTTPWriter):
     def start(self):
         super(AgentWriter, self).start()
         try:
-            # JJJ
-            # if config._telemetry_enabled and not telemetry.telemetry_writer.started:
-            #     telemetry.telemetry_writer._app_started_event()
-            #     telemetry.telemetry_writer._app_dependencies_loaded_event()
+            if config._telemetry_enabled and not telemetry.telemetry_writer.started:
+                telemetry.telemetry_writer._app_started_event()
 
             # appsec remote config should be enabled/started after the global tracer and configs
             # are initialized

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -64,6 +64,7 @@ def test_telemetry_enabled_on_first_tracer_flush(test_agent_session, ddtrace_run
     # Ensure telemetry events were sent to the agent (snapshot ensures one trace was generated)
     # Note event order is reversed e.g. event[0] is actually the last event
     events = _assert_dependencies_sort_and_remove(test_agent_session.get_events(), is_request=False)
+
     assert len(events) == 4
     assert events[0]["request_type"] == "app-closing"
     assert events[1]["request_type"] == "app-integrations-change"
@@ -257,7 +258,7 @@ def test_app_started_error_unhandled_exception(test_agent_session, run_python_co
     assert status == 1, stderr
     assert b"Unable to parse DD_SPAN_SAMPLING_RULES=" in stderr
 
-    events = _assert_dependencies_sort_and_remove(test_agent_session.get_events(), is_request=False)
+    events = test_agent_session.get_events()
 
     assert len(events) == 2
 

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -257,29 +257,6 @@ import ddtrace.auto
     ]
 
 
-def test_app_dependencies_loaded_event(telemetry_writer, test_agent_session, mock_time):
-    telemetry_writer._app_dependencies_loaded_event()
-    # force a flush
-    telemetry_writer.periodic()
-    events = test_agent_session.get_events()
-    assert len(events) == 1
-    already_imported = {}
-    sys_modules_paths = [str(origin(i)) for i in sys.modules.values()]
-    payload = {"dependencies": update_imported_dependencies(already_imported, sys_modules_paths)}
-    assert events[0] == _get_request_body(payload, "app-dependencies-loaded")
-
-
-def test_app_dependencies_loaded_event_when_disabled(telemetry_writer, test_agent_session, mock_time):
-    with override_global_config(dict(_telemetry_dependency_collection=False)):
-        telemetry_writer._app_dependencies_loaded_event()
-        # force a flush
-        telemetry_writer.periodic()
-        events = test_agent_session.get_events()
-        assert len(events) <= 1  # could have a heartbeat
-        if events:
-            assert events[0]["request_type"] != "app-dependencies-loaded"
-
-
 def test_update_dependencies_event(telemetry_writer, test_agent_session, mock_time):
     import xmltodict
 


### PR DESCRIPTION
## Description

Remove the initial reporting of dependencies on TelemetryWriter's `start` since this is not done in a thread and it's slow. The (non performance-critical) `periodic` method (run in a thread) will now report all dependencies imported at the start on it's first run and the new ones on further ones.

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
