### PR TITLE
fix(span_links): revert regression in v04 encoding

### DIFF
--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -571,8 +571,10 @@ cdef class MsgpackEncoderV03(MsgpackEncoderBase):
             # SpanLink.to_dict() returns all serializable span link fields
             d = link.to_dict()
             # Encode 128 bit trace ids usings two 64bit integers
-            d["trace_id_high"] = d["trace_id"][:16]
-            d["trace_id"] = d["trace_id"][16:]
+            d["trace_id_high"] = int(d["trace_id"][:16], 16)
+            d["trace_id"] = int(d["trace_id"][16:], 16)
+            # span id should be uint64 in v0.4 (it is hex in v0.5)
+            d["span_id"] = int(d["span_id"], 16)
 
             ret = msgpack_pack_map(&self.pk, len(d))
             if ret != 0:

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -464,8 +464,8 @@ def test_span_link_v04_encoding():
     assert b"span_links" in decoded_span
     assert decoded_span[b"span_links"] == [
         {
-            b"trace_id": b"00000000000001c8",
-            b"span_id": b"0000000000000002",
+            b"trace_id": 456,
+            b"span_id": 2,
             b"attributes": {
                 b"moon": b"ears",
                 b"link.name": b"link_name",
@@ -480,7 +480,7 @@ def test_span_link_v04_encoding():
             b"dropped_attributes_count": 1,
             b"tracestate": b"congo=t61rcWkgMzE",
             b"flags": 1,
-            b"trace_id_high": b"000000000000007b",
+            b"trace_id_high": 123,
         }
     ]
 


### PR DESCRIPTION
Partially Reverts: https://github.com/DataDog/dd-trace-py/pull/8054

This regression is unreleased so a release note is not required [if we can get this fix on the 2.5, 2.4, and 2.3 release lines fast enough] 

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
