### PR TITLE
chore(tests): remove dependencies between appsec tests

### DIFF
--- a/tests/appsec/appsec/test_appsec_trace_utils.py
+++ b/tests/appsec/appsec/test_appsec_trace_utils.py
@@ -5,7 +5,6 @@ import pytest
 from ddtrace import constants
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import LOGIN_EVENTS_MODE
-import ddtrace.appsec.rules as rules
 from ddtrace.appsec.trace_utils import block_request_if_user_blocked
 from ddtrace.appsec.trace_utils import should_block_user
 from ddtrace.appsec.trace_utils import track_custom_event
@@ -17,6 +16,7 @@ from ddtrace.ext import SpanTypes
 from ddtrace.ext import user
 from ddtrace.internal import core
 from tests.appsec.appsec.test_processor import tracer_appsec  # noqa: F401
+import tests.appsec.rules as rules
 from tests.utils import TracerTestCase
 from tests.utils import override_env
 

--- a/tests/appsec/appsec/test_appsec_trace_utils.py
+++ b/tests/appsec/appsec/test_appsec_trace_utils.py
@@ -5,6 +5,7 @@ import pytest
 from ddtrace import constants
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import LOGIN_EVENTS_MODE
+import ddtrace.appsec.rules as rules
 from ddtrace.appsec.trace_utils import block_request_if_user_blocked
 from ddtrace.appsec.trace_utils import should_block_user
 from ddtrace.appsec.trace_utils import track_custom_event
@@ -15,7 +16,6 @@ from ddtrace.contrib.trace_utils import set_user
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import user
 from ddtrace.internal import core
-from tests.appsec.appsec.test_processor import RULES_GOOD_PATH
 from tests.appsec.appsec.test_processor import tracer_appsec  # noqa: F401
 from tests.utils import TracerTestCase
 from tests.utils import override_env
@@ -210,7 +210,7 @@ class EventsSDKTestCase(TracerTestCase):
 
     def test_set_user_blocked(self):
         tracer = self._tracer_appsec
-        with override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+        with override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
             tracer.configure(api_version="v0.4")
             with tracer.trace("fake_span", span_type=SpanTypes.WEB) as span:
                 set_user(

--- a/tests/appsec/appsec/test_processor.py
+++ b/tests/appsec/appsec/test_processor.py
@@ -16,6 +16,7 @@ from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.trace_utils import set_http_meta
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
+import tests.appsec.rules as rules
 from tests.utils import flaky
 from tests.utils import override_env
 from tests.utils import override_global_config
@@ -27,19 +28,6 @@ try:
 except ImportError:
     # handling python 2.X import error
     JSONDecodeError = ValueError  # type: ignore
-
-ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
-RULES_GOOD_PATH = os.path.join(ROOT_DIR, "rules-good.json")
-RULES_BAD_PATH = os.path.join(ROOT_DIR, "rules-bad.json")
-RULES_MISSING_PATH = os.path.join(ROOT_DIR, "nonexistent")
-RULES_SRB = os.path.join(ROOT_DIR, "rules-suspicious-requests.json")
-RULES_SRBCA = os.path.join(ROOT_DIR, "rules-suspicious-requests-custom-actions.json")
-RULES_SRB_RESPONSE = os.path.join(ROOT_DIR, "rules-suspicious-requests-response.json")
-RULES_SRB_METHOD = os.path.join(ROOT_DIR, "rules-suspicious-requests-get.json")
-RULES_BAD_VERSION = os.path.join(ROOT_DIR, "rules-bad_version.json")
-
-RESPONSE_CUSTOM_JSON = os.path.join(ROOT_DIR, "response-custom.json")
-RESPONSE_CUSTOM_HTML = os.path.join(ROOT_DIR, "response-custom.html")
 
 
 @pytest.fixture
@@ -53,11 +41,6 @@ def _enable_appsec(tracer):
     # Hack: need to pass an argument to configure so that the processors are recreated
     tracer.configure(api_version="v0.4")
     return tracer
-
-
-class Config(object):
-    def __init__(self):
-        self.is_header_tracing_configured = False
 
 
 def test_transform_headers():
@@ -87,14 +70,14 @@ def test_enable(tracer_appsec):
 
 
 def test_enable_custom_rules():
-    with override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+    with override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
         processor = AppSecSpanProcessor()
 
     assert processor.enabled
-    assert processor.rules == RULES_GOOD_PATH
+    assert processor.rules == rules.RULES_GOOD_PATH
 
 
-@pytest.mark.parametrize("rule,exc", [(RULES_MISSING_PATH, IOError), (RULES_BAD_PATH, ValueError)])
+@pytest.mark.parametrize("rule,exc", [(rules.RULES_MISSING_PATH, IOError), (rules.RULES_BAD_PATH, ValueError)])
 def test_enable_bad_rules(rule, exc, tracer):
     # with override_env(dict(DD_APPSEC_RULES=rule)):
     #     with pytest.raises(exc):
@@ -131,7 +114,7 @@ def test_header_attack(tracer_appsec):
         with _asm_request_context.asm_request_context_manager(), tracer.trace("test", span_type=SpanTypes.WEB) as span:
             set_http_meta(
                 span,
-                Config(),
+                rules.Config(),
                 request_headers={
                     "User-Agent": "Arachni/v1",
                     "user-agent": "aa",
@@ -149,7 +132,7 @@ def test_headers_collection(tracer_appsec):
     with _asm_request_context.asm_request_context_manager(), tracer.trace("test", span_type=SpanTypes.WEB) as span:
         set_http_meta(
             span,
-            Config(),
+            rules.Config(),
             raw_uri="http://example.com/.git",
             status_code="404",
             request_headers={
@@ -218,37 +201,30 @@ def test_appsec_body_no_collection_snapshot(tracer):
         assert "triggers" in json.loads(span.get_tag(APPSEC.JSON))
 
 
-class _IP:
-    BLOCKED = "8.8.4.4"  # actively blocked
-    MONITORED = "8.8.5.5"  # on the pass list should never been blocked but still monitored
-    BYPASS = "8.8.6.6"  # on the pass list, should bypass all security
-    DEFAULT = "1.1.1.1"  # default behaviour
-
-
 def test_ip_block(tracer):
-    with override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)), override_global_config(dict(_asm_enabled=True)):
+    with override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)), override_global_config(dict(_asm_enabled=True)):
         _enable_appsec(tracer)
-        with _asm_request_context.asm_request_context_manager(_IP.BLOCKED, {}):
+        with _asm_request_context.asm_request_context_manager(rules._IP.BLOCKED, {}):
             with tracer.trace("test", span_type=SpanTypes.WEB) as span:
                 set_http_meta(
                     span,
-                    Config(),
+                    rules.Config(),
                 )
 
             assert "triggers" in json.loads(span.get_tag(APPSEC.JSON))
-            assert core.get_item("http.request.remote_ip", span) == _IP.BLOCKED
+            assert core.get_item("http.request.remote_ip", span) == rules._IP.BLOCKED
             assert core.get_item("http.request.blocked", span)
 
 
-@pytest.mark.parametrize("ip", [_IP.MONITORED, _IP.BYPASS, _IP.DEFAULT])
+@pytest.mark.parametrize("ip", [rules._IP.MONITORED, rules._IP.BYPASS, rules._IP.DEFAULT])
 def test_ip_not_block(tracer, ip):
-    with override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)), override_global_config(dict(_asm_enabled=True)):
+    with override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)), override_global_config(dict(_asm_enabled=True)):
         _enable_appsec(tracer)
         with _asm_request_context.asm_request_context_manager(ip, {}):
             with tracer.trace("test", span_type=SpanTypes.WEB) as span:
                 set_http_meta(
                     span,
-                    Config(),
+                    rules.Config(),
                 )
 
             assert core.get_item("http.request.remote_ip", span) == ip
@@ -263,7 +239,7 @@ def test_ip_update_rules_and_block(tracer):
                 "rules_data": [
                     {
                         "data": [
-                            {"value": _IP.BLOCKED},
+                            {"value": rules._IP.BLOCKED},
                         ],
                         "id": "blocked_ips",
                         "type": "ip_with_expiration",
@@ -271,14 +247,14 @@ def test_ip_update_rules_and_block(tracer):
                 ]
             }
         )
-        with _asm_request_context.asm_request_context_manager(_IP.BLOCKED, {}):
+        with _asm_request_context.asm_request_context_manager(rules._IP.BLOCKED, {}):
             with tracer.trace("test", span_type=SpanTypes.WEB) as span:
                 set_http_meta(
                     span,
-                    Config(),
+                    rules.Config(),
                 )
 
-                assert core.get_item("http.request.remote_ip", span) == _IP.BLOCKED
+                assert core.get_item("http.request.remote_ip", span) == rules._IP.BLOCKED
                 assert core.get_item("http.request.blocked", span)
 
 
