### PR TITLE
ci: fix missing paths in suitespec for CI Visibility-related jobs [backport 2.5]

### DIFF
--- a/tests/.suitespec.json
+++ b/tests/.suitespec.json
@@ -93,9 +93,18 @@
             "ddtrace/settings/dynamic_instrumentation.py",
             "ddtrace/settings/exception_debugging.py"
         ],
+        "ci": [
+            "ddtrace/ext/ci.py"
+        ],
         "ci_visibility": [
             "ddtrace/internal/ci_visibility/*",
             "ddtrace/ext/test.py"
+        ],
+        "coverage": [
+            "ddtrace/contrib/coverage/*"
+        ],
+        "llmobs": [
+            "ddtrace/llmobs/*"
         ],
         "sourcecode": [
             "ddtrace/sourcecode/*"
@@ -125,6 +134,9 @@
         ],
         "gevent": [
             "ddtrace/contrib/gevent/*"
+        ],
+        "git": [
+            "ddtrace/ext/git.py"
         ],
         "graphene": [
             "ddtrace/contrib/graphene/*"
@@ -309,7 +321,8 @@
         ],
         "pytest": [
             "ddtrace/contrib/pytest/*",
-            "ddtrace/contrib/pytest_bdd/*"
+            "ddtrace/contrib/pytest_bdd/*",
+            "ddtrace/contrib/pytest_benchmark/*"
         ],
         "unittest": [
             "ddtrace/contrib/unittest/*"
@@ -464,6 +477,9 @@
             "@core",
             "@tracing",
             "@ci_visibility",
+            "@ci",
+            "@coverage",
+            "@git",
             "@pytest",
             "tests/ci_visibility/*"
         ],
@@ -873,13 +889,19 @@
             "@tracing",
             "@pytest",
             "@ci_visibility",
-            "tests/contrib/pytest/*"
+            "@coverage",
+            "tests/contrib/pytest/*",
+            "tests/contrib/pytest_benchmark/*",
+            "tests/contrib/pytest_bdd/*",
+            "tests/snapshots/tests.contrib.pytest.*"
         ],
         "unittest": [
             "@contrib",
             "@unittest",
             "@ci_visibility",
-            "tests/contrib/unittest_plugin/*"
+            "@coverage",
+            "tests/contrib/unittest/*",
+            "tests/snapshots/tests.contrib.unittest.*"
         ],
         "asynctest": [
             "@bootstrap",
@@ -888,14 +910,6 @@
             "@tracing",
             "@asynctest",
             "tests/contrib/asynctest/*"
-        ],
-        "pytestbdd": [
-            "@bootstrap",
-            "@core",
-            "@contrib",
-            "@tracing",
-            "@pytest",
-            "tests/contrib/pytest_bdd/*"
         ],
         "pymemcache": [
             "@bootstrap",


### PR DESCRIPTION
Backport 06170cac10fa3e6a5dd3ca5aa2e08768268e196b from #8349 2.5.

This fixes the fact that some of the CI Visibility-related files were not covered by suite specs.

`git` and `ci` are being added as components because, for example, they are imported by other things:
```
ddtrace/internal/gitmetadata.py
5:from ddtrace.ext.ci import _filter_sensitive_info
6:from ddtrace.ext.git import COMMIT_SHA
7:from ddtrace.ext.git import MAIN_PACKAGE
8:from ddtrace.ext.git import REPOSITORY_URL
```
or
```
ddtrace/profiling/exporter/http.py
18:from ddtrace.ext.git import COMMIT_SHA
19:from ddtrace.ext.git import MAIN_PACKAGE
20:from ddtrace.ext.git import REPOSITORY_URL
```

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
