### PR TITLE
fix: only use first message context for trace propagation in aws messaging

### DIFF
--- a/ddtrace/contrib/botocore/utils.py
+++ b/ddtrace/contrib/botocore/utils.py
@@ -197,7 +197,9 @@ def extract_DD_context(messages):
         message = messages[0]
         context_json = extract_trace_context_json(message)
         if context_json is not None:
-            ctx = HTTPPropagator.extract(context_json)
+            child_of = HTTPPropagator.extract(context_json)
+            if child_of.trace_id is not None:
+                ctx = child_of
     return ctx
 
 

--- a/ddtrace/contrib/botocore/utils.py
+++ b/ddtrace/contrib/botocore/utils.py
@@ -193,23 +193,11 @@ def set_response_metadata_tags(span, result):
 
 def extract_DD_context(messages):
     ctx = None
-    if len(messages) == 1:
+    if len(messages) >= 1:
         message = messages[0]
         context_json = extract_trace_context_json(message)
         if context_json is not None:
             ctx = HTTPPropagator.extract(context_json)
-    elif len(messages) > 1:
-        prev_ctx = None
-        for message in messages:
-            prev_ctx = ctx
-            context_json = extract_trace_context_json(message)
-            if context_json is not None:
-                ctx = HTTPPropagator.extract(context_json)
-
-            # only want parenting for batches if all contexts are the same
-            if prev_ctx is not None and prev_ctx != ctx:
-                ctx = None
-                break
     return ctx
 
 


### PR DESCRIPTION
Small change to only use first message's extracted context during propagation for AWS messaging services

Also fixes bug where if context is not found, the span is created with a new context. After the fix, if a context is not found, the active context is used.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
