### PR TITLE
chore(wrapt): remove all references to pkg_resources

### DIFF
--- a/ddtrace/vendor/__init__.py
+++ b/ddtrace/vendor/__init__.py
@@ -18,6 +18,7 @@ License: BSD 2-Clause "Simplified" License
 
 Notes:
   `setup.py` will attempt to build the `wrapt/_wrappers.c` C module
+  replaced pkg_resources.iter_entry_points with importlib_metadata.entry_points
 
 
 dogstatsd

--- a/ddtrace/vendor/wrapt/importer.py
+++ b/ddtrace/vendor/wrapt/importer.py
@@ -110,12 +110,13 @@ def _create_import_hook_from_entrypoint(entrypoint):
     return import_hook
 
 def discover_post_import_hooks(group):
+    # ddtrace: Replace deprecated pkg_resources with importlib
     try:
-        import pkg_resources
+        from importlib.metadata import entry_points
     except ImportError:
-        return
+        from importlib_metadata import entry_points
 
-    for entrypoint in pkg_resources.iter_entry_points(group=group):
+    for entrypoint in entry_points(group=group):
         callback = _create_import_hook_from_entrypoint(entrypoint)
         register_post_import_hook(callback, entrypoint.name)
 


### PR DESCRIPTION
Resolves: https://github.com/DataDog/dd-trace-py/issues/7918

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
