### PR TITLE
fix: workaround potencial valueerror form importlib_metadata

### DIFF
--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -98,16 +98,19 @@ def _package_file_mapping():
         mapping = {}
 
         for ilmd_d in il_md.distributions():
-            if ilmd_d is not None and ilmd_d.files is not None:
-                d = Distribution(name=ilmd_d.metadata["name"], version=ilmd_d.version, path=None)
-                for f in ilmd_d.files:
-                    if _is_python_source_file(f):
-                        # mapping[fspath(f.locate())] = d
-                        _path = fspath(f.locate())
-                        mapping[_path] = d
-                        _realp = os.path.realpath(_path)
-                        if _realp != _path:
-                            mapping[_realp] = d
+            try:
+                if ilmd_d is not None and ilmd_d.files is not None:
+                    d = Distribution(name=ilmd_d.metadata["name"], version=ilmd_d.version, path=None)
+                    for f in ilmd_d.files:
+                        if _is_python_source_file(f):
+                            # mapping[fspath(f.locate())] = d
+                            _path = fspath(f.locate())
+                            mapping[_path] = d
+                            _realp = os.path.realpath(_path)
+                            if _realp != _path:
+                                mapping[_realp] = d
+            except ValueError:
+                continue
 
         return mapping
 

--- a/releasenotes/notes/handle-potential-valueerror-on-importlib-10d14cb957cbd421.yaml
+++ b/releasenotes/notes/handle-potential-valueerror-on-importlib-10d14cb957cbd421.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Handle potencial ValueError on importlib_metadata. Fixes #8068.


### PR DESCRIPTION
## Description

Handle a potential ValueError on `importlib_metadata` used from `internal/packags.py` when one path is not a subpath of the second as a workaround of https://github.com/python/importlib_metadata/issues/455

Fixes #8068.

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate.
- [ ] No unnecessary changes are introduced.
- [ ] Description motivates each change.
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [ ] Testing strategy adequately addresses listed risk(s).
- [ ] Change is maintainable (easy to change, telemetry, documentation).
- [ ] Release note makes sense to a user of the library.
- [ ] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
