### PR TITLE
ci(wsgi): actually skip executing the problematic test instead of just xpassing it

### DIFF
--- a/tests/contrib/wsgi/test_wsgi.py
+++ b/tests/contrib/wsgi/test_wsgi.py
@@ -318,6 +318,7 @@ def test_distributed_tracing_nested():
     assert resp.status_int == 200
 
 
+# FIXME: this test breaks other tests in this file in an unpredictable pattern
 """
 def test_wsgi_traced_iterable(tracer, test_spans):
     # Regression test to ensure wsgi iterable does not define an __len__ attribute

--- a/tests/contrib/wsgi/test_wsgi.py
+++ b/tests/contrib/wsgi/test_wsgi.py
@@ -6,7 +6,6 @@ from webtest import TestApp
 
 from ddtrace import config
 from ddtrace.contrib.wsgi import wsgi
-from tests.utils import flaky
 from tests.utils import override_config
 from tests.utils import override_http_config
 from tests.utils import snapshot
@@ -259,7 +258,6 @@ def test_200():
     assert resp.status_int == 200
 
 
-@flaky(1735812000)
 @snapshot(ignores=["meta.error.stack"])
 def test_500_py3():
     app = TestApp(wsgi.DDWSGIMiddleware(application))
@@ -291,7 +289,6 @@ def test_wsgi_base_middleware(use_global_tracer, tracer):
     assert resp.status_int == 200
 
 
-@flaky(1735812000)
 @pytest.mark.snapshot(
     token="tests.contrib.wsgi.test_wsgi.test_wsgi_base_middleware_500",
     ignores=["meta.error.stack", "meta.error.type"],
@@ -321,7 +318,7 @@ def test_distributed_tracing_nested():
     assert resp.status_int == 200
 
 
-@flaky(1709662372)
+"""
 def test_wsgi_traced_iterable(tracer, test_spans):
     # Regression test to ensure wsgi iterable does not define an __len__ attribute
     middleware = wsgi.DDWSGIMiddleware(application)
@@ -341,6 +338,7 @@ def test_wsgi_traced_iterable(tracer, test_spans):
     assert hasattr(resp, "close")
     assert hasattr(resp, "next") or hasattr(resp, "__next__")
     assert not hasattr(resp, "__len__"), "Iterables should not define __len__ attribute"
+"""
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This test does what #8024 intended to do, skipping the execution of a test that has problematic side effects on other tests rather than executing it with XPASS.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
