### PR TITLE
chore(ci): add itr:noskip check in needs_testrun.py

### DIFF
--- a/scripts/needs_testrun.py
+++ b/scripts/needs_testrun.py
@@ -59,6 +59,17 @@ def get_merge_base(pr_number: int) -> str:
 
 
 @cache
+def get_commit_message(sha: str) -> str:
+    """Get the commit message of a commit."""
+    if sha:
+        try:
+            return check_output(["git", "log", "-1", "--pretty=%B", sha]).decode("utf-8").strip()
+        except Exception:
+            pass
+    return ""
+
+
+@cache
 def get_changed_files(pr_number: int, sha: t.Optional[str] = None) -> t.Set[str]:
     """Get the files changed in a PR
 
@@ -100,6 +111,8 @@ def needs_testrun(suite: str, pr_number: int, sha: t.Optional[str] = None) -> bo
     >>> needs_testrun("foobar", 6412)
     True
     """
+    if "itr:noskip" in get_commit_message(sha):
+        return True
     try:
         patterns = get_patterns(suite)
     except Exception as exc:

--- a/scripts/needs_testrun.py
+++ b/scripts/needs_testrun.py
@@ -111,7 +111,7 @@ def needs_testrun(suite: str, pr_number: int, sha: t.Optional[str] = None) -> bo
     >>> needs_testrun("foobar", 6412)
     True
     """
-    if "itr:noskip" in get_commit_message(sha):
+    if "itr:noskip" in get_commit_message(sha).lower():
         return True
     try:
         patterns = get_patterns(suite)


### PR DESCRIPTION
Allow `itr:noskip` to be used (in commit message) to prevent skipping of tests.
In addition with `circleci:all`, it allows to run the entire test suite on a commit no matter what.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
