### PR TITLE
feat(tracer): re-enable v05 trace encoding

### DIFF
--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -35,6 +35,8 @@ from ..constants import _HTTPLIB_NO_TRACE_REQUEST
 from ..encoding import JSONEncoderV2
 from ..logger import get_logger
 from ..runtime import container
+from ..serverless import in_azure_function_consumption_plan
+from ..serverless import in_gcp_function
 from ..sma import SimpleMovingAverage
 from .writer_client import WRITER_CLIENTS
 from .writer_client import AgentWriterClientV3
@@ -478,7 +480,11 @@ class AgentWriter(HTTPWriter):
         #      https://docs.python.org/3/library/sys.html#sys.platform
         is_windows = sys.platform.startswith("win") or sys.platform.startswith("cygwin")
 
-        self._api_version = api_version or config._trace_api or ("v0.4" if priority_sampling else "v0.3")
+        default_api_version = (
+            "v0.4" if (is_windows or in_gcp_function() or in_azure_function_consumption_plan()) else "v0.5"
+        )
+
+        self._api_version = api_version or config._trace_api or (default_api_version if priority_sampling else "v0.3")
         if is_windows and self._api_version == "v0.5":
             raise RuntimeError(
                 "There is a known compatibility issue with v0.5 API and Windows, "

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -480,11 +480,11 @@ class AgentWriter(HTTPWriter):
         #      https://docs.python.org/3/library/sys.html#sys.platform
         is_windows = sys.platform.startswith("win") or sys.platform.startswith("cygwin")
 
-        default_api_version = (
-            "v0.4" if (is_windows or in_gcp_function() or in_azure_function_consumption_plan()) else "v0.5"
-        )
+        default_api_version = "v0.5"
+        if is_windows or in_gcp_function() or in_azure_function_consumption_plan():
+            default_api_version = "v0.4"
 
-        self._api_version = api_version or config._trace_api or (default_api_version if priority_sampling else "v0.3")
+        self._api_version = api_version or config._trace_api or default_api_version
         if is_windows and self._api_version == "v0.5":
             raise RuntimeError(
                 "There is a known compatibility issue with v0.5 API and Windows, "

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -279,7 +279,7 @@ The following environment variables for the tracer are supported:
 
    DD_TRACE_API_VERSION:
      default: |
-         ``v0.4``
+         ``v0.5``
      description: |
          The trace API version to use when sending traces to the Datadog agent.
 
@@ -288,6 +288,7 @@ The following environment variables for the tracer are supported:
        v0.56.0:
        v1.7.0: default changed to ``v0.5``.
        v1.19.1: default reverted to ``v0.4``.
+       v2.4.0: default changed to ``v0.5``.
 
    DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP:
      default: |

--- a/releasenotes/notes/upgrade-encoding-to-v05-601bce23c0928d8f.yaml
+++ b/releasenotes/notes/upgrade-encoding-to-v05-601bce23c0928d8f.yaml
@@ -1,4 +1,4 @@
 ---
 other:
   - |
-    tracing: Upgrades the trace encoding format to v0.5. This change improves the performance of encoding Spans. 
+    tracing: Upgrades the trace encoding format to v0.5. This change improves the performance of encoding and sending spans.

--- a/releasenotes/notes/upgrade-encoding-to-v05-601bce23c0928d8f.yaml
+++ b/releasenotes/notes/upgrade-encoding-to-v05-601bce23c0928d8f.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    tracing: Upgrades the trace encoding format to v0.5. This change improves the performance of encoding Spans. 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -127,7 +127,7 @@ def test_uds_wrong_socket_path():
         mock.call(
             "failed to send, dropping %d traces to intake at %s after %d retries",
             1,
-            "unix:///tmp/ddagent/nosockethere/{}/traces".format(encoding if encoding else "v0.4"),
+            "unix:///tmp/ddagent/nosockethere/{}/traces".format(encoding if encoding else "v0.5"),
             3,
         )
     ]
@@ -403,7 +403,7 @@ def test_trace_generates_error_logs_when_hostname_invalid():
         mock.call(
             "failed to send, dropping %d traces to intake at %s after %d retries",
             1,
-            "http://bad:1111/{}/traces".format(encoding if encoding else "v0.4"),
+            "http://bad:1111/{}/traces".format(encoding if encoding else "v0.5"),
             3,
         )
     ]
@@ -492,7 +492,7 @@ def test_trace_with_invalid_payload_generates_error_log():
         [
             mock.call(
                 "failed to send traces to intake at %s: HTTP error status %s, reason %s",
-                "http://localhost:8126/v0.4/traces",
+                "http://localhost:8126/v0.5/traces",
                 400,
                 "Bad Request",
             )
@@ -571,7 +571,7 @@ def test_api_version_downgrade_generates_no_warning_logs():
 
     from ddtrace import tracer as t
 
-    encoding = os.environ["DD_TRACE_API_VERSION"] or "v0.4"
+    encoding = os.environ["DD_TRACE_API_VERSION"] or "v0.5"
     t._writer._downgrade(None, None, t._writer._clients[0])
     assert t._writer._endpoint == {"v0.5": "v0.4/traces", "v0.4": "v0.3/traces"}[encoding]
     with mock.patch("ddtrace.internal.writer.writer.log") as log:

--- a/tests/snapshots/test_extended_sampling_resource.json
+++ b/tests/snapshots/test_extended_sampling_resource.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "should_not_send",
-    "service": null,
+    "service": "",
     "resource": "mycoolre$ource",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -24,11 +26,13 @@
 [
   {
     "name": "should_send",
-    "service": null,
+    "service": "",
     "resource": "something else",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",

--- a/tests/snapshots/test_extended_sampling_tags.json
+++ b/tests/snapshots/test_extended_sampling_tags.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "should_not_send",
-    "service": null,
+    "service": "",
     "resource": "should_not_send",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -25,11 +27,13 @@
 [
   {
     "name": "should_send",
-    "service": null,
+    "service": "",
     "resource": "should_send",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "banana": "True",

--- a/tests/snapshots/test_extended_sampling_tags_and_resource.json
+++ b/tests/snapshots/test_extended_sampling_tags_and_resource.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "should_not_send",
-    "service": null,
+    "service": "",
     "resource": "mycoolre$ource",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -25,11 +27,13 @@
 [
   {
     "name": "should_send1",
-    "service": null,
+    "service": "",
     "resource": "should_send1",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "banana": "True",
@@ -48,11 +52,13 @@
 [
   {
     "name": "should_send2",
-    "service": null,
+    "service": "",
     "resource": "banana",
     "trace_id": 2,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -71,11 +77,13 @@
 [
   {
     "name": "should_send3",
-    "service": null,
+    "service": "",
     "resource": "mycoolre$ource",
     "trace_id": 3,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "banana": "True",

--- a/tests/snapshots/test_extended_sampling_tags_glob.json
+++ b/tests/snapshots/test_extended_sampling_tags_glob.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "should_not_send",
-    "service": null,
+    "service": "",
     "resource": "should_not_send",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -25,11 +27,13 @@
 [
   {
     "name": "should_send",
-    "service": null,
+    "service": "",
     "resource": "should_send",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",

--- a/tests/snapshots/test_multi_trace.json
+++ b/tests/snapshots/test_multi_trace.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "root0",
-    "service": null,
+    "service": "",
     "resource": "root0",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -22,7 +24,7 @@
   },
      {
        "name": "child0",
-       "service": null,
+       "service": "",
        "resource": "child0",
        "trace_id": 0,
        "span_id": 2,
@@ -33,11 +35,13 @@
 [
   {
     "name": "root1",
-    "service": null,
+    "service": "",
     "resource": "root1",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -54,7 +58,7 @@
   },
      {
        "name": "child1",
-       "service": null,
+       "service": "",
        "resource": "child1",
        "trace_id": 1,
        "span_id": 2,

--- a/tests/snapshots/test_multi_trace.json
+++ b/tests/snapshots/test_multi_trace.json
@@ -29,6 +29,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 29000,
        "start": 1633030641740720000
      }],
@@ -63,6 +65,8 @@
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 15000,
        "start": 1633030641741273000
      }]]

--- a/tests/snapshots/test_sampling_with_default_sample_rate_1.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_1.json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 11602,
        "start": 1692637140104307759
      }]]

--- a/tests/snapshots/test_sampling_with_default_sample_rate_1.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_1.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "trace2",
-    "service": null,
+    "service": "",
     "resource": "trace2",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -23,7 +25,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/test_sampling_with_default_sample_rate_1_and_manual_drop.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_1_and_manual_drop.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "trace6",
-    "service": null,
+    "service": "",
     "resource": "trace6",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-4",
       "language": "python",
@@ -22,7 +24,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/test_sampling_with_default_sample_rate_1_and_manual_drop.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_1_and_manual_drop.json
@@ -29,6 +29,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 16195,
        "start": 1691163616781394547
      }]]

--- a/tests/snapshots/test_sampling_with_default_sample_rate_1_and_manual_keep.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_1_and_manual_keep.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "trace7",
-    "service": null,
+    "service": "",
     "resource": "trace7",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-4",
       "language": "python",
@@ -22,7 +24,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/test_sampling_with_default_sample_rate_1_and_manual_keep.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_1_and_manual_keep.json
@@ -29,6 +29,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 15852,
        "start": 1691163616795612344
      }]]

--- a/tests/snapshots/test_sampling_with_default_sample_rate_1_and_rule_0.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_1_and_rule_0.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "trace5",
-    "service": null,
+    "service": "",
     "resource": "trace5",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -23,7 +25,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/test_sampling_with_default_sample_rate_1_and_rule_0.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_1_and_rule_0.json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 10017,
        "start": 1692637140145900065
      }]]

--- a/tests/snapshots/test_sampling_with_default_sample_rate_1_and_rule_1.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_1_and_rule_1.json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 9941,
        "start": 1692637140131765552
      }]]

--- a/tests/snapshots/test_sampling_with_default_sample_rate_1_and_rule_1.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_1_and_rule_1.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "trace4",
-    "service": null,
+    "service": "",
     "resource": "trace4",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -23,7 +25,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/test_sampling_with_default_sample_rate_tiny.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_tiny.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "trace3",
-    "service": null,
+    "service": "",
     "resource": "trace3",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -23,7 +25,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/test_sampling_with_default_sample_rate_tiny.json
+++ b/tests/snapshots/test_sampling_with_default_sample_rate_tiny.json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 10120,
        "start": 1692637140116692585
      }]]

--- a/tests/snapshots/test_sampling_with_defaults.json
+++ b/tests/snapshots/test_sampling_with_defaults.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "trace1",
-    "service": null,
+    "service": "",
     "resource": "trace1",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -22,7 +24,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/test_sampling_with_defaults.json
+++ b/tests/snapshots/test_sampling_with_defaults.json
@@ -29,6 +29,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 10853,
        "start": 1691163616713219858
      }]]

--- a/tests/snapshots/test_sampling_with_rate_limit_3.json
+++ b/tests/snapshots/test_sampling_with_rate_limit_3.json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 11067,
        "start": 1692390478003347011
      }]]

--- a/tests/snapshots/test_sampling_with_rate_limit_3.json
+++ b/tests/snapshots/test_sampling_with_rate_limit_3.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "trace5",
-    "service": null,
+    "service": "",
     "resource": "trace5",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -23,7 +25,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/test_sampling_with_sample_rate_1_and_rate_limit_0.json
+++ b/tests/snapshots/test_sampling_with_sample_rate_1_and_rate_limit_0.json
@@ -31,6 +31,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 13513,
        "start": 1692390477975743489
      }]]

--- a/tests/snapshots/test_sampling_with_sample_rate_1_and_rate_limit_0.json
+++ b/tests/snapshots/test_sampling_with_sample_rate_1_and_rate_limit_0.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "trace5",
-    "service": null,
+    "service": "",
     "resource": "trace5",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -24,7 +26,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/test_sampling_with_sample_rate_1_and_rate_limit_3_and_rule_0.json
+++ b/tests/snapshots/test_sampling_with_sample_rate_1_and_rate_limit_3_and_rule_0.json
@@ -31,6 +31,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 10378,
        "start": 1692390477989570486
      }]]

--- a/tests/snapshots/test_sampling_with_sample_rate_1_and_rate_limit_3_and_rule_0.json
+++ b/tests/snapshots/test_sampling_with_sample_rate_1_and_rate_limit_3_and_rule_0.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "trace5",
-    "service": null,
+    "service": "",
     "resource": "trace5",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -24,7 +26,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/test_trace_missing_received.json
+++ b/tests/snapshots/test_trace_missing_received.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "root0",
-    "service": null,
+    "service": "",
     "resource": "root0",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -22,7 +24,7 @@
   },
      {
        "name": "child0",
-       "service": null,
+       "service": "",
        "resource": "child0",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/test_trace_missing_received.json
+++ b/tests/snapshots/test_trace_missing_received.json
@@ -29,6 +29,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 11000,
        "start": 1633030777324740000
      }]]

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "test",
-    "service": "None",
+    "service": null,
     "resource": "test",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "1.9.0",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"nfd-000-006\",\n      \"name\": \"Detect failed attempt to fetch sensitive files\",\n      \"tags\": {\n        \"capec\": \"1000/118/169\",\n        \"category\": \"attack_attempt\",\n        \"confidence\": \"1\",\n        \"cwe\": \"200\",\n        \"type\": \"security_scanner\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"^404$\",\n        \"parameters\": [\n          {\n            \"address\": \"server.response.status\",\n            \"highlight\": [\n              \"404\"\n            ],\n            \"key_path\": [],\n            \"value\": \"404\"\n          }\n        ]\n      },\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"\\\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)\",\n        \"parameters\": [\n          {\n            \"address\": \"server.request.uri.raw\",\n            \"highlight\": [\n              \".git\"\n            ],\n            \"key_path\": [],\n            \"value\": \"/.git\"\n          }\n        ]\n      }\n    ]\n  }\n]}",

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "1.9.0",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"nfd-000-006\",\n      \"name\": \"Detect failed attempt to fetch sensitive files\",\n      \"tags\": {\n        \"capec\": \"1000/118/169\",\n        \"category\": \"attack_attempt\",\n        \"confidence\": \"1\",\n        \"cwe\": \"200\",\n        \"type\": \"security_scanner\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"^404$\",\n        \"parameters\": [\n          {\n            \"address\": \"server.response.status\",\n            \"highlight\": [\n              \"404\"\n            ],\n            \"key_path\": [],\n            \"value\": \"404\"\n          }\n        ]\n      },\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"\\\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)\",\n        \"parameters\": [\n          {\n            \"address\": \"server.request.uri.raw\",\n            \"highlight\": [\n              \".git\"\n            ],\n            \"key_path\": [],\n            \"value\": \"/.git\"\n          }\n        ]\n      }\n    ]\n  }\n]}",

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "test",
-    "service": null,
+    "service": "",
     "resource": "test",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "test",
-    "service": "",
+    "service": "None",
     "resource": "test",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "1.9.0",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"nfd-000-006\",\n      \"name\": \"Detect failed attempt to fetch sensitive files\",\n      \"tags\": {\n        \"capec\": \"1000/118/169\",\n        \"category\": \"attack_attempt\",\n        \"confidence\": \"1\",\n        \"cwe\": \"200\",\n        \"type\": \"security_scanner\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"^404$\",\n        \"parameters\": [\n          {\n            \"address\": \"server.response.status\",\n            \"highlight\": [\n              \"404\"\n            ],\n            \"key_path\": [],\n            \"value\": \"404\"\n          }\n        ]\n      },\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"\\\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)\",\n        \"parameters\": [\n          {\n            \"address\": \"server.request.uri.raw\",\n            \"highlight\": [\n              \".git\"\n            ],\n            \"key_path\": [],\n            \"value\": \"/.git\"\n          }\n        ]\n      }\n    ]\n  }\n]}",

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "test",
-    "service": null,
+    "service": "",
     "resource": "test",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
@@ -1,13 +1,12 @@
 [[
   {
     "name": "test",
-    "service": "",
+    "service": "None",
     "resource": "test",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "1.9.0",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"nfd-000-006\",\n      \"name\": \"Detect failed attempt to fetch sensitive files\",\n      \"tags\": {\n        \"capec\": \"1000/118/169\",\n        \"category\": \"attack_attempt\",\n        \"confidence\": \"1\",\n        \"cwe\": \"200\",\n        \"type\": \"security_scanner\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"^404$\",\n        \"parameters\": [\n          {\n            \"address\": \"server.response.status\",\n            \"highlight\": [\n              \"404\"\n            ],\n            \"key_path\": [],\n            \"value\": \"404\"\n          }\n        ]\n      },\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"\\\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)\",\n        \"parameters\": [\n          {\n            \"address\": \"server.request.uri.raw\",\n            \"highlight\": [\n              \".git\"\n            ],\n            \"key_path\": [],\n            \"value\": \"/.git\"\n          }\n        ]\n      }\n    ]\n  }\n]}",

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "test",
-    "service": "None",
+    "service": null,
     "resource": "test",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "1.9.0",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"nfd-000-006\",\n      \"name\": \"Detect failed attempt to fetch sensitive files\",\n      \"tags\": {\n        \"capec\": \"1000/118/169\",\n        \"category\": \"attack_attempt\",\n        \"confidence\": \"1\",\n        \"cwe\": \"200\",\n        \"type\": \"security_scanner\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"^404$\",\n        \"parameters\": [\n          {\n            \"address\": \"server.response.status\",\n            \"highlight\": [\n              \"404\"\n            ],\n            \"key_path\": [],\n            \"value\": \"404\"\n          }\n        ]\n      },\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"\\\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)\",\n        \"parameters\": [\n          {\n            \"address\": \"server.request.uri.raw\",\n            \"highlight\": [\n              \".git\"\n            ],\n            \"key_path\": [],\n            \"value\": \"/.git\"\n          }\n        ]\n      }\n    ]\n  }\n]}",

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "test",
-    "service": null,
+    "service": "",
     "resource": "test",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot_with_errors.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot_with_errors.json
@@ -7,7 +7,6 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.errors": "{\"missing key 'conditions'\": [\"crs-913-110\"], \"missing key 'tags'\": [\"crs-942-100\"]}",
       "_dd.appsec.event_rules.version": "5.5.5",

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot_with_errors.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot_with_errors.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.errors": "{\"missing key 'conditions'\": [\"crs-913-110\"], \"missing key 'tags'\": [\"crs-942-100\"]}",
       "_dd.appsec.event_rules.version": "5.5.5",

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot_with_errors.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot_with_errors.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "test",
-    "service": null,
+    "service": "",
     "resource": "test",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request.json
@@ -36,6 +36,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "aiohttp"

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "aiohttp.request",
-    "service": null,
+    "service": "",
     "resource": "aiohttp.request",
     "trace_id": 0,
     "span_id": 1,
@@ -31,7 +31,7 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": null,
+       "service": "",
        "resource": "TCPConnector.connect",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request_post.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request_post.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request_post.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request_post.json
@@ -36,6 +36,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "aiohttp"

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request_post.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request_post.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "aiohttp.request",
-    "service": null,
+    "service": "",
     "resource": "aiohttp.request",
     "trace_id": 0,
     "span_id": 1,
@@ -31,7 +31,7 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": null,
+       "service": "",
        "resource": "TCPConnector.connect",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_500_request.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_500_request.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "aiohttp.request",
-    "service": null,
+    "service": "",
     "resource": "aiohttp.request",
     "trace_id": 0,
     "span_id": 1,
@@ -32,7 +32,7 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": null,
+       "service": "",
        "resource": "TCPConnector.connect",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_500_request.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_500_request.json
@@ -37,6 +37,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "aiohttp"

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_auth_200_request.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_auth_200_request.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_auth_200_request.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_auth_200_request.json
@@ -36,6 +36,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "aiohttp"

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_auth_200_request.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_auth_200_request.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "aiohttp.request",
-    "service": null,
+    "service": "",
     "resource": "aiohttp.request",
     "trace_id": 0,
     "span_id": 1,
@@ -31,7 +31,7 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": null,
+       "service": "",
        "resource": "TCPConnector.connect",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[None].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[None].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[None].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[None].json
@@ -36,6 +36,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "aiohttp"

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v0].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v0].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v0].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v0].json
@@ -36,6 +36,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "aiohttp"

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v1].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v1].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v1].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v1].json
@@ -38,6 +38,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "aiohttp"

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_service_name_pin.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_service_name_pin.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_service_name_pin.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_service_name_pin.json
@@ -37,6 +37,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_multiple.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_multiple.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -54,6 +55,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -101,6 +103,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_multiple.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_multiple.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "aiohttp.request",
-    "service": null,
+    "service": "",
     "resource": "aiohttp.request",
     "trace_id": 0,
     "span_id": 1,
@@ -31,7 +31,7 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": null,
+       "service": "",
        "resource": "TCPConnector.connect",
        "trace_id": 0,
        "span_id": 2,
@@ -46,7 +46,7 @@
 [
   {
     "name": "aiohttp.request",
-    "service": null,
+    "service": "",
     "resource": "aiohttp.request",
     "trace_id": 1,
     "span_id": 1,
@@ -76,7 +76,7 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": null,
+       "service": "",
        "resource": "TCPConnector.connect",
        "trace_id": 1,
        "span_id": 2,
@@ -91,7 +91,7 @@
 [
   {
     "name": "aiohttp.request",
-    "service": null,
+    "service": "",
     "resource": "aiohttp.request",
     "trace_id": 2,
     "span_id": 1,
@@ -121,7 +121,7 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": null,
+       "service": "",
        "resource": "TCPConnector.connect",
        "trace_id": 2,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_multiple.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_multiple.json
@@ -36,6 +36,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "aiohttp"
@@ -81,6 +83,8 @@
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "aiohttp"
@@ -126,6 +130,8 @@
        "trace_id": 2,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "aiohttp"

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_parenting.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_parenting.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "parent",
-    "service": null,
+    "service": "",
     "resource": "parent",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -23,7 +25,7 @@
   },
      {
        "name": "aiohttp.request",
-       "service": null,
+       "service": "",
        "resource": "aiohttp.request",
        "trace_id": 0,
        "span_id": 2,
@@ -44,7 +46,7 @@
      },
         {
           "name": "TCPConnector.connect",
-          "service": null,
+          "service": "",
           "resource": "TCPConnector.connect",
           "trace_id": 0,
           "span_id": 3,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_parenting.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_parenting.json
@@ -31,6 +31,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "aiohttp_client",
@@ -51,6 +52,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "aiohttp"

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_query_string.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_query_string.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_query_string.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_query_string.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "aiohttp.request",
-    "service": null,
+    "service": "",
     "resource": "aiohttp.request",
     "trace_id": 0,
     "span_id": 1,
@@ -32,7 +32,7 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": null,
+       "service": "",
        "resource": "TCPConnector.connect",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_query_string.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_query_string.json
@@ -37,6 +37,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "aiohttp"

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[None].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[None].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[None].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[None].json
@@ -36,6 +36,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "aiohttp"

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[None].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[None].json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "aiohttp.request",
-    "service": null,
+    "service": "",
     "resource": "aiohttp.request",
     "trace_id": 0,
     "span_id": 1,
@@ -31,7 +31,7 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": null,
+       "service": "",
        "resource": "TCPConnector.connect",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v0].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v0].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v0].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v0].json
