### PR TITLE
ci(release): set tag name correctly for release candidates

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -77,11 +77,11 @@ def _decide_next_release_number(base: str, candidate: bool = False) -> int:
 def _get_rc_parameters(dd_repo, base: str, rc, patch) -> ReleaseParameters:
     """Build a ReleaseParameters object representing the in-progress release candidate"""
     # patch value should always be 0 if we're doing an RC
-    name = "%s.0" % (base)
     new_rc_version = _decide_next_release_number(base, candidate=True)
     release_branch = DEFAULT_BRANCH if new_rc_version == 1 else base
     rn = clean_release_notes(generate_release_notes(release_branch))
-    return ReleaseParameters(release_branch, "%s.0rc%s" % (base, str(new_rc_version)), "v%s" % name, dd_repo, rn, True)
+    version_string = "%s.0rc%s" % (base, str(new_rc_version))
+    return ReleaseParameters(release_branch, version_string, "v%s" % version_string, dd_repo, rn, True)
 
 
 def _get_patch_parameters(dd_repo, base: str, rc, patch) -> ReleaseParameters:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -81,7 +81,8 @@ def _get_rc_parameters(dd_repo, base: str, rc, patch) -> ReleaseParameters:
     release_branch = DEFAULT_BRANCH if new_rc_version == 1 else base
     rn = clean_release_notes(generate_release_notes(release_branch))
     version_string = "%s.0rc%s" % (base, str(new_rc_version))
-    return ReleaseParameters(release_branch, version_string, "v%s" % version_string, dd_repo, rn, True)
+    tag_name = "v%s" % version_string
+    return ReleaseParameters(release_branch, version_string, tag_name, dd_repo, rn, True)
 
 
 def _get_patch_parameters(dd_repo, base: str, rc, patch) -> ReleaseParameters:


### PR DESCRIPTION
This change fixes the bug that caused releases `2.5.0` and `2.6.0` not to have release candidates pushed to PyPI.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
