### PR TITLE
feat: lazy load instrumentation telemetry everywhere

### DIFF
--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -11,9 +11,6 @@ from .settings import _config as config
 from .settings.asm import config as asm_config
 
 
-if config._telemetry_enabled:
-    from .internal import telemetry
-
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any  # noqa:F401
     from typing import Callable  # noqa:F401
@@ -165,6 +162,9 @@ def _on_import_factory(module, prefix="ddtrace.contrib", raise_errors=True, patc
         try:
             imported_module = importlib.import_module(path)
         except Exception as e:
+            if config._telemetry_enabled:
+                from .internal import telemetry
+
             if raise_errors:
                 raise
             error_msg = "failed to import ddtrace module %r when patching on import" % (path,)

--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -157,14 +157,13 @@ def _on_import_factory(module, prefix="ddtrace.contrib", raise_errors=True, patc
     """Factory to create an import hook for the provided module name"""
 
     def on_import(hook):
+        if config._telemetry_enabled:
+            from .internal import telemetry
         # Import and patch module
         path = "%s.%s" % (prefix, module)
         try:
             imported_module = importlib.import_module(path)
         except Exception as e:
-            if config._telemetry_enabled:
-                from .internal import telemetry
-
             if raise_errors:
                 raise
             error_msg = "failed to import ddtrace module %r when patching on import" % (path,)

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -660,10 +660,10 @@ class Config(object):
         for key, value, origin in items:
             item_names.append(key)
             self._config[key].set_value_source(value, origin)
+        if self._telemetry_enabled:
+            from ..internal.telemetry import telemetry_writer
 
-        from ..internal.telemetry import telemetry_writer
-
-        telemetry_writer.add_configs_changed(item_names)
+            telemetry_writer.add_configs_changed(item_names)
         self._notify_subscribers(item_names)
 
     def _reset(self):

--- a/releasenotes/notes/lazy-load-instrumentation-telemetry-again-f1ae23c302e234c4.yaml
+++ b/releasenotes/notes/lazy-load-instrumentation-telemetry-again-f1ae23c302e234c4.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Further lazy loads telemetry_writer so that it is not running when explicitly disabled. Users must explicitly set "DD_INSTRUMENTATION_TELEMETRY_ENABLED=false".


### PR DESCRIPTION
## Description
In a previous PR, we lazily-loaded `telemetry_writer` during init, unless it was disabled. This is important because it has a very high cold start cost, as detailed in [the pr](https://github.com/DataDog/dd-trace-py/pull/7683).

Unfortunately another [PR](https://github.com/DataDog/dd-trace-py/commit/c328aea335b8a0f319d96220c592ac442c66bb79#diff-b79457a3006017376c6ffaaeb34f3ffafa4f7f12e8f28dc96307faa196fd3e58R659) which landed in the same release also imported this upon init, so the effect of #7683 was basically moot.

I then discovered another path where we import the telemetry writer without checking if it is enabled.

This PR fixes this, and thus we see no telemetry writer loaded in the cold start trace:
<img width="2207" alt="image" src="https://github.com/DataDog/dd-trace-py/assets/1598537/a90913bc-d6ef-4e99-a5f6-f3a8da4de53d">
https://ddserverless.datadoghq.com/apm/trace/14863221237695016030?colorBy=service&env=dev&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=11572349096161165479&spanViewType=metadata&timeHint=1703088776346&view=spans

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