@@ -36,6 +36,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "aiohttp"

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v0].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v0].json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "aiohttp.request",
-    "service": null,
+    "service": "",
     "resource": "aiohttp.request",
     "trace_id": 0,
     "span_id": 1,
@@ -31,7 +31,7 @@
   },
      {
        "name": "TCPConnector.connect",
-       "service": null,
+       "service": "",
        "resource": "TCPConnector.connect",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v1].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v1].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v1].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v1].json
@@ -38,6 +38,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "aiohttp"

--- a/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot.json
+++ b/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "aiohttp.template",
-    "service": null,
+    "service": "",
     "resource": "aiohttp.template",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot.json
+++ b/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "template",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot[pyloop].json
+++ b/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot[pyloop].json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "aiohttp.template",
-    "service": null,
+    "service": "",
     "resource": "aiohttp.template",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot[pyloop].json
+++ b/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot[pyloop].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "template",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot_patched_server[True].json
+++ b/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot_patched_server[True].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot_patched_server[True].json
+++ b/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot_patched_server[True].json
@@ -38,6 +38,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "template",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot_patched_server[pyloop-True].json
+++ b/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot_patched_server[pyloop-True].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot_patched_server[pyloop-True].json
+++ b/tests/snapshots/tests.contrib.aiohttp_jinja2.test_aiohttp_jinja2.test_template_rendering_snapshot_patched_server[pyloop-True].json
@@ -38,6 +38,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "template",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_async_with_usage.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_async_with_usage.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_async_with_usage.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_async_with_usage.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "mysql.query",
-    "service": null,
+    "service": "",
     "resource": "SELECT 1",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_pin_override[True].json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_pin_override[True].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_queries.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_queries.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "mysql.query",
-    "service": null,
+    "service": "",
     "resource": "select 'Jellysmack'",
     "trace_id": 0,
     "span_id": 1,
@@ -36,7 +36,7 @@
 [
   {
     "name": "mysql.query",
-    "service": null,
+    "service": "",
     "resource": "select * from some_non_existant_table",
     "trace_id": 1,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_queries.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_queries.json
@@ -1,12 +1,13 @@
 [[
   {
     "name": "mysql.query",
-    "service": "",
+    "service": null,
     "resource": "select 'Jellysmack'",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -35,7 +36,7 @@
 [
   {
     "name": "mysql.query",
-    "service": "",
+    "service": null,
     "resource": "select * from some_non_existant_table",
     "trace_id": 1,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_queries.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_queries.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "mysql.query",
-    "service": null,
+    "service": "",
     "resource": "select 'Jellysmack'",
     "trace_id": 0,
     "span_id": 1,
@@ -35,7 +35,7 @@
 [
   {
     "name": "mysql.query",
-    "service": null,
+    "service": "",
     "resource": "select * from some_non_existant_table",
     "trace_id": 1,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v0].json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v0].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v0].json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v0].json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "mysql.query",
-    "service": null,
+    "service": "",
     "resource": "select 'dba4x4'",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v1].json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_schematized_span_name[v1].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_unspecified_service_v1.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_unspecified_service_v1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v0.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v0.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v1.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_user_specified_service_v1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_analytics_with_rate.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_analytics_with_rate.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_analytics_without_rate.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_analytics_without_rate.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_basics.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_basics.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_cmd_max_length.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_cmd_max_length.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_full_command_in_resource_config[True].json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_full_command_in_resource_config[True].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_full_command_in_resource_config[True].json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_full_command_in_resource_config[True].json
@@ -31,6 +31,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "aredis",
@@ -58,6 +59,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "aredis",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_full_command_in_resource_env.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_full_command_in_resource_env.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_full_command_in_resource_env.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_full_command_in_resource_env.json
@@ -31,6 +31,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "aredis",
@@ -58,6 +59,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "aredis",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_long_command.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_long_command.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_opentracing.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_opentracing.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_opentracing.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_opentracing.json
@@ -32,6 +32,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_pipeline_immediate.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_pipeline_immediate.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,6 +42,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_pipeline_traced.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_pipeline_traced.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aredis.test_aredis.test_unicode.json
+++ b/tests/snapshots/tests.contrib.aredis.test_aredis.test_unicode.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_bad_query.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_bad_query.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_configure_service_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_configure_service_name_env_v0.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,6 +40,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_configure_service_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_configure_service_name_env_v1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "unnamed-python-service",
       "_dd.p.dm": "-0",
@@ -41,6 +42,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "unnamed-python-service",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_connect.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_connect.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_connection_methods.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_connection_methods.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,6 +40,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -72,6 +74,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -105,6 +108,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -138,6 +142,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -171,6 +176,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_cursor.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_cursor.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,6 +40,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -72,6 +74,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -105,6 +108,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -138,6 +142,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -171,6 +176,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_cursor_manual.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_cursor_manual.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,6 +40,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -72,6 +74,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -105,6 +108,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -138,6 +142,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -171,6 +176,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_parenting.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_parenting.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -116,6 +117,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_parenting.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_parenting.json
@@ -33,11 +33,13 @@
 [
   {
     "name": "parent",
-    "service": null,
+    "service": "",
     "resource": "parent",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -82,11 +84,13 @@
 [
   {
     "name": "parent2",
-    "service": null,
+    "service": "",
     "resource": "parent2",
     "trace_id": 2,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_parenting.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_parenting.json
@@ -63,6 +63,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_select.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_select.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,6 +40,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_service_override_pin.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_service_override_pin.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,6 +40,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_span_name_by_schema[v0].json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_span_name_by_schema[v0].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,6 +40,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_span_name_by_schema[v1].json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_span_name_by_schema[v1].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -40,6 +41,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_unspecified_service_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_unspecified_service_name_env_v0.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,6 +40,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_unspecified_service_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_unspecified_service_name_env_v1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -40,6 +41,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[ClassHandler-class_handler].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[ClassHandler-class_handler].json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "aws.lambda",
-    "service": null,
+    "service": "",
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -23,7 +25,7 @@
   },
      {
        "name": "result-trace",
-       "service": null,
+       "service": "",
        "resource": "result-trace",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[ClassHandler-class_handler].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[ClassHandler-class_handler].json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 18783,
        "start": 1691161784459734381
      }]]

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[StaticHandler-static_handler].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[StaticHandler-static_handler].json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 20269,
        "start": 1691161784453016249
      }]]

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[StaticHandler-static_handler].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[StaticHandler-static_handler].json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "aws.lambda",
-    "service": null,
+    "service": "",
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -23,7 +25,7 @@
   },
      {
        "name": "result-trace",
-       "service": null,
+       "service": "",
        "resource": "result-trace",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[handler2-instance_handler].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[handler2-instance_handler].json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 18933,
        "start": 1691161784465284474
      }]]

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[handler2-instance_handler].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[handler2-instance_handler].json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "aws.lambda",
-    "service": null,
+    "service": "",
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -23,7 +25,7 @@
   },
      {
        "name": "result-trace",
-       "service": null,
+       "service": "",
        "resource": "result-trace",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[handler3-instance_handler_with_code].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[handler3-instance_handler_with_code].json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 19529,
        "start": 1691161784470564547
      }]]

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[handler3-instance_handler_with_code].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_class_based_handlers[handler3-instance_handler_with_code].json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "aws.lambda",
-    "service": null,
+    "service": "",
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -23,7 +25,7 @@
   },
      {
        "name": "result-trace",
-       "service": null,
+       "service": "",
        "resource": "result-trace",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_continue_on_early_trace_ending.json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_continue_on_early_trace_ending.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "aws.lambda",
-    "service": null,
+    "service": "",
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_file_patching.json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_file_patching.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "aws.lambda",
-    "service": null,
+    "service": "",
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_module_patching.json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_module_patching.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "result-trace",
-    "service": null,
+    "service": "",
     "resource": "result-trace",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[-100].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[-100].json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "aws.lambda",
-    "service": null,
+    "service": "",
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
@@ -26,7 +26,7 @@
   },
      {
        "name": "timeout",
-       "service": null,
+       "service": "",
        "resource": "timeout",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[-100].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[-100].json
@@ -31,6 +31,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 200258517,
        "start": 1691161771833341867
      }]]

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[-100].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[-100].json
@@ -6,6 +6,7 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[100].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[100].json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "aws.lambda",
-    "service": null,
+    "service": "",
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
@@ -26,7 +26,7 @@
   },
      {
        "name": "timeout",
-       "service": null,
+       "service": "",
        "resource": "timeout",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[100].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[100].json
@@ -6,6 +6,7 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[100].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[100].json
@@ -31,6 +31,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 200158722,
        "start": 1691161777881972654
      }]]

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[10].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[10].json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "aws.lambda",
-    "service": null,
+    "service": "",
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
@@ -26,7 +26,7 @@
   },
      {
        "name": "timeout",
-       "service": null,
+       "service": "",
        "resource": "timeout",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[10].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[10].json
@@ -6,6 +6,7 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[10].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[10].json
@@ -31,6 +31,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 290280174,
        "start": 1691161774867341917
      }]]

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[200].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[200].json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "aws.lambda",
-    "service": null,
+    "service": "",
     "resource": "aws.lambda",
     "trace_id": 0,
     "span_id": 1,
@@ -26,7 +26,7 @@
   },
      {
        "name": "timeout",
-       "service": null,
+       "service": "",
        "resource": "timeout",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[200].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[200].json
@@ -6,6 +6,7 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[200].json
+++ b/tests/snapshots/tests.contrib.aws_lambda.test_aws_lambda.test_timeout_traces[200].json
@@ -31,6 +31,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 100225899,
        "start": 1691161780889337821
      }]]

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_child.json
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_child.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_child.json
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_child.json
@@ -36,6 +36,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_success.json
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_success.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "1.9.0",
       "_dd.appsec.waf.version": "1.15.0",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled.json
@@ -56,6 +56,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -71,6 +73,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -86,6 +90,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -101,6 +107,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -116,6 +124,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -131,6 +141,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -146,6 +158,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -161,6 +175,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -176,6 +192,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -191,6 +209,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -206,6 +226,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -221,6 +243,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -236,6 +260,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -251,6 +277,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -266,6 +294,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "_dd.p.tid": "654a694400000000",
@@ -281,6 +311,8 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "_dd.p.tid": "654a694400000000",
@@ -296,6 +328,8 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -311,6 +345,8 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -326,6 +362,8 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -341,6 +379,8 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -356,6 +396,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -371,6 +413,8 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -386,6 +430,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -401,6 +447,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -416,6 +464,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "1.9.0",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"nfd-000-006\",\n      \"name\": \"Detect failed attempt to fetch sensitive files\",\n      \"tags\": {\n        \"capec\": \"1000/118/169\",\n        \"category\": \"attack_attempt\",\n        \"confidence\": \"1\",\n        \"cwe\": \"200\",\n        \"type\": \"security_scanner\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"^404$\",\n        \"parameters\": [\n          {\n            \"address\": \"server.response.status\",\n            \"highlight\": [\n              \"404\"\n            ],\n            \"key_path\": [],\n            \"value\": \"404\"\n          }\n        ]\n      },\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"\\\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)\",\n        \"parameters\": [\n          {\n            \"address\": \"server.request.uri.raw\",\n            \"highlight\": [\n              \".git\"\n            ],\n            \"key_path\": [],\n            \"value\": \"/.git\"\n          }\n        ]\n      }\n    ]\n  }\n]}",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
@@ -62,6 +62,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -77,6 +79,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -92,6 +96,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -107,6 +113,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -122,6 +130,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -137,6 +147,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -152,6 +164,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -167,6 +181,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -182,6 +198,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -197,6 +215,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -212,6 +232,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -227,6 +249,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -242,6 +266,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -257,6 +283,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -272,6 +300,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "_dd.p.tid": "654a694400000000",
@@ -287,6 +317,8 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "_dd.p.tid": "654a694400000000",
@@ -302,6 +334,8 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -317,6 +351,8 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -333,6 +369,7 @@
                                      "span_id": 26,
                                      "parent_id": 23,
                                      "type": "template",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -349,6 +386,8 @@
                                      "trace_id": 0,
                                      "span_id": 27,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -364,6 +403,8 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -379,6 +420,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -394,6 +437,8 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -409,6 +454,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -424,6 +471,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -439,6 +488,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-001\",\n      \"name\": \"Block IP addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"blocking\",\n        \"type\": \"ip_addresses\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"ip_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"http.client_ip\",\n            \"highlight\": [\n              \"8.8.4.4\"\n            ],\n            \"key_path\": [],\n            \"value\": \"8.8.4.4\"\n          }\n        ]\n      }\n    ]\n  }\n]}",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403_json.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403_json.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-001\",\n      \"name\": \"Block IP addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"blocking\",\n        \"type\": \"ip_addresses\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"ip_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"http.client_ip\",\n            \"highlight\": [\n              \"8.8.4.4\"\n            ],\n            \"key_path\": [],\n            \"value\": \"8.8.4.4\"\n          }\n        ]\n      }\n    ]\n  }\n]}",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_nomatch_200.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_nomatch_200.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.15.0",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_nomatch_200.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_nomatch_200.json
@@ -56,6 +56,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -71,6 +73,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -86,6 +90,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -101,6 +107,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -116,6 +124,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -131,6 +141,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -146,6 +158,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -161,6 +175,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -176,6 +192,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -191,6 +209,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -206,6 +226,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -221,6 +243,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -236,6 +260,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -251,6 +277,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -266,6 +294,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "_dd.p.tid": "654a694400000000",
@@ -281,6 +311,8 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "_dd.p.tid": "654a694400000000",
@@ -296,6 +328,8 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -311,6 +345,8 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -326,6 +362,8 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -341,6 +379,8 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -356,6 +396,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -371,6 +413,8 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -386,6 +430,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -401,6 +447,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -416,6 +464,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions.json
@@ -41,6 +41,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -56,6 +58,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -71,6 +75,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -86,6 +92,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -101,6 +109,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -116,6 +126,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -131,6 +143,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -146,6 +160,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -161,6 +177,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -176,6 +194,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -191,6 +211,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -206,6 +228,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -221,6 +245,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -236,6 +262,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -251,6 +279,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "_dd.p.tid": "654a694400000000",
@@ -266,6 +296,8 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "_dd.p.tid": "654a694400000000",
@@ -281,6 +313,8 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -296,6 +330,8 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -311,6 +347,8 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -326,6 +364,8 @@
                                      "trace_id": 0,
                                      "span_id": 27,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -341,6 +381,8 @@
                                      "trace_id": 0,
                                      "span_id": 28,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -356,6 +398,8 @@
                                      "trace_id": 0,
                                      "span_id": 29,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -372,6 +416,7 @@
                                      "span_id": 30,
                                      "parent_id": 23,
                                      "type": "template",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -388,6 +433,8 @@
                                      "trace_id": 0,
                                      "span_id": 31,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -403,6 +450,8 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -418,6 +467,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -433,6 +484,8 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -448,6 +501,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -463,6 +518,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -478,6 +535,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_111x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_111x.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_111x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_111x.json
@@ -39,6 +39,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -54,6 +56,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -69,6 +73,8 @@
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -84,6 +90,8 @@
        "trace_id": 0,
        "span_id": 5,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -99,6 +107,8 @@
        "trace_id": 0,
        "span_id": 6,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -114,6 +124,8 @@
        "trace_id": 0,
        "span_id": 7,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -129,6 +141,8 @@
        "trace_id": 0,
        "span_id": 8,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -144,6 +158,8 @@
        "trace_id": 0,
        "span_id": 9,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -159,6 +175,8 @@
        "trace_id": 0,
        "span_id": 10,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -175,6 +193,7 @@
        "span_id": 11,
        "parent_id": 1,
        "type": "template",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -191,6 +210,8 @@
        "trace_id": 0,
        "span_id": 12,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -206,6 +227,8 @@
        "trace_id": 0,
        "span_id": 13,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -221,6 +244,8 @@
        "trace_id": 0,
        "span_id": 14,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -236,6 +261,8 @@
        "trace_id": 0,
        "span_id": 15,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -251,6 +278,8 @@
        "trace_id": 0,
        "span_id": 16,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -266,6 +295,8 @@
        "trace_id": 0,
        "span_id": 17,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -281,6 +312,8 @@
        "trace_id": 0,
        "span_id": 18,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_18x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_18x.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_18x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_18x.json
@@ -38,6 +38,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django"
@@ -52,6 +54,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django"
@@ -66,6 +70,8 @@
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django"
@@ -80,6 +86,8 @@
        "trace_id": 0,
        "span_id": 5,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django"
@@ -94,6 +102,8 @@
        "trace_id": 0,
        "span_id": 6,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django"
@@ -108,6 +118,8 @@
        "trace_id": 0,
        "span_id": 7,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django"
@@ -122,6 +134,8 @@
        "trace_id": 0,
        "span_id": 8,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django"
@@ -137,6 +151,7 @@
        "span_id": 9,
        "parent_id": 1,
        "type": "template",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django",
@@ -152,6 +167,8 @@
        "trace_id": 0,
        "span_id": 10,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django"
@@ -166,6 +183,8 @@
        "trace_id": 0,
        "span_id": 11,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django"
@@ -180,6 +199,8 @@
        "trace_id": 0,
        "span_id": 12,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django"
@@ -194,6 +215,8 @@
        "trace_id": 0,
        "span_id": 13,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django"
@@ -208,6 +231,8 @@
        "trace_id": 0,
        "span_id": 14,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django"
@@ -222,6 +247,8 @@
        "trace_id": 0,
        "span_id": 15,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django"
@@ -236,6 +263,8 @@
        "trace_id": 0,
        "span_id": 16,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_21x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_21x.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_21x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_404_exceptions_21x.json
@@ -39,6 +39,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django"
@@ -53,6 +55,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "django"
@@ -67,6 +71,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "django"
@@ -81,6 +87,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.p.tid": "654a694400000000",
                "component": "django"
@@ -95,6 +103,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.p.tid": "654a694400000000",
                "component": "django"
@@ -109,6 +119,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.p.tid": "654a694400000000",
                   "component": "django"
@@ -123,6 +135,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.p.tid": "654a694400000000",
                   "component": "django"
@@ -137,6 +151,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.p.tid": "654a694400000000",
                      "component": "django"
@@ -151,6 +167,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.p.tid": "654a694400000000",
                      "component": "django"
@@ -165,6 +183,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.p.tid": "654a694400000000",
                         "component": "django"
@@ -179,6 +199,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.p.tid": "654a694400000000",
                         "component": "django"
@@ -193,6 +215,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.p.tid": "654a694400000000",
                            "component": "django"
@@ -207,6 +231,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.p.tid": "654a694400000000",
                               "component": "django"
@@ -221,6 +247,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.p.tid": "654a694400000000",
                               "component": "django"
@@ -235,6 +263,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.p.tid": "654a694400000000",
                                  "component": "django"
@@ -249,6 +279,8 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.p.tid": "654a694400000000",
                                     "component": "django"
@@ -263,6 +295,8 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.p.tid": "654a694400000000",
                                        "component": "django"
@@ -277,6 +311,8 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.p.tid": "654a694400000000",
                                        "component": "django"
@@ -291,6 +327,8 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.p.tid": "654a694400000000",
                                        "component": "django"
@@ -305,6 +343,8 @@
                                      "trace_id": 0,
                                      "span_id": 27,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.p.tid": "654a694400000000",
                                        "component": "django"
@@ -319,6 +359,8 @@
                                      "trace_id": 0,
                                      "span_id": 28,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.p.tid": "654a694400000000",
                                        "component": "django"
@@ -333,6 +375,8 @@
                                      "trace_id": 0,
                                      "span_id": 29,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.p.tid": "654a694400000000",
                                        "component": "django"
@@ -348,6 +392,7 @@
                                      "span_id": 30,
                                      "parent_id": 23,
                                      "type": "template",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.p.tid": "654a694400000000",
                                        "component": "django",
@@ -363,6 +408,8 @@
                                      "trace_id": 0,
                                      "span_id": 31,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.p.tid": "654a694400000000",
                                        "component": "django"
@@ -377,6 +424,8 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.p.tid": "654a694400000000",
                               "component": "django"
@@ -391,6 +440,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.p.tid": "654a694400000000",
                            "component": "django"
@@ -405,6 +456,8 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.p.tid": "654a694400000000",
                         "component": "django"
@@ -419,6 +472,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.p.tid": "654a694400000000",
                   "component": "django"
@@ -433,6 +488,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.p.tid": "654a694400000000",
                "component": "django"
