### PR TITLE
fix(tracing): fix context cloning

### DIFF
--- a/ddtrace/_trace/context.py
+++ b/ddtrace/_trace/context.py
@@ -116,7 +116,7 @@ class Context(object):
             lock=self._lock,
             baggage=self._baggage,
             span_links=self._span_links,
-            is_remote=self._is_remote,
+            is_remote=False,
         )
 
     def _update_tags(self, span):

--- a/tests/tracer/test_context.py
+++ b/tests/tracer/test_context.py
@@ -372,12 +372,12 @@ def test_is_remote():
     ctx = Context(trace_id=123, span_id=321)
     assert ctx._is_remote is True
 
-    # is_remote should be set to False in the context of a local span
+    # Span.context.is_remote should ALWAYS evaluate to False.
     local_span = Span("span_with_context", context=ctx)
     local_span.context.trace_id = 123
     local_span.context.span_id = 321
     local_span.context._is_remote = False
 
-    # is_remote should be False on root spans
+    # is_remote should be set to False on root spans.
     root = Span("root")
     assert root.context._is_remote is False

--- a/tests/tracer/test_context.py
+++ b/tests/tracer/test_context.py
@@ -86,8 +86,8 @@ def test_traceparent_basic():
     "context",
     [
         Context(),
-        Context(trace_id=123, span_id=321),
-        Context(trace_id=123, span_id=321, dd_origin="synthetics", sampling_priority=2),
+        Context(trace_id=123, span_id=321, is_remote=True),
+        Context(trace_id=123, span_id=321, dd_origin="synthetics", sampling_priority=2, is_remote=False),
         Context(trace_id=123, span_id=321, meta={"meta": "value"}, metrics={"metric": 4.556}),
         Context(
             trace_id=123,
@@ -363,3 +363,21 @@ def test_tracestate(context, expected_tracestate):
 def test_dd_origin_character_set(ctx, expected_dd_origin):
     # type: (Context,Optional[str]) -> None
     assert ctx.dd_origin == expected_dd_origin
+
+
+def test_is_remote():
+    # type: () -> None
+    """Ensure that the is_remote flag is set to False on all local spans"""
+    # Context._is_remote should be True by default
+    ctx = Context(trace_id=123, span_id=321)
+    assert ctx._is_remote is True
+
+    # is_remote should be set to False in the context of a local span
+    local_span = Span("span_with_context", context=ctx)
+    local_span.context.trace_id = 123
+    local_span.context.span_id = 321
+    local_span.context._is_remote = False
+
+    # is_remote should be False on root spans
+    root = Span("root")
+    assert root.context._is_remote is False

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -454,13 +454,14 @@ def test_last_dd_span_id():
     assert local_root.get_tag(LAST_DD_PARENT_ID_KEY) == "123067aa0ba902a6"
     for span in (root, child1, chunk_root):
         assert span.get_tag(LAST_DD_PARENT_ID_KEY) is None
-    # `p` value in tracestate is set using the current active datadog span
+    # `p` value in tracestate headers is set using the current active datadog span
+    for span in (child1, chunk_root, root, local_root):
+        headers = {}
+        HTTPPropagator.inject(span.context, headers)
+        assert "p:{:016x}".format(span.span_id) in headers["tracestate"]
+    # If a Datadog span is not active, `p` value is set to the last datadog span in the trace
     headers = {}
-    HTTPPropagator.inject(root.context, headers)
-    assert "p:{:016x}".format(root.span_id) in headers["tracestate"]
-    # `p` value is set to the last datadog span in the trace (via non_dd_remote_context's tracestate)
-    headers = {}
-    HTTPPropagator.inject(local_root.context, headers)
+    HTTPPropagator.inject(non_dd_remote_context, headers)
     assert "p:123067aa0ba902a6" in headers["tracestate"]
 
 

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -352,6 +352,7 @@ class TracerTestCases(TracerTestCase):
         ctx = self.tracer.current_trace_context()
         assert ctx.trace_id == span.trace_id
         assert ctx.span_id == span.span_id
+        assert ctx._is_remote is False
 
     def test_tracer_current_span(self):
         # the current span is in the local Context()


### PR DESCRIPTION
Currently `Context._is_remote` is set to `True` on ALL child spans. This is incorrect. 

FIX: When copying a Context object from a parent span to a child span ensure is_remote is set to `False`!

This regression was introduced in: https://github.com/DataDog/dd-trace-py/commit/90a3e3fed47763abf64cb4c04c6a32f5c64076cb. This bug is unreleased and does not require a release note.

`isRemote` is an OpenTelemetry concept and it's expected behavior is described here: https://opentelemetry.io/docs/specs/otel/trace/api/#isremote

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
