### PR TITLE
ci: update suitespec coverage

### DIFF
--- a/scripts/check_suitespec_coverage.py
+++ b/scripts/check_suitespec_coverage.py
@@ -21,6 +21,8 @@ SPEC_PATTERNS = {_ for suite in spec.get_suites() for _ in spec.get_patterns(sui
 
 # Ignore any embedded documentation
 IGNORE_PATTERNS.add("**/*.md")
+# The aioredis integration is deprecated and untested
+IGNORE_PATTERNS.add("ddtrace/contrib/aioredis/*")
 
 
 def filter_ignored(paths: t.Iterable[Path]) -> set[Path]:

--- a/tests/.suitespec.json
+++ b/tests/.suitespec.json
@@ -133,8 +133,7 @@
         "pg": [
             "ddtrace/contrib/aiopg/*",
             "ddtrace/contrib/asyncpg/*",
-            "ddtrace/contrib/psycopg/*",
-            "ddtrace/contrib/psycopg2/*"
+            "ddtrace/contrib/psycopg/*"
         ],
         "datastreams": [
             "ddtrace/internal/datastreams/*",
@@ -189,9 +188,6 @@
         ],
         "git": [
             "ddtrace/ext/git.py"
-        ],
-        "graphene": [
-            "ddtrace/contrib/graphene/*"
         ],
         "starlette": [
             "ddtrace/contrib/starlette/*"
@@ -296,16 +292,11 @@
         "mysql": [
             "ddtrace/contrib/mysql/*",
             "ddtrace/contrib/mysqldb/*",
-            "ddtrace/contrib/mysqlconnector/*",
-            "ddtrace/contrib/mysqlpython/*",
             "ddtrace/contrib/pymysql/*",
             "ddtrace/contrib/aiomysql/*"
         ],
         "pylibmc": [
             "ddtrace/contrib/pylibmc/*"
-        ],
-        "asynctest": [
-            "ddtrace/contrib/asynctest/*"
         ],
         "logbook": [
             "ddtrace/contrib/logbook/*"
@@ -369,9 +360,7 @@
             "ddtrace/ext/consul.py"
         ],
         "django": [
-            "ddtrace/contrib/django/*",
-            "ddtrace/contrib/django_hosts/*",
-            "ddtrace/contrib/djangorestframework/*"
+            "ddtrace/contrib/django/*"
         ],
         "pytest": [
             "ddtrace/contrib/pytest/*",
@@ -406,7 +395,6 @@
             "@core",
             "@remoteconfig",
             "@symbol_db",
-            "tests/test_module/*",
             "tests/internal/*",
             "tests/submod/*",
             "tests/cache/*"
@@ -849,7 +837,6 @@
             "@tracing",
             "@appsec",
             "@django",
-            "tests/contrib/django_hosts/*",
             "tests/snapshots/tests.contrib.{suite}.*"
         ],
         "djangorestframework": [
@@ -858,8 +845,7 @@
             "@contrib",
             "@tracing",
             "@appsec",
-            "@django",
-            "tests/contrib/djangorestframework/*"
+            "@django"
         ],
         "fastapi": [
             "@bootstrap",
@@ -902,10 +888,7 @@
             "@bootstrap",
             "@core",
             "@contrib",
-            "@tracing",
-            "@graphene",
-            "tests/contrib/graphene/*",
-            "tests/snapshots/tests.contrib.graphene.*"
+            "@tracing"
         ],
         "graphql": [
             "@bootstrap",
@@ -979,22 +962,6 @@
             "@mysql",
             "tests/contrib/mysqldb/*"
         ],
-        "mysqlconnector": [
-            "@bootstrap",
-            "@core",
-            "@contrib",
-            "@tracing",
-            "@mysql",
-            "tests/contrib/mysqlconnector/*"
-        ],
-        "mysqlpython": [
-            "@bootstrap",
-            "@core",
-            "@contrib",
-            "@tracing",
-            "@mysql",
-            "tests/contrib/mysqlpython/*"
-        ],
         "pymysql": [
             "@bootstrap",
             "@core",
@@ -1038,9 +1005,7 @@
             "@bootstrap",
             "@core",
             "@contrib",
-            "@tracing",
-            "@asynctest",
-            "tests/contrib/asynctest/*"
+            "@tracing"
         ],
         "pymemcache": [
             "@bootstrap",

--- a/tests/.suitespec.json
+++ b/tests/.suitespec.json
@@ -16,7 +16,20 @@
             "tests/__init__.py",
             "tests/.suitespec.json",
             "tests/suitespec.py",
-            ".circleci/*"
+            ".circleci/*",
+            "tests/meta/*",
+            "tests/smoke_test.py",
+            "tests/subprocesstest.py",
+            "tests/wait-for-services.py",
+            "tests/webclient.py",
+            "tests/test_module/*",
+            "tests/lib-injection/dd-lib-python-init-test-django/*",
+            "tests/lib-injection/dd-lib-python-init-test-django-gunicorn/*",
+            "tests/lib-injection/dd-lib-python-init-test-django-gunicorn-alpine/*",
+            "tests/lib-injection/dd-lib-python-init-test-django-no-perms/*",
+            "tests/lib-injection/dd-lib-python-init-test-django-pre-installed/*",
+            "tests/lib-injection/dd-lib-python-init-test-django-unsupported-python/*",
+            "tests/lib-injection/dd-lib-python-init-test-django-uvicorn/*"
         ],
         "core": [
             "ddtrace/internal/__init__.py",
@@ -115,6 +128,7 @@
             "ddtrace/propagation/*",
             "ddtrace/settings/_database_monitoring.py",
             "tests/contrib/patch.py",
+            "tests/contrib/config.py",
             "tests/contrib/__init__.py"
         ],
         "redis": [
@@ -287,6 +301,7 @@
         ],
         "botocore": [
             "ddtrace/contrib/botocore/*",
+            "ddtrace/contrib/boto/*",
             "ddtrace/contrib/aiobotocore/*"
         ],
         "mysql": [
@@ -305,7 +320,8 @@
             "ddtrace/contrib/logging/*"
         ],
         "loguru": [
-            "ddtrace/contrib/logging/*"
+            "ddtrace/contrib/logging/*",
+            "ddtrace/contrib/loguru/*"
         ],
         "sqlite3": [
             "ddtrace/contrib/sqlite3/*"
@@ -371,7 +387,8 @@
             "ddtrace/contrib/unittest/*"
         ],
         "appsec": [
-            "ddtrace/appsec/*"
+            "ddtrace/appsec/*",
+            "ddtrace/settings/asm.py"
         ],
         "appsec_iast": [
             "ddtrace/appsec/iast/*"
@@ -430,7 +447,8 @@
             "@contrib",
             "@serverless",
             "@remoteconfig",
-            "tests/tracer/*"
+            "tests/tracer/*",
+            "tests/snapshots/test_*"
         ],
         "integration_agent": [
             "@tracing",
@@ -655,7 +673,9 @@
             "@llmobs",
             "@botocore",
             "@llmobs",
-            "tests/contrib/botocore/*"
+            "tests/contrib/botocore/*",
+            "tests/contrib/boto/*",
+            "tests/snapshots/tests.contrib.botocore*"
         ],
         "test_logging": [
             "@bootstrap",
@@ -837,7 +857,9 @@
             "@tracing",
             "@appsec",
             "@django",
-            "tests/snapshots/tests.contrib.{suite}.*"
+            "tests/snapshots/tests.contrib.{suite}.*",
+            "tests/contrib/django_hosts/*",
+            "tests/contrib/django_hosts/django_app/*"
         ],
         "djangorestframework": [
             "@bootstrap",
@@ -845,7 +867,9 @@
             "@contrib",
             "@tracing",
             "@appsec",
-            "@django"
+            "@django",
+            "tests/contrib/djangorestframework/*",
+            "tests/contrib/djangorestframework/app/*"
         ],
         "fastapi": [
             "@bootstrap",
@@ -888,7 +912,9 @@
             "@bootstrap",
             "@core",
             "@contrib",
-            "@tracing"
+            "@tracing",
+            "tests/contrib/graphene/*",
+            "tests/snapshots/tests.contrib.graphene*"
         ],
         "graphql": [
             "@bootstrap",
@@ -960,7 +986,8 @@
             "@contrib",
             "@dbapi",
             "@mysql",
-            "tests/contrib/mysqldb/*"
+            "tests/contrib/mysqldb/*",
+            "tests/contrib/mysql/*"
         ],
         "pymysql": [
             "@bootstrap",
@@ -969,7 +996,8 @@
             "@tracing",
             "@dbapi",
             "@mysql",
-            "tests/contrib/pymysql/*"
+            "tests/contrib/pymysql/*",
+            "tests/contrib/mysql/*"
         ],
         "pylibmc": [
             "@bootstrap",
@@ -1005,7 +1033,8 @@
             "@bootstrap",
             "@core",
             "@contrib",
-            "@tracing"
+            "@tracing",
+            "tests/contrib/asynctest/*"
         ],
         "pymemcache": [
             "@bootstrap",

--- a/tests/suitespec.py
+++ b/tests/suitespec.py
@@ -38,7 +38,15 @@ def get_patterns(suite: str) -> t.Set[str]:
     'ddtrace/settings/integration.py', 'ddtrace/settings/peer_service.py', 'ddtrace/span.py', 'ddtrace/tracer.py',
     'ddtrace/tracing/*', 'ddtrace/version.py', 'docker/*', 'hatch.toml', 'pyproject.toml', 'riotfile.py',
     'scripts/ddtest', 'scripts/run-test-suite', 'setup.cfg', 'setup.py', 'tests/.suitespec.json', 'tests/__init__.py',
-    'tests/conftest.py', 'tests/debugging/*', 'tests/suitespec.py', 'tests/utils.py']
+    'tests/conftest.py', 'tests/debugging/*', 'tests/lib-injection/dd-lib-python-init-test-django-gunicorn-alpine/*',
+    'tests/lib-injection/dd-lib-python-init-test-django-gunicorn/*',
+    'tests/lib-injection/dd-lib-python-init-test-django-no-perms/*',
+    'tests/lib-injection/dd-lib-python-init-test-django-pre-installed/*',
+    'tests/lib-injection/dd-lib-python-init-test-django-unsupported-python/*',
+    'tests/lib-injection/dd-lib-python-init-test-django-uvicorn/*',
+    'tests/lib-injection/dd-lib-python-init-test-django/*', 'tests/meta/*', 'tests/smoke_test.py',
+    'tests/subprocesstest.py', 'tests/suitespec.py', 'tests/test_module/*', 'tests/utils.py',
+    'tests/wait-for-services.py', 'tests/webclient.py']
     >>> get_patterns("foobar")
     set()
     >>> sorted(get_patterns("urllib3"))  # doctest: +NORMALIZE_WHITESPACE
@@ -66,11 +74,19 @@ def get_patterns(suite: str) -> t.Set[str]:
     'ddtrace/propagation/*', 'ddtrace/provider.py', 'ddtrace/py.typed', 'ddtrace/sampler.py',
     'ddtrace/sampling_rule.py', 'ddtrace/settings/__init__.py', 'ddtrace/settings/_database_monitoring.py',
     'ddtrace/settings/config.py', 'ddtrace/settings/exceptions.py', 'ddtrace/settings/http.py',
-    'ddtrace/settings/integration.py', 'ddtrace/settings/peer_service.py', 'ddtrace/span.py',
-    'ddtrace/tracer.py', 'ddtrace/tracing/*', 'ddtrace/version.py', 'docker/*', 'hatch.toml', 'pyproject.toml',
-    'riotfile.py', 'scripts/ddtest', 'scripts/run-test-suite', 'setup.cfg', 'setup.py', 'tests/.suitespec.json',
-    'tests/__init__.py', 'tests/conftest.py', 'tests/contrib/__init__.py', 'tests/contrib/patch.py',
-    'tests/contrib/urllib3/*', 'tests/snapshots/tests.contrib.urllib3.*', 'tests/suitespec.py', 'tests/utils.py']
+    'ddtrace/settings/integration.py', 'ddtrace/settings/peer_service.py', 'ddtrace/span.py', 'ddtrace/tracer.py',
+    'ddtrace/tracing/*', 'ddtrace/version.py', 'docker/*', 'hatch.toml', 'pyproject.toml', 'riotfile.py',
+    'scripts/ddtest', 'scripts/run-test-suite', 'setup.cfg', 'setup.py', 'tests/.suitespec.json', 'tests/__init__.py',
+    'tests/conftest.py', 'tests/contrib/__init__.py', 'tests/contrib/config.py', 'tests/contrib/patch.py',
+    'tests/contrib/urllib3/*', 'tests/lib-injection/dd-lib-python-init-test-django-gunicorn-alpine/*',
+    'tests/lib-injection/dd-lib-python-init-test-django-gunicorn/*',
+    'tests/lib-injection/dd-lib-python-init-test-django-no-perms/*',
+    'tests/lib-injection/dd-lib-python-init-test-django-pre-installed/*',
+    'tests/lib-injection/dd-lib-python-init-test-django-unsupported-python/*',
+    'tests/lib-injection/dd-lib-python-init-test-django-uvicorn/*',
+    'tests/lib-injection/dd-lib-python-init-test-django/*', 'tests/meta/*', 'tests/smoke_test.py',
+    'tests/snapshots/tests.contrib.urllib3.*', 'tests/subprocesstest.py', 'tests/suitespec.py', 'tests/test_module/*',
+    'tests/utils.py', 'tests/wait-for-services.py', 'tests/webclient.py']
     """
     compos = SUITESPEC["components"]
     if suite not in SUITESPEC["suites"]:


### PR DESCRIPTION
This change updates the suitespec to cover all existing filepaths. This means that there is no code file in the repo whose editing will not trigger at least one test suite in CI.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