@@ -447,6 +504,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_3x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_3x.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_3x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_3x.json
@@ -44,6 +44,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -59,6 +61,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -74,6 +78,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -89,6 +95,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -104,6 +112,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -119,6 +129,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -134,6 +146,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -149,6 +163,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -164,6 +180,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -179,6 +197,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -194,6 +214,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -209,6 +231,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -224,6 +248,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -239,6 +265,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -254,6 +282,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "_dd.p.tid": "654a694400000000",
@@ -269,6 +299,8 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "_dd.p.tid": "654a694400000000",
@@ -284,6 +316,8 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -299,6 +333,8 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -314,6 +350,8 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -329,6 +367,8 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -344,6 +384,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -359,6 +401,8 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -374,6 +418,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -389,6 +435,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -404,6 +452,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_traced_simple_app.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_traced_simple_app.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_traced_simple_app.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_200_traced_simple_app.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "asgi.request",
-    "service": null,
+    "service": "",
     "resource": "GET /traced-simple-asgi-app/",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_500_3x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_asgi_500_3x.json
@@ -45,6 +45,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -60,6 +62,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -75,6 +79,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -90,6 +96,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -105,6 +113,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -120,6 +130,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -135,6 +147,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -150,6 +164,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -165,6 +181,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -180,6 +198,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -195,6 +215,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -210,6 +232,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -225,6 +249,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -240,6 +266,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -255,6 +283,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "_dd.p.tid": "654a694400000000",
@@ -270,6 +300,8 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "_dd.p.tid": "654a694400000000",
@@ -285,6 +317,8 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -300,6 +334,8 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -315,6 +351,7 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
+                                     "type": "",
                                      "error": 1,
                                      "meta": {
                                        "_dd.base_service": "",
@@ -334,6 +371,8 @@
                                      "trace_id": 0,
                                      "span_id": 27,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -349,6 +388,8 @@
                                      "trace_id": 0,
                                      "span_id": 28,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -364,6 +405,8 @@
                                      "trace_id": 0,
                                      "span_id": 29,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -379,6 +422,8 @@
                                      "trace_id": 0,
                                      "span_id": 30,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -395,6 +440,7 @@
                                      "span_id": 31,
                                      "parent_id": 23,
                                      "type": "template",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -411,6 +457,8 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -426,6 +474,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -441,6 +491,8 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -456,6 +508,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -471,6 +525,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -486,6 +542,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_django_resource_handler.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_django_resource_handler.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_django_resource_handler.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_django_resource_handler.json
@@ -44,6 +44,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -59,6 +61,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -74,6 +78,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -89,6 +95,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -104,6 +112,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -119,6 +129,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -134,6 +146,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -149,6 +163,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -164,6 +180,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -179,6 +197,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -194,6 +214,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -209,6 +231,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -224,6 +248,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -239,6 +265,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -254,6 +282,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "_dd.p.tid": "654a694400000000",
@@ -269,6 +299,8 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "_dd.p.tid": "654a694400000000",
@@ -284,6 +316,8 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -299,6 +333,8 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -314,6 +350,8 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -329,6 +367,8 @@
                                         "trace_id": 0,
                                         "span_id": 27,
                                         "parent_id": 26,
+                                        "type": "",
+                                        "error": 0,
                                         "meta": {
                                           "_dd.base_service": "",
                                           "_dd.p.tid": "654a694400000000",
@@ -344,6 +384,8 @@
                                         "trace_id": 0,
                                         "span_id": 28,
                                         "parent_id": 26,
+                                        "type": "",
+                                        "error": 0,
                                         "meta": {
                                           "_dd.base_service": "",
                                           "_dd.p.tid": "654a694400000000",
@@ -359,6 +401,8 @@
                                            "trace_id": 0,
                                            "span_id": 29,
                                            "parent_id": 28,
+                                           "type": "",
+                                           "error": 0,
                                            "meta": {
                                              "_dd.base_service": "",
                                              "_dd.p.tid": "654a694400000000",
@@ -374,6 +418,8 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -389,6 +435,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -404,6 +452,8 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -419,6 +469,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -434,6 +486,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -449,6 +503,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view.json
@@ -41,6 +41,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -56,6 +58,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -71,6 +75,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -86,6 +92,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -101,6 +109,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -116,6 +126,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -131,6 +143,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -146,6 +160,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -161,6 +177,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -176,6 +194,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -191,6 +211,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -206,6 +228,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -221,6 +245,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -236,6 +262,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -251,6 +279,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "_dd.p.tid": "654a694400000000",
@@ -266,6 +296,8 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "_dd.p.tid": "654a694400000000",
@@ -281,6 +313,8 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -296,6 +330,8 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -311,6 +347,8 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -326,6 +364,8 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -341,6 +381,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -356,6 +398,8 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -371,6 +415,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -386,6 +432,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -401,6 +449,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_111x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_111x.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_111x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_111x.json
@@ -40,6 +40,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -55,6 +57,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -70,6 +74,8 @@
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -85,6 +91,8 @@
        "trace_id": 0,
        "span_id": 5,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -100,6 +108,8 @@
        "trace_id": 0,
        "span_id": 6,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -115,6 +125,8 @@
        "trace_id": 0,
        "span_id": 7,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -130,6 +142,8 @@
        "trace_id": 0,
        "span_id": 8,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -145,6 +159,8 @@
        "trace_id": 0,
        "span_id": 9,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -160,6 +176,8 @@
        "trace_id": 0,
        "span_id": 10,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -175,6 +193,8 @@
        "trace_id": 0,
        "span_id": 11,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -190,6 +210,8 @@
        "trace_id": 0,
        "span_id": 12,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -205,6 +227,8 @@
        "trace_id": 0,
        "span_id": 13,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -220,6 +244,8 @@
        "trace_id": 0,
        "span_id": 14,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -235,6 +261,8 @@
        "trace_id": 0,
        "span_id": 15,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -250,6 +278,8 @@
        "trace_id": 0,
        "span_id": 16,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_21x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_21x.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_21x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_callable_view_21x.json
@@ -39,6 +39,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django"
@@ -53,6 +55,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "django"
@@ -67,6 +71,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "django"
@@ -81,6 +87,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.p.tid": "654a694400000000",
                "component": "django"
@@ -95,6 +103,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.p.tid": "654a694400000000",
                "component": "django"
@@ -109,6 +119,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.p.tid": "654a694400000000",
                   "component": "django"
@@ -123,6 +135,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.p.tid": "654a694400000000",
                   "component": "django"
@@ -137,6 +151,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.p.tid": "654a694400000000",
                      "component": "django"
@@ -151,6 +167,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.p.tid": "654a694400000000",
                      "component": "django"
@@ -165,6 +183,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.p.tid": "654a694400000000",
                         "component": "django"
@@ -179,6 +199,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.p.tid": "654a694400000000",
                         "component": "django"
@@ -193,6 +215,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.p.tid": "654a694400000000",
                            "component": "django"
@@ -207,6 +231,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.p.tid": "654a694400000000",
                               "component": "django"
@@ -221,6 +247,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.p.tid": "654a694400000000",
                               "component": "django"
@@ -235,6 +263,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.p.tid": "654a694400000000",
                                  "component": "django"
@@ -249,6 +279,8 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.p.tid": "654a694400000000",
                                     "component": "django"
@@ -263,6 +295,8 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.p.tid": "654a694400000000",
                                        "component": "django"
@@ -277,6 +311,8 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.p.tid": "654a694400000000",
                                        "component": "django"
@@ -291,6 +327,8 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.p.tid": "654a694400000000",
                                        "component": "django"
@@ -305,6 +343,8 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.p.tid": "654a694400000000",
                               "component": "django"
@@ -319,6 +359,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.p.tid": "654a694400000000",
                            "component": "django"
@@ -333,6 +375,8 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.p.tid": "654a694400000000",
                         "component": "django"
@@ -347,6 +391,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.p.tid": "654a694400000000",
                   "component": "django"
@@ -361,6 +407,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.p.tid": "654a694400000000",
                "component": "django"
@@ -375,6 +423,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view.json
@@ -41,6 +41,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -56,6 +58,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -71,6 +75,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -86,6 +92,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -101,6 +109,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -116,6 +126,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -131,6 +143,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -146,6 +160,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -161,6 +177,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -176,6 +194,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -191,6 +211,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -206,6 +228,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -221,6 +245,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -236,6 +262,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -251,6 +279,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "_dd.p.tid": "654a694400000000",
@@ -266,6 +296,8 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "_dd.p.tid": "654a694400000000",
@@ -281,6 +313,8 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -296,6 +330,8 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -311,6 +347,8 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -326,6 +364,8 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -341,6 +381,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -356,6 +398,8 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -371,6 +415,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -386,6 +432,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -401,6 +449,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_111x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_111x.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_111x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_111x.json
@@ -40,6 +40,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -55,6 +57,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -70,6 +74,8 @@
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -85,6 +91,8 @@
        "trace_id": 0,
        "span_id": 5,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -100,6 +108,8 @@
        "trace_id": 0,
        "span_id": 6,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -115,6 +125,8 @@
        "trace_id": 0,
        "span_id": 7,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -130,6 +142,8 @@
        "trace_id": 0,
        "span_id": 8,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -145,6 +159,8 @@
        "trace_id": 0,
        "span_id": 9,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -160,6 +176,8 @@
        "trace_id": 0,
        "span_id": 10,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -175,6 +193,8 @@
        "trace_id": 0,
        "span_id": 11,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -190,6 +210,8 @@
        "trace_id": 0,
        "span_id": 12,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -205,6 +227,8 @@
        "trace_id": 0,
        "span_id": 13,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -220,6 +244,8 @@
        "trace_id": 0,
        "span_id": 14,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -235,6 +261,8 @@
        "trace_id": 0,
        "span_id": 15,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -250,6 +278,8 @@
        "trace_id": 0,
        "span_id": 16,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_21x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_21x.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_21x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_middleware_trace_partial_based_view_21x.json
@@ -39,6 +39,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "django"
@@ -53,6 +55,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "django"
@@ -67,6 +71,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "django"
@@ -81,6 +87,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.p.tid": "654a694400000000",
                "component": "django"
@@ -95,6 +103,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.p.tid": "654a694400000000",
                "component": "django"
@@ -109,6 +119,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.p.tid": "654a694400000000",
                   "component": "django"
@@ -123,6 +135,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.p.tid": "654a694400000000",
                   "component": "django"
@@ -137,6 +151,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.p.tid": "654a694400000000",
                      "component": "django"
@@ -151,6 +167,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.p.tid": "654a694400000000",
                      "component": "django"
@@ -165,6 +183,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.p.tid": "654a694400000000",
                         "component": "django"
@@ -179,6 +199,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.p.tid": "654a694400000000",
                         "component": "django"
@@ -193,6 +215,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.p.tid": "654a694400000000",
                            "component": "django"
@@ -207,6 +231,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.p.tid": "654a694400000000",
                               "component": "django"
@@ -221,6 +247,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.p.tid": "654a694400000000",
                               "component": "django"
@@ -235,6 +263,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.p.tid": "654a694400000000",
                                  "component": "django"
@@ -249,6 +279,8 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.p.tid": "654a694400000000",
                                     "component": "django"
@@ -263,6 +295,8 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.p.tid": "654a694400000000",
                                        "component": "django"
@@ -277,6 +311,8 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.p.tid": "654a694400000000",
                                        "component": "django"
@@ -291,6 +327,8 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.p.tid": "654a694400000000",
                                        "component": "django"
@@ -305,6 +343,8 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.p.tid": "654a694400000000",
                               "component": "django"
@@ -319,6 +359,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.p.tid": "654a694400000000",
                            "component": "django"
@@ -333,6 +375,8 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.p.tid": "654a694400000000",
                         "component": "django"
@@ -347,6 +391,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.p.tid": "654a694400000000",
                   "component": "django"
@@ -361,6 +407,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.p.tid": "654a694400000000",
                "component": "django"
@@ -375,6 +423,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg2_query_default.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg2_query_default.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg2_query_default.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg2_query_default.json
@@ -37,6 +37,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg3_query_default.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg3_query_default.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg3_query_default.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg3_query_default.json
@@ -37,6 +37,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding.json
@@ -43,6 +43,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -58,6 +60,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -73,6 +77,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -88,6 +94,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -103,6 +111,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -118,6 +128,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -133,6 +145,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -148,6 +162,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -163,6 +179,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -178,6 +196,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -193,6 +213,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -208,6 +230,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -223,6 +247,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -238,6 +264,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -253,6 +281,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "_dd.p.tid": "654a694400000000",
@@ -268,6 +298,8 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "_dd.p.tid": "654a694400000000",
@@ -283,6 +315,8 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -298,6 +332,8 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -313,6 +349,8 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -328,6 +366,8 @@
                                         "trace_id": 0,
                                         "span_id": 29,
                                         "parent_id": 26,
+                                        "type": "",
+                                        "error": 0,
                                         "meta": {
                                           "_dd.base_service": "",
                                           "_dd.p.tid": "654a694400000000",
@@ -343,6 +383,8 @@
                                         "trace_id": 0,
                                         "span_id": 30,
                                         "parent_id": 26,
+                                        "type": "",
+                                        "error": 0,
                                         "meta": {
                                           "_dd.base_service": "",
                                           "_dd.p.tid": "654a694400000000",
@@ -358,6 +400,8 @@
                                            "trace_id": 0,
                                            "span_id": 32,
                                            "parent_id": 30,
+                                           "type": "",
+                                           "error": 0,
                                            "meta": {
                                              "_dd.base_service": "",
                                              "_dd.p.tid": "654a694400000000",
@@ -373,6 +417,8 @@
                                      "trace_id": 0,
                                      "span_id": 27,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -388,6 +434,8 @@
                                      "trace_id": 0,
                                      "span_id": 28,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -404,6 +452,7 @@
                                         "span_id": 31,
                                         "parent_id": 28,
                                         "type": "template",
+                                        "error": 0,
                                         "meta": {
                                           "_dd.base_service": "",
                                           "_dd.p.tid": "654a694400000000",
@@ -422,6 +471,7 @@
                                            "span_id": 33,
                                            "parent_id": 31,
                                            "type": "cache",
+                                           "error": 0,
                                            "meta": {
                                              "_dd.base_service": "",
                                              "_dd.p.tid": "654a694400000000",
@@ -442,6 +492,8 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -457,6 +509,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -472,6 +526,8 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -487,6 +543,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -502,6 +560,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -517,6 +577,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_111x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_111x.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_111x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_safe_string_encoding_111x.json
@@ -42,6 +42,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -57,6 +59,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -72,6 +76,8 @@
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -87,6 +93,8 @@
        "trace_id": 0,
        "span_id": 5,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -102,6 +110,8 @@
        "trace_id": 0,
        "span_id": 6,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -117,6 +127,8 @@
        "trace_id": 0,
        "span_id": 7,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -132,6 +144,8 @@
        "trace_id": 0,
        "span_id": 8,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -147,6 +161,8 @@
        "trace_id": 0,
        "span_id": 9,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -162,6 +178,8 @@
        "trace_id": 0,
        "span_id": 10,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -177,6 +195,8 @@
           "trace_id": 0,
           "span_id": 18,
           "parent_id": 10,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -192,6 +212,8 @@
              "trace_id": 0,
              "span_id": 20,
              "parent_id": 18,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -207,6 +229,8 @@
        "trace_id": 0,
        "span_id": 11,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -223,6 +247,7 @@
           "span_id": 19,
           "parent_id": 11,
           "type": "template",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -241,6 +266,7 @@
              "span_id": 21,
              "parent_id": 19,
              "type": "cache",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -261,6 +287,8 @@
        "trace_id": 0,
        "span_id": 12,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -276,6 +304,8 @@
        "trace_id": 0,
        "span_id": 13,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -291,6 +321,8 @@
        "trace_id": 0,
        "span_id": 14,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -306,6 +338,8 @@
        "trace_id": 0,
        "span_id": 15,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -321,6 +355,8 @@
        "trace_id": 0,
        "span_id": 16,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -336,6 +372,8 @@
        "trace_id": 0,
        "span_id": 17,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_streamed_file.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_streamed_file.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_streamed_file.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_streamed_file.json
@@ -40,6 +40,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "django"
@@ -54,6 +56,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -68,6 +72,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"
@@ -82,6 +88,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -96,6 +104,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -110,6 +120,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -124,6 +136,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -138,6 +152,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -152,6 +168,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "component": "django"
@@ -166,6 +184,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -180,6 +200,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -194,6 +216,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -208,6 +232,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -222,6 +248,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -236,6 +264,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "component": "django"
@@ -250,6 +280,8 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "component": "django"
@@ -264,6 +296,8 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -278,6 +312,8 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -292,6 +328,8 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "component": "django"
@@ -306,6 +344,8 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "component": "django"
@@ -320,6 +360,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "component": "django"
@@ -334,6 +376,8 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "component": "django"
@@ -348,6 +392,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "django"
@@ -362,6 +408,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "django"
@@ -376,6 +424,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "django"

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_templates_disabled_3x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_templates_disabled_3x.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_templates_disabled_3x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_templates_disabled_3x.json
@@ -45,6 +45,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -60,6 +62,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -75,6 +79,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -90,6 +96,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -105,6 +113,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -120,6 +130,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -135,6 +147,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -150,6 +164,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -165,6 +181,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -180,6 +198,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -195,6 +215,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -210,6 +232,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -225,6 +249,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -240,6 +266,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -255,6 +283,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "_dd.p.tid": "654a694400000000",
@@ -270,6 +300,8 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "_dd.p.tid": "654a694400000000",
@@ -285,6 +317,8 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -300,6 +334,8 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -315,6 +351,8 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -330,6 +368,8 @@
                                      "trace_id": 0,
                                      "span_id": 27,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -345,6 +385,8 @@
                                      "trace_id": 0,
                                      "span_id": 28,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -360,6 +402,8 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -375,6 +419,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -390,6 +436,8 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -405,6 +453,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -420,6 +470,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -435,6 +487,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_templates_enabled_3x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_templates_enabled_3x.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_templates_enabled_3x.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_templates_enabled_3x.json
@@ -45,6 +45,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -60,6 +62,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -75,6 +79,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -90,6 +96,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -105,6 +113,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -120,6 +130,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -135,6 +147,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -150,6 +164,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -165,6 +181,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -180,6 +198,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -195,6 +215,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -210,6 +232,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -225,6 +249,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -240,6 +266,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -255,6 +283,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "_dd.p.tid": "654a694400000000",
@@ -270,6 +300,8 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "_dd.p.tid": "654a694400000000",
@@ -285,6 +317,8 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -300,6 +334,8 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -315,6 +351,8 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -330,6 +368,8 @@
                                      "trace_id": 0,
                                      "span_id": 27,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -345,6 +385,8 @@
                                      "trace_id": 0,
                                      "span_id": 28,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -361,6 +403,7 @@
                                         "span_id": 29,
                                         "parent_id": 28,
                                         "type": "template",
+                                        "error": 0,
                                         "meta": {
                                           "_dd.base_service": "",
                                           "_dd.p.tid": "654a694400000000",
@@ -378,6 +421,8 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -393,6 +438,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -408,6 +455,8 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -423,6 +472,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -438,6 +489,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -453,6 +506,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include.json
@@ -41,6 +41,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -56,6 +58,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -71,6 +75,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -86,6 +92,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -101,6 +109,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -116,6 +126,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -131,6 +143,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -146,6 +160,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -161,6 +177,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 10,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -176,6 +194,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -191,6 +211,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -206,6 +228,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -221,6 +245,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -236,6 +262,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -251,6 +279,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 20,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "_dd.p.tid": "654a694400000000",
@@ -266,6 +296,8 @@
                                   "trace_id": 0,
                                   "span_id": 23,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "_dd.p.tid": "654a694400000000",
@@ -281,6 +313,8 @@
                                      "trace_id": 0,
                                      "span_id": 24,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -296,6 +330,8 @@
                                      "trace_id": 0,
                                      "span_id": 25,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -311,6 +347,8 @@
                                      "trace_id": 0,
                                      "span_id": 26,
                                      "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
                                      "meta": {
                                        "_dd.base_service": "",
                                        "_dd.p.tid": "654a694400000000",
@@ -326,6 +364,8 @@
                             "trace_id": 0,
                             "span_id": 21,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -341,6 +381,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -356,6 +398,8 @@
                       "trace_id": 0,
                       "span_id": 16,
                       "parent_id": 13,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -371,6 +415,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -386,6 +432,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -401,6 +449,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.django_hosts.test_django.test_django_hosts_request.json
+++ b/tests/snapshots/tests.contrib.django_hosts.test_django.test_django_hosts_request.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.django_hosts.test_django.test_django_hosts_request.json
+++ b/tests/snapshots/tests.contrib.django_hosts.test_django.test_django_hosts_request.json
@@ -41,6 +41,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -56,6 +58,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -71,6 +75,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -86,6 +92,8 @@
              "trace_id": 0,
              "span_id": 5,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -101,6 +109,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -116,6 +126,8 @@
                 "trace_id": 0,
                 "span_id": 8,
                 "parent_id": 6,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -131,6 +143,8 @@
                 "trace_id": 0,
                 "span_id": 9,
                 "parent_id": 6,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -146,6 +160,8 @@
                    "trace_id": 0,
                    "span_id": 11,
                    "parent_id": 9,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -161,6 +177,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 9,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -176,6 +194,8 @@
                       "trace_id": 0,
                       "span_id": 14,
                       "parent_id": 12,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -191,6 +211,8 @@
                       "trace_id": 0,
                       "span_id": 15,
                       "parent_id": 12,
+                      "type": "",
+                      "error": 0,
                       "meta": {
                         "_dd.base_service": "",
                         "_dd.p.tid": "654a694400000000",
@@ -206,6 +228,8 @@
                          "trace_id": 0,
                          "span_id": 16,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -221,6 +245,8 @@
                          "trace_id": 0,
                          "span_id": 17,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -236,6 +262,8 @@
                             "trace_id": 0,
                             "span_id": 19,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -251,6 +279,8 @@
                                "trace_id": 0,
                                "span_id": 21,
                                "parent_id": 19,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "_dd.p.tid": "654a694400000000",
@@ -266,6 +296,8 @@
                                "trace_id": 0,
                                "span_id": 22,
                                "parent_id": 19,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "_dd.p.tid": "654a694400000000",
@@ -281,6 +313,8 @@
                                   "trace_id": 0,
                                   "span_id": 24,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "_dd.p.tid": "654a694400000000",
@@ -296,6 +330,8 @@
                                   "trace_id": 0,
                                   "span_id": 25,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "_dd.p.tid": "654a694400000000",
@@ -311,6 +347,8 @@
                                   "trace_id": 0,
                                   "span_id": 26,
                                   "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
                                   "meta": {
                                     "_dd.base_service": "",
                                     "_dd.p.tid": "654a694400000000",
@@ -326,6 +364,8 @@
                                "trace_id": 0,
                                "span_id": 23,
                                "parent_id": 19,
+                               "type": "",
+                               "error": 0,
                                "meta": {
                                  "_dd.base_service": "",
                                  "_dd.p.tid": "654a694400000000",
@@ -341,6 +381,8 @@
                             "trace_id": 0,
                             "span_id": 20,
                             "parent_id": 17,
+                            "type": "",
+                            "error": 0,
                             "meta": {
                               "_dd.base_service": "",
                               "_dd.p.tid": "654a694400000000",
@@ -356,6 +398,8 @@
                          "trace_id": 0,
                          "span_id": 18,
                          "parent_id": 15,
+                         "type": "",
+                         "error": 0,
                          "meta": {
                            "_dd.base_service": "",
                            "_dd.p.tid": "654a694400000000",
@@ -371,6 +415,8 @@
                    "trace_id": 0,
                    "span_id": 13,
                    "parent_id": 9,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -386,6 +432,8 @@
                 "trace_id": 0,
                 "span_id": 10,
                 "parent_id": 6,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -401,6 +449,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.elasticsearch.test_async.test_elasticsearch.json
+++ b/tests/snapshots/tests.contrib.elasticsearch.test_async.test_elasticsearch.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -40,6 +41,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.elasticsearch.test_async.test_elasticsearch7.json
+++ b/tests/snapshots/tests.contrib.elasticsearch.test_async.test_elasticsearch7.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -38,6 +39,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.elasticsearch.test_async.test_opensearch.json
+++ b/tests/snapshots/tests.contrib.elasticsearch.test_async.test_opensearch.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -38,6 +39,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch.json
+++ b/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -40,6 +41,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch7.json
+++ b/tests/snapshots/tests.contrib.elasticsearch.test_elasticsearch_multi.test_elasticsearch7.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -39,6 +40,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "elasticsearch",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples0]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples0]_6_9.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples0]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples0]_6_9.json
@@ -39,6 +39,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -60,6 +61,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000"

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples0]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples0]_9.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "http.request",
-    "service": null,
+    "service": "",
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples0]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples0]_9.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples0]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples0]_9.json
@@ -38,6 +38,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -64,6 +65,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -85,6 +87,8 @@
              "trace_id": 0,
              "span_id": 4,
              "parent_id": 3,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000"

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples1]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples1]_6_9.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples1]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples1]_6_9.json
@@ -39,6 +39,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -60,6 +61,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000"

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples1]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples1]_9.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "http.request",
-    "service": null,
+    "service": "",
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples1]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples1]_9.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples1]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples1]_9.json
@@ -38,6 +38,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -64,6 +65,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -85,6 +87,8 @@
              "trace_id": 0,
              "span_id": 4,
              "parent_id": 3,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000"

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples2]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples2]_6_9.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples2]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples2]_6_9.json
@@ -38,6 +38,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "fastapi",
@@ -58,6 +59,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "duration": 28304,
           "start": 1691166901137325786
         }]]

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples2]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples2]_9.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples2]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples2]_9.json
@@ -40,6 +40,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "fastapi",
@@ -62,6 +63,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "fastapi",
@@ -82,6 +84,8 @@
              "trace_id": 0,
              "span_id": 4,
              "parent_id": 3,
