### PR TITLE
ci: don't run PR name check GitHub action on backport branches [backport 2.5]

### DIFF
--- a/.github/workflows/pr-name.yml
+++ b/.github/workflows/pr-name.yml
@@ -2,6 +2,8 @@ name: pr-name
 on:
   pull_request:
     types: ['opened', 'edited', 'reopened', 'synchronize']
+    branches-ignore:
+      - 'backport-[0-9]+-to-[0-9]+.[0-9]+'
 
 jobs:
   pr_name_lint:


### PR DESCRIPTION
Backport 2c22c01601138eab656520f53605a347a5a0c571 from #8366 2.5.

This removes the PR name check for backport branches (ie `backport-[0-9]+-to-[0-9]+.[0.9]+`) based on the assumption that the original PR name already passed the check but now has [backport M.N] appended at the end).

This addresses issues where CI is blocked for backports of PRs that originally had long names (eg: https://github.com/DataDog/dd-trace-py/pull/8341 ).

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
