### PR TITLE
fix(asm): remove import and dependency to avoid circular import [backport 2.4]

### DIFF
--- a/ddtrace/appsec/_iast/_patches/json_tainting.py
+++ b/ddtrace/appsec/_iast/_patches/json_tainting.py
@@ -5,9 +5,6 @@ from .._patch import set_and_check_module_is_patched
 from .._patch import set_module_unpatched
 from .._patch import try_unwrap
 from .._patch import try_wrap_function_wrapper
-from .._taint_utils import LazyTaintDict
-from .._taint_utils import LazyTaintList
-from .._taint_utils import taint_structure
 
 
 log = get_logger(__name__)
@@ -42,6 +39,8 @@ def patch():
 
 
 def wrapped_loads(wrapped, instance, args, kwargs):
+    from .._taint_utils import taint_structure
+
     obj = wrapped(*args, **kwargs)
     if asm_config._iast_enabled:
         try:
@@ -70,6 +69,9 @@ def wrapped_loads(wrapped, instance, args, kwargs):
 
 
 def patched_json_encoder_default(original_func, instance, args, kwargs):
+    from .._taint_utils import LazyTaintDict
+    from .._taint_utils import LazyTaintList
+
     if isinstance(args[0], (LazyTaintList, LazyTaintDict)):
         return args[0]._obj
 

--- a/ddtrace/appsec/_iast/_taint_utils.py
+++ b/ddtrace/appsec/_iast/_taint_utils.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 from collections import abc
-import dataclasses
 from typing import Any
 from typing import List
 from typing import Optional
@@ -19,15 +18,26 @@ log = get_logger(__name__)
 # Non Lazy Tainting
 
 
-@dataclasses.dataclass
+# don't use dataclass that can create circular import problems here
+# @dataclasses.dataclass
 class _DeepTaintCommand:
-    pre: bool
-    source_key: str
-    obj: Any
-    store_struct: Union[list, dict]
-    key: Optional[List[str]] = None
-    struct: Optional[Union[list, dict]] = None
-    is_key: bool = False
+    def __init__(
+        self,
+        pre: bool,
+        source_key: str,
+        obj: Any,
+        store_struct: Union[list, dict],
+        key: Optional[List[str]] = None,
+        struct: Optional[Union[list, dict]] = None,
+        is_key: bool = False,
+    ):
+        self.pre = pre
+        self.source_key = source_key
+        self.obj = obj
+        self.store_struct = store_struct
+        self.key = key
+        self.struct = struct
+        self.is_key = is_key
 
     def store(self, value):
         if isinstance(self.store_struct, list):

--- a/releasenotes/notes/less_imports_for_iast_tainting-d38a2ad26ad98f40.yaml
+++ b/releasenotes/notes/less_imports_for_iast_tainting-d38a2ad26ad98f40.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ASM: This fix resolves an issue where IAST could cause circular dependency at startup.


### PR DESCRIPTION
backport of https://github.com/DataDog/dd-trace-py/pull/7923 to 2.4

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
