### PR TITLE
ci: delay expiration for flaky tests

### DIFF
--- a/tests/appsec/integrations/test_flask_remoteconfig.py
+++ b/tests/appsec/integrations/test_flask_remoteconfig.py
@@ -276,7 +276,7 @@ def test_load_testing_appsec_ip_blocking_gunicorn_block_and_kill_child_worker():
         _request_200(gunicorn_client)
 
 
-@flaky(until=1704067200, reason="_request_403 is flaky, figure out the error")
+@flaky(until=1706677200, reason="_request_403 is flaky, figure out the error")
 def test_load_testing_appsec_1click_and_ip_blocking_gunicorn_block_and_kill_child_worker():
     token = "test_load_testing_appsec_1click_and_ip_blocking_gunicorn_block_and_kill_child_worker_{}".format(
         str(uuid.uuid4())

--- a/tests/appsec/integrations/test_flask_telemetry.py
+++ b/tests/appsec/integrations/test_flask_telemetry.py
@@ -2,7 +2,7 @@ from tests.appsec.appsec_utils import flask_server
 from tests.utils import flaky
 
 
-@flaky(until=1704067200)
+@flaky(until=1706677200)
 def test_iast_span_metrics():
     with flask_server(iast_enabled="true", token=None) as context:
         _, flask_client, pid = context

--- a/tests/contrib/asyncio/test_tracer_safety.py
+++ b/tests/contrib/asyncio/test_tracer_safety.py
@@ -1,0 +1,58 @@
+import asyncio
+
+import pytest
+
+from ddtrace.contrib.asyncio.compat import asyncio_current_task
+from ddtrace.internal.compat import CONTEXTVARS_IS_AVAILABLE
+from ddtrace.provider import DefaultContextProvider
+from tests.utils import flaky
+
+
+pytestmark = pytest.mark.skipif(
+    CONTEXTVARS_IS_AVAILABLE, reason="No configuration is necessary when contextvars available."
+)
+
+
+@pytest.mark.asyncio
+async def test_get_call_context(tracer):
+    tracer.configure(context_provider=DefaultContextProvider())
+    ctx = tracer.current_trace_context()
+    assert ctx is None
+    # test that it behaves the wrong way
+    task = asyncio_current_task()
+    assert task
+    task_ctx = getattr(task, "__datadog_context", None)
+    assert task_ctx is None
+
+
+def test_trace_coroutine(tracer):
+    # it should use the task context when invoked in a coroutine
+    with tracer.trace("coroutine") as span:
+        span.resource = "base"
+
+    traces = tracer.pop_traces()
+    assert 1 == len(traces)
+    assert 1 == len(traces[0])
+    assert "coroutine" == traces[0][0].name
+    assert "base" == traces[0][0].resource
+
+
+@flaky(until=1706677200)
+@pytest.mark.asyncio
+async def test_trace_multiple_calls(tracer):
+    tracer.configure(context_provider=DefaultContextProvider())
+
+    async def coro():
+        # another traced coroutine
+        with tracer.trace("coroutine"):
+            await asyncio.sleep(0.01)
+
+    # partial flushing is enabled, ensure the number of spans generated is less than 500
+    futures = [asyncio.ensure_future(coro()) for x in range(400)]
+    for future in futures:
+        await future
+
+    # the trace is wrong but the Context is finished
+    traces = tracer.pop_traces()
+    assert 1 == len(traces)
+    assert 400 == len(traces[0])

--- a/tests/contrib/django/test_django_snapshots.py
+++ b/tests/contrib/django/test_django_snapshots.py
@@ -85,7 +85,7 @@ def test_middleware_trace_callable_view(client):
     assert client.get("/feed-view/").status_code == 200
 
 
-@flaky(until=1704067200)
+@flaky(until=1706677200)
 @pytest.mark.skipif(
     sys.version_info >= (3, 10, 0),
     reason=("func_name changed with Python 3.10 which changes the resource name." "TODO: new snapshot required."),

--- a/tests/contrib/flask/test_flask_snapshot.py
+++ b/tests/contrib/flask/test_flask_snapshot.py
@@ -117,7 +117,7 @@ def test_flask_stream(flask_client):
     assert resp.status_code == 200
 
 
-@flaky(until=1704067200)
+@flaky(until=1706677200)
 @pytest.mark.snapshot(
     ignores=["meta.flask.version", "meta.http.useragent"],
     variants={"220": flask_version >= (2, 2, 0), "": flask_version < (2, 2, 0)},

--- a/tests/contrib/gunicorn/test_gunicorn.py
+++ b/tests/contrib/gunicorn/test_gunicorn.py
@@ -176,7 +176,7 @@ SETTINGS_GEVENT_SPANAGGREGATOR_NO_RLOCK = _gunicorn_settings_factory(
 )
 
 
-@flaky(until=1704067200)
+@flaky(until=1706677200)
 @pytest.mark.skipif(sys.version_info >= (3, 11), reason="Gunicorn is only supported up to 3.10")
 def test_no_known_errors_occur(tmp_path):
     for gunicorn_server_settings in [
@@ -195,7 +195,7 @@ def test_no_known_errors_occur(tmp_path):
         assert payload["profiler"]["is_active"] is True
 
 
-@flaky(until=1704067200)
+@flaky(until=1706677200)
 @pytest.mark.skipif(sys.version_info >= (3, 11), reason="Gunicorn is only supported up to 3.10")
 def test_span_schematization(tmp_path):
     for schema_version in [None, "v0", "v1"]:

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -237,7 +237,7 @@ def test_produce_multiple_servers(dummy_tracer, kafka_topic):
     assert produce_span.get_tag("messaging.kafka.bootstrap.servers") == ",".join([BOOTSTRAP_SERVERS] * 3)
 
 
-@flaky(until=1704067200)
+@flaky(until=1706677200)
 @pytest.mark.parametrize("tombstone", [False, True])
 @pytest.mark.snapshot(ignores=["metrics.kafka.message_offset"])
 def test_message(producer, consumer, tombstone, kafka_topic):

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -253,7 +253,7 @@ def pyramid_client(snapshot, pyramid_app):
         proc.terminate()
 
 
-@flaky(until=1704067200)
+@flaky(until=1706677200)
 @pytest.mark.parametrize(
     "pyramid_app",
     [

--- a/tests/debugging/probe/test_remoteconfig.py
+++ b/tests/debugging/probe/test_remoteconfig.py
@@ -546,7 +546,7 @@ def test_parse_metric_probe_with_probeid_tags():
     assert probe.tags["debugger.probeid"] == probeId
 
 
-@flaky(until=1704067200)
+@flaky(until=1706677200)
 def test_modified_probe_events(remote_config_worker, mock_config):
     events = []
 

--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -886,7 +886,7 @@ def test_debugger_lambda_fuction_access_locals():
             assert snapshot, d.test_queue
 
 
-@flaky(until=1704067200)
+@flaky(until=1706677200)
 def test_debugger_log_live_probe_generate_messages():
     from tests.submod.stuff import Stuff
 

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -10,7 +10,6 @@ import pytest
 from ddtrace.internal.module import origin
 from ddtrace.internal.telemetry.data import get_application
 from ddtrace.internal.telemetry.data import get_host_info
-from ddtrace.internal.telemetry.writer import TelemetryWriter
 from ddtrace.internal.telemetry.writer import TelemetryWriterModuleWatchdog
 from ddtrace.internal.telemetry.writer import get_runtime_id
 from ddtrace.internal.utils.version import _pep440_to_semver
@@ -479,7 +478,7 @@ def test_telemetry_graceful_shutdown(telemetry_writer, test_agent_session, mock_
 
 @flaky(1706677200)
 def test_app_heartbeat_event_periodic(mock_time, telemetry_writer, test_agent_session):
-    # type: (mock.Mock, Any, TelemetryWriter) -> None
+    # type: (mock.Mock, Any, Any) -> None
     """asserts that we queue/send app-heartbeat when periodc() is called"""
     with override_global_config(dict(_telemetry_dependency_collection=False)):
         # Ensure telemetry writer is initialized to send periodic events
@@ -503,7 +502,7 @@ def test_app_heartbeat_event_periodic(mock_time, telemetry_writer, test_agent_se
 
 @flaky(1706677200)
 def test_app_heartbeat_event(mock_time, telemetry_writer, test_agent_session):
-    # type: (mock.Mock, Any, TelemetryWriter) -> None
+    # type: (mock.Mock, Any, Any) -> None
     """asserts that we queue/send app-heartbeat event every 60 seconds when app_heartbeat_event() is called"""
 
     with override_global_config(dict(_telemetry_dependency_collection=False)):

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -461,7 +461,6 @@ def test_send_failing_request(mock_status, telemetry_writer):
             assert len(httpretty.latest_requests()) == 1
 
 
-@pytest.mark.parametrize("telemetry_writer", [TelemetryWriter()])
 @flaky(1706677200, reason="Invalid method encountered raised by testagent's aiohttp server causes connection errors")
 def test_telemetry_graceful_shutdown(telemetry_writer, test_agent_session, mock_time):
     with override_global_config(dict(_telemetry_dependency_collection=False)):

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -440,7 +440,7 @@ def test_add_integration_disabled_writer(telemetry_writer, test_agent_session):
     assert len(test_agent_session.get_requests()) == 0
 
 
-@flaky(until=1704067200)
+@flaky(until=1706677200)
 @pytest.mark.parametrize("mock_status", [300, 400, 401, 403, 500])
 def test_send_failing_request(mock_status, telemetry_writer):
     """asserts that a warning is logged when an unsuccessful response is returned by the http client"""
@@ -462,7 +462,7 @@ def test_send_failing_request(mock_status, telemetry_writer):
 
 
 @pytest.mark.parametrize("telemetry_writer", [TelemetryWriter()])
-@flaky(1704067200, reason="Invalid method encountered raised by testagent's aiohttp server causes connection errors")
+@flaky(1706677200, reason="Invalid method encountered raised by testagent's aiohttp server causes connection errors")
 def test_telemetry_graceful_shutdown(telemetry_writer, test_agent_session, mock_time):
     with override_global_config(dict(_telemetry_dependency_collection=False)):
         telemetry_writer.start()
@@ -478,7 +478,7 @@ def test_telemetry_graceful_shutdown(telemetry_writer, test_agent_session, mock_
         assert events[0] == _get_request_body({}, "app-closing", 1)
 
 
-@flaky(1704067200)
+@flaky(1706677200)
 def test_app_heartbeat_event_periodic(mock_time, telemetry_writer, test_agent_session):
     # type: (mock.Mock, Any, TelemetryWriter) -> None
     """asserts that we queue/send app-heartbeat when periodc() is called"""
@@ -502,7 +502,7 @@ def test_app_heartbeat_event_periodic(mock_time, telemetry_writer, test_agent_se
         assert len(heartbeat_events) == 1
 
 
-@flaky(1704067200)
+@flaky(1706677200)
 def test_app_heartbeat_event(mock_time, telemetry_writer, test_agent_session):
     # type: (mock.Mock, Any, TelemetryWriter) -> None
     """asserts that we queue/send app-heartbeat event every 60 seconds when app_heartbeat_event() is called"""

--- a/tests/tracer/runtime/test_metric_collectors.py
+++ b/tests/tracer/runtime/test_metric_collectors.py
@@ -32,7 +32,7 @@ class TestPSUtilRuntimeMetricCollector(BaseTestCase):
         for _, value in collector.collect(PSUTIL_RUNTIME_METRICS):
             self.assertIsNotNone(value)
 
-    @flaky(1704067200)
+    @flaky(1706677200)
     def test_static_metrics(self):
         import os
         import threading


### PR DESCRIPTION
Delay the expiration date for flaky tests as they have not been fixed.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
