### PR TITLE
chore(datastreams): botocore - dsm core API refactor

### DIFF
--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -1,5 +1,5 @@
 """
-Trace queries aws api done via botocore client
+Trace queries and data streams monitoring to aws api done via botocore client
 """
 import collections
 import os
@@ -221,6 +221,8 @@ def patched_api_call_fallback(original_func, instance, args, kwargs, function_va
                             params,
                             span,
                             endpoint_service=endpoint_name,
+                            pin=pin,
+                            data_streams_enabled=config._data_streams_enabled,
                         )
                         span.name = schematize_cloud_messaging_operation(
                             trace_operation,
@@ -233,6 +235,8 @@ def patched_api_call_fallback(original_func, instance, args, kwargs, function_va
                             params,
                             span,
                             endpoint_service=endpoint_name,
+                            pin=pin,
+                            data_streams_enabled=config._data_streams_enabled,
                         )
                         span.name = schematize_cloud_messaging_operation(
                             trace_operation,

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -1,5 +1,5 @@
 """
-Trace queries and data streams monitoring to aws api done via botocore client
+Trace queries to aws api done via botocore client
 """
 import collections
 import os
@@ -221,8 +221,6 @@ def patched_api_call_fallback(original_func, instance, args, kwargs, function_va
                             params,
                             span,
                             endpoint_service=endpoint_name,
-                            pin=pin,
-                            data_streams_enabled=config._data_streams_enabled,
                         )
                         span.name = schematize_cloud_messaging_operation(
                             trace_operation,
@@ -235,8 +233,6 @@ def patched_api_call_fallback(original_func, instance, args, kwargs, function_va
                             params,
                             span,
                             endpoint_service=endpoint_name,
-                            pin=pin,
-                            data_streams_enabled=config._data_streams_enabled,
                         )
                         span.name = schematize_cloud_messaging_operation(
                             trace_operation,

--- a/ddtrace/contrib/botocore/patch.py
+++ b/ddtrace/contrib/botocore/patch.py
@@ -1,5 +1,5 @@
 """
-Trace queries and data streams monitoring to aws api done via botocore client
+Trace queries aws api done via botocore client
 """
 import collections
 import os
@@ -221,8 +221,6 @@ def patched_api_call_fallback(original_func, instance, args, kwargs, function_va
                             params,
                             span,
                             endpoint_service=endpoint_name,
-                            pin=pin,
-                            data_streams_enabled=config._data_streams_enabled,
                         )
                         span.name = schematize_cloud_messaging_operation(
                             trace_operation,
@@ -235,8 +233,6 @@ def patched_api_call_fallback(original_func, instance, args, kwargs, function_va
                             params,
                             span,
                             endpoint_service=endpoint_name,
-                            pin=pin,
-                            data_streams_enabled=config._data_streams_enabled,
                         )
                         span.name = schematize_cloud_messaging_operation(
                             trace_operation,

--- a/ddtrace/contrib/botocore/services/kinesis.py
+++ b/ddtrace/contrib/botocore/services/kinesis.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import json
 from typing import Any  # noqa:F401
 from typing import Dict  # noqa:F401
@@ -10,6 +9,7 @@ import botocore.exceptions
 
 from ddtrace import Span  # noqa:F401
 from ddtrace import config
+from ddtrace.internal import core
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
 from ....ext import SpanTypes
@@ -22,7 +22,6 @@ from ....pin import Pin  # noqa:F401
 from ....propagation.http import HTTPPropagator
 from ..utils import extract_DD_context
 from ..utils import get_kinesis_data_object
-from ..utils import get_pathway
 from ..utils import set_patched_api_call_span_tags
 from ..utils import set_response_metadata_tags
 
@@ -35,16 +34,6 @@ MAX_KINESIS_DATA_SIZE = 1 << 20  # 1MB
 
 class TraceInjectionSizeExceed(Exception):
     pass
-
-
-def get_stream_arn(params):
-    # type: (str) -> str
-    """
-    :params: contains the params for the current botocore action
-    Return the name of the stream given the params
-    """
-    stream_arn = params.get("StreamARN", "")
-    return stream_arn
 
 
 def inject_trace_to_kinesis_stream_data(record, span):
@@ -81,44 +70,14 @@ def inject_trace_to_kinesis_stream_data(record, span):
         record["Data"] = data_json
 
 
-def record_data_streams_path_for_kinesis_stream(pin, params, results, span):
-    stream_arn = params.get("StreamARN")
-
-    if not stream_arn:
-        log.debug("Unable to determine StreamARN for request with params: ", params)
-        return
-
-    processor = pin.tracer.data_streams_processor
-    pathway = processor.new_pathway()
-    for record in results.get("Records", []):
-        time_estimate = record.get("ApproximateArrivalTimestamp", datetime.now()).timestamp()
-        pathway.set_checkpoint(
-            ["direction:in", "topic:" + stream_arn, "type:kinesis"],
-            edge_start_sec_override=time_estimate,
-            pathway_start_sec_override=time_estimate,
-            span=span,
-        )
-
-
-def inject_trace_to_kinesis_stream(params, span, pin=None, data_streams_enabled=False):
-    # type: (List[Any], Span, Optional[Pin], Optional[bool]) -> None
+def inject_trace_to_kinesis_stream(params, span):
+    # type: (List[Any], Span) -> None
     """
     :params: contains the params for the current botocore action
     :span: the span which provides the trace context to be propagated
-    :pin: patch info for the botocore client
-    :data_streams_enabled: boolean for whether data streams monitoring is enabled
     Max data size per record is 1MB (https://aws.amazon.com/kinesis/data-streams/faqs/)
     """
-    if data_streams_enabled:
-        stream_arn = get_stream_arn(params)
-        if stream_arn:  # If stream ARN isn't specified, we give up (it is not a required param)
-            # put_records has a "Records" entry but put_record does not, so we fake a record to
-            # collapse the logic for the two cases
-            for _ in params.get("Records", ["fake_record"]):
-                # In other DSM code, you'll see the pathway + context injection but not here.
-                # Kinesis DSM doesn't inject any data, so we only need to generate checkpoints.
-                get_pathway(pin, "kinesis", stream_arn, span)
-
+    core.dispatch("botocore.kinesis.start", [params])
     if "Records" in params:
         records = params["Records"]
 
@@ -147,7 +106,9 @@ def patched_kinesis_api_call(original_func, instance, args, kwargs, function_var
         try:
             start_ns = time_ns()
             func_run = True
+            core.dispatch(f"botocore.{endpoint_name}.{operation}.pre", [params])
             result = original_func(*args, **kwargs)
+            core.dispatch(f"botocore.{endpoint_name}.{operation}.post", [params, result])
         except Exception as e:
             func_run_err = e
         if result is not None and "Records" in result and len(result["Records"]) >= 1:
@@ -180,7 +141,7 @@ def patched_kinesis_api_call(original_func, instance, args, kwargs, function_var
                 try:
                     if endpoint_name == "kinesis" and operation in {"PutRecord", "PutRecords"}:
                         inject_trace_to_kinesis_stream(
-                            params, span, pin=pin, data_streams_enabled=config._data_streams_enabled
+                            params, span
                         )
                         span.name = schematize_cloud_messaging_operation(
                             trace_operation,
@@ -193,13 +154,9 @@ def patched_kinesis_api_call(original_func, instance, args, kwargs, function_var
 
             try:
                 if not func_run:
+                    core.dispatch(f"botocore.{endpoint_name}.{operation}.pre", [params])
                     result = original_func(*args, **kwargs)
-
-                if endpoint_name == "kinesis" and operation == "GetRecords" and config._data_streams_enabled:
-                    try:
-                        record_data_streams_path_for_kinesis_stream(pin, params, result, span)
-                    except Exception:
-                        log.debug("Failed to report data streams monitoring info for kinesis", exc_info=True)
+                    core.dispatch(f"botocore.{endpoint_name}.{operation}.post", [params, result])
 
                 # raise error if it was encountered before the span was started
                 if func_run_err:

--- a/ddtrace/contrib/botocore/services/kinesis.py
+++ b/ddtrace/contrib/botocore/services/kinesis.py
@@ -140,9 +140,7 @@ def patched_kinesis_api_call(original_func, instance, args, kwargs, function_var
             if args and config.botocore["distributed_tracing"]:
                 try:
                     if endpoint_name == "kinesis" and operation in {"PutRecord", "PutRecords"}:
-                        inject_trace_to_kinesis_stream(
-                            params, span
-                        )
+                        inject_trace_to_kinesis_stream(params, span)
                         span.name = schematize_cloud_messaging_operation(
                             trace_operation,
                             cloud_provider="aws",

--- a/ddtrace/contrib/botocore/services/kinesis.py
+++ b/ddtrace/contrib/botocore/services/kinesis.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import json
 from typing import Any  # noqa:F401
 from typing import Dict  # noqa:F401
@@ -9,7 +10,6 @@ import botocore.exceptions
 
 from ddtrace import Span  # noqa:F401
 from ddtrace import config
-from ddtrace.internal import core
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
 from ....ext import SpanTypes
@@ -22,6 +22,7 @@ from ....pin import Pin  # noqa:F401
 from ....propagation.http import HTTPPropagator
 from ..utils import extract_DD_context
 from ..utils import get_kinesis_data_object
+from ..utils import get_pathway
 from ..utils import set_patched_api_call_span_tags
 from ..utils import set_response_metadata_tags
 
@@ -34,6 +35,16 @@ MAX_KINESIS_DATA_SIZE = 1 << 20  # 1MB
 
 class TraceInjectionSizeExceed(Exception):
     pass
+
+
+def get_stream_arn(params):
+    # type: (str) -> str
+    """
+    :params: contains the params for the current botocore action
+    Return the name of the stream given the params
+    """
+    stream_arn = params.get("StreamARN", "")
+    return stream_arn
 
 
 def inject_trace_to_kinesis_stream_data(record, span):
@@ -70,14 +81,43 @@ def inject_trace_to_kinesis_stream_data(record, span):
         record["Data"] = data_json
 
 
-def inject_trace_to_kinesis_stream(params, span):
-    # type: (List[Any], Span) -> None
+def record_data_streams_path_for_kinesis_stream(pin, params, results, span):
+    stream_arn = params.get("StreamARN")
+
+    if not stream_arn:
+        log.debug("Unable to determine StreamARN for request with params: ", params)
+        return
+
+    processor = pin.tracer.data_streams_processor
+    pathway = processor.new_pathway()
+    for record in results.get("Records", []):
+        time_estimate = record.get("ApproximateArrivalTimestamp", datetime.now()).timestamp()
+        pathway.set_checkpoint(
+            ["direction:in", "topic:" + stream_arn, "type:kinesis"],
+            edge_start_sec_override=time_estimate,
+            pathway_start_sec_override=time_estimate,
+            span=span,
+        )
+
+
+def inject_trace_to_kinesis_stream(params, span, pin=None, data_streams_enabled=False):
+    # type: (List[Any], Span, Optional[Pin], Optional[bool]) -> None
     """
     :params: contains the params for the current botocore action
     :span: the span which provides the trace context to be propagated
+    :pin: patch info for the botocore client
+    :data_streams_enabled: boolean for whether data streams monitoring is enabled
     Max data size per record is 1MB (https://aws.amazon.com/kinesis/data-streams/faqs/)
     """
-    core.dispatch("botocore.kinesis.start", [params])
+    if data_streams_enabled:
+        stream_arn = get_stream_arn(params)
+        if stream_arn:  # If stream ARN isn't specified, we give up (it is not a required param)
+            # put_records has a "Records" entry but put_record does not, so we fake a record to
+            # collapse the logic for the two cases
+            for _ in params.get("Records", ["fake_record"]):
+                # In other DSM code, you'll see the pathway + context injection but not here.
+                # Kinesis DSM doesn't inject any data, so we only need to generate checkpoints.
+                get_pathway(pin, "kinesis", stream_arn, span)
 
     if "Records" in params:
         records = params["Records"]
@@ -139,7 +179,9 @@ def patched_kinesis_api_call(original_func, instance, args, kwargs, function_var
             if args and config.botocore["distributed_tracing"]:
                 try:
                     if endpoint_name == "kinesis" and operation in {"PutRecord", "PutRecords"}:
-                        inject_trace_to_kinesis_stream(params, span)
+                        inject_trace_to_kinesis_stream(
+                            params, span, pin=pin, data_streams_enabled=config._data_streams_enabled
+                        )
                         span.name = schematize_cloud_messaging_operation(
                             trace_operation,
                             cloud_provider="aws",

--- a/ddtrace/contrib/botocore/services/sqs.py
+++ b/ddtrace/contrib/botocore/services/sqs.py
@@ -8,18 +8,21 @@ import botocore.exceptions
 
 from ddtrace import Span  # noqa:F401
 from ddtrace import config
-from ddtrace.internal import core
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
 from ....ext import SpanTypes
 from ....ext import http
 from ....internal.compat import time_ns
+from ....internal.datastreams.processor import PROPAGATION_KEY_BASE_64
 from ....internal.logger import get_logger
 from ....internal.schema import schematize_cloud_messaging_operation
 from ....internal.schema import schematize_service_name
 from ....pin import Pin  # noqa:F401
 from ....propagation.http import HTTPPropagator
 from ..utils import extract_DD_context
+from ..utils import extract_trace_context_json
+from ..utils import get_pathway
+from ..utils import get_queue_name
 from ..utils import set_patched_api_call_span_tags
 from ..utils import set_response_metadata_tags
 
@@ -33,6 +36,16 @@ def _encode_data(trace_data):
     moto doesn't support auto-encoded SNS -> SQS as binary with RawDelivery enabled
     """
     return json.dumps(trace_data)
+
+
+def get_topic_arn(params):
+    # type: (str) -> str
+    """
+    :params: contains the params for the current botocore action
+    Return the name of the topic given the params
+    """
+    sns_arn = params.get("TopicArn")
+    return sns_arn
 
 
 def inject_trace_data_to_message_attributes(trace_data, entry, endpoint_service=None):
@@ -66,13 +79,15 @@ def inject_trace_data_to_message_attributes(trace_data, entry, endpoint_service=
         log.warning("skipping trace injection, max number (10) of MessageAttributes exceeded")
 
 
-def inject_trace_to_sqs_or_sns_batch_message(params, span, endpoint_service=None):
-    # type: (Any, Span, Optional[str]) -> None
+def inject_trace_to_sqs_or_sns_batch_message(params, span, endpoint_service=None, pin=None, data_streams_enabled=False):
+    # type: (Any, Span, Optional[str], Optional[Pin], Optional[bool]) -> None
     """
     :params: contains the params for the current botocore action
     :span: the span which provides the trace context to be propagated
     :endpoint_service: endpoint of message, "sqs" or "sns"
-    Inject trace headers info into MessageAttributes for all SQS or SNS records inside a batch
+    :pin: patch info for the botocore client
+    :data_streams_enabled: boolean for whether data streams monitoring is enabled
+    Inject trace headers and DSM info into MessageAttributes for all SQS or SNS records inside a batch
     """
 
     trace_data = {}
@@ -84,24 +99,39 @@ def inject_trace_to_sqs_or_sns_batch_message(params, span, endpoint_service=None
     entries = params.get("Entries", params.get("PublishBatchRequestEntries", []))
     if len(entries) != 0:
         for entry in entries:
-            core.dispatch("botocore.sqs_sns.start", [endpoint_service, trace_data, params])
+            if data_streams_enabled:
+                dsm_identifier = None
+                if endpoint_service == "sqs":
+                    dsm_identifier = get_queue_name(params)
+                elif endpoint_service == "sns":
+                    dsm_identifier = get_topic_arn(params)
+                trace_data[PROPAGATION_KEY_BASE_64] = get_pathway(pin, endpoint_service, dsm_identifier, span)
             inject_trace_data_to_message_attributes(trace_data, entry, endpoint_service)
     else:
         log.warning("Skipping injecting Datadog attributes to records, no records available")
 
 
-def inject_trace_to_sqs_or_sns_message(params, span, endpoint_service=None):
-    # type: (Any, Span, Optional[str]) -> None
+def inject_trace_to_sqs_or_sns_message(params, span, endpoint_service=None, pin=None, data_streams_enabled=False):
+    # type: (Any, Span, Optional[str], Optional[Pin], Optional[bool]) -> None
     """
     :params: contains the params for the current botocore action
     :span: the span which provides the trace context to be propagated
     :endpoint_service: endpoint of message, "sqs" or "sns"
-    Inject trace headers info into MessageAttributes for the SQS or SNS record
+    :pin: patch info for the botocore client
+    :data_streams_enabled: boolean for whether data streams monitoring is enabled
+    Inject trace headers and DSM info into MessageAttributes for the SQS or SNS record
     """
     trace_data = {}
     HTTPPropagator.inject(span.context, trace_data)
 
-    core.dispatch("botocore.sqs_sns.start", [endpoint_service, trace_data, params])
+    if data_streams_enabled:
+        dsm_identifier = None
+        if endpoint_service == "sqs":
+            dsm_identifier = get_queue_name(params)
+        elif endpoint_service == "sns":
+            dsm_identifier = get_topic_arn(params)
+
+        trace_data[PROPAGATION_KEY_BASE_64] = get_pathway(pin, endpoint_service, dsm_identifier, span)
 
     inject_trace_data_to_message_attributes(trace_data, params, endpoint_service)
 

--- a/ddtrace/contrib/botocore/services/sqs.py
+++ b/ddtrace/contrib/botocore/services/sqs.py
@@ -8,21 +8,18 @@ import botocore.exceptions
 
 from ddtrace import Span  # noqa:F401
 from ddtrace import config
+from ddtrace.internal import core
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
 from ....ext import SpanTypes
 from ....ext import http
 from ....internal.compat import time_ns
-from ....internal.datastreams.processor import PROPAGATION_KEY_BASE_64
 from ....internal.logger import get_logger
 from ....internal.schema import schematize_cloud_messaging_operation
 from ....internal.schema import schematize_service_name
 from ....pin import Pin  # noqa:F401
 from ....propagation.http import HTTPPropagator
 from ..utils import extract_DD_context
-from ..utils import extract_trace_context_json
-from ..utils import get_pathway
-from ..utils import get_queue_name
 from ..utils import set_patched_api_call_span_tags
 from ..utils import set_response_metadata_tags
 
@@ -36,16 +33,6 @@ def _encode_data(trace_data):
     moto doesn't support auto-encoded SNS -> SQS as binary with RawDelivery enabled
     """
     return json.dumps(trace_data)
-
-
-def get_topic_arn(params):
-    # type: (str) -> str
-    """
-    :params: contains the params for the current botocore action
-    Return the name of the topic given the params
-    """
-    sns_arn = params.get("TopicArn")
-    return sns_arn
 
 
 def inject_trace_data_to_message_attributes(trace_data, entry, endpoint_service=None):
@@ -79,15 +66,13 @@ def inject_trace_data_to_message_attributes(trace_data, entry, endpoint_service=
         log.warning("skipping trace injection, max number (10) of MessageAttributes exceeded")
 
 
-def inject_trace_to_sqs_or_sns_batch_message(params, span, endpoint_service=None, pin=None, data_streams_enabled=False):
-    # type: (Any, Span, Optional[str], Optional[Pin], Optional[bool]) -> None
+def inject_trace_to_sqs_or_sns_batch_message(params, span, endpoint_service=None):
+    # type: (Any, Span, Optional[str]) -> None
     """
     :params: contains the params for the current botocore action
     :span: the span which provides the trace context to be propagated
     :endpoint_service: endpoint of message, "sqs" or "sns"
-    :pin: patch info for the botocore client
-    :data_streams_enabled: boolean for whether data streams monitoring is enabled
-    Inject trace headers and DSM info into MessageAttributes for all SQS or SNS records inside a batch
+    Inject trace headers info into MessageAttributes for all SQS or SNS records inside a batch
     """
 
     trace_data = {}
@@ -99,40 +84,24 @@ def inject_trace_to_sqs_or_sns_batch_message(params, span, endpoint_service=None
     entries = params.get("Entries", params.get("PublishBatchRequestEntries", []))
     if len(entries) != 0:
         for entry in entries:
-            if data_streams_enabled:
-                dsm_identifier = None
-                if endpoint_service == "sqs":
-                    dsm_identifier = get_queue_name(params)
-                elif endpoint_service == "sns":
-                    dsm_identifier = get_topic_arn(params)
-                trace_data[PROPAGATION_KEY_BASE_64] = get_pathway(pin, endpoint_service, dsm_identifier, span)
+            core.dispatch("botocore.sqs_sns.start", [endpoint_service, trace_data, params])
             inject_trace_data_to_message_attributes(trace_data, entry, endpoint_service)
     else:
         log.warning("Skipping injecting Datadog attributes to records, no records available")
 
 
-def inject_trace_to_sqs_or_sns_message(params, span, endpoint_service=None, pin=None, data_streams_enabled=False):
-    # type: (Any, Span, Optional[str], Optional[Pin], Optional[bool]) -> None
+def inject_trace_to_sqs_or_sns_message(params, span, endpoint_service=None):
+    # type: (Any, Span, Optional[str]) -> None
     """
     :params: contains the params for the current botocore action
     :span: the span which provides the trace context to be propagated
     :endpoint_service: endpoint of message, "sqs" or "sns"
-    :pin: patch info for the botocore client
-    :data_streams_enabled: boolean for whether data streams monitoring is enabled
-    Inject trace headers and DSM info into MessageAttributes for the SQS or SNS record
+    Inject trace headers info into MessageAttributes for the SQS or SNS record
     """
     trace_data = {}
     HTTPPropagator.inject(span.context, trace_data)
 
-    if data_streams_enabled:
-        dsm_identifier = None
-        if endpoint_service == "sqs":
-            dsm_identifier = get_queue_name(params)
-        elif endpoint_service == "sns":
-            dsm_identifier = get_topic_arn(params)
-
-        trace_data[PROPAGATION_KEY_BASE_64] = get_pathway(pin, endpoint_service, dsm_identifier, span)
-
+    core.dispatch("botocore.sqs_sns.start", [endpoint_service, trace_data, params])
     inject_trace_data_to_message_attributes(trace_data, params, endpoint_service)
 
 
@@ -161,7 +130,10 @@ def patched_sqs_api_call(original_func, instance, args, kwargs, function_vars):
             start_ns = time_ns()
             func_run = True
             # run the function before in order to extract possible parent context before starting span
+
+            core.dispatch(f"botocore.{endpoint_name}.{operation}.pre", [params])
             result = original_func(*args, **kwargs)
+            core.dispatch(f"botocore.{endpoint_name}.{operation}.post", [params, result])
         except Exception as e:
             func_run_err = e
         if result is not None and "Messages" in result and len(result["Messages"]) >= 1:
@@ -197,8 +169,6 @@ def patched_sqs_api_call(original_func, instance, args, kwargs, function_vars):
                             params,
                             span,
                             endpoint_service=endpoint_name,
-                            pin=pin,
-                            data_streams_enabled=config._data_streams_enabled,
                         )
                         span.name = schematize_cloud_messaging_operation(
                             trace_operation,
@@ -211,8 +181,6 @@ def patched_sqs_api_call(original_func, instance, args, kwargs, function_vars):
                             params,
                             span,
                             endpoint_service=endpoint_name,
-                            pin=pin,
-                            data_streams_enabled=config._data_streams_enabled,
                         )
                         span.name = schematize_cloud_messaging_operation(
                             trace_operation,
@@ -230,41 +198,10 @@ def patched_sqs_api_call(original_func, instance, args, kwargs, function_vars):
                 except Exception:
                     log.warning("Unable to inject trace context", exc_info=True)
             try:
-                if endpoint_name == "sqs" and operation == "ReceiveMessage" and config._data_streams_enabled:
-                    queue_name = get_queue_name(params)
-
-                    if "MessageAttributeNames" not in params:
-                        params.update({"MessageAttributeNames": ["_datadog"]})
-                    elif "_datadog" not in params["MessageAttributeNames"]:
-                        params.update({"MessageAttributeNames": list(params["MessageAttributeNames"]) + ["_datadog"]})
-
                     if not func_run:
+                        core.dispatch(f"botocore.{endpoint_name}.{operation}.pre", [params])
                         result = original_func(*args, **kwargs)
-
-                    set_response_metadata_tags(span, result)
-
-                    try:
-                        if "Messages" in result:
-                            for message in result["Messages"]:
-                                # try to extract trace context from the request
-                                context_json = extract_trace_context_json(message)
-                                if context_json is None:
-                                    log.debug("DataStreams did not handle message: %r", message)
-
-                                pathway = context_json.get(PROPAGATION_KEY_BASE_64, None) if context_json else None
-                                ctx = pin.tracer.data_streams_processor.decode_pathway_b64(pathway)
-                                ctx.set_checkpoint(["direction:in", "topic:" + queue_name, "type:sqs"], span=span)
-
-                    except Exception:
-                        log.debug("Error receiving SQS message with data streams monitoring enabled", exc_info=True)
-
-                    # raise error if it was encountered before the span was started
-                    if func_run_err:
-                        raise func_run_err
-                    return result
-                else:
-                    if not func_run:
-                        result = original_func(*args, **kwargs)
+                        core.dispatch(f"botocore.{endpoint_name}.{operation}.post", [params, result])
 
                     set_response_metadata_tags(span, result)
                     return result

--- a/ddtrace/contrib/botocore/utils.py
+++ b/ddtrace/contrib/botocore/utils.py
@@ -1,5 +1,5 @@
 """
-Trace queries and data streams monitoring to aws api done via botocore client
+Trace queries monitoring to aws api done via botocore client
 """
 import base64
 import json
@@ -17,7 +17,6 @@ from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanKind
 from ...ext import aws
 from ...ext import http
-from ...internal.compat import parse
 from ...internal.constants import COMPONENT
 from ...internal.logger import get_logger
 from ...internal.utils.formats import deep_getattr

--- a/ddtrace/contrib/botocore/utils.py
+++ b/ddtrace/contrib/botocore/utils.py
@@ -40,35 +40,6 @@ def get_json_from_str(data_str):
     return None, data_obj
 
 
-def get_queue_name(params):
-    # type: (str) -> str
-    """
-    :params: contains the params for the current botocore action
-    Return the name of the queue given the params
-    """
-    queue_url = params["QueueUrl"]
-    url = parse.urlparse(queue_url)
-    return url.path.rsplit("/", 1)[-1]
-
-
-def get_pathway(pin, endpoint_service, dsm_identifier, span=None):
-    # type: (Pin, str, str, Span) -> str
-    """
-    :pin: patch info for the botocore client
-    :endpoint_service: the name  of the service (i.e. 'sns', 'sqs', 'kinesis')
-    :dsm_identifier: the identifier for the topic/queue/stream/etc
-    Set the data streams monitoring checkpoint and return the encoded pathway
-    """
-    path_type = "type:{}".format(endpoint_service)
-    if not dsm_identifier:
-        log.debug("pathway being generated with unrecognized service: ", dsm_identifier)
-
-    pathway = pin.tracer.data_streams_processor.set_checkpoint(
-        ["direction:out", "topic:{}".format(dsm_identifier), path_type], span=span
-    )
-    return pathway.encode_b64()
-
-
 def get_kinesis_data_object(data):
     # type: (str) -> Tuple[str, Optional[Dict[str, Any]]]
     """

--- a/ddtrace/contrib/botocore/utils.py
+++ b/ddtrace/contrib/botocore/utils.py
@@ -1,5 +1,5 @@
 """
-Trace queries monitoring to aws api done via botocore client
+Trace queries and data streams monitoring to aws api done via botocore client
 """
 import base64
 import json
@@ -17,6 +17,7 @@ from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanKind
 from ...ext import aws
 from ...ext import http
+from ...internal.compat import parse
 from ...internal.constants import COMPONENT
 from ...internal.logger import get_logger
 from ...internal.utils.formats import deep_getattr
@@ -37,6 +38,35 @@ def get_json_from_str(data_str):
     if data_str.endswith(LINE_BREAK):
         return LINE_BREAK, data_obj
     return None, data_obj
+
+
+def get_queue_name(params):
+    # type: (str) -> str
+    """
+    :params: contains the params for the current botocore action
+    Return the name of the queue given the params
+    """
+    queue_url = params["QueueUrl"]
+    url = parse.urlparse(queue_url)
+    return url.path.rsplit("/", 1)[-1]
+
+
+def get_pathway(pin, endpoint_service, dsm_identifier, span=None):
+    # type: (Pin, str, str, Span) -> str
+    """
+    :pin: patch info for the botocore client
+    :endpoint_service: the name  of the service (i.e. 'sns', 'sqs', 'kinesis')
+    :dsm_identifier: the identifier for the topic/queue/stream/etc
+    Set the data streams monitoring checkpoint and return the encoded pathway
+    """
+    path_type = "type:{}".format(endpoint_service)
+    if not dsm_identifier:
+        log.debug("pathway being generated with unrecognized service: ", dsm_identifier)
+
+    pathway = pin.tracer.data_streams_processor.set_checkpoint(
+        ["direction:out", "topic:{}".format(dsm_identifier), path_type], span=span
+    )
+    return pathway.encode_b64()
 
 
 def get_kinesis_data_object(data):

--- a/ddtrace/contrib/botocore/utils.py
+++ b/ddtrace/contrib/botocore/utils.py
@@ -1,5 +1,5 @@
 """
-Trace queries and data streams monitoring to aws api done via botocore client
+Trace queries monitoring to aws api done via botocore client
 """
 import base64
 import json
@@ -17,7 +17,6 @@ from ...constants import SPAN_MEASURED_KEY
 from ...ext import SpanKind
 from ...ext import aws
 from ...ext import http
-from ...internal.compat import parse
 from ...internal.constants import COMPONENT
 from ...internal.logger import get_logger
 from ...internal.utils.formats import deep_getattr
@@ -38,35 +37,6 @@ def get_json_from_str(data_str):
     if data_str.endswith(LINE_BREAK):
         return LINE_BREAK, data_obj
     return None, data_obj
-
-
-def get_queue_name(params):
-    # type: (str) -> str
-    """
-    :params: contains the params for the current botocore action
-    Return the name of the queue given the params
-    """
-    queue_url = params["QueueUrl"]
-    url = parse.urlparse(queue_url)
-    return url.path.rsplit("/", 1)[-1]
-
-
-def get_pathway(pin, endpoint_service, dsm_identifier, span=None):
-    # type: (Pin, str, str, Span) -> str
-    """
-    :pin: patch info for the botocore client
-    :endpoint_service: the name  of the service (i.e. 'sns', 'sqs', 'kinesis')
-    :dsm_identifier: the identifier for the topic/queue/stream/etc
-    Set the data streams monitoring checkpoint and return the encoded pathway
-    """
-    path_type = "type:{}".format(endpoint_service)
-    if not dsm_identifier:
-        log.debug("pathway being generated with unrecognized service: ", dsm_identifier)
-
-    pathway = pin.tracer.data_streams_processor.set_checkpoint(
-        ["direction:out", "topic:{}".format(dsm_identifier), path_type], span=span
-    )
-    return pathway.encode_b64()
 
 
 def get_kinesis_data_object(data):

--- a/ddtrace/internal/datastreams/__init__.py
+++ b/ddtrace/internal/datastreams/__init__.py
@@ -4,13 +4,15 @@ from ddtrace.internal import agent
 from ...internal.utils.importlib import require_modules
 
 
-required_modules = ["confluent_kafka"]
+required_modules = ["confluent_kafka", "botocore"]
 _processor = None
 
 if config._data_streams_enabled:
     with require_modules(required_modules) as missing_modules:
-        if not missing_modules:
+        if "confluent_kafka" not in missing_modules:
             from . import kafka  # noqa:F401
+        if "botocore" not in missing_modules:
+            from . import botocore  # noqa:F401
 
 
 def data_streams_processor():

--- a/ddtrace/internal/datastreams/botocore.py
+++ b/ddtrace/internal/datastreams/botocore.py
@@ -1,0 +1,186 @@
+import base64
+from datetime import datetime
+import json
+
+from ddtrace import config
+from ddtrace.internal import core
+from ddtrace.internal.compat import parse
+from ddtrace.internal.datastreams.processor import PROPAGATION_KEY_BASE_64
+from ddtrace.internal.logger import get_logger
+
+
+log = get_logger(__name__)
+
+
+def get_pathway(endpoint_service, dsm_identifier):
+    # type: (str, str) -> str
+    """
+    :endpoint_service: the name  of the service (i.e. 'sns', 'sqs', 'kinesis')
+    :dsm_identifier: the identifier for the topic/queue/stream/etc
+
+    Set the data streams monitoring checkpoint and return the encoded pathway
+    """
+    from . import data_streams_processor as processor
+
+    path_type = "type:{}".format(endpoint_service)
+    if not dsm_identifier:
+        log.debug("pathway being generated with unrecognized service: ", dsm_identifier)
+
+    pathway = processor().set_checkpoint(["direction:out", "topic:{}".format(dsm_identifier), path_type])
+    return pathway.encode_b64()
+
+
+def get_queue_name(params):
+    # type: (dict) -> str
+    """
+    :params: contains the params for the current botocore action
+
+    Return the name of the queue given the params
+    """
+    queue_url = params["QueueUrl"]
+    url = parse.urlparse(queue_url)
+    return url.path.rsplit("/", 1)[-1]
+
+
+def get_topic_arn(params):
+    # type: (dict) -> str
+    """
+    :params: contains the params for the current botocore action
+
+    Return the name of the topic given the params
+    """
+    sns_arn = params["TopicArn"]
+    return sns_arn
+
+
+def get_stream_arn(params):
+    # type: (dict) -> str
+    """
+    :params: contains the params for the current botocore action
+
+    Return the name of the stream given the params
+    """
+    stream_arn = params.get("StreamARN", "")
+    return stream_arn
+
+
+def inject_context(trace_data, endpoint_service, dsm_identifier):
+    pathway = get_pathway(endpoint_service, dsm_identifier)
+
+    if trace_data is not None:
+        trace_data[PROPAGATION_KEY_BASE_64] = pathway
+
+
+def handle_kinesis_produce(params):
+    stream_arn = get_stream_arn(params)
+    if stream_arn:  # If stream ARN isn't specified, we give up (it is not a required param)
+        # put_records has a "Records" entry but put_record does not, so we fake a record to
+        # collapse the logic for the two cases
+        for _ in params.get("Records", ["fake_record"]):
+            # In other DSM code, you'll see the pathway + context injection but not here.
+            # Kinesis DSM doesn't inject any data, so we only need to generate checkpoints.
+            inject_context(None, "kinesis", stream_arn)
+
+
+def handle_sqs_sns_produce(endpoint_service, trace_data, params):
+    dsm_identifier = None
+    if endpoint_service == "sqs":
+        dsm_identifier = get_queue_name(params)
+    elif endpoint_service == "sns":
+        dsm_identifier = get_topic_arn(params)
+    inject_context(trace_data, endpoint_service, dsm_identifier)
+
+
+def handle_sqs_prepare(params):
+    if "MessageAttributeNames" not in params:
+        params.update({"MessageAttributeNames": ["_datadog"]})
+    elif "_datadog" not in params["MessageAttributeNames"]:
+        params.update({"MessageAttributeNames": list(params["MessageAttributeNames"]) + ["_datadog"]})
+
+
+def get_datastreams_context(message):
+    """
+    Formats we're aware of:
+        - message.Body.MessageAttributes._datadog.Value.decode() (SQS)
+        - message.MessageAttributes._datadog.StringValue (SNS -> SQS)
+        - message.MesssageAttributes._datadog.BinaryValue.decode() (SNS -> SQS, raw)
+    """
+    context_json = None
+    message_body = message
+    try:
+        message_body = json.loads(message.get("Body"))
+    except ValueError:
+        log.debug("Unable to parse message body, treat as non-json")
+
+    if "MessageAttributes" not in message_body:
+        log.debug("DataStreams skipped message: %r", message)
+        return None
+
+    if "_datadog" not in message_body["MessageAttributes"]:
+        log.debug("DataStreams skipped message: %r", message)
+        return None
+
+    if message_body.get("Type") == "Notification":
+        # This is potentially a DSM SNS notification
+        if message_body["MessageAttributes"]["_datadog"]["Type"] == "Binary":
+            context_json = json.loads(base64.b64decode(message_body["MessageAttributes"]["_datadog"]["Value"]).decode())
+    elif "StringValue" in message["MessageAttributes"]["_datadog"]:
+        # The message originated from SQS
+        context_json = json.loads(message_body["MessageAttributes"]["_datadog"]["StringValue"])
+    elif "BinaryValue" in message["MessageAttributes"]["_datadog"]:
+        # Raw message delivery
+        context_json = json.loads(message_body["MessageAttributes"]["_datadog"]["BinaryValue"].decode())
+    else:
+        log.debug("DataStreams did not handle message: %r", message)
+
+    return context_json
+
+
+def handle_sqs_receive(params, result):
+    from . import data_streams_processor as processor
+
+    queue_name = get_queue_name(params)
+
+    for message in result.get("Messages"):
+        try:
+            context_json = get_datastreams_context(message)
+            pathway = context_json.get(PROPAGATION_KEY_BASE_64, None) if context_json else None
+            ctx = processor().decode_pathway_b64(pathway)
+            ctx.set_checkpoint(["direction:in", "topic:" + queue_name, "type:sqs"])
+
+        except Exception:
+            log.debug("Error receiving SQS message with data streams monitoring enabled", exc_info=True)
+
+
+def record_data_streams_path_for_kinesis_stream(params, results):
+    from . import data_streams_processor as processor
+
+    stream_arn = params.get("StreamARN")
+
+    if not stream_arn:
+        log.debug("Unable to determine StreamARN for request with params: ", params)
+        return
+
+    pathway = processor().new_pathway()
+    for record in results.get("Records", []):
+        time_estimate = record.get("ApproximateArrivalTimestamp", datetime.now()).timestamp()
+        pathway.set_checkpoint(
+            ["direction:in", "topic:" + stream_arn, "type:kinesis"],
+            edge_start_sec_override=time_estimate,
+            pathway_start_sec_override=time_estimate,
+        )
+
+
+def handle_kinesis_receive(params, result):
+    try:
+        record_data_streams_path_for_kinesis_stream(params, result)
+    except Exception:
+        log.debug("Failed to report data streams monitoring info for kinesis", exc_info=True)
+
+
+if config._data_streams_enabled:
+    core.on("botocore.kinesis.start", handle_kinesis_produce)
+    core.on("botocore.sqs_sns.start", handle_sqs_sns_produce)
+    core.on("botocore.sqs.ReceiveMessage.pre", handle_sqs_prepare)
+    core.on("botocore.sqs.ReceiveMessage.post", handle_sqs_receive)
+    core.on("botocore.kinesis.GetRecords.post", handle_kinesis_receive)


### PR DESCRIPTION
Prior to this change, the datastreams logic lived side by side with the tracing logic in the botocore contrib.  After this change, this logic has been moved into the datastreams internal folder.  The change uses the core API to refactor.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
