### PR TITLE
fix(botocore): fix bug causing no response to be returned from SQS and Kinesis when config.botocore.empty_poll_enabled is false

### DIFF
--- a/ddtrace/contrib/botocore/services/kinesis.py
+++ b/ddtrace/contrib/botocore/services/kinesis.py
@@ -121,8 +121,9 @@ def patched_kinesis_api_call(original_func, instance, args, kwargs, function_var
         - not func_run: The function is not `getRecords` and we need to run it
         - func_run and message_received: Received a message when polling
         - config.empty_poll_enabled: We want to trace empty poll operations
+        - func_run_err: There was an error when calling the `getRecords` function
     """
-    if (func_run and message_received) or config.botocore.empty_poll_enabled or not func_run:
+    if (func_run and message_received) or config.botocore.empty_poll_enabled or not func_run or func_run_err:
         with pin.tracer.start_span(
             trace_operation,
             service=schematize_service_name("{}.{}".format(pin.service, endpoint_name)),
@@ -173,3 +174,9 @@ def patched_kinesis_api_call(original_func, instance, args, kwargs, function_var
                 if status_code and not config.botocore.operations[span.resource].is_error_code(int(status_code)):
                     span._ignore_exception(botocore.exceptions.ClientError)
                 raise
+    # return results in the case that we ran the function, but no records were returned and empty
+    # poll spans are disabled
+    elif func_run:
+        if func_run_err:
+            raise func_run_err
+        return result

--- a/ddtrace/contrib/botocore/services/sqs.py
+++ b/ddtrace/contrib/botocore/services/sqs.py
@@ -146,8 +146,9 @@ def patched_sqs_api_call(original_func, instance, args, kwargs, function_vars):
         - not func_run: The function is not `ReceiveMessage` and we need to run it
         - func_run and message_received: Received a message when polling
         - config.empty_poll_enabled: We want to trace empty poll operations
+        - func_run_err: There was an error when calling the `ReceiveMessage` function
     """
-    if (func_run and message_received) or config.botocore.empty_poll_enabled or not func_run:
+    if (func_run and message_received) or config.botocore.empty_poll_enabled or not func_run or func_run_err:
         with pin.tracer.start_span(
             trace_operation,
             service=schematize_service_name("{}.{}".format(pin.service, endpoint_name)),
@@ -218,3 +219,9 @@ def patched_sqs_api_call(original_func, instance, args, kwargs, function_vars):
                 if status_code and not config.botocore.operations[span.resource].is_error_code(int(status_code)):
                     span._ignore_exception(botocore.exceptions.ClientError)
                 raise
+    # return results in the case that we ran the function, but no records were returned and empty
+    # poll spans are disabled
+    elif func_run:
+        if func_run_err:
+            raise func_run_err
+        return result

--- a/releasenotes/notes/fix-botocore-bug-when-empty-poll-disabled-config-set-033d13dee074ec23.yaml
+++ b/releasenotes/notes/fix-botocore-bug-when-empty-poll-disabled-config-set-033d13dee074ec23.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    botocore: fix bug that wrapped function results/errors are not returned for SQS and Kinesis when `DD_BOTOCORE_EMPTY_POLL_ENABLED=false` or 
+    botocore: Fixes bug where SQS and Kinesis results and errors were not recorded when `DD_BOTOCORE_EMPTY_POLL_ENABLED=false`.
     `config.botocore.empty_poll_enabled=false` and no records were found.

--- a/releasenotes/notes/fix-botocore-bug-when-empty-poll-disabled-config-set-033d13dee074ec23.yaml
+++ b/releasenotes/notes/fix-botocore-bug-when-empty-poll-disabled-config-set-033d13dee074ec23.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    botocore: fix bug that wrapped function results/errors are not returned for SQS and Kinesis when `DD_BOTOCORE_EMPTY_POLL_ENABLED=false` or 
+    `config.botocore.empty_poll_enabled=false` and no records were found.

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -2672,6 +2672,7 @@ class BotocoreTest(TracerTestCase):
 
         return decoded_record_data
 
+    @mock_kinesis
     def test_kinesis_get_records_empty_poll_disabled(self):
         # Tests that no span is created when empty poll is disabled and we received no records.
         with self.override_config("botocore", dict(empty_poll_enabled=False)):
@@ -2696,6 +2697,7 @@ class BotocoreTest(TracerTestCase):
             spans = self.get_spans()
             assert len(spans) == 0
 
+    @mock_kinesis
     def test_kinesis_get_records_empty_poll_enabled(self):
         # Tests that a span is created when empty poll is enabled and we received no records.
         with self.override_config("botocore", dict(empty_poll_enabled=True)):

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -2737,9 +2737,8 @@ class BotocoreTest(TracerTestCase):
                 MessageAttributeNames=["_datadog"],
                 WaitTimeSeconds=2,
             )
-            messages = response["Messages"]
 
-            assert len(messages) == 0
+            assert "Messages" not in response
 
             spans = self.get_spans()
             assert len(spans) == 0
@@ -2759,9 +2758,8 @@ class BotocoreTest(TracerTestCase):
                 MessageAttributeNames=["_datadog"],
                 WaitTimeSeconds=2,
             )
-            messages = response["Messages"]
 
-            assert len(messages) == 0
+            assert "Messages" not in response
 
             spans = self.get_spans()
             assert len(spans) == 1


### PR DESCRIPTION
## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
