### PR TITLE
refactor(profiling): variable name if arguments available

### DIFF
--- a/ddtrace/profiling/collector/_traceback.pyx
+++ b/ddtrace/profiling/collector/_traceback.pyx
@@ -14,8 +14,10 @@ cpdef _extract_class_name(frame):
 
     :param frame: The frame object.
     """
-    if frame.f_code.co_varnames:
-        argname = frame.f_code.co_varnames[0]
+    code = frame.f_code
+    if code.co_argcount > 0:
+        # Retrieve the name of the first argument, if the code object has any
+        argname = code.co_varnames[0]
         try:
             value = frame.f_locals[argname]
         except (KeyError, SystemError):


### PR DESCRIPTION
We retrieve the variable name corresponding to the first argument only if the code object actually has any arguments. This prevents us blindly trying to retrieve the first entry of the variable name array in the hope that it is one between `self` and `cls`. The benefit of this is a less noisy debug log where all the failed attempts to resolve a local variable that might not be set already are currently logged.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
