### PR TITLE
refactor(di): normalise tags

### DIFF
--- a/ddtrace/settings/dynamic_instrumentation.py
+++ b/ddtrace/settings/dynamic_instrumentation.py
@@ -15,10 +15,17 @@ DEFAULT_MAX_PROBES = 100
 DEFAULT_GLOBAL_RATE_LIMIT = 100.0
 
 
-def _derive_tags(c):
-    # type: (En) -> str
-    _tags = dict(env=ddconfig.env, version=ddconfig.version, debugger_version=get_version())
-    _tags.update(ddconfig.tags)
+def _derive_tags(c: "DynamicInstrumentationConfig") -> str:
+    _tags = ddconfig.tags.copy()
+
+    # Make sure that environment and version are normalised to lowercase
+    _tags.update(
+        dict(
+            env=ddconfig.env.lower() if ddconfig.env is not None else None,
+            version=ddconfig.version.lower() if ddconfig.version is not None else None,
+            debugger_version=get_version(),
+        )
+    )
 
     # Add git metadata tags, if available
     gitmetadata.add_tags(_tags)


### PR DESCRIPTION
We normalise the environment and version tags in DI payloads to ensure that the correct values can be matched in the backend.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
