### PR TITLE
chore(tracer): downgrade to v0.4 only if asm is enabled

### DIFF
--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -408,6 +408,15 @@ class Tracer(object):
 
         if appsec_enabled is not None:
             self._asm_enabled = asm_config._asm_enabled = appsec_enabled
+            if api_version is None:
+                # If appsec is enabled, we need to use the v0.4 API
+                api_version = "v0.4"
+            elif api_version != "v0.4":
+                log.warning(
+                    "ASM is enabled, but the API version is set to %s. "
+                    "ASM does not support API versions other than v0.4.",
+                    api_version,
+                )
 
         if iast_enabled is not None:
             self._iast_enabled = asm_config._iast_enabled = iast_enabled

--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -223,7 +223,7 @@ def _appsec_1click_activation(features: Mapping[str, Any], test_tracer: Optional
 
             if rc_asm_enabled:
                 if not tracer._asm_enabled:
-                    tracer.configure(appsec_enabled=True)
+                    tracer.configure(appsec_enabled=True, api_version="v0.4")
                 else:
                     asm_config._asm_enabled = True
             else:

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -478,7 +478,7 @@ class AgentWriter(HTTPWriter):
         is_windows = sys.platform.startswith("win") or sys.platform.startswith("cygwin")
 
         default_api_version = "v0.5"
-        if is_windows or in_gcp_function() or in_azure_function_consumption_plan() or asm_config._asm_can_be_enabled:
+        if is_windows or in_gcp_function() or in_azure_function_consumption_plan() or asm_config._asm_enabled:
             default_api_version = "v0.4"
 
         self._api_version = api_version or config._trace_api or default_api_version


### PR DESCRIPTION
Follow up to: https://github.com/DataDog/dd-trace-py/pull/8441/files

api_version `v0.5` is a more performant trace api and should be used whenever possible. We should only downgrade to `v0.4` if ASM is enabled. 

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [ ] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
