### PR TITLE
fix(asyncpg): working patch for asyncpg.Pool instances

### DIFF
--- a/ddtrace/contrib/asyncpg/patch.py
+++ b/ddtrace/contrib/asyncpg/patch.py
@@ -128,6 +128,7 @@ async def _traced_protocol_execute(asyncpg, pin, func, instance, args, kwargs):
 
 def _patch(asyncpg: ModuleType) -> None:
     wrap(asyncpg, "connect", _traced_connect(asyncpg))
+    wrap(asyncpg.connect_utils, "_connect_addr", _traced_connect(asyncpg))
     for method in ("execute", "bind_execute", "query", "bind_execute_many"):
         wrap(asyncpg.protocol, "Protocol.%s" % method, _traced_protocol_execute(asyncpg))
 
@@ -147,6 +148,7 @@ def patch():
 
 def _unpatch(asyncpg: ModuleType) -> None:
     unwrap(asyncpg, "connect")
+    unwrap(asyncpg.connect_utils, "_connect_addr")
     for method in ("execute", "bind_execute", "query", "bind_execute_many"):
         unwrap(asyncpg.protocol.Protocol, method)
 

--- a/ddtrace/contrib/asyncpg/patch.py
+++ b/ddtrace/contrib/asyncpg/patch.py
@@ -128,7 +128,7 @@ async def _traced_protocol_execute(asyncpg, pin, func, instance, args, kwargs):
 
 def _patch(asyncpg: ModuleType) -> None:
     wrap(asyncpg, "connect", _traced_connect(asyncpg))
-    wrap(asyncpg.connect_utils, "_connect_addr", _traced_connect(asyncpg))
+    wrap(asyncpg.connection, "connect", _traced_connect(asyncpg))
     for method in ("execute", "bind_execute", "query", "bind_execute_many"):
         wrap(asyncpg.protocol, "Protocol.%s" % method, _traced_protocol_execute(asyncpg))
 
@@ -148,7 +148,7 @@ def patch():
 
 def _unpatch(asyncpg: ModuleType) -> None:
     unwrap(asyncpg, "connect")
-    unwrap(asyncpg.connect_utils, "_connect_addr")
+    unwrap(asyncpg.connection, "connect")
     for method in ("execute", "bind_execute", "query", "bind_execute_many"):
         unwrap(asyncpg.protocol.Protocol, method)
 


### PR DESCRIPTION
Hello! I noticed that using `ddtrace.patch(asyncpg=True)` doesn't work as expected with connection pools, the most common way of using asyncpg database connections.

I'm trying to use `Pin.override()` on the connection object when it is created, which works for direct connections created with `asyncpg.connect()`. However, it does not work with pooled connections.

```python
import asyncpg
import ddtrace
from ddtrace import Pin

ddtrace.patch(asyncpg=True)

async def init_db_connection(conn):
    # print("DEBUG:", getattr(conn, "__getddpin__", None))
    Pin.override(conn, service="my-database-123")  # Let Datadog know what service this is.

pool = await asyncpg.create_pool(dsn="postgres://...", init=init_db_connection)
async with pool.acquire() as conn:
    await conn.fetch(...)
```

This Pin `service` override doesn't work with pools, even though it works with ordinary connections. If you uncomment the `DEBUG:` line above, you can see that the `__getddpin__` method is not present on the connection objects from a pool, even though it is on other asyncpg connections.

I noticed it's because of this [line of code](https://github.com/MagicStack/asyncpg/blob/d7faaff57a7a9c0029a31f09564d30ab35007907/asyncpg/pool.py#L501-L508) from asyncpg.Pool, which calls `asyncpg.connection.connect()`. But ddtrace only patches `asyncpg.connect()`, which is an alias for that.

We need to patch both methods for it to work!

Happy to add a release note, but I can't get `riot run` to work either locally or on a Linux machine. It freezes without making progress. Is there a way to manually add the release note file?

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
