### PR TITLE
try putting the test agent in a separate process

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -1091,12 +1091,14 @@ jobs:
           snapshot: true
 
   redis:
-    <<: *machine_executor
+    <<: *contrib_job
+    docker:
+      - image: *ddtrace_dev_image
+      - *testagent
     steps:
       - run_test:
           docker_services: 'redis rediscluster'
           pattern: 'redis$'
-          snapshot: true
 
   rediscluster:
     <<: *machine_executor

--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -149,6 +149,8 @@ commands:
               << parameters.snapshot >>
           steps:
             - setup_riot
+            - start_docker_services:
+                services: << parameters.docker_services >>
             - when:
                 condition:
                   << parameters.wait >>

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -8,7 +8,6 @@ from ddtrace.constants import ORIGIN_KEY
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
-from tests.utils import flaky
 from tests.webclient import Client
 
 from .utils import PyramidBase
@@ -253,7 +252,6 @@ def pyramid_client(snapshot, pyramid_app):
         proc.terminate()
 
 
-@flaky(until=1704067200)
 @pytest.mark.parametrize(
     "pyramid_app",
     [


### PR DESCRIPTION
## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
