### PR TITLE
chore(asm): add new api security env var support

### DIFF
--- a/ddtrace/appsec/_api_security/api_manager.py
+++ b/ddtrace/appsec/_api_security/api_manager.py
@@ -38,10 +38,8 @@ class APIManager(Service):
         ("REQUEST_PATH_PARAMS", API_SECURITY.REQUEST_PATH_PARAMS, dict),
         ("REQUEST_BODY", API_SECURITY.REQUEST_BODY, None),
         ("RESPONSE_HEADERS_NO_COOKIES", API_SECURITY.RESPONSE_HEADERS_NO_COOKIES, dict),
+        ("RESPONSE_BODY", API_SECURITY.RESPONSE_BODY, None),
     ]
-
-    if asm_config._api_security_parse_response_body:
-        COLLECTED.append(("RESPONSE_BODY", API_SECURITY.RESPONSE_BODY, None))
 
     _instance = None  # type: Optional[APIManager]
 
@@ -129,6 +127,8 @@ class APIManager(Service):
 
         waf_payload = {}
         for address, _, transform in self.COLLECTED:
+            if not asm_config._api_security_parse_response_body and address == "RESPONSE_BODY":
+                continue
             value = env.waf_addresses.get(SPAN_DATA_NAMES[address], _sentinel)
             if value is _sentinel:
                 log.debug("no value for %s", address)

--- a/ddtrace/appsec/_api_security/api_manager.py
+++ b/ddtrace/appsec/_api_security/api_manager.py
@@ -38,8 +38,10 @@ class APIManager(Service):
         ("REQUEST_PATH_PARAMS", API_SECURITY.REQUEST_PATH_PARAMS, dict),
         ("REQUEST_BODY", API_SECURITY.REQUEST_BODY, None),
         ("RESPONSE_HEADERS_NO_COOKIES", API_SECURITY.RESPONSE_HEADERS_NO_COOKIES, dict),
-        ("RESPONSE_BODY", API_SECURITY.RESPONSE_BODY, None),
     ]
+
+    if asm_config._api_security_parse_response_body:
+        COLLECTED.append(("RESPONSE_BODY", API_SECURITY.RESPONSE_BODY, None))
 
     _instance = None  # type: Optional[APIManager]
 

--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -489,7 +489,7 @@ def _set_headers_and_response(response, headers, *_):
             else:
                 list_headers = list(headers)
             set_headers_response(list_headers)
-        if response:
+        if response and asm_config._api_security_parse_response_body:
             set_body_response(response)
 
 

--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -131,7 +131,9 @@ class SPAN_DATA_NAMES(metaclass=Constant_Class):
 class API_SECURITY(metaclass=Constant_Class):
     """constants related to API Security"""
 
+    ENABLED = "_dd.appsec.api_security.enabled"
     ENV_VAR_ENABLED = "DD_EXPERIMENTAL_API_SECURITY_ENABLED"
+    PARSE_RESPONSE_BODY = "DD_API_SECURITY_PARSE_RESPONSE_BODY"
     REQUEST_HEADERS_NO_COOKIES = "_dd.appsec.s.req.headers"
     REQUEST_COOKIES = "_dd.appsec.s.req.cookies"
     REQUEST_QUERY = "_dd.appsec.s.req.query"
@@ -140,7 +142,6 @@ class API_SECURITY(metaclass=Constant_Class):
     RESPONSE_HEADERS_NO_COOKIES = "_dd.appsec.s.res.headers"
     RESPONSE_BODY = "_dd.appsec.s.res.body"
     SAMPLE_RATE = "DD_API_SECURITY_REQUEST_SAMPLE_RATE"
-    ENABLED = "_dd.appsec.api_security.enabled"
     MAX_PAYLOAD_SIZE = 0x1000000  # 16MB maximum size
 
 

--- a/ddtrace/settings/asm.py
+++ b/ddtrace/settings/asm.py
@@ -23,6 +23,7 @@ class ASMConfig(Env):
     _iast_enabled = Env.var(bool, IAST_ENV, default=False)
     _api_security_enabled = Env.var(bool, API_SECURITY.ENV_VAR_ENABLED, default=False)
     _api_security_sample_rate = Env.var(float, API_SECURITY.SAMPLE_RATE, validator=_validate_sample_rate, default=0.1)
