### PR TITLE
ci(telemetry): loosen an assertion that can sometimes fail

### DIFF
--- a/tests/telemetry/test_telemetry_metrics_e2e.py
+++ b/tests/telemetry/test_telemetry_metrics_e2e.py
@@ -73,7 +73,7 @@ def parse_payload(data):
 
 def test_telemetry_metrics_enabled_on_gunicorn_child_process(test_agent_session):
     token = "tests.telemetry.test_telemetry_metrics_e2e.test_telemetry_metrics_enabled_on_gunicorn_child_process"
-    assert len(test_agent_session.get_events()) == 0
+    initial_event_count = len(test_agent_session.get_events())
     with gunicorn_server(telemetry_metrics_enabled="true", token=token) as context:
         _, gunicorn_client = context
 
@@ -86,6 +86,7 @@ def test_telemetry_metrics_enabled_on_gunicorn_child_process(test_agent_session)
         assert response.status_code == 200
 
     events = test_agent_session.get_events()
+    assert len(events) > initial_event_count
     metrics = list(filter(lambda event: event["request_type"] == "generate-metrics", events))
     assert len(metrics) == 1
     assert metrics[0]["payload"]["series"][0]["metric"] == "test_metric"


### PR DESCRIPTION
This change resolves CI failures like [this one](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/55280/workflows/c985e8ec-a3b7-483f-b341-3f9ad419f3f0/jobs/3517704) that appear to result from unreliable communication with the test agent. Since the specific assertion that failed in this example is preliminary to the test logic itself, I've replaced it with an assertion that's more directly applicable to the functionality under test.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
