### PR TITLE
fix: dont patch BytesIO since we dont have any aspects for it

### DIFF
--- a/ddtrace/appsec/_iast/_ast/visitor.py
+++ b/ddtrace/appsec/_iast/_ast/visitor.py
@@ -66,7 +66,7 @@ class AstVisitor(ast.NodeTransformer):
             },
             # Replacement functions for modules
             "module_functions": {
-                "BytesIO": "ddtrace_aspects.stringio_aspect",
+                # "BytesIO": "ddtrace_aspects.stringio_aspect",
                 # "StringIO": "ddtrace_aspects.stringio_aspect",
                 # "format": "ddtrace_aspects.format_aspect",
                 # "format_map": "ddtrace_aspects.format_map_aspect",

--- a/releasenotes/notes/do-not-patch-bytesio-b16ccc16f36e8b67.yaml
+++ b/releasenotes/notes/do-not-patch-bytesio-b16ccc16f36e8b67.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    IAST: don't patch BytesIO since we don't have any aspects for it.


### PR DESCRIPTION
## Description

We had BytesIO as a patcheable module but it actually wasn't since we didn't have any aspects for it and could cause an exception. This comments it out in the visitor's list.

## Checklist

- [X] Change(s) are motivated and described in the PR description
- [X] Testing strategy is described if automated tests are not included in the PR
- [X] Risks are described (performance impact, potential for breakage, maintainability)
- [X] Change is maintainable (easy to change, telemetry, documentation)
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [X] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [X] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