@@ -290,7 +266,7 @@ def test_ip_update_rules_expired_no_block(tracer):
                 "rules_data": [
                     {
                         "data": [
-                            {"expiration": 1662804872, "value": _IP.BLOCKED},
+                            {"expiration": 1662804872, "value": rules._IP.BLOCKED},
                         ],
                         "id": "blocked_ips",
                         "type": "ip_with_expiration",
@@ -298,14 +274,14 @@ def test_ip_update_rules_expired_no_block(tracer):
                 ]
             }
         )
-        with _asm_request_context.asm_request_context_manager(_IP.BLOCKED, {}):
+        with _asm_request_context.asm_request_context_manager(rules._IP.BLOCKED, {}):
             with tracer.trace("test", span_type=SpanTypes.WEB) as span:
                 set_http_meta(
                     span,
-                    Config(),
+                    rules.Config(),
                 )
 
-            assert core.get_item("http.request.remote_ip", span) == _IP.BLOCKED
+            assert core.get_item("http.request.remote_ip", span) == rules._IP.BLOCKED
             assert core.get_item("http.request.blocked", span) is None
 
 
@@ -341,7 +317,7 @@ def test_appsec_span_tags_snapshot(tracer):
 )
 def test_appsec_span_tags_snapshot_with_errors(tracer):
     with override_global_config(dict(_asm_enabled=True)):
-        with override_env(dict(DD_APPSEC_RULES=os.path.join(ROOT_DIR, "rules-with-2-errors.json"))):
+        with override_env(dict(DD_APPSEC_RULES=os.path.join(rules.ROOT_DIR, "rules-with-2-errors.json"))):
             _enable_appsec(tracer)
             with _asm_request_context.asm_request_context_manager(), tracer.trace(
                 "test", service="test", span_type=SpanTypes.WEB
@@ -431,7 +407,7 @@ def test_obfuscation_parameter_value_unconfigured_not_matching(tracer_appsec):
     tracer = tracer_appsec
 
     with _asm_request_context.asm_request_context_manager(), tracer.trace("test", span_type=SpanTypes.WEB) as span:
-        set_http_meta(span, Config(), raw_uri="http://example.com/.git?hello=goodbye", status_code="404")
+        set_http_meta(span, rules.Config(), raw_uri="http://example.com/.git?hello=goodbye", status_code="404")
 
     assert "triggers" in json.loads(span.get_tag("_dd.appsec.json"))
 
@@ -444,7 +420,7 @@ def test_obfuscation_parameter_value_unconfigured_matching(tracer_appsec):
     tracer = tracer_appsec
 
     with _asm_request_context.asm_request_context_manager(), tracer.trace("test", span_type=SpanTypes.WEB) as span:
-        set_http_meta(span, Config(), raw_uri="http://example.com/.git?password=goodbye", status_code="404")
+        set_http_meta(span, rules.Config(), raw_uri="http://example.com/.git?password=goodbye", status_code="404")
 
     assert "triggers" in json.loads(span.get_tag("_dd.appsec.json"))
 
@@ -460,7 +436,7 @@ def test_obfuscation_parameter_value_configured_not_matching(tracer):
         _enable_appsec(tracer)
 
         with _asm_request_context.asm_request_context_manager(), tracer.trace("test", span_type=SpanTypes.WEB) as span:
-            set_http_meta(span, Config(), raw_uri="http://example.com/.git?password=goodbye", status_code="404")
+            set_http_meta(span, rules.Config(), raw_uri="http://example.com/.git?password=goodbye", status_code="404")
 
         assert "triggers" in json.loads(span.get_tag("_dd.appsec.json"))
 
@@ -476,7 +452,7 @@ def test_obfuscation_parameter_value_configured_matching(tracer):
         _enable_appsec(tracer)
 
         with _asm_request_context.asm_request_context_manager(), tracer.trace("test", span_type=SpanTypes.WEB) as span:
-            set_http_meta(span, Config(), raw_uri="http://example.com/.git?token=goodbye", status_code="404")
+            set_http_meta(span, rules.Config(), raw_uri="http://example.com/.git?token=goodbye", status_code="404")
 
         assert "triggers" in json.loads(span.get_tag("_dd.appsec.json"))
 
@@ -486,8 +462,8 @@ def test_obfuscation_parameter_value_configured_matching(tracer):
 
 
 def test_ddwaf_run():
-    with open(RULES_GOOD_PATH) as rules:
-        rules_json = json.loads(rules.read())
+    with open(rules.RULES_GOOD_PATH) as rule_set:
+        rules_json = json.loads(rule_set.read())
         _ddwaf = DDWaf(rules_json, b"", b"")
         data = {
             "server.request.query": {},
@@ -506,8 +482,8 @@ def test_ddwaf_run():
 
 
 def test_ddwaf_run_timeout():
-    with open(RULES_GOOD_PATH) as rules:
-        rules_json = json.loads(rules.read())
+    with open(rules.RULES_GOOD_PATH) as rule_set:
+        rules_json = json.loads(rule_set.read())
         _ddwaf = DDWaf(rules_json, b"", b"")
         data = {
             "server.request.path_params": {"param_{}".format(i): "value_{}".format(i) for i in range(100)},
@@ -522,8 +498,8 @@ def test_ddwaf_run_timeout():
 
 
 def test_ddwaf_info():
-    with open(RULES_GOOD_PATH) as rules:
-        rules_json = json.loads(rules.read())
+    with open(rules.RULES_GOOD_PATH) as rule_set:
+        rules_json = json.loads(rule_set.read())
         _ddwaf = DDWaf(rules_json, b"", b"")
 
         info = _ddwaf.info
@@ -534,8 +510,8 @@ def test_ddwaf_info():
 
 
 def test_ddwaf_info_with_2_errors():
-    with open(os.path.join(ROOT_DIR, "rules-with-2-errors.json")) as rules:
-        rules_json = json.loads(rules.read())
+    with open(os.path.join(rules.ROOT_DIR, "rules-with-2-errors.json")) as rule_set:
+        rules_json = json.loads(rule_set.read())
         _ddwaf = DDWaf(rules_json, b"", b"")
 
         info = _ddwaf.info
@@ -550,8 +526,8 @@ def test_ddwaf_info_with_2_errors():
 
 
 def test_ddwaf_info_with_3_errors():
-    with open(os.path.join(ROOT_DIR, "rules-with-3-errors.json")) as rules:
-        rules_json = json.loads(rules.read())
+    with open(os.path.join(rules.ROOT_DIR, "rules-with-3-errors.json")) as rule_set:
+        rules_json = json.loads(rule_set.read())
         _ddwaf = DDWaf(rules_json, b"", b"")
 
         info = _ddwaf.info
@@ -562,7 +538,7 @@ def test_ddwaf_info_with_3_errors():
 
 def test_ddwaf_info_with_json_decode_errors(tracer_appsec, caplog):
     tracer = tracer_appsec
-    config = Config()
+    config = rules.Config()
     config.http_tag_query_string = True
 
     with caplog.at_level(logging.WARNING), mock.patch(
@@ -599,7 +575,7 @@ def test_ddwaf_info_with_json_decode_errors(tracer_appsec, caplog):
 def test_ddwaf_run_contained_typeerror(tracer_appsec, caplog):
     tracer = tracer_appsec
 
-    config = Config()
+    config = rules.Config()
     config.http_tag_query_string = True
 
     with caplog.at_level(logging.DEBUG), mock.patch(
@@ -637,7 +613,7 @@ def test_ddwaf_run_contained_typeerror(tracer_appsec, caplog):
 def test_ddwaf_run_contained_oserror(tracer_appsec, caplog):
     tracer = tracer_appsec
 
-    config = Config()
+    config = rules.Config()
     config.http_tag_query_string = True
 
     with caplog.at_level(logging.DEBUG), mock.patch(

--- a/tests/appsec/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/appsec/test_remoteconfiguration.py
@@ -28,8 +28,7 @@ from ddtrace.internal.remoteconfig.client import ConfigMetadata
 from ddtrace.internal.remoteconfig.client import TargetFile
 from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
 from ddtrace.internal.utils.formats import asbool
-from tests.appsec.appsec.test_processor import ROOT_DIR
-from tests.appsec.appsec.test_processor import Config
+import tests.appsec.rules as rules
 from tests.appsec.utils import Either
 from tests.utils import override_env
 from tests.utils import override_global_config
@@ -905,7 +904,7 @@ def test_rc_activation_ip_blocking_data(tracer, remote_config_worker):
             with tracer.trace("test", span_type=SpanTypes.WEB) as span:
                 set_http_meta(
                     span,
-                    Config(),
+                    rules.Config(),
                 )
             assert "triggers" in json.loads(span.get_tag(APPSEC.JSON))
             assert core.get_item("http.request.remote_ip", span) == "8.8.4.4"
@@ -936,7 +935,7 @@ def test_rc_activation_ip_blocking_data_expired(tracer, remote_config_worker):
             with tracer.trace("test", span_type=SpanTypes.WEB) as span:
                 set_http_meta(
                     span,
-                    Config(),
+                    rules.Config(),
                 )
             assert span.get_tag(APPSEC.JSON) is None
 
@@ -966,14 +965,16 @@ def test_rc_activation_ip_blocking_data_not_expired(tracer, remote_config_worker
             with tracer.trace("test", span_type=SpanTypes.WEB) as span:
                 set_http_meta(
                     span,
-                    Config(),
+                    rules.Config(),
                 )
             assert "triggers" in json.loads(span.get_tag(APPSEC.JSON))
             assert core.get_item("http.request.remote_ip", span) == "8.8.4.4"
 
 
 def test_rc_rules_data(tracer):
-    RULES_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(ROOT_DIR))), "ddtrace/appsec/rules.json")
+    RULES_PATH = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(rules.ROOT_DIR))), "ddtrace/appsec/rules.json"
+    )
     with override_global_config(dict(_asm_enabled=True)), override_env({APPSEC.ENV: "true"}), open(
         RULES_PATH, "r"
     ) as dd_rules:

--- a/tests/appsec/appsec/test_telemetry.py
+++ b/tests/appsec/appsec/test_telemetry.py
@@ -13,11 +13,8 @@ from ddtrace.ext import SpanTypes
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE_TAG_APPSEC
 from ddtrace.internal.telemetry.constants import TELEMETRY_TYPE_DISTRIBUTION
 from ddtrace.internal.telemetry.constants import TELEMETRY_TYPE_GENERATE_METRICS
-from tests.appsec.appsec.test_processor import _IP
-from tests.appsec.appsec.test_processor import ROOT_DIR
-from tests.appsec.appsec.test_processor import RULES_GOOD_PATH
-from tests.appsec.appsec.test_processor import Config
 from tests.appsec.appsec.test_processor import _enable_appsec
+import tests.appsec.rules as rules
 from tests.utils import override_env
 from tests.utils import override_global_config
 
@@ -62,7 +59,7 @@ def test_metrics_when_appsec_doesnt_runs(telemetry_writer, tracer):
         with tracer.trace("test", span_type=SpanTypes.WEB) as span:
             set_http_meta(
                 span,
-                Config(),
+                rules.Config(),
             )
     metrics_data = telemetry_writer._namespace._metrics_data
     assert len(metrics_data[TELEMETRY_TYPE_GENERATE_METRICS][TELEMETRY_NAMESPACE_TAG_APPSEC]) == 0
@@ -76,29 +73,29 @@ def test_metrics_when_appsec_runs(telemetry_writer, tracer):
         with tracer.trace("test", span_type=SpanTypes.WEB) as span:
             set_http_meta(
                 span,
-                Config(),
+                rules.Config(),
             )
     _assert_generate_metrics(telemetry_writer._namespace._metrics_data)
 
 
 def test_metrics_when_appsec_attack(telemetry_writer, tracer):
-    with override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)), override_global_config(dict(_asm_enabled=True)):
+    with override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)), override_global_config(dict(_asm_enabled=True)):
         telemetry_writer._namespace.flush()
         _enable_appsec(tracer)
         with tracer.trace("test", span_type=SpanTypes.WEB) as span:
