### PR TITLE
chore(iast): cmdi performance

### DIFF
--- a/ddtrace/appsec/_iast/taint_sinks/command_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/command_injection.py
@@ -239,15 +239,15 @@ def _iast_report_cmdi(shell_args):
     # type: (Union[str, List[str]]) -> None
     report_cmdi = ""
     from .._metrics import _set_metric_iast_executed_sink
-    from .._taint_tracking import get_tainted_ranges
+    from .._taint_tracking import is_pyobject_tainted
     from .._taint_tracking.aspects import join_aspect
 
     if isinstance(shell_args, (list, tuple)):
         for arg in shell_args:
-            if get_tainted_ranges(arg):
+            if is_pyobject_tainted(arg):
                 report_cmdi = join_aspect(" ".join, 1, " ", shell_args)
                 break
-    elif get_tainted_ranges(shell_args):
+    elif is_pyobject_tainted(shell_args):
         report_cmdi = shell_args
 
     if report_cmdi:


### PR DESCRIPTION
`is_pyobject_tainted` is faster than `get_tainted_ranges`
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.