### PR TITLE
chore(di): add probe location kind

### DIFF
--- a/ddtrace/debugging/_probe/model.py
+++ b/ddtrace/debugging/_probe/model.py
@@ -125,6 +125,11 @@ class ProbeConditionMixin(object):
         )
 
 
+class ProbeLocationKind(str, Enum):
+    LINE = "line"
+    FUNCTION = "method"
+
+
 @attr.s
 class ProbeLocationMixin(object):
     def location(self) -> Tuple[Optional[str], Optional[Union[str, int]]]:

--- a/ddtrace/debugging/_probe/remoteconfig.py
+++ b/ddtrace/debugging/_probe/remoteconfig.py
@@ -23,6 +23,7 @@ from ddtrace.debugging._probe.model import LogLineProbe
 from ddtrace.debugging._probe.model import MetricFunctionProbe
 from ddtrace.debugging._probe.model import MetricLineProbe
 from ddtrace.debugging._probe.model import Probe
+from ddtrace.debugging._probe.model import ProbeLocationKind
 from ddtrace.debugging._probe.model import ProbeType
 from ddtrace.debugging._probe.model import SpanDecoration
 from ddtrace.debugging._probe.model import SpanDecorationFunctionProbe
@@ -87,7 +88,7 @@ class ProbeFactory(object):
         cls.update_args(args, attribs)
 
         where = attribs["where"]
-        if where.get("sourceFile", None) is not None:
+        if where["kind"] == ProbeLocationKind.LINE:
             if cls.__line_class__ is None:
                 raise TypeError("Line probe type is not supported")
 

--- a/tests/debugging/probe/test_remoteconfig.py
+++ b/tests/debugging/probe/test_remoteconfig.py
@@ -9,6 +9,7 @@ from ddtrace.debugging._probe.model import DEFAULT_PROBE_RATE
 from ddtrace.debugging._probe.model import DEFAULT_SNAPSHOT_PROBE_RATE
 from ddtrace.debugging._probe.model import LogProbeMixin
 from ddtrace.debugging._probe.model import Probe
+from ddtrace.debugging._probe.model import ProbeLocationKind
 from ddtrace.debugging._probe.model import ProbeType
 from ddtrace.debugging._probe.remoteconfig import InvalidProbeConfiguration
 from ddtrace.debugging._probe.remoteconfig import ProbePollerEvent
@@ -165,7 +166,7 @@ def test_poller_remove_probe():
                 "type": ProbeType.SPAN_PROBE,
                 "active": True,
                 "tags": ["foo:bar"],
-                "where": {"type": "Stuff", "method": "foo"},
+                "where": {"kind": ProbeLocationKind.FUNCTION, "type": "Stuff", "method": "foo"},
                 "resource": "resourceX",
             },
             "",
@@ -211,7 +212,7 @@ def test_poller_remove_multiple_probe():
                 "type": ProbeType.SPAN_PROBE,
                 "active": True,
                 "tags": ["foo:bar"],
-                "where": {"type": "Stuff", "method": "foo"},
+                "where": {"kind": ProbeLocationKind.FUNCTION, "type": "Stuff", "method": "foo"},
                 "resource": "resourceX",
             },
             "",
@@ -224,7 +225,7 @@ def test_poller_remove_multiple_probe():
                 "type": ProbeType.SPAN_PROBE,
                 "active": True,
                 "tags": ["foo:bar"],
-                "where": {"type": "Stuff", "method": "foo"},
+                "where": {"kind": ProbeLocationKind.FUNCTION, "type": "Stuff", "method": "foo"},
                 "resource": "resourceX",
             },
             "",
@@ -369,7 +370,7 @@ def test_multiple_configs(remote_config_worker):
                 "type": ProbeType.SPAN_PROBE,
                 "active": True,
                 "tags": ["foo:bar"],
-                "where": {"type": "Stuff", "method": "foo"},
+                "where": {"kind": ProbeLocationKind.FUNCTION, "type": "Stuff", "method": "foo"},
                 "resource": "resourceX",
             },
             "",
