### PR TITLE
chore(ci): move cibuildwheel config to pyproject

### DIFF
--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -53,23 +53,6 @@ jobs:
           CIBW_BUILD: ${{ inputs.cibw_build }}
           CIBW_SKIP: ${{ inputs.cibw_skip }}
           CIBW_PRERELEASE_PYTHONS: ${{ inputs.cibw_prerelease_pythons }}
-          CMAKE_BUILD_PARALLEL_LEVEL: 12
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: |
-            mkdir ./tempwheelhouse &&
-            auditwheel repair -w ./tempwheelhouse {wheel} &&
-            (yum install -y zip || apk add zip) &&
-            for w in ./tempwheelhouse/*.whl; do
-              zip -d $w \*.c \*.cpp \*.cc \*.h \*.hpp \*.pyx
-              mv $w {dest_dir}
-            done &&
-            rm -rf ./tempwheelhouse
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
-            zip -d {wheel} \*.c \*.cpp \*.cc \*.h \*.hpp \*.pyx &&
-            delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS:
-            choco install -y 7zip &&
-            7z d -r "{wheel}" *.c *.cpp *.cc *.h *.hpp *.pyx &&
-            move "{wheel}" "{dest_dir}"
           # DEV: Uncomment to debug MacOS
           # CIBW_BUILD_VERBOSITY_MACOS: 3
       - uses: actions/upload-artifact@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,16 +170,41 @@ exclude_dirs = [
 ]
 
 [tool.cibuildwheel]
-build = ["cp27-*", "cp35-*", "cp36-*", "cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
+build = ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*"]
 test-command = ["python {project}/tests/smoke_test.py"]
 # Skip trying to test arm64 builds on Intel Macs
 test-skip = "*-macosx_universal2:arm64"
+environment = "CMAKE_BUILD_PARALLEL_LEVEL=12"
+
 
 [tool.cibuildwheel.macos.environment]
 # Workaround for Macos 11.0 versioning issue, a.k.a.
 # `platform.mac_ver()` reports incorrect MacOS version at 11.0
 # See: https://stackoverflow.com/a/65402241
 SYSTEM_VERSION_COMPAT = "0"
+
+[tool.cibuildwheel.linux]
+repair-wheel-command = [
+  "mkdir ./tempwheelhouse",
+  "auditwheel repair -w ./tempwheelhouse {wheel}",
+  "(yum install -y zip || apk add zip)",
+  "for w in ./tempwheelhouse/*.whl; do zip -d $w \\*.c \\*.cpp \\*.cc \\*.h \\*.hpp \\*.pyx && mv $w {dest_dir} done",
+  "rm -rf ./tempwheelhouse",
+]
+
+
+[tool.cibuildwheel.macos]
+repair-wheel-command = [
+  "zip -d {wheel} \\*.c \\*.cpp \\*.cc \\*.h \\*.hpp \\*.pyx",
+  "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}",
+]
+
+[tool.cibuildwheel.windows]
+repair-wheel-command = [
+  "choco install -y 7zip",
+  "7z d -r {wheel} *.c *.cpp *.cc *.h *.hpp *.pyx",
+  "move {wheel} {dest_dir}",
+]
 
 [tool.ruff]
 exclude = [


### PR DESCRIPTION
## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [ ] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
