### PR TITLE
feat(ci_visibility): Intelligent Test Runner GA - change env var to default to True

### DIFF
--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -266,8 +266,8 @@ class CIVisibility(Service):
 
     def _check_enabled_features(self):
         # type: () -> Tuple[bool, bool]
-        # DEV: Remove this ``if`` once ITR is in GA
         if not ddconfig._ci_visibility_intelligent_testrunner_enabled:
+            log.warning("Datadog Intelligent Test Runner disabled by environment, disabling coverage and test skipping")
             return False, False
 
         if self._requests_mode == REQUESTS_MODE.EVP_PROXY_EVENTS:

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -499,7 +499,7 @@ class Config(object):
         self._ci_visibility_agentless_enabled = asbool(os.getenv("DD_CIVISIBILITY_AGENTLESS_ENABLED", default=False))
         self._ci_visibility_agentless_url = os.getenv("DD_CIVISIBILITY_AGENTLESS_URL", default="")
         self._ci_visibility_intelligent_testrunner_enabled = asbool(
-            os.getenv("DD_CIVISIBILITY_ITR_ENABLED", default=False)
+            os.getenv("DD_CIVISIBILITY_ITR_ENABLED", default=True)
         )
         self._otel_enabled = asbool(os.getenv("DD_TRACE_OTEL_ENABLED", False))
         if self._otel_enabled:

--- a/releasenotes/notes/ci_visibility-feat-intelligent_test_runner_ga-29333edb3933a74b.yaml
+++ b/releasenotes/notes/ci_visibility-feat-intelligent_test_runner_ga-29333edb3933a74b.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    CI Visibility: Intelligent Test Runner is now GA, and can be disabled via DD_CIVISIBILITY_ITR_ENABLED. The Datadog
+    API (configured via the Datadog dashboard) now determines whether code coverage and test skipping are enabled.

--- a/tests/ci_visibility/test_ci_visibility.py
+++ b/tests/ci_visibility/test_ci_visibility.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import contextlib
 from ctypes import c_int
 import json
 import multiprocessing
@@ -36,6 +37,23 @@ TEST_SHA_1 = "b3672ea5cbc584124728c48a443825d2940e0ddd"
 TEST_SHA_2 = "b3672ea5cbc584124728c48a443825d2940e0eee"
 
 
+# @pytest.fixture(scope="function")
+@contextlib.contextmanager
+def _dummy_noop_git_client():
+    with mock.patch.multiple(
+        CIVisibilityGitClient,
+        _get_repository_url=mock.Mock(return_value="https://testrepo.url:1245/reporepo.git"),
+        _is_shallow_repository=mock.Mock(return_value=True),
+        _get_latest_commits=mock.Mock(return_value=["latest1", "latest2"]),
+        _search_commits=mock.Mock(return_value=["latest1", "searched1", "searched2"]),
+        _get_filtered_revisions=mock.Mock(return_value=""),
+        upload_git_metadata=mock.Mock(return_value=None),
+        metadata_upload_finished=mock.Mock(return_value=True),
+        wait_for_metadata_upload_status=mock.Mock(return_value=METADATA_UPLOAD_STATUS.SUCCESS),
+    ):
+        yield
+
+
 def test_filters_test_spans():
     trace_filter = TraceCiVisibilityFilter(tags={"hello": "world"}, service="test-service")
     root_test_span = Span(name="span1", span_type="test")
@@ -65,7 +83,7 @@ def test_ci_visibility_service_enable():
             DD_API_KEY="foobar.baz",
             DD_CIVISIBILITY_AGENTLESS_ENABLED="1",
         )
-    ):
+    ), _dummy_noop_git_client():
         with _patch_dummy_writer():
             dummy_tracer = DummyTracer()
             CIVisibility.enable(tracer=dummy_tracer, service="test-service")
@@ -87,8 +105,9 @@ def test_ci_visibility_service_enable_with_app_key_and_itr_disabled(_do_request)
             DD_API_KEY="foobar.baz",
             DD_APP_KEY="foobar",
             DD_CIVISIBILITY_AGENTLESS_ENABLED="1",
+            DD_CIVISIBILITY_ITR_ENABLED="0",
         )
-    ):
+    ), _dummy_noop_git_client():
         ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()
         with _patch_dummy_writer():
             _do_request.return_value = Response(
@@ -110,9 +129,8 @@ def test_ci_visibility_service_settings_timeout(_do_request):
             DD_API_KEY="foobar.baz",
             DD_APP_KEY="foobar",
             DD_CIVISIBILITY_AGENTLESS_ENABLED="1",
-            DD_CIVISIBILITY_ITR_ENABLED="1",
         )
