### PR TITLE
fix(iast): fix memory leak error [backport #7788 to 2.3]

### DIFF
--- a/ddtrace/appsec/_iast/_ast/ast_patching.py
+++ b/ddtrace/appsec/_iast/_ast/ast_patching.py
@@ -5,13 +5,13 @@ import codecs
 import os
 import re
 from sys import builtin_module_names
-from typing import TYPE_CHECKING
+from types import ModuleType
+from typing import TYPE_CHECKING  # noqa:F401
+from typing import Tuple
 
 
 if TYPE_CHECKING:
-    from types import ModuleType
-    from typing import Optional
-    from typing import Tuple
+    from typing import Optional  # noqa:F401
 
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._python_info.stdlib import _stdlib_for_python_version
@@ -123,8 +123,7 @@ def _remove_flask_run(text):  # type (str) -> str
     return new_text
 
 
-def astpatch_module(module, remove_flask_run=False):
-    # type: (ModuleType, bool) -> Tuple[str, str]
+def astpatch_module(module: ModuleType, remove_flask_run: bool = False) -> Tuple[str, str]:
     module_name = module.__name__
     module_path = str(origin(module))
     try:

--- a/ddtrace/appsec/_iast/_ast/visitor.py
+++ b/ddtrace/appsec/_iast/_ast/visitor.py
@@ -4,9 +4,9 @@ from _ast import ImportFrom
 import ast
 import copy
 import sys
-from typing import Any
-from typing import List
-from typing import Set
+from typing import Any  # noqa:F401
+from typing import List  # noqa:F401
+from typing import Set  # noqa:F401
 
 from six import iteritems
 

--- a/ddtrace/appsec/_iast/_overhead_control_engine.py
+++ b/ddtrace/appsec/_iast/_overhead_control_engine.py
@@ -5,18 +5,18 @@ limit. It will measure operations being executed in a request and it will deacti
 """
 import os
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING  # noqa:F401
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.sampler import RateSampler
 
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Set
-    from typing import Tuple
-    from typing import Type
+    from typing import Set  # noqa:F401
+    from typing import Tuple  # noqa:F401
+    from typing import Type  # noqa:F401
 
-    from ddtrace.span import Span
+    from ddtrace.span import Span  # noqa:F401
 
 log = get_logger(__name__)
 
@@ -98,7 +98,8 @@ class OverheadControl(object):
     def reconfigure(self):
         self._sampler = RateSampler(sample_rate=get_request_sampling_value() / 100.0)
 
-    def acquire_request(self, span):  # type: (Span) -> None
+    def acquire_request(self, span):
+        # type: (Span) -> None
         """Decide whether if IAST analysis will be done for this request.
         - Block a request's quota at start of the request to limit simultaneous requests analyzed.
         - Use sample rating to analyze only a percentage of the total requests (30% by default).

--- a/ddtrace/appsec/_iast/_patch.py
+++ b/ddtrace/appsec/_iast/_patch.py
@@ -1,7 +1,7 @@
 import ctypes
 import gc
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING  # noqa:F401
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.vendor.wrapt import FunctionWrapper
@@ -11,10 +11,10 @@ from ._utils import _is_iast_enabled
 
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any
-    from typing import Callable
-    from typing import Dict
-    from typing import Optional
+    from typing import Any  # noqa:F401
+    from typing import Callable  # noqa:F401
+    from typing import Dict  # noqa:F401
+    from typing import Optional  # noqa:F401
 
 
 _DD_ORIGINAL_ATTRIBUTES = {}  # type: Dict[Any, Any]

--- a/ddtrace/appsec/_iast/_stacktrace.c
+++ b/ddtrace/appsec/_iast/_stacktrace.c
@@ -17,19 +17,22 @@
 #define GET_LINENO(frame) PyFrame_GetLineNumber((PyFrameObject*)frame)
 #define GET_FRAME(tstate) PyThreadState_GetFrame(tstate)
 #define GET_PREVIOUS(frame) PyFrame_GetBack(frame)
-#define FRAME_DECREF(frame) Py_DECREF(frame)
+#define FRAME_DECREF(frame) Py_DecRef(frame)
 #define FRAME_XDECREF(frame) Py_XDECREF(frame)
-#define FILENAME_DECREF(filename) Py_DECREF(filename)
-#define FILENAME_XDECREF(filename) Py_XDECREF(filename)
+#define FILENAME_DECREF(filename) Py_DecRef(filename)
+#define FILENAME_XDECREF(filename)                                                                                     \
+    if (filename)                                                                                                      \
+    Py_DecRef(filename)
 static inline PyObject*
 GET_FILENAME(PyFrameObject* frame)
 {
     PyCodeObject* code = PyFrame_GetCode(frame);
     if (!code) {
-        Py_DECREF(code);
         return NULL;
     }
-    return PyObject_GetAttrString((PyObject*)code, "co_filename");
+    PyObject* filename = PyObject_GetAttrString((PyObject*)code, "co_filename");
+    Py_DecRef(code);
+    return filename;
 }
 #else
 #define GET_FRAME(tstate) tstate->frame
@@ -113,7 +116,7 @@ get_file_and_line(PyObject* Py_UNUSED(module), PyObject* cwd_obj)
     }
 
 exit:
-    Py_DECREF(cwd_bytes);
+    Py_DecRef(cwd_bytes);
     FRAME_XDECREF(frame);
     FILENAME_XDECREF(filename_o);
     return result;
@@ -123,10 +126,10 @@ exit_0:; // fix: "a label can only be part of a statement and a declaration is n
     PyObject* line_obj = Py_BuildValue("i", 0);
     filename_o = PyUnicode_FromString("");
     result = PyTuple_Pack(2, filename_o, line_obj);
-    Py_DECREF(cwd_bytes);
+    Py_DecRef(cwd_bytes);
     FRAME_XDECREF(frame);
     FILENAME_XDECREF(filename_o);
-    Py_DECREF(line_obj);
+    Py_DecRef(line_obj);
     return result;
 }
 

--- a/ddtrace/appsec/_iast/_taint_dict.py
+++ b/ddtrace/appsec/_iast/_taint_dict.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 #
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING  # noqa:F401
 
 
 if TYPE_CHECKING:
-    from typing import Dict
-    from typing import Tuple
+    from typing import Dict  # noqa:F401
+    from typing import Tuple  # noqa:F401
 
-    from ._taint_tracking import Source
+    from ._taint_tracking import Source  # noqa:F401
 
 _IAST_TAINT_DICT = {}  # type: Dict[int, Tuple[Tuple[Source, int, int],...]]
 

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectExtend.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectExtend.cpp
@@ -1,5 +1,4 @@
 #include "AspectExtend.h"
-#include "Initializer/Initializer.h"
 
 PyObject*
 api_extend_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
@@ -28,7 +27,7 @@ api_extend_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     // Ensure no returns are done before this method call
     auto method_name = PyUnicode_FromString("extend");
     PyObject_CallMethodObjArgs(candidate_text, method_name, to_add, nullptr);
