### PR TITLE
fix(iast): handle value error thrown by numpy [backport 2.5]

### DIFF
--- a/ddtrace/appsec/_iast/taint_sinks/ast_taint.py
+++ b/ddtrace/appsec/_iast/taint_sinks/ast_taint.py
@@ -20,19 +20,23 @@ def ast_function(
     *args,  # type: Any
     **kwargs,  # type: Any
 ):  # type: (...) -> Any
-    cls = getattr(func, "__self__", None)
+    instance = getattr(func, "__self__", None)
     func_name = getattr(func, "__name__", None)
     cls_name = ""
-    if cls and func_name:
+    if instance is not None and func_name:
         try:
-            cls_name = cls.__class__.__name__
+            cls_name = instance.__class__.__name__
         except AttributeError:
             pass
 
     if flag_added_args > 0:
         args = args[flag_added_args:]
 
-    if cls.__class__.__module__ == "random" and cls_name == "Random" and func_name in DEFAULT_WEAK_RANDOMNESS_FUNCTIONS:
+    if (
+        instance.__class__.__module__ == "random"
+        and cls_name == "Random"
+        and func_name in DEFAULT_WEAK_RANDOMNESS_FUNCTIONS
+    ):
         # Weak, run the analyzer
         increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, WeakRandomness.vulnerability_type)
         _set_metric_iast_executed_sink(WeakRandomness.vulnerability_type)

--- a/releasenotes/notes/iast-fix-valueerror-on-ast-function-a06975ec55afc26b.yaml
+++ b/releasenotes/notes/iast-fix-valueerror-on-ast-function-a06975ec55afc26b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Vulnerability Management for Code-level (IAST): Fix an unhandled ValueError in ``ast_function`` thrown in some cases (i.e. Numpy arrays when converted to bool).

--- a/tests/appsec/iast/taint_sinks/test_ast_taint.py
+++ b/tests/appsec/iast/taint_sinks/test_ast_taint.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+from ddtrace.appsec._iast.taint_sinks.ast_taint import ast_function
+
+
+class MyArray:
+    def __init__(self, values):
+        self.values = values
+
+    def copy(self):
+        return self.values.copy()
+
+    def __bool__(self):
+        if len(self.values) > 0:
+            raise ValueError("Array is not empty")
+        return False
+
+
+def test_ast_function_with_valueerror_on_bool():
+    values = MyArray([7, 19, 20, 35, 10, 42, 8])
+    values_copy = ast_function(values.copy, False)
+    assert values_copy == values.values


### PR DESCRIPTION
Backport b8ca6e90ef3b6a6ead3632d998261cf83458eeae from #8088 to 2.5.

IAST: Fixes an issue where a ValueError is thrown by numpy while checking the existence of an array.

Regression test added.

## Checklist
- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.