-            set_http_meta(span, Config(), request_cookies={"attack": "1' or '1' = '1'"})
+            set_http_meta(span, rules.Config(), request_cookies={"attack": "1' or '1' = '1'"})
     _assert_generate_metrics(telemetry_writer._namespace._metrics_data, is_rule_triggered=True)
 
 
 def test_metrics_when_appsec_block(telemetry_writer, tracer):
-    with override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)), override_global_config(dict(_asm_enabled=True)):
+    with override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)), override_global_config(dict(_asm_enabled=True)):
         telemetry_writer._namespace.flush()
         _enable_appsec(tracer)
-        with _asm_request_context.asm_request_context_manager(_IP.BLOCKED, {}):
+        with _asm_request_context.asm_request_context_manager(rules._IP.BLOCKED, {}):
             with tracer.trace("test", span_type=SpanTypes.WEB) as span:
                 set_http_meta(
                     span,
-                    Config(),
+                    rules.Config(),
                 )
 
     _assert_generate_metrics(telemetry_writer._namespace._metrics_data, is_rule_triggered=True, is_blocked_request=True)
@@ -107,7 +104,8 @@ def test_metrics_when_appsec_block(telemetry_writer, tracer):
 def test_log_metric_error_ddwaf_init(telemetry_writer):
     with override_global_config(dict(_asm_enabled=True)), override_env(
         dict(
-            _DD_APPSEC_DEDUPLICATION_ENABLED="false", DD_APPSEC_RULES=os.path.join(ROOT_DIR, "rules-with-2-errors.json")
+            _DD_APPSEC_DEDUPLICATION_ENABLED="false",
+            DD_APPSEC_RULES=os.path.join(rules.ROOT_DIR, "rules-with-2-errors.json"),
         )
     ):
         AppSecSpanProcessor()
@@ -121,14 +119,14 @@ def test_log_metric_error_ddwaf_init(telemetry_writer):
 
 def test_log_metric_error_ddwaf_timeout(telemetry_writer, tracer):
     with override_env(
-        dict(_DD_APPSEC_DEDUPLICATION_ENABLED="false", DD_APPSEC_RULES=RULES_GOOD_PATH)
+        dict(_DD_APPSEC_DEDUPLICATION_ENABLED="false", DD_APPSEC_RULES=rules.RULES_GOOD_PATH)
     ), override_global_config(dict(_asm_enabled=True, _waf_timeout=0.0)):
         _enable_appsec(tracer)
-        with _asm_request_context.asm_request_context_manager(_IP.BLOCKED, {}):
+        with _asm_request_context.asm_request_context_manager(rules._IP.BLOCKED, {}):
             with tracer.trace("test", span_type=SpanTypes.WEB) as span:
                 set_http_meta(
                     span,
-                    Config(),
+                    rules.Config(),
                 )
 
         list_metrics_logs = list(telemetry_writer._logs)

--- a/tests/appsec/rules.py
+++ b/tests/appsec/rules.py
@@ -1,0 +1,27 @@
+import os.path
+
+
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__)) + "/appsec"
+RULES_GOOD_PATH = os.path.join(ROOT_DIR, "rules-good.json")
+RULES_BAD_PATH = os.path.join(ROOT_DIR, "rules-bad.json")
+RULES_MISSING_PATH = os.path.join(ROOT_DIR, "nonexistent")
+RULES_SRB = os.path.join(ROOT_DIR, "rules-suspicious-requests.json")
+RULES_SRBCA = os.path.join(ROOT_DIR, "rules-suspicious-requests-custom-actions.json")
+RULES_SRB_RESPONSE = os.path.join(ROOT_DIR, "rules-suspicious-requests-response.json")
+RULES_SRB_METHOD = os.path.join(ROOT_DIR, "rules-suspicious-requests-get.json")
+RULES_BAD_VERSION = os.path.join(ROOT_DIR, "rules-bad_version.json")
+
+RESPONSE_CUSTOM_JSON = os.path.join(ROOT_DIR, "response-custom.json")
+RESPONSE_CUSTOM_HTML = os.path.join(ROOT_DIR, "response-custom.html")
+
+
+class _IP:
+    BLOCKED = "8.8.4.4"  # actively blocked
+    MONITORED = "8.8.5.5"  # on the pass list should never been blocked but still monitored
+    BYPASS = "8.8.6.6"  # on the pass list, should bypass all security
+    DEFAULT = "1.1.1.1"  # default behaviour
+
+
+class Config(object):
+    def __init__(self):
+        self.is_header_tracing_configured = False

--- a/tests/contrib/django/test_django_appsec.py
+++ b/tests/contrib/django/test_django_appsec.py
@@ -6,6 +6,7 @@ import pytest
 
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import SPAN_DATA_NAMES
+from ddtrace.appsec._processor import AppSecSpanProcessor  # noqa: F401
 from ddtrace.ext import http
 from ddtrace.ext import user
 from ddtrace.internal import constants

--- a/tests/contrib/django/test_django_appsec.py
+++ b/tests/contrib/django/test_django_appsec.py
@@ -14,14 +14,7 @@ from ddtrace.internal.compat import urlencode
 from ddtrace.internal.constants import BLOCKED_RESPONSE_HTML
 from ddtrace.internal.constants import BLOCKED_RESPONSE_JSON
 from ddtrace.settings.asm import config as asm_config
-from tests.appsec.appsec.test_processor import _IP
-from tests.appsec.appsec.test_processor import RESPONSE_CUSTOM_HTML
-from tests.appsec.appsec.test_processor import RESPONSE_CUSTOM_JSON
-from tests.appsec.appsec.test_processor import RULES_GOOD_PATH
-from tests.appsec.appsec.test_processor import RULES_SRB
-from tests.appsec.appsec.test_processor import RULES_SRB_METHOD
-from tests.appsec.appsec.test_processor import RULES_SRB_RESPONSE
-from tests.appsec.appsec.test_processor import RULES_SRBCA
+import tests.appsec.rules as rules
 from tests.utils import override_env
 from tests.utils import override_global_config
 
