### PR TITLE
fix(tracing): enable settings to be unset (#8126) [backport 2.5]

### DIFF
--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -714,23 +714,23 @@ class Config(object):
 
         # If no data is submitted then the RC config has been deleted. Revert the settings.
         config = data["config"][0]
-        updated_items = []  # type: List[Tuple[str, Any]]
+        base_rc_config = {n: None for n in self._config}
 
-        if not config:
-            for item in self._config:
-                updated_items.append((item, None))
-        else:
+        if config:
             lib_config = config["lib_config"]
             if "tracing_sampling_rate" in lib_config:
-                updated_items.append(("_trace_sample_rate", lib_config["tracing_sampling_rate"]))
+                base_rc_config["_trace_sample_rate"] = lib_config["tracing_sampling_rate"]
+
+            if "log_injection_enabled" in lib_config:
+                base_rc_config["logs_injection"] = lib_config["log_injection_enabled"]
 
             if "tracing_tags" in lib_config:
                 tags = lib_config["tracing_tags"]
                 if tags:
                     tags = {k: v for k, v in [t.split(":") for t in lib_config["tracing_tags"]]}
-                updated_items.append(("tags", tags))
+                base_rc_config["tags"] = tags
 
-        self._set_config_items([(k, v, "remote_config") for k, v in updated_items])
+        self._set_config_items([(k, v, "remote_config") for k, v in base_rc_config.items()])
 
     def enable_remote_configuration(self):
         # type: () -> None

--- a/releasenotes/notes/tracer-rc-unset-361dc5080cd4a112.yaml
+++ b/releasenotes/notes/tracer-rc-unset-361dc5080cd4a112.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    tracing: Fix an issue where remote configuration values would not be reverted when unset in the UI.

--- a/tests/internal/test_settings.py
+++ b/tests/internal/test_settings.py
@@ -12,22 +12,13 @@ def config():
 
 
 def _base_rc_config(cfg):
-    lib_config = {
-        "tracing_sampling_rate": None,
-        "log_injection_enabled": None,
-        "tracing_header_tags": None,
-        "tracing_tags": None,
-        "data_streams_enabled": None,
-    }
-    lib_config.update(cfg)
-
     return {
         "metadata": [],
         "config": [
             {
                 "action": "enable",
                 "service_target": {"service": None, "env": None},
-                "lib_config": lib_config,
+                "lib_config": cfg,
             }
         ],
     }
@@ -117,7 +108,7 @@ def _deleted_rc_config():
         },
     ],
 )
-def test_settings(testcase, config, monkeypatch):
+def test_settings_asdf(testcase, config, monkeypatch):
     for env_name, env_value in testcase.get("env", {}).items():
         monkeypatch.setenv(env_name, env_value)
         config._reset()
@@ -125,7 +116,7 @@ def test_settings(testcase, config, monkeypatch):
     for code_name, code_value in testcase.get("code", {}).items():
         setattr(config, code_name, code_value)
 
-    rc_items = testcase.get("rc", {}).items()
+    rc_items = testcase.get("rc", {})
     if rc_items:
         config._handle_remoteconfig(_base_rc_config(rc_items), None)
 
@@ -162,7 +153,7 @@ with tracer.trace("test") as span:
     pass
 assert span.get_metric("_dd.rule_psr") == 0.2
 
-config._handle_remoteconfig(_base_rc_config({"tracing_sampling_rate": None}))
+config._handle_remoteconfig(_base_rc_config({}))
 with tracer.trace("test") as span:
     pass
 assert span.get_metric("_dd.rule_psr") == 0.1
@@ -178,7 +169,7 @@ with tracer.trace("test") as span:
     pass
 assert span.get_metric("_dd.rule_psr") == 0.4
 
-config._handle_remoteconfig(_base_rc_config({"tracing_sampling_rate": None}))
+config._handle_remoteconfig(_base_rc_config({}))
 with tracer.trace("test") as span:
     pass
 assert span.get_metric("_dd.rule_psr") == 0.3
@@ -216,7 +207,7 @@ with tracer.trace("test") as span:
     pass
 assert span.get_tag("team") == "onboarding", span._meta
 
-config._handle_remoteconfig(_base_rc_config({"tracing_tags": None}))
+config._handle_remoteconfig(_base_rc_config({}))
 with tracer.trace("test") as span:
     pass
 assert span.get_tag("team") == "apm"


### PR DESCRIPTION
The remote configuration backend omits settings when they are unset. This fix ensures that if settings are not set via remote config then we unset the previously set remote configuration values.

Regression tests are added by matching the backend behaviour of not including the configuration item at all in the payload.

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
