### PR TITLE
docs: add caveat note for DD_TRACE_SAMPLING_RULES

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -242,7 +242,8 @@ The following environment variables for the tracer are supported:
 
          **Example:** ``DD_TRACE_SAMPLING_RULES='[{"sample_rate":0.5,"service":"my-service","resource":"my-url","tags":{"my-tag":"example"}}]'``
 
-         **Note** that the JSON object must be included in single quotes (') to avoid problems with escaping of the double quote (") character.
+         **Note** that the JSON object must be included in single quotes (') to avoid problems with escaping of the double quote (") character.'
+         **Note** Tag and resource values must be passed in upon span start, or else they will not be evaluated. There is work planned to improve this.
      version_added:
        v1.19.0: added support for "resource"
        v1.20.0: added support for "tags"


### PR DESCRIPTION
Per solutions request, this part of the feature is currently a bit confusing and may mislead users to some degree. Work to fix this (lazy sampling) is planned for this quarter.
## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