@@ -96,7 +89,7 @@ def test_django_request_cookies(client, test_spans, tracer):
 
 def test_django_request_cookies_attack(client, test_spans, tracer):
     with override_global_config(dict(_asm_enabled=True)):
-        with override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+        with override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
             root_span, _ = _aux_appsec_get_root_span(client, test_spans, tracer, cookies={"attack": "1' or '1' = '1'"})
             query = dict(core.get_item("http.request.cookies", span=root_span))
             str_json = root_span.get_tag(APPSEC.JSON)
@@ -177,7 +170,7 @@ def test_django_request_body_json(client, test_spans, tracer):
 
 def test_django_request_body_json_attack(client, test_spans, tracer):
     with override_global_config(dict(_asm_enabled=True)):
-        with override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+        with override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
             payload = json.dumps({"attack": "1' or '1' = '1'"})
             root_span, _ = _aux_appsec_get_root_span(
                 client,
@@ -243,7 +236,7 @@ def test_django_request_body_plain(client, test_spans, tracer):
 
 
 def test_django_request_body_plain_attack(client, test_spans, tracer):
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
         root_span, _ = _aux_appsec_get_root_span(client, test_spans, tracer, payload="1' or '1' = '1'")
 
         query = core.get_item("http.request.body", span=root_span)
@@ -257,7 +250,7 @@ def test_django_request_body_json_bad(caplog, client, test_spans, tracer):
     # caplog where if you set this to WARNING the second test won't get
     # output unless you set all to DEBUG.
     with caplog.at_level(logging.DEBUG), override_global_config(dict(_asm_enabled=True)), override_env(
-        dict(DD_APPSEC_RULES=RULES_GOOD_PATH)
+        dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)
     ):
         payload = '{"attack": "bad_payload",}'
 
@@ -276,7 +269,7 @@ def test_django_request_body_json_bad(caplog, client, test_spans, tracer):
 def test_django_request_body_xml_bad_logs_warning(caplog, client, test_spans, tracer):
     # see above about caplog
     with caplog.at_level(logging.DEBUG), override_global_config(dict(_asm_enabled=True)), override_env(
-        dict(DD_APPSEC_RULES=RULES_GOOD_PATH)
+        dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)
     ):
         _, response = _aux_appsec_get_root_span(
             client,
@@ -407,18 +400,18 @@ def test_request_ipblock_403(client, test_spans, tracer):
     using the "normal" path for these Django tests.
     (They're also a lot less cumbersome to use for experimentation/debugging)
     """
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
         root, result = _aux_appsec_get_root_span(
             client,
             test_spans,
             tracer,
             url="/foobar",
-            headers={"HTTP_X_REAL_IP": _IP.BLOCKED, "HTTP_USER_AGENT": "fooagent"},
+            headers={"HTTP_X_REAL_IP": rules._IP.BLOCKED, "HTTP_USER_AGENT": "fooagent"},
         )
         assert result.status_code == 403
         as_bytes = bytes(constants.BLOCKED_RESPONSE_JSON, "utf-8")
         assert result.content == as_bytes
-        assert root.get_tag("actor.ip") == _IP.BLOCKED
+        assert root.get_tag("actor.ip") == rules._IP.BLOCKED
         assert root.get_tag(http.STATUS_CODE) == "403"
         assert root.get_tag(http.URL) == "http://testserver/foobar"
         assert root.get_tag(http.METHOD) == "GET"
@@ -435,23 +428,27 @@ def test_request_ipblock_403_html(client, test_spans, tracer):
     using the "normal" path for these Django tests.
     (They're also a lot less cumbersome to use for experimentation/debugging)
     """
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
         root, result = _aux_appsec_get_root_span(
-            client, test_spans, tracer, url="/", headers={"HTTP_X_REAL_IP": _IP.BLOCKED, "HTTP_ACCEPT": "text/html"}
+            client,
+            test_spans,
+            tracer,
+            url="/",
+            headers={"HTTP_X_REAL_IP": rules._IP.BLOCKED, "HTTP_ACCEPT": "text/html"},
         )
         assert result.status_code == 403
         as_bytes = bytes(BLOCKED_RESPONSE_HTML, "utf-8")
         assert result.content == as_bytes
-        assert root.get_tag("actor.ip") == _IP.BLOCKED
+        assert root.get_tag("actor.ip") == rules._IP.BLOCKED
         assert root.get_tag(SPAN_DATA_NAMES.RESPONSE_HEADERS_NO_COOKIES + ".content-type") == "text/html"
         if hasattr(result, "headers"):
             assert result.headers["content-type"] == "text/html"
 
 
 def test_request_ipblock_nomatch_200(client, test_spans, tracer):
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
         root, result = _aux_appsec_get_root_span(
-            client, test_spans, tracer, url="/", headers={"HTTP_X_REAL_IP": _IP.DEFAULT}
+            client, test_spans, tracer, url="/", headers={"HTTP_X_REAL_IP": rules._IP.DEFAULT}
         )
         assert result.status_code == 200
         assert result.content == b"Hello, test app."
@@ -459,13 +456,13 @@ def test_request_ipblock_nomatch_200(client, test_spans, tracer):
 
 
 def test_request_block_request_callable(client, test_spans, tracer):
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
         root, result = _aux_appsec_get_root_span(
             client,
             test_spans,
             tracer,
             url="/appsec/block/",
-            headers={"HTTP_X_REAL_IP": _IP.DEFAULT, "HTTP_USER_AGENT": "fooagent"},
+            headers={"HTTP_X_REAL_IP": rules._IP.DEFAULT, "HTTP_USER_AGENT": "fooagent"},
         )
         # Should not block by IP, but the block callable is called directly inside that view
         assert result.status_code == 403
@@ -485,7 +482,7 @@ _ALLOWED_USER = "111111"
 
 
 def test_request_userblock_200(client, test_spans, tracer):
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
         root, result = _aux_appsec_get_root_span(
             client, test_spans, tracer, url="/appsec/checkuser/%s/" % _ALLOWED_USER
         )
@@ -494,7 +491,7 @@ def test_request_userblock_200(client, test_spans, tracer):
 
 
 def test_request_userblock_403(client, test_spans, tracer):
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
         root, result = _aux_appsec_get_root_span(
             client, test_spans, tracer, url="/appsec/checkuser/%s/" % _BLOCKED_USER
         )
@@ -511,7 +508,7 @@ def test_request_userblock_403(client, test_spans, tracer):
 
 def test_request_suspicious_request_block_match_method(client, test_spans, tracer):
     # GET must be blocked
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB_METHOD)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB_METHOD)):
         root_span, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="/")
         assert response.status_code == 403
         as_bytes = bytes(BLOCKED_RESPONSE_JSON, "utf-8")
@@ -525,18 +522,18 @@ def test_request_suspicious_request_block_match_method(client, test_spans, trace
         if hasattr(response, "headers"):
             assert response.headers["content-type"] == "text/json"
     # POST must pass
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB_METHOD)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB_METHOD)):
         root_span, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="/", payload="any")
         assert response.status_code == 200
     # GET must pass if appsec disabled
-    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB_METHOD)):
+    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB_METHOD)):
         root_span, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="/")
         assert response.status_code == 200
 
 
 def test_request_suspicious_request_block_match_uri(client, test_spans, tracer):
     # .git must be blocked
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         root_span, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="/.git")
         assert response.status_code == 403
         as_bytes = bytes(BLOCKED_RESPONSE_JSON, "utf-8")
@@ -544,15 +541,15 @@ def test_request_suspicious_request_block_match_uri(client, test_spans, tracer):
         loaded = json.loads(root_span.get_tag(APPSEC.JSON))
         assert [t["rule"]["id"] for t in loaded["triggers"]] == ["tst-037-002"]
     # legit must pass
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         _, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="/legit")
         assert response.status_code == 404
     # appsec disabled must not block
-    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         _, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="/.git")
         assert response.status_code == 404
     # we must block with uri.raw not containing scheme or netloc
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         root_span, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="/we_should_block")
         assert response.status_code == 403
         as_bytes = bytes(BLOCKED_RESPONSE_JSON, "utf-8")
@@ -563,7 +560,7 @@ def test_request_suspicious_request_block_match_uri(client, test_spans, tracer):
 
 def test_request_suspicious_request_block_match_path_params(client, test_spans, tracer):
     # value AiKfOeRcvG45 must be blocked
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         root_span, response = _aux_appsec_get_root_span(
             client, test_spans, tracer, url="/appsec/path-params/2022/AiKfOeRcvG45/"
         )
@@ -573,11 +570,11 @@ def test_request_suspicious_request_block_match_path_params(client, test_spans, 
         loaded = json.loads(root_span.get_tag(APPSEC.JSON))
         assert [t["rule"]["id"] for t in loaded["triggers"]] == ["tst-037-007"]
     # other values must not be blocked
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         _, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="/appsec/path-params/2022/Anything/")
         assert response.status_code == 200
     # appsec disabled must not block
-    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         _, response = _aux_appsec_get_root_span(
             client, test_spans, tracer, url="/appsec/path-params/2022/AiKfOeRcvG45/"
         )
