### PR TITLE
docs: fix typo in release note

### DIFF
--- a/releasenotes/notes/trace-api-v05-encoding-reset-string-table-17ee19c026b22af9.yaml
+++ b/releasenotes/notes/trace-api-v05-encoding-reset-string-table-17ee19c026b22af9.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     tracing: Resolves trace encoding errors raised when ``DD_TRACE_API_VERSION`` is set to ``v0.5`` and a BufferFull
-    Exception is raised by the TraceWriter. This fix ensures span fields are not overwrriten and reduces the frequency
+    Exception is raised by the TraceWriter. This fix ensures span fields are not overwritten and reduces the frequency
     of 4XX errors in the trace agent.


### PR DESCRIPTION
We will need to re-enable spellchecks on docs.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
