### PR TITLE
docs: update changelog with all x.x.0 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2040,6 +2040,24 @@ These modules have been removed. Many were moved to the internal interface as th
 
 ---
 
+## v0.59.2
+
+### Bug Fixes
+
+- botocore: fix incorrect context propagation message attribute types for SNS. This addresses [Datadog/serverless-plugin-datadog#232](https://github.com/DataDog/serverless-plugin-datadog/issues/232)
+
+---
+
+## v0.59.1
+
+### Bug Fixes
+
+- Fix issue building `ddtrace` from source on macOS 12.
+- Fixes wrong numbers of memory allocation being reported in the memory profiler.
+- pymongo: fix `write_command` being patched with the wrong method signature.
+
+---
+
 ## v0.59.0
 
 ### Deprecation Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2164,6 +2164,39 @@ These modules have been removed. Many were moved to the internal interface as th
 
 ---
 
+## v0.55.4
+
+### Bug Fixes
+
+- Fixes parsing of `botocore` env variables to ensure they are parsed as booleans.
+- Ensure tornado spans are marked as an error if the response status code is 500 \<= x \< 600.
+
+---
+
+## v0.55.3
+
+### Bug Fixes
+
+- Fix memory leak caused when the tracer is disabled.
+
+---
+
+## v0.55.2
+
+### Bug Fixes
+
+- Set the correct package name in the Pyramid instrumentation. This should fix an issue where the incorrect package name was being used which would crash the application when trying to do relative imports within Pyramid (e.g. when including routes from a relative path).
+
+---
+
+## v0.55.1
+
+### Bug Fixes
+
+- Fix Pyramid caller_package level issue which resulted in crashes when starting Pyramid applications. Level now left at default (2).
+
+---
+
 ## v0.55.0
 
 ### Upgrade Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2353,6 +2353,40 @@ These modules have been removed. Many were moved to the internal interface as th
 
 ---
 
+## v0.50.4
+
+### Bug Fixes
+
+- Fixes a bug in the pytest plugin where xfail test cases in a test file with a module-wide skip raises attribute errors and are marked as xfail rather than skipped.
+
+---
+
+## v0.50.3
+
+### Bug Fixes
+
+- Fixed the handling of sanic endpoint paths with non-string arguments.
+
+---
+
+## v0.50.2
+
+### Bug Fixes
+
+- Fixed JSON encoding errors in the pytest plugin for parameterized tests with dictionary parameters with tuple keys. The pytest plugin now always JSON encodes the string representations of test parameters.
+
+---
+
+## v0.50.1
+
+### Bug Fixes
+
+- Fixed JSON encoding errors in the pytest plugin for parameterized tests with complex Python object parameters. The pytest plugin now defaults to encoding the string representations of non-JSON serializable test parameters.
+- Fix pymongo 3.12.0+ spans not being generated.
+- Fix a possible NoneType error in the WSGI middleware start_response method.
+
+---
+
 ## v0.50.0
 
 ### Prelude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2209,6 +2209,15 @@ These modules have been removed. Many were moved to the internal interface as th
 
 ---
 
+## v0.54.1
+
+### Bug Fixes
+
+- Fixed an issue with gevent worker processes that caused them to crash and stop.
+- Fixes exceptions raised when logging during tracer initialization when `DD_LOGS_INJECTION` is enabled.
+
+---
+
 ## v0.54.0
 
 ### Deprecation Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2261,6 +2261,22 @@ These modules have been removed. Many were moved to the internal interface as th
 
 ---
 
+## v0.52.2
+
+### Bug Fixes
+
+- Pin `protobuf` version to `<3.18` for Python \<=3.5 due to support being dropped.
+
+---
+
+## v0.52.1
+
+### Bug Fixes
+
+- Pin `setup_requires` dependency `setuptools_scm[toml]>=4,<6.1` to avoid breaking changes.
+
+---
+
 ## v0.52.0
 
 ### Deprecation Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2107,6 +2107,46 @@ These modules have been removed. Many were moved to the internal interface as th
 
 ---
 
+## v0.57.4
+
+### Bug Fixes
+
+- Fix an issue in the heap profiler where it would iterate on the wrong heap allocation tracker.
+
+---
+
+## v0.57.3
+
+### Bug Fixes
+
+- Fix JSON encoding error when a `bytes` string is used for span metadata.
+- Fix a bug in the heap profiler that could be triggered if more than 2^16 memory items were freed during heap data collection.
+- Fix a possible bug in the heap memory profiler that could trigger an overflow when too many allocations were being tracked.
+- Pymongo instrumentation raises an AttributeError when `tracer.enabled == False`
+
+---
+
+## v0.57.2
+
+### Bug Fixes
+
+- Fix application crash on startup when using `channels >= 3.0`.
+- Fix parenting of Redis command spans when using aioredis 1.3. Redis spans should now be correctly attributed as child of any active parent spans.
+- Fixes issue with aioredis when empty pool is not available and execute returns a coroutine instead of a future. When patch tries to add callback for the span using add_done_callback function it crashes because this function is only for futures.
+- Profiler raises a typing error when `Span.resource` is unicode on Python 2.7.
+
+---
+
+## v0.57.1
+
+### Bug Fixes
+
+- Fixes incompatibility of wrapped aioredis pipelines in `async with` statements.
+- Escape non-Unicode bytes when decoding aioredis args. This fixes a `UnicodeDecodeError` that can be thrown from the aioredis integration when interacting with binary-encoded data, as is done in channels-redis.
+- grpc: ensure grpc.intercept_channel is unpatched properly
+
+---
+
 ## v0.57.0
 
 ### Deprecation Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2136,6 +2136,14 @@ These modules have been removed. Many were moved to the internal interface as th
 
 ---
 
+## v0.56.1
+
+### Bug Fixes
+
+- Fix error when calling `concurrent.futures.ThreadPoolExecutor.submit` with `fn` keyword argument.
+
+---
+
 ## v0.56.0
 
 ### Upgrade Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,2753 @@
 # Changelog
 
-## 0.44.0+
-
 Changelogs beyond this version can be found at https://github.com/DataDog/dd-trace-py/releases
+
+---
+
+## v2.6.0
+
+### Upgrade Notes
+
+- CI Visibility: `DD_CIVISIBILITY_ITR_ENABLED` now defaults to true, and the Datadog API (configured via the Datadog dashboard) now determines whether code coverage and test skipping are enabled.
+- CI Visibility: the CI Visibility service is no longer enabled when the initial query to the Datadog test service settings API fails due to a 403 status code.
+
+### New Features
+
+- botocore: Adds optional feature to propagate context between producers and consumers for AWS SQS, AWS SNS, and AWS Kinesis via <span class="title-ref">DD_BOTOCORE_PROPAGATION_ENABLED</span> environment variable. Adds optional feature to disable tracing of AWS SQS <span class="title-ref">poll()</span> operation and AWS Kinesis 'get_records()' operation when no data is consumed via <span class="title-ref">DD_BOTOCORE_EMPTY_POLL_ENABLED</span> environment variable.
+
+- tracing: Adds new tag <span class="title-ref">python_main_package</span> containing the name of the main package of the application. profiling: Adds new tag <span class="title-ref">python_main_package</span> containing the name of the main package of the application.
+
+- ASM: API Security schema collection is now officially supported for Django, Flask and FastAPI. It can be enabled in the tracer using environment variable DD_API_SECURITY_ENABLED=true It will only be active when ASM is also enabled.
+
+- elasticsearch: This allows custom tags to be set on Elasticsearch spans via the Pin interface.
+
+- botocore: This introduces tracing support for bedrock-runtime operations.
+  See [the docs](https://ddtrace.readthedocs.io/en/stable/integrations.html#botocore) for more information.
+
+- datastreams: this change adds kombu auto-instrumentation for datastreams monitoring. tracing: this change adds the `DD_KOMBU_DISTRIBUTED_TRACING` flag (default `True`)
+
+- Vulnerability Management for Code-level (IAST): Add support for CMDi in langchain.
+
+- botocore: Add the ability to inject trace context into the input field of botocore stepfunction start_execution and start_sync_execution calls.
+
+- Removes another place where we always load instrumentation telemetry, even if it is disabled
+
+- tracing: This introduces the ability to disable tracing at runtime based on configuration values sent from the Datadog frontend. Disabling tracing in this way also disables instrumentation telemetry.
+
+- tracing: Adds support for remote configuration of `DD_TRACE_HEADER_TAGS`
+
+- tracing: Add support for remote configuration of trace-logs correlation.
+
+- grpc/grpc_aio: reports the available target host in client spans as `network.destination.ip` if only an IP is available, `peer.hostname` otherwise.
+
+- span: Adds a public api for setting span links
+
+- starlette,fastapi: Trace background tasks using span links
+
+### Bug Fixes
+
+- ASM: This fix resolves an issue where an exception would be logged while parsing an empty body JSON request.
+
+- CI Visibility: fixes an issue where coverage data for suites could be lost for long-running test sessions, reducing the possibility of skipping tests when using the Intelligent Test Runner.
+
+- IAST: Don't split AST Assign nodes since it's not needed for propagation to work.
+
+- ASM: This fix resolves an issue where suspicious request blocking on request data was preventing API Security to collect schemas in FastAPI, due to route not being computed.
+
+- ASM: This fix resolves an issue where ASM custom blocking actions with a redirect action could cause the server to drop the response.
+
+- Fixed an incompatible version requirements for one of the internal dependencies that could have caused an exception to be raised at runtime with Python 3.12.
+
+- data_streams: This change fixes a bug leading to lag being reported as 1 offset instead of 0 offsets.
+
+- IAST: fixes import overhead when IAST is disabled.
+
+- Fix an incomplete support for pkg_resouces that could have caused an exception on start-up.
+
+- Fix an issue that caused an exception to be raised when trying to access resource files via `pkg_resources`.
+
+- Fix for an import issue that caused the pytest plugin to fail to properly initialize a test session and exit with an import exception.
+
+- openai: This fixes a bug that prevents logs from being correlated with traces in the Datadog UI.
+
+- langchain: This fixes a bug that prevents logs from being correlated with traces in the Datadog UI.
+
+- openai: This fix resolves an issue where an internal OpenAI method <span class="title-ref">SyncAPIClient.\_process_response</span>
+  was not being patched correctly and led to to an AttributeError while patching.
+
+- profiling: handle a potential system error that may be raised when running a Celery-based application with CPython 3.11.
+
+- Fixed an issue that could have caused an exception as a result of a concurrent access to some internal value cache.
+
+- tracing: Ensures span links are serialized with the expected traceflag when `DD_TRACE_API_VERSION=v0.4`
+
+- ASM: This fix resolves an issue where IP Headers configured by the user in the environment could not work for frameworks handling requests with case insensitive headers like FastAPI.
+
+- Vulnerability Management for Code-level (IAST): Fixes a bug in the `str` aspect where encoding and errors arguments were not honored correctly.
+
+- Vulnerability Management for Code-level (IAST): Fix an unhandled ValueError in `ast_function` thrown in some cases (i.e. Numpy arrays when converted to bool).
+
+- opentelemetry: Ensures that span links are serialized in a json-compatible representation.
+
+- Pin importlib_metadata to 6.5.0 to avoid its issue 455 (<https://github.com/python/importlib_metadata/issues/455>).
+
+- profiler: Fixes a sigabrt when shutdown occurs during an upload
+
+- otel: Ensures all otel sampling decisions are consistent with Datadog Spans. This prevents otel spans in a distrbuted trace from being sampled differently than Datadog spans in the same trace.
+
+- tracing: Fix an issue where remote configuration values would not be reverted when unset in the UI.
+
+- tracing: Ensures hostnames are reported in statsd metrics if `DD_TRACE_REPORT_HOSTNAME=True` (default value is `False`).
+
+### Other Changes
+
+- setup: pins the default macOS deployment target to 10.14.
+- tracing: Updates the default value of `DD_TRACE_PROPAGATION_STYLE` from `tracecontext,datadog` to `datadog,tracecontext`. With this change w3c tracecontext headers will be parsed before datadog headers. This change is backwards compatible and should not affect existing users.
+
+---
+
+## v2.5.0
+
+### New Features
+
+- aiohttp: add <span class="title-ref">split_by_domain</span> config to split service name by domain
+- CI Visibility: Adds code coverage lines covered tag for `pytest` and `unittest`.
+- aiohttp: Adds http.route tag to `aiohttp.request` spans.
+- bottle: Adds http.route tag to `bottle.request` spans.
+- falcon: Adds http.route tag to `falcon.request` spans.
+- molten: Adds http.route tag to `molten.request` spans.
+- Adds distributed tracing for confluent-kafka integration. Distributed tracing connects Kafka consumer spans with Kafka producer spans within the same trace if a message is valid. To enable distributed tracing, set the configuration: `DD_KAFKA_DISTRIBUTED_TRACING_ENABLED=True` for both the consumer and producer service.
+- ASM: This introduces (experimental) api security support for fastAPI. Flask and Django were already supported in 2.4.0. Support schema computation on all addresses (requests and responses) and scanner support for pii, credentials and payment data.
+- CI Visibility: introduces a CI visibility-specific logger (enabled for the `pytest` plugin), enabled by setting the `DD_CIVISIBILITY_LOG_LEVEL` environment variable (with the same level names as Python logging levels).
+- CI Visibility: allows for waiting for the git metadata upload to complete before deciding whether or not to enable coverage (based on API response).
+- Further lazy loads telemetry_writer so that it is not running when explicitly disabled. Users must explicitly set "DD_INSTRUMENTATION_TELEMETRY_ENABLED=false".
+- tracer: Add support for remotely configuring trace tags.
+
+### Bug Fixes
+
+- loguru: Ensures log correlation is enabled when the root logger is initialized. Previously, log correlation was only enabled when a new sink was added.
+- Fix compatibility with other tools that try to infer the type of a Python object at runtime.
+- tracing: Fixes a bug that prevents span links from being visualized in the Datadog UI.
+- tracing: Resolves span encoding errors raised when span links do not contain expected types
+- ASM: This fix resolves an issue where custom event boolean properties were not reported as <span class="title-ref">true</span> and <span class="title-ref">false</span> like other tracers but as <span class="title-ref">True</span> and <span class="title-ref">False</span>.
+- Vulnerability Management for Code-level (IAST): Ensure that Cookies vulnerabilities report only the cookie name.
+- langchain: This fix resolves an `get_openai_token_cost_for_model` import error in langhcain version 0.0.351 or later.
+- ASM: This fix resolves an issue where IAST could cause circular dependency at startup.
+- tracing: Ensures all fields in `ddtrace.context.Context` are picklable.
+- pytest: This fix resolves an issue where the <span class="title-ref">--no-cov</span> flag did not take precedence over the <span class="title-ref">--cov</span> flag when deciding whether to report code coverage on spans.
+- rq: Fixed a bug where the RQ integration would emit a warning when setting `job.status` span tag.
+
+---
+
+## v2.4.0
+
+### Upgrade Notes
+
+- <div id="remove-unsupported-pylons">
+
+  This removes the `pylons` integration, which does not support Python 3.
+
+  </div>
+
+### Deprecation Notes
+
+- aioredis: The aioredis integration is deprecated and will be removed in a future version. As an alternative to the aioredis integration, you can use the redis integration with redis\>=4.2.0.
+
+### New Features
+
+- ASM: dependency telemetry metrics now will only report dependencies actually in use (imported) and will also report new imported modules periodically.
+
+- ASM: This introduces Threat Monitoring and Blocking on FastAPI.
+  - IP Blocking and all input addresses are supported on requests and responses
+
+  \- Custom Blocking This does not contain user blocking specific features yet.
+
+- tracing: Introduces support for OpenTracing Baggage Items with HTTP Propagation. Enable this support by `DD_TRACE_PROPAGATION_HTTP_BAGGAGE_ENABLED=true`. The `Context._set_baggage_item` and `Context._get_baggage_item` internal methods are provided for manual modifications to the Baggage Items. These API changes are subject to change.
+
+- dynamic instrumentation: Add support for more built-in container types, such as `defaultdict`, `frozenset`, `OrderedDict` and `Counter`.
+
+- Vulnerability Management for Code-level (IAST): Adds Python 3.12 compatibility
+
+- Optionally lazy loads and disables Instrumentation Telemetry. Users must explicitly set "DD_INSTRUMENTATION_TELEMETRY_ENABLED=false".
+
+- tracer: Add support for remotely setting the trace sample rate from the Datadog UI. This functionality is enabled by default when using `ddtrace-run` and library injection. To enable it when using the library manually, use `ddtrace.config.enable_remote_config()`.
+
+### Bug Fixes
+
+- tracer: tag spans that have been sampled due to an Agent sampling configuration.
+- lambda: This change disables the use of `multiprocessing.queue` in Lambda, because it is not supported in Lambda
+- langchain: This fix resolves a crash that could occur during embedding when no embeddings are found.
+- Fix a regression with the support for gevent that could have occurred if some products, like ASM, telemetry, were enabled.
+- kafka: Resolves `TypeError` raised by serializing producers and deserializing consumers when the `message.key` tag is set on spans.
+- dynamic instrumentation: Fix an issue that caused the instrumented application to fail to start if a non-standard module was imported.
+- openai: This fix resolves an issue where tagging image inputs in the chat completions endpoint resulted in attribute errors.
+- openai: This fix resolves an issue where requesting raw API responses from openai\>=1.0 resulted in attribute errors while tagging.
+- profiling: Fix an issue that prevented threading locks from being traced when using gevent.
+- profiling: Fix a segmentation fault with CPython 3.12 when sampling thread stacks.
+- pylibmc: Fixes an issue where using `ddtrace-run` or `ddtrace.patch_all()` with `DD_TRACE_ENABLED=False` would break with get, gets, and get_multi operations on pylibmc Clients.
+- tracing: This fix resolves an issue where concurrent mutations to the `context._meta` dict caused <span class="title-ref">RuntimeError: dictionary changed size during iteration</span>.
+- django: Resolves `AttributeError` raised by traced `StreamingHttpResponse`.
+- Vulnerability Management for Code-level (IAST): This fix resolves an issue where certain aspects incorrectly expected at least one argument, leading to an IndexError when none were provided. The solution removes this constraint and incorporates regression tests for stability assurance.
+- Vulnerability Management for Code-level (IAST): Cookies vulnerabilities are only reported if response cookies are insecure.
+- Vulnerability Management for Code-level (IAST): Fix propagation error on `.format` string method.
+- requests: Updates the resource names of `requests.requests` spans to include the method and path of the request.
+- propagation: This fix resolves an issue where a `Context` generated from extracted headers could lack a span_id or trace_id, leading `SpanLink` encoding errors.
+- psycopg: This fix resolves an issue where a circular import of the psycopg library could cause a crash during monkeypatching.
+- psycopg: This fix resolves an issue where exceptions originating from asynchronous Psycopg cursors were not propagated up the call stack.
+- redis: This fix resolves an issue where the yaaredis and aredis integrations imported code from the redis integration, causing a circular import error.
+- tracing: Resolves trace encoding errors raised when `DD_TRACE_API_VERSION` is set to `v0.5` and a BufferFull Exception is raised by the TraceWriter. This fix ensures span fields are not overwritten and reduces the frequency of 4XX errors in the trace agent.
+
+### Other Changes
+
+- tracing: Upgrades the trace encoding format to v0.5. This change improves the performance of encoding and sending spans.
+
+---
+
+## v2.3.0
+
+### New Features
+
+- propagation: 128-bit trace ids are now used by default for propagation. Previously the default was 64-bit. This change is backwards compatible with tracers that still use 64-bit trace ids and should not cause any breaking behavior.
+- Adds DSM `pathway.hash` tag to spans when DSM is enabled. This allows traces from the instrumented service to show up in the DSM traces tab.
+- propagation: When the tracer is configured to extract and inject `tracecontext`, the tracer will propagate the tracestate values from other vendors so long as the traceparent trace-id matches the first found trace context, regardless of propagator configuration order. To disable this behavior `DD_TRACE_PROPAGATION_EXTRACT_FIRST=true` can be set.
+- opentelemetry: Map reserved OpenTelemetry attributes to Datadog span model.
+- opentelemetry: datadog operation name from semantic conventions
+- propagation: If a valid context is extracted from headers, and the following extracted trace context's `trace_id`s do not match the valid context's, then add a span link to the root span to represent the broken propagation.
+- tracing: This change treats spans that terminated with `sys.exit(0)` as successful non-error spans.
+- tracing: This introduces the `DD_TRACE_SPAN_TRACEBACK_MAX_SIZE` environment variable, allowing the maximum size of tracebacks included on spans to be configured.
+
+### Bug Fixes
+
+- CI Visibility: fixes the fact that the GITHUB_SERVER_URL environment variable was not being sanitized for credentials
+- dynamic instrumentation: Needs to update the pubsub instance when the application forks because the probe mechanism should run in the child process. For that, DI needs the callback as the method of an instance of Debugger, which lives in the child process.
+- CI Visibility: Fixes an issue where a `ValueError` was raised when using different path drives on Windows
+- Fixes an issue where ddtrace could not be installed from source when using `setuptools>=69` due to a change in the license field.
+- tracing: Fixes an issue where the thread responsible for sending traces is killed due to concurrent dictionary modification.
+- structlog: Fixes `TypeError` raised when ddtrace log processor is configured with a tuple
+- Vulnerability Management for Code-level (IAST): Generates cookies vulnerabilities report if IAST is enabled. Before this fix, Cookies vulnerabilities were only generated if both IAST and Appsec were enabled.
+- Vulnerability Management for Code-level (IAST): This fix resolves an issue where, at AST patching to replace code with IAST aspects, passing the original function/method as an extra parameter for accurate patching unintentionally triggers side effects in methods obtained from an expression (like `decode` in `file.read(n).decode()`), resulting in unexpected multiple calls to the expression (`file.read(n)` in the example).
+- Vulnerability Management for Code-level (IAST): This fix eliminates some reference leaks and C-API usage when IAST reports a vulnerability and calls `get_info_frame`.
+- kafka: This fix resolves an issue where calls to `confluent_kafka`'s `produce` method with `key=None` would cause an exception to be raised.
+- tracing: This fix resolves an issue where ddtrace's signal handlers could cause Flask apps not to respond correctly to SIGINT.
+- logging: A log handler is automatically added to the ddtrace logger upon ddtrace import, when not using ddtrace-run. This can lead to duplicate logging if users add additional loggers and do not explicitly modify the ddtrace logger. This fix adds a feature flag that can be used to toggle this behavior off `DD_TRACE_LOG_STREAM_HANDLER` which defaults to `true`.
+
+---
+
+## v2.2.0
+
+### Upgrade Notes
+
+- The `wrapt` and `psutil` packages are vendored to help users avoid building these packages if wheels were not available for a given platform. This reverses a change released in v2.0.0.
+
+### New Features
+
+- CI Visibility: adds ITR support for `unittest`
+- CI Visibility: adds start/end line support for `pytest` test spans
+- CI Visibility: adds start/end line source file data to `unittest` test spans
+- aiohttp: This introduces basic tracing of streaming responses that stay open long after the <span class="title-ref">on_prepare</span> signal has been sent.
+- CI Visibility: introduce pytest hooks for modifying the module, suite, and test naming logic
+- CI Visibility: add support for AWS Codepipeline to CI env var gathering
+- datastreams: this change adds message payload size metrics and aggregations for Kafka.
+- structlog: Wraps get_logger function in order to add datadog injection processor regardless of configuration
+- openai: This adds support for openai v1.
+- Source Code: filters Git repo URLs from env vars and setuptools
+- logbook: This introduces log correlation for the logbook library. Refer to `logbook-docs <ddtrace.contrib.logbook>` for more details.
+- loguru: This introduces log correlation for the loguru library. Refer to `loguru-docs <ddtrace.contrib.loguru>` for more details.
+- openai: This adds support for tagging function call arguments when using OpenAI's function calling feature.
+- Adds ARM64 support for Single-Step instrumentation
+- structlog: This introduces log correlation for the structlog library. Refer to `structlog-docs <ddtrace.contrib.structlog>` for more details.
+- celery: Adds Python 3.11 and 3.12 support for the celery integration.
+
+### Known Issues
+
+- ASM: fix a body read problem on some corner case where passing empty content length makes wsgi.input.read() blocks.
+
+### Bug Fixes
+
+- Application Security Management (ASM): fix a body read error when `Transfer-Encoding: chunked` header is sent
+- CI Visibility: fixes an issue where class-based test methods with the same name across classes would be considered duplicates, and cause one (or more) tests to be dropped from results, by adding `--ddtrace-include-class-name` as an optional flag (defaulting to false) to prepend the class name to the test name.
+- CI Visibility: fixes a crash where the unittest integration would try to enable coverage when tests are run even if the Intelligent Test Runner is not enabled.
+- data_streams: This fix resolves an issue where tracing would crash if a kafka client produced a message with no key or value.
+- CI: fixes an issue which prevented the library from filtering user credentials for SSH Git repository URLs
+- dynamic instrumentation: fix an issue that caused function probes on the same module to fail to instrument and be reported in the `ERROR` status in the UI if the module was not yet imported.
+- Use a unique default service name across all the products provided by the library when one is not given via the configuration interface.
+- sampling: This fix reverts a refactor which affected how the tracer handled the trace-agent's recommended trace sampling rates, leading to an unintended increase in traces sampled.
+- tracing: Fixes a msgpack import error when `DD_TRACE_API` is set to `v0.5`
+- fix(profiling): numeric type exception in memalloc When pushing allocation samples, an exception was being thrown due to a float being passed instead of an integer. We now cast the ceiled value to an integer.
+- CI Visibility: fixes `unittest` data not being initialized properly
+- CI Visibility: fixes an issue where just importing <span class="title-ref">unittest</span> enabled CIVisibility and potentially caused unexpected logs and API requests
+- Vulnerability Management for Code-level (IAST): This fix addresses AST patching issues where custom functions or methods could be replaced by aspects with differing argument numbers, causing runtime errors as a result. Furthermore, it addresses a case during patching where the module is inadvertently passed as the first argument to the aspect.
+- Vulnerability Management for Code-level (IAST): Fix potential string id collisions that could cause false positives with non tainted objects being marked as tainted.
+- IAST: This fix resolves an issue where JSON encoder would throw an exception while encoding a tainted dict or list.
+- Vulnerability Management for Code-level (IAST): This fix resolves an issue where SimpleJSON encoder would throw an exception while encoding a tainted dict or list.
+- ASM: add support for psycopg2 adapt mechanism to LazyTaintList, preventing a ProgrammingError when using psycopg2 with IAST.
+- tracing: This fix resolves an issue where unserializable tracer attributes caused crashes when `DD_TRACE_DEBUG` was set.
+- This fix resolves an issue where `confluent_kafka`'s `SerializingProducer` and `DeserializingConsumer` classes were incorrectly patched, causing crashes when these classes are in use with Datadog patching.
+- langchain: This fix resolves an issue with tagging pydantic <span class="title-ref">SecretStr</span> type api keys.
+- lib injection: Fix permissions error raised when non-root users copy single step instrumentation files.
+- redis: The Datadog Agent removes command arguments from the resource name. However there are cases, like compressed keys, where this obfuscation cannot correctly remove command arguments. To safeguard that situation, the resource name set by the tracer will only be the command (e.g. SET) with no arguments. To retain the previous behavior and keep arguments in the span resource, with the potential risk of some command arguments not being fully obfuscated, set `DD_REDIS_RESOURCE_ONLY_COMMAND=false`.
+
+### Other Changes
+
+- tags: Previously `DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH` had a max limit setting of 512 characters. This change removes that limit but keeps the default at 512.
+
+---
+
+## v2.0.0
+
+### Prelude
+
+The Datadog APM Python team is happy to announce the release of v2.0.0 of ddtrace. This release drops support for Python 2.7, 3.5, and 3.6. This release adds support for Python 3.12.
+
+<div class="important">
+
+<div class="title">
+
+Important
+
+</div>
+
+If you are on version of Python not supported by v2, we will continue to maintain the ddtrace v1 with bug fixes.
+
+</div>
+
+<div class="note">
+
+<div class="title">
+
+Note
+
+</div>
+
+Before upgrading to v2.0.0, we recommend users install `ddtrace~=1.20.0` and enable deprecation warnings. All removals to the library interface and environment variables in v2 were deprecated in the 1.x release line.
+
+</div>
+
+<div class="note">
+
+<div class="title">
+
+Note
+
+</div>
+
+The changes to environment variables apply only to the configuration of the ddtrace library and not the Datadog Agent.
+
+</div>
+
+#### Upgrading summary
+
+##### Functionality changes
+
+The default logging configuration functionality of ddtrace has been changed to avoid conflicting with application logging configurations. `DD_CALL_BASIC_CONFIG` has been removed and the ddtrace logger will log to stdout by default, or a log file as specified using `DD_TRACE_LOG_FILE`.
+
+Setting the environment variable `DD_TRACE_PROPAGATION_STYLE='b3'`, which previously enabled `b3multi` now enables `b3 single header`. `b3 single header` still works but is deprecated for `b3`. Simplified: `b3` used to enable `b3multi`, but now enables `b3 single header` to better align with Opentelemetry's terms.
+
+##### Removed deprecated environment variables
+
+These environment variables have been removed. In all cases the same functionality is provided by other environment variables and replacements are provided as recommended actions for upgrading.
+
+| Variable                                   | Replacement                                | Note                                                |
+|--------------------------------------------|--------------------------------------------|-----------------------------------------------------|
+| `DD_GEVENT_PATCH_ALL`                      | None                                       | `📝<remove-dd-gevent-patch-all>`                    |
+| `DD_AWS_TAG_ALL_PARAMS`                    | None                                       | `📝<remove-aws-tag-all-params>`                     |
+| `DD_REMOTECONFIG_POLL_SECONDS`             | `DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS`   | `📝<rename-remote-config-poll-seconds>`             |
+| `DD_CALL_BASIC_CONFIG`                     | None                                       | `📝<remove-basic-config>`                           |
+| `DD_TRACE_OBFUSCATION_QUERY_STRING_PATERN` | `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP` | `📝<remove-trace-obfuscation-query-string-pattern>` |
+
+##### Removed deprecated library interfaces
+
+These methods and module attributes have been removed. Where the same functionality is provided by a different public method or module attribute, a recommended action is provided for upgrading. In a few limited cases, because the interface was no longer used or had been moved to the internal interface, it was removed and so no action is provided for upgrading.
+
+| Module                            | Method/Attribute                | Note                                               |
+|-----------------------------------|---------------------------------|----------------------------------------------------|
+| `ddtrace.constants`               | `APPSEC_ENABLED`                | `📝<remove-appsec-private-constants>`              |
+|                                   | `APPSEC_JSON`                   | `📝<remove-appsec-private-constants>`              |
+|                                   | `APPSEC_EVENT_RULE_VERSION`     | `📝<remove-appsec-private-constants>`              |
+|                                   | `APPSEC_EVENT_RULE_ERRORS`      | `📝<remove-appsec-private-constants>`              |
+|                                   | `APPSEC_EVENT_RULE_LOADED`      | `📝<remove-appsec-private-constants>`              |
+|                                   | `APPSEC_EVENT_RULE_ERROR_COUNT` | `📝<remove-appsec-private-constants>`              |
+|                                   | `APPSEC_WAF_DURATION`           | `📝<remove-appsec-private-constants>`              |
+|                                   | `APPSEC_WAF_DURATION_EXT`       | `📝<remove-appsec-private-constants>`              |
+|                                   | `APPSEC_WAF_TIMEOUTS`           | `📝<remove-appsec-private-constants>`              |
+|                                   | `APPSEC_WAF_VERSION`            | `📝<remove-appsec-private-constants>`              |
+|                                   | `APPSEC_ORIGIN_VALUE`           | `📝<remove-appsec-private-constants>`              |
+|                                   | `APPSEC_BLOCKED`                | `📝<remove-appsec-private-constants>`              |
+|                                   | `IAST_JSON`                     | `📝<remove-appsec-private-constants>`              |
+|                                   | `IAST_ENABLED`                  | `📝<remove-appsec-private-constants>`              |
+|                                   | `IAST_CONTEXT_KEY`              | `📝<remove-appsec-private-constants>`              |
+| `ddtrace.contrib.fastapi.patch`   | `span_modifier`                 | `📝<remove-fastapi-starlette-span-modifier>`       |
+|                                   | `aggregate_resources`           | `📝<remove-fastapi-starlette-aggregate-resources>` |
+| `ddtrace.contrib.starlette.patch` | `span_modifier`                 | `📝<remove-fastapi-starlette-span-modifier>`       |
+|                                   | `aggregate_resources`           | `📝<remove-fastapi-starlette-aggregate-resources>` |
+|                                   | `get_resource`                  | `📝<remove-fastapi-starlette-span-modifier>`       |
+| `ddtrace.contrib.grpc.constants`  | `GRPC_PORT_KEY`                 | `📝<remove-grpc-port-key>`                         |
+| `ddtrace.ext.cassandra`           | `ROW_COUNT`                     | `📝<remove-cassandra-row-count>`                   |
+| `ddtrace.ext.mongo`               | `ROWS`                          | `📝<remove-mongo-row-count>`                       |
+| `ddtrace.ext.sql`                 | `ROWS`                          | `📝<remove-sql-row-count>`                         |
+| `ddtrace.filters`                 | `TraceCiVisibilityFilter`       | `📝<remove-trace-ci-visibility-filter>`            |
+| `ddtrace.tracer`                  | `DD_LOG_FORMAT`                 | `📝<remove-dd-log-format>`                         |
+
+### Upgrade Notes
+
+- <div id="remove-dd-gevent-patch-all">
+
+  `DD_GEVENT_PATCH_ALL` is removed. There is no special configuration necessary to make ddtrace work with gevent if using ddtrace-run.
+
+  </div>
+
+- <div id="remove-aws-tag-all-params">
+
+  `DD_AWS_TAG_ALL_PARAMS` is removed. The boto/botocore/aiobotocore integrations no longer collect all API parameters by default.
+
+  </div>
+
+- <div id="rename-remote-config-poll-seconds">
+
+  `DD_REMOTECONFIG_POLL_SECONDS` is removed. Use the environment variable `DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS` instead.
+
+  </div>
+
+- <div id="remove-appsec-private-constants">
+
+  `APPSEC_ENABLED`, `APPSEC_JSON`, `APPSEC_EVENT_RULE_VERSION`, `APPSEC_EVENT_RULE_ERRORS`, `APPSEC_EVENT_RULE_LOADED`, `APPSEC_EVENT_RULE_ERROR_COUNT`, `APPSEC_WAF_DURATION`, `APPSEC_WAF_DURATION_EXT`, `APPSEC_WAF_TIMEOUTS`, `APPSEC_WAF_VERSION`, `APPSEC_ORIGIN_VALUE`, `APPSEC_BLOCKED`, `IAST_JSON`, `IAST_ENABLED`, `IAST_CONTEXT_KEY` are removed. This should not affect existing code as these deprecated ASM constants were meant for private use only.
+
+  </div>
+
+- <div id="remove-fastapi-starlette-span-modifier">
+
+  `ddtrace.contrib.starlette.get_resource`, `ddtrace.contrib.starlette.span_modifier`, and `ddtrace.contrib.fastapi.span_modifier` are removed. The starlette and fastapi integrations now provide the full route and not just the mounted route for sub-applications.
+
+  </div>
+
+- <div id="remove-fastapi-starlette-aggregate-resources">
+
+  `ddtrace.contrib.starlette.config['aggregate_resources']` and `ddtrace.contrib.fastapi.config['aggregate_resources']` are removed. The starlette and fastapi integrations no longer have the option to `aggregate_resources`, as it now occurs by default.
+
+  </div>
+
+- <div id="remove-grpc-port-key">
+
+  `ddtrace.contrib.grpc.constants.GRPC_PORT_KEY` is removed. Use `ddtrace.ext.net.TARGET_PORT` instead.
+
+  </div>
+
+- <div id="remove-cassandra-row-count">
+
+  `ddtrace.ext.cassandra.ROW_COUNT` is removed. Use `ddtrace.ext.db.ROWCOUNT` instead.
+
+  </div>
+
+- <div id="remove-mongo-row-count">
+
+  `ddtrace.ext.mongo.ROW_COUNT` is removed. Use `ddtrace.ext.db.ROWCOUNT` instead.
+
+  </div>
+
+- <div id="remove-sql-row-count">
+
+  `ddtrace.ext.sql.ROW_COUNT` is removed. Use `ddtrace.ext.db.ROWCOUNT` instead.
+
+  </div>
+
+- <div id="remove-trace-ci-visibility-filter">
+
+  `ddtrace.filters.TraceCiVisibilityFilter` is removed.
+
+  </div>
+
+- <div id="remove-dd-log-format">
+
+  `ddtrace.tracer.DD_LOG_FORMAT` is removed. As an alternative, please follow the log injection formatting as provided in the [log injection docs](https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#update-log-format).
+
+  </div>
+
+- <div id="remove-basic-config">
+
+  `DD_CALL_BASIC_CONFIG` is removed. There is no special configuration necessary to replace `DD_CALL_BASIC_CONFIG`. The ddtrace logger will log to stdout by default or additionally to a file specified by `DD_TRACE_LOG_FILE`.
+
+  </div>
+
+- <div id="remove-trace-obfuscation-query-string-pattern">
+
+  `DD_TRACE_OBFUSCATION_QUERY_STRING_PATTERN` is removed. Use `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP` instead.
+
+  </div>
+
+### New Features
+
+- Adds support for Python 3.12.
+
+### Known Issues
+
+- aiohttp: Python 3.12 is not supported.
+- aiohttp-jinja: Python 3.12 is not supported.
+- aiobotocore: Python 3.12 is not supported.
+- asm: IAST for Python 3.12 is not supported.
+- flask-caching: Python 3.12 is not supported.
+- openai/langchain: Python 3.12 is not supported.
+- opentelemetry-api: Python 3.12 is not supported.
+- opentracing: Python 3.12 is not supported.
+- pyramid: Python 3.12 is not supported.
+- pynamodb: Python 3.12 is not supported.
+- redis/redis-py-cluster: Python 3.12 is not supported.
+
+---
+
+## v1.20.0
+
+### Prelude
+
+Vulnerability Management for Code-level (IAST) is now available in private beta. Use the environment variable `DD_IAST_ENABLED=True` to enable this feature.
+
+### New Features
+
+- ASM: This introduces support for custom blocking actions of type redirect_request.
+- data_streams: Adds public api `set_produce_checkpoint` and `set_consume_checkpoint`
+
+### Bug Fixes
+
+- kafka: Resolves an issue where traced kafka connections were assigned a default timeout of 1 second. The default timeout in [Consumer.poll(...)](https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#confluent_kafka.Consumer.poll) should be None.
+- openai: This fix resolves an issue where errors during streamed requests resulted in unfinished spans.
+
+---
+
+## v1.19.0
+
+### New Features
+
+- Adds the <span class="title-ref">db.row_count</span> tag to redis and other redis-like integrations. The tag represents the number of returned results.
+- CI Visibility: adds test level visibility for [unittest](https://docs.python.org/3/library/unittest.html)
+- ASM: Adds detection of insecure cookie vulnerabilities on responses.
+- ASM: This introduces trusted IPs capabilities in the tracer, to allow specific IPs not to be blocked by ASM but still be monitored.
+- ASM: This introduces a new capability to configure the blocking response of ASM. Users can change the default blocking response behavior or create new custom actions. Configuration of a custom blocking page or payload can still be provided by using <span class="title-ref">DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON</span> and <span class="title-ref">DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML</span> to change the static files used for the response body. The action block, that can be defined in the static rule file or via remote configuration, allows now to create new custom blocking actions with any status code for the response.
+- The aiopg and aiomysql integrations no longer set the sql.query tag on query spans. This tag duplicated the value captured by the span resource. Users who want to send this query unobfuscated can use the tracer API to set tags on the query span.
+- data_streams: Starts tracking Kafka lag in seconds.
+- kafka: Adds support for the Kafka serializing producer and deserializing consumer.
+- profiling: allow individual collectors to be disabled.
+- tracing: This change introduces the `allow_false` keyword argument to `BaseSampler.sample()`, which defaults to `True`. `allow_false` controls the function's return value. If `allow_false` is `False`, the function will always return `True` regardless of the sampling decision it made. This is useful when `sample` is called only for its side effects, which can include setting span tags.
+
+### Known Issues
+
+- There are known issues configuring python's builtin multiprocessing library when ddtrace is installed. To use the multiprocessing library with ddtrace ensure `DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE` is set to `True`.
+- When running setup.py extensions with the CMake parameter "-j", it could potentially raise an out-of-memory error. If someone wants to expedite the ddtrace installation, they should manually set the "CMAKE_BUILD_PARALLEL_LEVEL" environment variable.
+
+### Bug Fixes
+
+- ASM: avoid potentially unneeded import of the IAST native module.
+
+- ASM: avoid potentially unneeded import of the IAST native module if setup doesn't build extensions correctly.
+
+- data_streams: This fix resolves an issue where data stream context propagation would not propagate via SNS if raw message delivery was enabled.
+
+- dynamic instrumentation: function duration measurements are now reported in milliseconds to match the expectation from the UI.
+
+- dynamic instrumentation: fixed an issue that prevented line probes from being injected in some finally blocks.
+
+- dynamic instrumentation: Fixed the programmatic API to ensure that the dynamic instrumentation service is fully enabled when `Dynamic Instrumentation.enable()` is called.
+
+- dynamic instrumentation: fixed a bug that might have caused probe status to fail to update correctly.
+
+- django: This fix resolves an issue where 'span.resource' would not include the endpoint when a Handler was interrupted, such as in the case of gunicorn worker timeouts.
+
+- CI Visibility: fixes an issue where the Intelligent Test Runner would not work when in EVP proxy mode due to missing `X-Datadog-NeedsAppKey` header.
+
+- CI Visibility: revert to using DD_CIVISIBILITY_ITR_ENABLED (instead of \_DISABLED) to conform with other tracers.
+
+- profiling: fixed a bug that prevented profiles from being correctly correlated to traces in gevent-based applications, thus causing code hotspot and end point data to be missing from the UI.
+
+- docs: Fix undefined variable reference in otel documentation
+
+- CI Visibility: fixes that Python 2.7 test results were not visible in UI due to improperly msgpack-ed data
+
+- ASM: This fix resolves an issue where <span class="title-ref">track_user_signup_event</span> and <span class="title-ref">track_custom_event</span> where not correctly tagging the span. This could lead to the loss of some events in the sampling.
+
+- appsec: Fixes an issue where ddtrace.appsec is imported and assumed to be available in all deployments of ddtrace
+
+- lib-inject: This fix resolves an issue where `libdl.so.2: cannot open shared object file: No such file or directory` errors occurred when the
+  injection image started.
+
+- lib-injection: Resolves permissions errors raised when ddtrace packages are copied from the InitContainer to the shared volume.
+
+- mariadb: This fix resolves an issue where MariaDB connection information objects not including the user or port caused exceptions to be raised.
+
+- appsec: This fix resolves an issue in which the library attempted to finalize twice a context object used by the Application Security Management product.
+
+- propagation: Prevent propagating unsupported non-ascii `origin` header values.
+
+- pymongo: This upgrades the PyMongo integration to work with PyMongo versions 4.5.0 and above by choosing the root function of the integration on the basis of the PyMongo version.
+
+- tracing: This fix resolves an issue where the <span class="title-ref">\_dd.p.dm</span> and <span class="title-ref">\_dd.\*\_psr</span> tags were applied to spans in ways that did not match their intended semantics, increasing the potential for metrics-counting bugs.
+
+- ASM: This fix resolves issue where user information was only set in root span. Now span for user information can be selected.
+
+- sqlalchemy: sqlalchemy rollbacks could previously cause intermittent deadlocks in some cases. To fix this `DD_TRACE_SPAN_AGGREGATOR_RLOCK` was introduced in 1.16.2 with the default as `False`. We are now changing the default to `True`.
+
+### Other Changes
+
+- Adds a <span class="title-ref">get_version</span> method to each integration and updates the basic template for developing an integration to include this method. The <span class="title-ref">get_version</span> method returns the integration's package distribution version and is to be included in the APM Telemetry integrations payload.
+- Add a <span class="title-ref">ddtrace_iast_flask_patch</span> function defined in <span class="title-ref">ddtrace.appsec.iast</span> to ensure that the main Flask <span class="title-ref">app.py</span> file is patched for IAST propagation. This function should be called before the <span class="title-ref">app.run()</span> call. You only need this if you have set <span class="title-ref">DD_IAST_ENABLED=1</span>. Only the main file needs to call this functions, other imported modules are automatically patched.
+- docs: Fixes formatting in ddtrace docs.
+- ASM: Improve default value of regex for query string obfuscation. Rename env var `DD_TRACE_OBFUSCATION_QUERY_STRING_PATTERN` to `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP`.
+
+---
+
+## v1.18.0
+
+### Prelude
+
+Data Streams Monitoring (DSM) has added support for AWS Kinesis
+
+**Breaking change** for CI Visibility: `test.suite` and `test.full_name` are changed, so any visualization or monitor that uses these fields is potentially affected.
+
+### Deprecation Notes
+
+- `DD_CALL_BASIC_CONFIG` will be removed in the upcoming 2.0.0 release. As an alternative to `DD_CALL_BASIC_CONFIG`, you can call `logging.basicConfig()` to configure logging in your application.
+- `DD_LOG_FORMAT` is deprecated and will be removed in 2.0.0. As an alternative, please follow the log injection formatting as provided in the [log injection docs](https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#update-log-format).
+
+### New Features
+
+- CI Visibility: added tracing support for pytest-benchmark
+
+- ASM: The vulnerability report now includes a feature to scrub potentially sensitive information. This scrubbing process looks for common patterns, and it can be further expanded using environment variables such as `DD_IAST_REDACTION_NAME_PATTERN` and `DD_IAST_REDACTION_VALUE_PATTERN`. See the [docs](https://ddtrace.readthedocs.io/en/stable/configuration.html#DD_IAST_REDACTION_ENABLED) for more information.
+
+- DSM: Adds DSM support for AWS Kinesis. For information about DSM, see the [official documentation](https://docs.datadoghq.com/data_streams/). This change requires users to use botocore version 1.26.30 or later and update calls to Kinesis' <span class="title-ref">PutRecord</span>, <span class="title-ref">PutRecords</span>, and <span class="title-ref">GetRecords</span> calls with the StreamARN argument.
+
+- pytest: This change introduces an option to the pytest plugin to disable ddtrace: `--no-ddtrace`
+
+- CI visibility: Adds support for tracking repository URLs via the BITBUCKET_GIT_HTTP_ORIGIN environment variable
+
+- CI visibility: Adds CodeFresh integration
+
+- CI Visibility: Beta release of `pytest` support for the [Intelligent Test Runner](https://docs.datadoghq.com/continuous_integration/intelligent_test_runner/) .
+
+- openai: `tiktoken` has been introduced as an optional package dependency to calculate the number of
+  tokens used in a prompt for a streamed completion or streamed chat completion. To enable this feature, install `ddtrace[openai]` or `tiktoken`. If `tiktoken` is not installed, the prompt token count will be continue to be estimated instead.
+
+- Allows the use of a new backend for storing and exporting profiling data. This feature can be enabled for now by setting the DD_PROFILING_EXPORT_LIBDD_ENABLED environment variable to true. This should improve performance while decreasing memory overhead.
+
+### Known Issues
+
+- sqlalchemy: sqlalchemy rollbacks can intermittently cause deadlocks in some cases. If experiencing this issue, set `DD_TRACE_SPAN_AGGREGATOR_RLOCK=True`. After testing and feedback we intend to make True the default value.
+
+### Bug Fixes
+
+- CI Visibility: fixes an issue where the CIVisibility client would raise an exception if it was started in agentless mode without the DD_API_KEY set
+
+- core: This fix moves `cmake` from `install_requires` to `setup_requires`.
+
+- data_streams: This change fixes a bug in the Kafka & SQS integrations in which the Data Streams product code incorrect set timestamps for statistics. This led to all points being submitted for the same timestamp (the start of the application).
+
+- dynamic instrumentation: handle null literal in conditions and expressions.
+
+- dynamic instrumentation: fixed a bug that prevented span decoration probes from being received and instrumented.
+
+- dynamic instrumentation: ensure that probes that fail to be instrumented because of invalid conditions/expressions are reported with status `ERROR` in the UI.
+
+- CI Visibility: This fix solves an issue where the git unshallow command wasn't called
+
+- tracing: Ensures health metrics are tagged with the correct values.
+
+- CI Visibility: This fix resolves an issue where test skipping was not working properly.
+
+- langchain: This fix resolves an issue where chat messages and embedding arguments
+  passed in as keyword arguments were not parsed correctly and resulted in an `ArgumentError`.
+
+- langchain: This fix resolves an issue where `langchain.embeddings.HuggingFaceEmbeddings` embedding
+  methods, and `langchain.vectorstores.Milvus.similarity_search` were patched twice due to a nested class hierarchy in `langchain`.
+
+- profiling: prevent deadlocks while recording events of different type.
+
+- pytest: This fix resolves an issue where test modules could be non-existent, causing errors in the CI Visibility product.
+
+- kafka: Resolves `UnicodeDecodeError` raised when kafka messages key contain characters that are not supported by UTF-8 encoding.
+
+- lib-injection: Adds support for non-root run applications in containers.
+
+- This fix resolves an issue causing span tags used by the Datadog backend not to be inherited by spans that exist in a different process from their parents.
+
+### Other Changes
+
+- tracing: Previously the maximum size of a span tag was set to the full size of trace writer buffer (via DD_TRACE_WRITER_BUFFER_SIZE_BYTES). With this change the maximum size of span tags will be set to 10% of the size of the writer's buffer. This should decrease the frequency of encoding errors due to large span tags.
+
+---
+
+## v1.17.0
+
+### Prelude
+
+Datadog has added support for automatically creating login success or failure events when a configured Django authentication backend is used. This will automatically fill the following tags in these cases:
+
+> - <span class="title-ref">appsec.events.users.login.success.track</span>
+> - <span class="title-ref">appsec.events.users.login.failure.track</span>
+> - <span class="title-ref">appsec.events.users.login.success.\[email\|login\|username\]</span>
+> - <span class="title-ref">appsec.events.users.login.failure.usr.exists</span>
+
+### New Features
+
+- ASM: Add support for automatic user login events in Django.
+
+- langchain: Adds integration with support for metrics, logs, and traces from LangChain requests.
+  See the `docs<langchain>` for more information.
+
+- redis: Add support for Async RedisCluster.
+
+### Bug Fixes
+
+- core: This fix removes the inclusion of our `benchmarks/` directory in the `ddtrace` wheels.
+- internal: call `_fixupChildren` when retrieving `DDLogger`
+- profiling: Fixed a regression whereby the profile exporter would not handle known request errors and asks the user to report an issue instead.
+- profiling: Handles a race condition, which would occasionally throw an error, which would read `"RuntimeError: the memalloc module was not started."`
+- CI visibility: fix version and step arguments gathering to enable plugin compatibility with pytest-bdd 6.1.x
+- Fixed a bug that caused applications using gevent and cassandra to fail to start with the ddtrace-run command.
+- tracing: This fix resolves a `google.protobuf` import error when module unloading.
+- wsgi: This fix resolves an issues when trying to parse the `environ` property `HTTPS` as an HTTP header.
+- Pin `cython<3` due to an incompatibility with `cython==3.0.0` and typing annotations in profiling code.
+- telemetry: resolves issue with sending unnecessary duplicate logs
+
+---
+
+## v1.16.0
+
+### Prelude
+
+Application Security Management (ASM) has added support for tracing subprocess executions.
+
+Exception Debugging allows capturing debug information from exceptions attached to traces. The information about local variables and function arguments is displayed in the Error Tracking UI and augments the traceback data already collected.
+
+### New Features
+
+- ASM: vulnerabilities related to insecure request cookies will be reported when `DD_APPSEC_ENABLED` is set to `true`.
+
+- ASM: add support for tracing subprocess executions (like <span class="title-ref">os.system</span>, <span class="title-ref">os.spawn</span>, <span class="title-ref">subprocess.Popen</span> and others) and adding
+  information to a span names <span class="title-ref">command_execution</span> with the new type <span class="title-ref">system</span>. Currently we add the <span class="title-ref">cmd.exec</span> or <span class="title-ref">cmd.shell</span> tags to store the full command line (<span class="title-ref">cmd.shell</span> will be used when the command is run under a shell like with <span class="title-ref">os.system</span> or <span class="title-ref">Popen</span> with <span class="title-ref">shell=True</span>), <span class="title-ref">cmd.exit_code</span> to hold the return code when available, <span class="title-ref">component</span> which will hold the Python module used and the span <span class="title-ref">resource</span> will hold the binary used. This feature requires ASM to be activated using the <span class="title-ref">DD_APPSEC_ENABLED=True</span> configuration environment variable.
+
+- botocore: Introduces environment variable `DD_BOTOCORE_INSTRUMENT_INTERNALS` that opts into tracing certain internal functionality.
+
+- botocore: Added message attributes to Amazon Simple Queue Service spans to support data streams monitoring.
+
+- exception debugging: Introduced the Exception Debugging feature that allows capturing debug information from exceptions attached to traces. This new feature can be enabled via the <span class="title-ref">DD_EXCEPTION_DEBUGGING_ENABLED</span>\` environment variable.
+
+- openai: Adds support for metrics, logs, and traces for the models, edits, images, audio, files, fine-tunes, and
+  moderations endpoints. See [the docs](https://ddtrace.readthedocs.io/en/stable/integrations.html#openai) for more information.
+
+- CI Visibility: Updates how pytest modules and test suites are reported. Modules names are now set to the fully qualified name, whereas test suites will be set to the file name.
+  Before this change: {"module": "tests", "suite":"my_module/tests/test_suite.py"} After this change: {"module": "my_module.tests", "suite": "test_suite.py"}
+
+- core: Apply `DD_TAGS` to runtime metrics.
+
+- kafka: Adds <span class="title-ref">messaging.kafka.bootstrap.servers</span> tag for the confluent-kafka producer configuration value found in <span class="title-ref">metadata.broker.list</span> or <span class="title-ref">bootstrap.servers</span>
+
+- tracing: This reports the GRPC package name (optional) and service name in a single <span class="title-ref">rpc.service</span> tag
+
+### Bug Fixes
+
+- botocore: This fix resolves an issue where ddtrace attempted to parse as URLs SQS QueueUrl attributes that were not well-formed URLs.
+- psycopg: Resolves `TypeError` raised when an async cursor object is traced. This fix ensures <span class="title-ref">exc_type</span>, <span class="title-ref">exc_val</span>, and <span class="title-ref">exc_tb</span> are passed down to the wrapped object on <span class="title-ref">\_\_aexit\_\_</span>.
+- Fixed an issue that prevented the library from working as expected when a combination of gevent and asyncio-based frameworks that rely on the functionalities of the ssl module is used.
+- openai: Fixes the issue with `ImportError` of `TypedDict` from `typing` module in Python 3.7.
+- openai: This fix resolves an issue where embeddings inputs were always tagged regardless of the configured prompt-completion sample rate.
+- pytest: This fix resolves an issue where failures and non-skipped tests were not propagated properly when `unittest.TestCase` classes were used.
+- Fixes an issue where harvesting runtime metrics on certain managed environments, such as Google Cloud Run, would cause ddtrace to throw an exception.
+- graphql: `graphql.execute` spans are now marked as measured.
+- tracing: This fix resolves an issue where negative trace ID values were allowed to propagate via Datadog distributed tracing HTTP headers.
+- openai: Resolves some inconsistencies in logs generated by the image and audio endpoints, including filenames, prompts, and not logging raw binary image data.
+- pymemcache: This fix resolves an issue where overriding span attributes on `HashClient` failed when `use_pooling` was set.
+- This fix resolves an issue causing MyPy linting to fail on files that import ddtrace.
+- The 1.15.0 version has a bug that arises when Remote Config receives both kinds of actions (removing target file configurations and loading new target file configurations) simultaneously, as the load action overrides the remove action. This error occurs if someone creates and removes Dynamic Instrumentation Probes rapidly, within a time interval shorter than the Remote Config interval (5s). To fix this issue, this update appends all new configurations and configurations to remove, and dispatches them at the end of the RC request.
+
+---
+
+## v1.15.0
+
+### New Features
+
+- pyramid: Adds http.route tag to `pyramid.request` spans.
+- data_streams: Add data streams core integration and instrument the confluent Kafka library with it. For more information, check out the docs, <https://docs.datadoghq.com/data_streams/>
+- dynamic instrumentation: Added support for span decoration probes.
+
+### Bug Fixes
+
+- ASM: This fix resolves an issue where the WAF rule file specified by DD_APPSEC_RULES was wrongly updated and modified by remote config.
+- celery: Resolves an issue where hostname tags were not set in spans generated by `celery>4.0`.
+- django: Resolves an issue where the resource name of django.request span did not contain the full name of a view when `DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=True`. This issue impacts `django>=4.0`.
+- CI Visibility: This fix resolves the compatibility for Gitlab 16.0 deprecated urls
+- openai: Resolves an issue where using an array of tokens or an array of token arrays for the Embeddings endpoint caused an AttributeError.
+- profiling: Fixed an issue with gunicorn and gevent workers that occasionally caused an `AttributeError` exception to be raised on profiler start-up.
+- psycopg: Fixes `ValueError` raised when dsn connection strings are parsed. This was fixed in ddtrace v1.9.0 and was re-introduced in v1.13.0.
+- gunicorn: This fix ensures ddtrace threads do not block the master process from spawning workers when `DD_TRACE_DEBUG=true`. This issue impacts gunicorn applications using gevent and `python<=3.6`.
+
+---
+
+## v1.14.0
+
+### Prelude
+
+profiling: Code provenance is a feature that enhances the "My code" experience in the Datadog UI by allowing the tracer to report packaging metadata about installed source files. This information is used to distinguish between user and third-party code.
+
+### New Features
+
+- aws: Adds span tags for consistency with tags collected by Datadog for AWS metrics and logs.
+
+- botocore: Adds the ability to control which botocore submodules will be patched.
+
+- ASM: Send WAF metrics over telemetry
+
+- pytest: This introduces test suite and module level visibility for the pytest integration. Pytest test traces will now include test session, test module, test suite, and test spans, which correlate to pytest session, pytest package, pytest module, and pytest test functions respectively.
+
+- redis: Introducing redis command span tag max length configuration for `aioredis<aioredis>`, `aredis<aredis>`, `redis<redis>`, `rediscluster<rediscluster>`, and `yaaredis<yaaredis>` integrations.
+
+- profiling: Code provenance is enabled by default.
+
+- OpenAI: Add integration with support for metrics, logs and traces from
+  OpenAI requests. See [the docs](https://ddtrace.readthedocs.io/en/stable/integrations.html#openai) for more information.
+
+### Bug Fixes
+
+- dependencies: Resolves an issue where ddtrace installs an incompatible version of cattrs when Python 3.6 is used.
+
+- tracing: Resolves an issue where `DD_TRACE_<INTEGRATION>_ENABLED=False` could not be used to disable the following integrations when `ddtrace-run` was used: flask, django, bottle, falcon, and pyramid.
+
+- asgi: Ensures `error.message` and `error.stack` tags are set when an exception is raised in a route.
+
+- appsec: Fixes an encoding error when we are unable to cleanup the AppSec request context associated with a span.
+
+- ASM: Fixes encoding error when using AppSec and a trace is partial flushed.
+
+- CI Visibility: This fix resolves an issue where the tracer was doing extra requests if the `DD_CIVISIBILITY_ITR_ENABLED` env var was not set.
+
+- CI Visibility: This fix resolves an issue where the API call would fail because it is reporting a null service name
+
+- bootstrap: fixed an issue with the behavior of `ddtrace.auto` that could have caused incompatibilities with frameworks such as `gevent` when used as a programmatic alternative to the `ddtrace-run` command.
+
+- django: Fixed a bug that prevented a Django application from starting with celery and gevent workers if `DJANGO_SETTINGS_MODULE` was not explicitly set.
+
+- tracing: Fixes a cryptic encoding exception message when a span tag is not a string.
+
+- ASM: fix extract_body for Django such that users of Django Rest Framework can still use custom parsers.
+
+- flask: Remove patching for Flask hooks `app.before_first_request` and `bp.before_app_first_request` if Flask version \>= 2.3.0.
+
+- gevent: Fix a bug that caused traceback objects to fail to pickle when using gevent.
+
+- OpenAI: Resolved an issue where OpenAI API keys set in individual requests rather than as an environment variable caused an error in the integration.
+
+- profiler: Fixed a bug that caused segmentation faults in applications that use protobuf as a runtime dependency.
+
+- redis: Resolves an issue where the aioredis/aredis/yaaredis integrations cross-imported a helper method from the redis integration, which triggered redis patching before the redis integration was fully loaded.
+
+- wsgi: Resolves an issue where accessing the `__len__` attribute on traced wsgi middlewares raised a TypeError
+
+- django: Adds catch to guard against a ValueError, AttributeError, or NotImplementedError from being thrown when evaluating a django cache result for `db.row_count` tag.
+
+- lib-injection: Ensure local package is installed. Previously the package
+  could still be pulled from the internet causing application slowdowns.
+
+- kafka: Fixes `TypeError` raised when arbitrary keyword arguments are passed to `confluent_kafka.Consumer`
+
+- profiler: Fix support for latest versions of protobuf.
+
+- psycopg: Resolves an issue where an AttributeError is raised when `psycopg.AsyncConnection` is traced.
+
+- sanic: Resolves `sanic_routing.exceptions.InvalidUsage` error raised when gevent is installed or `DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE` is set to True.
+
+- elasticsearch: This fix resolves an issue where the tracer would throw an error when patching unsupported versions of elasticsearch (\> 8.0). Patching is now skipped if an unsupported version is detected.
+
+### Other Changes
+
+- span: Increases the traceback limit in `error.stack` tags from 20 to 30
+- aws_lambda: Logs warnings and exceptions on cold start only.
+
+---
+
+## v1.13.0
+
+### New Features
+
+- psycopg: This release adds support for the new psycopg3 package. This new integration has all the same tracing functionality as the previous psycopg2-binary package, with added support for new methods including async connection and async cursor classes. The release also adds support for using Django\>=4.2 with psycopg3 integrated tracing.
+
+### Bug Fixes
+
+- algoliasearch: This fix resolves an issue where non-text search query arguments caused Type Errors when being added as tags.
+
+- ASM: fix calling <span class="title-ref">set_user</span> without a created span raising a <span class="title-ref">ValueError</span>.
+
+- django: Adds fix for bug where Django cache return object throws an error if it does not implement `__bool__()`.
+
+- kafka: Previously instantiating a subclass of kafka's Producer/Consumer classes would result in attribute errors due to patching the Producer/Consumer classes with an ObjectProxy. This fix resolves this issue by making the traced classes directly inherit from kafka's base Producer/Consumer classes.
+
+- profiling: Fixed a regression in the memory collector that caused it to fail to cleanly re-initialize after a fork, causing error messages to be logged.
+
+- logging: Ensure that the logging module can report thread information, such as thread names, correctly when a framework like gevent is used that requires modules cleanup.
+
+- ASM: This fix resolves an issue where path parameters for the Flask framework were handled at response time instead of at request time for suspicious request blocking. This close a known issue opened in 1.10.0.
+
+- lib-injection: Switch installation to install from included wheels. Prior,
+  the wheels were merged together which caused conflicts between versions of dependencies based on Python version.
+
+- tracer: Handle exceptions besides `ImportError` when integrations are loaded.
+
+### Other Changes
+
+- ASM: Add information about Application Security config values on <span class="title-ref">ddtrace-run --info</span>.
+- otel: Fixes code formatting in api docs
+
+---
+
+## v1.12.0
+
+### New Features
+
+- tracing: Adds support for 128 bit trace ids for b3 and w3c distributing tracing headers.
+- pytest: Adds the `DD_CIVISIBILITY_AGENTLESS_ENABLED` environment variable to configure the `CIVisibility` service to use an agent-less test reporting `CIVisibilityWriter`. Note that the `CIVisibility` service will use regular agent reporting by default.
+- sci: Extracts and sends git metadata from environment variables `DD_GIT_REPOSITORY_URL`, `DD_GIT_COMMIT_SHA`, or from the python package specified in the `DD_MAIN_PACKAGE`. This feature can be disabled by setting `DD_TRACE_GIT_METADATA_ENABLED=False`.
+- otel: Adds support for the [OpenTelemetry Tracing API](https://opentelemetry.io/docs/reference/specification/trace/api/). Please refer to the `docs <ddtrace.opentelemetry>` for more details.
+
+### Bug Fixes
+
+- tracing: Ensure datadog headers propagate 128 bit trace ids when `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED=False`
+- aws_lambda: Fix AttributeError raised when `ddtrace.patch_all()`, or `ddtrace.patch(aws_lambda=True)`, is set on user handler.
+- aws_lambda: Fix AttributeError raised when extracting context from arguments.
+- aws_lambda: Fix AttributeError raised when callable handlers are traced.
+- dynamic instrumentation: Fixed an issue with expressions in metric probes that prevented them from being evaluated.
+- Prevent exceptions when autoreloading modules that directly or indirectly import ddtrace with the iPython autoreload extension.
+- profiling: Corrects accounting of wall and CPU time for gevent tasks within the main Python thread.
+- profiling: Fixed an issue with the memory collector where a segmentation fault could occur during shutdown.
+- lib-injection: The ddtrace package is now provided via the Docker image rather than relying on a run-time `pip install`. This solves issues like containers blocking network requests, installation overhead during application startup, permissions issues with the install.
+
+---
+
+## v1.11.0
+
+### Deprecation Notes
+
+- ASM: Several deprecated ASM constants that were added to the public API will be removed. This should not affect existing code as they were meant for private use only.
+
+### New Features
+
+- tracing: Adds support for 128 bit trace ids. To generate and propagate 128 bit trace ids using Datadog distributed tracing headers set the following configuration: `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED=True`. Support for B3 and W3C distributed tracing headers will be added in a future change.
+- aiohttp: Add missing component meta tag to aiohttp server spans.
+- redis: Adds tracing support for <span class="title-ref">redis.cluster.RedisCluster</span>.
+- celery: Adds automatic tracing of the `celery.beat` scheduling service to the `celery` integration.
+- kafka: Adds instrumentation support for `confluent-kafka>=1.7`. See the `confluent-kafka<https://ddtrace.readthedocs.io/en/stable/integrations.html#kafka>` documentation for more information.
+- dynamic instrumentation: introduced support for dynamic span probes.
+- Adds source code integration with setuptools build metadata. This enables traces and profiles to be automatically tagged with git metadata to track deployments in Datadog.
+
+### Bug Fixes
+
+- tracing: This fix resolves an issue where making a sampling decision before the `env` span tag had been set caused sample rate data from the Datadog Agent to be ignored.
+- ASM: make `track_custom_event()` also set `appsec.events.<custom_event>.track` which was missing.
+- django: Fixes an issue where `http.route` was only set if `use_handler_resource_format` and `use_legacy_resource_format` were set to `False`.
+- tracing: This fix resolves an issue where a very long string as a span attribute would cause that span not to be delivered. It replaces string span attributes larger than DD_TRACE_WRITER_BUFFER_SIZE_BYTES (which as of this version defaults to 8388608) with a small string containing debug information and not containing any of the original attribute string.
+- ASM: Resolves installation issues with compiling native code on Windows and unknown platforms.
+- aws_lambda: Fixes a `RecursionError` which is raised when aws lambda signal handlers are wrapped infinitely. This caused lambdas to crash on startup.
+- botocore: Fix TypeError raised by injecting trace context into Kinesis messages.
+- dynamic instrumentation: Fix a bug where the dynamic instrumentation would stop injecting function probes after the first failed one.
+- dynamic instrumentation: This change fixes a bug whereby probes that have been disabled/removed from the front-end would not be removed by the client library.
+- futures: Resolves an issue that prevents tasks from being submitted to a thread pool executor when gevent is used (e.g. as a worker class for gunicorn or celery).
+- propagation: This fix resolves an issue where previously W3C tracestate propagation could not handle whitespace. With this fix whitespace is now removed for incoming and outgoing requests.
+- httplib: Fixes an issue with patching of http client upon import
+- Ensure DD_REMOTE_CONFIGURATION_ENABLED environment variable disables remote config if set to False
+
+### Other Changes
+
+- aws_lambda: Updates how <span class="title-ref">DD_APM_FLUSH_DEADLINE_MILLISECONDS</span> is used. Previously, we would set the deadline as the environment variable value, if set. Now, when the remaining time in an AWS Lambda invocation is less than <span class="title-ref">DD_APM_FLUSH_DEADLINE_MILLISECONDS</span>, the tracer will attempt to submit the current active spans and all finished spans. the value in the environment variable is used to subtract from the deadline. The default is still 100ms.
+
+---
+
+## v1.9.1
+
+### Deprecation Notes
+
+- gevent: `DD_GEVENT_PATCH_ALL` is deprecated and will be removed in the next major version. Gevent compatibility is now automatic and does not require extra configuration when running with `ddtrace-run`. If not using `ddtrace-run`, please import `ddtrace.auto` before calling `gevent.monkey.patch_all()`.
+
+### Bug Fixes
+
+- aws_lambda: Resolves an exception not being handled, which occurs when no root span is found before a lambda times out.
+- gevent: This fix resolves an incompatibility between ddtrace and gevent that caused threads to hang in certain configurations, for example the profiler running in a gunicorn application's gevent worker process.
+
+### Other Changes
+
+- ASM: The list of headers for retrieving the IP when Application Security Management is enabled or the
+  <span class="title-ref">DD_TRACE_CLIENT_IP_ENABLED</span> environment variable is set has been updated. "Via" has been removed as it rarely contains IP data and some common vendor headers have been added. You can also set the environment variable <span class="title-ref">DD_TRACE_CLIENT_IP_HEADER</span> to always retrieve the IP from the header specified as the value.
+
+---
+
+## v1.10.0
+
+### Prelude
+
+Application Security Management (ASM) has added Django support for blocking malicious users using one click within Datadog.
+
+<div class="note">
+
+<div class="title">
+
+Note
+
+</div>
+
+One click blocking for ASM is currently in beta.
+
+</div>
+
+### Deprecation Notes
+
+- dbapi: `ddtrace.ext.mongo.ROWS` is deprecated. Use `ddtrace.ext.db.ROWCOUNT` instead.
+
+### New Features
+
+- starlette: Add http.route tag to `starlette.request` spans.
+- fastapi: Add http.route tag to `fastapi.request` spans.
+- ASM: Add support for one click blocking of user ids with the Django framework using Remote Configuration Management.
+- ASM: This introduces the "suspicious request blocking" feature for Django and Flask.
+
+### Known Issues
+
+- ASM: There is a known issue with the flask support for any rule blocking on `server.request.path_params`. The request will be correctly blocked but the client application will be receiving and processing the suspicious request. Possible workaround: use `server.request.uri.raw` instead, if you want the request to be blocked before entering the flask application.
+
+### Bug Fixes
+
+- dbapi: The dbapi integration no longer assumes that a cursor object will have a rowcount as not all database drivers implement rowcount.
+
+- dbm: Support sql queries with the type `byte`.
+
+- elasticsearch: Omit large `elasticsearch.body` tag values that are
+  greater than 25000 characters to prevent traces from being too large to send.
+
+- aws_lambda: This fix resolves an issue where existing signals were wrapped multiple times.
+
+- profiling: Handles a race condition on process shutdown that would cause an error about a module not being started to occasionally appear in the logs.
+
+- Fix for KeyError exceptions when when <span class="title-ref">ASM_FEATURES</span> (1-click activation) disabled all ASM products. This could cause 1-click activation to work incorrectly in some cases.
+- ASM: Solve some corner cases where a Flask blocking request would fail because headers would be already sent.
+- ASM: Solve the content-type not always being correct in blocking responses.
+- ASM: Ensure the blocking responses have the following tags: <span class="title-ref">http.url</span>, <span class="title-ref">http.query_string</span>, <span class="title-ref">http.useragent</span>, <span class="title-ref">http.method</span>, <span class="title-ref">http.response.headers.content-type</span> and <span class="title-ref">http.response.headers.content-length</span>.
+- ASM: fix memory leaks and memory corruption in the interface between ASM and the WAF library
+- psycopg2: Fixes a bug with DSN parsing integration.
+
+### Other Changes
+
+- remote_config: Change the level of remote config startup logs to debug.
+
+---
+
+## v1.9.0
+
+### Prelude
+
+Application Security Management (ASM) has added Django support for blocking malicious IPs using one click within Datadog.
+
+<div class="note">
+
+<div class="title">
+
+Note
+
+</div>
+
+One click blocking for ASM is currently in beta.
+
+</div>
+
+Application Security Management (ASM) has added Flask support for blocking malicious IPs using one click within Datadog.
+
+<div class="note">
+
+<div class="title">
+
+Note
+
+</div>
+
+One click blocking for ASM is currently in beta.
+
+</div>
+
+### Deprecation Notes
+
+- grpc: Deprecates `ddtrace.contrib.grpc.constants.GRPC_PORT_KEY`. Use `ddtrace.ext.net.TARGET_PORT` instead.
+- dbapi: `ddtrace.ext.sql.ROWS` is deprecated. Use `ddtrace.ext.db.ROWCOUNT` instead.
+- cassandra: `ddtrace.ext.cassandra.ROW_COUNT` is deprecated. Use `ddtrace.ext.db.ROWCOUNT` instead.
+
+### New Features
+
+- Enable traces to be sent before an impending timeout for `datadog_lambda>=4.66.0`. Use `DD_APM_FLUSH_DEADLINE` to override the default flush deadline. The default is the AWS Lambda function configured timeout limit.
+
+- debugger: Add dynamic log probes to that generate a log message and optionally capture local variables, return value and exceptions
+
+- tracing: Add support for enabling collecting of HTTP request client IP addresses as the `http.client_ip` span tag. You can set the `DD_TRACE_CLIENT_IP_ENABLED` environment variable to `true` to enable. This feature is disabled by default.
+
+- ASM: add support for one click blocking of IPs with the Django framework using Remote Configuration Management.
+
+- ASM: add support for one click blocking of IPs with the Flask framework using
+  Remote Configuration Management.
+
+- ASM: also fetch loopback IPs if client IP fetching is enabled (either via ASM or DD_TRACE_CLIENT_IP_ENABLED).
+
+- ASM: Enable ability to remotely activate and configure ASM features. To enable, check the Python Security page in your account. Note that this is a beta feature.
+
+- profiling: Collects endpoint invocation counts.
+
+- dynamic instrumentation: Python 3.11 is now supported.
+
+- graphene: Adds support for Python 3.11.
+
+- graphql: Adds support for Python 3.11.
+
+- httpx: Add support for `httpx<0.14.0,>=0.9.0`.
+
+- tracer/span: Add `Span.finish_with_ancestors` method to enable the abrupt
+  finishing of a trace in cases where the trace or application must be immediately terminated.
+
+### Known Issues
+
+- remote config: There is a known issue with remote configuration management (RCM) when paired with gevent which can cause child processes to deadlock. If you are experiencing issues, we recommend disabling RCM with `DD_REMOTE_CONFIGURATION_ENABLED=false`. Note, this will disable one click activation for ASM.
+- gunicorn: ddtrace-run does not work with gunicorn. To instrument a gunicorn application, follow the instructions [here](https://ddtrace.readthedocs.io/en/latest/integrations.html#gunicorn).
+
+### Bug Fixes
+
+- fastapi: Previously, custom fastapi middlewares configured after application startup were not traced. This fix ensures that all fastapi middlewares are captured in the <span class="title-ref">fastapi.request</span> span.
+
+- tracing: Pads trace_id and span_ids in b3 headers to have a minimum length of 16.
+
+- Fix full stacktrace being sent to the log on remote config connection errors.
+
+- httpx: Only patch `httpx.AsyncClient` for `httpx>=0.11.0`.
+
+- tracing: This fix resolves an issue with the encoding of traces when using the v0.5 API version with the Python optimization option flag `-O` or the `PYTHONOPTIMIZE` environment variable.
+
+- pylons: This fix resolves an issue where `str.decode` could cause critical unicode decode errors when ASM is enabled. ASM is disabled by default.
+
+- gevent: This fix resolves incompatibility under 3.8\>=Python\<=3.10 between `ddtrace-run` and applications that depend on `gevent`, for example `gunicorn` servers. It accomplishes this by keeping copies that have not been monkey patched by `gevent` of most modules used by `ddtrace`. This "module cloning" logic can be controlled by the environment variable `DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE`. Valid values for this variable are "1", "0", and "auto". "1" tells `ddtrace` to run its module cloning logic unconditionally, "0" tells it never to run that logic, and "auto" tells it to run module cloning logic *only if* `gevent` is accessible from the application's runtime. The default value is "0".
+
+- lib-injection: Use package versions published to PyPI to install the
+  library. Formerly the published image was installing the package from source using the tagged commit SHA which resulted in slow and potentially failing installs.
+
+- profiler: Handles potential `AttributeErrors` which would arise while collecting frames during stack unwinding in Python 3.11.
+
+- remote config: ensure proper validation of responses from the agent.
+
+---
+
+## v1.8.0
+
+### Upgrade Notes
+
+- ASM: libddwaf upgraded to version 1.6.1 using a new library loading mechanism
+- profiling: upgrades the profiler to support the `v2.4` backend API for profile uploads, using a new request format.
+
+### Deprecation Notes
+
+- `DD_REMOTECONFIG_POLL_SECONDS` environment variable is deprecated and will be removed in v2.0. Please use `DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS` instead.
+
+### New Features
+
+- CI Visibility: Add support for CI provider buddy.works
+
+- The component tag has been added for all auto-instrumented spans. The value of the component tag is equal to the name of the integration that produced the span.
+
+- tracing: Adds support for IPv6 agent hostnames for <span class="title-ref">DD_AGENT_HOST</span>.
+
+- elasticsearch: Update `elasticsearch` integration to add support for `opensearch-py`. See [the elasticsearch documentation](https://ddtrace.readthedocs.io/en/stable/integrations.html#elasticsearch) for more information.
+
+- ASM: one click activation enabled by default using Remote Configuration Management (RCM). Set `DD_REMOTE_CONFIGURATION_ENABLED=false` to disable this feature.
+
+- ASM: New Application Security Events Tracking API, starting with the functions `track_user_login_success_event` and
+  `track_user_login_failure_event` for tracking user logins (it will also internally call `set_user`) and `track_custom_event` for any custom events. You can find these functions in the `ddtrace.appsec.trace_utils` module. Calling these functions will create new tags under the `appsec.events` namespace (`appsec.events.user.login` for logins) allowing you to track these events with Datadog. In the future this will be used to provide protection against account takeover attacks (ATO). Public documentation will be online soon.
+
+- celery: Enhances context tags containing dictionaries so that their contents are sent as individual tags (issue \#4771).
+
+- tornado: Support custom error codes: <https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#custom-error-codes>.
+
+- CI Visibility: Support reliably linking tests to the pipeline that executed them.
+
+### Known Issues
+
+- profiling: There is currently a known performance regression issue with the profiler's code provenance feature. Note that this feature is disabled by default and will only be enabled if `DD_PROFILING_ENABLE_CODE_PROVENANCE` is set to true.
+
+### Bug Fixes
+
+- This fix improves a cryptic error message encountered during some `pip install ddtrace` runs under pip versions \<18.
+- dynamic instrumentation: remove unnecessary log line from application start up
+- This fix removes unintended url parts in the `http.url` tag.
+- botocore: Before this change, the botocore integration stripped newlines from the JSON string encoded in the data blob of Amazon Kinesis records. This change includes a terminating newline if it is present in the decoded data.
+- profiling: This fix resolves an issue in Python 3.11 where a PyFrameObject strong reference count was not properly decremented in the stack collector.
+- telemetry: This fix resolves an issue when we try to fetch `platform.libc_ver()` on an unsupported system.
+- Fix for ValueError when `@` is not present in network location but other part of the url.
+
+### Other Changes
+
+- profiler: CPU overhead reduction.
+
+---
+
+## v1.7.0
+
+### Prelude
+
+Initial library support has been added for Python 3.11.
+
+<div class="note">
+
+<div class="title">
+
+Note
+
+</div>
+
+Continuous Profiler and Dynamic Instrumentation are not yet compatible and must be disabled in order to use the library with Python 3.11. Support for them will be added in a future release. To track the status, see the [Support Python 3.11](https://github.com/DataDog/dd-trace-py/issues/4149) issue on GitHub.
+
+</div>
+
+### Upgrade Notes
+
+- The default propagation style configuration changes to `DD_TRACE_PROPAGATION_STYLE=tracecontext,datadog`. To only support Datadog propagation and retain the existing default behavior, set `DD_TRACE_PROPAGATION_STYLE=datadog`.
+- tracer: support for Datadog Agent v5 has been dropped. Datadog Agent v5 is no longer supported since ddtrace==1.0.0. See <https://ddtrace.readthedocs.io/en/v1.0.0/versioning.html#release-support> for the version support.
+- Python 3.11: Continuous Profiler and Dynamic Instrumentation must be disabled as they do not current support Python 3.11.
+- The configured styles in `DD_TRACE_PROPAGATION_STYLE_EXTRACT` are now evaluated in order to specification. To keep the previous fixed evaluation order, set: `DD_TRACE_PROPAGATION_STYLE_EXTRACT=datadog,b3,b3 single header`.
+- tracing: upgrades the default trace API version to `v0.5` for non-Windows systems. The `v0.5` trace API version generates smaller payloads, thus increasing the throughput to the Datadog agent especially with larger traces.
+- tracing: configuring the `v0.5` trace API version on Windows machines will raise a `RuntimeError` due to known compatibility issues. Please see <https://github.com/DataDog/dd-trace-py/issues/4829> for more details.
+
+### Deprecation Notes
+
+- propagation: Configuration of propagation style with `DD_TRACE_PROPAGATION_STYLE=b3` is deprecated and will be removed in version 2.0.0. Please use the newly added `DD_TRACE_PROPAGATION_STYLE=b3multi` instead.
+- aws: The boto, botocore and aiobotocore integrations no longer include all API parameters by default. To retain the deprecated behavior, set the environment variable `DD_AWS_TAG_ALL_PARAMS=1`. The deprecated behavior and environment variable will be removed in v2.0.0.
+
+### New Features
+
+- django: add configuration option to allow a resource format like <span class="title-ref">{method} {handler}.{url_name}</span> in projects with Django \<2.2.0
+- django: Adds the `DD_DJANGO_INCLUDE_USER_NAME` option to toggle whether the integration sets the `django.user.name` tag.
+- Added environment variable `DD_TRACE_PROPAGATION_STYLE` to configure both injection and extraction propagation styles. The configured styles can be overridden with environment variables `DD_TRACE_PROPAGATION_STYLE_INJECT` and `DD_TRACE_PROPAGATION_STYLE_EXTRACT`.
+- tracing: This introduces `none` as a supported propagator for trace context extraction and injection. When `none` is the only propagator listed, the corresponding trace context operation is disabled. If there are other propagators in the inject or extract list, the none propagator has no effect. For example `DD_TRACE_PROPAGATION_STYLE=none`
+- ASM: now http.client_ip and network.client.ip will only be collected if ASM is enabled.
+- tracing: Adds support for W3C Trace Context propagation style for distributed tracing. The `traceparent` and `tracestate` HTTP headers are enabled by default for all incoming and outgoing HTTP request headers. The Datadog propagation style continue to be enabled by default.
+- flask: Adds support for streamed responses. Note that two additional spans: `flask.application` and `flask.response` will be generated.
+- profiling: Adds support for Python 3.11.
+- tracer: added support for Python 3.11.
+
+### Bug Fixes
+
+- ASGI: response headers are correctly processed instead of ignored
+- Fix issue with `attrs` and `contextlib2` version constraints for Python 2.7.
+- CGroup file parsing was fixed to correctly parse container UUID for PCF containers.
+- ASM: Do not raise exceptions when failing to parse XML request body.
+- ASM: fix a body read problem on some corner case where don't passing the content length makes wsgi.input.read() blocks.
+- aws: We are reducing the number of API parameters that the boto, botocore and aiobotocore integrations collect as span tags by default. This change limits span tags to a narrow set of parameters for specific AWS APIs using standard tag names. To opt out of the new default behavior and collect no API parameters, set the environment variable `DD_AWS_TAG_NO_PARAMS=1`. To retain the deprecated behavior and collect all API parameters, set the environment variable `DD_AWS_TAG_ALL_PARAMS=1`.
+- tracing: make `ddtrace.context.Context` serializable which fixes distributed tracing across processes.
+- django: avoid `SynchronousOnlyOperation` when failing to retrieve user information.
+- Remove `forbiddenfruit` as dependency and rollback `wrapt` changes where `forbiddenfruit` was called. IAST: Patch builtins only when IAST is enabled.
+- httpx: Fixes an incompatibility from `httpx==0.23.1` when the `URL.raw` property is not available.
+- Fix error in patching functions. `forbiddenfruit` package has conflicts with some libraries such as `asynctest`. This conflict raises `AttributeError` exception. See issue \#4484.
+- tracer: This fix resolves an issue where the rate limiter used for span and trace sampling rules did not reset the time since last call properly if the rate limiter already had max tokens. This fix resets the time since last call always, which leads to more accurate rate limiting.
+- Ensure that worker threads that run on start-up are recreated at the right time after fork on Python \< 3.7.
+- tracing: This fix resolves an issue where the `DD_SERVICE_MAPPING` mapped service names were not used when updating span metadata with the `DD_VERSION` set version string.
+- wsgi: This fix resolves an issue where `BaseException` raised in a WSGI application caused spans to not be submitted.
+- library injection: Pin the library version in the library injection image. Prior, the latest version of `ddtrace` would always be installed, regardless of the image version.
+- Fix error in the agent response payload when the user disabled ASM in a dashboard using 1-click Remote Configuration.
+- flask: add support for flask v2.3. Remove deprecated usages of `flask._app_ctx_stack` and `flask._request_ctx_stack`.
+- The specification of `DD_TRACE_PROPAGATION_STYLE_EXTRACT` now respects the configured styles evaluation order. The evaluation order had previously been fixed and so the configured order was ignored.
+- tracing: Ensures that encoding errors due to wrong span tag types will be logged. Previously, if non-text span tags were set, this resulted in v0.5 encoding errors to be output to `stderr` instead of to a logger.
+
+### Other Changes
+
+- Kubernetes library injection: run commands as non-root user.
+- tracing: The value of `ddtrace.constants.PID` has been changed from `system.pid` to `process_id`. All spans will now use the metric tag of `process_id` instead.
+- tracing: The exception logged for writing errors no longer includes a long, unhelpful stack trace. The message now also includes the number of traces dropped and the number of retries attempted.
+
+---
+
+## v1.6.0
+
+### Prelude
+
+Application Security Management (ASM) has added support for preventing attacks by blocking malicious IPs using one click within Datadog.
+
+<div class="note">
+
+<div class="title">
+
+Note
+
+</div>
+
+One click activation for ASM is currently in beta.
+
+</div>
+
+Dynamic instrumentation allows instrumenting a running service dynamically to extract runtime information that could be useful for, e.g., debugging purposes, or to add extra metrics without having to make code changes and re-deploy the service. See <https://ddtrace.readthedocs.io/en/stable/configuration.html> for more details.
+
+### Upgrade Notes
+
+- Pin \[attrs\](<https://pypi.org/project/attrs/>) dependency to version `>=20` due to incompatibility with \[cattrs\](<https://pypi.org/project/cattrs/>) version `22.1.0`.
+- Use `Span.set_tag_str()` instead of `Span.set_tag()` when the tag value is a text type as a performance optimizations in manual instrumentation.
+
+### New Features
+
+- ASM: add support for one click activation using Remote Configuration Management (RCM). Set `DD_REMOTE_CONFIGURATION_ENABLED=true` to enable this feature.
+- ASM: ip address collection will be enabled if not explicitly disabled and appsec is enabled.
+- tracing: HTTP query string tagged by default in http.url tag (sensitive query strings will be obfuscated).
+- Django: set <span class="title-ref">usr.id</span> tag by default if <span class="title-ref">request.user</span> is authenticated.
+- Introduced the public interface for the dynamic instrumentation service. See <https://ddtrace.readthedocs.io/en/stable/configuration.html> for more details.
+- Add `Span.set_tag_str()` as an alternative to the overloaded functionality of `Span.set_tag()` when the value can be coerced to unicode text.
+- Enable `telemetry <Instrumentation Telemetry>` collection when tracing is enabled.
+
+### Bug Fixes
+
+- ASM: only report actor.ip on attack.
+- aioredis: added exception handling for <span class="title-ref">CancelledError</span> in the aioredis integration.
+- CI Visibility: fixed AppVeyor integration not extracting the full commit message.
+- Add iterable methods on TracedCursor. Previously these were not present and would cause iterable usage of cursors in DB API integrations to fail.
+- Fix parsing of the `DD_TAGS` environment variable value to include support for values with colons (e.g. URLs). Also fixed the parsing of invalid tags that begin with a space (e.g. `DD_TAGS=" key:val"` will now produce a tag with label `key`, instead of `key`, and value `val`).
+- opentracing: don't raise an exception when distributed tracing headers are not present when attempting to extract.
+- sqlite3: fix error when using `connection.backup` method.
+- Change dependency from `` backport_ipaddress` to ``ipaddress`. Only install`ipaddress\`\` for Python \< 3.7.
+- gevent: disable gevent after fork hook which could result in a performance regression.
+- profiling: restart automatically on all Python versions.
+- profiling: fixes an issue with Gunicorn child processes not storing profiling events.
+- wsgi: when using more than one nested wsgi traced middleware in the same app ensure wsgi spans have the correct parenting.
+
+### Other Changes
+
+- tracing: add http.route tag to root span for Flask framework.
+
+---
+
+## v1.5.0
+
+### New Features
+
+- graphene: add support for `graphene>=2`. [See the graphql documentation](https://ddtrace.readthedocs.io/en/stable/integrations.html#graphql) for more information.
+- Add support for aiobotocore 1.x and 2.x.
+- ASM: add user information to traces.
+- ASM: collect http client_ip.
+- ASM: configure the sensitive data obfuscator.
+- ASM: Detect attacks on Pylons body.
+- ASM: propagate user id.
+- ASM: Support In-App WAF metrics report.
+- Collect user agent in normalized span tag `http.useragent`.
+- ASM: Detect attacks on XML body (for Django, Pylons and Flask).
+- Adds support for Lambda profiling, which can be enabled by starting the profiler outside of the handler (on cold start).
+- profiler: collect and export the class name for the wall time, CPU time and lock profiles, when available.
+- add DD_PYMONGO_SERVICE configuration
+- ASM: Redact sensitive query strings if sent in http.url.
+- redis: track the connection client_name.
+- rediscluster: add service name configuration with `DD_REDISCLUSTER_SERVICE`
+- snowflake: add snowflake query id tag to `sql.query` span
+
+### Bug Fixes
+
+- aiohttp_jinja2: use `app_key` to look up templates.
+- ASM: (flask) avoid json decode error while parsing request body.
+- ASM: fix Python 2 error reading WAF rules.
+- ASM: reset wsgi input after reading.
+- tracing: fix handling of unicode `_dd.origin` tag for Python 2
+- tracing: fix nested web frameworks re-extracting and activating HTTP context propagation headers.
+- requests: fix split-by-domain service name when multiple `@` signs are present in the url
+- profiling: internal use of RLock needs to ensure original threading locks are used rather than gevent threading lock. Because of an indirection in the initialization of the original RLock, we end up getting an underlying gevent lock. We work around this behavior with gevent by creating a patched RLock for use internally.
+- profiler: Remove lock for data structure linking threads to spans to avoid deadlocks with the trade-off of correctness of spans linked to threads by stack profiler at a given point in time.
+- profiling: fix a possible deadlock due to spans being activated unexpectedly.
+
+---
+
+## v1.4.0
+
+### New Features
+
+- graphql: add tracing for `graphql-core>2`. See [the graphql documentation](https://ddtrace.readthedocs.io/en/stable/integrations.html#graphql) for more information.
+- ASM: Detect attacks on Django body.
+- ASM: Detect attacks on Flask request cookies
+- ASM: Detect attacks on Django request cookies
+- ASM: Detect attacks on Pylons HTTP query.
+- ASM: Detect attacks on Pylons request cookies
+- ASM: detect attacks on Pylons path parameters.
+- ASM: Report HTTP method on Pylons framework
+- ASM: Collect raw uri for Pylons framework.
+- AppSec: collect response headers
+- ASM: Detect attacks on Flask body.
+- ASM: Detect attacks on path parameters
+- The profiler now supports Windows.
+- The profiler now supports code provenance reporting. This can be enabled by using the `enable_code_provenance=True` argument to the profiler or by setting the environment variable `DD_PROFILING_ENABLE_CODE_PROVENANCE` to `true`.
+
+### Bug Fixes
+
+- flask: add support for `flask>=2.2.0`
+- Fixed the environment variable used for log file size bytes to be `DD_TRACE_LOG_FILE_SIZE_BYTES` as documented.
+- jinja2: fix handling of template names which are not strings.
+- Fixed support for pytest-bdd 6.
+- Fixes cases where a pytest test parameter object string representation includes the `id()` of the object, causing the test fingerprint to constantly change across executions.
+- wsgi: ignore GeneratorExit Exception in wsgi.response spans
+- wsgi: ensures resource and http tags are always set on <span class="title-ref">wsgi.request</span> spans.
+
+### Other Changes
+
+- profiler: don't initialize the `AsyncioLockCollector` unless asyncio is
+  available. This prevents noisy logs messages from being emitted in Python 2.
+
+- docs: Added troubleshooting section for missing error details in the root span of a trace.
+
+---
+
+## v1.3.0
+
+### New Features
+
+- internal: Add support for Datadog trace tag propagation
+- django: added `DD_DJANGO_INSTRUMENT_TEMPLATES=false` to allow tracing of Django template rendering.
+- internal: Add sampling mechanism trace tag
+- Add environment variables to write `ddtrace` logs to a file with `DD_TRACE_LOG_FILE`, `DD_TRACE_LOG_FILE_LEVEL`, and `DD_TRACE_FILE_SIZE_BYTES`
+- Adds pytest-bdd integration to show more details in CI Visibility product.
+
+### Bug Fixes
+
+- starlette: Add back removed `aggregate_resources` feature.
+- fastapi: Add back removed `aggregate_resources` feature.
+- aiomysql: fix `AttributeError: __aenter__` when using cursors as context managers.
+- asgi, starlette, fastapi: Exclude background tasks duration from web request spans.
+- asgi: set the `http.url` tag using the hostname in the request header before defaulting to the hostname of the asgi server.
+- mypy: Avoid parsing redis asyncio files when type checking Python 2
+- starlette: Add back removed `ddtrace.contrib.starlette.get_resource` and `ddtrace.contrib.starlette.span_modifier`.
+- fastapi: Add back removed `ddtrace.contrib.fastapi.span_modifier`.
+- internal: fix exception raised for invalid values of `DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH`.
+- flask_caching: fix redis tagging after the v2.0 release.
+- redis: create default Pin on asyncio client. Not having a Pin was resulting in no traces being produced for the async redis client.
+
+### Other Changes
+
+- perf: don't encode default parent_id value.
+- profiling: add support for protobuf \>=4.0.
+
+---
+
+## v1.2.0
+
+### Upgrade Notes
+
+- The profiler `asyncio_loop_policy` attribute has been renamed to `asyncio_loop_policy_class` to accept a user-defined class. This guarantees the same asyncio loop policy class can be used process children.
+
+### New Features
+
+- Add tracing support for `aiomysql>=0.1.0`.
+
+- Add support for `grpc.aio`.
+
+- botocore: allow defining error status codes for specific API operations.
+
+  See our `botocore` document for more information on how to enable this feature.
+
+- ciapp: detect code owners of PyTest tests
+
+- The memory profile collector can now entirely disabled with the `DD_PROFILING_MEMORY_ENABLED` environment variable.
+
+- psycopg2: add option to enable tracing `psycopg2.connect` method.
+
+  See our `psycopg2` documentation for more information.
+
+- Add asyncio support of redis ≥ 4.2.0
+
+### Bug Fixes
+
+- Fixes deprecation warning for `asyncio.coroutine` decorator.
+
+- internal: normalize header names in ASM
+
+- profiling: implement `__aenter__` and `__aexit__` methods on `asyncio.Lock` wrapper.
+
+- tracing: fix issue with `ddtrace-run` having the wrong priority order of tracer host/port/url env variable configuration.
+
+- django,redis: fix unicode decode error when using unicode cache key on Python 2.7
+
+- fastapi/starlette: when using sub-apps, formerly a call to `/sub-app/hello/{name}` would give a resource name of `/sub-app`. Now the full path `/sub-app/hello/{name}` is used for the resource name.
+
+- sanic: Don't send non-500s error traces.
+
+- pin protobuf to version `>=3,<4` due to incompatibility with version `4.21`.
+
+- Fixes a performance issue with the profiler when used in an asyncio application.
+
+- The profiler now copy all user-provided attributes on fork.
+
+- pytest: Add note for disabling ddtrace plugin as workaround for side-effects
+
+- Set required header to indicate top level span computation is done in the client to the Datadog agent. This fixes an issue where spans were erroneously being marked as top level when partial flushing or in certain asynchronous applications.
+
+  The impact of this bug is the unintended computation of stats for non-top level spans.
+
+### Other Changes
+
+- The default number of events kept by the profiler has been reduced to decreased CPU and memory overhead.
+
+---
+
+## v1.1.0
+
+### Prelude
+
+The Datadog APM Python team is happy to announce the release of v1.0.0 of ddtrace. This release introduces a formal `versioning policy<versioning>` that simplifies the public `interface<versioning_interfaces>` and defines a `release version policy<versioning_release>` for backwards compatible and incompatible changes to the public interface.
+
+The v1.0.0 release is an important milestone for the library as it has grown substantially in scope. The first commit to the library was made on June 20, 2016. Nearly sixty minor releases later, the library now includes over sixty integrations for libraries. And the library has expanded from Tracing to support the Continuous Profiler and CI Visibility.
+
+<div class="important">
+
+<div class="title">
+
+Important
+
+</div>
+
+Before upgrading to v1.0.0, we recommend users install `ddtrace>=0.60.0,<1.0.0` and enable deprecation warnings. All removals to the library interface and environment variables were deprecated on 0.x branch. Consult `Upgrade 0.x<upgrade-0.x>` for recommendations on migrating from the 0.x release branch.
+
+</div>
+
+<div class="note">
+
+<div class="title">
+
+Note
+
+</div>
+
+The changes to environment variables apply only to the configuration of the ddtrace library and not the Datadog Agent.
+
+</div>
+
+#### Upgrading summary
+
+##### Functionality changes
+
+The default logging configuration functionality of `ddtrace-run` has changed to address conflicts with application logging configuration. See `note on the new default behavior<disable-basic-config-call-by-default>` and `note on deprecation<deprecate-basic-config-call>` for future removal.
+
+##### Removed legacy environment variables
+
+These environment variables have been removed. In all cases the same functionality is provided by other environment variables and replacements are provided as recommended actions for upgrading.
+
+| Variable                            | Replacement                        | Note                                   |
+|-------------------------------------|------------------------------------|----------------------------------------|
+| `DATADOG_` prefix                   | `DD_` prefix                       | `📝<remove-datadog-envs>`              |
+| `DATADOG_SERVICE_NAME`              | `DD_SERVICE`                       | `📝<remove-legacy-service-name-envs>`  |
+| `DD_LOGGING_RATE_LIMIT`             | `DD_TRACE_LOGGING_RATE`            | `📝<remove-logging-env>`               |
+| `DD_TRACER_PARTIAL_FLUSH_ENABLED`   | `DD_TRACE_PARTIAL_FLUSH_ENABLED`   | `📝<remove-partial-flush-enabled-env>` |
+| `DD_TRACER_PARTIAL_FLUSH_MIN_SPANS` | `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS` | `📝<remove-partial-flush-min-envs>`    |
+
+##### Removed legacy tracing interfaces
+
+These methods and module attributes have been removed. Where the same functionality is provided by a different public method or module attribute, a recommended action is provided for upgrading. In a few limited cases, because the interface was no longer used or had been moved to the internal interface, it was removed and so no action is provided for upgrading.
+
+| Module             | Method/Attribute           | Note                                  |
+|--------------------|----------------------------|---------------------------------------|
+| `ddtrace.context`  | `Context.clone`            | `📝<remove-clone-context>`            |
+| `ddtrace.pin`      | `Pin.app`                  | `📝<remove-pin-app>`                  |
+|                    | `Pin.app_type`             | `📝<remove-pin-apptype>`              |
+| `ddtrace.sampler`  | `Sampler.default_sampler`  | `📝<remove-default-sampler>`          |
+| `ddtrace.span`     | `Span.tracer`              | `📝<remove-span-tracer>`              |
+|                    | `Span.__init__(tracer=)`   | `📝<remove-span-init-tracer>`         |
+|                    | `Span.meta`                | `📝<remove-span-meta>`                |
+|                    | `Span.metrics`             | `📝<remove-span-metrics>`             |
+|                    | `Span.set_meta`            | `📝<remove-span-set-meta>`            |
+|                    | `Span.set_metas`           | `📝<remove-span-set-metas>`           |
+|                    | `Span.pprint`              | `📝<remove-span-pprint>`              |
+| `ddtrace.tracer`   | `Tracer.debug_logging`     | `📝<remove-tracer-debug-logging>`     |
+|                    | `Tracer.get_call_context`  | `📝<remove-tracer-get-call-context>`  |
+|                    | `Tracer.tags`              | `📝<remove-tracer-tags>`              |
+|                    | `Tracer.writer`            | `📝<remove-tracer-writer>`            |
+|                    | `Tracer.__call__`          | `📝<remove-tracer-call>`              |
+|                    | `Tracer.global_excepthook` | `📝<remove-tracer-global-excepthook>` |
+|                    | `Tracer.log`               | `📝<remove-tracer-log>`               |
+|                    | `Tracer.priority_sampler`  | `📝<remove-tracer-priority-sampler>`  |
+|                    | `Tracer.sampler`           | `📝<remove-tracer-sampler>`           |
+|                    | `Tracer.set_service_info`  | `📝<remove-tracer-set-service-info>`  |
+| `ddtrace.ext`      | `SpanTypes`                | `📝<remove-span-types-enum>`          |
+| `ddtrace.helpers`  | `get_correlation_ids`      | `📝<remove-helpers>`                  |
+| `ddtrace.settings` | `Config.HTTPServerConfig`  | `📝<remove-config-httpserver>`        |
+
+##### Removed legacy integration tracing
+
+These tracing functions in integrations were no longer used for automatic instrumentation so have been removed. Any manual instrumentation code in an application will need to be replaced with `ddtrace.patch_all` or `ddtrace.patch` when upgrading.
+
+| Module                        | Function/Class                          |                                          |
+|-------------------------------|-----------------------------------------|------------------------------------------|
+| `ddtrace.contrib.cassandra`   | `get_traced_cassandra`                  | `📝<remove-cassandra-traced>`            |
+| `ddtrace.contrib.celery`      | `patch_task`                            | `📝<remove-celery-patch-task>`           |
+| `ddtrace.contrib.celery`      | `unpatch_task`                          | `📝<remove-celery-unpatch-task>`         |
+| `ddtrace.contrib.flask`       | `middleware.TraceMiddleware`            | `📝<remove-flask-middleware>`            |
+| `ddtrace.contrib.mongoengine` | `trace_mongoengine`                     | `📝<remove-mongoengine-traced>`          |
+| `ddtrace.contrib.mysql`       | `get_traced_mysql_connection`           | `📝<remove-mysql-legacy>`                |
+| `ddtrace.contrib.psycopg`     | `connection_factory`                    | `📝<remove-psycopg-legacy>`              |
+| `ddtrace.contrib.pymongo`     | `patch.trace_mongo_client`              | `📝<remove-pymongo-client>`              |
+| `ddtrace.contrib.pymysql`     | `tracers.get_traced_pymysql_connection` | `📝<remove-pymysql-connection>`          |
+| `ddtrace.contrib.requests`    | `legacy`                                | `📝<remove-requests-legacy-distributed>` |
+| `ddtrace.contrib.redis`       | `tracers.get_traced_redis`              | `📝<remove-redis-traced>`                |
+| `ddtrace.contrib.redis`       | `tracers.get_traced_redis_from`         | `📝<remove-redis-traced-from>`           |
+| `ddtrace.contrib.sqlite3`     | `connection_factory`                    | `📝<remove-sqlite3-legacy>`              |
+
+##### Removed deprecated modules
+
+These modules have been removed. Many were moved to the internal interface as they were not intended to be used as part of the public interface. In these cases, no action is provided for upgrading. In a few cases, other modules are provided as alternatives to maintain functionality. See the notes for more information.
+
+| Module                      | Note                                   |
+|-----------------------------|----------------------------------------|
+| `ddtrace.compat`            | `📝<remove-ddtrace-compat>`            |
+| `ddtrace.contrib.util`      | `📝<remove-contrib-util>`              |
+| `ddtrace.encoding`          | `📝<remove-ddtrace-encoding>`          |
+| `ddtrace.ext.errors`        | `📝<remove-ext-errors>`                |
+| `ddtrace.ext.priority`      | `📝<remove-ext-priority>`              |
+| `ddtrace.ext.system`        | `📝<remove-ext-system>`                |
+| `ddtrace.http`              | `📝<remove-http>`                      |
+| `ddtrace.monkey`            | `📝<remove-ddtrace-monkey>`            |
+| `ddtrace.propagation.utils` | `📝<remove-ddtrace-propagation-utils>` |
+| `ddtrace.util`              | `📝<remove-ddtrace-util>`              |
+| `ddtrace.utils`             | `📝<remove-ddtrace-utils>`             |
+
+### Upgrade Notes
+
+- <div id="remove-default-sampler">
+
+  The deprecated attribute `ddtrace.Sampler.default_sampler` is removed.
+
+  </div>
+
+- Spans started after `Tracer.shutdown()` has been called will no longer be sent to the Datadog Agent.
+
+- <div id="disable-basic-config-call-by-default">
+
+  Default value of `DD_CALL_BASIC_CONFIG` was updated from `True` to `False`. Call `logging.basicConfig()` to configure logging in your application.
+
+  </div>
+
+- aiohttp_jinja2: use `patch(aiohttp_jinja2=True)` instead of `patch(aiohttp=True)` for enabling/disabling the integration.
+
+- <div id="remove-config-httpserver">
+
+  `ddtrace.settings.Config.HTTPServerConfig` is removed.
+
+  </div>
+
+- <div id="remove-cassandra-traced">
+
+  cassandra: `get_traced_cassandra` is removed. Use `ddtrace.patch(cassandra=True)` or `ddtrace.patch_all()` instead.
+
+  </div>
+
+- <div id="remove-celery-patch-task">
+
+  celery: `ddtrace.contrib.celery.patch_task` is removed. Use `ddtrace.patch(celery=True)` or `ddtrace.patch_all()` instead.
+
+  </div>
+
+- <div id="remove-celery-unpatch-task">
+
+  celery: `ddtrace.contrib.celery.unpatch_task` is removed. Use `ddtrace.contrib.celery.unpatch()` instead.
+
+  </div>
+
+- <div id="remove-clone-context">
+
+  `ddrace.context.Context.clone` is removed. This is no longer needed since the tracer now supports asynchronous frameworks out of the box.
+
+  </div>
+
+- `ddtrace.constants.FILTERS_KEY` is removed.
+
+- `ddtrace.constants.NUMERIC_TAGS` is removed.
+
+- `ddtrace.constants.LOG_SPAN_KEY` is removed.
+
+- <div id="remove-contrib-util">
+
+  The deprecated module `ddtrace.contrib.util` is removed.
+
+  </div>
+
+- <div id="remove-ddtrace-compat">
+
+  The deprecated module `ddtrace.compat` is removed.
+
+  </div>
+
+- <div id="remove-ddtrace-encoding">
+
+  The deprecated module `ddtrace.encoding` is removed.
+
+  </div>
+
+- <div id="remove-http">
+
+  The deprecated modules `ddtrace.http` and `ddtrace.http.headers` are removed. Use `ddtrace.contrib.trace_utils.set_http_meta` to store request and response headers on a span.
+
+  </div>
+
+- <div id="remove-ddtrace-install-excepthooks">
+
+  Remove deprecated `ddtrace.install_excepthook`.
+
+  </div>
+
+- <div id="remove-ddtrace-uninstall-excepthooks">
+
+  Remove deprecated `ddtrace.uninstall_excepthook`.
+
+  </div>
+
+- <div id="remove-ddtrace-monkey">
+
+  The deprecated module `ddtrace.monkey` is removed. Use `ddtrace.patch <ddtrace.patch>` or `ddtrace.patch_all <ddtrace.patch_all>` instead.
+
+  </div>
+
+- <div id="remove-ddtrace-propagation-utils">
+
+  The deprecated module `ddtrace.propagation.utils` is removed.
+
+  </div>
+
+- <div id="remove-ddtrace-utils">
+
+  The deprecated module `ddtrace.utils` and its submodules are removed:
+  - `ddtrace.utils.attr`
+  - `ddtrace.utils.attrdict`
+  - `ddtrace.utils.cache`
+  - `ddtrace.utils.config`
+  - `ddtrace.utils.deprecation`
+  - `ddtrace.utils.formats`
+  - `ddtrace.utils.http`
+  - `ddtrace.utils.importlib`
+  - `ddtrace.utils.time`
+  - `ddtrace.utils.version`
+  - `ddtrace.utils.wrappers`
+
+  </div>
+
+- <div id="remove-tracer-sampler">
+
+  `ddtrace.Tracer.sampler` is removed.
+
+  </div>
+
+- <div id="remove-tracer-priority-sampler">
+
+  `ddtrace.Tracer.priority_sampler` is removed.
+
+  </div>
+
+- <div id="remove-tracer-tags">
+
+  `ddtrace.Tracer.tags` is removed. Use the environment variable `DD_TAGS<dd-tags>` to set the global tags instead.
+
+  </div>
+
+- <div id="remove-tracer-log">
+
+  `ddtrace.Tracer.log` was removed.
+
+  </div>
+
+- <div id="remove-ext-errors">
+
+  The deprecated module `ddtrace.ext.errors` is removed. Use the `ddtrace.constants` module instead:
+
+      from ddtrace.constants import ERROR_MSG
+      from ddtrace.constants import ERROR_STACK
+      from ddtrace.constants import ERROR_TYPE
+
+  </div>
+
+- <div id="remove-ext-priority">
+
+  The deprecated module `ddtrace.ext.priority` is removed. Use the `ddtrace.constants` module instead for setting sampling priority tags:
+
+      from ddtrace.constants import USER_KEEP
+      from ddtrace.constants import USER_REJECT
+
+  </div>
+
+- <div id="remove-ext-system">
+
+  The deprecated module `ddtrace.ext.system` is removed. Use `ddtrace.constants.PID` instead.
+
+  </div>
+
+- <div id="remove-helpers">
+
+  The deprecated method `ddtrace.helpers.get_correlation_ids` is removed. Use `ddtrace.Tracer.get_log_correlation_context` instead.
+
+  </div>
+
+- <div id="remove-legacy-service-name-envs">
+
+  The legacy environment variables `DD_SERVICE_NAME` and `DATADOG_SERVICE_NAME` are removed. Use `DD_SERVICE` instead.
+
+  </div>
+
+- <div id="remove-mongoengine-traced">
+
+  mongoengine: The deprecated method `ddtrace.contrib.mongoengine.trace_mongoengine` is removed. Use `ddtrace.patch(mongoengine=True)` or `ddtrace.patch()` instead.
+
+  </div>
+
+- <div id="remove-mysql-legacy">
+
+  mysql: The deprecated method `ddtrace.contrib.mysql.get_traced_mysql_connection` is removed. Use `ddtrace.patch(mysql=True)` or `ddtrace.patch_all()` instead.
+
+  </div>
+
+- <div id="remove-pin-app">
+
+  `Pin.app` is removed.
+
+  </div>
+
+- <div id="remove-pin-apptype">
+
+  `Pin.app_type` is removed.
+
+  </div>
+
+- <div id="remove-psycopg-legacy">
+
+  psycopg: `ddtrace.contrib.psycopg.connection_factory` is removed. Use `ddtrace.patch(psycopg=True)` or `ddtrace.patch_all()` instead.
+
+  </div>
+
+- <div id="remove-requests-legacy-distributed">
+
+  requests: The legacy distributed tracing configuration is removed. Use `ddtrace.config.requests['distributed_tracing']<requests-config-distributed-tracing>` instead.
+
+  </div>
+
+- <div id="remove-span-meta">
+
+  `ddtrace.Span.meta` is removed. Use `ddtrace.Span.get_tag` and `ddtrace.Span.set_tag` instead.
+
+  </div>
+
+- <div id="remove-span-metrics">
+
+  `ddtrace.Span.metrics` is removed. Use `ddtrace.Span.get_metric` and `ddtrace.Span.set_metric` instead.
+
+  </div>
+
+- <div id="remove-span-pprint">
+
+  `ddtrace.Span.pprint` is removed.
+
+  </div>
+
+- <div id="remove-span-set-meta">
+
+  `ddtrace.Span.set_meta` is removed. Use `ddtrace.Span.set_tag` instead.
+
+  </div>
+
+- <div id="remove-span-set-metas">
+
+  `ddtrace.Span.set_metas` is removed. Use `ddtrace.Span.set_tags` instead.
+
+  </div>
+
+- `Span.to_dict` is removed.
+
+- <div id="remove-span-tracer">
+
+  `Span.tracer` is removed.
+
+  </div>
+
+- <div id="remove-span-init-tracer">
+
+  The deprecated <span class="title-ref">tracer</span> argument is removed from `ddtrace.Span.__init__`.
+
+  </div>
+
+- <div id="remove-sqlite3-legacy">
+
+  sqlite3: `ddtrace.contrib.sqlite3.connection_factory` is removed. Use `ddtrace.patch(sqlite3=True)` or `ddtrace.patch_all()` instead.
+
+  </div>
+
+- <div id="remove-tracer-debug-logging">
+
+  Remove deprecated attribute `ddtrace.Tracer.debug_logging`. Set the logging level for the `ddtrace.tracer` logger instead:
+
+      import logging
+      log = logging.getLogger("ddtrace.tracer")
+      log.setLevel(logging.DEBUG)
+
+  </div>
+
+- <div id="remove-tracer-call">
+
+  `ddtrace.Tracer.__call__` is removed.
+
+  </div>
+
+- <div id="remove-tracer-global-excepthook">
+
+  `ddtrace.Tracer.global_excepthook` is removed.
+
+  </div>
+
+- <div id="remove-tracer-get-call-context">
+
+  `ddtrace.Tracer.get_call_context` is removed. Use `ddtrace.Tracer.current_trace_context` instead.
+
+  </div>
+
+- <div id="remove-tracer-set-service-info">
+
+  `ddtrace.Tracer.set_service_info` is removed.
+
+  </div>
+
+- <div id="remove-tracer-writer">
+
+  `ddtrace.Tracer.writer` is removed. To force flushing of buffered traces to the agent, use `ddtrace.Tracer.flush` instead.
+
+  </div>
+
+- `ddtrace.warnings.DDTraceDeprecationWarning` is removed.
+
+- `DD_TRACE_RAISE_DEPRECATIONWARNING` environment variable is removed.
+
+- <div id="remove-datadog-envs">
+
+  The environment variables prefixed with `DATADOG_` are removed. Use environment variables prefixed with `DD_` instead.
+
+  </div>
+
+- <div id="remove-logging-env">
+
+  The environment variable `DD_LOGGING_RATE_LIMIT` is removed. Use `DD_TRACE_LOGGING_RATE` instead.
+
+  </div>
+
+- <div id="remove-partial-flush-enabled-env">
+
+  The environment variable `DD_TRACER_PARTIAL_FLUSH_ENABLED` is removed. Use `DD_TRACE_PARTIAL_FLUSH_ENABLED` instead.
+
+  </div>
+
+- <div id="remove-partial-flush-min-envs">
+
+  The environment variable `DD_TRACER_PARTIAL_FLUSH_MIN_SPANS` is removed. Use `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS` instead.
+
+  </div>
+
+- <div id="remove-ddtrace-util">
+
+  `ddtrace.util` is removed.
+
+  </div>
+
+- <div id="remove-span-types-enum">
+
+  `ddtrace.ext.SpanTypes` is no longer an `Enum`. Use `SpanTypes.<TYPE>` instead of `SpanTypes.<TYPE>.value`.
+
+  </div>
+
+- `Tracer.write` has been removed.
+
+- <div id="remove-flask-middleware">
+
+  Removed deprecated middleware `ddtrace.contrib.flask.middleware.py:TraceMiddleware`. Use `ddtrace.patch_all` or `ddtrace.patch` instead.
+
+  </div>
+
+- <div id="remove-pymongo-client">
+
+  Removed deprecated function `ddtrace.contrib.pymongo.patch.py:trace_mongo_client`. Use `ddtrace.patch_all` or `ddtrace.patch` instead.
+
+  </div>
+
+- <div id="remove-pymysql-connection">
+
+  Removed deprecated function `ddtrace.contrib.pymysql.tracers.py:get_traced_pymysql_connection`. Use `ddtrace.patch_all` or `ddtrace.patch` instead.
+
+  </div>
+
+- <div id="remove-redis-traced">
+
+  Removed deprecated function `ddtrace.contrib.redis.tracers.py:get_traced_redis`. Use `ddtrace.patch_all` or `ddtrace.patch` instead.
+
+  </div>
+
+- <div id="remove-redis-traced-from">
+
+  Removed deprecated function `ddtrace.contrib.redis.tracers.py:get_traced_redis_from`. Use `ddtrace.patch_all` or `ddtrace.patch` instead.
+
+  </div>
+
+### Deprecation Notes
+
+- <div id="deprecate-basic-config-call">
+
+  `DD_CALL_BASIC_CONFIG` is deprecated.
+
+  </div>
+
+### New Features
+
+- Add `Span.get_tags` and `Span.get_metrics`.
+
+- aiohttp: add client integration. This integration traces requests made using the aiohttp client and includes support for distributed tracing. See [the documentation](https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp) for more information.
+
+- aiohttp_jinja2: move into new integration. Formerly the aiohttp_jinja2 instrumentation was enabled using the aiohttp integration. Use `patch(aiohttp_jinja2=True)` instead of `patch(aiohttp=True)`. To support legacy behavior `patch(aiohttp=True)` will still enable aiohttp_jinja2.
+
+- asyncpg: add integration supporting v0.18.0 and above. See `the docs<asyncpg>` for more information.
+
+- fastapi: add support for tracing `fastapi.routing.serialize_response`.
+
+  This will give an insight into how much time is spent calling `jsonable_encoder` within a given request. This does not provide visibility into how long it takes for `Response.render`/`json.dumps`.
+
+- Add support to reuse HTTP connections when sending trace payloads to the agent. This feature is disabled by default. Set `DD_TRACE_WRITER_REUSE_CONNECTIONS=true` to enable this feature.
+
+- MySQLdb: Added optional tracing for MySQLdb.connect, using the configuration option `here<mysqldb_config_trace_connect>`.
+
+- The profiler now supports profiling `asyncio.Lock` objects.
+
+- Add support for injecting and extracting B3 propagation headers.
+
+  See `DD_TRACE_PROPAGATION_STYLE_EXTRACT <dd-trace-propagation-style-extract>` and `DD_TRACE_PROPAGATION_STYLE_INJECT <dd-trace-propagation-style-inject>` configuration documentation to enable.
+
+### Bug Fixes
+
+- botocore: fix incorrect context propagation message attribute types for SNS. This addresses [Datadog/serverless-plugin-datadog#232](https://github.com/DataDog/serverless-plugin-datadog/issues/232)
+
+- aiohttp: fix issue causing `ddtrace.contrib.aiohttp_jinja2.patch` module to be imported instead of the `patch()` function.
+
+- botocore: omit `SecretBinary` and `SecretString` from span metadata for calls to Secrets Manager.
+
+- tracing/internal: fix encoding of propagated internal tags.
+
+- Fix issue building `ddtrace` from source on macOS 12.
+
+- Fix issue building `ddtrace` for the Pyston Python implementation by not building the `_memalloc` extension anymore when using Pyston.
+
+- `tracer.get_log_correlation_context()`: use active context in addition to
+  active span. Formerly just the span was used and this would break cross execution log correlation as a context object is used for the propagation.
+
+- opentracer: update `set_tag` and `set_operation_name` to return a
+  reference to the span to match the OpenTracing spec.
+
+- The CPU profiler now reports the main thread CPU usage even when asyncio tasks are running.
+
+- Fixes wrong numbers of memory allocation being reported in the memory profiler.
+
+- pymongo: fix `write_command` being patched with the wrong method signature.
+
+### Other Changes
+
+- tracing/internal: disable Datadog internal tag propagation
+
+---
+
+## v0.59.0
+
+### Deprecation Notes
+
+- `ddtrace.constants.FILTERS_KEY` is deprecated. Use `settings={"FILTERS": ...}` instead when calling `tracer.configure`.
+- `ddtrace.constants.NUMERIC_TAGS` is deprecated.
+- `ddtrace.constants.LOG_SPAN_KEY` is deprecated.
+- `Pin.app` is deprecated.
+- `ddtrace.Span.set_meta` is deprecated. Use `ddtrace.Span.set_tag` instead.
+- `ddtrace.Span.set_metas` is deprecated. Use `ddtrace.Span.set_tags` instead.
+- `ddtrace.Span.metrics` is deprecated. Use `ddtrace.Span.get_metric` and `ddtrace.Span.set_metric` instead.
+- `ddtrace.Span.tracer` is deprecated.
+- `ddtrace.Tracer.log` is deprecated. Use `ddtrace.tracer.log` instead.
+- `ddtrace.Tracer.sampler` is deprecated.
+- `ddtrace.Tracer.priority_sampler` is deprecated.
+- `ddtrace.Tracer.tags` is deprecated. Use the environment variable `DD_TAGS<dd-tags>` to set the global tags instead.
+
+### New Features
+
+- The profiler now reports asyncio tasks as part as the task field in profiles. This is enabled by default by replacing the default asyncio loop policy. CPU time, wall time and threading lock times are supported.
+- Add tracing support for `sanic>=21.9.0`.
+
+### Bug Fixes
+
+- Fix internal import of deprecated `ddtrace.utils` module.
+- Set correct service in logs correlation attributes when a span override the service.
+- Fixes import path to not reference `__init__`. This could otherwise be a problem for `mypy`.
+- flask: fix resource naming of request span when errors occur in middleware.
+- Fix issue when `httpx` service name is `bytes`.
+- Fixes build issues on older MacOS versions by updating `libddwaf` to 1.0.18
+- pytest: fix unsafe access to xfail reason.
+
+---
+
+## v0.58.0
+
+### Deprecation Notes
+
+- HttpServerConfig is no longer part of the public API.
+- `ddtrace.Span.meta` has been deprecated. Use `ddtrace.Span.get_tag` and `ddtrace.Span.set_tag` instead.
+- `ddtrace.Span.pprint` is deprecated and will be removed in v1.0.
+- `ddtrace.Tracer.writer` is deprecated. To force flushing of buffered traces to the agent, use `ddtrace.Tracer.flush` instead.
+
+### New Features
+
+- botocore: add distributed tracing support for AWS EventBridge, AWS SNS & AWS Kinesis.
+- Add `ddtrace.Tracer.agent_trace_url` and `ddtrace.Tracer.flush`.
+- Only for CI Visibility (`pytest` integration): remove traces whose root span is not a test.
+
+### Bug Fixes
+
+- Fix application crash on startup when using `channels >= 3.0`.
+- Fix parenting of Redis command spans when using aioredis 1.3. Redis spans should now be correctly attributed as child of any active parent spans.
+- Fixes incompatibility of wrapped aioredis pipelines in `async with` statements.
+- Fixes issue with aioredis when empty pool is not available and execute returns a coroutine instead of a future. When patch tries to add callback for the span using add_done_callback function it crashes because this function is only for futures.
+- Escape non-Unicode bytes when decoding aioredis args. This fixes a `UnicodeDecodeError` that can be thrown from the aioredis integration when interacting with binary-encoded data, as is done in channels-redis.
+- Ensure `gevent` is automatically patched.
+- grpc: ensure grpc.intercept_channel is unpatched properly
+- Fix JSON encoding error when a `bytes` string is used for span metadata.
+- Profiler raises a typing error when `Span.resource` is unicode on Python 2.7.
+- Fix a bug in the heap profiler that could be triggered if more than 2^16 memory items were freed during heap data collection.
+- Fix a possible bug in the heap memory profiler that could trigger an overflow when too many allocations were being tracked.
+- Fix an issue in the heap profiler where it would iterate on the wrong heap allocation tracker.
+- Pymongo instrumentation raises an AttributeError when `tracer.enabled == False`
+
+---
+
+## v0.57.0
+
+### Deprecation Notes
+
+- `ddtrace.sampler.DatadogSampler.default_sampler` property is deprecated and will be removed in 1.0.
+- `ddtrace.propagation.utils` has been deprecated and will be removed in version 1.0.
+
+### New Features
+
+- Add new environment variables to enable/disable django database and cache instrumentation.
+
+  `DD_DJANGO_INSTRUMENT_DATABASES`, `DD_DJANGO_INSTRUMENT_CACHES`
+
+- Add tracing support for the `aioredis` library. Version 1.3+ is fully supported.
+
+- Add django 4.0 support.
+
+- The profiler now automatically injects running greenlets as tasks into the main thread. They can be seen within the wall time profiles.
+
+### Bug Fixes
+
+- The thread safety of the custom buffered encoder was fixed in order to eliminate a potential cause of decoding errors of trace payloads (missing trace data) in the agent.
+- Fix handling of Python exceptions during trace encoding. The tracer will no longer silently fail to encode invalid span data and instead log an exception.
+- Fix error when calling `concurrent.futures.ThreadPoolExecutor.submit` with `fn` keyword argument.
+- Configure a writer thread in a child process after forking based on writer configuration from its parent process.
+- Only for CI Visibility (`pytest` integration): Fix calculation of pipeline URL for GitHub Actions.
+
+---
+
+## v0.56.0
+
+### Upgrade Notes
+
+- The aredis integration is now enabled by default.
+
+### Deprecation Notes
+
+- The contents of `monkey.py` have been moved into `_monkey.py` in an effort to internalize the module. Public methods have been imported back into `monkey.py` in order to retain compatibility, but monkey.py will be removed entirely in version 1.0.0.
+- The `ddtrace.utils` module and all of its submodules have been copied over into `ddtrace.internal` in an effort to internalize these modules. Their public counterparts will be removed entirely in version 1.0.0.
+
+### New Features
+
+- Profiling now supports tracing greenlets with gevent version prior to 1.3.
+- The heap profiler is now enabled by default.
+- Add yaaredis ≥ 2.0.0 support.
+
+### Bug Fixes
+
+- Fix Pyramid caller_package level issue which resulted in crashes when starting Pyramid applications. Level now left at default (2).
+- Set the correct package name in the Pyramid instrumentation. This should fix an issue where the incorrect package name was being used which would crash the application when trying to do relative imports within Pyramid (e.g. when including routes from a relative path).
+- Fix memory leak caused when the tracer is disabled.
+- Allow the elasticsearch service name to be overridden using the integration config or the DD_SERVICE_MAPPING environment variable.
+- Fixes parsing of `botocore` env variables to ensure they are parsed as booleans.
+- Ensure tornado spans are marked as an error if the response status code is 500 \<= x \< 600.
+
+---
+
+## v0.55.0
+
+### Upgrade Notes
+
+- Instead of using error constants from `ddtrace.ext.errors`. Use constants from `ddtrace.constants` module. For example: `ddtrace.ext.errors.ERROR_MSG` -\> `ddtrace.constants.ERROR_MSG`
+- Instead of using priority constants from `ddtrace.ext.priority`. Use constants from `ddtrace.constants` module. For Example:: `ddtrace.ext.priority.AUTO_KEEP` -\> `ddtrace.constants.AUTO_KEEP`
+- Instead of using system constants from `ddtrace.ext.system`. Use constants from `ddtrace.constants` module. For Example:: `ddtrace.ext.system.PID` -\> `ddtrace.constants.PID`
+
+### Deprecation Notes
+
+- Deprecate DATADOG_TRACE_AGENT_HOSTNAME, DATADOG_TRACE_AGENT_PORT, DATADOG_PRIORITY_SAMPLING, DATADOG_PATCH_MODULES in favor of their DD equivalents.
+
+  \[Deprecated environment variable\] \| \[Recommended environment variable\]
+
+  - For `DATADOG_TRACE_AGENT_HOSTNAME`, use `DD_AGENT_HOST`
+  - For `DATADOG_TRACE_AGENT_PORT` use `DD_AGENT_PORT`
+  - For `DATADOG_PRIORITY_SAMPLING`, [follow ingestion controls](https://docs.datadoghq.com/tracing/trace_retention_and_ingestion/#recommended-setting-the-global-ingestion-rate-to-100)
+  - For `DATADOG_PATCH_MODULES`, use `DD_PATCH_MODULES`
+
+- Moved `ddtrace.ext.errors` constants into the `ddtrace.constants` module. `ddtrace.ext.errors` will be removed in v1.0. Shorthand error constant (MSG,TYPE,STACK) in `ddtrace.ext.errors` will be removed in v1.0. Function `get_traceback()` in ddtrace.ext.errors is now deprecated and will be removed v1.0.
+
+- Moved `ddtrace.ext.priority` constants into `ddtrace.constants` module.
+
+- Moved `ddtrace.ext.system` constants into `ddtrace.constants` module.
+
+### New Features
+
+- Add aredis support \>= 1.1.0
+- Add automatic unix domain socket detection for Dogstatsd. The expected path for the socket is `/var/run/datadog/dsd.socket` which if exists, will be used instead of the previous UDP default, `udp://localhost:8125/`. To be used in conjunction with `dogstatsd_socket` in your `datadog.yaml` file, or the `DD_DOGSTATSD_SOCKET` environment variable set on the Datadog agent.
+- Add new `DD_TRACE_SAMPLING_RULES` environment variable to override default sampling rules. For Example:: `DD_TRACE_SAMPLING_RULES='[{"sample_rate":0.5,"service":"my-service"}]'`
+- Add support for [snowflake-connector-python](https://pypi.org/project/snowflake-connector-python/) \>= 2.0.0. Note that this integration is in beta and is not enabled by default. See the snowflake integration documentation for how to enable.
+- Only for CI Visibility (`pytest` integration): include `pytest` version as a tag in the test span.
+- Added official support for Python 3.10
+- Only for CI Visibility (`pytest` integration): Extract stage and job name from environment data in Azure Pipelines.
+
+### Bug Fixes
+
+- Fixes an issue where all Django function middleware will share the same resource name.
+- Fixed an issue with gevent worker processes that caused them to crash and stop.
+- Fixes exceptions raised when logging during tracer initialization when `DD_LOGS_INJECTION` is enabled.
+- The `ddtrace.utils.wrappers.unwrap` function now raises an error if trying to unwrap a non-wrapped object.
+- Only for CI Visibility (`pytest` integration): Fix extraction of branch in GitLab CI.
+
+---
+
+## v0.54.0
+
+### Deprecation Notes
+
+- Deprecate the DATADOG_ENV environment variable in favor of DD_ENV. The use of DD_ENV should follow [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging) recommendations.
+
+### New Features
+
+- Add automatic unix domain socket detection for traces. The expected path for the socket is `/var/run/datadog/apm.socket` which if exists, will be used instead of the previous http default, `http://localhost:8126/`. To be used in conjunction with `apm_config.receiver_socket` in your `datadog.yaml` file, or the `DD_APM_RECEIVER_SOCKET` environment variable set on the Datadog agent.
+- Update the --info command to be easier to read and provide more helpful information.
+- Add support for `DD_PROFILING_ENDPOINT_COLLECTION_ENABLED` env variable to disable endpoint name collection in profiler.
+- Add rq integration.
+- Tag traces with HTTP headers specified on the `DD_TRACE_HEADER_TAGS` environment variable. Value must be either comma or space separated. e.g. `Host:http.host,User-Agent,http.user_agent` or `referer:http.referer Content-Type:http.content_type`.
+
+### Bug Fixes
+
+- pytest: report exception details directly instead of through a <span class="title-ref">RuntimeWarning</span> exception.
+- Fixed the support for Celery workers that fork sub-processes with Python 3.6 and earlier versions.
+- Fix the reporting of the allocated memory and the number of allocations in the profiler.
+- Fixes cases in which the `test.status` tag of a test span from `pytest` would be missing because `pytest_runtest_makereport` hook is not run, like when `pytest` has an internal error.
+- Pin `protobuf` version to `<3.18` for Python \<=3.5 due to support being dropped.
+- Make sure that correct endpoint name collected for profiling.
+
+### Other Changes
+
+- Added runtime metrics status and sampling rules to start-up logs.
+
+---
+
+## v0.53.0
+
+### Upgrade Notes
+
+- Replace DD_TRACER_PARTIAL_FLUSH_ENABLED with DD_TRACE_PARTIAL_FLUSH_ENABLED Replace DD_TRACER_PARTIAL_FLUSH_MIN_SPANS with DD_TRACE_PARTIAL_FLUSH_MIN_SPANS
+
+### Deprecation Notes
+
+- The DD_TRACER_PARTIAL_FLUSH_ENABLED and DD_TRACER_PARTIAL_FLUSH_MIN_SPANS environment variables have been deprecated and will be removed in version 1.0 of the library.
+
+### New Features
+
+- The `ddtrace.Tracer.get_log_correlation_context` method has been added to replace `ddtrace.helpers.get_correlation_ids`. It now returns a dictionary which includes the current span's trace and span ids, as well as the configured service, version, and environment names.
+- The gevent tasks are now tracked by the threading lock events
+
+### Bug Fixes
+
+- Fixes an issue where a manually set `django.request` span resource would get overwritten by the integration.
+- Pin `setup_requires` dependency `setuptools_scm[toml]>=4,<6.1` to avoid breaking changes.
+- The profiler now updates the trace resource when capturing span information with the stack and lock collectors. That means that if the trace resource changes after the profiling events are created, the profiler samples will also be updated. This avoids having trace resource being empty when profiling, e.g., WSGI middleware.
+
+---
+
+## v0.52.0
+
+### Deprecation Notes
+
+- Removed the `collect_metrics` argument from `Tracer.configure`. See the release notes for v0.49.0 for the migration instructions.
+
+### New Features
+
+- Add tracing support for the `httpx` library. Supported versions `>=0.14.0`.
+
+- ASGI: store the ASGI span in the scope. The span can be retrieved with the
+  `ddtrace.contrib.asgi.span_from_scope` function.
+
+- Submit runtime metrics as distribution metrics instead of gauge metrics.
+
+- Support flask-caching (\>= 1.10.0) with the Flask-Cache tracer.
+
+- Only for CI Visibility (<span class="title-ref">pytest</span> integration): It is now possible to specify any of the following git metadata through environment variables:
+  - \`DD_GIT_REPOSITORY_URL\`: The url of the repository where the code is stored
+  - \`DD_GIT_TAG\`: The tag of the commit, if it has one
+  - \`DD_GIT_BRANCH\`: The branch where this commit belongs to
+  - \`DD_GIT_COMMIT_SHA\`: The commit hash of the current code
+  - \`DD_GIT_COMMIT_MESSAGE\`: Commit message
+  - \`DD_GIT_COMMIT_AUTHOR_NAME\`: Commit author name
+  - \`DD_GIT_COMMIT_AUTHOR_EMAIL\`: Commit author email
+  - \`DD_GIT_COMMIT_AUTHOR_DATE\`: The commit author date (ISO 8601)
+  - \`DD_GIT_COMMIT_COMMITTER_NAME\`: Commit committer name
+  - \`DD_GIT_COMMIT_COMMITTER_EMAIL\`: Commit committer email
+  - \`DD_GIT_COMMIT_COMMITTER_DATE\`: The commit committer date (ISO 8601)
+
+### Bug Fixes
+
+- ASGI: handle decoding errors when extracting headers for trace propagation.
+
+- Corrected some typing annotations for PEP 484 compliance
+
+- Django: add support for version 3.1+ ASGI applications. A different codepath is taken for requests starting in Django 3.1 which led to the top level span not being generated for requests. The fix introduces automatic installation of the ASGI middleware to trace Django requests.
+
+- dogpile.cache: handle both kwargs and args in the wrapper functions (using
+  only kwargs would result in an IndexError.
+
+- Fixes an issue with the Django integration where if the `urlconf` changes at any point during the handling of the request then the resource name will only be `<METHOD> 404`. This fix moves resource name resolution to the end of the request.
+
+- Fixes error with tagging non-string Flask view args.
+
+- `werkzeug.exceptions.NotFound` 404 errors are no longer raised and logged as a server error in the Flask integration.
+
+- Fixes type hinting for `**patch_modules` parameter for `patch`/`patch_all` functions.
+
+- Fixes an issue when using the pytest plugin with doctest which raises an `AttributeError` on `DoctestItem`.
+
+- Fixes a bug in the pytest plugin where xfail test cases in a test file with a module-wide skip raises attribute errors and are marked as xfail rather than skipped.
+
+- Fixed the handling of sanic endpoint paths with non-string arguments.
+
+- opentracer: don't override default tracing config for the <span class="title-ref">ENABLED</span>,
+  <span class="title-ref">AGENT_HOSTNAME</span>, <span class="title-ref">AGENT_HTTPS</span> or <span class="title-ref">AGENT_PORT</span> settings.
+
+---
+
+## v0.51.0
+
+### Upgrade Notes
+
+- The legacy Django configuration method (deprecated in 0.34) has been removed.
+- botocore: Update trace propagation format for directly invoked Lambda functions. This breaks compatibility with Lambda functions instrumented with datadog-lambda-python \< v41 or datadog-lambda-js \< v3.57.0. Please upgrade datadog-lambda-\* in invoked lambda functions, or engage legacy compatibility mode in one of two ways:
+  - ddtrace.config.botocore.invoke_with_legacy_context = True
+  - DD_BOTOCORE_INVOKE_WITH_LEGACY_CONTEXT=true
+
+### Deprecation Notes
+
+- `monkey.patch_module` is deprecated.
+- `monkey.get_patch_module` is deprecated.
+
+### New Features
+
+- Added support for `jinja2~=3.0.0`.
+- The pytest integration now uses the name of the repository being tested as the default test service name.
+- Added support for `aiopg~=0.16.0`.
+- Add MariaDB integration.
+- The profiler now exports active tasks for CPU and wall time profiles.
+
+### Bug Fixes
+
+- Fixes an issue with enabling the runtime worker introduced in v0.49.0 where no runtime metrics were sent to the agent.
+- Fix pymongo 3.12.0+ spans not being generated.
+- Fixed JSON encoding errors in the pytest plugin for parameterized tests with dictionary parameters with tuple keys. The pytest plugin now always JSON encodes the string representations of test parameters.
+- Fixed JSON encoding errors in the pytest plugin for parameterized tests with complex Python object parameters. The pytest plugin now defaults to encoding the string representations of non-JSON serializable test parameters.
+- Fix a possible NoneType error in the WSGI middleware start_response method.
+
+---
+
+## v0.50.0
+
+### Prelude
+
+Major changes to context management. See the upgrade section for the specifics. Note that only advanced users of the library should be affected by these changes. For the details please refer to the Context section of the docs: <https://ddtrace.readthedocs.io/en/v0.50.0/advanced_usage.html>
+
+### Deprecation Notes
+
+- The reuse of a tracer that has been shut down has been deprecated. A new tracer should be created for generating new traces.
+- The deprecated dbapi2 configuration has been removed. The integration-specific configuration should be used instead. Look at the v0.48.0 release notes for migration instructions.
+
+### Upgrade Notes
+
+- `ddtrace.contrib.asyncio`
+
+  - `AsyncioContextProvider` can now return and activate `None`, `Span` or `Context` objects.
+
+- `ddtrace.contrib.gevent`
+
+  - `GeventContextProvider` can now return and activate `None`, `Span` or `Context` objects.
+
+- `ddtrace.contrib.tornado`
+
+  - `TracerStackContext` can now return and activate `None`, `Span` or `Context` objects.
+
+- `ddtrace.context.Context` no longer maintains the active/current span state.
+
+  `get_current_root_span()` has been removed. Use `tracer.current_root_span()` instead. `get_current_span()` has been removed. Use `tracer.current_span()` instead. `add_span()` has been removed. To activate a span in an execution use `tracer.context_provider.activate()` instead. `close_span()` has been removed. To deactivate a span in an execution use `tracer.context_provider.activate()` instead.
+
+- `ddtrace.provider.BaseContextProvider` `active()` now returns `None`, `Span` or `Context` objects. `activate()` now accepts `None`, `Span` or `Context` objects.
+
+- `ddtrace.span.Span`
+
+  - `Span.context` will now return a `Context`
+
+- `ddtrace.tracer.Tracer` `tracer.get_call_context()` will now return a one-off `Context` reference. This is to maintain backwards compatibility with the API but the functionality differs slightly. `tracer.start_span()` passing a `span.context` for `child_of` no longer adds the strong `_parent` reference to the new span.
+
+- Support for MySQL-python has been removed.
+
+- Support for psycopg \< 2.7 has been removed.
+
+### New Features
+
+- Add `DD_CALL_BASIC_CONFIG={true,false}` environment variable to control whether `ddtrace` calls `logging.basicConfig`. By default when using `ddtrace-run` or running in debug mode `logging.basicConfig` is called to ensure there is always a root handler. This has compatibility issues for some logging configurations. `DD_CALL_BASIC_CONFIG=false` can be used to skip calling `logging.basicConfig`. The default value is `true` to maintain existing behavior.
+- agent: support URL with a base path
+- Automated context management should now work in all asynchronous frameworks that use `contextvars`.
+- `tracer.start_span()` now accepts an `activate` argument (default `False`) to allow manual context management.
+- `tracer.current_trace_context()` has been added to be used to access the trace context of the active trace.
+- A warning has been added to alert when gevent monkey patching is done after ddtrace has been imported.
+- Add support for Flask 2
+- Added retry logic to the tracer to mitigate potential networking issues, like timeouts or dropped connections.
+- Add new `DD_TRACE_AGENT_TIMEOUT_SECONDS` to override the default connection timeout used when sending data to the trace agent. The default is `2.0` seconds.
+- The CI tagging for the pytest plugin now includes OS and Python Runtime metadata including system architecture, platform, version, and Python runtime name and version.
+- Add new environment variables to configure the internal trace writer.
+
+  `DD_TRACE_WRITER_MAX_BUFFER_SIZE`, `DD_TRACE_WRITER_INTERVAL_SECONDS`, `DD_TRACE_WRITER_MAX_PAYLOAD_SIZE_BYTES`
+
+- The exception profiler now gathers and exports the traces and spans information.
+- The pytest plugin now includes support for automatically tagging spans with parameters in parameterized tests.
+- The Python heap profiler can now be enabled by setting the `DD_PROFILING_HEAP_ENABLED` environment variable to `1`.
+
+### Bug Fixes
+
+- The OpenTracing `tracer.start_span` method no longer activates spans.
+- Datadog active spans will no longer take precedence over OpenTracing active spans.
+- django: fix a bug where multiple database backends would not be instrumented.
+- django: fix a bug when postgres query is composable sql object.
+- A possible memory leak that occurs when tracing across a fork has been fixed. See <https://github.com/DataDog/dd-trace-py/pull/2497> for more information.
+- Fix double patching of `pymongo` client topology.
+- The shutdown task is re-registered when a tracer is reused after it has been shut down.
+- Fixed the optional argument of `Span.finish` to `Optional[float]` instead of `Optional[int]`.
+- Fixed the handling of the Django template name tag causing type errors.
+
+- Fixes an issue when trying to manually start the runtime metrics worker:
+
+      AttributeError: module 'ddtrace.internal.runtime' has no attribute 'runtime_metrics'
+
+- sanic: update instrumentation to support version 21.
+
+- Performance of the Celery integration has been improved.
+
+- Fix runtime-id and system.pid tags not being set on distributed traces.
+
+### Other Changes
+
+- The pytest plugin now includes git metadata tags including author name and email as well as commit message from CI provider environments.
+- The profiler won't be ignoring its own resource usage anymore and will report it in the profiles.
+- The botocore integration excludes AWS endpoint call parameters that have a name ending with `Body` from the set of span tags.
+
+---
+
+## v0.49.0
+
+### Prelude
+
+Several deprecations have been made to `Context` as we prepare to move active span management out of this class.
+
+### Upgrade Notes
+
+- Support for aiohttp previous to 2.0 has been removed.
+
+- Support for deprecated <span class="title-ref">DD_PROFILING_API_URL</span> environment variable has been removed. Use <span class="title-ref">DD_SITE</span> instead.
+
+- Support for deprecated <span class="title-ref">DD_PROFILING_API_KEY</span> environment variable has been removed. Use <span class="title-ref">DD_API_KEY</span> instead.
+
+- Profiling support for agentless mode must now be explicitly enabled.
+
+- The ddtrace pytest plugin can now label spans from test cases marked xfail with the tag "pytest.result"
+  and the reason for being marked xfail under the tag "pytest.xfail.reason".
+
+- Removed <span class="title-ref">ddtrace.ext.AppTypes</span> and its usages in the tracer library.
+
+- requests: spans will no longer inherit the service name from the parent.
+
+- The return value of `Span.pprint()` has been changed to a single line in the tracer debug logs rather than the previous custom multiline format.
+
+- Spans are now processed per tracer instance. Formerly spans were stored per-Context which could be shared between tracer instances. Note that context management is not affected. Tracers will still share active spans.
+
+- Spans from asynchronous executions (asyncio, gevent, tornado) will now be processed and flushed together. Formerly the spans were handled per-task.
+
+- `tracer.write()` will no longer have filters applied to the spans passed to it.
+
+- The function `ddtrace.utils.merge_dicts` has been removed.
+
+### Deprecation Notes
+
+- `Context.clone` is deprecated. It will not be required in 0.50.
+
+- `Context.add_span` is deprecated and will be removed in 0.50.
+
+- `Context.add_span` is deprecated and will be removed in 0.50.
+
+- `Context.close_span` is deprecated and will be removed in 0.50.
+
+- `Context.get_current_span` is deprecated and will be removed in 0.50 please use <span class="title-ref">Tracer.current_span</span> instead.
+
+- `Context.get_current_root_span` is deprecated and will be removed in 0.50 please use `Tracer.current_root_span` instead.
+
+- Deprecate the configuration of the analytics through the generic dbapi2 configuration. This should now be configured via integration configurations, for example:
+
+      # Before
+      export DD_TRACE_DBAPI2_ANALYTICS_ENABLED=1
+
+      # After
+      export DD_TRACE_SQLITE3_ANALYTICS_ENABLED=1
+
+- <span class="title-ref">ddtrace.compat</span> has been deprecated and will be removed from the public API in ddtrace version 1.0.0.
+
+- Deprecate <span class="title-ref">ddtrace.config.dbapi2</span> as default for <span class="title-ref">TracedCursor</span> and <span class="title-ref">TracedConnection</span> as well as <span class="title-ref">DD_DBAPI2_TRACE_FETCH_METHODS</span>. Use <span class="title-ref">IntegrationConfig</span> and <span class="title-ref">DD\_\<INTEGRATION\>\_TRACE_FETCH_METHODS</span> specific to each dbapi-compliant library. For example:
+
+      # Before
+      config.dbapi2.trace_fetch_methods = True
+
+      # After
+      config.psycopg2.trace_fetch_methods = True
+
+- The use of `ddtrace.encoding` has been deprecated and will be removed in version 1.0.0.
+
+- The <span class="title-ref">ddtrace.http</span> module has been deprecated and will be removed in version 1.0.0, with the <span class="title-ref">ddtrace.http.headers</span> module now merged into <span class="title-ref">ddtrace.trace_utils</span>.
+
+- The `collect_metrics` argument of the `tracer.configure` method has been deprecated. Runtime metrics should be enabled only via the `DD_RUNTIME_METRICS_ENABLED` environment variable.
+
+### New Features
+
+- The futures integration is now enabled by default.
+- requests: add global config support. This enables the requests service name to be configured with `ddtrace.config.requests['service']` or the `DD_REQUESTS_SERVICE` environment variable.
+
+### Bug Fixes
+
+- Fix broken builds for Python 2.7 on windows where `<stdint.h>` was not available. This change also ensures we build and publish `cp27-win` wheels.
+- CGroup file parsing was fixed to correctly parse container ID with preceding characters.
+- grpc: handle None values for span tags.
+- grpc: handle no package in fully qualified method
+- grpc: Add done callback in streaming response to avoid unfinished spans if a <span class="title-ref">StopIteration</span> is never raised, as is found in the Google Cloud libraries.
+- grpc: handle IPv6 addresses and no port in target.
+- Fix DD_LOGS_INJECTION incompatibility when using a `logging.StrFormatStyle` (`logging.Formatter(fmt, style="{")`) log formatter.
+- Fixed a bug that prevented the right integration name to be used when trying to patch a module on import that is already loaded.
+- Fix `urllib3` patching not properly activating the integration.
+- gRPC client spans are now marked as measured by default.
+- Fixes issue of unfinished spans when response is not a <span class="title-ref">grpc.Future</span> but has the same interface, as is the case with the base future class in <span class="title-ref">google-api-core</span>.
+- In certain circumstances, the profiles generated in a uWSGI application could have been empty. This is now fixed and the profiler records correctly the generated events.
+- The default agent timeout for profiling has been restored from 2 to 10 seconds to avoid too many profiles from being dropped.
+- Fix issue with missing traces when using `pymemcache.client.hash.HashClient`.
+- Added missing pymongo integration configuration, which allows overriding the service name for all the emitted spans.
+
+### Other Changes
+
+- Added environment variable <span class="title-ref">DD_BOTTLE_DISTRIBUTED_TRACING</span> to enable distributed tracing for bottle.
+- The <span class="title-ref">attrs</span> library has been unvendored and is now required as a normal Python dependency with a minimum version requirement of 19.2.0.
+- The <span class="title-ref">six</span> library has been removed from <span class="title-ref">vendor</span> and the system-wide version is being used. It requires version 1.12.0 or later.
+- Documentation on how to use Gunicorn with the `gevent` worker class has been added.
+- Added environment variable <span class="title-ref">DD_FALCON_DISTRIBUTED_TRACING</span> to enable distributed tracing for falcon.
+- When extracting context information from HTTP headers, a new context is created when the trace ID is either 0 or not available within the headers.
+- Added environment variable <span class="title-ref">DD_PYLONS_DISTRIBUTED_TRACING</span> to enable distributed tracing for pylons.
+- Update `pymemcache` test suite to test latest versions.
+- Added <span class="title-ref">config.pyramid.distributed_tracing</span> setting to integration config for pyramid.
+- The `ddtrace.payload` submodule has been removed.
+- Added environment variable <span class="title-ref">DD_TORNADO_DISTRIBUTED_TRACING</span> to enable distributed tracing for tornado.
+
+---
+
+## v0.48.0
+
+### Upgrade Notes
+
+- The deprecated <span class="title-ref">dogstatsd_host</span> and <span class="title-ref">dogstatsd_port</span> arguments to <span class="title-ref">tracer.configure()</span> have been removed.
+- Support for gevent 1.0 has been removed and gevent \>= 1.1 is required.
+- flask: deprecated configuration option <span class="title-ref">extra_error_codes</span> has been removed.
+- The deprecated `pyddprofile` wrapper has been removed. Use `ddtrace-run` with `DD_PROFILING_ENABLED=1` set instead.
+- A <span class="title-ref">ValueError</span> will now be raised on tracer initialization if the Agent URL specified to the initializer or with the environment variable <span class="title-ref">DD_TRACE_AGENT_URL</span> is malformed.
+- **uWSGI** is no longer supported with `ddtrace-run` due to a limitation of how tracer initialization occurs. See the updated instructions for enabling tracing in the library `uWSGI documentation<uwsgi>`.
+
+### New Features
+
+- dogpile.cache: is now automatically instrumented by default.
+- pylons: now supports all the standard http tagging including query string, custom error codes, and request/response headers.
+- The ddtrace pytest plugin can now call `ddtrace.patch_all` via the `--ddtrace-patch-all` option.
+- `Span` now accepts a `on_finish` argument used for specifying functions to call when a span finishes.
+- Adds support for the Datadog Lambda Extension. The tracer will send traces to the extension by default if it is present.
+- Add support for space-separated <span class="title-ref">DD_TAGS</span>.
+- urllib3: add urllib3 integration
+
+### Bug Fixes
+
+- The `Records` parameter to `Firehose` endpoint calls is being excluded from the tags to avoid generating traces with a large payload.
+- Tracer: fix configuring tracer with dogstatsd url.
+- elasticsearch: patch versioned elasticsearch modules (elasticsearch1, ..., elasticsearch7).
+- botocore: Do not assume that ResponseMeta exists in the results.
+- django: handle erroneous middleware gracefully.
+- The tracer now captures the task ID from the cgroups file for Fargate \>= 1.4.0 and reports it to the agent as the Datadog-Container-ID tag.
+- Fix a bug when tracing a mako `DefTemplate` or any `Template` that does not have a `filename` property.
+- flask: fix a bug when the query string would contain non-Unicode characters
+- Fix a formatting issue on error exporting profiles.
+- A workaround is provided for the problem with uWSGI worker processes failing to respawn. This can occur when using `ddtrace-run` for automatic instrumentation and configuration or manual instrumentation and configuration without the necessary uWSGI options. The problem is caused by how the tracer can end up starting threads in the master process before uWSGI forks to initialize the workers processes. To avoid this, we have provided updated instructions for enabling tracing in the library `uWSGI documentation<uwsgi>`.
+
+### Other Changes
+
+- The logic behind the header extraction for distributed tracing has been improved.
+- The default connection timeout for the profiling agent has now been reduced from 10 to 2 seconds to match the tracer behavior.
+- The tracemalloc memory profiler, which was disabled by default, has been removed.
+- Query strings are stripped out from URLs by default when setting URL metadata on a span. This change affects all integrations that store HTTP metadata, like aiohttp, falcon, requests, urllib3.
+
+---
+
+## v0.47.0
+
+### Upgrade Notes
+
+- elasticsearch: removed <span class="title-ref">get_traced_transport</span> method and <span class="title-ref">ddtrace.contrib.elasticsearch.transport</span> module.
+- The profiler now automatically sets up uWSGI compatibility in auto mode or with <span class="title-ref">profile_children=True</span>. Make sure that you don't have custom code instrumenting the profiler in those cases.
+- The `Tracer` class properties DEFAULT_HOSTNAME, DEFAULT_PORT, DEFAULT_DOGSTATSD_PORT, DEFAULT_DOGSTATSD_URL, DEFAULT_AGENT_URL have been removed.
+
+### New Features
+
+- cherrypy: introduce TraceMiddleware for the CherryPy web framework.
+- django: tag root spans as measured.
+- elasticsearch: add support for version 7.
+- fastapi: add integration.
+- Introduce support for the DD_SERVICE_MAPPING environment variable to allow remapping service names on emitted spans.
+- httplib: distributed tracing is now enabled by default.
+- The profiler now supports most operation mode from uWSGI without much configuration. It will automatically plug itself in post fork hooks when multiprocess mode is used.
+- wsgi: add tracing middleware.
+
+### Bug Fixes
+
+- Resolves an issue in Django tracing where, if <span class="title-ref">query_string</span> is not present in request.META, a KeyError is raised, causing the request to 500
+- Deprecate the DD_LOGGING_RATE_LIMIT variable in favor of the standard DD_TRACE_LOGGING_RATE for configuring the logging rate limit.
+- sampler: removed bug causing sample_rate of 0 to be reset to 1, and raise ValueError instead of logging.
+- starlette: unpatch calls correctly.
+- flask: fix memory leak of sampled out traces.
+- Fix CPU time and wall time profiling not ignoring the profiler tasks with gevent.
+
+### Other Changes
+
+- The default maximum CPU time used for the stack profiler (CPU time, wall time and exceptions profiling) has been decreased from 2% to 1%.
+
+---
+
+## v0.46.0
+
+### Upgrade Notes
+
+- The profiler will only load tags from the DD_TAGS environment variable once at start.
+
+### Deprecation Notes
+
+- flask: Use `HTTP Custom Error Codes <http-custom-error>` instead of `ddtrace.config.flask['extra_error_codes']`.
+
+### New Features
+
+- aiohttp: store request and response headers.
+- bottle: store request and response headers.
+- flask: store response headers.
+- molten: store request headers.
+- pyramid: store request and response headers.
+- flask: store request and response headers when auto-instrumented.
+- The <span class="title-ref">ddtrace.profiling.auto</span> module will warn users if gevent monkey patching is done after the profiler is auto-instrumented.
+- The <span class="title-ref">Profiler</span> object can now be passed tags with the <span class="title-ref">tags</span> keyword argument.
+
+### Bug Fixes
+
+- dbapi: avoid type error with potential non-compliance in db libraries when setting tag for row count.
+- django: add legacy resource format of <span class="title-ref">{handler}</span>.
+- grpc: fix wrapper for streaming response to support libraries that call an internal method directly.
+- sanic: use path parameter names instead of parameter values for the resource.
+- The profiler won't deadlock on fork when gevent monkey patch is enabled.
+- requests: fix TracedSession when patches are not applied.
+
+---
+
+## v0.45.0
+
+### Prelude
+
+Build and deploy Python 3.9 wheels for releases
+
+### Upgrade Notes
+
+- Context.get() has been removed and the functionality has been rolled into Context.close_span().
+- Tracer.record() has similarly been removed as it is no longer useful with Context.get() removed.
+- The deprecated compatibility module <span class="title-ref">ddtrace.profile</span> has been removed.
+- The profiler now uses the tracer configuration is no configuration is provided.
+
+### Deprecation Notes
+
+- The <span class="title-ref">pyddprofile</span> wrapper is deprecated. Use <span class="title-ref">DD_PROFILING_ENABLED=true ddtrace-run</span> instead.
+- The profiler does not catch uncaught exception anymore.
+
+### New Features
+
+- botocore: added <span class="title-ref">distributed_tracing</span> configuration setting which is enabled by default.
+
+- The ddtrace-run command now supports the following arguments:
+  -h, --help -d, --debug enable debug mode (disabled by default) -i, --info print library info useful for debugging -p, --profiling enable profiling (disabled by default) -v, --version show program's version number and exit
+
+  It now also has friendlier error messages when used incorrectly.
+
+- Add functionality to call gevent.monkey.patch_all() with ddtrace-run by setting the environment variable DD_GEVENT_PATCH_ALL=true. This ensures that gevent patching is done as early as possible in the application.
+
+- botocore: inject distributed tracing data to <span class="title-ref">ClientContext</span> to trace lambda invocations.
+
+- botocore: inject tracing data to <span class="title-ref">MessageAttributes</span>.
+
+- The profiler now tracks the running gevent Greenlet and store it as part of the CPU and wall time profiling information.
+
+- The profiler is now able to upload profiles to the Datadog Agent by using a Unix Domain Socket.
+
+- It is now possible to pass a <span class="title-ref">url</span> parameter to the <span class="title-ref">Profiler</span> to specify the Datadog agent location.
+
+- The new memory profiler for Python is now enabled by default. This improves the profiler memory consumption and performance impact. It can still be disabled by setting <span class="title-ref">DD_PROFILING_MEMALLOC=0</span> as an environment variable.
+
+- The profiler now uses the tracer configuration is no configuration is provided.
+
+- pytest integration. This enables the [pytest](https://pytest.org) runner to trace test executions.
+
+### Bug Fixes
+
+- core: always reset the current_span in the context.
+- django: Http404 exceptions will no longer be flagged as errors
+- django: add safe guards for building http.url span tag.
+- aiobotocore: set span error for 5xx status codes.
+- elasticsearch: set span error for 5xx status codes.
+- django, DRF, ASGI: fix span type for web request spans.
+- Fixes span id tagging in lock profiling.
+- Fix UDS upload for profiling not using the correct path.
+- Fixed an issue in profiling exporting profiles twice when forking.
+- core: fix race condition in TracerTagCollector.
+
+### Other Changes
+
+- Start-up logs are now disabled by default. To enable start-up logs use <span class="title-ref">DD_TRACE_STARTUP_LOGS=true</span> or <span class="title-ref">DD_TRACE_DEBUG=true</span>.
+
+---
+
+## v0.44.0
+
+### Prelude
+
+Add support for Python 3.9
+
+### New Features
+
+- Store request headers in Flask integration.
+- pyodbc integration. This enables the [pyodbc](https://github.com/mkleehammer/pyodbc) library to trace queries.
+- starlette integration resource aggregation This aggregates endpoints to the starlette application resource that was accessed. It occurs by default but it is configurable through config.starlette\["aggregate_resources"\].
+- The profiler now captures the traces information with the lock profiling.
+- The Profiler instances now restart automatically in child process when the main program is forked. This only works for Python ≥ 3.7.
+
+### Bug Fixes
+
+- dbapi: add support for connection context manager usage
+- django: check view before instrumenting MRO.
+- core: use loose types when encoding.
+- Patch pynamodb on import to prevent patching conflicts with gevent.
+- tornado: handle when the current span is None in log_exception().
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Changelogs beyond this version can be found at https://github.com/DataDog/dd-trace-py/releases
+Changelogs for versions not listed here can be found at https://github.com/DataDog/dd-trace-py/releases
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2321,6 +2321,32 @@ These modules have been removed. Many were moved to the internal interface as th
 
 ---
 
+## v0.51.3
+
+### Bug Fixes
+
+- Pin `setup_requires` dependency `setuptools_scm[toml]>=4,<6.1` to avoid breaking changes.
+
+---
+
+## v0.51.2
+
+### New Features
+
+- ASGI: store the ASGI span in the scope. The span can be retrieved with the
+  `ddtrace.contrib.asgi.span_from_scope` function.
+
+### Bug Fixes
+
+- ASGI: handle decoding errors when extracting headers for trace propagation.
+- Corrected some typing annotations for PEP 484 compliance
+- Django: add support for version 3.1+ ASGI applications. A different codepath is taken for requests starting in Django 3.1 which led to the top level span not being generated for requests. The fix introduces automatic installation of the ASGI middleware to trace Django requests.
+- Fixes error with tagging non-string Flask view args.
+- Fixes type hinting for `**patch_modules` parameter for `patch`/`patch_all` functions.
+- Fixes a bug in the pytest plugin where xfail test cases in a test file with a module-wide skip raises attribute errors and are marked as xfail rather than skipped.
+
+---
+
 ## v0.51.0
 
 ### Upgrade Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2074,6 +2074,48 @@ These modules have been removed. Many were moved to the internal interface as th
 
 ---
 
+## v0.58.5
+
+### Bug Fixes
+
+- tracing/internal: fix encoding of propagated internal tags.
+
+---
+
+## v0.58.4
+
+### Bug Fixes
+
+- Set correct service in logs correlation attributes when a span override the service.
+
+---
+
+## v0.58.3
+
+### Bug Fixes
+
+- Fixes build issues on older MacOS versions by updating `libddwaf` to 1.0.18
+
+---
+
+## v0.58.2
+
+### Bug Fixes
+
+- flask: fix resource naming of request span when errors occur in middleware.
+- pytest: fix unsafe access to xfail reason.
+
+---
+
+## v0.58.1
+
+### Bug Fixes
+
+- Fix internal import of deprecated `ddtrace.utils` module.
+- Fixes import path to not reference `__init__`. This could otherwise be a problem for `mypy`.
+
+---
+
 ## v0.58.0
 
 ### Deprecation Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1479,6 +1479,611 @@ Dynamic instrumentation allows instrumenting a running service dynamically to ex
 
 ---
 
+## v1.1.4
+
+### Bug Fixes
+
+- pin protobuf to version `>=3,<4` due to incompatibility with version `4.21`.
+
+---
+
+## v1.1.3
+
+### Bug Fixes
+
+- tracing: fix issue with `ddtrace-run` having the wrong priority order of tracer host/port/url env variable configuration.
+- sanic: Don't send non-500s error traces.
+- Fixes a performance issue with the profiler when used in an asyncio application.
+
+---
+
+## v1.1.2
+
+### Bug Fixes
+
+- profiling: implement `__aenter__` and `__aexit__` methods on `asyncio.Lock` wrapper.
+
+---
+
+## v1.1.1
+
+### Bug Fixes
+
+- internal: normalize header names in ASM
+
+- Set required header to indicate top level span computation is done in the client to the Datadog agent. This fixes an issue where spans were erroneously being marked as top level when partial flushing or in certain asynchronous applications.
+
+  The impact of this bug is the unintended computation of stats for non-top level spans.
+
+---
+
+## v1.1.0
+
+### Prelude
+
+The Datadog APM Python team is happy to announce the release of v1.0.0 of ddtrace. This release introduces a formal `versioning policy<versioning>` that simplifies the public `interface<versioning_interfaces>` and defines a `release version policy<versioning_release>` for backwards compatible and incompatible changes to the public interface.
+
+The v1.0.0 release is an important milestone for the library as it has grown substantially in scope. The first commit to the library was made on June 20, 2016. Nearly sixty minor releases later, the library now includes over sixty integrations for libraries. And the library has expanded from Tracing to support the Continuous Profiler and CI Visibility.
+
+<div class="important">
+
+<div class="title">
+
+Important
+
+</div>
+
+Before upgrading to v1.0.0, we recommend users install `ddtrace>=0.60.0,<1.0.0` and enable deprecation warnings. All removals to the library interface and environment variables were deprecated on 0.x branch. Consult `Upgrade 0.x<upgrade-0.x>` for recommendations on migrating from the 0.x release branch.
+
+</div>
+
+<div class="note">
+
+<div class="title">
+
+Note
+
+</div>
+
+The changes to environment variables apply only to the configuration of the ddtrace library and not the Datadog Agent.
+
+</div>
+
+#### Upgrading summary
+
+##### Functionality changes
+
+The default logging configuration functionality of `ddtrace-run` has changed to address conflicts with application logging configuration. See `note on the new default behavior<disable-basic-config-call-by-default>` and `note on deprecation<deprecate-basic-config-call>` for future removal.
+
+##### Removed legacy environment variables
+
+These environment variables have been removed. In all cases the same functionality is provided by other environment variables and replacements are provided as recommended actions for upgrading.
+
+| Variable                            | Replacement                        | Note                                   |
+|-------------------------------------|------------------------------------|----------------------------------------|
+| `DATADOG_` prefix                   | `DD_` prefix                       | `📝<remove-datadog-envs>`              |
+| `DATADOG_SERVICE_NAME`              | `DD_SERVICE`                       | `📝<remove-legacy-service-name-envs>`  |
+| `DD_LOGGING_RATE_LIMIT`             | `DD_TRACE_LOGGING_RATE`            | `📝<remove-logging-env>`               |
+| `DD_TRACER_PARTIAL_FLUSH_ENABLED`   | `DD_TRACE_PARTIAL_FLUSH_ENABLED`   | `📝<remove-partial-flush-enabled-env>` |
+| `DD_TRACER_PARTIAL_FLUSH_MIN_SPANS` | `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS` | `📝<remove-partial-flush-min-envs>`    |
+
+##### Removed legacy tracing interfaces
+
+These methods and module attributes have been removed. Where the same functionality is provided by a different public method or module attribute, a recommended action is provided for upgrading. In a few limited cases, because the interface was no longer used or had been moved to the internal interface, it was removed and so no action is provided for upgrading.
+
+| Module             | Method/Attribute           | Note                                  |
+|--------------------|----------------------------|---------------------------------------|
+| `ddtrace.context`  | `Context.clone`            | `📝<remove-clone-context>`            |
+| `ddtrace.pin`      | `Pin.app`                  | `📝<remove-pin-app>`                  |
+|                    | `Pin.app_type`             | `📝<remove-pin-apptype>`              |
+| `ddtrace.sampler`  | `Sampler.default_sampler`  | `📝<remove-default-sampler>`          |
+| `ddtrace.span`     | `Span.tracer`              | `📝<remove-span-tracer>`              |
+|                    | `Span.__init__(tracer=)`   | `📝<remove-span-init-tracer>`         |
+|                    | `Span.meta`                | `📝<remove-span-meta>`                |
+|                    | `Span.metrics`             | `📝<remove-span-metrics>`             |
+|                    | `Span.set_meta`            | `📝<remove-span-set-meta>`            |
+|                    | `Span.set_metas`           | `📝<remove-span-set-metas>`           |
+|                    | `Span.pprint`              | `📝<remove-span-pprint>`              |
+| `ddtrace.tracer`   | `Tracer.debug_logging`     | `📝<remove-tracer-debug-logging>`     |
+|                    | `Tracer.get_call_context`  | `📝<remove-tracer-get-call-context>`  |
+|                    | `Tracer.tags`              | `📝<remove-tracer-tags>`              |
+|                    | `Tracer.writer`            | `📝<remove-tracer-writer>`            |
+|                    | `Tracer.__call__`          | `📝<remove-tracer-call>`              |
+|                    | `Tracer.global_excepthook` | `📝<remove-tracer-global-excepthook>` |
+|                    | `Tracer.log`               | `📝<remove-tracer-log>`               |
+|                    | `Tracer.priority_sampler`  | `📝<remove-tracer-priority-sampler>`  |
+|                    | `Tracer.sampler`           | `📝<remove-tracer-sampler>`           |
+|                    | `Tracer.set_service_info`  | `📝<remove-tracer-set-service-info>`  |
+| `ddtrace.ext`      | `SpanTypes`                | `📝<remove-span-types-enum>`          |
+| `ddtrace.helpers`  | `get_correlation_ids`      | `📝<remove-helpers>`                  |
+| `ddtrace.settings` | `Config.HTTPServerConfig`  | `📝<remove-config-httpserver>`        |
+
+##### Removed legacy integration tracing
+
+These tracing functions in integrations were no longer used for automatic instrumentation so have been removed. Any manual instrumentation code in an application will need to be replaced with `ddtrace.patch_all` or `ddtrace.patch` when upgrading.
+
+| Module                        | Function/Class                          |                                          |
+|-------------------------------|-----------------------------------------|------------------------------------------|
+| `ddtrace.contrib.cassandra`   | `get_traced_cassandra`                  | `📝<remove-cassandra-traced>`            |
+| `ddtrace.contrib.celery`      | `patch_task`                            | `📝<remove-celery-patch-task>`           |
+| `ddtrace.contrib.celery`      | `unpatch_task`                          | `📝<remove-celery-unpatch-task>`         |
+| `ddtrace.contrib.flask`       | `middleware.TraceMiddleware`            | `📝<remove-flask-middleware>`            |
+| `ddtrace.contrib.mongoengine` | `trace_mongoengine`                     | `📝<remove-mongoengine-traced>`          |
+| `ddtrace.contrib.mysql`       | `get_traced_mysql_connection`           | `📝<remove-mysql-legacy>`                |
+| `ddtrace.contrib.psycopg`     | `connection_factory`                    | `📝<remove-psycopg-legacy>`              |
+| `ddtrace.contrib.pymongo`     | `patch.trace_mongo_client`              | `📝<remove-pymongo-client>`              |
+| `ddtrace.contrib.pymysql`     | `tracers.get_traced_pymysql_connection` | `📝<remove-pymysql-connection>`          |
+| `ddtrace.contrib.requests`    | `legacy`                                | `📝<remove-requests-legacy-distributed>` |
+| `ddtrace.contrib.redis`       | `tracers.get_traced_redis`              | `📝<remove-redis-traced>`                |
+| `ddtrace.contrib.redis`       | `tracers.get_traced_redis_from`         | `📝<remove-redis-traced-from>`           |
+| `ddtrace.contrib.sqlite3`     | `connection_factory`                    | `📝<remove-sqlite3-legacy>`              |
+
+##### Removed deprecated modules
+
+These modules have been removed. Many were moved to the internal interface as they were not intended to be used as part of the public interface. In these cases, no action is provided for upgrading. In a few cases, other modules are provided as alternatives to maintain functionality. See the notes for more information.
+
+| Module                      | Note                                   |
+|-----------------------------|----------------------------------------|
+| `ddtrace.compat`            | `📝<remove-ddtrace-compat>`            |
+| `ddtrace.contrib.util`      | `📝<remove-contrib-util>`              |
+| `ddtrace.encoding`          | `📝<remove-ddtrace-encoding>`          |
+| `ddtrace.ext.errors`        | `📝<remove-ext-errors>`                |
+| `ddtrace.ext.priority`      | `📝<remove-ext-priority>`              |
+| `ddtrace.ext.system`        | `📝<remove-ext-system>`                |
+| `ddtrace.http`              | `📝<remove-http>`                      |
+| `ddtrace.monkey`            | `📝<remove-ddtrace-monkey>`            |
+| `ddtrace.propagation.utils` | `📝<remove-ddtrace-propagation-utils>` |
+| `ddtrace.util`              | `📝<remove-ddtrace-util>`              |
+| `ddtrace.utils`             | `📝<remove-ddtrace-utils>`             |
+
+### New Features
+
+- Add `Span.get_tags` and `Span.get_metrics`.
+
+- aiohttp: add client integration. This integration traces requests made using the aiohttp client and includes support for distributed tracing. See [the documentation](https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp) for more information.
+
+- aiohttp_jinja2: move into new integration. Formerly the aiohttp_jinja2 instrumentation was enabled using the aiohttp integration. Use `patch(aiohttp_jinja2=True)` instead of `patch(aiohttp=True)`. To support legacy behavior `patch(aiohttp=True)` will still enable aiohttp_jinja2.
+
+- asyncpg: add integration supporting v0.18.0 and above. See `the docs<asyncpg>` for more information.
+
+- fastapi: add support for tracing `fastapi.routing.serialize_response`.
+
+  This will give an insight into how much time is spent calling `jsonable_encoder` within a given request. This does not provide visibility into how long it takes for `Response.render`/`json.dumps`.
+
+- Add support to reuse HTTP connections when sending trace payloads to the agent. This feature is disabled by default. Set `DD_TRACE_WRITER_REUSE_CONNECTIONS=true` to enable this feature.
+
+- MySQLdb: Added optional tracing for MySQLdb.connect, using the configuration option `here<mysqldb_config_trace_connect>`.
+
+- The profiler now supports profiling `asyncio.Lock` objects.
+
+- psycopg2: add option to enable tracing `psycopg2.connect` method.
+
+  See our `psycopg2` documentation for more information.
+
+- Add support for injecting and extracting B3 propagation headers.
+
+  See `DD_TRACE_PROPAGATION_STYLE_EXTRACT <dd-trace-propagation-style-extract>` and `DD_TRACE_PROPAGATION_STYLE_INJECT <dd-trace-propagation-style-inject>` configuration documentation to enable.
+
+### Upgrade Notes
+
+- <div id="remove-default-sampler">
+
+  The deprecated attribute `ddtrace.Sampler.default_sampler` is removed.
+
+  </div>
+
+- Spans started after `Tracer.shutdown()` has been called will no longer be sent to the Datadog Agent.
+
+- <div id="disable-basic-config-call-by-default">
+
+  Default value of `DD_CALL_BASIC_CONFIG` was updated from `True` to `False`. Call `logging.basicConfig()` to configure logging in your application.
+
+  </div>
+
+- aiohttp_jinja2: use `patch(aiohttp_jinja2=True)` instead of `patch(aiohttp=True)` for enabling/disabling the integration.
+
+- <div id="remove-config-httpserver">
+
+  `ddtrace.settings.Config.HTTPServerConfig` is removed.
+
+  </div>
+
+- <div id="remove-cassandra-traced">
+
+  cassandra: `get_traced_cassandra` is removed. Use `ddtrace.patch(cassandra=True)` or `ddtrace.patch_all()` instead.
+
+  </div>
+
+- <div id="remove-celery-patch-task">
+
+  celery: `ddtrace.contrib.celery.patch_task` is removed. Use `ddtrace.patch(celery=True)` or `ddtrace.patch_all()` instead.
+
+  </div>
+
+- <div id="remove-celery-unpatch-task">
+
+  celery: `ddtrace.contrib.celery.unpatch_task` is removed. Use `ddtrace.contrib.celery.unpatch()` instead.
+
+  </div>
+
+- <div id="remove-clone-context">
+
+  `ddrace.context.Context.clone` is removed. This is no longer needed since the tracer now supports asynchronous frameworks out of the box.
+
+  </div>
+
+- `ddtrace.constants.FILTERS_KEY` is removed.
+
+- `ddtrace.constants.NUMERIC_TAGS` is removed.
+
+- `ddtrace.constants.LOG_SPAN_KEY` is removed.
+
+- <div id="remove-contrib-util">
+
+  The deprecated module `ddtrace.contrib.util` is removed.
+
+  </div>
+
+- <div id="remove-ddtrace-compat">
+
+  The deprecated module `ddtrace.compat` is removed.
+
+  </div>
+
+- <div id="remove-ddtrace-encoding">
+
+  The deprecated module `ddtrace.encoding` is removed.
+
+  </div>
+
+- <div id="remove-http">
+
+  The deprecated modules `ddtrace.http` and `ddtrace.http.headers` are removed. Use `ddtrace.contrib.trace_utils.set_http_meta` to store request and response headers on a span.
+
+  </div>
+
+- <div id="remove-ddtrace-install-excepthooks">
+
+  Remove deprecated `ddtrace.install_excepthook`.
+
+  </div>
+
+- <div id="remove-ddtrace-uninstall-excepthooks">
+
+  Remove deprecated `ddtrace.uninstall_excepthook`.
+
+  </div>
+
+- <div id="remove-ddtrace-monkey">
+
+  The deprecated module `ddtrace.monkey` is removed. Use `ddtrace.patch <ddtrace.patch>` or `ddtrace.patch_all <ddtrace.patch_all>` instead.
+
+  </div>
+
+- <div id="remove-ddtrace-propagation-utils">
+
+  The deprecated module `ddtrace.propagation.utils` is removed.
+
+  </div>
+
+- <div id="remove-ddtrace-utils">
+
+  The deprecated module `ddtrace.utils` and its submodules are removed:
+  - `ddtrace.utils.attr`
+  - `ddtrace.utils.attrdict`
+  - `ddtrace.utils.cache`
+  - `ddtrace.utils.config`
+  - `ddtrace.utils.deprecation`
+  - `ddtrace.utils.formats`
+  - `ddtrace.utils.http`
+  - `ddtrace.utils.importlib`
+  - `ddtrace.utils.time`
+  - `ddtrace.utils.version`
+  - `ddtrace.utils.wrappers`
+
+  </div>
+
+- <div id="remove-tracer-sampler">
+
+  `ddtrace.Tracer.sampler` is removed.
+
+  </div>
+
+- <div id="remove-tracer-priority-sampler">
+
+  `ddtrace.Tracer.priority_sampler` is removed.
+
+  </div>
+
+- <div id="remove-tracer-tags">
+
+  `ddtrace.Tracer.tags` is removed. Use the environment variable `DD_TAGS<dd-tags>` to set the global tags instead.
+
+  </div>
+
+- <div id="remove-tracer-log">
+
+  `ddtrace.Tracer.log` was removed.
+
+  </div>
+
+- <div id="remove-ext-errors">
+
+  The deprecated module `ddtrace.ext.errors` is removed. Use the `ddtrace.constants` module instead:
+
+      from ddtrace.constants import ERROR_MSG
+      from ddtrace.constants import ERROR_STACK
+      from ddtrace.constants import ERROR_TYPE
+
+  </div>
+
+- <div id="remove-ext-priority">
+
+  The deprecated module `ddtrace.ext.priority` is removed. Use the `ddtrace.constants` module instead for setting sampling priority tags:
+
+      from ddtrace.constants import USER_KEEP
+      from ddtrace.constants import USER_REJECT
+
+  </div>
+
+- <div id="remove-ext-system">
+
+  The deprecated module `ddtrace.ext.system` is removed. Use `ddtrace.constants.PID` instead.
+
+  </div>
+
+- <div id="remove-helpers">
+
+  The deprecated method `ddtrace.helpers.get_correlation_ids` is removed. Use `ddtrace.Tracer.get_log_correlation_context` instead.
+
+  </div>
+
+- <div id="remove-legacy-service-name-envs">
+
+  The legacy environment variables `DD_SERVICE_NAME` and `DATADOG_SERVICE_NAME` are removed. Use `DD_SERVICE` instead.
+
+  </div>
+
+- <div id="remove-mongoengine-traced">
+
+  mongoengine: The deprecated method `ddtrace.contrib.mongoengine.trace_mongoengine` is removed. Use `ddtrace.patch(mongoengine=True)` or `ddtrace.patch()` instead.
+
+  </div>
+
+- <div id="remove-mysql-legacy">
+
+  mysql: The deprecated method `ddtrace.contrib.mysql.get_traced_mysql_connection` is removed. Use `ddtrace.patch(mysql=True)` or `ddtrace.patch_all()` instead.
+
+  </div>
+
+- <div id="remove-pin-app">
+
+  `Pin.app` is removed.
+
+  </div>
+
+- <div id="remove-pin-apptype">
+
+  `Pin.app_type` is removed.
+
+  </div>
+
+- <div id="remove-psycopg-legacy">
+
+  psycopg: `ddtrace.contrib.psycopg.connection_factory` is removed. Use `ddtrace.patch(psycopg=True)` or `ddtrace.patch_all()` instead.
+
+  </div>
+
+- <div id="remove-requests-legacy-distributed">
+
+  requests: The legacy distributed tracing configuration is removed. Use `ddtrace.config.requests['distributed_tracing']<requests-config-distributed-tracing>` instead.
+
+  </div>
+
+- <div id="remove-span-meta">
+
+  `ddtrace.Span.meta` is removed. Use `ddtrace.Span.get_tag` and `ddtrace.Span.set_tag` instead.
+
+  </div>
+
+- <div id="remove-span-metrics">
+
+  `ddtrace.Span.metrics` is removed. Use `ddtrace.Span.get_metric` and `ddtrace.Span.set_metric` instead.
+
+  </div>
+
+- <div id="remove-span-pprint">
+
+  `ddtrace.Span.pprint` is removed.
+
+  </div>
+
+- <div id="remove-span-set-meta">
+
+  `ddtrace.Span.set_meta` is removed. Use `ddtrace.Span.set_tag` instead.
+
+  </div>
+
+- <div id="remove-span-set-metas">
+
+  `ddtrace.Span.set_metas` is removed. Use `ddtrace.Span.set_tags` instead.
+
+  </div>
+
+- `Span.to_dict` is removed.
+
+- <div id="remove-span-tracer">
+
+  `Span.tracer` is removed.
+
+  </div>
+
+- <div id="remove-span-init-tracer">
+
+  The deprecated <span class="title-ref">tracer</span> argument is removed from `ddtrace.Span.__init__`.
+
+  </div>
+
+- <div id="remove-sqlite3-legacy">
+
+  sqlite3: `ddtrace.contrib.sqlite3.connection_factory` is removed. Use `ddtrace.patch(sqlite3=True)` or `ddtrace.patch_all()` instead.
+
+  </div>
+
+- <div id="remove-tracer-debug-logging">
+
+  Remove deprecated attribute `ddtrace.Tracer.debug_logging`. Set the logging level for the `ddtrace.tracer` logger instead:
+
+      import logging
+      log = logging.getLogger("ddtrace.tracer")
+      log.setLevel(logging.DEBUG)
+
+  </div>
+
+- <div id="remove-tracer-call">
+
+  `ddtrace.Tracer.__call__` is removed.
+
+  </div>
+
+- <div id="remove-tracer-global-excepthook">
+
+  `ddtrace.Tracer.global_excepthook` is removed.
+
+  </div>
+
+- <div id="remove-tracer-get-call-context">
+
+  `ddtrace.Tracer.get_call_context` is removed. Use `ddtrace.Tracer.current_trace_context` instead.
+
+  </div>
+
+- <div id="remove-tracer-set-service-info">
+
+  `ddtrace.Tracer.set_service_info` is removed.
+
+  </div>
+
+- <div id="remove-tracer-writer">
+
+  `ddtrace.Tracer.writer` is removed. To force flushing of buffered traces to the agent, use `ddtrace.Tracer.flush` instead.
+
+  </div>
+
+- `ddtrace.warnings.DDTraceDeprecationWarning` is removed.
+
+- `DD_TRACE_RAISE_DEPRECATIONWARNING` environment variable is removed.
+
+- <div id="remove-datadog-envs">
+
+  The environment variables prefixed with `DATADOG_` are removed. Use environment variables prefixed with `DD_` instead.
+
+  </div>
+
+- <div id="remove-logging-env">
+
+  The environment variable `DD_LOGGING_RATE_LIMIT` is removed. Use `DD_TRACE_LOGGING_RATE` instead.
+
+  </div>
+
+- <div id="remove-partial-flush-enabled-env">
+
+  The environment variable `DD_TRACER_PARTIAL_FLUSH_ENABLED` is removed. Use `DD_TRACE_PARTIAL_FLUSH_ENABLED` instead.
+
+  </div>
+
+- <div id="remove-partial-flush-min-envs">
+
+  The environment variable `DD_TRACER_PARTIAL_FLUSH_MIN_SPANS` is removed. Use `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS` instead.
+
+  </div>
+
+- <div id="remove-ddtrace-util">
+
+  `ddtrace.util` is removed.
+
+  </div>
+
+- <div id="remove-span-types-enum">
+
+  `ddtrace.ext.SpanTypes` is no longer an `Enum`. Use `SpanTypes.<TYPE>` instead of `SpanTypes.<TYPE>.value`.
+
+  </div>
+
+- `Tracer.write` has been removed.
+
+- <div id="remove-flask-middleware">
+
+  Removed deprecated middleware `ddtrace.contrib.flask.middleware.py:TraceMiddleware`. Use `ddtrace.patch_all` or `ddtrace.patch` instead.
+
+  </div>
+
+- <div id="remove-pymongo-client">
+
+  Removed deprecated function `ddtrace.contrib.pymongo.patch.py:trace_mongo_client`. Use `ddtrace.patch_all` or `ddtrace.patch` instead.
+
+  </div>
+
+- <div id="remove-pymysql-connection">
+
+  Removed deprecated function `ddtrace.contrib.pymysql.tracers.py:get_traced_pymysql_connection`. Use `ddtrace.patch_all` or `ddtrace.patch` instead.
+
+  </div>
+
+- <div id="remove-redis-traced">
+
+  Removed deprecated function `ddtrace.contrib.redis.tracers.py:get_traced_redis`. Use `ddtrace.patch_all` or `ddtrace.patch` instead.
+
+  </div>
+
+- <div id="remove-redis-traced-from">
+
+  Removed deprecated function `ddtrace.contrib.redis.tracers.py:get_traced_redis_from`. Use `ddtrace.patch_all` or `ddtrace.patch` instead.
+
+  </div>
+
+### Deprecation Notes
+
+- <div id="deprecate-basic-config-call">
+
+  `DD_CALL_BASIC_CONFIG` is deprecated.
+
+  </div>
+
+### Bug Fixes
+
+- Fixes deprecation warning for `asyncio.coroutine` decorator.
+
+- botocore: fix incorrect context propagation message attribute types for SNS. This addresses [Datadog/serverless-plugin-datadog#232](https://github.com/DataDog/serverless-plugin-datadog/issues/232)
+
+- aiohttp: fix issue causing `ddtrace.contrib.aiohttp_jinja2.patch` module to be imported instead of the `patch()` function.
+
+- botocore: omit `SecretBinary` and `SecretString` from span metadata for calls to Secrets Manager.
+
+- tracing/internal: fix encoding of propagated internal tags.
+
+- Fix issue building `ddtrace` from source on macOS 12.
+
+- Fix issue building `ddtrace` for the Pyston Python implementation by not building the `_memalloc` extension anymore when using Pyston.
+
+- `tracer.get_log_correlation_context()`: use active context in addition to
+  active span. Formerly just the span was used and this would break cross execution log correlation as a context object is used for the propagation.
+
+- opentracer: update `set_tag` and `set_operation_name` to return a
+  reference to the span to match the OpenTracing spec.
+
+- The CPU profiler now reports the main thread CPU usage even when asyncio tasks are running.
+
+- Fixes wrong numbers of memory allocation being reported in the memory profiler.
+
+- pymongo: fix `write_command` being patched with the wrong method signature.
+
+### Other Notes
+
+- tracing/internal: disable Datadog internal tag propagation
+
+---
+
 ## v1.0.3
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1479,7 +1479,38 @@ Dynamic instrumentation allows instrumenting a running service dynamically to ex
 
 ---
 
-## v1.1.0
+## v1.0.3
+
+### Bug Fixes
+
+- Set required header to indicate top level span computation is done in the client to the Datadog agent. This fixes an issue where spans were erroneously being marked as top level when partial flushing or in certain asynchronous applications.
+
+  The impact of this bug is the unintended computation of stats for non-top level spans.
+
+---
+
+## v1.0.2
+
+### Bug Fixes
+
+- Fixes deprecation warning for `asyncio.coroutine` decorator.
+
+---
+
+## v1.0.1
+
+### Bug Fixes
+
+- Fix issue building `ddtrace` for the Pyston Python implementation by not building the `_memalloc` extension anymore when using Pyston.
+
+- `tracer.get_log_correlation_context()`: use active context in addition to
+  active span. Formerly just the span was used and this would break cross execution log correlation as a context object is used for the propagation.
+
+- The CPU profiler now reports the main thread CPU usage even when asyncio tasks are running.
+
+---
+
+## v1.0.0
 
 ### Prelude
 
@@ -1597,6 +1628,13 @@ These modules have been removed. Many were moved to the internal interface as th
 | `ddtrace.propagation.utils` | `📝<remove-ddtrace-propagation-utils>` |
 | `ddtrace.util`              | `📝<remove-ddtrace-util>`              |
 | `ddtrace.utils`             | `📝<remove-ddtrace-utils>`             |
+
+### New Features
+
+- Add `Span.get_tags` and `Span.get_metrics`.
+- aiohttp: add client integration. This integration traces requests made using the aiohttp client and includes support for distributed tracing. See [the documentation](https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp) for more information.
+- aiohttp_jinja2: move into new integration. Formerly the aiohttp_jinja2 instrumentation was enabled using the aiohttp integration. Use `patch(aiohttp_jinja2=True)` instead of `patch(aiohttp=True)`. To support legacy behavior `patch(aiohttp=True)` will still enable aiohttp_jinja2.
+- asyncpg: add integration supporting v0.18.0 and above. See `the docs<asyncpg>` for more information.
 
 ### Upgrade Notes
 
@@ -1984,57 +2022,16 @@ These modules have been removed. Many were moved to the internal interface as th
 
   </div>
 
-### New Features
-
-- Add `Span.get_tags` and `Span.get_metrics`.
-
-- aiohttp: add client integration. This integration traces requests made using the aiohttp client and includes support for distributed tracing. See [the documentation](https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp) for more information.
-
-- aiohttp_jinja2: move into new integration. Formerly the aiohttp_jinja2 instrumentation was enabled using the aiohttp integration. Use `patch(aiohttp_jinja2=True)` instead of `patch(aiohttp=True)`. To support legacy behavior `patch(aiohttp=True)` will still enable aiohttp_jinja2.
-
-- asyncpg: add integration supporting v0.18.0 and above. See `the docs<asyncpg>` for more information.
-
-- fastapi: add support for tracing `fastapi.routing.serialize_response`.
-
-  This will give an insight into how much time is spent calling `jsonable_encoder` within a given request. This does not provide visibility into how long it takes for `Response.render`/`json.dumps`.
-
-- Add support to reuse HTTP connections when sending trace payloads to the agent. This feature is disabled by default. Set `DD_TRACE_WRITER_REUSE_CONNECTIONS=true` to enable this feature.
-
-- MySQLdb: Added optional tracing for MySQLdb.connect, using the configuration option `here<mysqldb_config_trace_connect>`.
-
-- The profiler now supports profiling `asyncio.Lock` objects.
-
-- Add support for injecting and extracting B3 propagation headers.
-
-  See `DD_TRACE_PROPAGATION_STYLE_EXTRACT <dd-trace-propagation-style-extract>` and `DD_TRACE_PROPAGATION_STYLE_INJECT <dd-trace-propagation-style-inject>` configuration documentation to enable.
-
 ### Bug Fixes
 
 - botocore: fix incorrect context propagation message attribute types for SNS. This addresses [Datadog/serverless-plugin-datadog#232](https://github.com/DataDog/serverless-plugin-datadog/issues/232)
-
 - aiohttp: fix issue causing `ddtrace.contrib.aiohttp_jinja2.patch` module to be imported instead of the `patch()` function.
-
-- botocore: omit `SecretBinary` and `SecretString` from span metadata for calls to Secrets Manager.
-
 - tracing/internal: fix encoding of propagated internal tags.
-
 - Fix issue building `ddtrace` from source on macOS 12.
-
-- Fix issue building `ddtrace` for the Pyston Python implementation by not building the `_memalloc` extension anymore when using Pyston.
-
-- `tracer.get_log_correlation_context()`: use active context in addition to
-  active span. Formerly just the span was used and this would break cross execution log correlation as a context object is used for the propagation.
-
-- opentracer: update `set_tag` and `set_operation_name` to return a
-  reference to the span to match the OpenTracing spec.
-
-- The CPU profiler now reports the main thread CPU usage even when asyncio tasks are running.
-
 - Fixes wrong numbers of memory allocation being reported in the memory profiler.
-
 - pymongo: fix `write_command` being patched with the wrong method signature.
 
-### Other Changes
+### Other Notes
 
 - tracing/internal: disable Datadog internal tag propagation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2554,6 +2554,52 @@ Several deprecations have been made to `Context` as we prepare to move active sp
 
 ---
 
+## v0.48.5
+
+### Bug Fixes
+
+- django: fix a bug where multiple database backends would not be instrumented.
+- django: fix a bug when postgres query is composable sql object.
+
+---
+
+## v0.48.4
+
+### Bug Fixes
+
+- grpc: handle None values for span tags.
+- grpc: Add done callback in streaming response to avoid unfinished spans if a <span class="title-ref">StopIteration</span> is never raised, as is found in the Google Cloud libraries.
+
+## v0.48.3
+
+---
+
+### Bug Fixes
+
+- grpc: handle no package in fully qualified method
+- grpc: handle IPv6 addresses and no port in target.
+- gRPC client spans are now marked as measured by default.
+- Fixes issue of unfinished spans when response is not a <span class="title-ref">grpc.Future</span> but has the same interface, as is the case with the base future class in <span class="title-ref">google-api-core</span>.
+
+## v0.48.2
+
+---
+
+### Bug Fixes
+
+- The default agent timeout for profiling has been restored from 2 to 10 seconds to avoid too many profiles from being dropped.
+
+---
+
+## v0.48.1
+
+### Bug Fixes
+
+- Fix `urllib3` patching not properly activating the integration.
+- In certain circumstances, the profiles generated in a uWSGI application could have been empty. This is now fixed and the profiler records correctly the generated events.
+
+---
+
 ## v0.48.0
 
 ### Upgrade Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2238,6 +2238,32 @@ These modules have been removed. Many were moved to the internal interface as th
 
 ---
 
+## v0.53.3
+
+### Bug Fixes
+
+- Fixes an issue where all Django function middleware will share the same resource name.
+
+---
+
+## v0.53.2
+
+### Bug Fixes
+
+- Fix the reporting of the allocated memory and the number of allocations in the profiler.
+
+---
+
+## v0.53.1
+
+### Bug Fixes
+
+- Fixed the support for Celery workers that fork sub-processes with Python 3.6 and earlier versions.
+- Fixes cases in which the `test.status` tag of a test span from `pytest` would be missing because `pytest_runtest_makereport` hook is not run, like when `pytest` has an internal error.
+- Pin `protobuf` version to `<3.18` for Python \<=3.5 due to support being dropped.
+
+---
+
 ## v0.53.0
 
 ### Upgrade Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2727,6 +2727,14 @@ Build and deploy Python 3.9 wheels for releases
 
 ---
 
+## v0.44.1
+
+### Bug Fixes
+
+- Fixes span id tagging in lock profiling.
+
+---
+
 ## v0.44.0
 
 ### Prelude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2444,6 +2444,43 @@ Major changes to context management. See the upgrade section for the specifics. 
 
 ---
 
+## v0.49.4
+
+### Bug Fixes
+
+- Fixes an issue when trying to manually start the runtime metrics worker:
+
+      AttributeError: module 'ddtrace.internal.runtime' has no attribute 'runtime_metrics'
+
+- Fixes an issue with enabling the runtime worker introduced in v0.49.0 where no runtime metrics were sent to the agent.
+
+---
+
+## v0.49.3
+
+### Bug Fixes
+
+- django: fix a bug where multiple database backends would not be instrumented.
+- django: fix a bug when postgres query is composable sql object.
+
+---
+
+## v0.49.2
+
+### Bug Fixes
+
+- Fix double patching of `pymongo` client topology.
+
+---
+
+## v0.49.1
+
+### New Features
+
+- Add support for Flask 2
+
+---
+
 ## v0.49.0
 
 ### Prelude


### PR DESCRIPTION
This change adds release notes for all currently extant x.x.0 releases, as well as some patch releases, to the single-file changelog. I did this with a lot of manual steps, but in the near future I hope to automate this process and include it in the release script.

Related to #7227

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