-    Py_DECREF(method_name);
+    Py_DecRef(method_name);
 
     if (not ctx_map or ctx_map->empty() or to_result == nullptr) {
         Py_RETURN_NONE;

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectExtend.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectExtend.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Initializer/Initializer.h"
 #include <Python.h>
 
 PyObject*

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.cpp
@@ -1,0 +1,53 @@
+#pragma once
+#include "Aspects/AspectFormat.h"
+
+template<class StrType>
+StrType
+api_format_aspect(StrType& candidate_text,
+                  const py::tuple& parameter_list,
+                  const py::args& args,
+                  const py::kwargs& kwargs)
+{
+    auto [ranges_orig, candidate_text_ranges] = are_all_text_all_ranges(candidate_text.ptr(), parameter_list);
+
+    if (!ranges_orig.empty() or !candidate_text_ranges.empty()) {
+        auto new_template =
+          _int_as_formatted_evidence<StrType>(candidate_text, candidate_text_ranges, TagMappingMode::Mapper);
+
+        py::list new_args;
+        py::dict new_kwargs;
+        for (const auto arg : args) {
+            if (is_text(arg.ptr())) {
+                auto str_arg = py::cast<py::str>(arg);
+                auto n_arg = _all_as_formatted_evidence<py::str>(str_arg, TagMappingMode::Mapper);
+                new_args.append(n_arg);
+            } else {
+                new_args.append(arg);
+            }
+        }
+        for (auto [key, value] : kwargs) {
+            if (is_text(value.ptr())) {
+                auto str_value = py::cast<py::str>(value);
+                auto n_value = _all_as_formatted_evidence<py::str>(str_value, TagMappingMode::Mapper);
+                new_kwargs[key] = n_value;
+            } else {
+                new_kwargs[key] = value;
+            }
+        }
+        StrType new_template_format =
+          py::getattr(new_template, "format")(*(py::cast<py::tuple>(new_args)), **new_kwargs);
+        std::tuple result = _convert_escaped_text_to_taint_text<StrType>(new_template_format, ranges_orig);
+        StrType result_text = get<0>(result);
+        TaintRangeRefs result_ranges = get<1>(result);
+        PyObject* new_result = new_pyobject_id(result_text.ptr());
+        set_ranges(new_result, result_ranges);
+        return py::reinterpret_steal<StrType>(new_result);
+    }
+    return py::getattr(candidate_text, "format")(*args, **kwargs);
+}
+
+void
+pyexport_format_aspect(py::module& m)
+{
+    m.def("_format_aspect", &api_format_aspect<py::str>, "candidate_text"_a, "parameter_list"_a);
+}

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "Aspects/Helpers.h"
+#include "Initializer/Initializer.h"
+#include "TaintTracking/Source.h"
+#include "TaintTracking/TaintRange.h"
+#include "TaintTracking/TaintedObject.h"
+
+template<class StrType>
+StrType
+api_format_aspect(StrType& candidate_text,
+                  const py::tuple& parameter_list,
+                  const py::args& args,
+                  const py::kwargs& kwargs);
+
+void
+pyexport_format_aspect(py::module& m);

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
@@ -1,5 +1,3 @@
-#include <pybind11/stl.h>
-
 #include "AspectIndex.h"
 
 PyObject*
@@ -16,7 +14,7 @@ index_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* idx, TaintR
     }
 
     const auto& res_new_id = new_pyobject_id(result_o);
-    Py_DECREF(result_o);
+    Py_DecRef(result_o);
 
     if (ranges_to_set.empty()) {
         return res_new_id;

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
@@ -53,7 +53,7 @@ aspect_join_str(PyObject* sep,
 
     PyObject* new_result{ new_pyobject_id(result) };
     set_tainted_object(new_result, result_to, tx_taint_map);
-    Py_DECREF(result);
+    Py_DecRef(result);
     return new_result;
 }
 
@@ -134,7 +134,7 @@ aspect_join(PyObject* sep, PyObject* result, PyObject* iterable_elements, TaintR
 
     PyObject* new_result{ new_pyobject_id(result) };
     set_tainted_object(new_result, result_to, tx_taint_map);
-    Py_DECREF(result);
+    Py_DecRef(result);
     return new_result;
 }
 
@@ -160,7 +160,7 @@ api_join_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
                 PyList_Append(list_aux, item);
             }
             arg0 = list_aux;
-            Py_DECREF(iterator);
+            Py_DecRef(iterator);
             decref_arg0 = true;
         }
     }
@@ -181,7 +181,7 @@ api_join_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     if (get_pyobject_size(result) == 0) {
         // Empty result cannot have taint ranges
         if (decref_arg0) {
-            Py_DECREF(arg0);
+            Py_DecRef(arg0);
         }
         return result;
     }
@@ -192,7 +192,7 @@ api_join_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     }
     auto res = aspect_join(sep, result, arg0, ctx_map);
     if (decref_arg0) {
-        Py_DECREF(arg0);
+        Py_DecRef(arg0);
     }
     return res;
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.h
@@ -1,11 +1,7 @@
 #pragma once
-#include "Aspects/Helpers.h"
 #include "Initializer/Initializer.h"
-#include "TaintTracking//TaintedObject.h"
 #include "TaintTracking/TaintRange.h"
-#include "TaintedOps/TaintedOps.h"
-#include <Python.h>
-#include <pybind11/pybind11.h>
+#include "TaintTracking/TaintedObject.h"
 
 namespace py = pybind11;
 

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
@@ -26,7 +26,7 @@ add_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* text_to_add, 
     const auto& to_candidate_text = get_tainted_object(candidate_text, tx_taint_map);
     if (to_candidate_text and to_candidate_text->get_ranges().size() >= TaintedObject::TAINT_RANGE_LIMIT) {
         const auto& res_new_id = new_pyobject_id(result_o);
-        Py_DECREF(result_o);
+        Py_DecRef(result_o);
         // If left side is already at the maximum taint ranges, we just reuse its
         // ranges, we don't need to look at left side.
         set_tainted_object(res_new_id, to_candidate_text, tx_taint_map);
@@ -39,15 +39,15 @@ add_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* text_to_add, 
     }
     if (!to_text_to_add) {
         const auto& res_new_id = new_pyobject_id(result_o);
-        Py_DECREF(result_o);
+        Py_DecRef(result_o);
         set_tainted_object(res_new_id, to_candidate_text, tx_taint_map);
         return res_new_id;
     }
 
     auto tainted = initializer->allocate_tainted_object_copy(to_candidate_text);
     tainted->add_ranges_shifted(to_text_to_add, (RANGE_START)len_candidate_text);
-    const auto& res_new_id = new_pyobject_id(result_o);
-    Py_DECREF(result_o);
+    const auto res_new_id = new_pyobject_id(result_o);
+    Py_DecRef(result_o);
     set_tainted_object(res_new_id, tainted, tx_taint_map);
 
     return res_new_id;

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.h
@@ -1,13 +1,7 @@
-#ifndef _NATIVE_ASPECTOPERATORADD_H
-#define _NATIVE_ASPECTOPERATORADD_H
-#include "Aspects/Helpers.h"
+#pragma once
 #include "Initializer/Initializer.h"
 #include "TaintTracking/TaintRange.h"
 #include "TaintTracking/TaintedObject.h"
-#include "TaintedOps/TaintedOps.h"
-#include <pybind11/pybind11.h>
 
 PyObject*
 api_add_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs);
-
-#endif //_NATIVE_ASPECTOPERATORADD_H

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
@@ -19,7 +19,7 @@ reduce_ranges_from_index_range_map(TaintRangeRefs index_range_map)
             current_start = index;
         }
     }
-    if (current_range != nullptr) {
+    if (current_range != NULL) {
         new_ranges.emplace_back(
           initializer->allocate_taint_range(current_start, index - current_start, current_range->source));
     }
@@ -42,13 +42,31 @@ build_index_range_map(PyObject* text, TaintRangeRefs& ranges, PyObject* start, P
             index++;
         }
     }
-    while (index < (long long)py::len(text)) {
+    long length_text = (long long)py::len(text);
+    while (index < length_text) {
         index_range_map.emplace_back(nullptr);
         index++;
     }
-    py::list pylist{ py::cast(index_range_map) };
-    auto res{ pylist[py::slice(start, stop, step)].cast<TaintRangeRefs>() };
-    return res;
+    TaintRangeRefs index_range_map_result;
+    long start_int = PyLong_AsLong(start);
+    long stop_int = length_text;
+    if (stop != NULL) {
+        stop_int = PyLong_AsLong(stop);
+        if (stop_int > length_text) {
+            stop_int = length_text;
+        } else if (stop_int < 0) {
+            stop_int = length_text + stop_int;
+        }
+    }
+    long step_int = 1;
+    if (step != NULL) {
+        step_int = PyLong_AsLong(step);
+    }
+    for (auto i = start_int; i < stop_int; i += step_int) {
+        index_range_map_result.emplace_back(index_range_map[i]);
+    }
+
+    return index_range_map_result;
 }
 
 PyObject*
