### PR TITLE
ci: fix amd64 testrunner build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,7 +76,7 @@ RUN git clone --depth 1 --branch v2.3.33 https://github.com/pyenv/pyenv "${PYENV
   && cd -
 
 RUN if [ "$TARGETARCH" = "amd64" ]; \
-    then curl -L https://github.com/pypa/hatch/releases/download/hatch-v${HATCH_VERSION} hatch-${HATCH_VERSION}-x86_64-unknown-linux-gnu.tar.gz | tar zx; \
+    then curl -L https://github.com/pypa/hatch/releases/download/hatch-v${HATCH_VERSION}/hatch-${HATCH_VERSION}-x86_64-unknown-linux-gnu.tar.gz | tar zx; \
     else curl -L https://github.com/pypa/hatch/releases/download/hatch-v${HATCH_VERSION}/hatch-${HATCH_VERSION}-aarch64-unknown-linux-gnu.tar.gz | tar zx; \
     fi \
   && mv hatch-${HATCH_VERSION}-* hatch \


### PR DESCRIPTION
This fixes the change from #7888 so the testrunner image is properly built for amd64.

See error:

https://github.com/DataDog/dd-trace-py/actions/runs/7264375897/job/19791778138#step:6:5816
 
## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
