### PR TITLE
chore(iast): fix flaky tests

### DIFF
--- a/scripts/run-test-suite
+++ b/scripts/run-test-suite
@@ -31,18 +31,18 @@ fi
 
 set -e
 
-if ! [[ -v CIRCLECI && $CIRCLE_BRANCH =~ [0-9]\.x ]]; then
-    if [[ -f "$CHECKPOINT_FILENAME" ]]; then
-        latest_success_commit=$(cat $CHECKPOINT_FILENAME)
-        if ! ./scripts/needs_testrun.py $CIRCLE_JOB --sha $latest_success_commit; then
-            echo "The $CIRCLE_JOB job succeeded at commit $latest_success_commit."
-            echo "None of the changes on this branch since that commit affect the $CIRCLE_JOB job."
-            echo "Skipping this job."
-            circleci step halt
-            exit 0
-        fi
-    fi
-fi
+# if ! [[ -v CIRCLECI && $CIRCLE_BRANCH =~ [0-9]\.x ]]; then
+#     if [[ -f "$CHECKPOINT_FILENAME" ]]; then
+#         latest_success_commit=$(cat $CHECKPOINT_FILENAME)
+#         if ! ./scripts/needs_testrun.py $CIRCLE_JOB --sha $latest_success_commit; then
+#             echo "The $CIRCLE_JOB job succeeded at commit $latest_success_commit."
+#             echo "None of the changes on this branch since that commit affect the $CIRCLE_JOB job."
+#             echo "Skipping this job."
+#             circleci step halt
+#             exit 0
+#         fi
+#     fi
+# fi
 
 for hash in ${RIOT_HASHES[@]}; do
     echo "Running riot hash: $hash"

--- a/scripts/run-test-suite
+++ b/scripts/run-test-suite
@@ -31,18 +31,18 @@ fi
 
 set -e
 
-# if ! [[ -v CIRCLECI && $CIRCLE_BRANCH =~ [0-9]\.x ]]; then
-#     if [[ -f "$CHECKPOINT_FILENAME" ]]; then
-#         latest_success_commit=$(cat $CHECKPOINT_FILENAME)
-#         if ! ./scripts/needs_testrun.py $CIRCLE_JOB --sha $latest_success_commit; then
-#             echo "The $CIRCLE_JOB job succeeded at commit $latest_success_commit."
-#             echo "None of the changes on this branch since that commit affect the $CIRCLE_JOB job."
-#             echo "Skipping this job."
-#             circleci step halt
-#             exit 0
-#         fi
-#     fi
-# fi
+if ! [[ -v CIRCLECI && $CIRCLE_BRANCH =~ [0-9]\.x ]]; then
+    if [[ -f "$CHECKPOINT_FILENAME" ]]; then
+        latest_success_commit=$(cat $CHECKPOINT_FILENAME)
+        if ! ./scripts/needs_testrun.py $CIRCLE_JOB --sha $latest_success_commit; then
+            echo "The $CIRCLE_JOB job succeeded at commit $latest_success_commit."
+            echo "None of the changes on this branch since that commit affect the $CIRCLE_JOB job."
+            echo "Skipping this job."
+            circleci step halt
+            exit 0
+        fi
+    fi
+fi
 
 for hash in ${RIOT_HASHES[@]}; do
     echo "Running riot hash: $hash"

--- a/tests/appsec/appsec/test_processor.py
+++ b/tests/appsec/appsec/test_processor.py
@@ -316,7 +316,9 @@ def test_ip_update_rules_expired_no_block(tracer):
 def test_appsec_span_tags_snapshot(tracer):
     with override_global_config(dict(_asm_enabled=True)):
         _enable_appsec(tracer)
-        with _asm_request_context.asm_request_context_manager(), tracer.trace("test", span_type=SpanTypes.WEB) as span:
+        with _asm_request_context.asm_request_context_manager(), tracer.trace(
+            "test", service="test", span_type=SpanTypes.WEB
+        ) as span:
             span.set_tag("http.url", "http://example.com/.git")
             set_http_meta(span, {}, raw_uri="http://example.com/.git", status_code="404")
 