+             "type": "",
+             "error": 0,
              "duration": 86457,
              "start": 1691166910649033755
            }]]

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples3]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples3]_6_9.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples3]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples3]_6_9.json
@@ -38,6 +38,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "fastapi",
@@ -58,6 +59,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "duration": 26869,
           "start": 1691166901856948993
         }]]

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples3]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples3]_9.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples3]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples3]_9.json
@@ -38,6 +38,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "fastapi",
@@ -60,6 +61,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "fastapi",
@@ -80,6 +82,8 @@
              "trace_id": 0,
              "span_id": 4,
              "parent_id": 3,
+             "type": "",
+             "error": 0,
              "duration": 87587,
              "start": 1691166911366639806
            }]]

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples4]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples4]_6_9.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples4]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples4]_6_9.json
@@ -38,6 +38,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "fastapi",
@@ -58,6 +59,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "duration": 44074,
           "start": 1691166902578225677
         }]]

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples4]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples4]_9.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples4]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples4]_9.json
@@ -38,6 +38,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "fastapi",
@@ -60,6 +61,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "fastapi",
@@ -80,6 +82,8 @@
              "trace_id": 0,
              "span_id": 4,
              "parent_id": 3,
+             "type": "",
+             "error": 0,
              "duration": 85739,
              "start": 1691166912035584642
            }]]

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples5]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples5]_6_9.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples5]_6_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples5]_6_9.json
@@ -38,6 +38,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "fastapi",
@@ -58,6 +59,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "duration": 26097,
           "start": 1691166903278571376
         }]]

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples5]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples5]_9.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples5]_9.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_schematization[schema_tuples5]_9.json
@@ -40,6 +40,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "fastapi",
@@ -62,6 +63,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "fastapi",
@@ -82,6 +84,8 @@
              "trace_id": 0,
              "span_id": 4,
              "parent_id": 3,
+             "type": "",
+             "error": 0,
              "duration": 88214,
              "start": 1691166912732966652
            }]]

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_subapp_no_aggregate_snapshot.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_subapp_no_aggregate_snapshot.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_subapp_no_aggregate_snapshot.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_subapp_no_aggregate_snapshot.json
@@ -38,6 +38,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -59,6 +60,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000"

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_subapp_snapshot.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_subapp_snapshot.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_subapp_snapshot.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_subapp_snapshot.json
@@ -39,6 +39,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -60,6 +61,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000"

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_table_query_snapshot.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_table_query_snapshot.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -56,6 +57,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_table_query_snapshot.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_table_query_snapshot.json
@@ -38,6 +38,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000"
@@ -85,6 +87,8 @@
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000"

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_tracing_in_middleware.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_tracing_in_middleware.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_tracing_in_middleware.json
+++ b/tests/snapshots/tests.contrib.fastapi.test_fastapi.test_tracing_in_middleware.json
@@ -38,6 +38,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000"
@@ -52,6 +54,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000"

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-001\",\n      \"name\": \"Block IP addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"blocking\",\n        \"type\": \"ip_addresses\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"ip_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"http.client_ip\",\n            \"highlight\": [\n              \"8.8.4.4\"\n            ],\n            \"key_path\": [],\n            \"value\": \"8.8.4.4\"\n          }\n        ]\n      }\n    ]\n  }\n]}",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env].json
@@ -54,6 +54,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env]_220.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-001\",\n      \"name\": \"Block IP addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"blocking\",\n        \"type\": \"ip_addresses\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"ip_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"http.client_ip\",\n            \"highlight\": [\n              \"8.8.4.4\"\n            ],\n            \"key_path\": [],\n            \"value\": \"8.8.4.4\"\n          }\n        ]\n      }\n    ]\n  }\n]}",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env]_220.json
@@ -54,6 +54,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-001\",\n      \"name\": \"Block IP addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"blocking\",\n        \"type\": \"ip_addresses\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"ip_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"http.client_ip\",\n            \"highlight\": [\n              \"8.8.4.4\"\n            ],\n            \"key_path\": [],\n            \"value\": \"8.8.4.4\"\n          }\n        ]\n      }\n    ]\n  }\n]}",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env].json
@@ -54,6 +54,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-001\",\n      \"name\": \"Block IP addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"blocking\",\n        \"type\": \"ip_addresses\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"ip_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"http.client_ip\",\n            \"highlight\": [\n              \"8.8.4.4\"\n            ],\n            \"key_path\": [],\n            \"value\": \"8.8.4.4\"\n          }\n        ]\n      }\n    ]\n  }\n]}",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -54,6 +54,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.15.0",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env].json
@@ -53,6 +53,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -70,6 +72,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -85,6 +89,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -100,6 +106,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -115,6 +123,8 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 6,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -131,6 +141,7 @@
                 "span_id": 11,
                 "parent_id": 10,
                 "type": "system",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -149,6 +160,7 @@
                    "span_id": 12,
                    "parent_id": 11,
                    "type": "system",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -165,6 +177,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -180,6 +194,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -195,6 +211,8 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -210,6 +228,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env]_220.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.15.0",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_osspawn[flask_appsec_good_rules_env]_220.json
@@ -53,6 +53,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -70,6 +72,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -85,6 +89,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -100,6 +106,8 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 5,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -116,6 +124,7 @@
                 "span_id": 10,
                 "parent_id": 9,
                 "type": "system",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -134,6 +143,7 @@
                    "span_id": 11,
                    "parent_id": 10,
                    "type": "system",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": "",
                      "_dd.p.tid": "654a694400000000",
@@ -150,6 +160,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -165,6 +177,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -180,6 +194,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -195,6 +211,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env].json
@@ -53,6 +53,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -70,6 +72,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -85,6 +89,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -100,6 +106,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -115,6 +123,8 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 6,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -131,6 +141,7 @@
                 "span_id": 11,
                 "parent_id": 10,
                 "type": "system",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -148,6 +159,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -163,6 +176,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -178,6 +193,8 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -193,6 +210,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.15.0",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env]_220.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.15.0",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_ossystem[flask_appsec_good_rules_env]_220.json
@@ -53,6 +53,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -70,6 +72,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -85,6 +89,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -100,6 +106,8 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 5,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -116,6 +124,7 @@
                 "span_id": 10,
                 "parent_id": 9,
                 "type": "system",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -133,6 +142,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -148,6 +159,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -163,6 +176,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -178,6 +193,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env].json
@@ -53,6 +53,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -70,6 +72,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -85,6 +89,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -100,6 +106,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -115,6 +123,8 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 6,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -131,6 +141,7 @@
                 "span_id": 11,
                 "parent_id": 10,
                 "type": "system",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000"
@@ -146,6 +157,7 @@
                 "span_id": 12,
                 "parent_id": 10,
                 "type": "system",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -164,6 +176,7 @@
                 "span_id": 13,
                 "parent_id": 10,
                 "type": "system",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -181,6 +194,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -196,6 +211,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -211,6 +228,8 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -226,6 +245,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.15.0",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env]_220.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.15.0",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicatenoshell[flask_appsec_good_rules_env]_220.json
@@ -53,6 +53,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -70,6 +72,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -85,6 +89,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -100,6 +106,8 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 5,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -116,6 +124,7 @@
                 "span_id": 10,
                 "parent_id": 9,
                 "type": "system",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000"
@@ -131,6 +140,7 @@
                 "span_id": 11,
                 "parent_id": 9,
                 "type": "system",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -149,6 +159,7 @@
                 "span_id": 12,
                 "parent_id": 9,
                 "type": "system",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -166,6 +177,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -181,6 +194,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -196,6 +211,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -211,6 +228,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env].json
@@ -53,6 +53,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -70,6 +72,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -85,6 +89,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -100,6 +106,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -115,6 +123,8 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 6,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -131,6 +141,7 @@
                 "span_id": 11,
                 "parent_id": 10,
                 "type": "system",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000"
@@ -146,6 +157,7 @@
                 "span_id": 12,
                 "parent_id": 10,
                 "type": "system",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -164,6 +176,7 @@
                 "span_id": 13,
                 "parent_id": 10,
                 "type": "system",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -181,6 +194,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -196,6 +211,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -211,6 +228,8 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -226,6 +245,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.15.0",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env]_220.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.15.0",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env]_220.json
@@ -53,6 +53,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -70,6 +72,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -85,6 +89,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -100,6 +106,8 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 5,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -116,6 +124,7 @@
                 "span_id": 10,
                 "parent_id": 9,
                 "type": "system",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000"
@@ -131,6 +140,7 @@
                 "span_id": 11,
                 "parent_id": 9,
                 "type": "system",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -149,6 +159,7 @@
                 "span_id": 12,
                 "parent_id": 9,
                 "type": "system",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -166,6 +177,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -181,6 +194,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -196,6 +211,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -211,6 +228,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.15.0",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
@@ -54,6 +54,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -72,6 +74,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -87,6 +91,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -102,6 +108,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -117,6 +125,8 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 6,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -132,6 +142,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -147,6 +159,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -162,6 +176,8 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -177,6 +193,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.waf.version": "1.15.0",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
@@ -54,6 +54,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -72,6 +74,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -87,6 +91,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -102,6 +108,8 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 5,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -117,6 +125,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -132,6 +142,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -147,6 +159,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -162,6 +176,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-002\",\n      \"name\": \"Block User Addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"security_response\",\n        \"type\": \"block_user\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"exact_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"usr.id\",\n            \"highlight\": [\n              \"123456\"\n            ],\n            \"key_path\": [],\n            \"value\": \"123456\"\n          }\n        ]\n      }\n    ]\n  }\n]}",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
@@ -64,6 +64,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -85,6 +87,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -100,6 +104,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -115,6 +121,7 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
           "error": 1,
           "meta": {
             "_dd.base_service": "",
@@ -134,6 +141,7 @@
              "trace_id": 0,
              "span_id": 11,
              "parent_id": 6,
+             "type": "",
              "error": 1,
              "meta": {
                "_dd.base_service": "",
@@ -153,6 +161,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -168,6 +178,8 @@
              "trace_id": 0,
              "span_id": 12,
              "parent_id": 7,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -183,6 +195,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -198,6 +212,8 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -213,6 +229,8 @@
           "trace_id": 0,
           "span_id": 10,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -228,6 +246,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -64,6 +64,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -85,6 +87,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -100,6 +104,7 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
           "error": 1,
           "meta": {
             "_dd.base_service": "",
@@ -119,6 +124,7 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 5,
+             "type": "",
              "error": 1,
              "meta": {
                "_dd.base_service": "",
@@ -138,6 +144,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -153,6 +161,8 @@
              "trace_id": 0,
              "span_id": 11,
              "parent_id": 6,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -168,6 +178,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -183,6 +195,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -198,6 +212,8 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -213,6 +229,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-002\",\n      \"name\": \"Block User Addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"security_response\",\n        \"type\": \"block_user\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"exact_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"usr.id\",\n            \"highlight\": [\n              \"123456\"\n            ],\n            \"key_path\": [],\n            \"value\": \"123456\"\n          }\n        ]\n      }\n    ]\n  }\n]}",

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_200[flask_default_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_200[flask_default_env].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_200[flask_default_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_200[flask_default_env].json
@@ -41,6 +41,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -58,6 +60,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -73,6 +77,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -88,6 +94,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -103,6 +111,8 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 6,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -118,6 +128,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -133,6 +145,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -148,6 +162,8 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -163,6 +179,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_200[flask_default_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_200[flask_default_env]_220.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_200[flask_default_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_200[flask_default_env]_220.json
@@ -41,6 +41,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -58,6 +60,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -73,6 +77,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -88,6 +94,8 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 5,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -103,6 +111,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -118,6 +128,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -133,6 +145,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -148,6 +162,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_get_user[flask_default_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_get_user[flask_default_env].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_get_user[flask_default_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_get_user[flask_default_env].json
@@ -47,6 +47,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -64,6 +66,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -79,6 +83,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -94,6 +100,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -109,6 +117,8 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 6,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -124,6 +134,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -139,6 +151,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -154,6 +168,8 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -169,6 +185,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_get_user[flask_default_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_get_user[flask_default_env]_220.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_get_user[flask_default_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_get_user[flask_default_env]_220.json
@@ -47,6 +47,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -64,6 +66,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -79,6 +83,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -94,6 +100,8 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 5,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -109,6 +117,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -124,6 +134,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -139,6 +151,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -154,6 +168,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_stream[flask_default_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_stream[flask_default_env].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_stream[flask_default_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_stream[flask_default_env].json
@@ -41,6 +41,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -58,6 +60,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -73,6 +77,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -88,6 +94,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -103,6 +111,8 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 6,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -118,6 +128,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -133,6 +145,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -148,6 +162,8 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -163,6 +179,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_stream[flask_default_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_stream[flask_default_env]_220.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_stream[flask_default_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_flask_snapshot.test_flask_stream[flask_default_env]_220.json
@@ -41,6 +41,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -58,6 +60,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -73,6 +77,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -88,6 +94,8 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 5,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -103,6 +111,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -118,6 +128,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -133,6 +145,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -148,6 +162,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_execute.json
+++ b/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_execute.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_execute.json
+++ b/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_execute.json
@@ -33,6 +33,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -50,6 +51,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -67,6 +69,7 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_execute_with_resolvers.json
+++ b/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_execute_with_resolvers.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_execute_with_resolvers.json
+++ b/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_execute_with_resolvers.json
@@ -33,6 +33,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -50,6 +51,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -67,6 +69,7 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_execute_with_resolvers.json
+++ b/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_execute_with_resolvers.json
@@ -92,6 +92,7 @@
           "span_id": 5,
           "parent_id": 4,
           "type": "graphql",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -108,6 +109,7 @@
           "span_id": 6,
           "parent_id": 4,
           "type": "graphql",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -124,6 +126,7 @@
           "span_id": 7,
           "parent_id": 4,
           "type": "graphql",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -140,6 +143,7 @@
           "span_id": 8,
           "parent_id": 4,
           "type": "graphql",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_failing_execute.json
+++ b/tests/snapshots/tests.contrib.graphene.test_graphene.test_schema_failing_execute.json
@@ -36,6 +36,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -53,6 +54,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql.json
@@ -33,6 +33,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -50,6 +51,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -67,6 +69,7 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_error.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_error.json
@@ -36,6 +36,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_execute_with_middleware.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_execute_with_middleware.json
@@ -31,6 +31,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -51,6 +52,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -89,6 +91,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 5,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000"
@@ -104,6 +108,7 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -142,6 +147,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 6,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000"

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_execute_with_middleware.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_execute_with_middleware.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "test-execute-instrumentation",
-    "service": null,
+    "service": "",
     "resource": "test-execute-instrumentation",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_execute_with_middleware.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_execute_with_middleware.json
@@ -76,6 +76,7 @@
           "span_id": 5,
           "parent_id": 3,
           "type": "graphql",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -132,6 +133,7 @@
           "span_id": 6,
           "parent_id": 4,
           "type": "graphql",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_with_document_with_no_location.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_with_document_with_no_location.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -34,6 +35,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_with_traced_resolver.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_with_traced_resolver.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_with_traced_resolver.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_with_traced_resolver.json
@@ -33,6 +33,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -50,6 +51,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -67,6 +69,7 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_with_traced_resolver.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_with_traced_resolver.json
@@ -93,6 +93,7 @@
           "span_id": 5,
           "parent_id": 4,
           "type": "graphql",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-None].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-None].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-None].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-None].json
@@ -33,6 +33,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -50,6 +51,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -67,6 +69,7 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-v0].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-v0].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-v0].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-v0].json
@@ -33,6 +33,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -50,6 +51,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -67,6 +69,7 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-v1].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-v1].json
@@ -32,6 +32,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "graphql",
@@ -48,6 +49,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "graphql",
@@ -64,6 +66,7 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "graphql",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-v1].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[None-v1].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-None].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-None].json
@@ -32,6 +32,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "graphql",
@@ -48,6 +49,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "graphql",
@@ -64,6 +66,7 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "graphql",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-None].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-None].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-v0].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-v0].json
@@ -32,6 +32,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "graphql",
@@ -48,6 +49,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "graphql",
@@ -64,6 +66,7 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "graphql",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-v0].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-v0].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-v1].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-v1].json
@@ -32,6 +32,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "graphql",
@@ -48,6 +49,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "graphql",
@@ -64,6 +66,7 @@
        "span_id": 4,
        "parent_id": 1,
        "type": "graphql",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "graphql",

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-v1].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_span_schematization[my-service-v1].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "graphql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.grpc.test_grpc.test_method_service.json
+++ b/tests/snapshots/tests.contrib.grpc.test_grpc.test_method_service.json
@@ -42,6 +42,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "grpc",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -107,6 +108,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "grpc",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.grpc.test_grpc.test_method_service.json
+++ b/tests/snapshots/tests.contrib.grpc.test_grpc.test_method_service.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "grpc",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -72,6 +73,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "grpc",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-None].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-None].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-None].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-None].json
@@ -36,6 +36,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -52,6 +54,7 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -68,6 +71,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-v0].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-v0].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-v0].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-v0].json
@@ -36,6 +36,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -52,6 +54,7 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -68,6 +71,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-v1].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-v1].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-v1].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[None-v1].json
@@ -35,6 +35,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi"
@@ -50,6 +52,7 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "wsgi",
@@ -65,6 +68,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-None].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-None].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-None].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-None].json
@@ -35,6 +35,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi"
@@ -50,6 +52,7 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "wsgi",
@@ -65,6 +68,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-v0].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-v0].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-v0].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-v0].json
@@ -35,6 +35,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi"
@@ -50,6 +52,7 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "wsgi",
@@ -65,6 +68,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-v1].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-v1].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-v1].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_span_schematization[mysvc-v1].json
@@ -35,6 +35,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi"
@@ -50,6 +52,7 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "wsgi",
@@ -65,6 +68,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_traced_basic[gunicorn_server_settings0].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_traced_basic[gunicorn_server_settings0].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_traced_basic[gunicorn_server_settings0].json
+++ b/tests/snapshots/tests.contrib.gunicorn.test_gunicorn.test_traced_basic[gunicorn_server_settings0].json
@@ -35,6 +35,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi"
@@ -50,6 +52,7 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "wsgi",
@@ -65,6 +68,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_configure_service_name.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_configure_service_name.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_configure_service_name_env.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_configure_service_name_env.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.base_service": "global-service-name",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_get_200.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_get_200.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "http.request",
-    "service": null,
+    "service": "",
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_get_200.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_get_200.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_get_500.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_get_500.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "http.request",
-    "service": null,
+    "service": "",
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_request_headers.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_request_headers.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "http.request",
-    "service": null,
+    "service": "",
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_request_headers.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_request_headers.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_default.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_default.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v0.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_configure_global_service_name_env_v1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v0.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "http.request",
-    "service": null,
+    "service": "",
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v0.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_operation_name_env_v1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_default.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_default.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "http.request",
-    "service": null,
+    "service": "",
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_default.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_default.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v0.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "http.request",
-    "service": null,
+    "service": "",
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v0.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v1.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_split_by_domain.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_split_by_domain.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_trace_query_string.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_trace_query_string.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "http.request",
-    "service": null,
+    "service": "",
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_trace_query_string.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_trace_query_string.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_analytics_with_rate.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_analytics_with_rate.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -45,6 +46,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_analytics_without_rate.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_analytics_without_rate.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -45,6 +46,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_commit.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_commit.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -44,6 +45,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_commit_with_offset.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_commit_with_offset.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -44,6 +45,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_commit_with_only_async_arg.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_commit_with_only_async_arg.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -44,6 +45,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_message[False].json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_message[False].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -44,6 +45,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_message[True].json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_message[True].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -44,6 +45,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[None-None].json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[None-None].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -44,6 +45,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[None-mysvc].json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[None-mysvc].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
@@ -44,6 +45,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[v0-None].json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[v0-None].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -44,6 +45,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[v0-mysvc].json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[v0-mysvc].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
@@ -44,6 +45,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[v1-None].json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[v1-None].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -43,6 +44,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[v1-mysvc].json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_schematized_span_service_and_operation[v1-mysvc].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -43,6 +44,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_service_override.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_service_override.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -44,6 +45,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.kafka.test_kafka.test_service_override_env_var.json
+++ b/tests/snapshots/tests.contrib.kafka.test_kafka.test_service_override_env_var.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -44,6 +45,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_ai21_llm_sync.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_ai21_llm_sync.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.llms.ai21.AI21",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_cohere_llm_sync.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_cohere_llm_sync.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.llms.cohere.Cohere",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_cohere_math_chain.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_cohere_math_chain.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.chains.llm_math.base.LLMMathChain",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -30,7 +32,7 @@
   },
      {
        "name": "langchain.request",
-       "service": null,
+       "service": "",
        "resource": "langchain.chains.llm.LLMChain",
        "trace_id": 0,
        "span_id": 2,
@@ -54,7 +56,7 @@
      },
         {
           "name": "langchain.request",
-          "service": null,
+          "service": "",
           "resource": "langchain.llms.cohere.Cohere",
           "trace_id": 0,
           "span_id": 3,

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_cohere_math_chain.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_cohere_math_chain.json
@@ -37,6 +37,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "langchain.request.inputs.question": "what is thirteen raised to the .3432 power?",
@@ -61,6 +63,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_fake_embedding_document.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_fake_embedding_document.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.embeddings.fake.FakeEmbeddings",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_fake_embedding_query.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_fake_embedding_query.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.embeddings.fake.FakeEmbeddings",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_huggingfacehub_llm_sync.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_huggingfacehub_llm_sync.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.llms.huggingface_hub.HuggingFaceHub",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_call.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_call.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.chat_models.openai.ChatOpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_generate.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_generate.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.chat_models.openai.ChatOpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_stream.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_stream.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.chat_models.openai.ChatOpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_sync_call_39.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_sync_call_39.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.chat_models.openai.ChatOpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_sync_generate_39.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_chat_model_sync_generate_39.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.chat_models.openai.ChatOpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_embedding_document.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_embedding_document.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.embeddings.openai.OpenAIEmbeddings",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_embedding_query.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_embedding_query.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.embeddings.openai.OpenAIEmbeddings",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_integration.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_integration.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "656758d100000000",
@@ -45,7 +47,7 @@
   },
      {
        "name": "openai.request",
-       "service": null,
+       "service": "",
        "resource": "createCompletion",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_integration.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_integration.json
@@ -52,6 +52,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "component": "openai",
          "openai.api_base": "https://api.openai.com/v1",
@@ -91,6 +93,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "http",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "requests",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_async.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_async.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_error.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_error.json
@@ -6,6 +6,7 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_error.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_error.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_stream.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_stream.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_sync.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_sync.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_sync_39.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_sync_39.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_sync_multiple_prompts.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_sync_multiple_prompts.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_sync_multiple_prompts_39.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_llm_sync_multiple_prompts_39.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_math_chain.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_math_chain.json
@@ -41,6 +41,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "langchain.request.inputs.question": "what is two raised to the fifty-fourth power?",
@@ -69,6 +71,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_math_chain.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_math_chain.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.chains.llm_math.base.LLMMathChain",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -34,7 +36,7 @@
   },
      {
        "name": "langchain.request",
-       "service": null,
+       "service": "",
        "resource": "langchain.chains.llm.LLMChain",
        "trace_id": 0,
        "span_id": 2,
@@ -62,7 +64,7 @@
      },
         {
           "name": "langchain.request",
-          "service": null,
+          "service": "",
           "resource": "langchain.llms.openai.OpenAI",
           "trace_id": 0,
           "span_id": 3,

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.chains.sequential.SequentialChain",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -35,7 +37,7 @@
   },
      {
        "name": "langchain.request",
-       "service": null,
+       "service": "",
        "resource": "langchain.chains.transform.TransformChain",
        "trace_id": 0,
        "span_id": 2,
@@ -56,7 +58,7 @@
      },
      {
        "name": "langchain.request",
-       "service": null,
+       "service": "",
        "resource": "langchain.chains.llm.LLMChain",
        "trace_id": 0,
        "span_id": 3,
@@ -83,7 +85,7 @@
      },
         {
           "name": "langchain.request",
-          "service": null,
+          "service": "",
           "resource": "langchain.llms.openai.OpenAI",
           "trace_id": 0,
           "span_id": 4,

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain.json
@@ -94,6 +94,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 3,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain.json
@@ -42,6 +42,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "langchain.request.inputs.style": "a 90s rapper",
@@ -63,6 +65,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "langchain.request.inputs.output_text": "\\n Chains allow us to combine multiple\\n components together to create a single, coherent application.\\n For example, we can cre...",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain_with_multiple_llm_async.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain_with_multiple_llm_async.json
@@ -134,6 +134,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 3,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain_with_multiple_llm_async.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain_with_multiple_llm_async.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.chains.sequential.SequentialChain",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -33,7 +35,7 @@
   },
      {
        "name": "langchain.request",
-       "service": null,
+       "service": "",
        "resource": "langchain.chains.llm.LLMChain",
        "trace_id": 0,
        "span_id": 2,
@@ -58,7 +60,7 @@
      },
         {
           "name": "langchain.request",
-          "service": null,
+          "service": "",
           "resource": "langchain.llms.openai.OpenAI",
           "trace_id": 0,
           "span_id": 4,
@@ -95,7 +97,7 @@
         },
      {
        "name": "langchain.request",
-       "service": null,
+       "service": "",
        "resource": "langchain.chains.llm.LLMChain",
        "trace_id": 0,
        "span_id": 3,
@@ -121,7 +123,7 @@
      },
         {
           "name": "langchain.request",
-          "service": null,
+          "service": "",
           "resource": "langchain.llms.openai.OpenAI",
           "trace_id": 0,
           "span_id": 5,

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain_with_multiple_llm_async.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain_with_multiple_llm_async.json
@@ -40,6 +40,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "langchain.request.inputs.input_text": "\\n            I have convinced myself that there is absolutely nothing in the world, no sky, no earth, no minds, no\\n           ...",
@@ -65,6 +67,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "langchain.request.api_key": "...key>",
@@ -102,6 +106,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "langchain.request.inputs.input_text": "\\n            I have convinced myself that there is absolutely nothing in the world, no sky, no earth, no minds, no\\n           ...",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain_with_multiple_llm_sync.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain_with_multiple_llm_sync.json
@@ -134,6 +134,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 3,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain_with_multiple_llm_sync.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain_with_multiple_llm_sync.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.chains.sequential.SequentialChain",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -33,7 +35,7 @@
   },
      {
        "name": "langchain.request",
-       "service": null,
+       "service": "",
        "resource": "langchain.chains.llm.LLMChain",
        "trace_id": 0,
        "span_id": 2,
@@ -58,7 +60,7 @@
      },
         {
           "name": "langchain.request",
-          "service": null,
+          "service": "",
           "resource": "langchain.llms.openai.OpenAI",
           "trace_id": 0,
           "span_id": 4,
@@ -95,7 +97,7 @@
         },
      {
        "name": "langchain.request",
-       "service": null,
+       "service": "",
        "resource": "langchain.chains.llm.LLMChain",
        "trace_id": 0,
        "span_id": 3,
@@ -121,7 +123,7 @@
      },
         {
           "name": "langchain.request",
-          "service": null,
+          "service": "",
           "resource": "langchain.llms.openai.OpenAI",
           "trace_id": 0,
           "span_id": 5,

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain_with_multiple_llm_sync.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_sequential_chain_with_multiple_llm_sync.json
@@ -40,6 +40,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "langchain.request.inputs.input_text": "\\n            I have convinced myself that there is absolutely nothing in the world, no sky, no earth, no minds, no\\n           ...",
@@ -65,6 +67,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "langchain.request.api_key": "...key>",
@@ -102,6 +106,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "langchain.request.inputs.input_text": "\\n            I have convinced myself that there is absolutely nothing in the world, no sky, no earth, no minds, no\\n           ...",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-None].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-None].json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "6567589f00000000",
@@ -45,7 +47,7 @@
   },
      {
        "name": "openai.request",
-       "service": null,
+       "service": "",
        "resource": "createCompletion",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-None].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-None].json
