### PR TITLE
docs: document use of the flaky decorator

### DIFF
--- a/docs/contributing-testing.rst
+++ b/docs/contributing-testing.rst
@@ -196,7 +196,7 @@ What do I do when my pull request has failing tests unrelated to my changes?
 The test suite is not completely reliable. There are usually some tests that can fail without any of their code paths being
 changed. This slows down development because most tests are required to pass for pull requests to be merged.
 
-The ``tests/utils`` module provides the [``@flaky`` decorator](https://github.com/DataDog/dd-trace-py/blob/623f2df4de802563a463acc4d3c000dbc742e3d3/tests/utils.py#L1285) to enable contributors to handle this situation. As a contributor,
+The ``tests/utils`` module provides the ```@flaky`` decorator <https://github.com/DataDog/dd-trace-py/blob/623f2df4de802563a463acc4d3c000dbc742e3d3/tests/utils.py#L1285>`_ to enable contributors to handle this situation. As a contributor,
 when you notice a test failure that is unrelated to the changes you've made, you can add the ``@flaky`` decorator to that test.
 This will cause the test's result not to count as a failure during pre-merge checks.
 

--- a/docs/contributing-testing.rst
+++ b/docs/contributing-testing.rst
@@ -209,4 +209,4 @@ test. It is, however, a short-term fix that you should not consider to be a perm
 Using ``@flaky`` comes with the responsibility of maintaining the test suite's coverage over the library. If you're in the habit
 of using it, periodically set aside some time to ``grep -R 'flaky' tests`` and remove some of the decorators. This may require
 finding and fixing the root cause of the unreliable behavior. Upholding this responsibility is an important way to keep the test
-suite's coverage meaningfully broad while benefitting from skipping tests.
+suite's coverage meaningfully broad while skipping tests.

--- a/docs/contributing-testing.rst
+++ b/docs/contributing-testing.rst
@@ -196,7 +196,7 @@ What do I do when my pull request has failing tests unrelated to my changes?
 The test suite is not completely reliable. There are usually some tests that can fail without any of their code paths being
 changed. This slows down development because most tests are required to pass for pull requests to be merged.
 
-The ``tests/utils`` module provides the ```@flaky`` decorator <https://github.com/DataDog/dd-trace-py/blob/623f2df4de802563a463acc4d3c000dbc742e3d3/tests/utils.py#L1285>`_ to enable contributors to handle this situation. As a contributor,
+The ``tests/utils`` module provides the ``@flaky`` decorator (`link <https://github.com/DataDog/dd-trace-py/blob/623f2df4de802563a463acc4d3c000dbc742e3d3/tests/utils.py#L1285>`_) to enable contributors to handle this situation. As a contributor,
 when you notice a test failure that is unrelated to the changes you've made, you can add the ``@flaky`` decorator to that test.
 This will cause the test's result not to count as a failure during pre-merge checks.
 

--- a/docs/contributing-testing.rst
+++ b/docs/contributing-testing.rst
@@ -189,3 +189,24 @@ environment object.
 3. Delete all of the requirements lockfiles for the chosen environment, then regenerate them:
    ``for h in `riot list --hash-only "^${VENV_NAME}$"`; do rm .riot/requirements/${h}.txt; done; scripts/compile-and-prune-test-requirements``
 4. Commit the resulting changes to the ``.riot`` directory, and open a pull request against the trunk branch.
+
+What do I do when my pull request has failing tests unrelated to my changes?
+----------------------------------------------------------------------------
+
+The test suite is not completely reliable. There are usually some tests that can fail without any of their code paths being
+changed. This slows down development because most tests are required to pass for pull requests to be merged.
+
+The ``tests/utils`` module provides the ``@flaky`` decorator to enable contributors to handle this situation. As a contributor,
+when you notice a test failure that is unrelated to the changes you've made, you can add the ``@flaky`` decorator to that test.
+This will cause the test's result not to count as a failure during pre-merge checks.
+
+The decorator requires as a parameter a UNIX timestamp specifying the time at which the decorator will stop skipping the test.
+A timestamp a few months in the future is a fine default to use.
+
+``@flaky`` is intended to be used liberally by contributors to unblock their work. Add it whenever you notice an apparently flaky
+test. It is, however, a short-term fix that you should not consider to be a permanent resolution.
+
+Using ``@flaky`` comes with the responsibility of maintaining the test suite's coverage over the library. If you're in the habit
+of using it, periodically set aside some time to ``grep -R 'flaky' tests`` and remove some of the decorators. This may require
+finding and fixing the root cause of the unreliable behavior. Upholding this responsibility is an important way to keep the test
+suite's coverage meaningfully broad while benefitting from skipping tests.

--- a/docs/contributing-testing.rst
+++ b/docs/contributing-testing.rst
@@ -196,7 +196,7 @@ What do I do when my pull request has failing tests unrelated to my changes?
 The test suite is not completely reliable. There are usually some tests that can fail without any of their code paths being
 changed. This slows down development because most tests are required to pass for pull requests to be merged.
 
-The ``tests/utils`` module provides the ``@flaky`` decorator to enable contributors to handle this situation. As a contributor,
+The ``tests/utils`` module provides the [``@flaky`` decorator](https://github.com/DataDog/dd-trace-py/blob/623f2df4de802563a463acc4d3c000dbc742e3d3/tests/utils.py#L1285) to enable contributors to handle this situation. As a contributor,
 when you notice a test failure that is unrelated to the changes you've made, you can add the ``@flaky`` decorator to that test.
 This will cause the test's result not to count as a failure during pre-merge checks.
 


### PR DESCRIPTION
This pull request documents my thinking about the intended use of the `@flaky` test decorator.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