@@ -586,7 +583,7 @@ def test_request_suspicious_request_block_match_path_params(client, test_spans, 
 
 def test_request_suspicious_request_block_match_query_value(client, test_spans, tracer):
     # value xtrace must be blocked
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         root_span, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="index.html?toto=xtrace")
         assert response.status_code == 403
         as_bytes = bytes(BLOCKED_RESPONSE_JSON, "utf-8")
@@ -594,18 +591,18 @@ def test_request_suspicious_request_block_match_query_value(client, test_spans, 
         loaded = json.loads(root_span.get_tag(APPSEC.JSON))
         assert [t["rule"]["id"] for t in loaded["triggers"]] == ["tst-037-001"]
     # other values must not be blocked
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         _, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="index.html?toto=ytrace")
         assert response.status_code == 404
     # appsec disabled must not block
-    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         _, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="index.html?toto=xtrace")
         assert response.status_code == 404
 
 
 def test_request_suspicious_request_block_match_header(client, test_spans, tracer):
     # value 01972498723465 must be blocked
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         root_span, response = _aux_appsec_get_root_span(
             client, test_spans, tracer, url="/", headers={"HTTP_USER_AGENT": "01972498723465"}
         )
@@ -615,13 +612,13 @@ def test_request_suspicious_request_block_match_header(client, test_spans, trace
         loaded = json.loads(root_span.get_tag(APPSEC.JSON))
         assert [t["rule"]["id"] for t in loaded["triggers"]] == ["tst-037-004"]
     # other values must not be blocked
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         _, response = _aux_appsec_get_root_span(
             client, test_spans, tracer, url="/", headers={"HTTP_USER_AGENT": "01973498523465"}
         )
         assert response.status_code == 200
     # appsec disabled must not block
-    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         _, response = _aux_appsec_get_root_span(
             client, test_spans, tracer, url="/", headers={"HTTP_USER_AGENT": "01972498723465"}
         )
@@ -655,7 +652,7 @@ def test_request_suspicious_request_block_match_body(client, test_spans, tracer)
             # other values must not be blocked
             ('{"attack": "zqrweytqwreasldhkuqxgervflnmlnli"}', "application/json", False),
         ]:
-            with override_global_config(dict(_asm_enabled=appsec)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+            with override_global_config(dict(_asm_enabled=appsec)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
                 root_span, response = _aux_appsec_get_root_span(
                     client,
                     test_spans,
@@ -676,7 +673,7 @@ def test_request_suspicious_request_block_match_body(client, test_spans, tracer)
 
 def test_request_suspicious_request_block_match_response_code(client, test_spans, tracer):
     # 404 must be blocked
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB_RESPONSE)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB_RESPONSE)):
         root_span, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="/do_not_exist.php")
         assert response.status_code == 403
         as_bytes = bytes(BLOCKED_RESPONSE_JSON, "utf-8")
@@ -684,18 +681,18 @@ def test_request_suspicious_request_block_match_response_code(client, test_spans
         loaded = json.loads(root_span.get_tag(APPSEC.JSON))
         assert [t["rule"]["id"] for t in loaded["triggers"]] == ["tst-037-005"]
     # 200 must not be blocked
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB_RESPONSE)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB_RESPONSE)):
         _, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="/")
         assert response.status_code == 200
     # appsec disabled must not block
-    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB_RESPONSE)):
+    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB_RESPONSE)):
         _, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="/do_not_exist.php")
         assert response.status_code == 404
 
 
 def test_request_suspicious_request_block_match_request_cookie(client, test_spans, tracer):
     # value jdfoSDGFkivRG_234 must be blocked
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         root_span, response = _aux_appsec_get_root_span(
             client, test_spans, tracer, url="", cookies={"mytestingcookie_key": "jdfoSDGFkivRG_234"}
         )
