### PR TITLE
chore(tests):  move asm overridable config keys for tests into asm config

### DIFF
--- a/ddtrace/settings/asm.py
+++ b/ddtrace/settings/asm.py
@@ -15,12 +15,12 @@ def _validate_sample_rate(r: float) -> None:
 
 class ASMConfig(Env):
     _asm_enabled = Env.var(bool, APPSEC_ENV, default=False)
+    _iast_enabled = Env.var(bool, IAST_ENV, default=False)
 
     _automatic_login_events_mode = Env.var(str, APPSEC.AUTOMATIC_USER_EVENTS_TRACKING, default="safe")
     _user_model_login_field = Env.var(str, APPSEC.USER_MODEL_LOGIN_FIELD, default="")
     _user_model_email_field = Env.var(str, APPSEC.USER_MODEL_EMAIL_FIELD, default="")
     _user_model_name_field = Env.var(str, APPSEC.USER_MODEL_NAME_FIELD, default="")
-    _iast_enabled = Env.var(bool, IAST_ENV, default=False)
     _api_security_enabled = Env.var(bool, API_SECURITY.ENV_VAR_ENABLED, default=False)
     _api_security_sample_rate = Env.var(float, API_SECURITY.SAMPLE_RATE, validator=_validate_sample_rate, default=0.1)
     _waf_timeout = Env.var(
@@ -47,6 +47,24 @@ class ASMConfig(Env):
         + r"[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}",
     )
     _iast_lazy_taint = Env.var(bool, IAST.LAZY_TAINT, default=False)
+
+    # for tests purposes
+    _asm_config_keys = [
+        "_asm_enabled",
+        "_iast_enabled",
+        "_automatic_login_events_mode",
+        "_user_model_login_field",
+        "_user_model_email_field",
+        "_user_model_name_field",
+        "_api_security_enabled",
+        "_api_security_sample_rate",
+        "_waf_timeout",
+        "_iast_redaction_enabled",
+        "_iast_redaction_name_pattern",
+        "_iast_redaction_value_pattern",
+        "_iast_lazy_taint",
+        "_asm_config_keys",
+    ]
 
 
 config = ASMConfig()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -33,6 +33,7 @@ from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import parse_tags_str
 from ddtrace.internal.writer import AgentWriter
 from ddtrace.propagation.http import _DatadogMultiHeader
+from ddtrace.settings.asm import config as asm_config
 from ddtrace.vendor import wrapt
 from tests.subprocesstest import SubprocessTestCase
 
@@ -140,17 +141,7 @@ def override_global_config(values):
         "_telemetry_dependency_collection",
     ]
 
-    asm_config_keys = [
-        "_asm_enabled",
-        "_api_security_enabled",
-        "_api_security_sample_rate",
-        "_waf_timeout",
-        "_iast_enabled",
-        "_automatic_login_events_mode",
-        "_user_model_login_field",
-        "_user_model_email_field",
-        "_user_model_name_field",
-    ]
+    asm_config_keys = asm_config._asm_config_keys
 
     subscriptions = ddtrace.config._subscriptions
     ddtrace.config._subscriptions = []


### PR DESCRIPTION
`override_global_config` allows tests to use different global config options.
This PR moves the list of asm global config options into asm owned config file.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
