### PR TITLE
fix(tracer): remove USED_IP_HEADER

### DIFF
--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -169,16 +169,8 @@ def _get_request_header_user_agent(headers, headers_are_case_sensitive=False):
     return ""
 
 
-# Used to cache the last header used for the cache. From the same server/framework
-# usually the same header will be used on further requests, so we use this to check
-# only it.
-_USED_IP_HEADER = ""
-
-
 def _get_request_header_client_ip(headers, peer_ip=None, headers_are_case_sensitive=False):
     # type: (Optional[Mapping[str, str]], Optional[str], bool) -> str
-
-    global _USED_IP_HEADER
 
     def get_header_value(key):  # type: (str) -> Optional[str]
         if not headers_are_case_sensitive:
@@ -213,18 +205,11 @@ def _get_request_header_client_ip(headers, peer_ip=None, headers_are_case_sensit
             return ""
 
     else:
-        # No configured IP header, go through the IP_PATTERNS headers in order
-        if _USED_IP_HEADER:
-            # Check first the caught header that previously contained an IP
-            ip_header_value = get_header_value(_USED_IP_HEADER)
-
-        if not ip_header_value:
-            for ip_header in IP_PATTERNS:
-                tmp_ip_header_value = get_header_value(ip_header)
-                if tmp_ip_header_value:
-                    ip_header_value = tmp_ip_header_value
-                    _USED_IP_HEADER = ip_header
-                    break
+        for ip_header in IP_PATTERNS:
+            tmp_ip_header_value = get_header_value(ip_header)
+            if tmp_ip_header_value:
+                ip_header_value = tmp_ip_header_value
+                break
 
     private_ip_from_headers = ""
 


### PR DESCRIPTION
RFC https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2118779066/Client+IP+addresses+resolution#The-Algorithm
ensure that IP headers should be 

> checked in order and the search stop once a public IP has been found

But an optimisation was introduced that break that order. It made the python tracer the only tracer failing system-tests 
`tests/test_standard_tags.py::Test_StandardTagsClientIp::test_client_ip`

This PR fixes that by removing the optimisation.

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [ ] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
