### PR TITLE
ci: bump absl dependency

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/CMakeLists.txt
+++ b/ddtrace/appsec/_iast/_taint_tracking/CMakeLists.txt
@@ -26,7 +26,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
     message("Release mode: using abseil")
         FetchContent_Declare(
                 absl
-                URL "https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.zip"
+                URL "https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.zip"
         )
         FetchContent_MakeAvailable(absl)
 else()


### PR DESCRIPTION
In order to fix alpine compilation issue:
https://github.com/DataDog/dd-trace-py/actions/runs/7179979155/job/19551323413?pr=7892

Upstream fix in abseil:
https://github.com/abseil/abseil-cpp/commit/4500c2fada4e952037c59bd65e8be1ba0b29f21e

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