-    ):
+    ), _dummy_noop_git_client():
         ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()
         CIVisibility.enable(service="test-service")
         assert CIVisibility._instance._code_coverage_enabled_by_api is False
@@ -128,9 +146,8 @@ def test_ci_visibility_service_skippable_timeout(_do_request, _check_enabled_fea
             DD_API_KEY="foobar.baz",
             DD_APP_KEY="foobar",
             DD_CIVISIBILITY_AGENTLESS_ENABLED="1",
-            DD_CIVISIBILITY_ITR_ENABLED="1",
         )
-    ):
+    ), _dummy_noop_git_client():
         ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()
         CIVisibility.enable(service="test-service")
         assert CIVisibility._instance._test_suites_to_skip == []
@@ -139,13 +156,16 @@ def test_ci_visibility_service_skippable_timeout(_do_request, _check_enabled_fea
 
 @mock.patch("ddtrace.internal.ci_visibility.recorder._do_request")
 def test_ci_visibility_service_enable_with_itr_enabled(_do_request):
-    with override_env(
-        dict(
-            DD_API_KEY="foobar.baz",
-            DD_CIVISIBILITY_AGENTLESS_ENABLED="1",
-            DD_CIVISIBILITY_ITR_ENABLED="1",
-        )
-    ), mock.patch("ddtrace.internal.ci_visibility.recorder.CIVisibility._fetch_tests_to_skip"):
+    with (
+        override_env(
+            dict(
+                DD_API_KEY="foobar.baz",
+                DD_CIVISIBILITY_AGENTLESS_ENABLED="1",
+            )
+        ),
+        mock.patch("ddtrace.internal.ci_visibility.recorder.CIVisibility._fetch_tests_to_skip"),
+        _dummy_noop_git_client(),
+    ):
         ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()
         _do_request.return_value = Response(
             status=200,
@@ -159,6 +179,25 @@ def test_ci_visibility_service_enable_with_itr_enabled(_do_request):
 
 
 @mock.patch("ddtrace.internal.ci_visibility.recorder._do_request")
+@pytest.mark.parametrize("agentless_enabled", [False, True])
+def test_ci_visibility_service_enable_with_itr_disabled_in_env(_do_request, agentless_enabled):
+    agentless_enabled_str = "1" if agentless_enabled else "0"
+    with override_env(
+        dict(
+            DD_API_KEY="foobar.baz",
+            DD_CIVISIBILITY_AGENTLESS_ENABLED=agentless_enabled_str,
+            DD_CIVISIBILITY_ITR_ENABLED="0",
+        )
+    ), _dummy_noop_git_client():
+        ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()
+        CIVisibility.enable(service="test-service")
+        assert CIVisibility._instance._code_coverage_enabled_by_api is False
+        assert CIVisibility._instance._test_skipping_enabled_by_api is False
+        _do_request.assert_not_called()
+        CIVisibility.disable()
+
+
+@mock.patch("ddtrace.internal.ci_visibility.recorder._do_request")
 def test_ci_visibility_service_enable_with_app_key_and_error_response(_do_request):
     with override_env(
         dict(
@@ -166,7 +205,7 @@ def test_ci_visibility_service_enable_with_app_key_and_error_response(_do_reques
             DD_APP_KEY="foobar",
             DD_CIVISIBILITY_AGENTLESS_ENABLED="1",
         )
-    ):
+    ), _dummy_noop_git_client():
         _do_request.return_value = Response(
             status=404,
             body='{"errors": ["Not found"]}',
@@ -178,7 +217,7 @@ def test_ci_visibility_service_enable_with_app_key_and_error_response(_do_reques
 
 
 def test_ci_visibility_service_disable():
-    with override_env(dict(DD_API_KEY="foobar.baz")):
+    with override_env(dict(DD_API_KEY="foobar.baz")), _dummy_noop_git_client():
         with _patch_dummy_writer():
             dummy_tracer = DummyTracer()
             CIVisibility.enable(tracer=dummy_tracer, service="test-service")
@@ -218,82 +257,6 @@ def test_repository_name_not_extracted_warning():
 
 
 DUMMY_RESPONSE = Response(status=200, body='{"data": [{"type": "commit", "id": "%s", "attributes": {}}]}' % TEST_SHA_1)
-
-
-@mock.patch("ddtrace.internal.ci_visibility.recorder._do_request")
-def test_git_client_worker_agentless(_do_request, git_repo):
-    _do_request.return_value = Response(
-        status=200,
-        body='{"data":{"id":"1234","type":"ci_app_tracers_test_service_settings","attributes":'
-        '{"code_coverage":true,"tests_skipping":true}}}',
-    )
-    with override_env(
-        dict(
-            DD_API_KEY="foobar.baz",
-            DD_APPLICATION_KEY="banana",
-            DD_CIVISIBILITY_ITR_ENABLED="1",
-            DD_CIVISIBILITY_AGENTLESS_ENABLED="1",
-            DD_SITE="datadoghq.com",
-        )
-    ):
-        ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()
-        with _patch_dummy_writer():
-            dummy_tracer = DummyTracer()
-            start_time = time.time()
-            with mock.patch("ddtrace.internal.ci_visibility.recorder.CIVisibility._fetch_tests_to_skip"), mock.patch(
-                "ddtrace.internal.ci_visibility.recorder._get_git_repo"
-            ) as ggr:
-                original = ddtrace.internal.ci_visibility.git_client.RESPONSE
-                ddtrace.internal.ci_visibility.git_client.RESPONSE = DUMMY_RESPONSE
-                ggr.return_value = git_repo
-                CIVisibility.enable(tracer=dummy_tracer, service="test-service")
-                assert CIVisibility._instance._git_client is not None
-                assert CIVisibility._instance._git_client._worker is not None
-                assert CIVisibility._instance._git_client._base_url == "https://api.datadoghq.com/api/v2/git"
-                CIVisibility.disable()
-    shutdown_timeout = dummy_tracer.SHUTDOWN_TIMEOUT
-    assert (
-        time.time() - start_time <= shutdown_timeout + 0.1
-    ), "CIVisibility.disable() should not block for longer than tracer timeout"
-    ddtrace.internal.ci_visibility.git_client.RESPONSE = original
-
-
-@mock.patch("ddtrace.internal.ci_visibility.recorder._do_request")
-def test_git_client_worker_evp_proxy(_do_request, git_repo):
-    _do_request.return_value = Response(
-        status=200,
-        body='{"data":{"id":"1234","type":"ci_app_tracers_test_service_settings","attributes":'
-        '{"code_coverage":true,"tests_skipping":true}}}',
-    )
-    with override_env(
-        dict(
-            DD_API_KEY="foobar.baz",
-            DD_APPLICATION_KEY="banana",
-            DD_CIVISIBILITY_ITR_ENABLED="1",
-        )
-    ), mock.patch(
-        "ddtrace.internal.ci_visibility.recorder.CIVisibility._agent_evp_proxy_is_available", return_value=True
-    ):
-        ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()
-        with _patch_dummy_writer():
-            dummy_tracer = DummyTracer()
-            start_time = time.time()
-            with mock.patch("ddtrace.internal.ci_visibility.recorder.CIVisibility._fetch_tests_to_skip"), mock.patch(
-                "ddtrace.internal.ci_visibility.recorder._get_git_repo"
-            ) as ggr:
-                original = ddtrace.internal.ci_visibility.git_client.RESPONSE
-                ddtrace.internal.ci_visibility.git_client.RESPONSE = DUMMY_RESPONSE
-                ggr.return_value = git_repo
-                CIVisibility.enable(tracer=dummy_tracer, service="test-service")
-                assert CIVisibility._instance._git_client is not None
-                assert CIVisibility._instance._git_client._worker is not None
-                assert CIVisibility._instance._git_client._base_url == "http://localhost:8126/evp_proxy/v2/api/v2/git"
-                CIVisibility.disable()
-    shutdown_timeout = dummy_tracer.SHUTDOWN_TIMEOUT
-    assert (
-        time.time() - start_time <= shutdown_timeout + 0.1
-    ), "CIVisibility.disable() should not block for longer than tracer timeout"
-    ddtrace.internal.ci_visibility.git_client.RESPONSE = original
 
 
 def test_git_client_get_repository_url(git_repo):
@@ -534,7 +497,7 @@ def test_civisibilitywriter_agentless_url_envvar():
             DD_CIVISIBILITY_AGENTLESS_URL="https://foo.bar",
             DD_CIVISIBILITY_AGENTLESS_ENABLED="1",
         )
-    ):
+    ), _dummy_noop_git_client():
         ddtrace.internal.ci_visibility.writer.config = ddtrace.settings.Config()
         ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()
         CIVisibility.enable()
@@ -550,7 +513,7 @@ def test_civisibilitywriter_evp_proxy_url():
         )
     ), mock.patch(
         "ddtrace.internal.ci_visibility.recorder.CIVisibility._agent_evp_proxy_is_available", return_value=True
-    ):
+    ), _dummy_noop_git_client():
         ddtrace.internal.ci_visibility.writer.config = ddtrace.settings.Config()
         ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()
         CIVisibility.enable()
