### PR TITLE
fix(otel): ensure booleans have json compatible representation

### DIFF
--- a/ddtrace/tracing/_span_link.py
+++ b/ddtrace/tracing/_span_link.py
@@ -91,6 +91,9 @@ class SpanLink:
                 # flatten all values with the type list, tuple and set
                 for k1, v1 in flatten_key_value(k, v).items():
                     # convert all values to string
+                    if isinstance(v1, bool):
+                        # convert bool to lowercase string to be consistent with json encoding
+                        v1 = "true" if v1 else "false"
                     d["attributes"][k1] = str(v1)
 
         if self._dropped_attributes > 0:

--- a/ddtrace/tracing/_span_link.py
+++ b/ddtrace/tracing/_span_link.py
@@ -91,10 +91,13 @@ class SpanLink:
                 # flatten all values with the type list, tuple and set
                 for k1, v1 in flatten_key_value(k, v).items():
                     # convert all values to string
-                    if isinstance(v1, bool):
+                    if isinstance(v1, str):
+                        d["attributes"][k1] = v1
+                    elif isinstance(v1, bool):
                         # convert bool to lowercase string to be consistent with json encoding
-                        v1 = "true" if v1 else "false"
-                    d["attributes"][k1] = str(v1)
+                        d["attributes"][k1] = str(v1).lower()
+                    else:
+                        d["attributes"][k1] = str(v1)
 
         if self._dropped_attributes > 0:
             d["dropped_attributes_count"] = self._dropped_attributes

--- a/releasenotes/notes/otel-span-links-json-encoding-b91b3923d19e78fb.yaml
+++ b/releasenotes/notes/otel-span-links-json-encoding-b91b3923d19e78fb.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    opentelemetry: Ensures that span links are serialized in a json-compatible representation.

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -471,7 +471,7 @@ def test_span_link_v04_encoding():
                 b"link.name": b"link_name",
                 b"link.kind": b"link_kind",
                 b"someval": b"1",
-                b"key_other.0": b"True",
+                b"key_other.0": b"true",
                 b"key_other.1": b"2",
                 b"key_other.2.0": b"hello",
                 b"key_other.2.1": b"4",
@@ -502,7 +502,7 @@ def test_span_link_v05_encoding():
                     "link.name": "link_name",
                     "link.kind": "link_kind",
                     "drop_me": "bye",
-                    "key2": [True, 2, ["hello", 4, {"5"}]],
+                    "key2": ["false", 2, ["hello", 4, {"5"}]],
                 },
             )
         ],
@@ -525,7 +525,7 @@ def test_span_link_v05_encoding():
     assert (
         encoded_span_meta[b"_dd.span_links"] == b'[{"trace_id": "7fffffffffffffffffffffffffffffff", '
         b'"span_id": "ffffffffffffffff", "attributes": {"moon": "ears", "link.name": "link_name", "link.kind": '
-        b'"link_kind", "key2.0": "True", "key2.1": "2", "key2.2.0": "hello", "key2.2.1": "4", "key2.2.2.0": "5"}, '
+        b'"link_kind", "key2.0": "false", "key2.1": "2", "key2.2.0": "hello", "key2.2.1": "4", "key2.2.2.0": "5"}, '
         b'"dropped_attributes_count": 1, "tracestate": "congo=t61rcWkgMzE", "flags": 0}]'
     )
 


### PR DESCRIPTION
Booleans in span links are currently serialized as strings with uppercase letters (ex: `True`/`False`). This format is incompatible with json's representation of strings. To address this issue we ensure booleans are converted to a lowercase string (`true`/`false`).

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
