### PR TITLE
ci: add missing sampling snapshot test

### DIFF
--- a/tests/snapshots/test_sampling_with_rate_sampler_with_tiny_rate.json
+++ b/tests/snapshots/test_sampling_with_rate_sampler_with_tiny_rate.json
@@ -1,0 +1,35 @@
+[[
+  {
+    "name": "trace8",
+    "service": "",
+    "resource": "trace8",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "",
+    "error": 0,
+    "meta": {
+      "_dd.p.tid": "65cbd89000000000",
+      "language": "python",
+      "runtime-id": "7a2aa1b276634a76b25c928fffea4cdc"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "process_id": 83161
+    },
+    "duration": 64000,
+    "start": 1707858064774777000
+  },
+     {
+       "name": "child",
+       "service": "",
+       "resource": "child",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "duration": 13000,
+       "start": 1707858064774816000
+     }]]


### PR DESCRIPTION
Somehow we merged a snapshot test without the actual snapshot file. Perhaps the test suite spec needs to be changed? Regardless this is failing now for tests that run  `tests/integration/test_sampling.py`, because the snapshot doesn't exist. This unblocks CI.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.


## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
