### PR TITLE
fix: incomplete pkg_resources support

### DIFF
--- a/ddtrace/internal/module.py
+++ b/ddtrace/internal/module.py
@@ -242,6 +242,12 @@ class BaseModuleWatchdog(abc.ABC):
         # type: () -> None
         self._finding = set()  # type: Set[str]
 
+        # DEV: pkg_resources support to prevent errors such as
+        # NotImplementedError: Can't perform this operation for unregistered
+        pkg_resources = sys.modules.get("pkg_resources")
+        if pkg_resources is not None:
+            pkg_resources.register_loader_type(_ImportHookChainedLoader, pkg_resources.DefaultProvider)
+
     def _add_to_meta_path(self):
         # type: () -> None
         sys.meta_path.insert(0, self)  # type: ignore[arg-type]
@@ -373,9 +379,10 @@ class ModuleWatchdog(BaseModuleWatchdog):
 
     def __init__(self):
         # type: () -> None
+        super().__init__()
+
         self._hook_map = defaultdict(list)  # type: DefaultDict[str, List[ModuleHookType]]
         self._om = None  # type: Optional[Dict[str, ModuleType]]
-        self._finding = set()  # type: Set[str]
         self._pre_exec_module_hooks = []  # type: List[Tuple[PreExecHookCond, PreExecHookType]]
 
     @property

--- a/releasenotes/notes/fix-incomplete-pkg_resources-support-58baf819ea8705ef.yaml
+++ b/releasenotes/notes/fix-incomplete-pkg_resources-support-58baf819ea8705ef.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix an incomplete support for pkg_resouces that could have caused an
+    exception on start-up.


### PR DESCRIPTION
We fix an incomplete support for pkg_resources. This change covers for the case where pkg_resources was somehow already imported before ddtrace.

Follow-up on #8113.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
