### PR TITLE
fix(asm): avoid logging exception on flask empty body

### DIFF
--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -100,8 +100,11 @@ async def _on_asgi_request_parse_body(receive, headers):
 
         content_type = headers.get("content-type") or headers.get("Content-Type")
         try:
-            if content_type == "application/json" or content_type == "text/json":
-                req_body = json.loads(body.decode())
+            if content_type in ("application/json", "text/json"):
+                if body is None or body == b"":
+                    req_body = None
+                else:
+                    req_body = json.loads(body.decode())
             elif content_type in ("application/xml", "text/xml"):
                 req_body = xmltodict.parse(body)
             elif content_type == "text/plain":
@@ -169,7 +172,7 @@ def _on_request_span_modifier(
             xmltodict.expat.ExpatError,
             xmltodict.ParsingInterrupted,
         ):
-            log.warning("Failed to parse request body", exc_info=True)
+            log.debug("Failed to parse request body", exc_info=True)
         finally:
             # Reset wsgi input to the beginning
             if wsgi_input:

--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -148,7 +148,7 @@ def _on_request_span_modifier(
             if content_type in ("application/json", "text/json"):
                 if _HAS_JSON_MIXIN and hasattr(request, "json") and request.json:
                     req_body = request.json
-                elif request.data is None:
+                elif request.data is None or request.data == b"":
                     req_body = None
                 else:
                     req_body = json.loads(request.data.decode("UTF-8"))

--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -145,9 +145,11 @@ def _on_request_span_modifier(
                 environ["wsgi.input"] = io.BytesIO(body)
 
         try:
-            if content_type == "application/json" or content_type == "text/json":
+            if content_type in ("application/json", "text/json"):
                 if _HAS_JSON_MIXIN and hasattr(request, "json") and request.json:
                     req_body = request.json
+                elif request.data is None:
+                    req_body = None
                 else:
                     req_body = json.loads(request.data.decode("UTF-8"))
             elif content_type in ("application/xml", "text/xml"):

--- a/releasenotes/notes/asm-fix-json-decode-error-none-af2c99becf9041a4.yaml
+++ b/releasenotes/notes/asm-fix-json-decode-error-none-af2c99becf9041a4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ASM: This fix resolves an issue where an exception would be logged while parsing an empty body JSON request.

--- a/tests/contrib/flask/test_flask_appsec.py
+++ b/tests/contrib/flask/test_flask_appsec.py
@@ -264,14 +264,20 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
     def test_flask_body_json_empty_body_does_not_log_warning(self):
         with self._caplog.at_level(logging.DEBUG), override_global_config(dict(_asm_enabled=True)):
             self._aux_appsec_prepare_tracer()
-            self.client.post("/", data="", content_type="application/json")
+            self.client.get("/", content_type="application/json")
             assert "Failed to parse request body" not in self._caplog.text
 
-    def test_flask_body_json_bad_logs_warning(self):
+    def test_flask_body_json_bad_logs_debug(self):
         with self._caplog.at_level(logging.DEBUG), override_global_config(dict(_asm_enabled=True)):
             self._aux_appsec_prepare_tracer()
             self.client.post("/", data="not valid json", content_type="application/json")
             assert "Failed to parse request body" in self._caplog.text
+
+    def test_flask_body_json_bad_logs_not_warning(self):
+        with self._caplog.at_level(logging.WARNING), override_global_config(dict(_asm_enabled=True)):
+            self._aux_appsec_prepare_tracer()
+            self.client.post("/", data="not valid json", content_type="application/json")
+            assert "Failed to parse request body" not in self._caplog.text
 
     def test_flask_body_xml_bad_logs_warning(self):
         with self._caplog.at_level(logging.DEBUG), override_global_config(dict(_asm_enabled=True)):


### PR DESCRIPTION
ASM: This fix resolves an issue where we would log an exception while parsing a flask request with empty body

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