@@ -52,6 +52,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "component": "openai",
          "openai.api_base": "https://api.openai.com/v1",
@@ -91,6 +93,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "http",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "requests",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-v0].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-v0].json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.llms.openai.OpenAI",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "656758a100000000",
@@ -45,7 +47,7 @@
   },
      {
        "name": "openai.request",
-       "service": null,
+       "service": "",
        "resource": "createCompletion",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-v0].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-v0].json
@@ -52,6 +52,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "component": "openai",
          "openai.api_base": "https://api.openai.com/v1",
@@ -91,6 +93,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "http",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "requests",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-v1].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-v1].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "656758a200000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-v1].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[None-v1].json
@@ -52,6 +52,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "component": "openai",
          "openai.api_base": "https://api.openai.com/v1",
@@ -91,6 +93,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "http",
+          "error": 0,
           "meta": {
             "_dd.peer.service.source": "out.host",
             "component": "requests",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-None].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-None].json
@@ -52,6 +52,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "component": "openai",
          "openai.api_base": "https://api.openai.com/v1",
@@ -91,6 +93,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "http",
+          "error": 0,
           "meta": {
             "_dd.base_service": "mysvc",
             "component": "requests",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-None].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-None].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "656758a400000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-v0].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-v0].json
@@ -52,6 +52,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "component": "openai",
          "openai.api_base": "https://api.openai.com/v1",
@@ -91,6 +93,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "http",
+          "error": 0,
           "meta": {
             "_dd.base_service": "mysvc",
             "component": "requests",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-v0].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-v0].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "656758a600000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-v1].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-v1].json
@@ -52,6 +52,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "component": "openai",
          "openai.api_base": "https://api.openai.com/v1",
