### PR TITLE
fix(ci_visibility): use partial trace flushing when using the CIVisibility service

### DIFF
--- a/ddtrace/internal/ci_visibility/constants.py
+++ b/ddtrace/internal/ci_visibility/constants.py
@@ -50,6 +50,9 @@ SKIPPABLE_ENDPOINT = "/api/v2/ci/tests/skippable"
 ITR_UNSKIPPABLE_REASON = "datadog_itr_unskippable"
 SKIPPED_BY_ITR_REASON = "Skipped by Datadog Intelligent Test Runner"
 
+# Tracer configuration defaults:
+TRACER_PARTIAL_FLUSH_MIN_SPANS = 1
+
 
 class REQUESTS_MODE(IntEnum):
     AGENTLESS_EVENTS = 0

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -124,15 +124,15 @@ class CIVisibility(Service):
         if tracer:
             self.tracer = tracer
         else:
-            self.tracer = Tracer()
+            if asbool(os.getenv("_DD_CIVISIBILITY_USE_CI_CONTEXT_PROVIDER")):
+                # Create a new CI tracer
+                self.tracer = Tracer(context_provider=CIContextProvider())
+            else:
+                self.tracer = Tracer()
 
             # Partial traces are required for ITR to work in suite-level skipping for long test sessions, but we
             # assume that a tracer is already configured if it's been passed in.
             self.tracer.configure(partial_flush_enabled=True, partial_flush_min_spans=TRACER_PARTIAL_FLUSH_MIN_SPANS)
-
-            if asbool(os.getenv("_DD_CIVISIBILITY_USE_CI_CONTEXT_PROVIDER")):
-                # Create a new CI tracer
-                self.tracer = Tracer(context_provider=CIContextProvider())
 
         self._configurations = ci._get_runtime_and_os_metadata()
         custom_configurations = _get_custom_configurations()

--- a/releasenotes/notes/ci_visibility-fix-flush-partial-traces-4c21167f7b4feb2a.yaml
+++ b/releasenotes/notes/ci_visibility-fix-flush-partial-traces-4c21167f7b4feb2a.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    CI Visibility: fixes an issue where coverage data for suites could be lost for long-running test sessions,
+    reducing the possibility of skipping tests when using the Intelligent Test Runner.

--- a/tests/ci_visibility/test_ci_visibility.py
+++ b/tests/ci_visibility/test_ci_visibility.py
@@ -1455,7 +1455,7 @@ def test_civisibility_enable_respects_passed_in_tracer():
     ), _dummy_noop_git_client():
         ddtrace.internal.ci_visibility.writer.config = ddtrace.settings.Config()
         ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()
-        tracer = DummyTracer()
+        tracer = ddtrace.Tracer()
         tracer.configure(partial_flush_enabled=False, partial_flush_min_spans=100)
         CIVisibility.enable(tracer=tracer)
         assert CIVisibility._instance.tracer._partial_flush_enabled is False


### PR DESCRIPTION
Allowing flushing partial traces allows the CIVisibility service to send suite-level coverage data (when the unreleased suite-level skipping is used) fixes an issue where the Intelligent Test Runner coverage processing backend could drop coverage data during long test sessions due to time delays between the events being created by the tracer and showing up in the backend. 

This change comes with a public release notes since it does introduce partial trace flushing to the `CIVisibility` service's tracer, but the change is not being backported since it applies to an unreleased feature.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