@@ -67,7 +85,7 @@ PyObject*
 api_slice_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 {
     if (nargs < 3) {
-        return nullptr;
+        return NULL;
     }
     PyObject* candidate_text = args[0];
     PyObject* start = PyLong_FromLong(0);
@@ -75,7 +93,7 @@ api_slice_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     if (PyNumber_Check(args[1])) {
         start = PyNumber_Long(args[1]);
     }
-    PyObject* stop = nullptr;
+    PyObject* stop = NULL;
     if (PyNumber_Check(args[2])) {
         stop = PyNumber_Long(args[2]);
     }
@@ -87,32 +105,32 @@ api_slice_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     }
 
     PyObject* slice = PySlice_New(start, stop, step);
-    if (slice == nullptr) {
+    if (slice == NULL) {
         PyErr_Print();
-        if (start != nullptr) {
-            Py_DECREF(start);
+        if (start != NULL) {
+            Py_DecRef(start);
         }
-        if (stop != nullptr) {
-            Py_DECREF(stop);
+        if (stop != NULL) {
+            Py_DecRef(stop);
         }
-        if (step != nullptr) {
-            Py_DECREF(step);
+        if (step != NULL) {
+            Py_DecRef(step);
         }
-        return nullptr;
+        return NULL;
     }
     PyObject* result = PyObject_GetItem(candidate_text, slice);
 
     auto res = slice_aspect(result, candidate_text, start, stop, step);
 
-    if (start != nullptr) {
-        Py_DECREF(start);
+    if (start != NULL) {
+        Py_DecRef(start);
     }
-    if (stop != nullptr) {
-        Py_DECREF(stop);
+    if (stop != NULL) {
+        Py_DecRef(stop);
     }
-    if (step != nullptr) {
-        Py_DECREF(step);
+    if (step != NULL) {
+        Py_DecRef(step);
     }
-    Py_DECREF(slice);
+    Py_DecRef(slice);
     return res;
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.cpp
@@ -6,20 +6,6 @@
 using namespace pybind11::literals;
 namespace py = pybind11;
 
-size_t
-get_pyobject_size(PyObject* obj)
-{
-    size_t len_candidate_text{ 0 };
-    if (PyUnicode_Check(obj)) {
-        len_candidate_text = PyUnicode_GET_LENGTH(obj);
-    } else if (PyBytes_Check(obj)) {
-        len_candidate_text = PyBytes_Size(obj);
-    } else if (PyByteArray_Check(obj)) {
-        len_candidate_text = PyByteArray_Size(obj);
-    }
-    return len_candidate_text;
-}
-
 template<class StrType>
 StrType
 common_replace(const py::str& string_method,
@@ -34,7 +20,7 @@ common_replace(const py::str& string_method,
         return res;
     }
 
-    set_ranges(res.ptr(), api_shift_taint_ranges(candidate_text_ranges, 0));
+    set_ranges(res.ptr(), shift_taint_ranges(candidate_text_ranges, 0));
     return res;
 }
 
@@ -94,25 +80,37 @@ range_sort(const TaintRangePtr& t1, const TaintRangePtr& t2)
     return t1->start < t2->start;
 }
 
+template<class StrType>
+StrType
+_all_as_formatted_evidence(StrType& text, TagMappingMode tag_mapping_mode)
+{
+    TaintRangeRefs text_ranges = api_get_ranges(text);
+    return AsFormattedEvidence<StrType>(text, text_ranges, tag_mapping_mode, nullopt);
+}
+
+template<class StrType>
+StrType
+_int_as_formatted_evidence(StrType& text, TaintRangeRefs text_ranges, TagMappingMode tag_mapping_mode)
+{
+    return AsFormattedEvidence<StrType>(text, text_ranges, tag_mapping_mode, nullopt);
+}
+
 // TODO OPTIMIZATION: Remove py::types once this isn't used in Python
 template<class StrType>
 StrType
-as_formatted_evidence(StrType& text,
-                      optional<TaintRangeRefs>& text_ranges,
-                      const optional<TagMappingMode>& tag_mapping_mode,
-                      const optional<const py::dict>& new_ranges)
+AsFormattedEvidence(StrType& text,
+                    TaintRangeRefs& text_ranges,
+                    const optional<TagMappingMode>& tag_mapping_mode,
+                    const optional<const py::dict>& new_ranges)
 {
-    if (!text_ranges) {
-        text_ranges = api_get_ranges(text);
-    }
-    if (text_ranges->empty()) {
+    if (text_ranges.empty()) {
         return text;
     }
     vector<StrType> res_vector;
     long index = 0;
 
-    sort(text_ranges->begin(), text_ranges->end(), &range_sort);
-    for (const auto& taint_range : *text_ranges) {
+    sort(text_ranges.begin(), text_ranges.end(), &range_sort);
+    for (const auto& taint_range : text_ranges) {
         py::object content;
         if (!tag_mapping_mode) {
             content = get_default_content(taint_range);
@@ -128,7 +126,7 @@ as_formatted_evidence(StrType& text,
                     // Nothing
                 }
             }
-        StrType tag = get_tag<StrType>(content);
+        auto tag = get_tag<StrType>(content);
 
         auto range_end = taint_range->start + taint_range->length;
 
@@ -143,6 +141,22 @@ as_formatted_evidence(StrType& text,
     }
     res_vector.push_back(text[py::slice(py::int_(index), nullptr, nullptr)]);
     return StrType(EVIDENCE_MARKS::BLANK).attr("join")(res_vector);
+}
+
+template<class StrType>
+StrType
+ApiAsFormattedEvidence(StrType& text,
+                       optional<TaintRangeRefs>& text_ranges,
+                       const optional<TagMappingMode>& tag_mapping_mode,
+                       const optional<const py::dict>& new_ranges)
+{
+    TaintRangeRefs _ranges;
+    if (!text_ranges) {
+        _ranges = api_get_ranges(text);
+    } else {
+        _ranges = text_ranges.value();
+    }
+    return AsFormattedEvidence<StrType>(text, _ranges, tag_mapping_mode, new_ranges);
 }
 
 vector<string>
@@ -165,10 +179,10 @@ api_convert_escaped_text_to_taint_text_ba(const py::bytearray& taint_escaped_tex
 {
     py::bytes bytes_text = py::bytes() + taint_escaped_text;
 
-    std::tuple result = _convert_escaped_text_to_taint_text<py::bytes>(bytes_text, ranges_orig);
-    py::bytearray result_new_id = copy_string_new_id(py::bytearray() + get<0>(result));
-    set_ranges(result_new_id.ptr(), get<1>(result));
-    return result_new_id;
+    std::tuple result = _convert_escaped_text_to_taint_text<py::bytes>(bytes_text, std::move(ranges_orig));
+    PyObject* new_result = new_pyobject_id((py::bytearray() + get<0>(result)).ptr());
+    set_ranges(new_result, get<1>(result));
+    return py::reinterpret_steal<py::bytearray>(new_result);
 }
 
 template<class StrType>
@@ -178,9 +192,9 @@ api_convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, TaintR
     std::tuple result = _convert_escaped_text_to_taint_text<StrType>(taint_escaped_text, ranges_orig);
     StrType result_text = get<0>(result);
     TaintRangeRefs result_ranges = get<1>(result);
-    StrType result_new_id = copy_string_new_id(result_text);
-    set_ranges(result_new_id.ptr(), result_ranges);
-    return result_new_id;
+    PyObject* new_result = new_pyobject_id(result_text.ptr());
+    set_ranges(new_result, result_ranges);
+    return py::reinterpret_steal<StrType>(new_result);
 }
 
 unsigned long int
@@ -190,11 +204,11 @@ getNum(std::string s)
     try {
         n = std::stoul(s, nullptr, 10);
         if (errno != 0) {
-            std::cout << "ERROR" << '\n';
+            PyErr_Print();
         }
     } catch (std::exception& e) {
         // throw std::invalid_argument("Value is too big");
-        std::cout << "Invalid value: " << s << '\n';
+        PyErr_Print();
     }
     return n;
 }
@@ -315,24 +329,38 @@ pyexport_aspect_helpers(py::module& m)
     m.def("common_replace", &common_replace<py::bytes>, "string_method"_a, "candidate_text"_a);
     m.def("common_replace", &common_replace<py::str>, "string_method"_a, "candidate_text"_a);
     m.def("common_replace", &common_replace<py::bytearray>, "string_method"_a, "candidate_text"_a);
-    m.def("as_formatted_evidence",
-          &as_formatted_evidence<py::bytes>,
+    m.def("_all_as_formatted_evidence",
+          &_all_as_formatted_evidence<py::str>,
+          "text"_a,
+          "tag_mapping_function"_a = nullopt,
+          py::return_value_policy::move);
+    m.def("_int_as_formatted_evidence",
+          &_int_as_formatted_evidence<py::str>,
           "text"_a,
           "text_ranges"_a = nullopt,
           "tag_mapping_function"_a = nullopt,
-          "new_ranges"_a = nullopt);
+          py::return_value_policy::move);
     m.def("as_formatted_evidence",
-          &as_formatted_evidence<py::str>,
+          &ApiAsFormattedEvidence<py::bytes>,
           "text"_a,
           "text_ranges"_a = nullopt,
           "tag_mapping_function"_a = nullopt,
-          "new_ranges"_a = nullopt);
+          "new_ranges"_a = nullopt,
+          py::return_value_policy::move);
     m.def("as_formatted_evidence",
-          &as_formatted_evidence<py::bytearray>,
+          &ApiAsFormattedEvidence<py::str>,
           "text"_a,
           "text_ranges"_a = nullopt,
           "tag_mapping_function"_a = nullopt,
-          "new_ranges"_a = nullopt);
+          "new_ranges"_a = nullopt,
+          py::return_value_policy::move);
+    m.def("as_formatted_evidence",
+          &ApiAsFormattedEvidence<py::bytearray>,
+          "text"_a,
+          "text_ranges"_a = nullopt,
+          "tag_mapping_function"_a = nullopt,
+          "new_ranges"_a = nullopt,
+          py::return_value_policy::move);
     m.def("_convert_escaped_text_to_tainted_text",
           &api_convert_escaped_text_to_taint_text<py::bytes>,
           "taint_escaped_text"_a,

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
@@ -9,9 +9,6 @@
 using namespace pybind11::literals;
 namespace py = pybind11;
 
-size_t
-get_pyobject_size(PyObject* obj);
-
 // Calls the specified method and applies the same ranges to the result. Used
 // for wrapping simple methods that doesn't change the string size like upper(),
 // lower() and similar.
@@ -24,10 +21,25 @@ common_replace(const py::str& string_method,
 
 template<class StrType>
 StrType
-as_formatted_evidence(StrType& text,
-                      optional<TaintRangeRefs>& text_ranges,
-                      const optional<TagMappingMode>& tag_mapping_mode,
-                      const optional<const py::dict>& new_ranges);
+_all_as_formatted_evidence(StrType& text, TagMappingMode tag_mapping_mode);
+
+template<class StrType>
+StrType
+_int_as_formatted_evidence(StrType& text, TaintRangeRefs text_ranges, TagMappingMode tag_mapping_mode);
+
+template<class StrType>
+StrType
+AsFormattedEvidence(StrType& text,
+                    optional<TaintRangeRefs>& text_ranges,
+                    const TagMappingMode& tag_mapping_mode,
+                    const optional<const py::dict>& new_ranges);
+
+template<class StrType>
+StrType
+ApiAsFormattedEvidence(StrType& text,
+                       optional<TaintRangeRefs>& text_ranges,
+                       const optional<TagMappingMode>& tag_mapping_mode,
+                       const optional<const py::dict>& new_ranges);
 
 py::bytearray
 api_convert_escaped_text_to_taint_text_ba(const py::bytearray& taint_escaped_text, TaintRangeRefs ranges_orig);

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/_aspects_exports.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/_aspects_exports.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "AspectFormat.h"
 #include "Helpers.h"
 #include <pybind11/pybind11.h>
 
@@ -7,4 +8,6 @@ pyexport_m_aspect_helpers(py::module& m)
 {
     py::module m_aspect_helpers = m.def_submodule("aspect_helpers", "Aspect Helpers");
     pyexport_aspect_helpers(m_aspect_helpers);
+    py::module m_aspect_format = m.def_submodule("aspect_format", "Aspect Format");
+    pyexport_format_aspect(m_aspect_format);
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
@@ -1,66 +1,6 @@
 #include "TaintRange.h"
 #include "Initializer/Initializer.h"
-
-#include <utility>
-
-using namespace pybind11::literals;
-
-using namespace std;
-
-#define _GET_HASH_KEY(hash) (hash & 0xFFFFFF)
-
-typedef struct _PyASCIIObject_State_Hidden
-{
-    unsigned int : 8;
-    unsigned int hidden : 24;
-} PyASCIIObject_State_Hidden;
-
-// Used to quickly exit on cases where the object is a non interned unicode
-// string and does not have the fast-taint mark on its internal data structure.
-// In any other case it will return false so the evaluation continue for (more
-// slowly) checking if bytes and bytearrays are tainted.
-__attribute__((flatten)) bool
-is_notinterned_notfasttainted_unicode(const PyObject* objptr)
-{
-    if (!objptr) {
-        return true; // cannot taint a nullptr
-    }
-
-    if (!PyUnicode_Check(objptr)) {
-        return false; // not a unicode, continue evaluation
-    }
-
-    if (PyUnicode_CHECK_INTERNED(objptr)) {
-        return true; // interned but it could still be tainted
-    }
-
-    const PyASCIIObject_State_Hidden* e = (PyASCIIObject_State_Hidden*)&(((PyASCIIObject*)objptr)->state);
-    if (!e) {
-        return true; // broken string object? better to skip it
-    }
-    // it cannot be fast tainted if hash is set to -1 (not computed)
-    Py_hash_t hash = ((PyASCIIObject*)objptr)->hash;
-    return hash == -1 || e->hidden != _GET_HASH_KEY(hash);
-}
-
-// For non interned unicode strings, set a hidden mark on it's internsal data
-// structure that will allow us to quickly check if the string is not tainted
-// and thus skip further processing without having to search on the tainting map
-__attribute__((flatten)) void
-set_fast_tainted_if_notinterned_unicode(PyObject* objptr)
-{
-    if (not objptr or !PyUnicode_Check(objptr) or PyUnicode_CHECK_INTERNED(objptr)) {
-        return;
-    }
-    auto e = (PyASCIIObject_State_Hidden*)&(((PyASCIIObject*)objptr)->state);
-    if (e) {
-        Py_hash_t hash = ((PyASCIIObject*)objptr)->hash;
-        if (hash == -1) {
-            hash = PyObject_Hash(objptr);
-        }
-        e->hidden = _GET_HASH_KEY(hash);
-    }
-}
+#include "Utils/StringUtils.h"
 
 void
 TaintRange::reset()
@@ -105,7 +45,7 @@ api_shift_taint_range(const TaintRangePtr& source_taint_range, RANGE_START offse
 }
 
 TaintRangeRefs
-api_shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, RANGE_START offset)
+shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, RANGE_START offset)
 {
     TaintRangeRefs new_ranges;
     new_ranges.reserve(source_taint_ranges.size());
@@ -114,6 +54,63 @@ api_shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, RANGE_START of
         new_ranges.emplace_back(api_shift_taint_range(trange, offset));
     }
     return new_ranges;
+}
+
+TaintRangeRefs
+api_shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, RANGE_START offset)
+{
+    return shift_taint_ranges(source_taint_ranges, offset);
+}
+
+/**
+ * set_ranges_from_values.
+ *
+ * The equivalent Python script of this function is:
+ *  ```
+ *  api_set_ranges_from_values
+ *  pyobject_newid = new_pyobject_id(pyobject)
+ *  source = Source(source_name, source_value, source_origin)
+ *  pyobject_range = TaintRange(0, len(pyobject), source)
+ *  set_ranges(pyobject_newid, [pyobject_range])
+ *  ```
+ *
+ * @param self The Python extension module.
+ * @param args An array of Python objects containing the candidate text and text aspect.
+ *   @param args[0] PyObject, string to set the ranges
+ *   @param args[1] long. Lenght of the string
+ *   @param args[2] string. source name
+ *   @param args[3] string. source value
+ *   @param args[4] int. origin type
+ * @param nargs The number of arguments in the 'args' array.
+ */
+PyObject*
+api_set_ranges_from_values(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
+{
+
+    if (nargs != 5) {
+        PyErr_SetString(
+          PyExc_TypeError,
+          "Invalid number of params: pyobject_newid, len(pyobject), source_name, source_value, source_origin");
+        throw std::runtime_error(
+          "Invalid number of params: pyobject_newid, len(pyobject), source_name, source_value, source_origin");
+    }
+    PyObject* tainted_object = args[0];
+    if (!PyUnicode_Check(tainted_object) and !PyByteArray_Check(tainted_object) and !PyBytes_Check(tainted_object)) {
+        return tainted_object;
+    }
+    auto ctx_map = initializer->get_tainting_map();
+    PyObject* pyobject_n = new_pyobject_id(tainted_object);
+    PyObject* len_pyobject_py = args[1];
+
+    long len_pyobject = PyLong_AsLong(len_pyobject_py);
+    string source_name = PyObjectToString(args[2]);
+    string source_value = PyObjectToString(args[3]);
+    auto source_origin = OriginType(PyLong_AsLong(args[4]));
+    auto source = Source(source_name, source_value, source_origin);
+    auto range = initializer->allocate_taint_range(0, len_pyobject, source);
+    TaintRangeRefs ranges = vector{ range };
+    set_ranges(pyobject_n, ranges, ctx_map);
+    return pyobject_n;
 }
 
 TaintRangeRefs
@@ -219,6 +216,22 @@ get_range_by_hash(size_t range_hash, optional<TaintRangeRefs>& taint_ranges)
         }
     }
     return null_range;
+}
+
+inline void
+api_copy_ranges_from_strings(py::object& str_1, py::object& str_2)
+{
+    auto tx_map = initializer->get_tainting_map();
+    auto ranges = get_ranges(str_1.ptr(), tx_map);
+    set_ranges(str_2.ptr(), ranges, tx_map);
+}
+
+inline void
+api_copy_and_shift_ranges_from_strings(py::object& str_1, py::object& str_2, int offset)
+{
+    auto tx_map = initializer->get_tainting_map();
+    auto ranges = get_ranges(str_1.ptr(), tx_map);
+    set_ranges(str_2.ptr(), shift_taint_ranges(ranges, offset), tx_map);
 }
 
 TaintedObjectPtr
@@ -341,6 +354,10 @@ pyexport_taintrange(py::module& m)
     m.def("set_ranges", py::overload_cast<PyObject*, const TaintRangeRefs&>(&set_ranges), "str"_a, "ranges"_a);
     m.def("set_ranges", &api_set_ranges, "str"_a, "ranges"_a);
 
+    m.def("copy_ranges_from_strings", &api_copy_ranges_from_strings, "str_1"_a, "str_2"_a);
+    m.def(
+      "copy_and_shift_ranges_from_strings", &api_copy_and_shift_ranges_from_strings, "str_1"_a, "str_2"_a, "offset"_a);
+
     m.def("get_ranges",
           py::overload_cast<PyObject*>(&get_ranges),
           "string_input"_a,
@@ -361,7 +378,6 @@ pyexport_taintrange(py::module& m)
 
     py::class_<TaintRange, shared_ptr<TaintRange>>(m, "TaintRange_")
       // Normal constructor disabled on the Python side, see above
-      // .def(py::init<int, int, Source>(), "start"_a = "", "length"_a, "source"_a)
       .def_readonly("start", &TaintRange::start)
       .def_readonly("length", &TaintRange::length)
       .def_readonly("source", &TaintRange::source)
@@ -369,7 +385,6 @@ pyexport_taintrange(py::module& m)
       .def("__repr__", &TaintRange::toString)
       .def("__hash__", &TaintRange::get_hash)
       .def("get_hash", &TaintRange::get_hash)
-      // FIXME: check source to for these two?
       .def("__eq__",
            [](const TaintRangePtr& self, const TaintRangePtr& other) {
                if (other == nullptr)

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
@@ -32,12 +32,6 @@ using TaintRangeMapType = std::map<uintptr_t, std::pair<Py_hash_t, TaintedObject
 
 #endif // NDEBUG
 
-inline static uintptr_t
-get_unique_id(const PyObject* str)
-{
-    return uintptr_t(str);
-}
-
 struct TaintRange
 {
     RANGE_START start = 0;
@@ -75,6 +69,9 @@ TaintRangePtr
 api_shift_taint_range(const TaintRangePtr& source_taint_range, RANGE_START offset);
 
 TaintRangeRefs
+shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, RANGE_START offset);
+
+TaintRangeRefs
 api_shift_taint_ranges(const TaintRangeRefs&, RANGE_START offset);
 
 TaintRangeRefs
@@ -104,6 +101,15 @@ api_set_ranges(py::object& str, const TaintRangeRefs& ranges)
     set_ranges(str.ptr(), ranges);
 }
 
+inline void
+api_copy_ranges_from_strings(py::object& str_1, py::object& str_2);
+
+inline void
+api_copy_and_shift_ranges_from_strings(py::object& str_1, py::object& str_2, int offset);
+
+PyObject*
+api_set_ranges_from_values(PyObject* self, PyObject* const* args, Py_ssize_t nargs);
+
 // Returns a tuple with (all ranges, ranges of candidate_text)
 std::tuple<TaintRangeRefs, TaintRangeRefs>
 are_all_text_all_ranges(PyObject* candidate_text, const py::tuple& parameter_list);
@@ -116,16 +122,12 @@ api_are_all_text_all_ranges(py::object& candidate_text, const py::tuple& paramet
 TaintRangePtr
 get_range_by_hash(size_t range_hash, optional<TaintRangeRefs>& taint_ranges);
 
-void
-set_fast_tainted_if_notinterned_unicode(PyObject* objptr);
 inline void
 api_set_fast_tainted_if_unicode(const py::object& obj)
 {
     set_fast_tainted_if_notinterned_unicode(obj.ptr());
 }
 
-bool
-is_notinterned_notfasttainted_unicode(const PyObject* objptr);
 inline bool
 api_is_unicode_and_not_fast_tainted(const py::object str)
 {

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.cpp
@@ -1,37 +1,4 @@
-#include "TaintedOps.h"
-
-PyObject*
-new_pyobject_id(PyObject* tainted_object)
-{
-    if (PyUnicode_Check(tainted_object)) {
-        PyObject* empty_unicode = PyUnicode_New(0, 127);
-        PyObject* val = Py_BuildValue("(OO)", tainted_object, empty_unicode);
-        PyObject* result = PyUnicode_Join(empty_unicode, val);
-        Py_DECREF(empty_unicode);
-        Py_DECREF(val);
-        return result;
-    }
-    if (PyBytes_Check(tainted_object)) {
-        PyObject* empty_bytes = PyBytes_FromString("");
-        auto bytes_join_ptr = py::reinterpret_borrow<py::bytes>(empty_bytes).attr("join");
-        auto val = Py_BuildValue("(OO)", tainted_object, empty_bytes);
-        auto res = PyObject_CallFunctionObjArgs(bytes_join_ptr.ptr(), val, NULL);
-        Py_DECREF(val);
-        Py_DECREF(empty_bytes);
-        return res;
-    } else if (PyByteArray_Check(tainted_object)) {
-        PyObject* empty_bytes = PyBytes_FromString("");
-        PyObject* empty_bytearray = PyByteArray_FromObject(empty_bytes);
-        auto bytearray_join_ptr = py::reinterpret_borrow<py::bytes>(empty_bytearray).attr("join");
-        auto val = Py_BuildValue("(OO)", tainted_object, empty_bytearray);
-        auto res = PyObject_CallFunctionObjArgs(bytearray_join_ptr.ptr(), val, NULL);
-        Py_DECREF(val);
-        Py_DECREF(empty_bytes);
-        Py_DECREF(empty_bytearray);
-        return res;
-    }
-    return tainted_object;
-}
+#include "TaintedOps/TaintedOps.h"
 
 PyObject*
 api_new_pyobject_id(PyObject* Py_UNUSED(module), PyObject* args)

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.h
@@ -2,15 +2,13 @@
 #include "Initializer/Initializer.h"
 #include "TaintTracking/TaintRange.h"
 #include "TaintTracking/TaintedObject.h"
+#include "Utils/StringUtils.h"
 #include <Python.h>
 #include <pybind11/pybind11.h>
 
 using namespace std;
 using namespace pybind11::literals;
 namespace py = pybind11;
-
-PyObject*
-new_pyobject_id(PyObject* tainted_object);
 
 PyObject*
 api_new_pyobject_id(PyObject* Py_UNUSED(module), PyObject* args);

--- a/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.cpp
@@ -6,91 +6,120 @@
 // if CLion tells it's not used!
 #include "StringUtils.h"
 
-// TODO: check if really needed
-// #define PY_SSIZE_T_CLEAN
-#include <Python.h>
-
-using namespace std;
 using namespace pybind11::literals;
 
-py::str
-copy_string_new_id(const py::str& source)
+using namespace std;
+
+#define _GET_HASH_KEY(hash) (hash & 0xFFFFFF)
+
+typedef struct _PyASCIIObject_State_Hidden
 {
-    if (PyUnicode_CHECK_INTERNED(source.ptr()) == SSTATE_NOT_INTERNED) {
-        return source;
+    unsigned int : 8;
+    unsigned int hidden : 24;
+} PyASCIIObject_State_Hidden;
+
+// Used to quickly exit on cases where the object is a non interned unicode
+// string and does not have the fast-taint mark on its internal data structure.
+// In any other case it will return false so the evaluation continue for (more
+// slowly) checking if bytes and bytearrays are tainted.
+__attribute__((flatten)) bool
+is_notinterned_notfasttainted_unicode(const PyObject* objptr)
+{
+    if (!objptr) {
+        return true; // cannot taint a nullptr
     }
 
-    py::str newstr = string(source);
-    return newstr;
-}
-
-py::bytes
-copy_string_new_id(const py::bytes& source)
-{
-    if (PyUnicode_CHECK_INTERNED(source.ptr()) == SSTATE_NOT_INTERNED) {
-        return source;
+    if (!PyUnicode_Check(objptr)) {
+        return false; // not a unicode, continue evaluation
     }
-    auto newstr = strdup(PYBIND11_BYTES_AS_STRING(source.ptr()));
-    py::bytes newbytes = newstr;
-    free(newstr);
-    return newbytes;
+
+    if (PyUnicode_CHECK_INTERNED(objptr)) {
+        return true; // interned but it could still be tainted
+    }
+
+    const _PyASCIIObject_State_Hidden* e = (_PyASCIIObject_State_Hidden*)&(((PyASCIIObject*)objptr)->state);
+    if (!e) {
+        return true; // broken string object? better to skip it
+    }
+    // it cannot be fast tainted if hash is set to -1 (not computed)
+    Py_hash_t hash = ((PyASCIIObject*)objptr)->hash;
+    return hash == -1 || e->hidden != _GET_HASH_KEY(hash);
 }
 
-py::bytearray
-copy_string_new_id(const py::bytearray& source)
+// For non interned unicode strings, set a hidden mark on it's internsal data
+// structure that will allow us to quickly check if the string is not tainted
+// and thus skip further processing without having to search on the tainting map
+__attribute__((flatten)) void
+set_fast_tainted_if_notinterned_unicode(PyObject* objptr)
 {
-    return source;
+    if (not objptr or !PyUnicode_Check(objptr) or PyUnicode_CHECK_INTERNED(objptr)) {
+        return;
+    }
+    auto e = (_PyASCIIObject_State_Hidden*)&(((PyASCIIObject*)objptr)->state);
+    if (e) {
+        Py_hash_t hash = ((PyASCIIObject*)objptr)->hash;
+        if (hash == -1) {
+            hash = PyObject_Hash(objptr);
+        }
+        e->hidden = _GET_HASH_KEY(hash);
+    }
 }
 
-py::object
-copy_string_new_id(const py::object& source)
+string
+PyObjectToString(PyObject* obj)
 {
-    return source;
+    const char* str = PyUnicode_AsUTF8(obj);
+
+    if (str == nullptr) {
+        PyErr_Print();
+        throw runtime_error("PyObjectToString error");
+    }
+    return str;
 }
 
 PyObject*
-copy_string_new_str_id(PyObject* source)
+new_pyobject_id(PyObject* tainted_object)
 {
-    if (PyUnicode_CHECK_INTERNED(source) == SSTATE_NOT_INTERNED) {
-        return source;
+    if (PyUnicode_Check(tainted_object)) {
+        PyObject* empty_unicode = PyUnicode_New(0, 127);
+        PyObject* val = Py_BuildValue("(OO)", tainted_object, empty_unicode);
+        PyObject* result = PyUnicode_Join(empty_unicode, val);
+        Py_DecRef(empty_unicode);
+        Py_DecRef(val);
+        return result;
     }
-
-    const Py_ssize_t length = PyUnicode_GET_LENGTH(source);
-    if (length >= 4097) {
-        return source;
+    if (PyBytes_Check(tainted_object)) {
+        PyObject* empty_bytes = PyBytes_FromString("");
+        auto bytes_join_ptr = py::reinterpret_borrow<py::bytes>(empty_bytes).attr("join");
+        auto val = Py_BuildValue("(OO)", tainted_object, empty_bytes);
+        auto res = PyObject_CallFunctionObjArgs(bytes_join_ptr.ptr(), val, NULL);
+        Py_DecRef(val);
+        Py_DecRef(empty_bytes);
+        return res;
+    } else if (PyByteArray_Check(tainted_object)) {
+        PyObject* empty_bytes = PyBytes_FromString("");
+        PyObject* empty_bytearray = PyByteArray_FromObject(empty_bytes);
+        auto bytearray_join_ptr = py::reinterpret_borrow<py::bytes>(empty_bytearray).attr("join");
+        auto val = Py_BuildValue("(OO)", tainted_object, empty_bytearray);
+        auto res = PyObject_CallFunctionObjArgs(bytearray_join_ptr.ptr(), val, NULL);
+        Py_DecRef(val);
+        Py_DecRef(empty_bytes);
+        Py_DecRef(empty_bytearray);
+        return res;
     }
-    const Py_ssize_t byte_length = length * PyUnicode_KIND(source);
-
-    // Despite its name, this macro computes the a reference maxchar based on
-    // is_ascii and kind. It does not iterate contents at all. Which other
-    // variants like ucs1lib_find_max_char do.
-    const Py_UCS4 maxchar = PyUnicode_MAX_CHAR_VALUE(source);
-    // Using this PyUnicode_New constructor, and the manual copy, we avoid any
-    // iteration of contents too. And we also avoid any decoding process like
-    // unicode_decode_utf8.
-    PyObject* newobj = PyUnicode_New(length, maxchar);
-    memcpy(PyUnicode_DATA(newobj), PyUnicode_DATA(source), byte_length);
-    Py_DECREF(source);
-    return newobj;
+    return tainted_object;
 }
 
-void
-pyexport_string_utils(py::module& m)
+size_t
+get_pyobject_size(PyObject* obj)
 {
-    m.def("copy_string_new_id",
-          py::overload_cast<const py::bytes&>(&copy_string_new_id),
-          "s"_a,
-          py::return_value_policy::move);
-    m.def("copy_string_new_id",
-          py::overload_cast<const py::str&>(&copy_string_new_id),
-          "s"_a,
-          py::return_value_policy::move);
-    m.def("copy_string_new_id",
-          py::overload_cast<const py::bytearray&>(&copy_string_new_id),
-          "s"_a,
-          py::return_value_policy::move);
-    m.def("copy_string_new_id",
-          py::overload_cast<const py::object&>(&copy_string_new_id),
-          "s"_a,
-          py::return_value_policy::move);
+    size_t len_candidate_text{ 0 };
+    if (PyUnicode_Check(obj)) {
+        len_candidate_text = PyUnicode_GET_LENGTH(obj);
+    } else if (PyBytes_Check(obj)) {
+        len_candidate_text = PyBytes_Size(obj);
+    } else if (PyByteArray_Check(obj)) {
+        len_candidate_text = PyByteArray_Size(obj);
+    }
+    return len_candidate_text;
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
@@ -1,24 +1,24 @@
 #pragma once
 
+#include <Python.h>
 #include <pybind11/pybind11.h>
 
 using namespace std;
+using namespace pybind11::literals;
+
 namespace py = pybind11;
 
-inline string
-str2lower(string_view s)
+inline static uintptr_t
+get_unique_id(const PyObject* str)
 {
-    string ret{ s };
-    std::transform(ret.begin(), ret.end(), ret.begin(), [](unsigned char c) { return std::tolower(c); });
-    return ret;
+    return uintptr_t(str);
 }
 
-inline bool
-str2bool(string_view s)
-{
-    string lowered = str2lower(s);
-    return lowered == "yes" or lowered == "1" or lowered == "true";
-}
+bool
+is_notinterned_notfasttainted_unicode(const PyObject* objptr);
+
+void
+set_fast_tainted_if_notinterned_unicode(PyObject* objptr);
 
 inline bool
 is_text(const PyObject* pyptr)
@@ -29,20 +29,11 @@ is_text(const PyObject* pyptr)
     return PyUnicode_Check(pyptr) || PyBytes_Check(pyptr) || PyByteArray_Check(pyptr);
 }
 
-py::str
-copy_string_new_id(const py::str& source);
-
-py::bytes
-copy_string_new_id(const py::bytes& source);
-
-py::bytearray
-copy_string_new_id(const py::bytearray& source);
-
-py::object
-copy_string_new_id(const py::object& source);
+string
+PyObjectToString(PyObject* obj);
 
 PyObject*
-copy_string_new_str_id(PyObject* source);
+new_pyobject_id(PyObject* tainted_object);
 
-void
-pyexport_string_utils(py::module& m);
+size_t
+get_pyobject_size(PyObject* obj);

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -12,6 +12,7 @@ if _is_python_version_supported():
     from ._native.aspect_helpers import _convert_escaped_text_to_tainted_text
     from ._native.aspect_helpers import as_formatted_evidence
     from ._native.aspect_helpers import common_replace
+    from ._native.aspect_format import _format_aspect
     from ._native.aspect_helpers import parse_params
     from ._native.initializer import active_map_addreses_size
     from ._native.initializer import create_context
@@ -31,19 +32,21 @@ if _is_python_version_supported():
     from ._native.taint_tracking import origin_to_str
     from ._native.taint_tracking import set_fast_tainted_if_notinterned_unicode
     from ._native.taint_tracking import set_ranges
+    from ._native.taint_tracking import copy_ranges_from_strings
+    from ._native.taint_tracking import copy_and_shift_ranges_from_strings
     from ._native.taint_tracking import shift_taint_range
     from ._native.taint_tracking import shift_taint_ranges
     from ._native.taint_tracking import str_to_origin
     from ._native.taint_tracking import taint_range as TaintRange
 
     new_pyobject_id = ops.new_pyobject_id
+    set_ranges_from_values = ops.set_ranges_from_values
     is_pyobject_tainted = is_tainted
 
 if TYPE_CHECKING:
     from typing import Any
     from typing import Dict
     from typing import List
-    from typing import Optional
     from typing import Tuple
     from typing import Union
 
@@ -58,6 +61,8 @@ __all__ = [
     "TaintRange",
     "get_ranges",
     "set_ranges",
+    "copy_ranges_from_strings",
+    "copy_and_shift_ranges_from_strings",
     "are_all_text_all_ranges",
     "shift_taint_range",
     "shift_taint_ranges",
@@ -73,6 +78,7 @@ __all__ = [
     "str_to_origin",
     "origin_to_str",
     "common_replace",
+    "_format_aspect",
     "as_formatted_evidence",
     "parse_params",
     "num_objects_tainted",
@@ -89,16 +95,17 @@ def taint_pyobject(pyobject, source_name, source_value, source_origin=None):
     if not pyobject or not isinstance(pyobject, (str, bytes, bytearray)):
         return pyobject
 
-    pyobject_newid = new_pyobject_id(pyobject)
     if isinstance(source_name, (bytes, bytearray)):
         source_name = str(source_name, encoding="utf8")
+    if isinstance(source_name, OriginType):
+        source_name = origin_to_str(source_name)
+
     if isinstance(source_value, (bytes, bytearray)):
         source_value = str(source_value, encoding="utf8")
     if source_origin is None:
         source_origin = OriginType.PARAMETER
-    source = Source(source_name, source_value, source_origin)
-    pyobject_range = TaintRange(0, len(pyobject), source)
-    set_ranges(pyobject_newid, [pyobject_range])
+
+    pyobject_newid = set_ranges_from_values(pyobject, len(pyobject), source_name, source_value, source_origin)
     _set_metric_iast_executed_source(source_origin)
     return pyobject_newid
 

--- a/ddtrace/appsec/_iast/_taint_tracking/_native.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/_native.cpp
@@ -13,7 +13,7 @@
 #include "Aspects/AspectJoin.h"
 #include "Aspects/AspectOperatorAdd.h"
 #include "Aspects/AspectSlice.h"
-#include "Aspects/_aspects_helpers.h"
+#include "Aspects/_aspects_exports.h"
 #include "Constants.h"
 #include "Initializer/_initializer.h"
 #include "TaintTracking/_taint_tracking.h"
@@ -49,6 +49,7 @@ static PyMethodDef OpsMethods[] = {
     // python 3.5, 3.6. but METH_FASTCALL could be used instead for python
     // >= 3.7
     { "new_pyobject_id", (PyCFunction)api_new_pyobject_id, METH_VARARGS, "new pyobject id" },
+    { "set_ranges_from_values", ((PyCFunction)api_set_ranges_from_values), METH_FASTCALL, "set_ranges_from_values" },
     { nullptr, nullptr, 0, nullptr }
 };
 

--- a/ddtrace/appsec/_iast/_utils.py
+++ b/ddtrace/appsec/_iast/_utils.py
@@ -2,7 +2,7 @@ import json
 import re
 import string
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING  # noqa:F401
 
 import attr
 
@@ -11,15 +11,15 @@ from ddtrace.settings.asm import config as asm_config
 
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import List
-    from typing import Set
-    from typing import Tuple
+    from typing import Any  # noqa:F401
+    from typing import List  # noqa:F401
+    from typing import Set  # noqa:F401
+    from typing import Tuple  # noqa:F401
 
 
 def _is_python_version_supported():  # type: () -> bool
-    # IAST supports Python versions 3.6 to 3.11
-    return (3, 6, 0) <= sys.version_info < (3, 12, 0)
+    # IAST supports Python versions 3.6 to 3.12
+    return (3, 6, 0) <= sys.version_info < (3, 13, 0)
 
 
 def _is_iast_enabled():

--- a/ddtrace/appsec/_iast/processor.py
+++ b/ddtrace/appsec/_iast/processor.py
@@ -20,7 +20,7 @@ from ._utils import _is_iast_enabled
 
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ddtrace.span import Span
+    from ddtrace.span import Span  # noqa:F401
 
 log = get_logger(__name__)
 

--- a/ddtrace/appsec/_iast/reporter.py
+++ b/ddtrace/appsec/_iast/reporter.py
@@ -9,13 +9,11 @@ import zlib
 
 import attr
 
-from ddtrace.internal.compat import PY2
-
 
 if TYPE_CHECKING:
-    import Any
-    import Dict
-    import Optional
+    import Any  # noqa:F401
+    import Dict  # noqa:F401
+    import Optional  # noqa:F401
 
 
 def _only_if_true(value):
@@ -69,8 +67,6 @@ class Vulnerability(object):
 
     def __attrs_post_init__(self):
         self.hash = zlib.crc32(repr(self).encode())
-        if PY2 and self.hash < 0:
-            self.hash += 1 << 32
 
 
 @attr.s(eq=True, hash=True)

--- a/ddtrace/appsec/_iast/taint_sinks/_base.py
+++ b/ddtrace/appsec/_iast/taint_sinks/_base.py
@@ -1,7 +1,7 @@
 import os
 import time
-from typing import TYPE_CHECKING
-from typing import cast
+from typing import TYPE_CHECKING  # noqa:F401
+from typing import cast  # noqa:F401
 
 from ddtrace import tracer
 from ddtrace.appsec._constants import IAST
@@ -14,6 +14,7 @@ from ddtrace.settings.asm import config as asm_config
 from ..._deduplications import deduplication
 from .. import oce
 from .._overhead_control_engine import Operation
+from .._stacktrace import get_info_frame
 from .._utils import _has_to_scrub
 from .._utils import _is_evidence_value_parts
 from .._utils import _scrub
@@ -24,22 +25,15 @@ from ..reporter import Source
 from ..reporter import Vulnerability
 
 
-try:
-    # Python >= 3.4
-    from .._stacktrace import get_info_frame
-except ImportError:
-    # Python 2
-    from .._stacktrace_py2 import get_info_frame
-
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any
-    from typing import Callable
-    from typing import Dict
-    from typing import List
-    from typing import Optional
-    from typing import Set
-    from typing import Text
-    from typing import Union
+    from typing import Any  # noqa:F401
+    from typing import Callable  # noqa:F401
+    from typing import Dict  # noqa:F401
+    from typing import List  # noqa:F401
+    from typing import Optional  # noqa:F401
+    from typing import Set  # noqa:F401
+    from typing import Text  # noqa:F401
+    from typing import Union  # noqa:F401
 
 log = get_logger(__name__)
 

--- a/ddtrace/appsec/_iast/taint_sinks/ast_taint.py
+++ b/ddtrace/appsec/_iast/taint_sinks/ast_taint.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING  # noqa:F401
 
 from ..._constants import IAST_SPAN_TAGS
 from .._metrics import _set_metric_iast_executed_sink
@@ -10,8 +10,8 @@ from .weak_randomness import WeakRandomness
 
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Callable
+    from typing import Any  # noqa:F401
+    from typing import Callable  # noqa:F401
 
 
 def ast_function(

--- a/ddtrace/appsec/_iast/taint_sinks/command_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/command_injection.py
@@ -1,11 +1,10 @@
 import os
 import re
-import shlex
 import subprocess  # nosec
-from typing import TYPE_CHECKING
-from typing import List
-from typing import Set
-from typing import Union
+from typing import TYPE_CHECKING  # noqa:F401
+from typing import List  # noqa:F401
+from typing import Set  # noqa:F401
+from typing import Union  # noqa:F401
 
 import six
 
@@ -26,11 +25,11 @@ from ._base import _check_positions_contained
 
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Dict
+    from typing import Any  # noqa:F401
+    from typing import Dict  # noqa:F401
 
-    from ..reporter import IastSpanReporter
-    from ..reporter import Vulnerability
+    from ..reporter import IastSpanReporter  # noqa:F401
+    from ..reporter import Vulnerability  # noqa:F401
 
 
 log = get_logger(__name__)
@@ -84,8 +83,7 @@ def _iast_cmdi_osspawn(wrapped, instance, args, kwargs):
 
 def _iast_cmdi_subprocess_init(wrapped, instance, args, kwargs):
     cmd_args = args[0] if len(args) else kwargs["args"]
-    cmd_args_list = shlex.split(cmd_args) if isinstance(cmd_args, str) else cmd_args
-    _iast_report_cmdi(cmd_args_list)
+    _iast_report_cmdi(cmd_args)
 
     return wrapped(*args, **kwargs)
 
@@ -106,7 +104,6 @@ class CommandInjection(VulnerabilityBase):
     @classmethod
     def _extract_sensitive_tokens(cls, vulns_to_text):
         # type: (Dict[Vulnerability, str]) -> Dict[int, Dict[str, Any]]
-
         ret = {}  # type: Dict[int, Dict[str, Any]]
         for vuln, text in six.iteritems(vulns_to_text):
             vuln_hash = hash(vuln)

--- a/ddtrace/appsec/_iast/taint_sinks/insecure_cookie.py
+++ b/ddtrace/appsec/_iast/taint_sinks/insecure_cookie.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING  # noqa:F401
 
 from ddtrace.internal.compat import six
 
@@ -14,8 +14,8 @@ from ..taint_sinks._base import VulnerabilityBase
 
 
 if TYPE_CHECKING:
-    from typing import Dict
-    from typing import Optional
+    from typing import Dict  # noqa:F401
+    from typing import Optional  # noqa:F401
 
 
 @oce.register

--- a/ddtrace/appsec/_iast/taint_sinks/sql_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/sql_injection.py
@@ -1,5 +1,5 @@
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING  # noqa:F401
 
 import six
 
@@ -12,10 +12,10 @@ from ._base import VulnerabilityBase
 
 
 if TYPE_CHECKING:
-    from typing import Any
-    from typing import Dict
+    from typing import Any  # noqa:F401
+    from typing import Dict  # noqa:F401
 
-    from .reporter import Vulnerability
+    from .reporter import Vulnerability  # noqa:F401
 
 
 _INSIDE_QUOTES_REGEXP = re.compile(r'["\']([^"\']*?)["\']')
@@ -35,7 +35,6 @@ class SqlInjection(VulnerabilityBase):
     @classmethod
     def _extract_sensitive_tokens(cls, vulns_to_text):
         # type: (Dict[Vulnerability, str]) -> Dict[int, Dict[str, Any]]
-
         ret = {}  # type: Dict[int, Dict[str, Any]]
         for vuln, text in six.iteritems(vulns_to_text):
             vuln_hash = hash(vuln)

--- a/ddtrace/appsec/_iast/taint_sinks/ssrf.py
+++ b/ddtrace/appsec/_iast/taint_sinks/ssrf.py
@@ -1,7 +1,7 @@
 import re
-from typing import Callable
-from typing import Dict
-from typing import Set
+from typing import Callable  # noqa:F401
+from typing import Dict  # noqa:F401
+from typing import Set  # noqa:F401
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
@@ -16,7 +16,7 @@ from .._utils import _scrub_get_tokens_positions
 from ..constants import EVIDENCE_SSRF
 from ..constants import VULN_SSRF
 from ..constants import VULNERABILITY_TOKEN_TYPE
-from ..reporter import IastSpanReporter
+from ..reporter import IastSpanReporter  # noqa:F401
 from ..reporter import Vulnerability
 from ._base import VulnerabilityBase
 from ._base import _check_positions_contained

--- a/ddtrace/appsec/_iast/taint_sinks/weak_cipher.py
+++ b/ddtrace/appsec/_iast/taint_sinks/weak_cipher.py
@@ -1,5 +1,5 @@
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING  # noqa:F401
 
 from ddtrace.internal.logger import get_logger
 
@@ -23,9 +23,9 @@ from ._base import VulnerabilityBase
 
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any
-    from typing import Callable
-    from typing import Set
+    from typing import Any  # noqa:F401
+    from typing import Callable  # noqa:F401
+    from typing import Set  # noqa:F401
 
 log = get_logger(__name__)
 

--- a/ddtrace/appsec/_iast/taint_sinks/weak_hash.py
+++ b/ddtrace/appsec/_iast/taint_sinks/weak_hash.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING  # noqa:F401
 
 from ddtrace.internal.logger import get_logger
 
@@ -22,9 +22,9 @@ from ._base import VulnerabilityBase
 
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any
-    from typing import Callable
-    from typing import Set
+    from typing import Any  # noqa:F401
+    from typing import Callable  # noqa:F401
+    from typing import Set  # noqa:F401
 
 log = get_logger(__name__)
 


### PR DESCRIPTION
This below backports list to 2.3.
- chore(iast): `format_aspect` refactor https://github.com/DataDog/dd-trace-py/pull/7884 and https://github.com/DataDog/dd-trace-py/pull/7772
- fix(iast): iast leak for python 3.11: https://github.com/DataDog/dd-trace-py/pull/7788
- chore(iast): add propagation for str aspect join: https://github.com/DataDog/dd-trace-py/pull/6940
- chore(iast): add collision tests for bytes and bytearray: https://github.com/DataDog/dd-trace-py/pull/7367
- chore(iast): store hash and id separately in tx_taint_map: https://github.com/DataDog/dd-trace-py/pull/7340

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