@@ -650,7 +613,7 @@ class TestCheckEnabledFeatures:
                 "runtime.name": "RPython",
                 "runtime.version": "11.5.2",
             }
-            mock_civisibility._git_client = mock.MagicMock(spec=CIVisibilityGitClient)
+            mock_civisibility._git_client = mock.Mock(spec=CIVisibilityGitClient)
 
         return mock_civisibility
 
@@ -782,10 +745,10 @@ class TestCheckEnabledFeatures:
     @pytest.mark.parametrize(
         "second_do_request_side_effect",
         [
-            [TimeoutError],
-            [Response(status=200, body="} this is bad JSON")],
-            [Response(status=200, body='{"not correct key": "not correct value"}')],
-            [Response(status=600, body="Only status code matters here")],
+            TimeoutError,
+            Response(status=200, body="} this is bad JSON"),
+            Response(status=200, body='{"not correct key": "not correct value"}'),
+            Response(status=600, body="Only status code matters here"),
         ],
     )
     def test_civisibility_check_enabled_features_any_api_error_disables_itr(
@@ -814,27 +777,6 @@ class TestCheckEnabledFeatures:
 
             assert mock_do_request.call_count == expected_call_count
             assert enabled_features == (False, False)
-
-
-@mock.patch("ddtrace.internal.ci_visibility.recorder._do_request")
-def test_civisibility_check_enabled_features_itr_disabled_request_not_called(_do_request):
-    with override_env(
-        dict(
-            DD_API_KEY="foo.bar",
-            DD_APP_KEY="foobar.baz",
-            DD_CIVISIBILITY_AGENTLESS_URL="https://foo.bar",
-            DD_CIVISIBILITY_AGENTLESS_ENABLED="1",
-        )
-    ):
-        ddtrace.internal.ci_visibility.writer.config = ddtrace.settings.Config()
-        ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()
-        CIVisibility.enable()
-
-        _do_request.assert_not_called()
-        assert CIVisibility._instance._code_coverage_enabled_by_api is False
-        assert CIVisibility._instance._test_skipping_enabled_by_api is False
-
-        CIVisibility.disable()
 
 
 def test_run_protocol_unshallow_git_ge_227():
@@ -962,7 +904,7 @@ class TestUploadGitMetadata:
     def test_upload_git_metadata_upload_value_error_fails(self, api_key, requests_mode):
         with mock.patch.object(CIVisibilityGitClient, "_upload_packfiles", return_value=True):
             git_client = CIVisibilityGitClient(api_key, requests_mode)
-            git_client._worker = mock.MagicMock(spec=multiprocessing.Process)
+            git_client._worker = mock.Mock(spec=multiprocessing.Process)
             git_client._worker.exitcode = 0
             git_client.upload_git_metadata()
             with pytest.raises(ValueError):
@@ -972,7 +914,7 @@ class TestUploadGitMetadata:
     def test_upload_git_metadata_upload_timeout_raises_timeout(self, api_key, requests_mode):
         with mock.patch.object(CIVisibilityGitClient, "upload_git_metadata", lambda *args, **kwargs: time.sleep(3)):
             git_client = CIVisibilityGitClient(api_key, requests_mode)
-            git_client._worker = mock.MagicMock(spec=multiprocessing.Process)
+            git_client._worker = mock.Mock(spec=multiprocessing.Process)
             git_client._worker.exitcode = None
             git_client.upload_git_metadata()
             with pytest.raises(TimeoutError):
@@ -1137,7 +1079,7 @@ class TestFetchTestsToSkip:
                 "runtime.name": "RPython",
                 "runtime.version": "11.5.2",
             }
