### PR TITLE
ci(flaky): add flaky decorator to failing tests

### DIFF
--- a/tests/contrib/asyncpg/test_asyncpg.py
+++ b/tests/contrib/asyncpg/test_asyncpg.py
@@ -10,6 +10,7 @@ from ddtrace.contrib.asyncpg import patch
 from ddtrace.contrib.asyncpg import unpatch
 from ddtrace.contrib.trace_utils import iswrapped
 from tests.contrib.config import POSTGRES_CONFIG
+from tests.utils import flaky
 
 
 @pytest.fixture(autouse=True)
@@ -157,6 +158,7 @@ async def test_service_override_pin(patched_conn):
     await patched_conn.execute("SELECT 1")
 
 
+@flaky(1735812000)
 @pytest.mark.asyncio
 @pytest.mark.snapshot
 async def test_parenting(patched_conn):

--- a/tests/contrib/aws_lambda/test_aws_lambda.py
+++ b/tests/contrib/aws_lambda/test_aws_lambda.py
@@ -52,6 +52,7 @@ def setup():
     unpatch()
 
 
+@flaky(1735812000)
 @pytest.mark.parametrize("customApmFlushDeadline", [("-100"), ("10"), ("100"), ("200")])
 @pytest.mark.snapshot
 @flaky(1709306303)

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -38,6 +38,7 @@ from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
 from ddtrace.vendor import wrapt
 from tests.opentracer.utils import init_tracer
 from tests.utils import assert_dict_issuperset
+from tests.utils import flaky
 from tests.utils import override_config
 from tests.utils import override_env
 from tests.utils import override_global_config
@@ -1440,6 +1441,7 @@ def test_cached_view(client, test_spans):
     assert span_header.get_tags() == expected_meta_header
 
 
+@flaky(1735812000)
 @pytest.mark.django_db
 def test_cached_template(client, test_spans):
     # make the first request so that the view is cached

--- a/tests/contrib/django/test_django_snapshots.py
+++ b/tests/contrib/django/test_django_snapshots.py
@@ -61,6 +61,7 @@ def daphne_client(django_asgi, additional_env=None):
         proc.terminate()
 
 
+@flaky(1735812000)
 @pytest.mark.skipif(django.VERSION < (2, 0), reason="")
 @snapshot(variants={"": django.VERSION >= (2, 2)}, ignores=SNAPSHOT_IGNORES)
 def test_urlpatterns_include(client):

--- a/tests/contrib/django/test_django_snapshots.py
+++ b/tests/contrib/django/test_django_snapshots.py
@@ -148,6 +148,7 @@ def psycopg2_patched(transactional_db):
     unpatch()
 
 
+@flaky(1735812000)
 @pytest.mark.django_db
 def test_psycopg2_query_default(client, snapshot_context, psycopg2_patched):
     """Execute a psycopg2 query on a Django database wrapper.
@@ -236,6 +237,7 @@ def test_asgi_200(django_asgi):
         assert resp.content == b"Hello, test app."
 
 
+@flaky(1735812000)
 @pytest.mark.skipif(django.VERSION < (3, 0, 0), reason="ASGI not supported in django<3")
 @snapshot(ignores=SNAPSHOT_IGNORES + ["meta.http.useragent"])
 def test_asgi_200_simple_app():

--- a/tests/contrib/django/test_django_snapshots.py
+++ b/tests/contrib/django/test_django_snapshots.py
@@ -196,6 +196,7 @@ def psycopg3_patched(transactional_db):
         unpatch()
 
 
+@flaky(1735812000)
 @pytest.mark.django_db
 @pytest.mark.skipif(django.VERSION < (4, 2, 0), reason="Psycopg3 not supported in django<4.2")
 def test_psycopg3_query_default(client, snapshot_context, psycopg3_patched):

--- a/tests/contrib/httpx/test_httpx.py
+++ b/tests/contrib/httpx/test_httpx.py
@@ -9,6 +9,7 @@ from ddtrace.contrib.httpx.patch import unpatch
 from ddtrace.pin import Pin
 from ddtrace.settings.http import HttpConfig
 from ddtrace.vendor.wrapt import ObjectProxy
+from tests.utils import flaky
 from tests.utils import override_config
 from tests.utils import override_http_config
 
@@ -73,6 +74,7 @@ def test_httpx_service_name(tracer, test_spans):
     assert isinstance(spans[0].service, six.text_type)
 
 
+@flaky(1735812000)
 @pytest.mark.asyncio
 async def test_get_200(snapshot_context):
     url = get_url("/status/200")
@@ -146,6 +148,7 @@ async def test_configure_service_name_pin(tracer, test_spans):
     assert_spans(test_spans, service="async-client")
 
 
+@flaky(1735812000)
 @pytest.mark.subprocess(
     env=dict(
         DD_HTTPX_SERVICE="env-overridden-service-name",
@@ -220,6 +223,7 @@ def test_schematized_configure_global_service_name_env_default():
     asyncio.run(test())
 
 
+@flaky(1735812000)
 @pytest.mark.subprocess(env=dict(DD_SERVICE="global-service-name", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
 def test_schematized_configure_global_service_name_env_v0():
     """
