### PR TITLE
ci(sca): run datadog sca in the ci

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -104,3 +104,6 @@ mypy.ini                            @DataDog/python-guild  @DataDog/apm-core-pyt
 .github/CODEOWNERS                  @DataDog/python-guild  @DataDog/apm-core-python
 .github/workflows/system-tests.yml  @DataDog/python-guild  @DataDog/apm-core-python
 ddtrace/internal/compat.py          @DataDog/python-guild  @DataDog/apm-core-python
+
+# Security
+/.gitlab/software_composition_analysis.yaml  @DataDog/software-integrity-and-trust

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ stages:
 include:
   - remote: https://gitlab-templates.ddbuild.io/apm/packaging.yml
   - local: ".gitlab/benchmarks.yml"
-  - /.gitlab/software_composition_analysis.yaml
+  - local: .gitlab/software_composition_analysis.yaml
 
 variables:
   DOWNSTREAM_BRANCH:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ stages:
 include:
   - remote: https://gitlab-templates.ddbuild.io/apm/packaging.yml
   - local: ".gitlab/benchmarks.yml"
+  - /.gitlab/software_composition_analysis.yaml
 
 variables:
   DOWNSTREAM_BRANCH:

--- a/.gitlab/software_composition_analysis.yaml
+++ b/.gitlab/software_composition_analysis.yaml
@@ -1,0 +1,23 @@
+---
+datadog-sca-ci:
+  stage: package
+  tags: ["arch:amd64"]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci-sbom:2024011006
+  when: always
+  # We don't want to disrupt the pipeline so let's fail silently.
+  allow_failure: true
+  # This specifies the job does not have any dependency, meaning it can start as soon as it can.
+  needs: []
+  script:
+    # Disabling tracing to avoid leaking secrets.
+    # See https://www.gnu.org/software/bash/manual/bash.html#The-Set-Builtin:
+    # "Using ‘+’ rather than ‘-’ causes these options to be turned off"
+    - set +o xtrace
+    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name "ci.dd-trace-py.datadog_api_key_org2" --with-decryption --query "Parameter.Value" --out text)
+    - export DD_APP_KEY=$(aws ssm get-parameter --region us-east-1 --name "ci.dd-trace-py.datadog_app_key_org2" --with-decryption --query "Parameter.Value" --out text)
+    - set -o xtrace
+    - trivy fs --output /tmp/trivy.sbom --format cyclonedx --offline-scan --skip-update .
+    # Required until we use datadog-ci version https://github.com/DataDog/datadog-ci/releases/tag/v2.30.0
+    # Current version is v2.27.0
+    - export DD_BETA_COMMANDS_ENABLED=true
+    - datadog-ci sbom upload --service dd-trace-py --env ci /tmp/trivy.sbom


### PR DESCRIPTION
### What does this PR do?
Add a new Gitlab CI job listing this repository dependencies with trivy and uploading them to Datadog. This will make it possible to use the SCA product for this repository (see https://app.datadoghq.com/ci/code-analysis?limit=100&offset=0).

### Motivation
@DataDog/software-integrity-and-trust partners with @DataDog/static-analysis to dogfood their SCA product and secure Datadog's supply chain.

### Additional Notes
[Successful CI run](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/440743128)

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