@@ -705,13 +702,13 @@ def test_request_suspicious_request_block_match_request_cookie(client, test_span
         loaded = json.loads(root_span.get_tag(APPSEC.JSON))
         assert [t["rule"]["id"] for t in loaded["triggers"]] == ["tst-037-008"]
     # other value must not be blocked
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         _, response = _aux_appsec_get_root_span(
             client, test_spans, tracer, url="", cookies={"mytestingcookie_key": "jdfoSDGEkivRH_234"}
         )
         assert response.status_code == 200
     # appsec disabled must not block
-    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         _, response = _aux_appsec_get_root_span(
             client, test_spans, tracer, url="", cookies={"mytestingcookie_key": "jdfoSDGFkivRG_234"}
         )
@@ -720,7 +717,7 @@ def test_request_suspicious_request_block_match_request_cookie(client, test_span
 
 def test_request_suspicious_request_block_match_response_headers(client, test_spans, tracer):
     # value MagicKey_Al4h7iCFep9s1 must be blocked
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         root_span, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="/appsec/response-header/")
         assert response.status_code == 403
         as_bytes = bytes(BLOCKED_RESPONSE_JSON, "utf-8")
@@ -728,7 +725,7 @@ def test_request_suspicious_request_block_match_response_headers(client, test_sp
         loaded = json.loads(root_span.get_tag(APPSEC.JSON))
         assert [t["rule"]["id"] for t in loaded["triggers"]] == ["tst-037-009"]
     # appsec disabled must not block
-    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         root_span, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="/appsec/response-header/")
         assert response.status_code == 200
 
@@ -743,9 +740,9 @@ def test_request_suspicious_request_block_custom_actions(client, test_spans, tra
     # value suspicious_306_auto must be blocked
     with override_global_config(dict(_asm_enabled=True)), override_env(
         dict(
-            DD_APPSEC_RULES=RULES_SRBCA,
-            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=RESPONSE_CUSTOM_JSON,
-            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=RESPONSE_CUSTOM_HTML,
+            DD_APPSEC_RULES=rules.RULES_SRBCA,
+            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=rules.RESPONSE_CUSTOM_JSON,
+            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=rules.RESPONSE_CUSTOM_HTML,
         )
     ):
         root_span, response = _aux_appsec_get_root_span(
@@ -761,9 +758,9 @@ def test_request_suspicious_request_block_custom_actions(client, test_spans, tra
     # value suspicious_306_auto must be blocked with text if required
     with override_global_config(dict(_asm_enabled=True)), override_env(
         dict(
-            DD_APPSEC_RULES=RULES_SRBCA,
-            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=RESPONSE_CUSTOM_JSON,
-            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=RESPONSE_CUSTOM_HTML,
+            DD_APPSEC_RULES=rules.RULES_SRBCA,
+            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=rules.RESPONSE_CUSTOM_JSON,
+            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=rules.RESPONSE_CUSTOM_HTML,
         )
     ):
         root_span, response = _aux_appsec_get_root_span(
@@ -778,9 +775,9 @@ def test_request_suspicious_request_block_custom_actions(client, test_spans, tra
     # value suspicious_429_json must be blocked
     with override_global_config(dict(_asm_enabled=True)), override_env(
         dict(
-            DD_APPSEC_RULES=RULES_SRBCA,
-            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=RESPONSE_CUSTOM_JSON,
-            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=RESPONSE_CUSTOM_HTML,
+            DD_APPSEC_RULES=rules.RULES_SRBCA,
+            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=rules.RESPONSE_CUSTOM_JSON,
+            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=rules.RESPONSE_CUSTOM_HTML,
         )
     ):
         root_span, response = _aux_appsec_get_root_span(
@@ -796,9 +793,9 @@ def test_request_suspicious_request_block_custom_actions(client, test_spans, tra
     # value suspicious_429_json must be blocked with json even if text if required
     with override_global_config(dict(_asm_enabled=True)), override_env(
         dict(
-            DD_APPSEC_RULES=RULES_SRBCA,
-            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=RESPONSE_CUSTOM_JSON,
-            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=RESPONSE_CUSTOM_HTML,
+            DD_APPSEC_RULES=rules.RULES_SRBCA,
+            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=rules.RESPONSE_CUSTOM_JSON,
+            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=rules.RESPONSE_CUSTOM_HTML,
         )
     ):
         root_span, response = _aux_appsec_get_root_span(
@@ -815,9 +812,9 @@ def test_request_suspicious_request_block_custom_actions(client, test_spans, tra
     # value suspicious_503_html must be blocked with text even if json is required
     with override_global_config(dict(_asm_enabled=True)), override_env(
         dict(
-            DD_APPSEC_RULES=RULES_SRBCA,
-            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=RESPONSE_CUSTOM_JSON,
-            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=RESPONSE_CUSTOM_HTML,
+            DD_APPSEC_RULES=rules.RULES_SRBCA,
+            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=rules.RESPONSE_CUSTOM_JSON,
+            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=rules.RESPONSE_CUSTOM_HTML,
         )
     ):
         root_span, response = _aux_appsec_get_root_span(
@@ -832,9 +829,9 @@ def test_request_suspicious_request_block_custom_actions(client, test_spans, tra
     # value suspicious_503_html must be blocked with text if required
     with override_global_config(dict(_asm_enabled=True)), override_env(
         dict(
-            DD_APPSEC_RULES=RULES_SRBCA,
-            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=RESPONSE_CUSTOM_JSON,
-            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=RESPONSE_CUSTOM_HTML,
+            DD_APPSEC_RULES=rules.RULES_SRBCA,
+            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=rules.RESPONSE_CUSTOM_JSON,
+            DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=rules.RESPONSE_CUSTOM_HTML,
         )
     ):
         root_span, response = _aux_appsec_get_root_span(
@@ -847,11 +844,11 @@ def test_request_suspicious_request_block_custom_actions(client, test_spans, tra
         assert [t["rule"]["id"] for t in loaded["triggers"]] == ["tst-040-003"]
 
     # other values must not be blocked
-    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         _, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="index.html?toto=ytrace")
         assert response.status_code == 404
     # appsec disabled must not block
-    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+    with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
         _, response = _aux_appsec_get_root_span(client, test_spans, tracer, url="index.html?toto=suspicious_503_html")
         assert response.status_code == 404
     # remove cache to avoid other tests from using the templates of this test
@@ -870,7 +867,7 @@ def test_request_suspicious_request_redirect_actions(client, test_spans, tracer,
     # value suspicious_306_auto must be blocked
     with override_global_config(dict(_asm_enabled=True)), override_env(
         dict(
-            DD_APPSEC_RULES=RULES_SRBCA,
+            DD_APPSEC_RULES=rules.RULES_SRBCA,
         )
     ):
         root_span, response = _aux_appsec_get_root_span(

--- a/tests/contrib/django/test_django_appsec_snapshots.py
+++ b/tests/contrib/django/test_django_appsec_snapshots.py
@@ -6,8 +6,7 @@ import django
 import pytest
 
 import ddtrace.internal.constants as constants
-from tests.appsec.appsec.test_processor import _IP
-from tests.appsec.appsec.test_processor import RULES_GOOD_PATH
+import tests.appsec.rules as rules
 from tests.utils import snapshot
 from tests.webclient import Client
 
@@ -113,10 +112,10 @@ def test_request_ipblock_nomatch_200():
         additional_env={
             "DD_DJANGO_INSTRUMENT_TEMPLATES": "false",
             "DD_APPSEC_ENABLED": "true",
-            "DD_APPSEC_RULES": RULES_GOOD_PATH,
+            "DD_APPSEC_RULES": rules.RULES_GOOD_PATH,
         },
     ) as client:
-        result = client.get("/", headers={"X-Real-Ip": _IP.DEFAULT})
+        result = client.get("/", headers={"X-Real-Ip": rules._IP.DEFAULT})
         assert result.status_code == 200
         assert result.content == b"Hello, test app."
 
@@ -140,13 +139,13 @@ def test_request_ipblock_match_403():
         "application",
         additional_env={
             "DD_APPSEC_ENABLED": "true",
-            "DD_APPSEC_RULES": RULES_GOOD_PATH,
+            "DD_APPSEC_RULES": rules.RULES_GOOD_PATH,
         },
     ) as client:
         result = client.get(
             "/",
             headers={
-                "X-Real-Ip": _IP.BLOCKED,
+                "X-Real-Ip": rules._IP.BLOCKED,
                 "Accept": "text/html",
             },
         )
@@ -174,13 +173,13 @@ def test_request_ipblock_match_403_json():
         "application",
         additional_env={
             "DD_APPSEC_ENABLED": "true",
-            "DD_APPSEC_RULES": RULES_GOOD_PATH,
+            "DD_APPSEC_RULES": rules.RULES_GOOD_PATH,
         },
     ) as client:
         result = client.get(
             "/",
             headers={
-                "X-Real-Ip": _IP.BLOCKED,
+                "X-Real-Ip": rules._IP.BLOCKED,
             },
         )
         assert result.status_code == 403

--- a/tests/contrib/flask/test_appsec_flask_snapshot.py
+++ b/tests/contrib/flask/test_appsec_flask_snapshot.py
@@ -15,8 +15,7 @@ from ddtrace.contrib.flask.patch import flask_version
 from ddtrace.internal.constants import BLOCKED_RESPONSE_HTML
 from ddtrace.internal.constants import BLOCKED_RESPONSE_JSON
 from ddtrace.internal.utils.retry import RetryError
-from tests.appsec.appsec.test_processor import _IP
-from tests.appsec.appsec.test_processor import RULES_GOOD_PATH
+import tests.appsec.rules as rules
 from tests.contrib.flask.test_flask_appsec import _ALLOWED_USER
 from tests.contrib.flask.test_flask_appsec import _BLOCKED_USER
 from tests.webclient import Client
@@ -55,7 +54,7 @@ def flask_appsec_good_rules_env(flask_wsgi_application):
             "DD_TRACE_SQLITE3_ENABLED": "0",
             "FLASK_APP": flask_wsgi_application,
             "DD_APPSEC_ENABLED": "true",
-            "DD_APPSEC_RULES": RULES_GOOD_PATH,
+            "DD_APPSEC_RULES": rules.RULES_GOOD_PATH,
         }
     )
     return env
@@ -130,7 +129,7 @@ def flask_client(flask_command, flask_port, flask_wsgi_application, flask_env_ar
 )
 @pytest.mark.parametrize("flask_env_arg", (flask_appsec_good_rules_env,))
 def test_flask_ipblock_match_403(flask_client):
-    resp = flask_client.get("/", headers={"X-Real-Ip": _IP.BLOCKED, "ACCEPT": "text/html"})
+    resp = flask_client.get("/", headers={"X-Real-Ip": rules._IP.BLOCKED, "ACCEPT": "text/html"})
     assert resp.status_code == 403
     if hasattr(resp, "text"):
         assert resp.text == BLOCKED_RESPONSE_HTML
@@ -159,7 +158,7 @@ def test_flask_ipblock_match_403(flask_client):
 )
 @pytest.mark.parametrize("flask_env_arg", (flask_appsec_good_rules_env,))
 def test_flask_ipblock_match_403_json(flask_client):
-    resp = flask_client.get("/", headers={"X-Real-Ip": _IP.BLOCKED})
+    resp = flask_client.get("/", headers={"X-Real-Ip": rules._IP.BLOCKED})
     assert resp.status_code == 403
     if hasattr(resp, "text"):
         assert resp.text == BLOCKED_RESPONSE_JSON

--- a/tests/contrib/flask/test_flask_appsec.py
+++ b/tests/contrib/flask/test_flask_appsec.py
@@ -13,15 +13,7 @@ from ddtrace.ext import http
 from ddtrace.internal import constants
 from ddtrace.internal import core
 from ddtrace.internal.compat import urlencode
-from tests.appsec.appsec.test_processor import _IP
-from tests.appsec.appsec.test_processor import RESPONSE_CUSTOM_HTML
-from tests.appsec.appsec.test_processor import RESPONSE_CUSTOM_JSON
-from tests.appsec.appsec.test_processor import RULES_BAD_VERSION
-from tests.appsec.appsec.test_processor import RULES_GOOD_PATH
-from tests.appsec.appsec.test_processor import RULES_SRB
-from tests.appsec.appsec.test_processor import RULES_SRB_METHOD
-from tests.appsec.appsec.test_processor import RULES_SRB_RESPONSE
-from tests.appsec.appsec.test_processor import RULES_SRBCA
+import tests.appsec.rules as rules
 from tests.contrib.flask import BaseFlaskTestCase
 from tests.utils import override_env
 from tests.utils import override_global_config
@@ -90,7 +82,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         def dynamic_url(item):
             return item
 
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
             self._aux_appsec_prepare_tracer()
             resp = self.client.get("/params/w00tw00t.at.isc.sans.dfind")
             assert resp.status_code == 200
@@ -115,7 +107,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             assert len(core.get_item("http.request.query", span=root_span)) == 0
 
     def test_flask_cookie_sql_injection(self):
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
             self._aux_appsec_prepare_tracer()
             self.client.set_cookie("localhost", "attack", "1' or '1' = '1'")
             resp = self.client.get("/")
@@ -282,8 +274,10 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         def route():
             return "OK", 200
 
-        for ip in [_IP.MONITORED, _IP.BYPASS, _IP.DEFAULT]:
-            with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+        for ip in [rules._IP.MONITORED, rules._IP.BYPASS, rules._IP.DEFAULT]:
+            with override_global_config(dict(_asm_enabled=True)), override_env(
+                dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)
+            ):
                 self._aux_appsec_prepare_tracer()
                 resp = self.client.get("/", headers={"X-Real-Ip": ip})
                 root_span = self.pop_spans()[0]
@@ -291,18 +285,18 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
                 assert not core.get_item("http.request.blocked", span=root_span)
 
     def test_flask_ipblock_nomatch_200_bypass(self):
-        self.flask_ipblock_nomatch_200_json(_IP.BYPASS)
+        self.flask_ipblock_nomatch_200_json(rules._IP.BYPASS)
 
     def test_flask_ipblock_nomatch_200_monitor(self):
-        self.flask_ipblock_nomatch_200_json(_IP.MONITORED)
+        self.flask_ipblock_nomatch_200_json(rules._IP.MONITORED)
 
     def test_flask_ipblock_nomatch_200_default(self):
-        self.flask_ipblock_nomatch_200_json(_IP.DEFAULT)
+        self.flask_ipblock_nomatch_200_json(rules._IP.DEFAULT)
 
     def test_flask_ipblock_match_403_json(self):
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
             self._aux_appsec_prepare_tracer()
-            resp = self.client.get("/foobar", headers={"X-Real-Ip": _IP.BLOCKED})
+            resp = self.client.get("/foobar", headers={"X-Real-Ip": rules._IP.BLOCKED})
             assert resp.status_code == 403
             assert get_response_body(resp) == constants.BLOCKED_RESPONSE_JSON
             root_span = self.pop_spans()[0]
@@ -322,9 +316,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         def route():
             return "OK", 200
 
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
             self._aux_appsec_prepare_tracer()
-            resp = self.client.get("/?value=block_that_value", headers={"X-Real-Ip": _IP.MONITORED})
+            resp = self.client.get("/?value=block_that_value", headers={"X-Real-Ip": rules._IP.MONITORED})
             assert resp.status_code == 200
             root_span = self.pop_spans()[0]
             assert root_span.get_tag(http.STATUS_CODE) == "200"
@@ -347,9 +341,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         def route():
             return "OK", 200
 
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
             self._aux_appsec_prepare_tracer()
-            resp = self.client.get("/?value=block_that_value", headers={"X-Real-Ip": _IP.BYPASS})
+            resp = self.client.get("/?value=block_that_value", headers={"X-Real-Ip": rules._IP.BYPASS})
             assert resp.status_code == 200
             root_span = self.pop_spans()[0]
             assert root_span.get_tag(http.STATUS_CODE) == "200"
@@ -371,9 +365,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
 
             return block_request()
 
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
             self._aux_appsec_prepare_tracer()
-            resp = self.client.get("/block", headers={"X-REAL-IP": _IP.DEFAULT})
+            resp = self.client.get("/block", headers={"X-REAL-IP": rules._IP.DEFAULT})
             # Should not block by IP but since the route is calling block_request it will be blocked
             assert resp.status_code == 403
             assert get_response_body(resp) == constants.BLOCKED_RESPONSE_JSON
@@ -392,7 +386,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             block_request_if_user_blocked(tracer, user_id)
             return "Ok", 200
 
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
             self._aux_appsec_prepare_tracer()
             resp = self.client.get("/checkuser/%s" % _BLOCKED_USER)
             assert resp.status_code == 403
@@ -417,7 +411,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             return "Ok: %s" % request.args.get("toto", ""), 200
 
         # value xtrace must be blocked
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer()
             resp = self.client.get("/index.html?toto=xtrace")
             assert resp.status_code == 403
@@ -431,13 +425,13 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             assert root_span.get_tag(http.USER_AGENT).startswith("werkzeug/")
             assert root_span.get_tag(SPAN_DATA_NAMES.RESPONSE_HEADERS_NO_COOKIES + ".content-type") == "text/json"
         # other values must not be blocked
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer()
             resp = self.client.get("/index.html?toto=ytrace")
             assert resp.status_code == 200
             assert get_response_body(resp) == "Ok: ytrace"
         # appsec disabled must not block
-        with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer(appsec_enabled=False)
             resp = self.client.get("/index.html?toto=xtrace")
             assert resp.status_code == 200
@@ -449,7 +443,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             return "git file", 200
 
         # value .git must be blocked
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer()
             resp = self.client.get("/.git")
             assert resp.status_code == 403
@@ -463,18 +457,18 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             assert root_span.get_tag(http.USER_AGENT).startswith("werkzeug/")
             assert root_span.get_tag(SPAN_DATA_NAMES.RESPONSE_HEADERS_NO_COOKIES + ".content-type") == "text/json"
         # other values must not be blocked
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer()
             resp = self.client.get("/legit")
             assert resp.status_code == 404
         # appsec disabled must not block
-        with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer(appsec_enabled=False)
             resp = self.client.get("/.git")
             assert resp.status_code == 200
             assert get_response_body(resp) == "git file"
         # we must block with uri.raw not containing scheme or netloc
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer()
             resp = self.client.get("/we_should_block")
             assert resp.status_code == 403
@@ -513,7 +507,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
                 # other values must not be blocked
                 ('{"attack": "zqrweytqwreasldhkuqxgervflnmlnli"}', "application/json", False),
             ]:
-                with override_global_config(dict(_asm_enabled=appsec)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+                with override_global_config(dict(_asm_enabled=appsec)), override_env(
+                    dict(DD_APPSEC_RULES=rules.RULES_SRB)
+                ):
                     self._aux_appsec_prepare_tracer(appsec_enabled=appsec)
                     resp = self.client.post(
                         "/index.html?args=test",
@@ -536,7 +532,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             return "Ok", 200
 
         # value 01972498723465 must be blocked
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer()
 
             resp = self.client.get("/", headers={"User-Agent": "01972498723465"})
@@ -546,13 +542,13 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             loaded = json.loads(root_span.get_tag(APPSEC.JSON))
             assert [t["rule"]["id"] for t in loaded["triggers"]] == ["tst-037-004"]
         # other values must not be blocked
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer()
 
             resp = self.client.get("/", headers={"User-Agent": "31972498723467"})
             assert resp.status_code == 200
         # appsec disabled must not block
-        with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer(appsec_enabled=False)
 
             resp = self.client.get("/", headers={"User-Agent": "01972498723465"})
@@ -564,7 +560,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             return "Ok", 200
 
         # 404 must be blocked
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB_RESPONSE)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(
+            dict(DD_APPSEC_RULES=rules.RULES_SRB_RESPONSE)
+        ):
             self._aux_appsec_prepare_tracer()
 
             resp = self.client.get("/do_not_exist.php")
@@ -574,13 +572,17 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             loaded = json.loads(root_span.get_tag(APPSEC.JSON))
             assert [t["rule"]["id"] for t in loaded["triggers"]] == ["tst-037-005"]
         # 200 must not be blocked
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB_RESPONSE)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(
+            dict(DD_APPSEC_RULES=rules.RULES_SRB_RESPONSE)
+        ):
             self._aux_appsec_prepare_tracer()
 
             resp = self.client.get("/do_exist.php")
             assert resp.status_code == 200
         # appsec disabled must not block
-        with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB_RESPONSE)):
+        with override_global_config(dict(_asm_enabled=False)), override_env(
+            dict(DD_APPSEC_RULES=rules.RULES_SRB_RESPONSE)
+        ):
             self._aux_appsec_prepare_tracer(appsec_enabled=False)
 
             resp = self.client.get("/do_not_exist.php")
@@ -592,7 +594,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             return "Ok", 200
 
         # GET must be blocked
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB_METHOD)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(
+            dict(DD_APPSEC_RULES=rules.RULES_SRB_METHOD)
+        ):
             self._aux_appsec_prepare_tracer()
 
             resp = self.client.get("/")
@@ -602,12 +606,16 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             loaded = json.loads(root_span.get_tag(APPSEC.JSON))
             assert [t["rule"]["id"] for t in loaded["triggers"]] == ["tst-037-006"]
         # POST must not be blocked
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB_METHOD)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(
+            dict(DD_APPSEC_RULES=rules.RULES_SRB_METHOD)
+        ):
             self._aux_appsec_prepare_tracer()
             resp = self.client.post("/", data="post data")
             assert resp.status_code == 200
         # GET must pass if appsec disabled
-        with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB_METHOD)):
+        with override_global_config(dict(_asm_enabled=False)), override_env(
+            dict(DD_APPSEC_RULES=rules.RULES_SRB_METHOD)
+        ):
             self._aux_appsec_prepare_tracer(appsec_enabled=False)
 
             resp = self.client.get("/")
@@ -619,7 +627,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             return "Ok", 200
 
         # value jdfoSDGFkivRG_234 must be blocked
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer()
             self.client.set_cookie("localhost", "keyname", "jdfoSDGFkivRG_234")
             resp = self.client.get("/")
@@ -629,13 +637,17 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             loaded = json.loads(root_span.get_tag(APPSEC.JSON))
             assert [t["rule"]["id"] for t in loaded["triggers"]] == ["tst-037-008"]
         # other value must not be blocked
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB_RESPONSE)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(
+            dict(DD_APPSEC_RULES=rules.RULES_SRB_RESPONSE)
+        ):
             self._aux_appsec_prepare_tracer()
             self.client.set_cookie("localhost", "keyname", "jdfoSDGFHappykivRG_234")
             resp = self.client.get("/")
             assert resp.status_code == 200
         # appsec disabled must not block
