### PR TITLE
fix(encoding): resolves v04 span links encoding bug

### DIFF
--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -6,7 +6,6 @@ from libc.string cimport strlen
 from json import dumps as json_dumps
 import threading
 from json import dumps as json_dumps
-from numbers import Number
 
 from ._utils cimport PyBytesLike_Check
 
@@ -585,7 +584,7 @@ cdef class MsgpackEncoderV03(MsgpackEncoderBase):
                 if ret != 0:
                     return ret
                 # pack the value of a span link field (values can be number, string or dict)
-                if isinstance(v, Number):
+                if isinstance(v, (int, float)):
                     ret = pack_number(&self.pk, v)
                 elif isinstance(v, str):
                     ret = pack_text(&self.pk, v)

--- a/releasenotes/notes/fix-span-link-trace-id-encoding-errror-abe142ac4a6c5fc3.yaml
+++ b/releasenotes/notes/fix-span-link-trace-id-encoding-errror-abe142ac4a6c5fc3.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    tracing: Resolves span encoding errors raised when span links do not contain expected types


### PR DESCRIPTION
Attempts to resolve https://github.com/DataDog/dd-trace-py/issues/7701 by replacing `numbers.Number` with `ddtrace.internal.compat.NumericType`. Hopefully this resolves this weird cython typing issue. 

Testing strategy: I could not reproduce this bug in a unit test. I plan to test this fix on impacted internal services.

Note: This bug only impacts the `v0.4` span encoder. `DD_TRACE_API_VERSION` must be set to `v0.4` to reproduce this bug (`DD_TRACE_API_VERSION` was upgraded from `v0.4` to `v0.5` in `ddtrace>2.3`)  

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
