### PR TITLE
feat(llmobs): add tracer version as `ddtrace.version` tag

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -387,6 +387,7 @@ class LLMObsTraceProcessor(TraceProcessor):
             "service:{}".format(span.service or ""),
             "source:integration",
             "ml_app:{}".format(os.getenv("DD_LLMOBS_APP_NAME", "unnamed-ml-app")),
+            "ddtrace.version:{}".format(ddtrace.__version__),
             "error:%d" % span.error,
         ]
         err_type = span.get_tag(ERROR_TYPE)

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -2,6 +2,8 @@ import os
 
 import vcr
 
+import ddtrace
+
 
 logs_vcr = vcr.VCR(
     cassette_library_dir=os.path.join(os.path.dirname(__file__), "llmobs_cassettes/"),
@@ -22,6 +24,7 @@ def _expected_llmobs_tags(error=None, tags=None):
         "service:{}".format(tags.get("service", "")),
         "source:integration",
         "ml_app:{}".format(tags.get("ml_app", "unnamed-ml-app")),
+        "ddtrace.version:{}".format(ddtrace.__version__),
     ]
     if error:
         expected_tags.append("error:1")


### PR DESCRIPTION
This PR adds a `ddtrace.version` tag for each LLMObs span event submitted to LLMObs to track the tracer version.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [X] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
