### PR TITLE
ci: remove ``pytest_ignore_collect`` hook

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -64,47 +64,6 @@ def pytest_configure(config):
         config.option.benchmark_save = str(time()).replace(".", "_") + gc + "_py%d_%d" % sys.version_info[:2]
 
 
-# Determine if the folder should be ignored
-# https://docs.pytest.org/en/3.10.1/reference.html#_pytest.hookspec.pytest_ignore_collect
-# DEV: We can only ignore folders/modules, we cannot ignore individual files
-# DEV: We must wrap with `@pytest.mark.hookwrapper` to inherit from default (e.g. honor `--ignore`)
-#      https://github.com/pytest-dev/pytest/issues/846#issuecomment-122129189
-@pytest.hookimpl(hookwrapper=True)
-def pytest_ignore_collect(path, config):
-    """
-    Skip directories defining a required minimum Python version
-
-    Example::
-
-        File: tests/contrib/vertica/py35/test.py
-        Python 2.7: Skip
-        Python 3.4: Skip
-        Python 3.5: Collect
-        Python 3.6: Collect
-    """
-    # Execute original behavior first
-    # DEV: We need to set `outcome.force_result(True)` if we need to override
-    #      these results and skip this directory
-    outcome = yield
-
-    # Was not ignored by default behavior
-    if not outcome.get_result():
-        # DEV: `path` is a `LocalPath`
-        path = str(path)
-        if not os.path.isdir(path):
-            path = os.path.dirname(path)
-        dirname = os.path.basename(path)
-
-        # Directory name match `py[23][0-9]`
-        if PY_DIR_PATTERN.match(dirname):
-            # Split out version numbers into a tuple: `py35` -> `(3, 5)`
-            min_required = tuple((int(v) for v in dirname.strip("py")))
-
-            # If the current Python version does not meet the minimum required, skip this directory
-            if sys.version_info[0:2] < min_required:
-                outcome.force_result(True)
-
-
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     # Attach the outcome of the test (failed, passed, skipped) to the test node so that fixtures


### PR DESCRIPTION
CI: Remove unused hook that is giving problems with pytest 8.1

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
