### PR TITLE
fix(iast): report cookie name

### DIFF
--- a/ddtrace/appsec/_iast/taint_sinks/insecure_cookie.py
+++ b/ddtrace/appsec/_iast/taint_sinks/insecure_cookie.py
@@ -46,17 +46,16 @@ def asm_check_cookies(cookies):  # type: (Optional[Dict[str, str]]) -> None
 
     for cookie_key, cookie_value in six.iteritems(cookies):
         lvalue = cookie_value.lower().replace(" ", "")
-        evidence = "%s=%s" % (cookie_key, cookie_value)
 
         if ";secure" not in lvalue:
             increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, InsecureCookie.vulnerability_type)
             _set_metric_iast_executed_sink(InsecureCookie.vulnerability_type)
-            InsecureCookie.report(evidence_value=evidence)
+            InsecureCookie.report(evidence_value=cookie_key)
 
         if ";httponly" not in lvalue:
             increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, NoHttpOnlyCookie.vulnerability_type)
             _set_metric_iast_executed_sink(NoHttpOnlyCookie.vulnerability_type)
-            NoHttpOnlyCookie.report(evidence_value=evidence)
+            NoHttpOnlyCookie.report(evidence_value=cookie_key)
 
         if ";samesite=" in lvalue:
             ss_tokens = lvalue.split(";samesite=")
@@ -72,4 +71,4 @@ def asm_check_cookies(cookies):  # type: (Optional[Dict[str, str]]) -> None
         if report_samesite:
             increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, NoSameSite.vulnerability_type)
             _set_metric_iast_executed_sink(NoSameSite.vulnerability_type)
-            NoSameSite.report(evidence_value=evidence)
+            NoSameSite.report(evidence_value=cookie_key)

--- a/releasenotes/notes/iast-fix-cookies-name-report-d5c3381d8c951bab.yaml
+++ b/releasenotes/notes/iast-fix-cookies-name-report-d5c3381d8c951bab.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Vulnerability Management for Code-level (IAST): Ensure that Cookies vulnerabilities report only the cookie name.

--- a/tests/appsec/iast/taint_sinks/test_insecure_cookie.py
+++ b/tests/appsec/iast/taint_sinks/test_insecure_cookie.py
@@ -20,9 +20,9 @@ def test_insecure_cookies(iast_span_defaults):
     assert VULN_INSECURE_COOKIE in vulnerabilities_types
     assert VULN_NO_SAMESITE_COOKIE in vulnerabilities_types
 
-    assert vulnerabilities[0].evidence.value == "foo=bar"
-    assert vulnerabilities[1].evidence.value == "foo=bar"
-    assert vulnerabilities[2].evidence.value == "foo=bar"
+    assert vulnerabilities[0].evidence.value == "foo"
+    assert vulnerabilities[1].evidence.value == "foo"
+    assert vulnerabilities[2].evidence.value == "foo"
 
     assert vulnerabilities[0].location.line is None
     assert vulnerabilities[0].location.path is None
@@ -39,8 +39,8 @@ def test_nohttponly_cookies(iast_span_defaults):
     assert VULN_NO_HTTPONLY_COOKIE in vulnerabilities_types
     assert VULN_NO_SAMESITE_COOKIE in vulnerabilities_types
 
-    assert vulnerabilities[0].evidence.value == "foo=bar;secure"
-    assert vulnerabilities[1].evidence.value == "foo=bar;secure"
+    assert vulnerabilities[0].evidence.value == "foo"
+    assert vulnerabilities[1].evidence.value == "foo"
 
     assert vulnerabilities[0].location.line is None
     assert vulnerabilities[0].location.path is None
@@ -61,7 +61,7 @@ def test_nosamesite_cookies_missing(iast_span_defaults):
 
     assert len(vulnerabilities) == 1
     assert vulnerabilities[0].type == VULN_NO_SAMESITE_COOKIE
-    assert vulnerabilities[0].evidence.value == "foo=bar;secure;httponly"
+    assert vulnerabilities[0].evidence.value == "foo"
 
 
 def test_nosamesite_cookies_none(iast_span_defaults):
@@ -74,7 +74,7 @@ def test_nosamesite_cookies_none(iast_span_defaults):
     assert len(vulnerabilities) == 1
 
     assert vulnerabilities[0].type == VULN_NO_SAMESITE_COOKIE
-    assert vulnerabilities[0].evidence.value == "foo=bar;secure;httponly;samesite=none"
+    assert vulnerabilities[0].evidence.value == "foo"
 
 
 def test_nosamesite_cookies_other(iast_span_defaults):
@@ -87,7 +87,7 @@ def test_nosamesite_cookies_other(iast_span_defaults):
     assert len(vulnerabilities) == 1
 
     assert vulnerabilities[0].type == VULN_NO_SAMESITE_COOKIE
-    assert vulnerabilities[0].evidence.value == "foo=bar;secure;httponly;samesite=none"
+    assert vulnerabilities[0].evidence.value == "foo"
 
 
 def test_nosamesite_cookies_lax_no_error(iast_span_defaults):


### PR DESCRIPTION
## Description
Ensure that Cookies vulnerabilities report only the cookie name

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
