### PR TITLE
feat(ci_visibilty): introduce CI Visibility-specific log handler controlled by env var

### DIFF
--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -390,8 +390,8 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     unpatch_unittest()
     config.addinivalue_line("markers", "dd_tags(**kwargs): add tags to current span")
-    take_over_logger_stream_handler()
     if is_enabled(config):
+        take_over_logger_stream_handler()
         _CIVisibility.enable(config=ddtrace.config.pytest)
     if _is_pytest_cov_enabled(config):
         patch_coverage()

--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -58,6 +58,7 @@ from ddtrace.internal.ci_visibility.utils import _add_start_end_source_file_path
 from ddtrace.internal.ci_visibility.utils import _generate_fully_qualified_module_name
 from ddtrace.internal.ci_visibility.utils import _generate_fully_qualified_test_name
 from ddtrace.internal.ci_visibility.utils import get_relative_or_absolute_path_for_path
+from ddtrace.internal.ci_visibility.utils import take_over_logger_stream_handler
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
 
@@ -389,6 +390,7 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     unpatch_unittest()
     config.addinivalue_line("markers", "dd_tags(**kwargs): add tags to current span")
+    take_over_logger_stream_handler()
     if is_enabled(config):
         _CIVisibility.enable(config=ddtrace.config.pytest)
     if _is_pytest_cov_enabled(config):

--- a/ddtrace/internal/ci_visibility/constants.py
+++ b/ddtrace/internal/ci_visibility/constants.py
@@ -59,3 +59,5 @@ class REQUESTS_MODE(IntEnum):
 
 # Miscellaneous constants
 CUSTOM_CONFIGURATIONS_PREFIX = "test.configuration"
+
+CIVISIBILITY_LOG_FILTER_RE = r"^ddtrace\.(internal\.ci_visibility|ext\.git)"

--- a/ddtrace/internal/ci_visibility/utils.py
+++ b/ddtrace/internal/ci_visibility/utils.py
@@ -1,10 +1,14 @@
 import inspect
+import logging
 import os
+import re
 import typing
 
 import ddtrace
+from ddtrace import config as ddconfig
 from ddtrace.contrib.coverage.constants import PCT_COVERED_KEY
 from ddtrace.ext import test
+from ddtrace.internal.ci_visibility.constants import CIVISIBILITY_LOG_FILTER_RE
 from ddtrace.internal.logger import get_logger
 
 
