### PR TITLE
chore(rc): add skip shutdown option

### DIFF
--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -152,3 +152,19 @@ def is_stdlib(path: Path) -> bool:
     return (rpath.is_relative_to(stdlib_path) or rpath.is_relative_to(platstdlib_path)) and not (
         rpath.is_relative_to(purelib_path) or rpath.is_relative_to(platlib_path)
     )
+
+
+@cached()
+def is_distribution_available(name: str) -> bool:
+    """Determine if a distribution is available in the current environment."""
+    try:
+        import importlib.metadata as importlib_metadata
+    except ImportError:
+        import importlib_metadata  # type: ignore[no-redef]
+
+    try:
+        importlib_metadata.distribution(name)
+    except importlib_metadata.PackageNotFoundError:
+        return False
+
+    return True

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -25,6 +25,7 @@ from ddtrace.internal import gitmetadata
 from ddtrace.internal import runtime
 from ddtrace.internal.hostname import get_hostname
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.packages import is_distribution_available
 from ddtrace.internal.remoteconfig.constants import REMOTE_CONFIG_AGENT_ENDPOINT
 from ddtrace.internal.runtime import container
 from ddtrace.internal.service import ServiceStatus
@@ -39,17 +40,30 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Callable  # noqa:F401
     from typing import MutableMapping  # noqa:F401
     from typing import Tuple  # noqa:F401
-    from typing import Union  # noqa:F401
 
 log = get_logger(__name__)
 
 TARGET_FORMAT = re.compile(r"^(datadog/\d+|employee)/([^/]+)/([^/]+)/([^/]+)$")
 
 
+REQUIRE_SKIP_SHUTDOWN = frozenset({"django-q"})
+
+
+def derive_skip_shutdown(c: "RemoteConfigClientConfig") -> bool:
+    return (
+        c._skip_shutdown
+        if c._skip_shutdown is not None
+        else any(is_distribution_available(_) for _ in REQUIRE_SKIP_SHUTDOWN)
+    )
+
+
 class RemoteConfigClientConfig(En):
     __prefix__ = "_dd.remote_configuration"
 
     log_payloads = En.v(bool, "log_payloads", default=False)
+
+    _skip_shutdown = En.v(Optional[bool], "skip_shutdown", default=None)
+    skip_shutdown = En.d(bool, derive_skip_shutdown)
 
 
 config = RemoteConfigClientConfig()

--- a/ddtrace/internal/remoteconfig/worker.py
+++ b/ddtrace/internal/remoteconfig/worker.py
@@ -8,6 +8,7 @@ from ddtrace.internal import periodic
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.remoteconfig._pubsub import PubSub  # noqa:F401
 from ddtrace.internal.remoteconfig.client import RemoteConfigClient
+from ddtrace.internal.remoteconfig.client import config as rc_config
 from ddtrace.internal.remoteconfig.constants import REMOTE_CONFIG_AGENT_ENDPOINT
 from ddtrace.internal.remoteconfig.utils import get_poll_interval_seconds
 from ddtrace.internal.service import ServiceStatus
@@ -82,7 +83,8 @@ class RemoteConfigPoller(periodic.PeriodicService):
 
             self.start()
             forksafe.register(self.reset_at_fork)
-            atexit.register(self.disable)
+            if not rc_config.skip_shutdown:
+                atexit.register(self.disable)
             return True
         return False
 
@@ -160,6 +162,12 @@ class RemoteConfigPoller(periodic.PeriodicService):
             log.debug("error starting the RCM client", exc_info=True)
 
     def unregister(self, product):
+        if rc_config.skip_shutdown:
+            # If we are asked to skip shutdown, then we likely don't want to
+            # unregister any of the products, because this is generally done
+            # when the application is shutting down.
+            return
+
         try:
             self._client.unregister_product(product)
         except Exception:


### PR DESCRIPTION
We add an internal option to RC to skip the shutdown step and prevent products from being unregistered. This is a workaroud for adding support for systems such as Django Q. On platforms like Linux, these systems use multiprocessing, and the default fork start method, to spawn child processes. The main process then invokes the shutdown, potentially leaving the child processes without an RC client to listen to for new configuration payload. With the proposed changes, we prevent the RC client in the parent process to responding to the shutdown, thus keeping the RC poller worker alive. We also prevent products from being unregistered, which would also prevent configuration from being fetched for these products.

## Testing strategy

A comprehensive testing scenario would require a working Django Q instance. The changes were tested locally on a sample Django Q project.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