+    _api_security_parse_response_body = Env.var(bool, API_SECURITY.PARSE_RESPONSE_BODY, default=True)
     _waf_timeout = Env.var(
         float,
         "DD_APPSEC_WAF_TIMEOUT",

--- a/ddtrace/settings/asm.py
+++ b/ddtrace/settings/asm.py
@@ -59,6 +59,7 @@ class ASMConfig(Env):
         "_user_model_name_field",
         "_api_security_enabled",
         "_api_security_sample_rate",
+        "_api_security_parse_response_body",
         "_waf_timeout",
         "_iast_redaction_enabled",
         "_iast_redaction_name_pattern",

--- a/tests/contrib/fastapi/test_fastapi_appsec_api_security.py
+++ b/tests/contrib/fastapi/test_fastapi_appsec_api_security.py
@@ -14,7 +14,6 @@ from ddtrace.contrib.fastapi import unpatch as fastapi_unpatch
 from tests.appsec.appsec.api_security.test_schema_fuzz import equal_with_meta
 from tests.utils import DummyTracer
 from tests.utils import TracerSpanContainer
-from tests.utils import override_env
 from tests.utils import override_global_config
 
 from . import app as fastapi_app
@@ -110,9 +109,7 @@ def test_api_security(app, client, tracer, test_spans, name, expected_value):
 
     payload = {"key": "secret", "ids": [0, 1, 2, 3]}
 
-    with override_global_config(
-        dict(_asm_enabled=True, _api_security_enabled=True, _api_security_sample_rate=1.0)
-    ), override_env({API_SECURITY.SAMPLE_RATE: "1.0"}):
+    with override_global_config(dict(_asm_enabled=True, _api_security_enabled=True, _api_security_sample_rate=1.0)):
         _aux_appsec_prepare_tracer(tracer)
         resp = client.post(
             "/response-header-apisec/posting?x=2&extended=345&x=3",
@@ -138,9 +135,7 @@ def test_api_security_scanners(app, client, tracer, test_spans):
 
     payload = {"key": "secret", "ids": [0, 1, 2, 3]}
 
-    with override_global_config(
-        dict(_asm_enabled=True, _api_security_enabled=True, _api_security_sample_rate=1.0)
-    ), override_env({API_SECURITY.SAMPLE_RATE: "1.0"}):
+    with override_global_config(dict(_asm_enabled=True, _api_security_enabled=True, _api_security_sample_rate=1.0)):
         _aux_appsec_prepare_tracer(tracer)
         resp = client.post(
             "/response-header-apisec/posting?x=2&extended=345&x=3",

--- a/tests/contrib/flask/test_appsec_api_security.py
+++ b/tests/contrib/flask/test_appsec_api_security.py
@@ -11,7 +11,6 @@ from ddtrace.contrib.sqlite3.patch import patch
 from ddtrace.settings.asm import config as asm_config
 from tests.appsec.appsec.api_security.test_schema_fuzz import equal_with_meta
 from tests.contrib.flask import BaseFlaskTestCase
-from tests.utils import override_env
 from tests.utils import override_global_config
 
 
@@ -47,9 +46,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
 
         payload = {"key": "secret", "ids": [0, 1, 2, 3]}
 
-        with override_global_config(
-            dict(_asm_enabled=True, _api_security_enabled=True, _api_security_sample_rate=1.0)
-        ), override_env({API_SECURITY.SAMPLE_RATE: "1.0"}):
+        with override_global_config(dict(_asm_enabled=True, _api_security_enabled=True, _api_security_sample_rate=1.0)):
             self._aux_appsec_prepare_tracer()
             self.client.set_cookie("localhost", "secret", "a1b2c3d4e5f6")
             resp = self.client.post(
@@ -92,9 +89,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
 
         payload = {"key": "secret", "ids": [0, 1, 2, 3]}
 
-        with override_global_config(
-            dict(_asm_enabled=True, _api_security_enabled=True, _api_security_sample_rate=1.0)
-        ), override_env({API_SECURITY.SAMPLE_RATE: "1.0"}):
+        with override_global_config(dict(_asm_enabled=True, _api_security_enabled=True, _api_security_sample_rate=1.0)):
             self._aux_appsec_prepare_tracer()
             self.client.set_cookie("localhost", "secret", "a1b2c3d4e5f6")
             resp = self.client.post(
@@ -140,8 +135,8 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
 
         payload = {"key": "secret", "ids": [0, 1, 2, 3]}
         # appsec disabled must not block
-        with override_global_config(dict(_asm_enabled=False, _api_security_enabled=False)), override_env(
-            {API_SECURITY.SAMPLE_RATE: "1.0"}
+        with override_global_config(
+            dict(_asm_enabled=False, _api_security_enabled=False, _api_security_sample_rate=1.0)
         ):
             self._aux_appsec_prepare_tracer(appsec_enabled=False)
             self.client.set_cookie("localhost", "secret", "a1b2c3d4e5f6")


### PR DESCRIPTION
Improve support of RFC "Tracer Schema Extraction Integration" last additions by adding new configuration option via env var with `DD_API_SECURITY_PARSE_RESPONSE_BODY`

Improve unit tests for Django for api security to check for that parameter. Use parametrization to improve the test reports.

This will also be tested in new system tests with https://github.com/DataDog/system-tests/pull/2023

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
