### PR TITLE
ci(redis): unpatch after patching to avoid corrupting later test results

### DIFF
--- a/tests/contrib/redis/test_redis_asyncio.py
+++ b/tests/contrib/redis/test_redis_asyncio.py
@@ -10,7 +10,6 @@ from ddtrace import tracer
 from ddtrace.contrib.redis.patch import patch
 from ddtrace.contrib.redis.patch import unpatch
 from ddtrace.vendor.wrapt import ObjectProxy
-from tests.utils import flaky
 from tests.utils import override_config
 
 from ..config import REDIS_CONFIG
@@ -65,7 +64,6 @@ def test_patching():
     assert not isinstance(redis.asyncio.client.Pipeline.pipeline, ObjectProxy)
 
 
-@flaky(1735812000)
 @pytest.mark.asyncio
 @pytest.mark.snapshot(wait_for_num_traces=1)
 async def test_basic_request(redis_client):
@@ -92,7 +90,6 @@ async def test_connection_error(redis_client):
             await redis_client.get("foo")
 
 
-@flaky(1735812000)
 @pytest.mark.asyncio
 @pytest.mark.snapshot(wait_for_num_traces=2)
 async def test_decoding_non_utf8_args(redis_client):
@@ -117,7 +114,6 @@ async def test_decoding_non_utf8_pipeline_args(redis_client):
     assert response_list[3] == b"\x80abc"
 
 
-@flaky(1735812000)
 @pytest.mark.asyncio
 @pytest.mark.snapshot(wait_for_num_traces=1)
 async def test_long_command(redis_client):
@@ -167,7 +163,6 @@ async def test_pipeline_traced(redis_client):
     assert response_list[3].decode() == "bar"
 
 
-@flaky(1735812000)
 @pytest.mark.asyncio
 @pytest.mark.snapshot(wait_for_num_traces=1)
 async def test_pipeline_traced_context_manager_transaction(redis_client):
@@ -194,7 +189,6 @@ async def test_pipeline_traced_context_manager_transaction(redis_client):
     assert get_2.decode() == "bar"
 
 
-@flaky(1735812000)
 @pytest.mark.asyncio
 @pytest.mark.snapshot(wait_for_num_traces=1)
 async def test_two_traced_pipelines(redis_client):

--- a/tests/contrib/redis/test_redis_cluster_asyncio.py
+++ b/tests/contrib/redis/test_redis_cluster_asyncio.py
@@ -125,7 +125,7 @@ async def test_patch_unpatch(redis_cluster):
     patch()
 
     r = redis_cluster
-    Pin.get_from(r).clone(tracer=tracer).onto(r)
+    Pin.override(r, tracer=tracer)
     await r.get("key")
 
     spans = tracer.pop()
@@ -145,12 +145,13 @@ async def test_patch_unpatch(redis_cluster):
     patch()
 
     r = redis_cluster
-    Pin.get_from(r).clone(tracer=tracer).onto(r)
+    Pin.override(r, tracer=tracer)
     await r.get("key")
 
     spans = tracer.pop()
     assert spans, spans
     assert len(spans) == 1
+    unpatch()
 
 
 @pytest.mark.skipif(redis.VERSION < (4, 3, 0), reason="redis.asyncio.cluster is not implemented in redis<4.3.0")


### PR DESCRIPTION
This pull request resolves all of the unreliable behavior I'm currently aware of in the `redis` test suite. After having done a few of these I'm starting to notice a pattern in which leaving a global object patched with the `DummyTracer` after a test can cause corrupt results in snapshot tests that run later.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
