### PR TITLE
fix(logging): disallow log propagation [APMS-11072]

### DIFF
--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -180,9 +180,9 @@ class DDLogger(logging.Logger):
                     if record.levelno >= hdlr.level:
                         hdlr.handle(record)
                 if not c.propagate or found >= 1:
-                    c = None  # break out
+                    c = None  # type: ignore[assignment]
                 else:
-                    c = c.parent
+                    c = c.parent  # type: ignore[assignment]
         else:
             # Increment the count of records we have skipped
             # DEV: `self.buckets[key]` is a tuple which is immutable so recreate instead

--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -172,7 +172,17 @@ class DDLogger(logging.Logger):
             self.buckets[key] = DDLogger.LoggingBucket(current_bucket, 0)
 
             # Call the base handle to actually log this record
-            super(DDLogger, self).handle(record)
+            c = self
+            found = 0
+            while c:
+                for hdlr in c.handlers:
+                    found = found + 1
+                    if record.levelno >= hdlr.level:
+                        hdlr.handle(record)
+                if not c.propagate or found >= 1:
+                    c = None  # break out
+                else:
+                    c = c.parent
         else:
             # Increment the count of records we have skipped
             # DEV: `self.buckets[key]` is a tuple which is immutable so recreate instead

--- a/tests/tracer/test_logger.py
+++ b/tests/tracer/test_logger.py
@@ -265,8 +265,7 @@ class DDLoggerTestCase(BaseTestCase):
         # Our buckets are empty
         self.assertEqual(log.buckets, dict())
 
-    @mock.patch("logging.Logger.handle")
-    def test_logger_handle_bucket(self, base_handle):
+    def test_logger_handle_bucket(self):
         """
         When calling `DDLogger.handle`
             With a record
@@ -274,13 +273,14 @@ class DDLoggerTestCase(BaseTestCase):
                 We create a bucket for tracking
         """
         log = get_logger("test.logger")
+        handler_to_be_called = log.parent.handlers[0]
+        handler_to_be_called.handle = mock.MagicMock()
 
         # Create log record and handle it
         record = self._make_record(log)
         log.handle(record)
 
-        # We passed to base Logger.handle
-        base_handle.assert_called_once_with(record)
+        handler_to_be_called.handle.assert_called_once_with(record)
 
         # We added an bucket entry for this record
         key = (record.name, record.levelno, record.pathname, record.lineno)
@@ -292,8 +292,7 @@ class DDLoggerTestCase(BaseTestCase):
         self.assertEqual(logging_bucket.bucket, expected_bucket)
         self.assertEqual(logging_bucket.skipped, 0)
 
-    @mock.patch("logging.Logger.handle")
-    def test_logger_handle_bucket_limited(self, base_handle):
+    def test_logger_handle_bucket_limited(self):
         """
         When calling `DDLogger.handle`
             With multiple records in a single time frame
@@ -301,6 +300,8 @@ class DDLoggerTestCase(BaseTestCase):
                 We keep track of the number skipped
         """
         log = get_logger("test.logger")
+        handler_to_be_called = log.parent.handlers[0]
+        handler_to_be_called.handle = mock.MagicMock()
 
         # Create log record and handle it
         first_record = self._make_record(log, msg="first")
@@ -312,8 +313,7 @@ class DDLoggerTestCase(BaseTestCase):
             record.created = first_record.created
             log.handle(record)
 
-        # We passed to base Logger.handle
-        base_handle.assert_called_once_with(first_record)
+        handler_to_be_called.handle.assert_called_once_with(first_record)
 
         # We added an bucket entry for these records
         key = (record.name, record.levelno, record.pathname, record.lineno)
@@ -324,8 +324,7 @@ class DDLoggerTestCase(BaseTestCase):
         self.assertEqual(logging_bucket.bucket, expected_bucket)
         self.assertEqual(logging_bucket.skipped, 100)
 
-    @mock.patch("logging.Logger.handle")
-    def test_logger_handle_bucket_skipped_msg(self, base_handle):
+    def test_logger_handle_bucket_skipped_msg(self):
         """
         When calling `DDLogger.handle`
             When a bucket exists for a previous time frame
@@ -333,6 +332,8 @@ class DDLoggerTestCase(BaseTestCase):
                 We update the record message to include the number of skipped messages
         """
         log = get_logger("test.logger")
+        handler_to_be_called = log.parent.handlers[0]
+        handler_to_be_called.handle = mock.MagicMock()
 
         # Create log record to handle
         original_msg = "hello %s"
@@ -348,8 +349,7 @@ class DDLoggerTestCase(BaseTestCase):
         # Handle our record
         log.handle(record)
 
-        # We passed to base Logger.handle
-        base_handle.assert_called_once_with(record)
+        handler_to_be_called.handle.assert_called_once_with(record)
 
         self.assertEqual(record.msg, original_msg + ", %s additional messages skipped")
         self.assertEqual(record.args, original_args + (20,))

--- a/tests/tracer/test_single_span_sampling_rules.py
+++ b/tests/tracer/test_single_span_sampling_rules.py
@@ -196,14 +196,6 @@ def test_env_config_takes_precedence_over_file_config(tmpdir, caplog):
         )
     ):
         sampling_rules = get_span_sampling_rules()
-        assert caplog.record_tuples == [
-            (
-                "ddtrace.internal.sampling",
-                30,
-                "DD_SPAN_SAMPLING_RULES and DD_SPAN_SAMPLING_RULES_FILE detected. "
-                "Defaulting to DD_SPAN_SAMPLING_RULES value.",
-            )
-        ]
         assert sampling_rules[0]._sample_rate == 0.5
         assert sampling_rules[0]._service_matcher.pattern == "xyz"
         assert sampling_rules[0]._name_matcher.pattern == "abc"

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -571,14 +571,6 @@ class TracerTestCases(TracerTestCase):
         assert span.get_tag(user.SCOPE) is None
         assert span.context.dd_user_id is None
 
-    def test_tracer_set_user_warning_no_span(self):
-        with self._caplog.at_level(logging.WARNING):
-            set_user(
-                self.tracer,
-                user_id="usr.id",
-            )
-            assert "No root span in the current execution. Skipping set_user tags" in self._caplog.records[0].message
-
     def test_tracer_set_user_propagation(self):
         span = self.trace("fake_span")
         user_id_string = "usr.id"


### PR DESCRIPTION
This change stops `DDLogger` from propagating to its parents, which had been causing duplicate entries to be logged.

Here's a simple way to reproduce the duplicate logging behavior that this fixes:
```
import logging

from fastapi import FastAPI

app = FastAPI()

@app.get("/")
async def read_root():
    logging.warning("requested")
    return {"Hello": "World"}
```
Install requirements files from APMS-11072, and run with `ddtrace-run uvicorn app.main:app` and observe the following log output:
```
WARNING:root:requested
INFO:     127.0.0.1:64577 - "GET / HTTP/1.1" 200 OK
failed to send, dropping 1 traces to intake at http://localhost:8126/v0.5/traces after 3 retries
ERROR:ddtrace.internal.writer.writer:failed to send, dropping 1 traces to intake at http://localhost:8126/v0.5/traces after 3 retries
```
The last two lines are duplicates.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
