### PR TITLE
ci(telemetry): loosen an assertion that can sometimes fail

### DIFF
--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -317,7 +317,8 @@ def test_update_dependencies_event(telemetry_writer, test_agent_session, mock_ti
     assert "payload" in events[-1]
     assert "dependencies" in events[-1]["payload"]
     assert len(events[-1]["payload"]["dependencies"]) >= 1
-    assert events[-1]["payload"]["dependencies"][0]["name"] == "xmltodict"
+    xmltodict_events = [e for e in events if e["payload"]["dependencies"][0]["name"] == "xmltodict"]
+    assert len(xmltodict_events) == 1
     assert "xmltodict" in telemetry_writer._imported_dependencies
     assert telemetry_writer._imported_dependencies["xmltodict"].name == "xmltodict"
     assert telemetry_writer._imported_dependencies["xmltodict"].version


### PR DESCRIPTION
This change builds on https://github.com/DataDog/dd-trace-py/pull/8300 by allowing the expected event to be anywhere in the payload rather than only at the end. This can probably sometimes happen due to unreliable communication with the test agent.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