@@ -91,6 +93,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "http",
+          "error": 0,
           "meta": {
             "_dd.peer.service.source": "out.host",
             "component": "requests",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-v1].json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_openai_service_name[mysvc-v1].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "656758a700000000",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_retrieval_chain.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_retrieval_chain.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.chains.qa_with_sources.retrieval.RetrievalQAWithSourcesChain",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -34,7 +36,7 @@
   },
      {
        "name": "langchain.request",
-       "service": null,
+       "service": "",
        "resource": "langchain.vectorstores.pinecone.Pinecone",
        "trace_id": 0,
        "span_id": 2,
@@ -79,7 +81,7 @@
      },
         {
           "name": "langchain.request",
-          "service": null,
+          "service": "",
           "resource": "langchain.embeddings.openai.OpenAIEmbeddings",
           "trace_id": 0,
           "span_id": 4,
@@ -103,7 +105,7 @@
         },
      {
        "name": "langchain.request",
-       "service": null,
+       "service": "",
        "resource": "langchain.chains.combine_documents.stuff.StuffDocumentsChain",
        "trace_id": 0,
        "span_id": 3,
@@ -130,7 +132,7 @@
      },
         {
           "name": "langchain.request",
-          "service": null,
+          "service": "",
           "resource": "langchain.chains.llm.LLMChain",
           "trace_id": 0,
           "span_id": 5,
@@ -158,7 +160,7 @@
         },
            {
              "name": "langchain.request",
-             "service": null,
+             "service": "",
              "resource": "langchain.llms.openai.OpenAI",
              "trace_id": 0,
              "span_id": 6,

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_retrieval_chain.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_retrieval_chain.json
@@ -41,6 +41,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "langchain.request.api_key": "...key>",
@@ -86,6 +88,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "langchain.request.api_key": "...key>",
@@ -110,6 +114,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "langchain.request.inputs.input_documents": "[Document(page_content='A brilliant mathematician and cryptographer Alan was to become the founder of modern-day computer scienc...",
@@ -165,6 +171,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 5,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.p.tid": "654a694400000000",
                "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_retrieval_chain.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_retrieval_chain.json
@@ -143,6 +143,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 3,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "langchain.request.inputs.question": "Who was Alan Turing?",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_retrieval_chain_39.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_retrieval_chain_39.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.chains.qa_with_sources.retrieval.RetrievalQAWithSourcesChain",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -34,7 +36,7 @@
   },
      {
        "name": "langchain.request",
-       "service": null,
+       "service": "",
        "resource": "langchain.vectorstores.pinecone.Pinecone",
        "trace_id": 0,
        "span_id": 2,
@@ -79,7 +81,7 @@
      },
         {
           "name": "langchain.request",
-          "service": null,
+          "service": "",
           "resource": "langchain.embeddings.openai.OpenAIEmbeddings",
           "trace_id": 0,
           "span_id": 4,
@@ -103,7 +105,7 @@
         },
      {
        "name": "langchain.request",
-       "service": null,
+       "service": "",
        "resource": "langchain.chains.combine_documents.stuff.StuffDocumentsChain",
        "trace_id": 0,
        "span_id": 3,
@@ -130,7 +132,7 @@
      },
         {
           "name": "langchain.request",
-          "service": null,
+          "service": "",
           "resource": "langchain.chains.llm.LLMChain",
           "trace_id": 0,
           "span_id": 5,
@@ -158,7 +160,7 @@
         },
            {
              "name": "langchain.request",
-             "service": null,
+             "service": "",
              "resource": "langchain.llms.openai.OpenAI",
              "trace_id": 0,
              "span_id": 6,

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_retrieval_chain_39.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_retrieval_chain_39.json
@@ -41,6 +41,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "langchain.request.api_key": "...key>",
@@ -86,6 +88,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "langchain.request.api_key": "...key>",
@@ -110,6 +114,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "langchain.request.inputs.input_documents": "[Document(page_content='A brilliant mathematician and cryptographer Alan was to become the founder of modern-day computer scienc...",
@@ -165,6 +171,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 5,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.p.tid": "654a694400000000",
                "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_retrieval_chain_39.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_retrieval_chain_39.json
@@ -143,6 +143,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 3,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "langchain.request.inputs.question": "Who was Alan Turing?",

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_similarity_search.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_similarity_search.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "langchain.request",
-    "service": null,
+    "service": "",
     "resource": "langchain.vectorstores.pinecone.Pinecone",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -39,7 +41,7 @@
   },
      {
        "name": "langchain.request",
-       "service": null,
+       "service": "",
        "resource": "langchain.embeddings.openai.OpenAIEmbeddings",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_similarity_search.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain.test_pinecone_vectorstore_similarity_search.json
@@ -46,6 +46,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "langchain.request.api_key": "...key>",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_analytics_with_rate_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_analytics_with_rate_snapshot_post_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_analytics_with_rate_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_analytics_with_rate_snapshot_pre_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_analytics_without_rate_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_analytics_without_rate_snapshot_post_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_analytics_without_rate_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_analytics_without_rate_snapshot_pre_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_commit_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_commit_snapshot_post_1_1.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_commit_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_commit_snapshot_pre_1_1.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_many_fetchall_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_many_fetchall_snapshot_post_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -42,6 +43,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -76,6 +78,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_many_fetchall_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_many_fetchall_snapshot_pre_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -42,6 +43,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -76,6 +78,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_proc_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_proc_snapshot_post_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_proc_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_proc_snapshot_pre_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_fetchall_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_fetchall_snapshot_post_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,6 +42,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_fetchall_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_fetchall_snapshot_pre_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,6 +42,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_snapshot_post_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_query_with_several_rows_snapshot_pre_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema0]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema0]_post_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema0]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema0]_pre_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema1]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema1]_post_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema1]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema1]_pre_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema2]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema2]_post_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema2]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema2]_pre_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema3]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema3]_post_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema3]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema3]_pre_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema4]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema4]_post_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema4]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema4]_pre_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema5]_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema5]_post_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema5]_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_schematized_service_and_operation[service_schema5]_pre_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_fetchall_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_fetchall_snapshot_post_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,6 +42,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_fetchall_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_fetchall_snapshot_pre_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,6 +42,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_snapshot_post_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_simple_query_snapshot_pre_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_mariadb_service_snapshot_post_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_mariadb_service_snapshot_post_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_mariadb_service_snapshot_pre_1_1.json
+++ b/tests/snapshots/tests.contrib.mariadb.test_mariadb.test_user_specified_dd_mariadb_service_snapshot_pre_1_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_acompletion.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_acompletion.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_atranscribe.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_atranscribe.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createTranscription",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_atranslate.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_atranslate.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createTranslation",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_azure_openai_chat_completion.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_azure_openai_chat_completion.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createChatCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_azure_openai_completion.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_azure_openai_completion.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_azure_openai_embedding.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_azure_openai_embedding.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createEmbedding",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_chat_completion.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_chat_completion.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createChatCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_chat_completion_function_calling.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_chat_completion_function_calling.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createChatCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_chat_completion_image_input.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_chat_completion_image_input.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createChatCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "6564c89d00000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_completion.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_completion.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_create_moderation.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_create_moderation.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createModeration",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "openai",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_edit.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_edit.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createEdit",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_embedding.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_embedding.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createEmbedding",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_embedding_array_of_token_arrays.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_embedding_array_of_token_arrays.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createEmbedding",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_embedding_string_array.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_embedding_string_array.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createEmbedding",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_embedding_token_array.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_embedding_token_array.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createEmbedding",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_file_create.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_file_create.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createFile",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_file_delete.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_file_delete.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "deleteFile",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_file_download.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_file_download.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "downloadFile",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_file_list.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_file_list.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "listFiles",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_file_retrieve.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_file_retrieve.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "retrieveFile",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_cancel.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_cancel.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "cancelFineTune",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_create.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_create.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createFineTune",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_list.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_list.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "listFineTunes",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_list_events.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_list_events.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "listFineTuneEvents",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_retrieve.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_fine_tune_retrieve.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "retrieveFineTune",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_image_b64_json_response.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_image_b64_json_response.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createImage",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_image_create.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_image_create.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createImage",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_image_edit.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_image_edit.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createImageEdit",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_image_edit_binary_input.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_image_edit_binary_input.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createImageEdit",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_image_variation.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_image_variation.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createImageVariation",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_integration_async.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_integration_async.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_integration_sync.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_integration_sync.json
@@ -55,6 +55,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "requests",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_integration_sync.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_integration_sync.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "6567512700000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_misuse.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_misuse.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_misuse.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_misuse.json
@@ -6,6 +6,7 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_model_delete.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_model_delete.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "deleteModel",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_model_list.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_model_list.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "listModels",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_model_retrieve.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_model_retrieve.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "retrieveModel",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_span_finish_on_stream_error.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_span_finish_on_stream_error.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_span_finish_on_stream_error.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_span_finish_on_stream_error.json
@@ -6,6 +6,7 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_transcribe.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_transcribe.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createTranscription",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai.test_translate.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai.test_translate.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createTranslation",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[None-None].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[None-None].json
@@ -55,6 +55,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "requests",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[None-None].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[None-None].json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "65674d7100000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[None-v0].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[None-v0].json
@@ -55,6 +55,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "requests",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[None-v0].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[None-v0].json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "65674d7200000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[None-v1].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[None-v1].json
@@ -55,6 +55,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
+       "error": 0,
        "meta": {
          "_dd.peer.service.source": "out.host",
          "component": "requests",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[None-v1].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[None-v1].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "65674d7400000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[mysvc-None].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[mysvc-None].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "65674d7500000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[mysvc-None].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[mysvc-None].json
@@ -55,6 +55,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
+       "error": 0,
        "meta": {
          "_dd.base_service": "mysvc",
          "component": "requests",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[mysvc-v0].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[mysvc-v0].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "65674d7600000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[mysvc-v0].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[mysvc-v0].json
@@ -55,6 +55,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
+       "error": 0,
        "meta": {
          "_dd.base_service": "mysvc",
          "component": "requests",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[mysvc-v1].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[mysvc-v1].json
@@ -55,6 +55,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
+       "error": 0,
        "meta": {
          "_dd.peer.service.source": "out.host",
          "component": "requests",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[mysvc-v1].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v0.test_integration_service_name[mysvc-v1].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "65674d7700000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v1.test_integration_service_name[None-None].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v1.test_integration_service_name[None-None].json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "65674d7a00000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v1.test_integration_service_name[None-v0].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v1.test_integration_service_name[None-v0].json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "65674d7b00000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v1.test_integration_service_name[None-v1].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v1.test_integration_service_name[None-v1].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "65674d7c00000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v1.test_integration_service_name[mysvc-None].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v1.test_integration_service_name[mysvc-None].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "65674d7d00000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v1.test_integration_service_name[mysvc-v0].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v1.test_integration_service_name[mysvc-v0].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "65674d7e00000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v1.test_integration_service_name[mysvc-v1].json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v1.test_integration_service_name[mysvc-v1].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "65674d7f00000000",

--- a/tests/snapshots/tests.contrib.openai.test_openai_v1.test_integration_sync.json
+++ b/tests/snapshots/tests.contrib.openai.test_openai_v1.test_integration_sync.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "openai.request",
-    "service": null,
+    "service": "",
     "resource": "createCompletion",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "6567512a00000000",

--- a/tests/snapshots/tests.contrib.psycopg.test_psycopg.test_composed_query_encoding.json
+++ b/tests/snapshots/tests.contrib.psycopg.test_psycopg.test_composed_query_encoding.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.psycopg.test_psycopg.test_postgres_dbm_propagation_tag.json
+++ b/tests/snapshots/tests.contrib.psycopg.test_psycopg.test_postgres_dbm_propagation_tag.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
@@ -43,6 +44,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
@@ -80,6 +82,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
@@ -116,6 +119,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
@@ -153,6 +157,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
@@ -189,6 +194,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",

--- a/tests/snapshots/tests.contrib.psycopg.test_psycopg_snapshot.test_connect_traced.json
+++ b/tests/snapshots/tests.contrib.psycopg.test_psycopg_snapshot.test_connect_traced.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.psycopg2.test_psycopg.test_composed_query_encoding.json
+++ b/tests/snapshots/tests.contrib.psycopg2.test_psycopg.test_composed_query_encoding.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.psycopg2.test_psycopg.test_postgres_dbm_propagation_tag.json
+++ b/tests/snapshots/tests.contrib.psycopg2.test_psycopg.test_postgres_dbm_propagation_tag.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
@@ -43,6 +44,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
@@ -80,6 +82,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",
@@ -116,6 +119,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.dbm_trace_injected": "true",

--- a/tests/snapshots/tests.contrib.psycopg2.test_psycopg_snapshot.test_connect_traced.json
+++ b/tests/snapshots/tests.contrib.psycopg2.test_psycopg_snapshot.test_connect_traced.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.pyramid.test_pyramid.test_simple_pyramid_app_endpoint.json
+++ b/tests/snapshots/tests.contrib.pyramid.test_pyramid.test_simple_pyramid_app_endpoint.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.pyramid.test_pyramid.test_simple_pyramid_app_endpoint[ddtrace-run_pserve_tests_contrib_pyramid_pserve_app_development.ini].json
+++ b/tests/snapshots/tests.contrib.pyramid.test_pyramid.test_simple_pyramid_app_endpoint[ddtrace-run_pserve_tests_contrib_pyramid_pserve_app_development.ini].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.pyramid.test_pyramid.test_simple_pyramid_app_endpoint[ddtrace-run_python_tests_contrib_pyramid_app_app.py].json
+++ b/tests/snapshots/tests.contrib.pyramid.test_pyramid.test_simple_pyramid_app_endpoint[ddtrace-run_python_tests_contrib_pyramid_app_app.py].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_analytics_with_rate.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_analytics_with_rate.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_analytics_without_rate.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_analytics_without_rate.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_basics.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_basics.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_custom_cmd_length.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_custom_cmd_length.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_custom_cmd_length_env.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_custom_cmd_length_env.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_env_user_specified_redis_service.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_env_user_specified_redis_service.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -42,6 +43,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_full_command_in_resource_config.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_full_command_in_resource_config.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,6 +42,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_full_command_in_resource_env.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_full_command_in_resource_env.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,6 +42,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_long_command.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_long_command.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_meta_override.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_meta_override.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_opentracing.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_opentracing.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_opentracing.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_opentracing.json
@@ -32,6 +32,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_pipeline_immediate.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_pipeline_immediate.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,6 +42,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_pipeline_traced.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_pipeline_traced.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_service_precedence.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_service_precedence.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "app-svc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_unicode.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_unicode.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis.test_user_specified_service.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis.test_user_specified_service.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_basic_request.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_basic_request.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_client_name.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_client_name.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_client_name.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_client_name.json
@@ -32,6 +32,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_decoding_non_utf8_args.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_decoding_non_utf8_args.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,6 +42,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_decoding_non_utf8_pipeline_args.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_decoding_non_utf8_pipeline_args.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_long_command.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_long_command.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_override_service_name.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_override_service_name.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -42,6 +43,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -76,6 +78,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_parenting.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_parenting.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_parenting.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_parenting.json
@@ -32,6 +32,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -59,6 +60,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_pin.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_pin.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_pipeline_traced.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_pipeline_traced.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_pipeline_traced_context_manager_transaction.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_pipeline_traced_context_manager_transaction.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_two_traced_pipelines.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_two_traced_pipelines.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_two_traced_pipelines.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_two_traced_pipelines.json
@@ -32,6 +32,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -59,6 +60,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_unicode_request.json
+++ b/tests/snapshots/tests.contrib.redis.test_redis_asyncio.test_unicode_request.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rediscluster.test.test_cmd_max_length.json
+++ b/tests/snapshots/tests.contrib.rediscluster.test.test_cmd_max_length.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -38,6 +39,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rediscluster.test.test_full_command_in_resource_config[True].json
+++ b/tests/snapshots/tests.contrib.rediscluster.test.test_full_command_in_resource_config[True].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rediscluster.test.test_full_command_in_resource_config[True].json
+++ b/tests/snapshots/tests.contrib.rediscluster.test.test_full_command_in_resource_config[True].json
@@ -36,6 +36,8 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rediscluster.test.test_full_command_in_resource_config[True].json
+++ b/tests/snapshots/tests.contrib.rediscluster.test.test_full_command_in_resource_config[True].json
@@ -61,6 +61,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "rediscluster",
@@ -85,6 +86,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "rediscluster",

--- a/tests/snapshots/tests.contrib.rediscluster.test.test_full_command_in_resource_env.json
+++ b/tests/snapshots/tests.contrib.rediscluster.test.test_full_command_in_resource_env.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rediscluster.test.test_full_command_in_resource_env.json
+++ b/tests/snapshots/tests.contrib.rediscluster.test.test_full_command_in_resource_env.json
@@ -31,6 +31,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "rediscluster",
@@ -55,6 +56,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "rediscluster",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_False_worker_service_None.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_False_worker_service_None.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -55,6 +56,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_False_worker_service_None.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_False_worker_service_None.json
@@ -35,6 +35,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_False_worker_service_custom-worker-service.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_False_worker_service_custom-worker-service.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -53,6 +54,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_False_worker_service_custom-worker-service.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_False_worker_service_custom-worker-service.json
@@ -34,6 +34,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_None_worker_service_None.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_None_worker_service_None.json
@@ -36,6 +36,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -66,6 +67,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_None_worker_service_None.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_None_worker_service_None.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_None_worker_service_custom-worker-service.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_None_worker_service_custom-worker-service.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_None_worker_service_custom-worker-service.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_enqueue_distributed_tracing_enabled_None_worker_service_custom-worker-service.json
@@ -36,6 +36,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
+       "error": 0,
        "meta": {
          "_dd.p.dm": "-0",
          "_dd.p.tid": "654a694400000000",
@@ -65,6 +66,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "rq",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_queue_failing_job.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_queue_failing_job.json
@@ -35,6 +35,7 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
        "error": 1,
        "meta": {
          "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_queue_failing_job.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_queue_failing_job.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_queue_failing_job_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_queue_failing_job_pre_1_10_1.json
@@ -39,6 +39,7 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
        "error": 1,
        "meta": {
          "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_queue_pin_service.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_queue_pin_service.json
@@ -36,6 +36,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -66,6 +67,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_queue_pin_service.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_queue_pin_service.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema0].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema0].json
@@ -67,6 +67,7 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
           "error": 1,
           "meta": {
             "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema0].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema0].json
@@ -88,6 +88,8 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema0].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema0].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema0]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema0]_pre_1_10_1.json
@@ -67,6 +67,7 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
           "error": 1,
           "meta": {
             "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema0]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema0]_pre_1_10_1.json
@@ -88,6 +88,8 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema0]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema0]_pre_1_10_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema1].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema1].json
@@ -67,6 +67,7 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
           "error": 1,
           "meta": {
             "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema1].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema1].json
@@ -88,6 +88,8 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema1].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema1].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema1]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema1]_pre_1_10_1.json
@@ -67,6 +67,7 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
           "error": 1,
           "meta": {
             "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema1]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema1]_pre_1_10_1.json
@@ -88,6 +88,8 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema1]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema1]_pre_1_10_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema2].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema2].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema2].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema2].json
@@ -85,6 +85,8 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema2].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema2].json
@@ -65,6 +65,7 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
           "error": 1,
           "meta": {
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema2]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema2]_pre_1_10_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema2]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema2]_pre_1_10_1.json
@@ -85,6 +85,8 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema2]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema2]_pre_1_10_1.json
@@ -65,6 +65,7 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
           "error": 1,
           "meta": {
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema3].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema3].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema3].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema3].json
@@ -85,6 +85,8 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema3].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema3].json
@@ -65,6 +65,7 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
           "error": 1,
           "meta": {
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema3]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema3]_pre_1_10_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema3]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema3]_pre_1_10_1.json
@@ -85,6 +85,8 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema3]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema3]_pre_1_10_1.json
@@ -65,6 +65,7 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
           "error": 1,
           "meta": {
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema4].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema4].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema4].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema4].json
@@ -85,6 +85,8 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema4].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema4].json
@@ -65,6 +65,7 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
           "error": 1,
           "meta": {
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema4]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema4]_pre_1_10_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema4]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema4]_pre_1_10_1.json
@@ -85,6 +85,8 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema4]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema4]_pre_1_10_1.json
@@ -65,6 +65,7 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
           "error": 1,
           "meta": {
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema5].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema5].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema5].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema5].json
@@ -85,6 +85,8 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema5].json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema5].json
@@ -65,6 +65,7 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
           "error": 1,
           "meta": {
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema5]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema5]_pre_1_10_1.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema5]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema5]_pre_1_10_1.json
@@ -85,6 +85,8 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema5]_pre_1_10_1.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_schematization[service_schema5]_pre_1_10_1.json
@@ -65,6 +65,7 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
           "error": 1,
           "meta": {
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_sync_queue_enqueue.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_sync_queue_enqueue.json
@@ -35,6 +35,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_sync_queue_enqueue.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_sync_queue_enqueue.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker.json
@@ -36,6 +36,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -66,6 +67,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_config_service.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_config_service.json
@@ -36,6 +36,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -66,6 +67,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_config_service.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_config_service.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_multiple_jobs.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_multiple_jobs.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -87,6 +88,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -167,6 +169,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_multiple_jobs.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_multiple_jobs.json
@@ -36,6 +36,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -66,6 +67,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -113,6 +116,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -143,6 +147,8 @@
           "trace_id": 1,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -190,6 +196,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -220,6 +227,8 @@
           "trace_id": 2,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_pin_service.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_pin_service.json
@@ -36,6 +36,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -66,6 +67,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_pin_service.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_sync_worker_pin_service.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_worker_class_job.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_worker_class_job.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -87,6 +88,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_worker_class_job.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_worker_class_job.json
@@ -36,6 +36,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -66,6 +67,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -113,6 +116,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "worker",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -143,6 +147,8 @@
           "trace_id": 1,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_worker_failing_job.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_worker_failing_job.json
@@ -67,6 +67,7 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
           "error": 1,
           "meta": {
             "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.rq.test_rq.test_worker_failing_job.json
+++ b/tests/snapshots/tests.contrib.rq.test_rq.test_worker_failing_job.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "worker",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -55,6 +56,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http.json
@@ -37,6 +37,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000"
@@ -83,6 +85,8 @@
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000"

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http_pre_21.9.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http_pre_21.9.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -54,6 +55,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http_pre_21.9.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http_pre_21.9.json
@@ -36,6 +36,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000"
@@ -81,6 +83,8 @@
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000"

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_sanic_errors.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_sanic_errors.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_sanic_errors_pre_21.9.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_sanic_errors_pre_21.9.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema0].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema0].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema1].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema1].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema2].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema2].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema3].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema3].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema4].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema4].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema5].json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_schematization[service_schema5].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_analytics_with_rate.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_analytics_with_rate.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_analytics_without_rate.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_analytics_without_rate.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_commit.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_commit.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_executemany_insert.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_executemany_insert.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchall.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchall.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchall_multiple_rows.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchall_multiple_rows.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchone.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_fetchone.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_executemany_insert.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_executemany_insert.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_executemany_insert.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_executemany_insert.json
@@ -32,6 +32,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchall.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchall.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchall.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchall.json
@@ -32,6 +32,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchall_multiple_rows.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchall_multiple_rows.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchall_multiple_rows.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchall_multiple_rows.json
@@ -32,6 +32,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchone.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchone.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchone.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_ot_fetchone.json
@@ -32,6 +32,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_pin_override.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_pin_override.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_rollback.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_rollback.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_service_env.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_service_env.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_settings_override.json
+++ b/tests/snapshots/tests.contrib.snowflake.test_snowflake.test_snowflake_settings_override.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "sql",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema0]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema0]_rest.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema0]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema0]_rest.json
@@ -39,6 +39,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema1]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema1]_rest.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema1]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema1]_rest.json
@@ -39,6 +39,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema2]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema2]_rest.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema2]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema2]_rest.json
@@ -38,6 +38,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "starlette",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema3]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema3]_rest.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema3]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema3]_rest.json
@@ -38,6 +38,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "starlette",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema4]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema4]_rest.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema4]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema4]_rest.json
@@ -38,6 +38,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "starlette",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema5]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema5]_rest.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema5]_rest.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_schematization[service_schema5]_rest.json
@@ -38,6 +38,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "starlette",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_subapp_no_aggregate_snapshot.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_subapp_no_aggregate_snapshot.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_subapp_no_aggregate_snapshot.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_subapp_no_aggregate_snapshot.json
@@ -38,6 +38,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_subapp_snapshot.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_subapp_snapshot.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_subapp_snapshot.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_subapp_snapshot.json
@@ -39,6 +39,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_table_query_snapshot.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_table_query_snapshot.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -64,6 +65,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_table_query_snapshot.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_table_query_snapshot.json
@@ -39,6 +39,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -95,6 +96,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "sql",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_generates_coverage_correctly.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_generates_coverage_correctly.json
@@ -48,6 +48,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "test",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.origin": "ciapp-test",
@@ -83,6 +84,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "test",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.origin": "ciapp-test",
@@ -118,6 +120,7 @@
              "span_id": 4,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",
@@ -161,6 +164,7 @@
              "span_id": 5,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_generates_coverage_correctly.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_generates_coverage_correctly.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "test",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.origin": "ciapp-test",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_generates_coverage_correctly_with_skipped.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_generates_coverage_correctly_with_skipped.json
@@ -48,6 +48,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "test",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.origin": "ciapp-test",
@@ -83,6 +84,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "test",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.origin": "ciapp-test",
@@ -118,6 +120,7 @@
              "span_id": 4,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",
@@ -161,6 +164,7 @@
              "span_id": 5,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_generates_coverage_correctly_with_skipped.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_generates_coverage_correctly_with_skipped.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "test",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.origin": "ciapp-test",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_generates_source_file_data.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_generates_source_file_data.json
@@ -49,6 +49,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "test",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.origin": "ciapp-test",
@@ -85,6 +86,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "test",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.origin": "ciapp-test",
@@ -121,6 +123,7 @@
              "span_id": 4,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",
@@ -164,6 +167,7 @@
              "span_id": 5,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_generates_source_file_data.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_generates_source_file_data.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "test",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.origin": "ciapp-test",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_force_run_multiple_unskippable_tests.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_force_run_multiple_unskippable_tests.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "test",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.ci.itr.tests_skipped": "false",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_force_run_multiple_unskippable_tests.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_force_run_multiple_unskippable_tests.json
@@ -54,6 +54,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "test",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.ci.itr.tests_skipped": "false",
@@ -97,6 +98,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "test",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.origin": "ciapp-test",
@@ -132,6 +134,7 @@
              "span_id": 4,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",
@@ -177,6 +180,7 @@
              "span_id": 5,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",
@@ -222,6 +226,7 @@
              "span_id": 6,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_force_run_unskippable_tests.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_force_run_unskippable_tests.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "test",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.ci.itr.tests_skipped": "false",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_force_run_unskippable_tests.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_force_run_unskippable_tests.json
@@ -54,6 +54,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "test",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.ci.itr.tests_skipped": "false",
@@ -97,6 +98,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "test",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.origin": "ciapp-test",
@@ -132,6 +134,7 @@
              "span_id": 4,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",
@@ -177,6 +180,7 @@
              "span_id": 5,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_include_custom_tests.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_include_custom_tests.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "test",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.ci.itr.tests_skipped": "false",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_include_custom_tests.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_include_custom_tests.json
@@ -55,6 +55,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "test",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.ci.itr.tests_skipped": "false",
@@ -99,6 +100,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "test",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.origin": "ciapp-test",
@@ -135,6 +137,7 @@
              "span_id": 4,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",
@@ -181,6 +184,7 @@
              "span_id": 5,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_report_coverage_by_test_with_itr_skipped.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_report_coverage_by_test_with_itr_skipped.json
@@ -54,6 +54,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "test",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.ci.itr.tests_skipped": "true",
@@ -97,6 +98,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "test",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.origin": "ciapp-test",
@@ -132,6 +134,7 @@
              "span_id": 4,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",
@@ -176,6 +179,7 @@
              "span_id": 5,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_report_coverage_by_test_with_itr_skipped.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_report_coverage_by_test_with_itr_skipped.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "test",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.ci.itr.tests_skipped": "true",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_report_coverage_by_test_with_itr_skipped_multiple.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_report_coverage_by_test_with_itr_skipped_multiple.json
@@ -54,6 +54,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "test",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.ci.itr.tests_skipped": "true",
@@ -97,6 +98,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "test",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.origin": "ciapp-test",
@@ -132,6 +134,7 @@
              "span_id": 4,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",
@@ -176,6 +179,7 @@
              "span_id": 5,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_report_coverage_by_test_with_itr_skipped_multiple.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_report_coverage_by_test_with_itr_skipped_multiple.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "test",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.ci.itr.tests_skipped": "true",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_skip_invalid_unskippable_tests.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_skip_invalid_unskippable_tests.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "test",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.ci.itr.tests_skipped": "false",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_skip_invalid_unskippable_tests.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_skip_invalid_unskippable_tests.json
@@ -54,6 +54,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "test",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.ci.itr.tests_skipped": "false",
@@ -97,6 +98,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "test",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.origin": "ciapp-test",
@@ -132,6 +134,7 @@
              "span_id": 4,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",
@@ -175,6 +178,7 @@
              "span_id": 5,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",
@@ -218,6 +222,7 @@
              "span_id": 6,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",
@@ -261,6 +266,7 @@
              "span_id": 7,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_skip_unskippable_test_if_skip_decorator.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_skip_unskippable_test_if_skip_decorator.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "test",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.ci.itr.tests_skipped": "false",

--- a/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_skip_unskippable_test_if_skip_decorator.json
+++ b/tests/snapshots/tests.contrib.unittest.test_unittest_snapshot.test_unittest_will_skip_unskippable_test_if_skip_decorator.json
@@ -54,6 +54,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "test",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.ci.itr.tests_skipped": "false",
@@ -97,6 +98,7 @@
           "span_id": 3,
           "parent_id": 2,
           "type": "test",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.origin": "ciapp-test",
@@ -132,6 +134,7 @@
              "span_id": 4,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",
@@ -176,6 +179,7 @@
              "span_id": 5,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",
@@ -220,6 +224,7 @@
              "span_id": 6,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",
@@ -264,6 +269,7 @@
              "span_id": 7,
              "parent_id": 3,
              "type": "test",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.origin": "ciapp-test",

--- a/tests/snapshots/tests.contrib.urllib3.test_urllib3.test_urllib3_connectionpool_snapshot.json
+++ b/tests/snapshots/tests.contrib.urllib3.test_urllib3.test_urllib3_connectionpool_snapshot.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.urllib3.test_urllib3.test_urllib3_poolmanager_snapshot.json
+++ b/tests/snapshots/tests.contrib.urllib3.test_urllib3.test_urllib3_poolmanager_snapshot.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "http",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_200.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_200.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_200.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_200.json
@@ -36,6 +36,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -52,6 +54,7 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -68,6 +71,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_500_py3.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_500_py3.json
@@ -38,6 +38,7 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
        "error": 1,
        "meta": {
          "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_base_exception_in_wsgi_app_py3.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_base_exception_in_wsgi_app_py3.json
@@ -38,6 +38,7 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
        "error": 1,
        "meta": {
          "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_chunked.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_chunked.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_chunked.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_chunked.json
@@ -36,6 +36,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -52,6 +54,7 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -68,6 +71,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_distributed_tracing_nested.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_distributed_tracing_nested.json
@@ -34,6 +34,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -50,6 +52,7 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -70,6 +73,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -86,6 +91,7 @@
                 "span_id": 8,
                 "parent_id": 6,
                 "type": "web",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "_dd.p.tid": "654a694400000000",
@@ -102,6 +108,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "_dd.p.tid": "654a694400000000",
@@ -119,6 +127,7 @@
           "span_id": 5,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -135,6 +144,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_distributed_tracing_nested.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_distributed_tracing_nested.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 1234,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_generator_exit_ignored_snapshot.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_generator_exit_ignored_snapshot.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_generator_exit_ignored_snapshot.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_generator_exit_ignored_snapshot.json
@@ -36,6 +36,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -52,6 +54,7 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -68,6 +71,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-None].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-None].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-None].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-None].json
@@ -36,6 +36,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -52,6 +54,7 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -68,6 +71,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-v0].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-v0].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-v0].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-v0].json
@@ -36,6 +36,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -52,6 +54,7 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "_dd.p.tid": "654a694400000000",
@@ -68,6 +71,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-v1].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-v1].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-v1].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[None-v1].json
@@ -35,6 +35,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi"
@@ -50,6 +52,7 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "wsgi",
@@ -65,6 +68,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-None].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-None].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-None].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-None].json
@@ -35,6 +35,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi"
@@ -50,6 +52,7 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "wsgi",
@@ -65,6 +68,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-v0].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-v0].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-v0].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-v0].json
@@ -35,6 +35,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi"
@@ -50,6 +52,7 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "wsgi",
@@ -65,6 +68,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-v1].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-v1].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-v1].json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_schematization[mysvc-v1].json
@@ -35,6 +35,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi"
@@ -50,6 +52,7 @@
           "span_id": 4,
           "parent_id": 2,
           "type": "web",
