### PR TITLE
chore(asm): improve api security import handling and refactor

### DIFF
--- a/ddtrace/appsec/_utils.py
+++ b/ddtrace/appsec/_utils.py
@@ -73,7 +73,7 @@ def _appsec_rc_features_is_enabled() -> bool:
 
 
 def _appsec_apisec_features_is_active() -> bool:
-    return asm_config._asm_enabled and asm_config._api_security_enabled
+    return asm_config._asm_libddwaf_available and asm_config._asm_enabled and asm_config._api_security_enabled
 
 
 def _safe_userid(user_id):

--- a/ddtrace/settings/asm.py
+++ b/ddtrace/settings/asm.py
@@ -114,3 +114,4 @@ if not config._asm_libddwaf_available:
     config._asm_enabled = False
     config._asm_can_be_enabled = False
     config._iast_enabled = False
+    config._api_security_enabled = False


### PR DESCRIPTION
Following https://github.com/DataDog/dd-trace-py/pull/8226, this PR ensure that we never import api security manager module if the WAF is unavailable or asm is disabled or api security is disabled.

Also refactor `_default_span_processors_factory` to use one argument instead of 10.


## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [ ] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
