### PR TITLE
ci: pin commitlint versions to <1.19.0 to fix error [backport 2.5]

### DIFF
--- a/.github/workflows/pr-name.yml
+++ b/.github/workflows/pr-name.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 16
       - name: Install dependencies
         run: |
-          npm install @commitlint/lint @commitlint/load @commitlint/config-conventional @actions/core
+          npm install @commitlint/lint@18.6.1 @commitlint/load@18.6.1 @commitlint/config-conventional@18.6.2 @actions/core
       - name: Lint PR name
         uses: actions/github-script@v6.4.1
         with:


### PR DESCRIPTION
commitlint 1.19.0 [was released
today](https://www.npmjs.com/package/commitlint?activeTab=versions) (February 27, 2024) and is likely causing this issue: https://github.com/DataDog/dd-trace-py/actions/runs/8068170404/job/22040283374?pr=8461.

This pins the version. The other option would be to know more about Node and do whatever the error is suggesting.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

(cherry picked from commit 826c602478e9a5a3bff39d40dc6236dcdfc5f849)