### PR TITLE
chore(profiling): handle startup errors

### DIFF
--- a/ddtrace/bootstrap/preload.py
+++ b/ddtrace/bootstrap/preload.py
@@ -43,7 +43,10 @@ log = get_logger(__name__)
 
 if profiling_config.enabled:
     log.debug("profiler enabled via environment variable")
-    import ddtrace.profiling.auto  # noqa: F401
+    try:
+        import ddtrace.profiling.auto  # noqa: F401
+    except Exception:
+        log.error("failed to enable profiling", exc_info=True)
 
 if di_config.enabled or ed_config.enabled:
     from ddtrace.debugging import DynamicInstrumentation


### PR DESCRIPTION
We ensure that we can handle any profiling startup failures so that the bootstrap script can run in its entirety, instead of stopping early.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