@@ -87,3 +91,51 @@ def _generate_fully_qualified_test_name(test_module_path: str, test_suite_name: 
 
 def _generate_fully_qualified_module_name(test_module_path: str, test_suite_name: str) -> str:
     return "{}.{}".format(test_module_path, test_suite_name)
+
+
+def take_over_logger_stream_handler(remove_ddtrace_stream_handlers=True):
+    """Creates a handler with a filter for CIVisibility-specific messages. The also removes the existing
+    handlers on the DDTrace logger, to prevent double-logging.
+
+    This is useful for testrunners (currently pytest) that have their own logger.
+
+    NOTE: This should **only** be called from testrunner-level integrations (eg: pytest, unittest).
+    """
+    if ddconfig._debug_mode:
+        log.debug("CIVisibility not taking over ddtrace logger handler because debug mode is enabled")
+        return
+
+    level = ddconfig.ci_visibility_log_level
+
+    if level.upper() == "NONE":
+        log.debug("CIVisibility not taking over ddtrace logger because level is set to: %s", level)
+        return
+
+    root_logger = logging.getLogger()
+
+    if remove_ddtrace_stream_handlers:
+        log.debug("CIVisibility removing DDTrace logger handler")
+        ddtrace_logger = logging.getLogger("ddtrace")
+        for handler in ddtrace_logger.handlers:
+            ddtrace_logger.removeHandler(handler)
+    else:
+        log.warning("Keeping DDTrace logger handler, double logging is likely")
+
+    logger_name_re = re.compile(CIVISIBILITY_LOG_FILTER_RE)
+
+    ci_visibility_handler = logging.StreamHandler()
+    ci_visibility_handler.addFilter(lambda record: bool(logger_name_re.match(record.name)))
+    ci_visibility_handler.setFormatter(
+        logging.Formatter("[Datadog CI Visibility] %(levelname)-8s %(name)s:%(filename)s:%(lineno)d %(message)s")
+    )
+
+    try:
+        ci_visibility_handler.setLevel(level.upper())
+    except ValueError:
+        log.warning("Invalid log level: %s", level)
+        return
+
+    root_logger.addHandler(ci_visibility_handler)
+    root_logger.setLevel(min(root_logger.level, ci_visibility_handler.level))
+
+    log.info("logger setup complete")

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -501,6 +501,7 @@ class Config(object):
         self._ci_visibility_intelligent_testrunner_enabled = asbool(
             os.getenv("DD_CIVISIBILITY_ITR_ENABLED", default=False)
         )
+        self.ci_visibility_log_level = os.getenv("DD_CIVISIBILITY_LOG_LEVEL", default="info")
         self._otel_enabled = asbool(os.getenv("DD_TRACE_OTEL_ENABLED", False))
         if self._otel_enabled:
             # Replaces the default otel api runtime context with DDRuntimeContext

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -553,8 +553,7 @@ The following environment variables for the tracer are supported:
          only displays messages related to the ``CIVisibility`` service, at a level of or higher than the given log
          level. The Datadog logger's file handler is unaffected. Valid, case-insensitive, values are ``critical``,
          ``error``, ``warning``, ``info``, or ``debug``. A value of ``none`` silently disables the logger. Note:
-         setting the ``DD_TRACE_DEBUG`` environment variable to a truthy value overrides this behavior and leaves the
-         debug-level logging enabled.
+         enabling debug logging with the ``DD_TRACE_DEBUG`` environment variable overrides this behavior.
       version_added:
          v2.5.0:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -539,12 +539,24 @@ The following environment variables for the tracer are supported:
 
    DD_CIVISIBILITY_ITR_ENABLED:
      type: Boolean
-     default: False
+     default: True
      description: |
-        Configures the ``CIVisibility`` service to generate and upload git packfiles in support
-        of the Datadog Intelligent Test Runner. This configuration has no effect if ``DD_CIVISIBILITY_AGENTLESS_ENABLED`` is false.
+        Configures the ``CIVisibility`` service query the Datadog API to enable the Datadog Intelligent Test Runner.
      version_added:
         v1.13.0:
+
+   DD_CIVISIBILITY_LOG_LEVEL:
+      type: String
+      default: "info"
+      description: |
+         Configures the ``CIVisibility`` service to replace the default Datadog logger's stream handler with one that
+         only displays messages related to the ``CIVisibility`` service, at a level of or higher than the given log
+         level. The Datadog logger's file handler is unaffected. Valid, case-insensitive, values are ``critical``,
+         ``error``, ``warning``, ``info``, or ``debug``. A value of ``none`` silently disables the logger. Note:
+         setting the ``DD_TRACE_DEBUG`` environment variable to a truthy value overrides this behavior and leaves the
+         debug-level logging enabled.
+      version_added:
+         v2.5.0:
 
    DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING:
       type: String

--- a/releasenotes/notes/ci_visibility-feat-civisbility_specifci_logger-c3205b659f4ae6fd.yaml
+++ b/releasenotes/notes/ci_visibility-feat-civisbility_specifci_logger-c3205b659f4ae6fd.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    CI Visibility: introduces a CI visibility-specific logger (enabled for the ``pytest`` plugin), enabled by setting
+    the ``DD_CIVISIBILITY_LOG_LEVEL`` environment variable (with the same level names as Python logging levels).

--- a/riotfile.py
+++ b/riotfile.py
@@ -245,6 +245,9 @@ venv = Venv(
                 "fastapi": latest,
                 "httpx": latest,
             },
+            env={
+                "DD_CIVISIBILITY_LOG_LEVEL": "none",
+            },
             venvs=[
                 Venv(pys=select_pys()),
                 # This test variant ensures tracer tests are compatible with both 64bit and 128bit trace ids.


### PR DESCRIPTION
This introduces the `DD_CIVISIBILITY_LOG_LEVEL` env var, which adds a log handler to the root logger that filters messages specifically from the CI Visibility-related paths (`ddtrace.internal.ci_visibility` and `ddtrace.ext.git`). The use of `DD_TRACE_DEBUG` preempts this behavior and maintains the original debug behavior. 

This is to support better logging for products like the `pytest` plugin, where logging to `pytest`'s plugin is both intrusive, and results in double-logging due to the stream handler on the `DDTrace` logger.

The handler is added to the root logger, instead of the `DDTrace` logger, in order to preserve the latter's log levels (specifically for the `FileHandler`).

This PR enables the behavior by default for `pytest`, and is considered a feature (the extra logging is not considered a breaking change).

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
