### PR TITLE
fix(kafka): catch typeerror during tombstone tagging

### DIFF
--- a/ddtrace/contrib/kafka/patch.py
+++ b/ddtrace/contrib/kafka/patch.py
@@ -244,7 +244,12 @@ def traced_poll(func, instance, args, kwargs):
                 ):
                     span.set_tag_str(kafkax.MESSAGE_KEY, message_key)
                 span.set_tag(kafkax.PARTITION, message.partition())
-                span.set_tag_str(kafkax.TOMBSTONE, str(len(message) == 0))
+                is_tombstone = False
+                try:
+                    is_tombstone = len(message) == 0
+                except TypeError:  # https://github.com/confluentinc/confluent-kafka-python/issues/1192
+                    pass
+                span.set_tag_str(kafkax.TOMBSTONE, str(is_tombstone))
                 span.set_tag(kafkax.MESSAGE_OFFSET, message_offset)
             span.set_tag(SPAN_MEASURED_KEY)
             rate = config.kafka.get_analytics_sample_rate()

--- a/releasenotes/notes/kafka-typeerror-b39a35c5338b05aa.yaml
+++ b/releasenotes/notes/kafka-typeerror-b39a35c5338b05aa.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    kafka: This fix resolves an issue where the use of a Kafka ``DeserializingConsumer`` could result in
+    a crash when the deserializer in use returns a type without a ``__len__`` attribute.


### PR DESCRIPTION
This pull request resolves https://github.com/DataDog/dd-trace-py/issues/8016 by catching an error that can occur during message consumption due to https://github.com/confluentinc/confluent-kafka-python/issues/1192.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
