### PR TITLE
fix(profiling): serialisable stack key [backport #8435 to 2.5]

### DIFF
--- a/ddtrace/profiling/exporter/pprof.pyx
+++ b/ddtrace/profiling/exporter/pprof.pyx
@@ -13,6 +13,7 @@ from ddtrace.internal import packages
 from ddtrace.internal._encoding import ListStringTable as _StringTable
 from ddtrace.internal.compat import ensure_text
 from ddtrace.internal.datadog.profiling.utils import sanitize_string
+from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import config
 from ddtrace.profiling import event
 from ddtrace.profiling import exporter
@@ -21,6 +22,9 @@ from ddtrace.profiling.collector import _lock
 from ddtrace.profiling.collector import memalloc
 from ddtrace.profiling.collector import stack_event
 from ddtrace.profiling.collector import threading
+
+
+log = get_logger(__name__)
 
 
 if hasattr(typing, "TypedDict"):
@@ -129,7 +133,10 @@ cdef groupby(object collection, object key):
     cdef dict groups = {}
 
     for item in collection:
-        groups.setdefault(key(item), []).append(item)
+        try:
+            groups.setdefault(key(item), []).append(item)
+        except Exception:
+            log.warning("Failed to group item %r", item, exc_info=True)
 
     return groups.items()
 

--- a/releasenotes/notes/fix-profiling-stack-event-data-dc50c8e7663718cc.yaml
+++ b/releasenotes/notes/fix-profiling-stack-event-data-dc50c8e7663718cc.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: handle unexpected stack data to prevent the profiler from
+    stopping.


### PR DESCRIPTION
Backport of #8435 to 2.5

Ensure that the stack key used to group events is actually hashable.

## Testing strategy

This is an attempt to mitigate #8218, for which we don't have a reproducer. Should the issue occur again, we should be able to act on any future reports with the extra context that this proposed change provides.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