@@ -336,7 +338,7 @@ def test_appsec_span_tags_snapshot_with_errors(tracer):
         with override_env(dict(DD_APPSEC_RULES=os.path.join(ROOT_DIR, "rules-with-2-errors.json"))):
             _enable_appsec(tracer)
             with _asm_request_context.asm_request_context_manager(), tracer.trace(
-                "test", span_type=SpanTypes.WEB
+                "test", service="test", span_type=SpanTypes.WEB
             ) as span:
                 span.set_tag("http.url", "http://example.com/.git")
                 set_http_meta(span, {}, raw_uri="http://example.com/.git", status_code="404")

--- a/tests/appsec/appsec/test_processor.py
+++ b/tests/appsec/appsec/test_processor.py
@@ -314,7 +314,6 @@ def test_ip_update_rules_expired_no_block(tracer):
         "metrics._dd.appsec.waf.duration_ext",
     ],
 )
-@flaky(until=1704067200)
 def test_appsec_span_tags_snapshot(tracer):
     with override_global_config(dict(_asm_enabled=True)):
         _enable_appsec(tracer)
@@ -333,7 +332,6 @@ def test_appsec_span_tags_snapshot(tracer):
         "meta._dd.appsec.event_rules.errors",
     ],
 )
-@flaky(until=1704067200)
 def test_appsec_span_tags_snapshot_with_errors(tracer):
     with override_global_config(dict(_asm_enabled=True)):
         with override_env(dict(DD_APPSEC_RULES=os.path.join(ROOT_DIR, "rules-with-2-errors.json"))):

--- a/tests/appsec/appsec/test_processor.py
+++ b/tests/appsec/appsec/test_processor.py
@@ -16,7 +16,6 @@ from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.trace_utils import set_http_meta
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
-from tests.utils import flaky
 from tests.utils import override_env
 from tests.utils import override_global_config
 from tests.utils import snapshot

--- a/tests/appsec/iast_memcheck/test_iast_mem_check.py
+++ b/tests/appsec/iast_memcheck/test_iast_mem_check.py
@@ -18,6 +18,7 @@ from ddtrace.internal import core
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
 from tests.appsec.iast_memcheck._stacktrace_py import get_info_frame as get_info_frame_py
 from tests.appsec.iast_memcheck.fixtures.stacktrace import func_1
+from tests.utils import flaky
 
 
 FIXTURES_PATH = "tests/appsec/iast/fixtures/propagation_path.py"
@@ -44,6 +45,7 @@ class IASTFilter(LeaksFilterFunction):
         return False
 
 