+          "error": 0,
           "meta": {
             "_dd.p.tid": "654a694400000000",
             "component": "wsgi",
@@ -65,6 +68,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "654a694400000000",
          "component": "wsgi",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_wsgi_base_middleware.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_wsgi_base_middleware.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_wsgi_base_middleware.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_wsgi_base_middleware.json
@@ -35,6 +35,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",
@@ -54,6 +56,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_wsgi_base_middleware_500.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_wsgi_base_middleware_500.json
@@ -38,6 +38,7 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
        "error": 1,
        "meta": {
          "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_analytics_with_rate.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_analytics_with_rate.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_analytics_without_rate.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_analytics_without_rate.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_basics.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_basics.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_cmd_max_length.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_cmd_max_length.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_full_command_in_resource_config[True].json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_full_command_in_resource_config[True].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_full_command_in_resource_config[True].json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_full_command_in_resource_config[True].json
@@ -31,6 +31,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "yaaredis",
@@ -58,6 +59,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "yaaredis",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_full_command_in_resource_env.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_full_command_in_resource_env.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_full_command_in_resource_env.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_full_command_in_resource_env.json
@@ -31,6 +31,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "yaaredis",
@@ -58,6 +59,7 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "component": "yaaredis",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_long_command.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_long_command.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_opentracing.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_opentracing.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_opentracing.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_opentracing.json
@@ -32,6 +32,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "redis",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_pipeline_immediate.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_pipeline_immediate.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,6 +42,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_pipeline_traced.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_pipeline_traced.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema0].json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema0].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,6 +42,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema1].json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema1].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -41,6 +42,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema2].json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema2].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -42,6 +43,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema3].json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema3].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
@@ -41,6 +42,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema4].json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema4].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",
@@ -41,6 +42,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "mysvc",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema5].json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_schematization[service_schema5].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
@@ -42,6 +43,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",

--- a/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_unicode.json
+++ b/tests/snapshots/tests.contrib.yaaredis.test_yaaredis.test_unicode.json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "redis",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.integration.test_context_snapshots.test_context_multiprocess.json
+++ b/tests/snapshots/tests.integration.test_context_snapshots.test_context_multiprocess.json
@@ -29,6 +29,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.dm": "-0",
          "language": "python",

--- a/tests/snapshots/tests.integration.test_context_snapshots.test_context_multiprocess.json
+++ b/tests/snapshots/tests.integration.test_context_snapshots.test_context_multiprocess.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "work",
-    "service": null,
+    "service": "",
     "resource": "work",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -22,7 +24,7 @@
   },
      {
        "name": "proc",
-       "service": null,
+       "service": "",
        "resource": "proc",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_env_vars.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_env_vars.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "env": "prod",

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_filters.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_filters.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "root",
-    "service": null,
+    "service": "",
     "resource": "root",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "boop": "beep",
@@ -23,7 +25,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_filters.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_filters.json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "boop": "beep"
        },

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_multiple_traces.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_multiple_traces.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -46,6 +48,8 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_multiple_traces.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_multiple_traces.json
@@ -34,6 +34,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": ""
        },
@@ -76,6 +78,8 @@
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": ""
        },

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_sampling.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_sampling.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "trace7",
-    "service": null,
+    "service": "",
     "resource": "trace7",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-4",
       "language": "python",
@@ -23,7 +25,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,
@@ -34,11 +36,13 @@
 [
   {
     "name": "trace6",
-    "service": null,
+    "service": "",
     "resource": "trace6",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "language": "python",
       "runtime-id": "6f2eeb0b30c54268b96f6eca8a2d66ba"
@@ -55,7 +59,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 1,
        "span_id": 2,
@@ -66,11 +70,13 @@
 [
   {
     "name": "trace5",
-    "service": null,
+    "service": "",
     "resource": "trace5",
     "trace_id": 2,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "language": "python",
       "runtime-id": "6f2eeb0b30c54268b96f6eca8a2d66ba"
@@ -87,7 +93,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 2,
        "span_id": 2,
@@ -98,11 +104,13 @@
 [
   {
     "name": "trace4",
-    "service": null,
+    "service": "",
     "resource": "trace4",
     "trace_id": 3,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -120,7 +128,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 3,
        "span_id": 2,
@@ -131,11 +139,13 @@
 [
   {
     "name": "trace3",
-    "service": null,
+    "service": "",
     "resource": "trace3",
     "trace_id": 4,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "language": "python",
       "runtime-id": "6f2eeb0b30c54268b96f6eca8a2d66ba"
@@ -152,7 +162,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 4,
        "span_id": 2,
@@ -163,11 +173,13 @@
 [
   {
     "name": "trace2",
-    "service": null,
+    "service": "",
     "resource": "trace2",
     "trace_id": 5,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -185,7 +197,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 5,
        "span_id": 2,
@@ -196,11 +208,13 @@
 [
   {
     "name": "trace1",
-    "service": null,
+    "service": "",
     "resource": "trace1",
     "trace_id": 6,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -217,7 +231,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 6,
        "span_id": 2,

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_sampling.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_sampling.json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 11715,
        "start": 1690574476628770928
      }],
@@ -64,6 +66,8 @@
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 12752,
        "start": 1690574476627692203
      }],
@@ -98,6 +102,8 @@
        "trace_id": 2,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 7332,
        "start": 1690574476626585194
      }],
@@ -133,6 +139,8 @@
        "trace_id": 3,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 7522,
        "start": 1690574476625479881
      }],
@@ -167,6 +175,8 @@
        "trace_id": 4,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 7704,
        "start": 1690574476624305295
      }],
@@ -202,6 +212,8 @@
        "trace_id": 5,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 7840,
        "start": 1690574476622978394
      }],
@@ -236,6 +248,8 @@
        "trace_id": 6,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 13539,
        "start": 1690574476621625665
      }]]

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_setting_span_tags_and_metrics_generates_no_error_logs[v0.4].json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_setting_span_tags_and_metrics_generates_no_error_logs[v0.4].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_setting_span_tags_and_metrics_generates_no_error_logs[v0.5].json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_setting_span_tags_and_metrics_generates_no_error_logs[v0.5].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_single_trace_single_span.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_single_trace_single_span.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_synchronous_writer.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_synchronous_writer.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -42,6 +44,8 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_synchronous_writer.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_synchronous_writer.json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": ""
        },
@@ -68,6 +70,8 @@
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": ""
        },

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_tracer_trace_across_fork.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_tracer_trace_across_fork.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "parent",
-    "service": null,
+    "service": "",
     "resource": "parent",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -22,7 +24,7 @@
   },
      {
        "name": "child",
-       "service": null,
+       "service": "",
        "resource": "child",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_tracer_trace_across_fork.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_tracer_trace_across_fork.json
@@ -29,6 +29,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "language": "python",
          "runtime-id": "36f1a5c9396e469291422d40f4296160"

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_tracer_trace_across_multiple_forks.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_tracer_trace_across_multiple_forks.json
@@ -29,6 +29,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "language": "python",
          "runtime-id": "60f937fe2fa5494c8aeceab4b18a5174"
@@ -49,6 +51,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "language": "python",
             "runtime-id": "0a98b167e74c408abbb58db3fd26a2e7"

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_tracer_trace_across_multiple_forks.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_tracer_trace_across_multiple_forks.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "parent",
-    "service": null,
+    "service": "",
     "resource": "parent",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",
@@ -22,7 +24,7 @@
   },
      {
        "name": "child1",
-       "service": null,
+       "service": "",
        "resource": "child1",
        "trace_id": 0,
        "span_id": 2,
@@ -42,7 +44,7 @@
      },
         {
           "name": "child2",
-          "service": null,
+          "service": "",
           "resource": "child2",
           "trace_id": 0,
           "span_id": 3,

--- a/tests/snapshots/tests.integration.test_integration_snapshots.test_tracetagsprocessor_only_adds_new_tags.json
+++ b/tests/snapshots/tests.integration.test_integration_snapshots.test_tracetagsprocessor_only_adds_new_tags.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "web.request",
-    "service": null,
+    "service": "",
     "resource": "web.request",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",

--- a/tests/snapshots/tests.integration.test_priority_sampling.test_agent_sample_rate_keep.json
+++ b/tests/snapshots/tests.integration.test_priority_sampling.test_agent_sample_rate_keep.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-1",
@@ -26,11 +28,13 @@
 [
   {
     "name": "",
-    "service": null,
+    "service": "",
     "resource": "",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "656a1a2a00000000",

--- a/tests/snapshots/tests.integration.test_priority_sampling.test_agent_sample_rate_reject.json
+++ b/tests/snapshots/tests.integration.test_priority_sampling.test_agent_sample_rate_reject.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-1",
@@ -26,11 +28,13 @@
 [
   {
     "name": "",
-    "service": null,
+    "service": "",
     "resource": "",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "656a1a2b00000000",

--- a/tests/snapshots/tests.integration.test_propagation.test_sampling_decision_downstream.json
+++ b/tests/snapshots/tests.integration.test_propagation.test_sampling_decision_downstream.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 5678,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-4",

--- a/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer0].json
+++ b/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer0].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 5678,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-1",
       "_dd.p.test": "value",
@@ -58,6 +60,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 3,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.test": "value"
           },

--- a/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer0].json
+++ b/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer0].json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "p",
-    "service": null,
+    "service": "",
     "resource": "p",
     "trace_id": 0,
     "span_id": 1,
@@ -23,7 +23,7 @@
   },
      {
        "name": "c1",
-       "service": null,
+       "service": "",
        "resource": "c1",
        "trace_id": 0,
        "span_id": 2,
@@ -36,7 +36,7 @@
      },
      {
        "name": "c2",
-       "service": null,
+       "service": "",
        "resource": "c2",
        "trace_id": 0,
        "span_id": 3,
@@ -49,7 +49,7 @@
      },
         {
           "name": "gc",
-          "service": null,
+          "service": "",
           "resource": "gc",
           "trace_id": 0,
           "span_id": 4,

--- a/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer0].json
+++ b/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer0].json
@@ -28,6 +28,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.test": "value"
        },
@@ -41,6 +43,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.test": "value"
        },

--- a/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer1].json
+++ b/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer1].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 5678,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-1",
       "_dd.p.test": "value",
@@ -58,6 +60,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 3,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.test": "value"
           },

--- a/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer1].json
+++ b/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer1].json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "p",
-    "service": null,
+    "service": "",
     "resource": "p",
     "trace_id": 0,
     "span_id": 1,
@@ -23,7 +23,7 @@
   },
      {
        "name": "c1",
-       "service": null,
+       "service": "",
        "resource": "c1",
        "trace_id": 0,
        "span_id": 2,
@@ -36,7 +36,7 @@
      },
      {
        "name": "c2",
-       "service": null,
+       "service": "",
        "resource": "c2",
        "trace_id": 0,
        "span_id": 3,
@@ -49,7 +49,7 @@
      },
         {
           "name": "gc",
-          "service": null,
+          "service": "",
           "resource": "gc",
           "trace_id": 0,
           "span_id": 4,

--- a/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer1].json
+++ b/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer1].json
@@ -28,6 +28,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.test": "value"
        },
@@ -41,6 +43,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.test": "value"
        },

--- a/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer2].json
+++ b/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer2].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 5678,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-1",
       "_dd.p.test": "value",
@@ -66,6 +68,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 3,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.p.test": "value"
           },

--- a/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer2].json
+++ b/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer2].json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "p",
-    "service": null,
+    "service": "",
     "resource": "p",
     "trace_id": 0,
     "span_id": 1,
@@ -24,7 +24,7 @@
   },
      {
        "name": "c1",
-       "service": null,
+       "service": "",
        "resource": "c1",
        "trace_id": 0,
        "span_id": 2,
@@ -44,7 +44,7 @@
      },
      {
        "name": "c2",
-       "service": null,
+       "service": "",
        "resource": "c2",
        "trace_id": 0,
        "span_id": 3,
@@ -57,7 +57,7 @@
      },
         {
           "name": "gc",
-          "service": null,
+          "service": "",
           "resource": "gc",
           "trace_id": 0,
           "span_id": 4,

--- a/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer2].json
+++ b/tests/snapshots/tests.integration.test_propagation.test_trace_tags_multispan[tracer2].json
@@ -29,6 +29,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.dm": "-1",
          "_dd.p.test": "value",
@@ -49,6 +51,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.test": "value"
        },

--- a/tests/snapshots/tests.integration.test_trace_stats.test_measured_span_tracestats.json
+++ b/tests/snapshots/tests.integration.test_trace_stats.test_measured_span_tracestats.json
@@ -6,7 +6,7 @@
       {
         "Name": "child_stats",
         "Resource": "child_stats",
-        "Service": null,
+        "service": "",
         "Type": null,
         "HTTPStatusCode": 0,
         "Synthetics": false,
@@ -20,7 +20,7 @@
       {
         "Name": "parent",
         "Resource": "parent",
-        "Service": null,
+        "service": "",
         "Type": null,
         "HTTPStatusCode": 0,
         "Synthetics": false,

--- a/tests/snapshots/tests.integration.test_trace_stats.test_sampling_rate[0.0]_tracestats.json
+++ b/tests/snapshots/tests.integration.test_trace_stats.test_sampling_rate[0.0]_tracestats.json
@@ -6,7 +6,7 @@
       {
         "Name": "operation",
         "Resource": "operation",
-        "Service": null,
+        "service": "",
         "Type": null,
         "HTTPStatusCode": 0,
         "Synthetics": false,

--- a/tests/snapshots/tests.integration.test_trace_stats.test_sampling_rate[1.0].json
+++ b/tests/snapshots/tests.integration.test_trace_stats.test_sampling_rate[1.0].json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "operation",
-    "service": null,
+    "service": "",
     "resource": "operation",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -24,11 +26,13 @@
 [
   {
     "name": "operation",
-    "service": null,
+    "service": "",
     "resource": "operation",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -47,11 +51,13 @@
 [
   {
     "name": "operation",
-    "service": null,
+    "service": "",
     "resource": "operation",
     "trace_id": 2,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -70,11 +76,13 @@
 [
   {
     "name": "operation",
-    "service": null,
+    "service": "",
     "resource": "operation",
     "trace_id": 3,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -93,11 +101,13 @@
 [
   {
     "name": "operation",
-    "service": null,
+    "service": "",
     "resource": "operation",
     "trace_id": 4,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -116,11 +126,13 @@
 [
   {
     "name": "operation",
-    "service": null,
+    "service": "",
     "resource": "operation",
     "trace_id": 5,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -139,11 +151,13 @@
 [
   {
     "name": "operation",
-    "service": null,
+    "service": "",
     "resource": "operation",
     "trace_id": 6,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -162,11 +176,13 @@
 [
   {
     "name": "operation",
-    "service": null,
+    "service": "",
     "resource": "operation",
     "trace_id": 7,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -185,11 +201,13 @@
 [
   {
     "name": "operation",
-    "service": null,
+    "service": "",
     "resource": "operation",
     "trace_id": 8,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",
@@ -208,11 +226,13 @@
 [
   {
     "name": "operation",
-    "service": null,
+    "service": "",
     "resource": "operation",
     "trace_id": 9,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-3",
       "language": "python",

--- a/tests/snapshots/tests.integration.test_trace_stats.test_sampling_rate[1.0]_tracestats.json
+++ b/tests/snapshots/tests.integration.test_trace_stats.test_sampling_rate[1.0]_tracestats.json
@@ -6,7 +6,7 @@
       {
         "Name": "operation",
         "Resource": "operation",
-        "Service": null,
+        "service": "",
         "Type": null,
         "HTTPStatusCode": 0,
         "Synthetics": false,

--- a/tests/snapshots/tests.integration.test_trace_stats.test_single_span_sampling[sampling_rule0].json
+++ b/tests/snapshots/tests.integration.test_trace_stats.test_single_span_sampling[sampling_rule0].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 13700571859906052169,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": ""
     },

--- a/tests/snapshots/tests.integration.test_trace_stats.test_single_span_sampling[sampling_rule1].json
+++ b/tests/snapshots/tests.integration.test_trace_stats.test_single_span_sampling[sampling_rule1].json
@@ -31,6 +31,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.base_service": ""
        },

--- a/tests/snapshots/tests.integration.test_trace_stats.test_single_span_sampling[sampling_rule1].json
+++ b/tests/snapshots/tests.integration.test_trace_stats.test_single_span_sampling[sampling_rule1].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-3",

--- a/tests/snapshots/tests.integration.test_tracemethods.test_ddtrace_run_trace_methods_async.json
+++ b/tests/snapshots/tests.integration.test_tracemethods.test_ddtrace_run_trace_methods_async.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "trace.annotation",
-    "service": null,
+    "service": "",
     "resource": "_async_test_method",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "trace",
@@ -24,11 +26,13 @@
 [
   {
     "name": "trace.annotation",
-    "service": null,
+    "service": "",
     "resource": "_async_test_method2",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "trace",
@@ -47,11 +51,13 @@
 [
   {
     "name": "trace.annotation",
-    "service": null,
+    "service": "",
     "resource": "_Class.async_test_method",
     "trace_id": 2,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "trace",
@@ -70,11 +76,13 @@
 [
   {
     "name": "trace.annotation",
-    "service": null,
+    "service": "",
     "resource": "_Class.async_test_method",
     "trace_id": 3,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "trace",

--- a/tests/snapshots/tests.integration.test_tracemethods.test_ddtrace_run_trace_methods_sync.json
+++ b/tests/snapshots/tests.integration.test_tracemethods.test_ddtrace_run_trace_methods_sync.json
@@ -55,6 +55,8 @@
        "trace_id": 1,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "component": "trace"
        },
@@ -118,6 +120,8 @@
        "trace_id": 3,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "component": "trace"
        },

--- a/tests/snapshots/tests.integration.test_tracemethods.test_ddtrace_run_trace_methods_sync.json
+++ b/tests/snapshots/tests.integration.test_tracemethods.test_ddtrace_run_trace_methods_sync.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "trace.annotation",
-    "service": null,
+    "service": "",
     "resource": "_test_method",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "trace",
@@ -24,11 +26,13 @@
 [
   {
     "name": "trace.annotation",
-    "service": null,
+    "service": "",
     "resource": "_test_method2",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "trace",
@@ -46,7 +50,7 @@
   },
      {
        "name": "trace.annotation",
-       "service": null,
+       "service": "",
        "resource": "_test_method",
        "trace_id": 1,
        "span_id": 2,
@@ -60,11 +64,13 @@
 [
   {
     "name": "trace.annotation",
-    "service": null,
+    "service": "",
     "resource": "_Class.test_method",
     "trace_id": 2,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "trace",
@@ -83,11 +89,13 @@
 [
   {
     "name": "trace.annotation",
-    "service": null,
+    "service": "",
     "resource": "_Class.test_method2",
     "trace_id": 3,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "trace",
@@ -105,7 +113,7 @@
   },
      {
        "name": "trace.annotation",
-       "service": null,
+       "service": "",
        "resource": "_Class.test_method",
        "trace_id": 3,
        "span_id": 2,
@@ -119,11 +127,13 @@
 [
   {
     "name": "trace.annotation",
-    "service": null,
+    "service": "",
     "resource": "NestedClass.test_method",
     "trace_id": 4,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "component": "trace",

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_ddtrace_mixed_parenting.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_ddtrace_mixed_parenting.json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 110661292,
        "start": 1700080043283026467
      },
@@ -40,6 +42,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "duration": 41143250,
           "start": 1700080043303321550
         },
@@ -50,6 +54,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "duration": 49070375,
           "start": 1700080043344572342
         },
@@ -60,6 +66,8 @@
              "trace_id": 0,
              "span_id": 5,
              "parent_id": 4,
+             "type": "",
+             "error": 0,
              "duration": 25307375,
              "start": 1700080043368281717
            },
@@ -70,6 +78,8 @@
                 "trace_id": 0,
                 "span_id": 6,
                 "parent_id": 5,
+                "type": "",
+                "error": 0,
                 "duration": 25177958,
                 "start": 1700080043368341134
               }]]

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_ddtrace_mixed_parenting.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_ddtrace_mixed_parenting.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "internal",
-    "service": null,
+    "service": "",
     "resource": "otel-top-level",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655529ab00000000",
@@ -23,7 +25,7 @@
   },
      {
        "name": "ddtrace-top-level",
-       "service": null,
+       "service": "",
        "resource": "ddtrace-top-level",
        "trace_id": 0,
        "span_id": 2,
@@ -33,7 +35,7 @@
      },
         {
           "name": "ddtrace-child",
-          "service": null,
+          "service": "",
           "resource": "ddtrace-child",
           "trace_id": 0,
           "span_id": 3,
@@ -43,7 +45,7 @@
         },
         {
           "name": "internal",
-          "service": null,
+          "service": "",
           "resource": "otel-child",
           "trace_id": 0,
           "span_id": 4,
@@ -53,7 +55,7 @@
         },
            {
              "name": "ddtrace-grandchild",
-             "service": null,
+             "service": "",
              "resource": "ddtrace-grandchild",
              "trace_id": 0,
              "span_id": 5,
@@ -63,7 +65,7 @@
            },
               {
                 "name": "internal",
-                "service": null,
+                "service": "",
                 "resource": "otel-grandchild",
                 "trace_id": 0,
                 "span_id": 6,

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_multithreading.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_multithreading.json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
        },
@@ -47,6 +49,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "duration": 23362125,
           "start": 1700080043406289967
         },
@@ -57,6 +61,8 @@
           "trace_id": 0,
           "span_id": 7,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "duration": 61255875,
           "start": 1700080043429745967
         },
@@ -67,6 +73,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
        },
@@ -104,6 +112,8 @@
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
        },
@@ -141,6 +151,8 @@
        "trace_id": 0,
        "span_id": 5,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
        },

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_multithreading.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_multithreading.json
@@ -92,6 +92,8 @@
           "trace_id": 0,
           "span_id": 8,
           "parent_id": 3,
+          "type": "",
+          "error": 0,
           "duration": 23411792,
           "start": 1700080043406774092
         },
@@ -102,6 +104,8 @@
           "trace_id": 0,
           "span_id": 9,
           "parent_id": 3,
+          "type": "",
+          "error": 0,
           "duration": 61850083,
           "start": 1700080043430265967
         },
@@ -131,6 +135,8 @@
           "trace_id": 0,
           "span_id": 10,
           "parent_id": 4,
+          "type": "",
+          "error": 0,
           "duration": 22181375,
           "start": 1700080043407196592
         },
@@ -141,6 +147,8 @@
           "trace_id": 0,
           "span_id": 11,
           "parent_id": 4,
+          "type": "",
+          "error": 0,
           "duration": 62950666,
           "start": 1700080043429524884
         },
@@ -170,6 +178,8 @@
           "trace_id": 0,
           "span_id": 12,
           "parent_id": 5,
+          "type": "",
+          "error": 0,
           "duration": 22272375,
           "start": 1700080043407654425
         },
@@ -180,6 +190,8 @@
           "trace_id": 0,
           "span_id": 13,
           "parent_id": 5,
+          "type": "",
+          "error": 0,
           "duration": 62895166,
           "start": 1700080043430002634
         }]]

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_multithreading.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_multithreading.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "internal",
-    "service": null,
+    "service": "",
     "resource": "otel-threading-root",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655529ab00000000",
@@ -23,7 +25,7 @@
   },
      {
        "name": "internal",
-       "service": null,
+       "service": "",
        "resource": "s1",
        "trace_id": 0,
        "span_id": 2,
@@ -40,7 +42,7 @@
      },
         {
           "name": "internal",
-          "service": null,
+          "service": "",
           "resource": "s2",
           "trace_id": 0,
           "span_id": 6,
@@ -50,7 +52,7 @@
         },
         {
           "name": "internal",
-          "service": null,
+          "service": "",
           "resource": "s3",
           "trace_id": 0,
           "span_id": 7,
@@ -60,7 +62,7 @@
         },
      {
        "name": "internal",
-       "service": null,
+       "service": "",
        "resource": "s1",
        "trace_id": 0,
        "span_id": 3,
@@ -77,7 +79,7 @@
      },
         {
           "name": "internal",
-          "service": null,
+          "service": "",
           "resource": "s2",
           "trace_id": 0,
           "span_id": 8,
@@ -87,7 +89,7 @@
         },
         {
           "name": "internal",
-          "service": null,
+          "service": "",
           "resource": "s3",
           "trace_id": 0,
           "span_id": 9,
@@ -97,7 +99,7 @@
         },
      {
        "name": "internal",
-       "service": null,
+       "service": "",
        "resource": "s1",
        "trace_id": 0,
        "span_id": 4,
@@ -114,7 +116,7 @@
      },
         {
           "name": "internal",
-          "service": null,
+          "service": "",
           "resource": "s2",
           "trace_id": 0,
           "span_id": 10,
@@ -124,7 +126,7 @@
         },
         {
           "name": "internal",
-          "service": null,
+          "service": "",
           "resource": "s3",
           "trace_id": 0,
           "span_id": 11,
@@ -134,7 +136,7 @@
         },
      {
        "name": "internal",
-       "service": null,
+       "service": "",
        "resource": "s1",
        "trace_id": 0,
        "span_id": 5,
@@ -151,7 +153,7 @@
      },
         {
           "name": "internal",
-          "service": null,
+          "service": "",
           "resource": "s2",
           "trace_id": 0,
           "span_id": 12,
@@ -161,7 +163,7 @@
         },
         {
           "name": "internal",
-          "service": null,
+          "service": "",
           "resource": "s3",
           "trace_id": 0,
           "span_id": 13,

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_span_parenting.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_span_parenting.json
@@ -85,6 +85,8 @@
           "trace_id": 0,
           "span_id": 6,
           "parent_id": 4,
+          "type": "",
+          "error": 0,
           "meta": {
             "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
           },

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_span_parenting.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_span_parenting.json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 110618583,
        "start": 1700080042974075675
      },
@@ -40,6 +42,8 @@
           "trace_id": 0,
           "span_id": 5,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "duration": 65187750,
           "start": 1700080043019322133
         },
@@ -50,6 +54,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 127379917,
        "start": 1700080043084759842
      },
@@ -60,6 +66,8 @@
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "runtime-id": "e4724609efa84cf58424a8b1ef44b17d"
        },

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_span_parenting.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_span_parenting.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "internal",
-    "service": null,
+    "service": "",
     "resource": "otel-root",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655529aa00000000",
@@ -23,7 +25,7 @@
   },
      {
        "name": "internal",
-       "service": null,
+       "service": "",
        "resource": "otel-parent1",
        "trace_id": 0,
        "span_id": 2,
@@ -33,7 +35,7 @@
      },
         {
           "name": "internal",
-          "service": null,
+          "service": "",
           "resource": "otel-child1",
           "trace_id": 0,
           "span_id": 5,
@@ -43,7 +45,7 @@
         },
      {
        "name": "internal",
-       "service": null,
+       "service": "",
        "resource": "orphan1",
        "trace_id": 0,
        "span_id": 3,
@@ -53,7 +55,7 @@
      },
      {
        "name": "internal",
-       "service": null,
+       "service": "",
        "resource": "otel-parent2",
        "trace_id": 0,
        "span_id": 4,
@@ -70,7 +72,7 @@
      },
         {
           "name": "internal",
-          "service": null,
+          "service": "",
           "resource": "otel-child2",
           "trace_id": 0,
           "span_id": 6,

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_trace_across_fork.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_trace_across_fork.json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "655529ab00000000",
          "language": "python",

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_trace_across_fork.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_trace_across_fork.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "internal",
-    "service": null,
+    "service": "",
     "resource": "root",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655529ab00000000",
@@ -23,7 +25,7 @@
   },
      {
        "name": "internal",
-       "service": null,
+       "service": "",
        "resource": "task",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_trace_multiple_coroutines.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_trace_multiple_coroutines.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "internal",
-    "service": null,
+    "service": "",
     "resource": "root",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655529ab00000000",
@@ -23,7 +25,7 @@
   },
      {
        "name": "internal",
-       "service": null,
+       "service": "",
        "resource": "corountine 1",
        "trace_id": 0,
        "span_id": 2,
@@ -33,7 +35,7 @@
      },
      {
        "name": "internal",
-       "service": null,
+       "service": "",
        "resource": "corountine 2",
        "trace_id": 0,
        "span_id": 3,
@@ -43,7 +45,7 @@
      },
      {
        "name": "internal",
-       "service": null,
+       "service": "",
        "resource": "corountine 3",
        "trace_id": 0,
        "span_id": 4,
@@ -53,7 +55,7 @@
      },
      {
        "name": "internal",
-       "service": null,
+       "service": "",
        "resource": "corountine 4",
        "trace_id": 0,
        "span_id": 5,

--- a/tests/snapshots/tests.opentelemetry.test_context.test_otel_trace_multiple_coroutines.json
+++ b/tests/snapshots/tests.opentelemetry.test_context.test_otel_trace_multiple_coroutines.json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 24014375,
        "start": 1700080043577829384
      },
@@ -40,6 +42,8 @@
        "trace_id": 0,
        "span_id": 3,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 25175167,
        "start": 1700080043602012175
      },
@@ -50,6 +54,8 @@
        "trace_id": 0,
        "span_id": 4,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 25196042,
        "start": 1700080043627275592
      },
@@ -60,6 +66,8 @@
        "trace_id": 0,
        "span_id": 5,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "duration": 25230083,
        "start": 1700080043652546967
      }]]

--- a/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes.json
+++ b/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes.json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -35,6 +37,8 @@
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override0].json
+++ b/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override0].json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "operation-override",
-    "service": null,
+    "service": "",
     "resource": "set-operation.name",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655529ab00000000",