@@ -253,6 +257,7 @@ def test_schematized_configure_global_service_name_env_v0():
     asyncio.run(test())
 
 
+@flaky(1735812000)
 @pytest.mark.subprocess(env=dict(DD_SERVICE="global-service-name", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
 def test_schematized_configure_global_service_name_env_v1():
     """
@@ -318,6 +323,7 @@ def test_schematized_unspecified_service_name_env_default():
     asyncio.run(test())
 
 
+@flaky(1735812000)
 @pytest.mark.subprocess(env=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
 def test_schematized_unspecified_service_name_env_v0():
     """

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -271,6 +271,7 @@ def test_commit_with_offset(producer, consumer, kafka_topic):
     consumer.commit(offsets=[TopicPartition(kafka_topic)])
 
 
+@flaky(1735812000)
 @pytest.mark.snapshot(ignores=["metrics.kafka.message_offset"])
 def test_commit_with_only_async_arg(producer, consumer, kafka_topic):
     producer.produce(kafka_topic, PAYLOAD, key=KEY)
@@ -303,6 +304,7 @@ def test_analytics_with_rate(producer, consumer, kafka_topic):
             message = consumer.poll(1.0)
 
 
+@flaky(1735812000)
 @pytest.mark.snapshot(ignores=["metrics.kafka.message_offset"])
 def test_analytics_without_rate(producer, consumer, kafka_topic):
     with override_config("kafka", dict(analytics_enabled=True)):
@@ -464,6 +466,7 @@ def _generate_in_subprocess(random_topic):
     consumer.close()
 
 
+@flaky(1735812000)
 @pytest.mark.snapshot(
     token="tests.contrib.kafka.test_kafka.test_service_override_env_var", ignores=["metrics.kafka.message_offset"]
 )
@@ -490,6 +493,7 @@ if __name__ == "__main__":
     assert err == b"", err.decode()
 
 
+@flaky(1735812000)
 @pytest.mark.snapshot(ignores=["metrics.kafka.message_offset"])
 @pytest.mark.parametrize("service", [None, "mysvc"])
 @pytest.mark.parametrize("schema", [None, "v0", "v1"])
@@ -585,6 +589,7 @@ def test_data_streams_kafka_offset_monitoring_offsets(dsm_processor, non_auto_co
     assert list(buckets.values())[0].latest_commit_offsets[ConsumerPartitionKey("test_group", kafka_topic, 0)] == 1
 
 
+@flaky(until=1704067200)
 def test_data_streams_kafka_offset_monitoring_auto_commit(dsm_processor, consumer, producer, kafka_topic):
     def _read_single_message(consumer):
         message = None

--- a/tests/contrib/langchain/test_langchain.py
+++ b/tests/contrib/langchain/test_langchain.py
@@ -496,6 +496,7 @@ async def test_openai_chat_model_async_stream(langchain, request_vcr):
         await chat.agenerate([[langchain.schema.HumanMessage(content="What is the secret Krabby Patty recipe?")]])
 
 
+@flaky(1735812000)
 def test_chat_model_metrics(langchain, request_vcr, mock_metrics, mock_logs, snapshot_tracer):
     chat = langchain.chat_models.ChatOpenAI(temperature=0, max_tokens=256)
     if sys.version_info >= (3, 10, 0):
@@ -611,6 +612,7 @@ def test_chat_model_logs(langchain, ddtrace_config_langchain, request_vcr, mock_
     mock_metrics.count.assert_not_called()
 
 
+@flaky(1735812000)
 @pytest.mark.snapshot
 def test_openai_embedding_query(langchain, request_vcr):
     embeddings = langchain.embeddings.OpenAIEmbeddings()
@@ -646,6 +648,7 @@ def test_fake_embedding_document(langchain):
     embeddings.embed_documents(texts=["foo", "bar"])
 
 
+@flaky(1735812000)
 def test_openai_embedding_metrics(langchain, request_vcr, mock_metrics, mock_logs, snapshot_tracer):
     embeddings = langchain.embeddings.OpenAIEmbeddings()
     if sys.version_info >= (3, 10, 0):
@@ -677,6 +680,7 @@ def test_openai_embedding_metrics(langchain, request_vcr, mock_metrics, mock_log
     mock_logs.assert_not_called()
 
 
+@flaky(1735812000)
 @pytest.mark.parametrize(
     "ddtrace_config_langchain",
     [
@@ -1074,6 +1078,7 @@ def test_chat_prompt_template_does_not_parse_template(langchain, mock_tracer):
     assert chain_span.get_tag("langchain.request.prompt") is None
 
 
+@flaky(1735812000)
 @pytest.mark.snapshot
 def test_pinecone_vectorstore_similarity_search(langchain, request_vcr):
     """
@@ -1122,6 +1127,7 @@ def test_pinecone_vectorstore_retrieval_chain(langchain, request_vcr):
         qa_with_sources("Who was Alan Turing?")
 
 
+@flaky(1735812000)
 @pytest.mark.skipif(sys.version_info >= (3, 10, 0), reason="Cassette specific to Python 3.9")
 @pytest.mark.snapshot
 def test_pinecone_vectorstore_retrieval_chain_39(langchain, request_vcr):
@@ -1147,6 +1153,7 @@ def test_pinecone_vectorstore_retrieval_chain_39(langchain, request_vcr):
         qa_with_sources("Who was Alan Turing?")
 
 
+@flaky(1735812000)
 def test_vectorstore_similarity_search_metrics(langchain, request_vcr, mock_metrics, mock_logs, snapshot_tracer):
     import pinecone
 
@@ -1186,6 +1193,7 @@ def test_vectorstore_similarity_search_metrics(langchain, request_vcr, mock_metr
     mock_logs.assert_not_called()
 
 
+@flaky(1735812000)
 @pytest.mark.parametrize(
     "ddtrace_config_langchain",
     [
@@ -1432,6 +1440,7 @@ def test_chat_model_logs_when_response_not_completed(
     )
 
 
+@flaky(1735812000)
 @pytest.mark.parametrize(
     "ddtrace_config_langchain",
     [
@@ -1528,6 +1537,7 @@ def test_chain_logs_when_response_not_completed(
     )
 
 
+@flaky(1735812000)
 @pytest.mark.parametrize(
     "ddtrace_config_langchain",
     [

--- a/tests/contrib/langchain/test_langchain.py
+++ b/tests/contrib/langchain/test_langchain.py
@@ -109,6 +109,7 @@ def mock_tracer(langchain, mock_logs, mock_metrics):
     mock_metrics.reset_mock()
 
 
+@flaky(1735812000)
 @pytest.mark.parametrize(
     "ddtrace_config_langchain",
     [dict(_api_key="<not-real-but-it's-something>", logs_enabled=True, log_prompt_completion_sample_rate=1.0)],
@@ -481,6 +482,7 @@ async def test_openai_chat_model_async_generate(langchain, request_vcr):
         )
 
 
+@flaky(1735812000)
 @pytest.mark.snapshot(token="tests.contrib.langchain.test_langchain.test_openai_chat_model_stream")
 def test_openai_chat_model_sync_stream(langchain, request_vcr):
     chat = langchain.chat_models.ChatOpenAI(streaming=True, temperature=0, max_tokens=256)
@@ -488,6 +490,7 @@ def test_openai_chat_model_sync_stream(langchain, request_vcr):
         chat([langchain.schema.HumanMessage(content="What is the secret Krabby Patty recipe?")])
 
 
+@flaky(1735812000)
 @pytest.mark.asyncio
 @pytest.mark.snapshot(token="tests.contrib.langchain.test_langchain.test_openai_chat_model_stream")
 async def test_openai_chat_model_async_stream(langchain, request_vcr):
@@ -1102,6 +1105,7 @@ def test_pinecone_vectorstore_similarity_search(langchain, request_vcr):
         vectorstore.similarity_search("Who was Alan Turing?", 1)
 
 
+@flaky(1735812000)
 @pytest.mark.skipif(sys.version_info < (3, 10, 0), reason="Cassette specific to Python 3.10+")
 @pytest.mark.snapshot
 def test_pinecone_vectorstore_retrieval_chain(langchain, request_vcr):

--- a/tests/contrib/langchain/test_langchain.py
+++ b/tests/contrib/langchain/test_langchain.py
@@ -12,6 +12,7 @@ from ddtrace.contrib.langchain.patch import unpatch
 from ddtrace.internal.utils.version import parse_version
 from tests.utils import DummyTracer
 from tests.utils import DummyWriter
+from tests.utils import flaky
 from tests.utils import override_config
 from tests.utils import override_global_config
 
@@ -331,6 +332,7 @@ def test_openai_llm_metrics(langchain, request_vcr, mock_metrics, mock_logs, sna
     mock_logs.assert_not_called()
 
 
+@flaky(1735812000)
 @pytest.mark.parametrize(
     "ddtrace_config_langchain",
     [
@@ -545,6 +547,7 @@ def test_chat_model_metrics(langchain, request_vcr, mock_metrics, mock_logs, sna
     mock_logs.assert_not_called()
 
 
+@flaky(1735812000)
 @pytest.mark.parametrize(
     "ddtrace_config_langchain",
     [
@@ -952,6 +955,7 @@ def test_openai_chain_metrics(langchain, request_vcr, mock_metrics, mock_logs, s
     mock_logs.assert_not_called()
 
 
+@flaky(1735812000)
 @pytest.mark.parametrize(
     "ddtrace_config_langchain",
     [

--- a/tests/contrib/redis/test_redis_asyncio.py
+++ b/tests/contrib/redis/test_redis_asyncio.py
@@ -10,6 +10,7 @@ from ddtrace import tracer
 from ddtrace.contrib.redis.patch import patch
 from ddtrace.contrib.redis.patch import unpatch
 from ddtrace.vendor.wrapt import ObjectProxy
+from tests.utils import flaky
 from tests.utils import override_config
 
 from ..config import REDIS_CONFIG
@@ -90,6 +91,7 @@ async def test_connection_error(redis_client):
             await redis_client.get("foo")
 
 
+@flaky(1735812000)
 @pytest.mark.asyncio
 @pytest.mark.snapshot(wait_for_num_traces=2)
 async def test_decoding_non_utf8_args(redis_client):
@@ -189,6 +191,7 @@ async def test_pipeline_traced_context_manager_transaction(redis_client):
     assert get_2.decode() == "bar"
 
 
+@flaky(1735812000)
 @pytest.mark.asyncio
 @pytest.mark.snapshot(wait_for_num_traces=1)
 async def test_two_traced_pipelines(redis_client):

--- a/tests/contrib/wsgi/test_wsgi.py
+++ b/tests/contrib/wsgi/test_wsgi.py
@@ -267,6 +267,7 @@ def test_500_py3():
         app.get("/error")
 
 
+@flaky(1735812000)
 @snapshot(ignores=["meta.error.stack"])
 def test_base_exception_in_wsgi_app_py3():
     # Ensure wsgi.request and wsgi.application spans are closed when

--- a/tests/contrib/wsgi/test_wsgi.py
+++ b/tests/contrib/wsgi/test_wsgi.py
@@ -277,6 +277,7 @@ def test_base_exception_in_wsgi_app_py3():
         app.get("/baseException")
 
 
+@flaky(1735812000)
 @pytest.mark.snapshot(token="tests.contrib.wsgi.test_wsgi.test_wsgi_base_middleware")
 @pytest.mark.parametrize("use_global_tracer", [True])
 def test_wsgi_base_middleware(use_global_tracer, tracer):

--- a/tests/contrib/wsgi/test_wsgi.py
+++ b/tests/contrib/wsgi/test_wsgi.py
@@ -251,6 +251,7 @@ def test_chunked():
     assert resp.text.endswith("999")
 
 
+@flaky(1735812000)
 @snapshot()
 def test_200():
     app = TestApp(wsgi.DDWSGIMiddleware(application))

--- a/tests/contrib/wsgi/test_wsgi.py
+++ b/tests/contrib/wsgi/test_wsgi.py
@@ -6,6 +6,7 @@ from webtest import TestApp
 
 from ddtrace import config
 from ddtrace.contrib.wsgi import wsgi
+from tests.utils import flaky
 from tests.utils import override_config
 from tests.utils import override_http_config
 from tests.utils import snapshot
@@ -258,6 +259,7 @@ def test_200():
     assert resp.status_int == 200
 
 
+@flaky(1735812000)
 @snapshot(ignores=["meta.error.stack"])
 def test_500_py3():
     app = TestApp(wsgi.DDWSGIMiddleware(application))
@@ -283,6 +285,7 @@ def test_wsgi_base_middleware(use_global_tracer, tracer):
     assert resp.status_int == 200
 
 
+@flaky(1735812000)
 @pytest.mark.snapshot(
     token="tests.contrib.wsgi.test_wsgi.test_wsgi_base_middleware_500", ignores=["meta.error.stack", "meta.error.type"]
 )

--- a/tests/opentelemetry/test_context.py
+++ b/tests/opentelemetry/test_context.py
@@ -6,6 +6,7 @@ import opentelemetry
 import pytest
 
 import ddtrace
+from tests.utils import flaky
 
 
 @pytest.mark.snapshot
@@ -31,6 +32,7 @@ def test_otel_span_parenting(oteltracer):
         orphan1.end()
 
 
+@flaky(1735812000)
 @pytest.mark.snapshot
 def test_otel_ddtrace_mixed_parenting(oteltracer):
     with oteltracer.start_as_current_span("otel-top-level"):

--- a/tests/opentelemetry/test_span.py
+++ b/tests/opentelemetry/test_span.py
@@ -12,6 +12,7 @@ from opentelemetry.trace.status import StatusCode as OtelStatusCode
 import pytest
 
 from ddtrace.constants import MANUAL_DROP_KEY
+from tests.utils import flaky
 
 
 @pytest.mark.snapshot
@@ -53,6 +54,7 @@ def test_otel_span_attributes_overrides(oteltracer, override):
         span.set_attribute(otel, value)
 
 
+@flaky(1735812000)
 @pytest.mark.snapshot
 def test_otel_span_kind(oteltracer):
     with oteltracer.start_span("otel-client", kind=OtelSpanKind.CLIENT):

--- a/tests/opentelemetry/test_trace.py
+++ b/tests/opentelemetry/test_trace.py
@@ -5,6 +5,7 @@ import pytest
 from ddtrace.internal.utils.version import parse_version
 from tests.contrib.flask.test_flask_snapshot import flask_client  # noqa:F401
 from tests.contrib.flask.test_flask_snapshot import flask_default_env  # noqa:F401
+from tests.utils import flaky
 
 
 OTEL_VERSION = parse_version(opentelemetry.version.__version__)
@@ -134,6 +135,7 @@ def test_otel_start_current_span_without_default_args(oteltracer):
     otel_span.end()
 
 
+@flaky(1735812000)
 @pytest.mark.parametrize(
     "flask_wsgi_application,flask_env_arg,flask_port,flask_command",
     [

--- a/tests/opentelemetry/test_trace.py
+++ b/tests/opentelemetry/test_trace.py
@@ -37,6 +37,7 @@ def test_otel_start_span_with_default_args(oteltracer):
     otel_span.end()
 
 
+@flaky(1735812000)
 @pytest.mark.snapshot
 def test_otel_start_span_without_default_args(oteltracer):
     root = oteltracer.start_span("root-span")

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -3,6 +3,8 @@ import re
 
 import pytest
 
+from tests.utils import flaky
+
 
 def _assert_dependencies_sort_and_remove(items, is_request=True, must_have_deps=True, remove_heartbeat=True):
     """
@@ -305,6 +307,7 @@ def test_telemetry_with_raised_exception(test_agent_session, run_python_code_in_
     assert event_types == ["app-closing", "app-started", "generate-metrics"]
 
 
+@flaky(1735812000)
 def test_handled_integration_error(test_agent_session, run_python_code_in_subprocess):
     code = """
 import logging


### PR DESCRIPTION
Adds flaky decorator to failing tests in CI

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
