### PR TITLE
ci: skip some test_stack.py tests on 3.12

### DIFF
--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -170,6 +170,7 @@ def _fib(n):
 
 
 @pytest.mark.skipif(not TESTING_GEVENT, reason="Not testing gevent")
+@pytest.mark.skipif(sys.version_info >= (3, 12), reason="FIXME: causes segfaults in 3.12")
 @pytest.mark.subprocess(ddtrace_run=True)
 def test_collect_gevent_thread_task():
     from gevent import monkey  # noqa:F401
@@ -695,6 +696,7 @@ def test_thread_time_cache():
 
 
 @pytest.mark.skipif(not TESTING_GEVENT, reason="Not testing gevent")
+@pytest.mark.skipif(sys.version_info >= (3, 12), reason="FIXME: causes segfaults in 3.12")
 @pytest.mark.subprocess(ddtrace_run=True)
 def test_collect_gevent_threads():
     import gevent.monkey

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -21,7 +21,8 @@ from ddtrace.profiling.collector import stack_event
 from . import test_collector
 
 
-TESTING_GEVENT = os.getenv("DD_PROFILE_TEST_GEVENT", False)
+# FIXME: remove version limitation when gevent segfaults are fixed on Python 3.12
+TESTING_GEVENT = os.getenv("DD_PROFILE_TEST_GEVENT", False) and sys.version_info < (3, 12)
 
 
 def func1():
@@ -170,7 +171,6 @@ def _fib(n):
 
 
 @pytest.mark.skipif(not TESTING_GEVENT, reason="Not testing gevent")
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="FIXME: causes segfaults in 3.12")
 @pytest.mark.subprocess(ddtrace_run=True)
 def test_collect_gevent_thread_task():
     from gevent import monkey  # noqa:F401
@@ -696,7 +696,6 @@ def test_thread_time_cache():
 
 
 @pytest.mark.skipif(not TESTING_GEVENT, reason="Not testing gevent")
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="FIXME: causes segfaults in 3.12")
 @pytest.mark.subprocess(ddtrace_run=True)
 def test_collect_gevent_threads():
     import gevent.monkey


### PR DESCRIPTION
The gevent tests are known to throw segmentation faults on 3.12. Skipping them until we fix this.

This has been flaky for a while, so also backporting to assist the backport pipeline.

## Checklist

- [X] Change(s) are motivated and described in the PR description.
- [X] Testing strategy is described if automated tests are not included in the PR.
- [X] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [X] Change is maintainable (easy to change, telemetry, documentation).
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
