### PR TITLE
ci: avoid skipping tests on main

### DIFF
--- a/scripts/run-test-suite
+++ b/scripts/run-test-suite
@@ -31,7 +31,7 @@ fi
 
 set -e
 
-if ! [[ -v CIRCLECI && $CIRCLE_BRANCH =~ [0-9]\.x ]]; then
+if ! [[ -v CIRCLECI && $CIRCLE_BRANCH =~ main ]]; then
     if [[ -f "$CHECKPOINT_FILENAME" ]]; then
         latest_success_commit=$(cat $CHECKPOINT_FILENAME)
         if ! ./scripts/needs_testrun.py $CIRCLE_JOB --sha $latest_success_commit; then

--- a/scripts/run-test-suite-hatch
+++ b/scripts/run-test-suite-hatch
@@ -30,7 +30,7 @@ fi
 
 set -e
 
-if ! [[ -v CIRCLECI && $CIRCLE_BRANCH =~ [0-9]\.x ]]; then
+if ! [[ -v CIRCLECI && $CIRCLE_BRANCH =~ main ]]; then
     if [[ -f "$CHECKPOINT_FILENAME" ]]; then
         latest_success_commit=$(cat $CHECKPOINT_FILENAME)
         if ! ./scripts/needs_testrun.py $CIRCLE_JOB --sha $latest_success_commit; then


### PR DESCRIPTION
This change updates the testrunner scripts used in CI to avoid skipping tests on the main branch. This was always the intent of the script, and it regressed when we changed the main branch from *.x to main.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