@@ -387,7 +388,7 @@ def test_multiple_configs(remote_config_worker):
                 "version": 1,
                 "type": ProbeType.METRIC_PROBE,
                 "tags": ["foo:bar"],
-                "where": {"sourceFile": "tests/submod/stuff.p", "lines": ["36"]},
+                "where": {"kind": ProbeLocationKind.LINE, "sourceFile": "tests/submod/stuff.p", "lines": ["36"]},
                 "metricName": "test.counter",
                 "kind": "COUNTER",
             },
@@ -407,7 +408,7 @@ def test_multiple_configs(remote_config_worker):
                 "version": 1,
                 "type": ProbeType.LOG_PROBE,
                 "tags": ["foo:bar"],
-                "where": {"sourceFile": "tests/submod/stuff.p", "lines": ["36"]},
+                "where": {"kind": ProbeLocationKind.LINE, "sourceFile": "tests/submod/stuff.p", "lines": ["36"]},
                 "template": "hello {#foo}",
                 "segments:": [{"str": "hello "}, {"dsl": "foo", "json": "#foo"}],
             },
@@ -459,6 +460,7 @@ def test_log_probe_attributes_parsing():
             "type": ProbeType.LOG_PROBE,
             "language": "python",
             "where": {
+                "kind": ProbeLocationKind.LINE,
                 "sourceFile": "foo.py",
                 "lines": ["57"],
             },
@@ -488,7 +490,7 @@ def test_parse_log_probe_with_rate():
             "version": 0,
             "type": ProbeType.LOG_PROBE,
             "tags": ["foo:bar"],
-            "where": {"sourceFile": "tests/submod/stuff.p", "lines": ["36"]},
+            "where": {"kind": ProbeLocationKind.LINE, "sourceFile": "tests/submod/stuff.p", "lines": ["36"]},
             "template": "hello {#foo}",
             "segments:": [{"str": "hello "}, {"dsl": "foo", "json": "#foo"}],
             "sampling": {"snapshotsPerSecond": 1337},
@@ -505,7 +507,7 @@ def test_parse_log_probe_default_rates():
             "version": 0,
             "type": ProbeType.LOG_PROBE,
             "tags": ["foo:bar"],
-            "where": {"sourceFile": "tests/submod/stuff.p", "lines": ["36"]},
+            "where": {"kind": ProbeLocationKind.LINE, "sourceFile": "tests/submod/stuff.p", "lines": ["36"]},
             "template": "hello {#foo}",
             "segments:": [{"str": "hello "}, {"dsl": "foo", "json": "#foo"}],
             "captureSnapshot": True,
@@ -520,7 +522,7 @@ def test_parse_log_probe_default_rates():
             "version": 0,
             "type": ProbeType.LOG_PROBE,
             "tags": ["foo:bar"],
-            "where": {"sourceFile": "tests/submod/stuff.p", "lines": ["36"]},
+            "where": {"kind": ProbeLocationKind.LINE, "sourceFile": "tests/submod/stuff.p", "lines": ["36"]},
             "template": "hello {#foo}",
             "segments:": [{"str": "hello "}, {"dsl": "foo", "json": "#foo"}],
             "captureSnapshot": False,
@@ -538,7 +540,7 @@ def test_parse_metric_probe_with_probeid_tags():
             "version": 0,
             "type": ProbeType.METRIC_PROBE,
             "tags": ["foo:bar"],
-            "where": {"sourceFile": "tests/submod/stuff.p", "lines": ["36"]},
+            "where": {"kind": ProbeLocationKind.LINE, "sourceFile": "tests/submod/stuff.p", "lines": ["36"]},
             "metricName": "test.counter",
             "kind": "COUNTER",
         }


### PR DESCRIPTION
We add support for the new probe location kind field. This is used to replace the old logic of inferring the probe location kind on the basis of the property contents of the probe location attribute. Instead, we make the logic more robust by basing it on the value of the new extra field.

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [ ] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
