### PR TITLE
chore: ignore embedded doc sources in suitespec check

### DIFF
--- a/scripts/check_suitespec_coverage.py
+++ b/scripts/check_suitespec_coverage.py
@@ -19,6 +19,9 @@ TEST_PATH = ROOT / "tests"
 IGNORE_PATTERNS = {_ for _ in GITIGNORE_FILE.read_text().strip().splitlines() if _ and not _.startswith("#")}
 SPEC_PATTERNS = {_ for suite in spec.get_suites() for _ in spec.get_patterns(suite)}
 
+# Ignore any embedded documentation
+IGNORE_PATTERNS.add("**/*.md")
+
 
 def filter_ignored(paths: t.Iterable[Path]) -> set[Path]:
     return {
@@ -39,21 +42,24 @@ uncovered_tests = uncovered(TEST_PATH)
 unmatched_patterns = unmatched()
 
 if uncovered_sources:
-    print("Source files not covered by any suite specs:", len(uncovered_sources))
+    print(f"▶️ {len(uncovered_sources)} source files not covered by any suite specs:")
     for f in sorted(uncovered_sources):
-        print(f"  {f}")
+        print(f"    {f}")
+    print()
 if uncovered_tests:
-    print("Test scripts not covered by any suite specs:", len(uncovered_tests))
+    print(f"🧪 {len(uncovered_tests)} test files not covered by any suite specs:")
     for f in sorted(uncovered_tests):
-        print(f"  {f}")
+        print(f"    {f}")
+    print()
 if not uncovered_sources and not uncovered_tests:
-    print("All files are covered by suite specs")
+    print("✨ 🍰 ✨ All files are covered by suite specs")
 
 if unmatched_patterns:
-    print("Unmatched patterns:", len(unmatched_patterns))
+    print(f"🧹 {len(unmatched_patterns)} unmatched patterns:")
     for p in sorted(unmatched_patterns):
-        print(f"  {p}")
+        print(f"    {p}")
+    print()
 else:
-    print("All patterns are matching")
+    print("✨ 🧹 ✨ All patterns are matching")
 
 sys.exit(bool(uncovered_sources | uncovered_tests | unmatched_patterns))


### PR DESCRIPTION
## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
