### PR TITLE
chore(telemetry): track ddtrace installations

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -429,6 +429,14 @@ class TelemetryWriter(PeriodicService):
                 "message": self._error[1],
             },
         }  # type: Dict[str, Union[Dict[str, Any], List[Any]]]
+        # Add time to value telemetry metrics for single step instrumentation
+        if config._telemetry_install_id or config._telemetry_install_type or config._telemetry_install_time:
+            payload["install_signature"] = {
+                "install_id": config._telemetry_install_id,
+                "install_type": config._telemetry_install_type,
+                "install_time": config._telemetry_install_time,
+            }
+
         # Reset the error after it has been reported.
         self._error = (0, "")
         self.add_event(payload, "app-started")

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -513,6 +513,10 @@ class Config(object):
 
         self.trace_methods = os.getenv("DD_TRACE_METHODS")
 
+        self._telemetry_install_id = os.getenv("DD_INSTRUMENTATION_INSTALL_ID", None)
+        self._telemetry_install_type = os.getenv("DD_INSTRUMENTATION_INSTALL_TYPE", None)
+        self._telemetry_install_time = os.getenv("DD_INSTRUMENTATION_INSTALL_TIME", None)
+
     def __getattr__(self, name):
         if name in self._config:
             return self._config[name].value()


### PR DESCRIPTION
Add metadata about ddtrace installation to app-started events. These values will be used to track customer onboarding via Single Step Instrumentation.

Jira: [Update Python library to handle install signature](https://datadoghq.atlassian.net/browse/AIT-9230)

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