--- a/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override1].json
+++ b/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override1].json
@@ -6,6 +6,8 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override2].json
+++ b/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override2].json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "internal",
-    "service": null,
+    "service": "",
     "resource": "resource-override",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655529ab00000000",

--- a/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override3].json
+++ b/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override3].json
@@ -7,6 +7,7 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "type-override",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655529ab00000000",

--- a/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override3].json
+++ b/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override3].json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "internal",
-    "service": null,
+    "service": "",
     "resource": "set-span.type",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override4].json
+++ b/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_attributes_overrides[override4].json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "internal",
-    "service": null,
+    "service": "",
     "resource": "set-analytics.event",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655529ab00000000",

--- a/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_kind.json
+++ b/tests/snapshots/tests.opentelemetry.test_span.test_otel_span_kind.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "client",
-    "service": null,
+    "service": "",
     "resource": "otel-client",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655529ab00000000",
@@ -25,11 +27,13 @@
 [
   {
     "name": "server",
-    "service": null,
+    "service": "",
     "resource": "otel-server",
     "trace_id": 1,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655529ab00000000",
@@ -49,11 +53,13 @@
 [
   {
     "name": "producer",
-    "service": null,
+    "service": "",
     "resource": "otel-producer",
     "trace_id": 2,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655529ab00000000",
@@ -73,11 +79,13 @@
 [
   {
     "name": "consumer",
-    "service": null,
+    "service": "",
     "resource": "otel-consumer",
     "trace_id": 3,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655529ab00000000",
@@ -97,11 +105,13 @@
 [
   {
     "name": "internal",
-    "service": null,
+    "service": "",
     "resource": "otel-internal",
     "trace_id": 4,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655529ab00000000",

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_ddtrace_run].json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_ddtrace_run].json
@@ -31,6 +31,7 @@
        "span_id": 2,
        "parent_id": 1,
        "type": "web",
+       "error": 0,
        "meta": {
          "_dd.base_service": "",
          "_dd.p.dm": "-0",
@@ -67,6 +68,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask",
@@ -83,6 +86,8 @@
              "trace_id": 0,
              "span_id": 5,
              "parent_id": 3,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -97,6 +102,8 @@
              "trace_id": 0,
              "span_id": 6,
              "parent_id": 3,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -111,6 +118,8 @@
              "trace_id": 0,
              "span_id": 7,
              "parent_id": 3,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -125,6 +134,8 @@
                 "trace_id": 0,
                 "span_id": 11,
                 "parent_id": 7,
+                "type": "",
+                "error": 0,
                 "meta": {
                   "_dd.base_service": "",
                   "component": "flask"
@@ -139,6 +150,8 @@
                    "trace_id": 0,
                    "span_id": 12,
                    "parent_id": 11,
+                   "type": "",
+                   "error": 0,
                    "meta": {
                      "_dd.base_service": ""
                    },
@@ -152,6 +165,8 @@
              "trace_id": 0,
              "span_id": 8,
              "parent_id": 3,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -166,6 +181,8 @@
              "trace_id": 0,
              "span_id": 9,
              "parent_id": 3,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -180,6 +197,8 @@
              "trace_id": 0,
              "span_id": 10,
              "parent_id": 3,
+             "type": "",
+             "error": 0,
              "meta": {
                "_dd.base_service": "",
                "component": "flask"
@@ -194,6 +213,8 @@
           "trace_id": 0,
           "span_id": 4,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "meta": {
             "_dd.base_service": "",
             "component": "flask"

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_ddtrace_run].json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_ddtrace_run].json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "internal",
-    "service": null,
+    "service": "",
     "resource": "test-otel-distributed-trace",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655535db00000000",

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_opentelemetry_instrument].json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_opentelemetry_instrument].json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "_dd.p.tid": "655535dc00000000",
          "http.flavor": "1.1",
@@ -65,6 +67,8 @@
           "trace_id": 0,
           "span_id": 3,
           "parent_id": 2,
+          "type": "",
+          "error": 0,
           "duration": 18250,
           "start": 1700083164081867259
         }]]

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_opentelemetry_instrument].json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_distributed_trace_with_flask_app[with_opentelemetry_instrument].json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "internal",
-    "service": null,
+    "service": "",
     "resource": "test-otel-distributed-trace",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655535dc00000000",
@@ -23,7 +25,7 @@
   },
      {
        "name": "server",
-       "service": null,
+       "service": "",
        "resource": "/otel",
        "trace_id": 0,
        "span_id": 2,
@@ -58,7 +60,7 @@
      },
         {
           "name": "internal",
-          "service": null,
+          "service": "",
           "resource": "otel-flask-manual-span",
           "trace_id": 0,
           "span_id": 3,

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_with_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_with_default_args.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "internal",
-    "service": null,
+    "service": "",
     "resource": "rename-start-current-span",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655535da00000000",

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_without_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_without_default_args.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "internal",
-    "service": null,
+    "service": "",
     "resource": "root-span",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655535da00000000",
@@ -23,7 +25,7 @@
   },
      {
        "name": "server",
-       "service": null,
+       "service": "",
        "resource": "rename-start-current-span",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_without_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_current_span_without_default_args.json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "span.kind": "server",
          "start_current_span_tag": "start_cspan_val"

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_ignore_exceptions.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_ignore_exceptions.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "internal",
-    "service": null,
+    "service": "",
     "resource": "otel-error-span",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655535da00000000",

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_with_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_with_default_args.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "internal",
-    "service": null,
+    "service": "",
     "resource": "rename-start-span",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655535da00000000",

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_without_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_without_default_args.json
@@ -30,6 +30,8 @@
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
+       "type": "",
+       "error": 0,
        "meta": {
          "span.kind": "client",
          "start_span_tag": "start_span_val"

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_without_default_args.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_without_default_args.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "internal",
-    "service": null,
+    "service": "",
     "resource": "root-span",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "655535da00000000",
@@ -23,7 +25,7 @@
   },
      {
        "name": "client",
-       "service": null,
+       "service": "",
        "resource": "rename-start-span",
        "trace_id": 0,
        "span_id": 2,

--- a/tests/snapshots/tests.telemetry.test_telemetry.test_telemetry_enabled_on_first_tracer_flush.json
+++ b/tests/snapshots/tests.telemetry.test_telemetry.test_telemetry_enabled_on_first_tracer_flush.json
@@ -1,11 +1,13 @@
 [[
   {
     "name": "test-telemetry",
-    "service": null,
+    "service": "",
     "resource": "test-telemetry",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
+    "type": "",
+    "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
       "language": "python",

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -35,6 +35,7 @@ from ddtrace.contrib.trace_utils import set_user
 from ddtrace.ext import user
 from ddtrace.internal import telemetry
 from ddtrace.internal._encoding import MsgpackEncoderV03
+from ddtrace.internal._encoding import MsgpackEncoderV05
 from ddtrace.internal.serverless import has_aws_lambda_agent_extension
 from ddtrace.internal.serverless import in_aws_lambda
 from ddtrace.internal.writer import AgentWriter
@@ -1856,7 +1857,7 @@ def test_fork_pid(tracer):
 
 def test_tracer_api_version():
     t = Tracer()
-    assert isinstance(t._writer._encoder, MsgpackEncoderV03)
+    assert isinstance(t._writer._encoder, MsgpackEncoderV05)
 
     t.configure(api_version="v0.3")
     assert isinstance(t._writer._encoder, MsgpackEncoderV03)

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -89,13 +89,21 @@ class AgentWriterTests(BaseTestCase):
 
     def test_metrics_trace_too_big(self):
         statsd = mock.Mock()
-        with override_global_config(dict(health_metrics_enabled=True, _trace_writer_buffer_size=8 << 20)):
+        with override_global_config(dict(health_metrics_enabled=True, _trace_writer_buffer_size=15000)):
             writer = self.WRITER_CLASS("http://asdf:1234", dogstatsd=statsd)
             for i in range(10):
                 writer.write([Span(name="name", trace_id=i, span_id=j + 1, parent_id=j or None) for j in range(5)])
-            writer.write(
-                [Span(name="a" * 5000, trace_id=i, span_id=j + 1, parent_id=j or None) for j in range(1, 2**10)]
-            )
+
+            massive_trace = []
+            for i in range(10):
+                span = Span("mmon", "mmon" + str(i), "mmon" + str(i))
+                for j in range(50):
+                    key = "opqr012|~" + str(i) + str(j)
+                    val = "stuv345!@#" + str(i) + str(j)
+                    span.set_tag_str(key, val)
+                massive_trace.append(span)
+
+            writer.write(massive_trace)
             writer.stop()
             writer.join()
 
@@ -119,7 +127,7 @@ class AgentWriterTests(BaseTestCase):
         with override_global_config(dict(health_metrics_enabled=True)):
             writer = self.WRITER_CLASS("http://asdf:1234", dogstatsd=statsd, sync_mode=False)
             for i in range(10):
-                writer.write([Span(name="name", trace_id=i, span_id=j + 1, parent_id=j or None) for j in range(5)])
+                writer.write([Span(name="name", trace_id=i, span_id=j + 1, parent_id=j) for j in range(5)])
             writer.flush_queue()
             statsd.distribution.assert_has_calls(
                 [mock.call("datadog.%s.buffer.accepted.traces" % writer.STATSD_NAMESPACE, 1, tags=None)] * 10
@@ -134,7 +142,7 @@ class AgentWriterTests(BaseTestCase):
             statsd.reset_mock()
 
             for i in range(10):
-                writer.write([Span(name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)])
+                writer.write([Span(name="name", trace_id=i, span_id=j + 1, parent_id=j) for j in range(5)])
             writer.stop()
             writer.join()
 
@@ -218,24 +226,21 @@ class AgentWriterTests(BaseTestCase):
     def test_drop_reason_trace_too_big(self):
         statsd = mock.Mock()
         with override_global_config(dict(health_metrics_enabled=True)):
-            writer = self.WRITER_CLASS("http://asdf:1234", dogstatsd=statsd)
+            writer = self.WRITER_CLASS("http://asdf:1234", dogstatsd=statsd, buffer_size=1000)
             for i in range(10):
-                writer.write([Span(name="name", trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(5)])
-            writer.write(
-                [Span(name="a" * 5000 * i, trace_id=i, span_id=j, parent_id=j - 1 or None) for j in range(2**10)]
-            )
+                writer.write([Span(name="name", trace_id=i, span_id=j + 1, parent_id=j or None) for j in range(5)])
+            writer.write([Span(name="a" * i, trace_id=i, span_id=j + 1, parent_id=j or None) for j in range(2**10)])
             writer.stop()
             writer.join()
 
             # metrics should be reset after traces are sent
             assert writer._metrics == {"accepted_traces": 0, "sent_traces": 0}
 
-        client_count = len(writer._clients)
         statsd.distribution.assert_has_calls(
             [
                 mock.call(
                     "datadog.%s.buffer.dropped.traces" % writer.STATSD_NAMESPACE,
-                    client_count,
+                    1,
                     tags=["reason:t_too_big"],
                 ),
             ],
@@ -245,7 +250,7 @@ class AgentWriterTests(BaseTestCase):
     def test_drop_reason_buffer_full(self):
         statsd = mock.Mock()
         with override_global_config(dict(health_metrics_enabled=True)):
-            writer = self.WRITER_CLASS("http://asdf:1234", buffer_size=5125, dogstatsd=statsd)
+            writer = self.WRITER_CLASS("http://asdf:1234", buffer_size=1000, dogstatsd=statsd)
             for i in range(10):
                 writer.write([Span(name="name", trace_id=i, span_id=j + 1, parent_id=j or None) for j in range(5)])
             writer.write([Span(name="a", trace_id=i, span_id=j + 1, parent_id=j or None) for j in range(5)])
@@ -299,17 +304,17 @@ class AgentWriterTests(BaseTestCase):
         writer_put = mock.Mock()
         writer_put.return_value = Response(status=200)
         with override_global_config(dict(health_metrics_enabled=False, _trace_writer_buffer_size=8 << 20)):
-            writer = self.WRITER_CLASS("http://asdf:1234", dogstatsd=statsd)
+            # this test decodes the msgpack payload to verify the keep rate. v04 is easier to decode so we use that here
+            writer = self.WRITER_CLASS("http://asdf:1234", dogstatsd=statsd, api_version="v0.4")
             writer.run_periodic = writer_run_periodic
             writer._put = writer_put
 
             traces = [
-                [Span(name="name", trace_id=i, span_id=j + 1, parent_id=j or None) for j in range(5)]
-                for i in range(1, 5)
+                [Span(name="name", trace_id=i, span_id=j + 1, parent_id=j) for j in range(5)] for i in range(1, 5)
             ]
 
             traces_too_big = [
-                [Span(name="a" * 5000, trace_id=i, span_id=j + 1, parent_id=j or None) for j in range(1, 2**10)]
+                [Span(name="a" * 5000, trace_id=i, span_id=j + 1, parent_id=j) for j in range(1, 2**10)]
                 for i in range(4)
             ]
 
@@ -725,7 +730,7 @@ def test_writer_recreate_api_version(init_api_version, api_version, endpoint, en
         # Defaults on windows
         ("cygwin", None, None, False, False, "v0.4"),
         # Default with priority sampler
-        ("cygwin", None, None, True, False, "v0.5"),
+        ("cygwin", None, None, True, False, "v0.4"),
         # Explicitly passed in API version is always used
         ("cygwin", "v0.3", None, True, False, "v0.3"),
         ("cygwin", "v0.3", "v0.4", False, False, "v0.3"),

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -741,7 +741,7 @@ def test_writer_recreate_api_version(init_api_version, api_version, endpoint, en
         # defaults
         ("darwin", None, None, None, False, "v0.3"),
         # Default with priority sample
-        ("darwin", None, None, True, False, "v0.4"),
+        ("darwin", None, None, True, False, "v0.5"),
         # Explicitly setting api version
         ("darwin", "v0.4", None, True, False, "v0.4"),
         # Explicitly set version takes precedence


### PR DESCRIPTION
This PR upgrades the default trace api from v0.4 to v0.5. This should improve the performance of encoding traces.

Follow up to: https://github.com/DataDog/dd-trace-py/pull/7874. 

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
