### PR TITLE
fix(asm): fix boolean property reporting for appsec

### DIFF
--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -211,7 +211,11 @@ def track_custom_event(tracer: Tracer, event_name: str, metadata: dict) -> None:
     span.set_tag_str("%s.%s.track" % (APPSEC.CUSTOM_EVENT_PREFIX, event_name), "true")
 
     for k, v in metadata.items():
-        span.set_tag_str("%s.%s.%s" % (APPSEC.CUSTOM_EVENT_PREFIX, event_name, k), str(v))
+        if isinstance(v, bool):
+            str_v = "true" if v else "false"
+        else:
+            str_v = str(v)
+        span.set_tag_str("%s.%s.%s" % (APPSEC.CUSTOM_EVENT_PREFIX, event_name, k), str_v)
         _asm_manual_keep(span)
 
 

--- a/releasenotes/notes/fix_bool_report_for_appsec_custom_event-da5503b0fbb78c95.yaml
+++ b/releasenotes/notes/fix_bool_report_for_appsec_custom_event-da5503b0fbb78c95.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    ASM: This fix resolves an issue where custom event boolean properties were not reported as `true` and `false`
+    like other tracers but as `True` and `False`.


### PR DESCRIPTION
For custom appsec events, python tracer was reporting boolean properties as `True` and `False` while other tracers are using `true`/`false`. This PR fixes that discrepancy. 
A specific test should be added to system tests to ensure all tracers follow the same standard.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