-            _civisibility._git_client = mock.MagicMock(spec=CIVisibilityGitClient)
+            _civisibility._git_client = mock.Mock(spec=CIVisibilityGitClient)
             _civisibility._git_client.wait_for_metadata_upload_status.return_value = METADATA_UPLOAD_STATUS.SUCCESS
 
             yield _civisibility
@@ -1380,7 +1322,6 @@ def test_fetch_tests_to_skip_custom_configurations():
         dict(
             DD_API_KEY="foobar.baz",
             DD_CIVISIBILITY_AGENTLESS_ENABLED="1",
-            DD_CIVISIBILITY_ITR_ENABLED="1",
             DD_TAGS="test.configuration.disk:slow,test.configuration.memory:low",
             DD_SERVICE="test-service",
             DD_ENV="test-env",
@@ -1410,7 +1351,7 @@ def test_fetch_tests_to_skip_custom_configurations():
             "git.repository_url": "git@github.com:TestDog/dd-test-py.git",
             "git.commit.sha": "mytestcommitsha1234",
         },
-    ), mock.patch(
+    ), _dummy_noop_git_client(), mock.patch(
         "ddtrace.internal.ci_visibility.recorder._do_request",
         return_value=Response(
             status=200,


### PR DESCRIPTION
The DD_CIVISIBILITY_ITR_ENABLED env var now defaults to "true", which means the Intelligent Test Runner is enabled by the setting API endpoint, unless the env var is set to a falsy value.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
