### PR TITLE
feat(tracing): shutdown tracer on app crashes

### DIFF
--- a/ddtrace/internal/atexit.py
+++ b/ddtrace/internal/atexit.py
@@ -16,50 +16,8 @@ from ddtrace.internal.utils import signals
 log = logging.getLogger(__name__)
 
 
-if hasattr(atexit, "unregister"):
-    register = atexit.register
-    unregister = atexit.unregister
-else:
-    # Hello Python 2!
-    _registry = []  # type: typing.List[typing.Tuple[typing.Callable[..., None], typing.Tuple, typing.Dict]]
-
-    def _ddtrace_atexit():
-        # type: (...) -> None
-        """Wrapper function that calls all registered function on normal program termination"""
-        global _registry
-
-        # DEV: we make a copy of the registry to prevent hook execution from
-        # introducing new hooks, potentially causing an infinite loop.
-        for hook, args, kwargs in list(_registry):
-            try:
-                hook(*args, **kwargs)
-            except Exception:
-                # Mimic the behaviour of Python's atexit hooks.
-                log.exception("Error in atexit hook %r", hook)
-
-    def register(
-        func,  # type: typing.Callable[..., typing.Any]
-        *args,  # type: typing.Any
-        **kwargs,  # type: typing.Any
-    ):
-        # type: (...) -> typing.Callable[..., typing.Any]
-        """Register a function to be executed upon normal program termination"""
-
-        _registry.append((func, args, kwargs))
-        return func
-
-    def unregister(func):
-        # type: (typing.Callable[..., typing.Any]) -> None
-        """
-        Unregister an exit function which was previously registered using
-        atexit.register.
-        If the function was not registered, it is ignored.
-        """
-        global _registry
-
-        _registry = [(f, args, kwargs) for f, args, kwargs in _registry if f != func]
-
-    atexit.register(_ddtrace_atexit)
+register = atexit.register
+unregister = atexit.unregister
 
 
 # registers a function to be called when an exit signal (TERM or INT) or received.

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -48,7 +48,6 @@ from .internal import compat
 from .internal import debug
 from .internal import forksafe
 from .internal import hostname
-from .internal.atexit import register_on_exit_signal
 from .internal.constants import SAMPLING_DECISION_TRACE_TAG_KEY
 from .internal.constants import SPAN_API_DATADOG
 from .internal.dogstatsd import get_dogstatsd_client
@@ -276,10 +275,9 @@ class Tracer(object):
             from .internal.datastreams.processor import DataStreamsProcessor
 
             self.data_streams_processor = DataStreamsProcessor(self._agent_url)
-            register_on_exit_signal(self._atexit)
 
         self._hooks = _hooks.Hooks()
-        atexit.register(self._atexit)
+        atexit.register(self._atexit, True)
         forksafe.register(self._child_after_fork)
 
         self._shutdown_lock = RLock()


### PR DESCRIPTION
Attempts to resolve: https://github.com/DataDog/dd-trace-py/issues/8252

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [ ] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
