### PR TITLE
chore(tracing): implement basic remote-disablement functionality

### DIFF
--- a/ddtrace/internal/telemetry/constants.py
+++ b/ddtrace/internal/telemetry/constants.py
@@ -8,11 +8,8 @@ TELEMETRY_TYPE_LOGS = "logs"
 
 # Configuration names must map to values supported by backend services:
 # https://github.com/DataDog/dd-go/blob/f88e85d64b173e7733ac03e23576d1c9be37f32e/trace/apps/tracer-telemetry-intake/telemetry-payload/static/config_norm_rules.json
-TELEMETRY_PROFILING_ENABLED = "DD_PROFILING_ENABLED"
-TELEMETRY_ASM_ENABLED = "DD_APPSEC_ENABLED"
 TELEMETRY_DYNAMIC_INSTRUMENTATION_ENABLED = "DD_DYNAMIC_INSTRUMENTATION_ENABLED"
 TELEMETRY_EXCEPTION_DEBUGGING_ENABLED = "DD_EXCEPTION_DEBUGGING_ENABLED"
-TELEMETRY_DSM_ENABLED = "DD_DATA_STREAMS_ENABLED"
 
 
 # Tracing Features

--- a/ddtrace/internal/telemetry/constants.py
+++ b/ddtrace/internal/telemetry/constants.py
@@ -8,8 +8,11 @@ TELEMETRY_TYPE_LOGS = "logs"
 
 # Configuration names must map to values supported by backend services:
 # https://github.com/DataDog/dd-go/blob/f88e85d64b173e7733ac03e23576d1c9be37f32e/trace/apps/tracer-telemetry-intake/telemetry-payload/static/config_norm_rules.json
+TELEMETRY_PROFILING_ENABLED = "DD_PROFILING_ENABLED"
+TELEMETRY_ASM_ENABLED = "DD_APPSEC_ENABLED"
 TELEMETRY_DYNAMIC_INSTRUMENTATION_ENABLED = "DD_DYNAMIC_INSTRUMENTATION_ENABLED"
 TELEMETRY_EXCEPTION_DEBUGGING_ENABLED = "DD_EXCEPTION_DEBUGGING_ENABLED"
+TELEMETRY_DSM_ENABLED = "DD_DATA_STREAMS_ENABLED"
 
 
 # Tracing Features

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -21,12 +21,10 @@ from ...internal.module import origin
 from ...internal.schema import SCHEMA_VERSION
 from ...internal.schema import _remove_client_service_names
 from ...settings import _config as config
-from ...settings.asm import config as asm_config
 from ...settings.config import _ConfigSource
 from ...settings.dynamic_instrumentation import config as di_config
 from ...settings.exception_debugging import config as ed_config
 from ...settings.peer_service import _ps_config
-from ...settings.profiling import config as profiling_config
 from ..agent import get_connection
 from ..agent import get_trace_url
 from ..compat import get_connection_response
@@ -46,11 +44,9 @@ from .constants import TELEMETRY_AGENT_HOST
 from .constants import TELEMETRY_AGENT_PORT
 from .constants import TELEMETRY_AGENT_URL
 from .constants import TELEMETRY_ANALYTICS_ENABLED
-from .constants import TELEMETRY_ASM_ENABLED
 from .constants import TELEMETRY_CLIENT_IP_ENABLED
 from .constants import TELEMETRY_DOGSTATSD_PORT
 from .constants import TELEMETRY_DOGSTATSD_URL
-from .constants import TELEMETRY_DSM_ENABLED
 from .constants import TELEMETRY_DYNAMIC_INSTRUMENTATION_ENABLED
 from .constants import TELEMETRY_ENABLED
 from .constants import TELEMETRY_EXCEPTION_DEBUGGING_ENABLED
@@ -59,7 +55,6 @@ from .constants import TELEMETRY_OTEL_ENABLED
 from .constants import TELEMETRY_PARTIAL_FLUSH_ENABLED
 from .constants import TELEMETRY_PARTIAL_FLUSH_MIN_SPANS
 from .constants import TELEMETRY_PRIORITY_SAMPLING
