### PR TITLE
feat(llmobs): add tags to llmobs payloads

### DIFF
--- a/ddtrace/contrib/openai/patch.py
+++ b/ddtrace/contrib/openai/patch.py
@@ -4,6 +4,7 @@ import time
 from typing import TYPE_CHECKING  # noqa:F401
 from typing import Any  # noqa:F401
 from typing import Dict  # noqa:F401
+from typing import List  # noqa:F401
 from typing import Optional  # noqa:F401
 
 from openai import version
@@ -230,6 +231,24 @@ class _OpenAIIntegration(BaseLLMIntegration):
             "openai.organization.name:%s" % (span.get_tag("openai.organization.name") or ""),
             "openai.user.api_key:%s" % (span.get_tag("openai.user.api_key") or ""),
             "error:%d" % span.error,
+        ]
+        err_type = span.get_tag("error.type")
+        if err_type:
+            tags.append("error_type:%s" % err_type)
+        return tags
+
+    @classmethod
+    def _llmobs_tags(cls, span: Span) -> List[str]:
+        tags = [
+            "version:%s" % (config.version or ""),
+            "env:%s" % (config.env or ""),
+            "service:%s" % (span.service or ""),
+            "src:integration",
+            "dd.trace_id:%s" % (span.trace_id or ""),
+            "dd.span_id:%s" % (span.span_id or ""),
+            "ml_obs.request.model:%s" % (span.get_tag("openai.request.model") or ""),
+            "ml_obs.request.model_provider:%s" % (span.get_tag("openai.organization.name") or ""),
+            "ml_obs.request.error:%d" % span.error,
         ]
         err_type = span.get_tag("error.type")
         if err_type:

--- a/ddtrace/internal/llmobs/writer.py
+++ b/ddtrace/internal/llmobs/writer.py
@@ -109,7 +109,7 @@ class LLMObsWriter(PeriodicService):
             "data": {
                 "type": "records",
                 "attributes": {
-                    "tags": ["src:integration"],
+                    "tags": record["ddtags"],
                     "model": model,
                     "model_provider": model_provider,
                     "records": llm_records,


### PR DESCRIPTION
WIP: this PR requires the LLMObs intake API to change to move forward.
The ingest API currently only accepts this format:
`` `
data: {..., "attributes": {"tags", \[...\], "model": "...", "model_provider": "...", "records": \[...\]}}
```

The consequence of this format is that `model`, `model_provider`, and `tags` apply over all records in that payload, i.e. all records in a payload must have the same model, provider, and tags.
The current integration already has to do a rough workaround to send model/provider only payloads instead of efficiently sending XYZ number of unrelated records per payload. If we want to move forward with submitting UST tags, model/model_provider, and chain/session/span/trace IDs per record, we need to have the intake API change to allow per-record model/provider/tag fields.
Note: https://github.com/DataDog/dd-source/blob/main/domains/ml-observability/apps/apis/llm-obs/internal/adapters/handlers/v1/http/record.go#L36-L42

## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
