### PR TITLE
ci: get latest commit message to look for itr:noskip

### DIFF
--- a/scripts/needs_testrun.py
+++ b/scripts/needs_testrun.py
@@ -59,13 +59,12 @@ def get_merge_base(pr_number: int) -> str:
 
 
 @cache
-def get_commit_message(sha: str) -> str:
-    """Get the commit message of a commit."""
-    if sha:
-        try:
-            return check_output(["git", "log", "-1", "--pretty=%B", sha]).decode("utf-8").strip()
-        except Exception:
-            pass
+def get_latest_commit_message() -> str:
+    """Get the commit message of the last commit."""
+    try:
+        return check_output(["git", "log", "-1", "--pretty=%B"]).decode("utf-8").strip()
+    except Exception:
+        pass
     return ""
 
 
@@ -111,7 +110,7 @@ def needs_testrun(suite: str, pr_number: int, sha: t.Optional[str] = None) -> bo
     >>> needs_testrun("foobar", 6412)
     True
     """
-    if "itr:noskip" in get_commit_message(sha).lower():
+    if "itr:noskip" in get_latest_commit_message().lower():
         return True
     try:
         patterns = get_patterns(suite)


### PR DESCRIPTION
CI: fix needs test run command to get latest commit message

This PR will effectively disable the "needs_testrun" mechanism if "ITR:NoSkip" is added in the commit message.

An improvement could be just disabling the "last successful run" cache just for the required test suite if "ITR:NoSkip" is found so we run only the required suites instead of all.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