-from .constants import TELEMETRY_PROFILING_ENABLED
 from .constants import TELEMETRY_PROPAGATION_STYLE_EXTRACT
 from .constants import TELEMETRY_PROPAGATION_STYLE_INJECT
 from .constants import TELEMETRY_REMOTE_CONFIGURATION_ENABLED
@@ -334,7 +329,19 @@ class TelemetryWriter(PeriodicService):
 
     def _telemetry_entry(self, cfg_name: str) -> Tuple[str, str, _ConfigSource]:
         item = config._config[cfg_name]
-        if cfg_name == "_trace_sample_rate":
+        if cfg_name == "_trace_enabled":
+            name = "trace_enabled"
+            value = "true" if item.value() else "false"
+        elif cfg_name == "_profiling_enabled":
+            name = "profiling_enabled"
+            value = "true" if item.value() else "false"
+        elif cfg_name == "_asm_enabled":
+            name = "appsec_enabled"
+            value = "true" if item.value() else "false"
+        elif cfg_name == "_dsm_enabled":
+            name = "data_streams_enabled"
+            value = "true" if item.value() else "false"
+        elif cfg_name == "_trace_sample_rate":
             name = "trace_sample_rate"
             value = str(item.value())
         elif cfg_name == "logs_injection":
@@ -367,15 +374,16 @@ class TelemetryWriter(PeriodicService):
 
         self.add_configurations(
             [
+                self._telemetry_entry("_trace_enabled"),
+                self._telemetry_entry("_profiling_enabled"),
+                self._telemetry_entry("_asm_enabled"),
+                self._telemetry_entry("_dsm_enabled"),
                 self._telemetry_entry("_trace_sample_rate"),
                 self._telemetry_entry("logs_injection"),
                 self._telemetry_entry("trace_http_header_tags"),
                 self._telemetry_entry("tags"),
                 self._telemetry_entry("_tracing_enabled"),
                 (TELEMETRY_STARTUP_LOGS_ENABLED, config._startup_logs_enabled, "unknown"),
-                (TELEMETRY_DSM_ENABLED, config._data_streams_enabled, "unknown"),
-                (TELEMETRY_ASM_ENABLED, asm_config._asm_enabled, "unknown"),
-                (TELEMETRY_PROFILING_ENABLED, profiling_config.enabled, "unknown"),
                 (TELEMETRY_DYNAMIC_INSTRUMENTATION_ENABLED, di_config.enabled, "unknown"),
                 (TELEMETRY_EXCEPTION_DEBUGGING_ENABLED, ed_config.enabled, "unknown"),
                 (TELEMETRY_PROPAGATION_STYLE_INJECT, ",".join(config._propagation_style_inject), "unknown"),

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -272,11 +272,6 @@ def _parse_global_tags(s):
 def _default_config():
     # type: () -> Dict[str, _ConfigItem]
     return {
-        "_trace_enabled": _ConfigItem(
-            name="trace_enabled",
-            default=True,
-            envs=[("DD_TRACE_ENABLED", asbool)],
-        ),
         "_trace_sample_rate": _ConfigItem(
             name="trace_sample_rate",
             default=1.0,
@@ -297,20 +292,10 @@ def _default_config():
             default=lambda: {},
             envs=[("DD_TAGS", _parse_global_tags)],
         ),
-        "_profiling_enabled": _ConfigItem(
-            name="profiling_enabled",
-            default=False,
-            envs=[("DD_PROFILING_ENABLED", asbool)],
-        ),
-        "_asm_enabled": _ConfigItem(
-            name="asm_enabled",
-            default=False,
-            envs=[("DD_APPSEC_ENABLED", asbool)],
-        ),
-        "_dsm_enabled": _ConfigItem(
-            name="dsm_enabled",
-            default=False,
-            envs=[("DD_DATA_STREAMS_ENABLED", asbool)],
+        "_tracing_enabled": _ConfigItem(
+            name="tracing_enabled",
+            default=True,
+            envs=[("DD_TRACE_ENABLED", asbool)],
         ),
     }
 
@@ -384,7 +369,6 @@ class Config(object):
         self._priority_sampling = asbool(os.getenv("DD_PRIORITY_SAMPLING", default=True))
 
         self.http = HttpConfig(header_tags=self.trace_http_header_tags)
-        self._tracing_enabled = asbool(os.getenv("DD_TRACE_ENABLED", default=True))
         self._remote_config_enabled = asbool(os.getenv("DD_REMOTE_CONFIGURATION_ENABLED", default=True))
         self._remote_config_poll_interval = float(
             os.getenv(
@@ -749,6 +733,9 @@ class Config(object):
                 if tags:
                     tags = self._format_tags(lib_config["tracing_tags"])
                 base_rc_config["tags"] = tags
+
+            if "tracing_enabled" in lib_config and lib_config["tracing_enabled"] is not None:
+                base_rc_config["_tracing_enabled"] = asbool(lib_config["tracing_enabled"])  # type: ignore[assignment]
 
             if "tracing_header_tags" in lib_config:
                 tags = lib_config["tracing_header_tags"]

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -301,6 +301,7 @@ def _default_config():
             name="tracing_enabled",
             default=True,
             envs=[("DD_TRACE_ENABLED", asbool)],
+        ),
         "_profiling_enabled": _ConfigItem(
             name="profiling_enabled",
             default=False,

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -272,6 +272,11 @@ def _parse_global_tags(s):
 def _default_config():
     # type: () -> Dict[str, _ConfigItem]
     return {
+        "_trace_enabled": _ConfigItem(
+            name="trace_enabled",
+            default=True,
+            envs=[("DD_TRACE_ENABLED", asbool)],
+        ),
         "_trace_sample_rate": _ConfigItem(
             name="trace_sample_rate",
             default=1.0,
@@ -296,6 +301,20 @@ def _default_config():
             name="tracing_enabled",
             default=True,
             envs=[("DD_TRACE_ENABLED", asbool)],
+        "_profiling_enabled": _ConfigItem(
+            name="profiling_enabled",
+            default=False,
+            envs=[("DD_PROFILING_ENABLED", asbool)],
+        ),
+        "_asm_enabled": _ConfigItem(
+            name="asm_enabled",
+            default=False,
+            envs=[("DD_APPSEC_ENABLED", asbool)],
+        ),
+        "_dsm_enabled": _ConfigItem(
+            name="dsm_enabled",
+            default=False,
+            envs=[("DD_DATA_STREAMS_ENABLED", asbool)],
         ),
     }
 

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -282,6 +282,7 @@ class Tracer(object):
         config._subscribe(["_trace_sample_rate"], self._on_global_config_update)
         config._subscribe(["logs_injection"], self._on_global_config_update)
         config._subscribe(["tags"], self._on_global_config_update)
+        config._subscribe(["_tracing_enabled"], self._on_global_config_update)
 
     def _atexit(self) -> None:
         key = "ctrl-break" if os.name == "nt" else "ctrl-c"
@@ -1073,6 +1074,15 @@ class Tracer(object):
 
         if "tags" in items:
             self._tags = cfg.tags.copy()
+
+        if "_tracing_enabled" in items:
+            if self.enabled:
+                if cfg._tracing_enabled is False:
+                    self.enabled = False
+            else:
+                # the product specification says not to allow tracing to be re-enabled remotely at runtime
+                if cfg._tracing_enabled is True and cfg._get_source("_tracing_enabled") != "remote_config":
+                    self.enabled = True
 
         if "logs_injection" in items:
             if config.logs_injection:


### PR DESCRIPTION
This pull request implements the internal functionality on which remote tracing disablement relies. That functionality is disabled per https://github.com/DataDog/dd-trace-py/pull/8080#discussion_r1468239851 in the interest of coordinating release timelines. Thus, there are no tests or release note added here; instead they are implemented in https://github.com/DataDog/dd-trace-py/pull/8080.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
