### PR TITLE
fix(iast): format aspect propagation error

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.cpp
@@ -17,16 +17,23 @@ api_format_aspect(StrType& candidate_text,
         py::list new_args;
         py::dict new_kwargs;
         for (const auto arg : args) {
-            auto str_arg = py::cast<py::str>(arg);
-            auto n_arg = _all_as_formatted_evidence<py::str>(str_arg, TagMappingMode::Mapper);
-            new_args.append(n_arg);
+            if (is_text(arg.ptr())) {
+                auto str_arg = py::cast<py::str>(arg);
+                auto n_arg = _all_as_formatted_evidence<py::str>(str_arg, TagMappingMode::Mapper);
+                new_args.append(n_arg);
+            } else {
+                new_args.append(arg);
+            }
         }
-        for (auto [key, value] : new_kwargs) {
-            auto str_value = py::cast<py::str>(value);
-            auto n_value = _all_as_formatted_evidence<py::str>(str_value, TagMappingMode::Mapper);
-            new_kwargs[key] = n_value;
+        for (auto [key, value] : kwargs) {
+            if (is_text(value.ptr())) {
+                auto str_value = py::cast<py::str>(value);
+                auto n_value = _all_as_formatted_evidence<py::str>(str_value, TagMappingMode::Mapper);
+                new_kwargs[key] = n_value;
+            } else {
+                new_kwargs[key] = value;
+            }
         }
-
         StrType new_template_format =
           py::getattr(new_template, "format")(*(py::cast<py::tuple>(new_args)), **new_kwargs);
         std::tuple result = _convert_escaped_text_to_taint_text<StrType>(new_template_format, ranges_orig);

--- a/releasenotes/notes/iast-fix-propagation-error-b59b1b0db93c0f23.yaml
+++ b/releasenotes/notes/iast-fix-propagation-error-b59b1b0db93c0f23.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Vulnerability Management for Code-level (IAST): Fix propagation error on ``.format`` string method.

--- a/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
@@ -109,7 +109,6 @@ class TestOperatorFormatReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template⚠️<input1>-+: " ":+-<input2>parameter⚠️<input2>-+:",
         )
 
-    @pytest.mark.skip(reason="Migrating format_aspect to C++ breaks this test")
     def test_format_when_tainted_template_range_no_brackets_and_param_not_str_then_tainted(self):
         # type: () -> None
         self._assert_format_result(
@@ -119,7 +118,6 @@ class TestOperatorFormatReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template<input1>-+: 3.14",
         )
 
-    @pytest.mark.skip(reason="Migrating format_aspect to C++ breaks this test")
     def test_format_when_tainted_template_range_with_brackets_and_param_not_str_then_tainted(self):
         # type: () -> None
         self._assert_format_result(
@@ -159,9 +157,8 @@ class TestOperatorFormatReplacement(BaseReplacement):
         assert as_formatted_evidence(res) == "-1234 6 1"
 
         string_input = create_taint_range_with_format(":+--12-+:34 {} {test_var}")
-        mod.do_args_kwargs_1(string_input, 6, test_var=1)  # pylint: disable=no-member
-        # TODO format with params doesn't work correctly
-        #  assert as_formatted_evidence(res) == ":+--12-+:34 6 1"
+        res = mod.do_args_kwargs_1(string_input, 6, test_var=1)  # pylint: disable=no-member
+        assert as_formatted_evidence(res) == ":+--12-+:34 6 1"
 
     def test_format_with_one_argument_args_and_kwargs(self):  # type: () -> None
         string_input = "-1234 {} {} {test_var}"
@@ -173,9 +170,8 @@ class TestOperatorFormatReplacement(BaseReplacement):
         assert as_formatted_evidence(res) == "-1234 1 6 1"
 
         string_input = create_taint_range_with_format(":+--12-+:34 {} {} {test_var}")
-        mod.do_args_kwargs_2(string_input, 6, test_var=1)  # pylint: disable=no-member
-        # TODO format with params doesn't work correctly
-        #  as_formatted_evidence(res) == ":+--12-+:34 1 6 1"
+        res = mod.do_args_kwargs_2(string_input, 6, test_var=1)  # pylint: disable=no-member
+        assert as_formatted_evidence(res) == ":+--12-+:34 1 6 1"
 
     def test_format_with_two_argument_args_and_kwargs(self):  # type: () -> None
         string_input = "-1234 {} {} {} {test_var}"
@@ -187,9 +183,8 @@ class TestOperatorFormatReplacement(BaseReplacement):
         assert as_formatted_evidence(res) == "-1234 1 2 6 1"
 
         string_input = create_taint_range_with_format(":+--12-+:34 {} {} {} {test_var}")
-        mod.do_args_kwargs_3(string_input, 6, test_var=1)  # pylint: disable=no-member
-        # TODO format with params doesn't work correctly
-        #  as_formatted_evidence(res) == ":+--12-+:34 1 2 6 1"
+        res = mod.do_args_kwargs_3(string_input, 6, test_var=1)  # pylint: disable=no-member
+        assert as_formatted_evidence(res) == ":+--12-+:34 1 2 6 1"
 
     def test_format_with_two_argument_two_keywordargument_args_kwargs(self):  # type: () -> None
         string_input = "-1234 {} {} {} {test_kwarg} {test_var}"
@@ -201,9 +196,8 @@ class TestOperatorFormatReplacement(BaseReplacement):
         assert as_formatted_evidence(res) == "-1234 1 2 6 3 1"
 
         string_input = create_taint_range_with_format(":+--12-+:34 {} {} {} {test_kwarg} {test_var}")
-        mod.do_args_kwargs_4(string_input, 6, test_var=1)  # pylint: disable=no-member
-        # TODO format with params doesn't work correctly
-        #  as_formatted_evidence(res) == ":+--12-+:34 1 2 6 3 1"
+        res = mod.do_args_kwargs_4(string_input, 6, test_var=1)  # pylint: disable=no-member
+        assert as_formatted_evidence(res) == ":+--12-+:34 1 2 6 3 1"
 
     def test_format_when_tainted_template_range_special_then_tainted_result(self):  # type: () -> None
         self._assert_format_result(

--- a/tests/appsec/iast/aspects/test_format_map_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_format_map_aspect_fixtures.py
@@ -33,23 +33,19 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
 
         assert as_formatted_evidence(result, tag_mapping_function=None) == escaped_expected_result
 
-    @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_template_is_none_then_raises_attribute_error(self):  # type: () -> None
         with pytest.raises(AttributeError):
             mod.do_format_map(None, {})
 
-    @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_parameter_is_none_then_raises_type_error(self):  # type: () -> None
         with pytest.raises(TypeError):
             assert mod.do_format_map("{key}", None) == "None"
 
-    @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_no_tainted_strings_then_no_tainted_result(self):  # type: () -> None
         result = mod.do_format_map("template {key}", {"key": "parameter"})
         assert result, "template parameter"
         assert not get_ranges(result)
 
-    @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_tainted_parameter_then_tainted_result(self):  # type: () -> None
         self._assert_format_map_result(
             taint_escaped_template="template {key}",
@@ -58,7 +54,6 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
             escaped_expected_result="template :+-<input1>parameter<input1>-+:",
         )
 
-    @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_tainted_template_range_no_brackets_then_tainted_result(self):  # type: () -> None
         self._assert_format_map_result(
             taint_escaped_template=":+-<input1>template<input1>-+: {key}",
@@ -67,7 +62,6 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template<input1>-+: parameter",
         )
 
-    @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_tainted_template_range_with_brackets_then_tainted_result(self):  # type: () -> None
         self._assert_format_map_result(
             taint_escaped_template="template :+-<input1>{key}<input1>-+:",
@@ -76,7 +70,6 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
             escaped_expected_result="template :+-<input1>parameter<input1>-+:",
         )
 
-    @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_tainted_template_range_no_brackets_and_tainted_param_then_tainted(
         self,
     ):  # type: () -> None
@@ -87,7 +80,6 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template<input1>-+: " ":+-<input2>parameter<input2>-+:",
         )
 
-    @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_tainted_template_range_with_brackets_and_tainted_param_then_tainted(
         self,
     ):  # type: () -> None
@@ -98,7 +90,6 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template <input1>-+:" ":+-<input2>parameter<input2>-+:",
         )
 
-    @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_ranges_overlap_then_give_preference_to_ranges_from_parameter(self):  # type: () -> None
         self._assert_format_map_result(
             taint_escaped_template=":+-<input1>template {key} range overlapping<input1>-+:",
@@ -109,7 +100,6 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
             ":+-<input1> range overlapping<input1>-+:",
         )
 
-    @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_tainted_str_emoji_strings_then_tainted_result(self):  # type: () -> None
         self._assert_format_map_result(
             taint_escaped_template=":+-<input1>template⚠️<input1>-+: {key}",
@@ -118,7 +108,6 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template⚠️<input1>-+: " ":+-<input2>parameter⚠️<input2>-+:",
         )
 
-    @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_tainted_template_range_no_brackets_and_param_not_str_then_tainted(
         self,
     ):  # type: () -> None
@@ -129,7 +118,6 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template<input1>-+: 3.14",
         )
 
-    @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_tainted_template_range_with_brackets_and_param_not_str_then_tainted(
         self,
     ):  # type: () -> None
@@ -140,7 +128,6 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
             escaped_expected_result=":+-<input1>template 3.14<input1>-+:",
         )
 
-    @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_texts_tainted_and_contain_escape_sequences_then_result_uncorrupted(
         self,
     ):  # type: () -> None
@@ -153,7 +140,6 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
             ":+-<0>my_code<0>-+:",
         )
 
-    @pytest.mark.skipif(not hasattr("", "format_map"), reason="Method format_map not supported")
     def test_format_map_when_parameter_value_already_present_in_template_then_range_is_correct(
         self,
     ):  # type: () -> None


### PR DESCRIPTION
IAST: Fix propagation error on ``.format`` string method.

Error partially introduced in: https://github.com/DataDog/dd-trace-py/pull/7772
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
