### PR TITLE
docs: updated `contributing.rst` with small note about merge option

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -54,6 +54,8 @@ in pull request names are enumerated :ref:`in the release notes documentation<re
 Pull requests that change the library's public API require a :ref:`release note<release_notes>`.
 If your pull request doesn't change the public API, apply the ``no-changelog`` label.
 
+Once approved, pull requests should be merged with the "Squah and Merge" option.
+
 Backporting
 -----------
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -55,6 +55,7 @@ Pull requests that change the library's public API require a :ref:`release note<
 If your pull request doesn't change the public API, apply the ``no-changelog`` label.
 
 Once approved, pull requests should be merged with the "Squah and Merge" option.
+At this time, do not use the merge queue option.
 
 Backporting
 -----------

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -54,7 +54,7 @@ in pull request names are enumerated :ref:`in the release notes documentation<re
 Pull requests that change the library's public API require a :ref:`release note<release_notes>`.
 If your pull request doesn't change the public API, apply the ``no-changelog`` label.
 
-Once approved, pull requests should be merged with the "Squah and Merge" option.
+Once approved, pull requests should be merged with the "Squash and Merge" option.
 At this time, do not use the merge queue option.
 
 Backporting


### PR DESCRIPTION
## Description
Updated `contributing.rst` with small note specifying "Squash and Merge" as the merge option, not the merge queue.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
