### PR TITLE
fix(setup): reduce static TLS consumption

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/CMakeLists.txt
+++ b/ddtrace/appsec/_iast/_taint_tracking/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_CXX_STANDARD 17)
 # -U_FORTIFY_SOURCE to fix a bug in alpine and pybind11
 # https://github.com/pybind/pybind11/issues/1650
 # https://gitlab.alpinelinux.org/alpine/aports/-/issues/8626
-add_compile_options(-fPIC -fexceptions -fvisibility=hidden -fpermissive -pthread -Wall -Wno-unknown-pragmas -U_FORTIFY_SOURCE)
+add_compile_options(-fPIC -fexceptions -fvisibility=hidden -fpermissive -pthread -Wall -Wno-unknown-pragmas -U_FORTIFY_SOURCE -ftls-model=global-dynamic)
 
 if(BUILD_MACOS)
     # https://pybind11.readthedocs.io/en/stable/compiling.html#building-manually

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/CMakeLists.txt
@@ -36,6 +36,9 @@ add_ddup_config(dd_wrapper)
 # and overall binary size.
 target_compile_features(dd_wrapper PUBLIC cxx_std_17)
 
+# Limit the TLS model in everything we build.
+add_compile_options(-ftls-model=global-dynamic
+
 # Statically link libstdc++ to avoid manylinux2014 conflicts
 target_link_options(dd_wrapper PRIVATE -static-libstdc++)
 

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/CMakeLists.txt
@@ -37,7 +37,7 @@ add_ddup_config(dd_wrapper)
 target_compile_features(dd_wrapper PUBLIC cxx_std_17)
 
 # Limit the TLS model in everything we build.
-add_compile_options(-ftls-model=global-dynamic
+add_compile_options(-ftls-model=global-dynamic)
 
 # Statically link libstdc++ to avoid manylinux2014 conflicts
 target_link_options(dd_wrapper PRIVATE -static-libstdc++)

--- a/ddtrace/internal/datadog/profiling/ddup/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/ddup/CMakeLists.txt
@@ -51,6 +51,11 @@ target_compile_options(${EXTENSION_NAME} PRIVATE
   "$<$<CONFIG:Release>:-Os>"
   -ffunction-sections -fno-semantic-interposition
 )
+
+# Set TLS model to global-dynamic for everything we build
+add_compile_options(-ftls-model=global-dynamic)
+
+
 target_link_options(${EXTENSION_NAME} PRIVATE
   "$<$<CONFIG:Release>:-s>"
   -Wl,--as-needed -Wl,-Bsymbolic-functions -Wl,--gc-sections

--- a/ddtrace/internal/datadog/profiling/stack_v2/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/stack_v2/CMakeLists.txt
@@ -51,6 +51,9 @@ add_cppcheck_target(${EXTENSION_NAME}
   SRC ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
+# Reduce static TLS for everyone
+add_compile_option(-ftls-model=global-dynamic)
+
 # This project is build with C++17, even though the underlying repo adheres to the manylinux 2014 standard.
 # This isn't currently a problem, but if it becomes one, we may have to structure the library differently.
 target_compile_features(${EXTENSION_NAME} PUBLIC cxx_std_17)

--- a/ddtrace/internal/datadog/profiling/stack_v2/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/stack_v2/CMakeLists.txt
@@ -52,7 +52,7 @@ add_cppcheck_target(${EXTENSION_NAME}
 )
 
 # Reduce static TLS for everyone
-add_compile_option(-ftls-model=global-dynamic)
+add_compile_options(-ftls-model=global-dynamic)
 
 # This project is build with C++17, even though the underlying repo adheres to the manylinux 2014 standard.
 # This isn't currently a problem, but if it becomes one, we may have to structure the library differently.

--- a/releasenotes/notes/reduce-static-tls-use-b7ff651f75392dfa.yaml
+++ b/releasenotes/notes/reduce-static-tls-use-b7ff651f75392dfa.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    various: This fix improves the static TLS usage of native extensions.


### PR DESCRIPTION
As reported in #8616, it's possible for Python libraries (and their transitive dependencies) to exhaust the static TLS block created during startup of the Python process.

In the general case, `ddtrace` has no control over dynamic libraries we bring in (for example, libc or libstdc++), but we can at least reduce what we do consume.

For the interested, I wrote some analysis and an almost-useful auditing script [here](https://github.com/sanchda/systems_experiments/tree/main/static_tls).

This PR adjusts global compile options in our affected extensions to use a different flavor of TLS when possible.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
