### PR TITLE
fix(internal): ignore non-standard modules [backport #7732 to 1.20]

### DIFF
--- a/releasenotes/notes/fix-ignore-non-standard-modules-318862ee5c68be0f.yaml
+++ b/releasenotes/notes/fix-ignore-non-standard-modules-318862ee5c68be0f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: Fix an issue that caused the instrumented
+    application to fail to start if a non-standard module was imported.

--- a/tests/internal/test_module.py
+++ b/tests/internal/test_module.py
@@ -400,3 +400,17 @@ def test_module_watchdog_no_lazy_force_load():
         lazy.__spec__
     except AttributeError:
         pass
+
+
+@pytest.mark.subprocess(ddtrace_run=True)
+def test_module_watchdog_weakref():
+    """Check that we can ignore entries in sys.modules that cannot be weakref'ed."""
+    import sys
+
+    sys.modules["bogus"] = str.__init__  # Cannot create weak ref to method_descriptor
+
+    from ddtrace.internal.module import ModuleWatchdog
+
+    instance = ModuleWatchdog._instance
+    instance._om = None
+    assert ModuleWatchdog._instance._origin_map


### PR DESCRIPTION
Backport of #7732 to 1.20

When mapping imported modules to their origin, we handle non-standard objects to ensure that we do not raise an exception if we find a module that either has no origin, or that cannot be referenced weakly. We expect these cases to be of no importance to the tracking process, as these modules are unlikely to provide useful information via the Python runtime.

Fixes #7730.

## Checklist

- [x] Change(s) are motivated and described in the PR description.
- [x] Testing strategy is described if automated tests are not included in the PR.
- [x] Risk is outlined (performance impact, potential for breakage, maintainability, etc).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed. If no release note is required, add label `changelog/no-changelog`.
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/)).
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate.
- [x] No unnecessary changes are introduced.
- [x] Description motivates each change.
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes unless absolutely necessary.
- [x] Testing strategy adequately addresses listed risk(s).
- [x] Change is maintainable (easy to change, telemetry, documentation).
- [x] Release note makes sense to a user of the library.
- [x] Reviewer has explicitly acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment.
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
