### PR TITLE
fix(otel): ensures ids in span links are in hex

### DIFF
--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -571,8 +571,8 @@ cdef class MsgpackEncoderV03(MsgpackEncoderBase):
             # SpanLink.to_dict() returns all serializable span link fields
             d = link.to_dict()
             # Encode 128 bit trace ids usings two 64bit integers
-            d["trace_id_high"] = d["trace_id"] >> 64
-            d["trace_id"] = MAX_UINT_64BITS & d["trace_id"]
+            d["trace_id_high"] = d["trace_id"][:16]
+            d["trace_id"] = d["trace_id"][16:]
 
             ret = msgpack_pack_map(&self.pk, len(d))
             if ret != 0:

--- a/ddtrace/tracing/_span_link.py
+++ b/ddtrace/tracing/_span_link.py
@@ -80,8 +80,8 @@ class SpanLink:
 
     def to_dict(self):
         d = {
-            "trace_id": self.trace_id,
-            "span_id": self.span_id,
+            "trace_id": "{:032x}".format(self.trace_id),
+            "span_id": "{:016x}".format(self.span_id),
         }
         if self.attributes:
             d["attributes"] = {k: str(v) for k, v in self.attributes.items()}

--- a/releasenotes/notes/fix-span-link-ids-e8161faabb39f5ee.yaml
+++ b/releasenotes/notes/fix-span-link-ids-e8161faabb39f5ee.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    tracing: Fixes a critical bug that prevented span links from being visualized in the Datadog UI.

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -463,8 +463,8 @@ def test_span_link_v04_encoding():
     assert b"span_links" in decoded_span
     assert decoded_span[b"span_links"] == [
         {
-            b"trace_id": 456,
-            b"span_id": 2,
+            b"trace_id": b"00000000000001c8",
+            b"span_id": b"0000000000000002",
             b"attributes": {
                 b"moon": b"ears",
                 b"link.name": b"link_name",
@@ -474,7 +474,7 @@ def test_span_link_v04_encoding():
             b"dropped_attributes_count": 1,
             b"tracestate": b"congo=t61rcWkgMzE",
             b"flags": 1,
-            b"trace_id_high": 123,
+            b"trace_id_high": b"000000000000007b",
         }
     ]
 
@@ -487,8 +487,8 @@ def test_span_link_v05_encoding():
         context=Context(sampling_priority=1),
         links=[
             SpanLink(
-                trace_id=1,
-                span_id=2,
+                trace_id=(2**127) - 1,
+                span_id=(2**64) - 1,
                 tracestate="congo=t61rcWkgMzE",
                 flags=0,
                 attributes={"moon": "ears", "link.name": "link_name", "link.kind": "link_kind", "drop_me": "bye"},
@@ -511,9 +511,9 @@ def test_span_link_v05_encoding():
     encoded_span_meta = decoded_trace[0][0][9]
     assert b"_dd.span_links" in encoded_span_meta
     assert (
-        encoded_span_meta[b"_dd.span_links"] == b'[{"trace_id": 1, "span_id": 2, '
-        b'"attributes": {"moon": "ears", "link.name": "link_name", "link.kind": "link_kind"}, '
-        b'"dropped_attributes_count": 1, "tracestate": "congo=t61rcWkgMzE", "flags": 0}]'
+        encoded_span_meta[b"_dd.span_links"] == b'[{"trace_id": "7fffffffffffffffffffffffffffffff", '
+        b'"span_id": "ffffffffffffffff", "attributes": {"moon": "ears", "link.name": "link_name", "link.kind": '
+        b'"link_kind"}, "dropped_attributes_count": 1, "tracestate": "congo=t61rcWkgMzE", "flags": 0}]'
     )
 
 


### PR DESCRIPTION
Resolves: https://github.com/DataDog/dd-trace-py/issues/8049


## Reproduction

```
import ddtrace


with ddtrace.tracer.trace("s1", service="upstream") as s1:
    pass

with ddtrace.tracer.trace("s2", service="downstream") as s2:
    s2.link_span(
        s1.context, 
        {
            "link.name": "s1_to_s2",
            "link.kind": "scheduled_by",
            "key1": "value2",
            "key2": [True, 2, ["hello", 4, ["5", "6asda"]]],
        }
    )
```


## Datadog UI with fix

<img width="1050" alt="Screenshot 2024-01-09 at 5 43 13 PM" src="https://github.com/DataDog/dd-trace-py/assets/62392438/5380023e-1ec1-4da1-a342-6a051e92a821">


## Checklist

- [ ] Change(s) are motivated and described in the PR description.
- [ ] Testing strategy is described if automated tests are not included in the PR.
- [ ] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