-        with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB_RESPONSE)):
+        with override_global_config(dict(_asm_enabled=False)), override_env(
+            dict(DD_APPSEC_RULES=rules.RULES_SRB_RESPONSE)
+        ):
             self._aux_appsec_prepare_tracer(appsec_enabled=False)
             self.client.set_cookie("localhost", "keyname", "jdfoSDGFkivRG_234")
             resp = self.client.get("/")
@@ -647,7 +659,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             return item
 
         # value AiKfOeRcvG45 must be blocked
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer()
             resp = self.client.get("/params/AiKfOeRcvG45")
             assert resp.status_code == 403
@@ -658,13 +670,13 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             assert flask_args == "AiKfOeRcvG45"
             assert [t["rule"]["id"] for t in loaded["triggers"]] == ["tst-037-007"]
         # other values must not be blocked
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer()
             resp = self.client.get("/params/Anything")
             assert resp.status_code == 200
             assert get_response_body(resp) == "Anything"
         # appsec disabled must not block
-        with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer(appsec_enabled=False)
             resp = self.client.get("/params/AiKfOeRcvG45")
             assert resp.status_code == 200
@@ -677,7 +689,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             resp.headers["Content-Disposition"] = 'attachment; filename="MagicKey_Al4h7iCFep9s1"'
             return resp
 
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer()
             resp = self.client.get("/response-header/")
             assert resp.status_code == 403
