### PR TITLE
feat(aiohttp): add split_by_domain option

### DIFF
--- a/ddtrace/contrib/aiohttp/__init__.py
+++ b/ddtrace/contrib/aiohttp/__init__.py
@@ -30,6 +30,12 @@ Global Configuration
 
    Default: ``True``
 
+.. py:data:: ddtrace.config.aiohttp_client['split_by_domain']
+
+   Whether or not to use the domain name of requests as the service name.
+
+   Default: ``False``
+
 
 Server
 ******

--- a/ddtrace/contrib/aiohttp/patch.py
+++ b/ddtrace/contrib/aiohttp/patch.py
@@ -40,6 +40,7 @@ config._add(
     dict(
         distributed_tracing=asbool(os.getenv("DD_AIOHTTP_CLIENT_DISTRIBUTED_TRACING", True)),
         default_http_tag_query_string=os.getenv("DD_HTTP_CLIENT_TAG_QUERY_STRING", "true"),
+        split_by_domain=asbool(os.getenv("DD_AIOHTTP_CLIENT_SPLIT_BY_DOMAIN", default=False)),
     ),
 )
 
@@ -83,6 +84,9 @@ async def _traced_clientsession_request(aiohttp, pin, func, instance, args, kwar
         span_type=SpanTypes.HTTP,
         service=ext_service(pin, config.aiohttp_client),
     ) as span:
+        if config.aiohttp_client.split_by_domain:
+            span.service = url.host
+
         if pin._config["distributed_tracing"]:
             HTTPPropagator.inject(span.context, headers)
             kwargs["headers"] = headers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,6 +184,7 @@ services:
 
     httpbin_local:
       image: kennethreitz/httpbin@sha256:2c7abc4803080c22928265744410173b6fea3b898872c01c5fd0f0f9df4a59fb
+      platform: linux/amd64
       ports:
         - "127.0.0.1:8001:80"
 

--- a/releasenotes/notes/add-aiohttp-split-by-domain-f8f3242025c96cc1.yaml
+++ b/releasenotes/notes/add-aiohttp-split-by-domain-f8f3242025c96cc1.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    aiohttp: add `split_by_domain` config to split service name by domain

--- a/tests/contrib/aiohttp/test_aiohttp_client.py
+++ b/tests/contrib/aiohttp/test_aiohttp_client.py
@@ -7,6 +7,7 @@ from ddtrace import Pin
 from ddtrace.contrib.aiohttp import patch
 from ddtrace.contrib.aiohttp import unpatch
 from ddtrace.contrib.aiohttp.patch import extract_netloc_and_query_info_from_url
+from tests.utils import override_config
 from tests.utils import override_http_config
 
 from ..config import HTTPBIN_CONFIG
@@ -197,6 +198,19 @@ asyncio.run(test())
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=os.environ.copy())
     assert status == 0, err
     assert err == b""
+
+
+@pytest.mark.asyncio
+async def test_configure_service_name_split_by_domain(snapshot_context):
+    """
+    When split_by_domain is configured
+        We set the service name to the url host
+    """
+    with override_config("aiohttp_client", {"split_by_domain": True}):
+        with snapshot_context():
+            async with aiohttp.ClientSession() as session:
+                async with session.get(URL_200) as resp:
+                    assert resp.status == 200
 
 
 @pytest.mark.asyncio

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_service_name_split_by_domain.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_service_name_split_by_domain.json
@@ -1,0 +1,50 @@
+[[
+  {
+    "name": "aiohttp.request",
+    "service": "localhost",
+    "resource": "aiohttp.request",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "http",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6583754d00000000",
+      "component": "aiohttp_client",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.status_msg": "OK",
+      "http.url": "http://localhost:8001/status/200",
+      "language": "python",
+      "out.host": "localhost",
+      "runtime-id": "4c401c35daea4876be809e40a325baeb",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 11676
+    },
+    "duration": 14881083,
+    "start": 1703114061731607250
+  },
+     {
+       "name": "TCPConnector.connect",
+       "service": "localhost",
+       "resource": "TCPConnector.connect",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "_dd.base_service": "",
+         "_dd.p.tid": "6583754d00000000",
+         "component": "aiohttp"
+       },
+       "duration": 2263416,
+       "start": 1703114061732442750
+     }]]


### PR DESCRIPTION
Adds `split_by_domain` flag for the aiohttp_client so we can use the domain name of requests as the service name.
This is already an option for a number of the other request clients ([httpx](https://ddtrace.readthedocs.io/en/stable/integrations.html#id81), [requests](https://ddtrace.readthedocs.io/en/stable/integrations.html#id153), [urllib3](https://ddtrace.readthedocs.io/en/stable/integrations.html#urllib3)).

Includes a happy path test.

Risk seems low; we are adding new functionality that is by default disabled

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] (Not Applicable here b/c it's a "feature") Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
