### PR TITLE
fix(iast): avoid patching errors from stopping module load

### DIFF
--- a/ddtrace/appsec/_iast/_loader.py
+++ b/ddtrace/appsec/_iast/_loader.py
@@ -14,6 +14,7 @@ IS_IAST_ENABLED = _is_iast_enabled()
 
 def _exec_iast_patched_module(module_watchdog, module):
     patched_source = None
+    compiled_code = None
     if IS_IAST_ENABLED:
         try:
             module_path, patched_source = astpatch_module(module)
@@ -22,8 +23,15 @@ def _exec_iast_patched_module(module_watchdog, module):
             patched_source = None
 
     if patched_source:
+        try:
+            # Patched source is compiled in order to execute it
+            compiled_code = compile(patched_source, module_path, "exec")
+        except Exception:
+            log.debug("Unexpected exception while compiling patched code", exc_info=True)
+            compiled_code = None
+
+    if compiled_code:
         # Patched source is executed instead of original module
-        compiled_code = compile(patched_source, module_path, "exec")
         exec(compiled_code, module.__dict__)  # nosec B102
     elif module_watchdog.loader is not None:
         module_watchdog.loader.exec_module(module)

--- a/tests/appsec/iast/fixtures/loader.py
+++ b/tests/appsec/iast/fixtures/loader.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+
+def add(a, b):
+    return a + b

--- a/tests/appsec/iast/test_loader.py
+++ b/tests/appsec/iast/test_loader.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import importlib
+import sys
+
+import mock
+
+from tests.utils import override_env
+
+
+def setup():
+    import ddtrace.appsec._iast._loader
+
+    ddtrace.appsec._iast._loader.IS_IAST_ENABLED = True
+
+
+def test_patching_error():
+    """
+    When IAST is enabled and the loader fails to compile the module,
+    the module should still be imported successfully.
+    """
+
+    with override_env({"DD_IAST_ENABLED": "true"}), mock.patch(
+        "ddtrace.appsec._iast._loader.compile", side_effect=ValueError
+    ):
+        importlib.import_module("tests.appsec.iast.fixtures.loader")
+
+        assert "ddtrace.appsec._iast._taint_tracking.aspects" not in sys.modules.keys()


### PR DESCRIPTION
## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [ ] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
