### PR TITLE
fix(asm): fix comment about waf timeout in asm settings

### DIFF
--- a/ddtrace/settings/asm.py
+++ b/ddtrace/settings/asm.py
@@ -63,7 +63,7 @@ class ASMConfig(Env):
         "DD_APPSEC_WAF_TIMEOUT",
         default=DEFAULT.WAF_TIMEOUT,
         help_type=float,
-        help="Timeout in microseconds for WAF computations",
+        help="Timeout in milliseconds for WAF computations",
     )
 
     _iast_redaction_enabled = Env.var(bool, "DD_IAST_REDACTION_ENABLED", default=True)


### PR DESCRIPTION
Values provided by the user for waf timeout are in milliseconds.

- default value is 5 milliseconds defined in [`ddtrace/appsec/_constants.py` ligne 207](https://github.com/DataDog/dd-trace-py/blob/e4d3f7f687078b98f043dcd3e070dd131dd064ed/ddtrace/appsec/_constants.py#L207)
- timeout is converted to microseconds in [`ddtrace/appsec/_ddwaf/__init__.py` ligne 163](https://github.com/DataDog/dd-trace-py/blob/e4d3f7f687078b98f043dcd3e070dd131dd064ed/ddtrace/appsec/_ddwaf/__init__.py#L163)

This PR fix the faulty comment in asm settings.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
