### PR TITLE
feat(openai): chain/session ID propagation 

### DIFF
--- a/ddtrace/contrib/openai/utils.py
+++ b/ddtrace/contrib/openai/utils.py
@@ -120,3 +120,18 @@ def _tag_tool_calls(integration, span, tool_calls, choice_idx):
             integration.trunc(str(tool_call.arguments)),
         )
         span.set_tag("openai.response.choices.%d.message.tool_calls.%d.name" % (choice_idx, idy), str(tool_call.name))
+
+
+def _propagate_chain_session_ids(span):
+    """Helper to propagate chain_id and session_id from parent spans to child spans."""
+    parent = span._parent
+    while parent is not None:
+        session_id = parent.get_tag("ml_obs.session_id")
+        chain_id = parent.get_tag("ml_obs.chain_id")
+        if chain_id is not None:
+            span.set_tag_str("ml_obs.chain_id", str(chain_id))
+        if session_id is not None:
+            span.set_tag_str("ml_obs.session_id", str(session_id))
+        if chain_id is not None and session_id is not None:
+            break
+        parent = parent._parent


### PR DESCRIPTION
wip: This PR adds chain/session ID tag propagation from root spans to OpenAI spans if these are set on root spans by users.

### Install steps
Install this branch via pip:
```shell
pip install git+https://github.com/DataDog/dd-trace-py.git@bc9af621621420033ec8eae4bf8bda7b0ec4deb7
```
Have the Datadog Agent installed:
```shell
docker run -d
  --cgroupns host \
  --pid host \
  -v /var/run/docker.sock:/var/run/docker.sock:ro \
  -v /proc/:/host/proc/:ro \
  -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
  -e DD_API_KEY=<DATADOG_API_KEY> \
  -p 127.0.0.1:8126:8126/tcp \
  -p 127.0.0.1:8125:8125/udp \
  -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true \
  -e DD_APM_ENABLED=true \
  gcr.io/datadoghq/agent:latest
```

### Example Usage
Example demo <demo.py> file:
```python
import ddtrace
import openai
with ddtrace.tracer.trace("Session span") as session_span:
    session_span.set_tag("ml_obs.session_id", "<SESSION_ID>")
    with ddtrace.tracer.trace("Chain span") as chain_span:
        chain_span.set_tag("ml_obs.chain_id", "<CHAIN_ID>")
        resp1 = openai.client.completion.create(...)  # first openai completion call here
        resp2 = openai.client.completion.create(...)  # second openai completion call here
        # ... more OpenAI operations happen here
```
Run this command after installing:
```shell
DD_SITE="datad0g.com" DD_API_KEY=<API_KEY> DD_APP_KEY=<APPLICATION_KEY> DD_OPENAI_LLMOBS_ENABLED=1 ddtrace-run python <demo.py>
```


Should result in a large trace containing all of the above operations as children spans, as well as each OpenAI completion operation sent to LLMObs including `ml_obs.chain_id` and `ml_obs.session_id` as a tag.

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
