### PR TITLE
chore(llmobs): rename openai model tag to model_name

### DIFF
--- a/ddtrace/internal/llmobs/integrations/openai.py
+++ b/ddtrace/internal/llmobs/integrations/openai.py
@@ -102,7 +102,7 @@ class OpenAIIntegration(BaseLLMIntegration):
             "env:%s" % (config.env or ""),
             "service:%s" % (span.service or ""),
             "source:integration",
-            "model:%s" % (span.get_tag("openai.request.model") or ""),
+            "model_name:%s" % (span.get_tag("openai.request.model") or ""),
             "model_provider:openai",
             "error:%d" % span.error,
         ]

--- a/tests/contrib/openai/test_openai_v0.py
+++ b/tests/contrib/openai/test_openai_v0.py
@@ -2302,7 +2302,7 @@ def test_llmobs_completion(openai_vcr, openai, ddtrace_config_openai, mock_llmob
         "env:",
         "service:",
         "source:integration",
-        "model:{}".format(model),
+        "model_name:{}".format(model),
         "model_provider:openai",
         "error:0",
     ]
@@ -2409,7 +2409,7 @@ def test_llmobs_chat_completion(openai_vcr, openai, ddtrace_config_openai, mock_
         "env:",
         "service:",
         "source:integration",
-        "model:{}".format(model),
+        "model_name:{}".format(model),
         "model_provider:openai",
         "error:0",
     ]
@@ -2509,7 +2509,7 @@ def test_llmobs_chat_completion_function_call(
         "env:",
         "service:",
         "source:integration",
-        "model:{}".format(model),
+        "model_name:{}".format(model),
         "model_provider:openai",
         "error:0",
     ]

--- a/tests/contrib/openai/test_openai_v1.py
+++ b/tests/contrib/openai/test_openai_v1.py
@@ -1944,7 +1944,7 @@ def test_llmobs_completion(openai_vcr, openai, ddtrace_config_openai, mock_llmob
         "env:",
         "service:",
         "source:integration",
-        "model:{}".format(model),
+        "model_name:{}".format(model),
         "model_provider:openai",
         "error:0",
     ]
@@ -2050,7 +2050,7 @@ def test_llmobs_chat_completion(openai_vcr, openai, ddtrace_config_openai, mock_
         "env:",
         "service:",
         "source:integration",
-        "model:{}".format(model),
+        "model_name:{}".format(model),
         "model_provider:openai",
         "error:0",
     ]
@@ -2149,7 +2149,7 @@ def test_llmobs_chat_completion_function_call(
         "env:",
         "service:",
         "source:integration",
-        "model:{}".format(model),
+        "model_name:{}".format(model),
         "model_provider:openai",
         "error:0",
     ]


### PR DESCRIPTION
This PR updates the LLMObs payloads sent by the openAI integration to rename the `model` tag to `model_name`. This only applies for LLMObs payloads and not APM traces.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
