### PR TITLE
fix(ci_visibility): catch socket.timeouterrors [...] generated by python<3.10 [backport 2.4]

### DIFF
--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 import json
 import os
+import socket
 from typing import TYPE_CHECKING  # noqa:F401
 from uuid import uuid4
 
@@ -347,7 +348,7 @@ class CIVisibility(Service):
 
         try:
             response = _do_request("POST", url, json.dumps(payload), _headers)
-        except TimeoutError:
+        except (TimeoutError, socket.timeout):
             log.warning("Request timeout while fetching skippable tests")
             self._test_suites_to_skip = []
             return

--- a/releasenotes/notes/ci_visibility-fix-socket-timeout-exception-fabf40a398249c26.yaml
+++ b/releasenotes/notes/ci_visibility-fix-socket-timeout-exception-fabf40a398249c26.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    CI Visibility: fix a potential crash for Python<3.10 when a socket.timeout error was raised instead of the expected TimeoutError during CI Visiblity API requests
+    CI Visibility: fix a potential crash for Python<3.10 when a socket.timeout error was raised instead of the expected TimeoutError during CI Visibility API requests

--- a/releasenotes/notes/ci_visibility-fix-socket-timeout-exception-fabf40a398249c26.yaml
+++ b/releasenotes/notes/ci_visibility-fix-socket-timeout-exception-fabf40a398249c26.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    CI Visibility: fix a potential crash for Python<3.10 when a socket.timeout error was raised instead of the expected TimeoutError during CI Visiblity API requests

--- a/tests/ci_visibility/test_ci_visibility.py
+++ b/tests/ci_visibility/test_ci_visibility.py
@@ -118,8 +118,9 @@ def test_ci_visibility_service_settings_timeout(_do_request):
         CIVisibility.disable()
 
 
+@mock.patch("ddtrace.internal.ci_visibility.recorder.CIVisibility._check_enabled_features", return_value=(True, True))
 @mock.patch("ddtrace.internal.ci_visibility.recorder._do_request", side_effect=socket.timeout)
-def test_ci_visibility_service_settings_socket_timeout(_do_request):
+def test_ci_visibility_service_settings_socket_timeout(_do_request, _check_enabled_features):
     with override_env(
         dict(
             DD_API_KEY="foobar.baz",
@@ -129,11 +130,11 @@ def test_ci_visibility_service_settings_socket_timeout(_do_request):
     ):
         ddtrace.internal.ci_visibility.recorder.ddconfig = ddtrace.settings.Config()
         CIVisibility.enable(service="test-service")
-        assert CIVisibility._instance._api_settings.coverage_enabled is False
-        assert CIVisibility._instance._api_settings.skipping_enabled is False
+        assert CIVisibility._instance._test_suites_to_skip == []
         CIVisibility.disable()
 
 
+@mock.patch("ddtrace.internal.ci_visibility.recorder.CIVisibility._check_enabled_features", return_value=(True, True))
 @mock.patch("ddtrace.internal.ci_visibility.recorder._do_request", side_effect=TimeoutError)
 def test_ci_visibility_service_skippable_timeout(_do_request, _check_enabled_features):
     with override_env(


### PR DESCRIPTION
Backport a89d85e757a904590f66759084ecbbd90717fe7c from #8434 to 2.4.

This fixes an issue where older Python versions raise `socket.timeout` errors which are not equivalent to `TimeoutError`.

Eg, in python 3.9:
```
Python 3.9.16 (main, Jun 13 2023, 17:56:34)
>>> import socket
>>> isinstance(socket.timeout(), TimeoutError)
False
```

vs 3.10:
```
Python 3.10.5 (main, Jun 16 2023, 11:07:50) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
>>> import socket
>>> isinstance(socket.timeout(), TimeoutError)
True
>>>
```

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
