### PR TITLE
fix(iast): insecure cookies error

### DIFF
--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -523,9 +523,6 @@ def set_http_meta(
     if _is_iast_enabled():
         from ddtrace.appsec._iast.taint_sinks.insecure_cookie import asm_check_cookies
 
-        if request_cookies:
-            asm_check_cookies(request_cookies)
-
         if response_cookies:
             asm_check_cookies(response_cookies)
 

--- a/releasenotes/notes/iast-fix-cookies-error-2084dea1413104bd.yaml
+++ b/releasenotes/notes/iast-fix-cookies-error-2084dea1413104bd.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Vulnerability Management for Code-level (IAST): Cookies vulnerabilities are only reported
+    if response cookies are insecure.

--- a/tests/contrib/flask/test_flask_appsec_iast.py
+++ b/tests/contrib/flask/test_flask_appsec_iast.py
@@ -6,9 +6,6 @@ import pytest
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast import oce
 from ddtrace.appsec._iast._utils import _is_python_version_supported as python_supported_by_iast
-from ddtrace.appsec._iast.constants import VULN_INSECURE_COOKIE
-from ddtrace.appsec._iast.constants import VULN_NO_HTTPONLY_COOKIE
-from ddtrace.appsec._iast.constants import VULN_NO_SAMESITE_COOKIE
 from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.contrib.sqlite3.patch import patch
 from tests.appsec.iast.iast_utils import get_line_and_hash
@@ -438,12 +435,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
                     assert vulnerability["location"]["path"] == TEST_FILE_PATH
                     assert vulnerability["hash"] == hash_value
 
-            assert {
-                VULN_SQL_INJECTION,
-                VULN_INSECURE_COOKIE,
-                VULN_NO_HTTPONLY_COOKIE,
-                VULN_NO_SAMESITE_COOKIE,
-            } == vulnerabilities
+            assert {VULN_SQL_INJECTION} == vulnerabilities
 
     @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
     def test_flask_full_sqli_iast_http_request_parameter(self):

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from ipaddress import ip_network
-import sys
 
 from hypothesis import given
 from hypothesis.strategies import booleans
@@ -488,18 +487,6 @@ def test_set_http_meta_insecure_cookies_iast_disabled(span, int_config):
         trace_utils.set_http_meta(span, int_config.myint, request_cookies=cookies)
         span_report = core.get_item(IAST.CONTEXT_KEY, span=span)
         assert not span_report
-
-
-@pytest.mark.skipif(
-    sys.version_info >= (3, 12),
-    reason="Python 3.7+ test, IAST not supported with Python 3.12",
-)
-def test_set_http_meta_insecure_cookies_iast_enabled(span, int_config):
-    with override_global_config(dict(_iast_enabled=True, _asm_enabled=True)):
-        cookies = {"foo": "bar"}
-        trace_utils.set_http_meta(span, int_config.myint, request_cookies=cookies)
-        span_report = core.get_item(IAST.CONTEXT_KEY, span=span)
-        assert span_report.vulnerabilities
 
 
 @mock.patch("ddtrace.contrib.trace_utils._store_headers")


### PR DESCRIPTION
Cookies vulnerabilities are only reported  if response cookies are insecure.
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
