### PR TITLE
ci: honor xfails that happen in subprocess snapshot tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,6 +237,7 @@ def run_function_from_file(item, params=None):
 
             xfailed = "_pytest.outcomes.XFailed" in err and status == 1
             if xfailed:
+                pytest.xfail("subprocess test resulted in XFail")
                 return
 
             if status != expected_status:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,7 +235,7 @@ def run_function_from_file(item, params=None):
         def _subprocess_wrapper():
             out, err, status, _ = call_program(*args, env=env, cwd=cwd, timeout=timeout)
 
-            xfailed = "_pytest.outcomes.XFailed" in err and status == 1
+            xfailed = b"_pytest.outcomes.XFailed" in err and status == 1
             if xfailed:
                 pytest.xfail("subprocess test resulted in XFail")
                 return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,6 +235,10 @@ def run_function_from_file(item, params=None):
         def _subprocess_wrapper():
             out, err, status, _ = call_program(*args, env=env, cwd=cwd, timeout=timeout)
 
+            xfailed = "_pytest.outcomes.XFailed" in err and status == 1
+            if xfailed:
+                return
+
             if status != expected_status:
                 raise AssertionError(
                     "Expected status %s, got %s."


### PR DESCRIPTION
This pull request resolves failures like [this one](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/56935/workflows/ae60ef0e-2215-43e7-be75-004e35ad97f8/jobs/3610594) recently observed on main by propagating xfails that happen in subprocess tests back to the main pytest session.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