@@ -686,7 +698,7 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             loaded = json.loads(root_span.get_tag(APPSEC.JSON))
             assert [t["rule"]["id"] for t in loaded["triggers"]] == ["tst-037-009"]
         # appsec disabled must not block
-        with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer(appsec_enabled=False)
             resp = self.client.get("/response-header/")
             assert resp.status_code == 200
@@ -699,7 +711,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             resp.headers["Content-Disposition"] = 'attachment;"'
             return resp
 
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_BAD_VERSION)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(
+            dict(DD_APPSEC_RULES=rules.RULES_BAD_VERSION)
+        ):
             self._aux_appsec_prepare_tracer()
             resp = self.client.get("/response-header/")
             # it must not completely fail on an invalid rule file
@@ -722,9 +736,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         # value suspicious_306_auto must be blocked
         with override_global_config(dict(_asm_enabled=True)), override_env(
             dict(
-                DD_APPSEC_RULES=RULES_SRBCA,
-                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=RESPONSE_CUSTOM_JSON,
-                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=RESPONSE_CUSTOM_HTML,
+                DD_APPSEC_RULES=rules.RULES_SRBCA,
+                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=rules.RESPONSE_CUSTOM_JSON,
+                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=rules.RESPONSE_CUSTOM_HTML,
             )
         ):
             self._aux_appsec_prepare_tracer()
@@ -743,9 +757,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         # value suspicious_306_auto must be blocked with text if required
         with override_global_config(dict(_asm_enabled=True)), override_env(
             dict(
-                DD_APPSEC_RULES=RULES_SRBCA,
-                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=RESPONSE_CUSTOM_JSON,
-                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=RESPONSE_CUSTOM_HTML,
+                DD_APPSEC_RULES=rules.RULES_SRBCA,
+                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=rules.RESPONSE_CUSTOM_JSON,
+                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=rules.RESPONSE_CUSTOM_HTML,
             )
         ):
             self._aux_appsec_prepare_tracer()
@@ -764,9 +778,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         # value suspicious_429_json must be blocked
         with override_global_config(dict(_asm_enabled=True)), override_env(
             dict(
-                DD_APPSEC_RULES=RULES_SRBCA,
-                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=RESPONSE_CUSTOM_JSON,
-                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=RESPONSE_CUSTOM_HTML,
+                DD_APPSEC_RULES=rules.RULES_SRBCA,
+                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=rules.RESPONSE_CUSTOM_JSON,
+                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=rules.RESPONSE_CUSTOM_HTML,
             )
         ):
             self._aux_appsec_prepare_tracer()
@@ -785,9 +799,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         # value suspicious_429_json must be blocked with json even if text if required
         with override_global_config(dict(_asm_enabled=True)), override_env(
             dict(
-                DD_APPSEC_RULES=RULES_SRBCA,
-                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=RESPONSE_CUSTOM_JSON,
-                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=RESPONSE_CUSTOM_HTML,
+                DD_APPSEC_RULES=rules.RULES_SRBCA,
+                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=rules.RESPONSE_CUSTOM_JSON,
+                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=rules.RESPONSE_CUSTOM_HTML,
             )
         ):
             self._aux_appsec_prepare_tracer()
@@ -806,9 +820,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         # value suspicious_503_html must be blocked with text even if json is required
         with override_global_config(dict(_asm_enabled=True)), override_env(
             dict(
-                DD_APPSEC_RULES=RULES_SRBCA,
-                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=RESPONSE_CUSTOM_JSON,
-                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=RESPONSE_CUSTOM_HTML,
+                DD_APPSEC_RULES=rules.RULES_SRBCA,
+                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=rules.RESPONSE_CUSTOM_JSON,
+                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=rules.RESPONSE_CUSTOM_HTML,
             )
         ):
             self._aux_appsec_prepare_tracer()
@@ -827,9 +841,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         # value suspicious_503_html must be blocked with text if required
         with override_global_config(dict(_asm_enabled=True)), override_env(
             dict(
-                DD_APPSEC_RULES=RULES_SRBCA,
-                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=RESPONSE_CUSTOM_JSON,
-                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=RESPONSE_CUSTOM_HTML,
+                DD_APPSEC_RULES=rules.RULES_SRBCA,
+                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=rules.RESPONSE_CUSTOM_JSON,
+                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=rules.RESPONSE_CUSTOM_HTML,
             )
         ):
             self._aux_appsec_prepare_tracer()
@@ -846,13 +860,13 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
             assert root_span.get_tag(SPAN_DATA_NAMES.RESPONSE_HEADERS_NO_COOKIES + ".content-type") == "text/html"
 
         # other values must not be blocked
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer()
             resp = self.client.get("/index.html?toto=ytrace")
             assert resp.status_code == 200
             assert get_response_body(resp) == "Ok: ytrace"
         # appsec disabled must not block
-        with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=RULES_SRB)):
+        with override_global_config(dict(_asm_enabled=False)), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
             self._aux_appsec_prepare_tracer(appsec_enabled=False)
             resp = self.client.get("/index.html?toto=suspicious_306_auto")
             assert resp.status_code == 200
@@ -870,9 +884,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         # value suspicious_301 must be redirected
         with override_global_config(dict(_asm_enabled=True)), override_env(
             dict(
-                DD_APPSEC_RULES=RULES_SRBCA,
-                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=RESPONSE_CUSTOM_JSON,
-                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=RESPONSE_CUSTOM_HTML,
+                DD_APPSEC_RULES=rules.RULES_SRBCA,
+                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=rules.RESPONSE_CUSTOM_JSON,
+                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=rules.RESPONSE_CUSTOM_HTML,
             )
         ):
             self._aux_appsec_prepare_tracer()
@@ -899,9 +913,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         # value suspicious_301 must be redirected
         with override_global_config(dict(_asm_enabled=True)), override_env(
             dict(
-                DD_APPSEC_RULES=RULES_SRBCA,
-                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=RESPONSE_CUSTOM_JSON,
-                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=RESPONSE_CUSTOM_HTML,
+                DD_APPSEC_RULES=rules.RULES_SRBCA,
+                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON=rules.RESPONSE_CUSTOM_JSON,
+                DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML=rules.RESPONSE_CUSTOM_HTML,
             )
         ):
             self._aux_appsec_prepare_tracer()

--- a/tests/contrib/flask/test_flask_appsec_telemetry.py
+++ b/tests/contrib/flask/test_flask_appsec_telemetry.py
@@ -6,9 +6,8 @@ from ddtrace.appsec._constants import APPSEC
 from ddtrace.internal import core
 from ddtrace.internal.compat import urlencode
 from ddtrace.internal.constants import BLOCKED_RESPONSE_JSON
-from tests.appsec.appsec.test_processor import _IP
-from tests.appsec.appsec.test_processor import RULES_GOOD_PATH
 from tests.appsec.appsec.test_telemetry import _assert_generate_metrics
+import tests.appsec.rules as rules
 from tests.contrib.flask import BaseFlaskTestCase
 from tests.utils import override_env
 from tests.utils import override_global_config
@@ -25,9 +24,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
         self.tracer.configure(api_version="v0.4")
 
     def test_telemetry_metrics_block(self):
-        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=RULES_GOOD_PATH)):
+        with override_global_config(dict(_asm_enabled=True)), override_env(dict(DD_APPSEC_RULES=rules.RULES_GOOD_PATH)):
             self._aux_appsec_prepare_tracer()
-            resp = self.client.get("/", headers={"X-Real-Ip": _IP.BLOCKED})
+            resp = self.client.get("/", headers={"X-Real-Ip": rules._IP.BLOCKED})
             assert resp.status_code == 403
             if hasattr(resp, "text"):
                 assert resp.text == BLOCKED_RESPONSE_JSON


### PR DESCRIPTION
Remove many imports between different appsec tests.
Create a new file containing definitions without dependencies.

## Motivation

Importing between tests from different test suites can force dependencies to be installed for tests that does not require them. It can also create side effects. We want to avoid that.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