+@flaky(1735812000)
 @pytest.mark.limit_leaks("8.2 KB", filter_fn=IASTFilter())
 @pytest.mark.parametrize(
     "origin1, origin2",
@@ -102,6 +104,7 @@ def test_propagation_memory_check(origin1, origin2, iast_span_defaults):
         reset_context()
 
 
+@flaky(1735812000)
 @pytest.mark.limit_leaks("460 B", filter_fn=IASTFilter())
 def test_stacktrace_memory_check():
     for _ in range(LOOPS):
@@ -114,6 +117,7 @@ def test_stacktrace_memory_check():
         assert line_number > 0
 
 
+@flaky(1735812000)
 @pytest.mark.limit_leaks("460 B", filter_fn=IASTFilter())
 def test_stacktrace_memory_check_direct_call():
     for _ in range(LOOPS):
@@ -126,6 +130,7 @@ def test_stacktrace_memory_check_direct_call():
         assert line_number > 0
 
 
+@flaky(1735812000)
 @pytest.mark.limit_leaks("460 KB", filter_fn=IASTFilter())
 def test_stacktrace_memory_check_no_native():
     for _ in range(LOOPS):
@@ -138,6 +143,7 @@ def test_stacktrace_memory_check_no_native():
         assert line_number > 0
 
 
+@flaky(1735812000)
 @pytest.mark.limit_leaks("24 KB", filter_fn=IASTFilter())
 def test_stacktrace_memory_check_no_native_direct_call():
     for _ in range(2):
@@ -150,6 +156,7 @@ def test_stacktrace_memory_check_no_native_direct_call():
         assert line_number > 0
 
 
+@flaky(1735812000)
 @pytest.mark.limit_leaks("440 B", filter_fn=IASTFilter())
 def test_stacktrace_memory_empty_byte_check():
     for _ in range(LOOPS):
@@ -162,6 +169,7 @@ def test_stacktrace_memory_empty_byte_check():
         assert line_number > 0
 
 
+@flaky(1735812000)
 @pytest.mark.limit_leaks("440 B", filter_fn=IASTFilter())
 def test_stacktrace_memory_empty_string_check():
     for _ in range(LOOPS):
@@ -174,6 +182,7 @@ def test_stacktrace_memory_empty_string_check():
         assert line_number > 0
 
 
+@flaky(1735812000)
 @pytest.mark.limit_leaks("10 KB", filter_fn=IASTFilter())
 def test_stacktrace_memory_random_string_check():
     """2.1 KB is enough but CI allocates 1.0 MB bytes"""

--- a/tests/appsec/iast_memcheck/test_iast_mem_check.py
+++ b/tests/appsec/iast_memcheck/test_iast_mem_check.py
@@ -45,7 +45,6 @@ class IASTFilter(LeaksFilterFunction):
         return False
 
 
-@flaky(1704067200)
 @pytest.mark.limit_leaks("8.2 KB", filter_fn=IASTFilter())
 @pytest.mark.parametrize(
     "origin1, origin2",
@@ -104,7 +103,6 @@ def test_propagation_memory_check(origin1, origin2, iast_span_defaults):
         reset_context()
 
 
-@flaky(1704067200)
 @pytest.mark.limit_leaks("460 B", filter_fn=IASTFilter())
 def test_stacktrace_memory_check():
     for _ in range(LOOPS):
@@ -117,7 +115,6 @@ def test_stacktrace_memory_check():
         assert line_number > 0
 
 
-@flaky(1704067200)
 @pytest.mark.limit_leaks("460 B", filter_fn=IASTFilter())
 def test_stacktrace_memory_check_direct_call():
     for _ in range(LOOPS):
@@ -130,7 +127,6 @@ def test_stacktrace_memory_check_direct_call():
         assert line_number > 0
 
 
-@flaky(1704067200)
 @pytest.mark.limit_leaks("460 KB", filter_fn=IASTFilter())
 def test_stacktrace_memory_check_no_native():
     for _ in range(LOOPS):
@@ -143,7 +139,6 @@ def test_stacktrace_memory_check_no_native():
         assert line_number > 0
 
 
-@flaky(1704067200)
 @pytest.mark.limit_leaks("24 KB", filter_fn=IASTFilter())
 def test_stacktrace_memory_check_no_native_direct_call():
     for _ in range(2):
@@ -156,7 +151,6 @@ def test_stacktrace_memory_check_no_native_direct_call():
         assert line_number > 0
 
 
-@flaky(1704067200)
 @pytest.mark.limit_leaks("440 B", filter_fn=IASTFilter())
 def test_stacktrace_memory_empty_byte_check():
     for _ in range(LOOPS):
@@ -169,7 +163,6 @@ def test_stacktrace_memory_empty_byte_check():
         assert line_number > 0
 
 
-@flaky(1704067200)
 @pytest.mark.limit_leaks("440 B", filter_fn=IASTFilter())
 def test_stacktrace_memory_empty_string_check():
     for _ in range(LOOPS):
@@ -182,7 +175,6 @@ def test_stacktrace_memory_empty_string_check():
         assert line_number > 0
 
 
-@flaky(1704067200)
 @pytest.mark.limit_leaks("10 KB", filter_fn=IASTFilter())
 def test_stacktrace_memory_random_string_check():
     """2.1 KB is enough but CI allocates 1.0 MB bytes"""

--- a/tests/appsec/iast_memcheck/test_iast_mem_check.py
+++ b/tests/appsec/iast_memcheck/test_iast_mem_check.py
@@ -18,7 +18,6 @@ from ddtrace.internal import core
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
 from tests.appsec.iast_memcheck._stacktrace_py import get_info_frame as get_info_frame_py
 from tests.appsec.iast_memcheck.fixtures.stacktrace import func_1
-from tests.utils import flaky
 
 
 FIXTURES_PATH = "tests/appsec/iast/fixtures/propagation_path.py"

--- a/tests/appsec/integrations/test_remoteconfiguration_e2e.py
+++ b/tests/appsec/integrations/test_remoteconfiguration_e2e.py
@@ -276,7 +276,7 @@ def test_load_testing_appsec_ip_blocking_gunicorn_block_and_kill_child_worker():
         _request_200(gunicorn_client)
 
 
-@flaky(until=1704067200)
+@flaky(until=1704067200, reason="_request_403 is flaky, figure out the error")
 def test_load_testing_appsec_1click_and_ip_blocking_gunicorn_block_and_kill_child_worker():
     token = "test_load_testing_appsec_1click_and_ip_blocking_gunicorn_block_and_kill_child_worker_{}".format(
         str(uuid.uuid4())

--- a/tests/appsec/integrations/test_remoteconfiguration_e2e.py
+++ b/tests/appsec/integrations/test_remoteconfiguration_e2e.py
@@ -276,7 +276,7 @@ def test_load_testing_appsec_ip_blocking_gunicorn_block_and_kill_child_worker():
         _request_200(gunicorn_client)
 
 
-@flaky
+@flaky(until=1704067200)
 def test_load_testing_appsec_1click_and_ip_blocking_gunicorn_block_and_kill_child_worker():
     token = "test_load_testing_appsec_1click_and_ip_blocking_gunicorn_block_and_kill_child_worker_{}".format(
         str(uuid.uuid4())

--- a/tests/appsec/integrations/test_remoteconfiguration_e2e.py
+++ b/tests/appsec/integrations/test_remoteconfiguration_e2e.py
@@ -15,7 +15,6 @@ from ddtrace import tracer
 from ddtrace.internal.compat import httplib
 from ddtrace.internal.compat import parse
 from tests.appsec.appsec_utils import gunicorn_server
-from tests.utils import flaky
 
 
 def _get_agent_client():

--- a/tests/appsec/integrations/test_remoteconfiguration_e2e.py
+++ b/tests/appsec/integrations/test_remoteconfiguration_e2e.py
@@ -223,7 +223,6 @@ def _request_403(client, debug_mode=False, max_retries=40, sleep_time=1):
     raise AssertionError("request_403 failed, max_retries=%d, sleep_time=%f" % (max_retries, sleep_time))
 
 
-@flaky(until=1704067200)
 @pytest.mark.skipif(sys.version_info >= (3, 11), reason="Gunicorn is only supported up to 3.10")
 def test_load_testing_appsec_ip_blocking_gunicorn_rc_disabled():
     token = "test_load_testing_appsec_ip_blocking_gunicorn_rc_disabled_{}".format(str(uuid.uuid4()))
@@ -239,7 +238,6 @@ def test_load_testing_appsec_ip_blocking_gunicorn_rc_disabled():
         _unblock_ip(token)
 
 
-@flaky(until=1704067200)
 @pytest.mark.skipif(sys.version_info >= (3, 11), reason="Gunicorn is only supported up to 3.10")
 def test_load_testing_appsec_ip_blocking_gunicorn_block():
     token = "test_load_testing_appsec_ip_blocking_gunicorn_block_{}".format(str(uuid.uuid4()))
@@ -257,7 +255,6 @@ def test_load_testing_appsec_ip_blocking_gunicorn_block():
         _request_200(gunicorn_client)
 
 
-@flaky(until=1704067200)
 @pytest.mark.skipif(list(sys.version_info[:2]) != [3, 10], reason="Run this tests in python 3.10")
 def test_load_testing_appsec_ip_blocking_gunicorn_block_and_kill_child_worker():
     token = "test_load_testing_appsec_ip_blocking_gunicorn_block_and_kill_child_worker_{}".format(str(uuid.uuid4()))
@@ -279,7 +276,6 @@ def test_load_testing_appsec_ip_blocking_gunicorn_block_and_kill_child_worker():
         _request_200(gunicorn_client)
 
 
-@flaky(until=1704067200, reason="_request_403 is flaky, figure out the error")
 def test_load_testing_appsec_1click_and_ip_blocking_gunicorn_block_and_kill_child_worker():
     token = "test_load_testing_appsec_1click_and_ip_blocking_gunicorn_block_and_kill_child_worker_{}".format(
         str(uuid.uuid4())

--- a/tests/appsec/integrations/test_remoteconfiguration_e2e.py
+++ b/tests/appsec/integrations/test_remoteconfiguration_e2e.py
@@ -6,7 +6,6 @@ from multiprocessing.pool import ThreadPool
 import os
 import signal
 import sys
-from test.utils import flaky
 import time
 import uuid
 
@@ -16,6 +15,7 @@ from ddtrace import tracer
 from ddtrace.internal.compat import httplib
 from ddtrace.internal.compat import parse
 from tests.appsec.appsec_utils import gunicorn_server
+from tests.utils import flaky
 
 
 def _get_agent_client():

--- a/tests/appsec/integrations/test_remoteconfiguration_e2e.py
+++ b/tests/appsec/integrations/test_remoteconfiguration_e2e.py
@@ -6,6 +6,7 @@ from multiprocessing.pool import ThreadPool
 import os
 import signal
 import sys
+from test.utils import flaky
 import time
 import uuid
 
@@ -275,6 +276,7 @@ def test_load_testing_appsec_ip_blocking_gunicorn_block_and_kill_child_worker():
         _request_200(gunicorn_client)
 
 
+@flaky
 def test_load_testing_appsec_1click_and_ip_blocking_gunicorn_block_and_kill_child_worker():
     token = "test_load_testing_appsec_1click_and_ip_blocking_gunicorn_block_and_kill_child_worker_{}".format(
         str(uuid.uuid4())

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "test",
-    "service": "",
+    "service": "test",
     "resource": "test",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
@@ -7,11 +7,11 @@
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
-    "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "1.10.0",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"nfd-000-006\",\n      \"name\": \"Detect failed attempt to fetch sensitive files\",\n      \"tags\": {\n        \"capec\": \"1000/118/169\",\n        \"category\": \"attack_attempt\",\n        \"confidence\": \"1\",\n        \"cwe\": \"200\",\n        \"type\": \"security_scanner\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"^404$\",\n        \"parameters\": [\n          {\n            \"address\": \"server.response.status\",\n            \"highlight\": [\n              \"404\"\n            ],\n            \"key_path\": [],\n            \"value\": \"404\"\n          }\n        ]\n      },\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"\\\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)\",\n        \"parameters\": [\n          {\n            \"address\": \"server.request.uri.raw\",\n            \"highlight\": [\n              \".git\"\n            ],\n            \"key_path\": [],\n            \"value\": \"/.git\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
       "_dd.appsec.waf.version": "1.15.1",
+      "_dd.base_service": "",
       "_dd.origin": "appsec",
       "_dd.p.dm": "-5",
       "_dd.runtime_family": "python",

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot_with_errors.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot_with_errors.json
@@ -11,6 +11,7 @@
       "_dd.appsec.event_rules.errors": "{\"missing key 'conditions'\": [\"crs-913-110\"], \"missing key 'tags'\": [\"crs-942-100\"]}",
       "_dd.appsec.event_rules.version": "5.5.5",
       "_dd.appsec.waf.version": "1.15.1",
+      "_dd.base_service": "",
       "_dd.p.dm": "-0",
       "_dd.runtime_family": "python",
       "http.status_code": "404",

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot_with_errors.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot_with_errors.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "test",
-    "service": "",
+    "service": "test",
     "resource": "test",
     "trace_id": 0,
     "span_id": 1,


### PR DESCRIPTION
IAST:
- Improved some tests that used to be flaky so they are not anymore.
- Expanded expiration date for memory check tests. 

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
