### PR TITLE
chore(di): migrate to isDefined

### DIFF
--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -1218,9 +1218,14 @@ def test_debugger_exception_conditional_function_probe():
                 dsl="expr.__class__.__name__ == 'Exception'",
                 callable=dd_compile(
                     {
-                        "eq": [
-                            {"getmember": [{"getmember": [{"ref": "@exception"}, "__class__"]}, "__name__"]},
-                            "Exception",
+                        "and": [
+                            {"isDefined": "@exception"},
+                            {
+                                "eq": [
+                                    {"getmember": [{"getmember": [{"ref": "@exception"}, "__class__"]}, "__name__"]},
+                                    "Exception",
+                                ]
+                            },
                         ]
                     }
                 ),

--- a/tests/debugging/test_expressions.py
+++ b/tests/debugging/test_expressions.py
@@ -102,8 +102,8 @@ class CustomDict(dict):
         # Test literal values
         (42, {}, 42),
         (True, {}, True),
-        ({"isUndefined": "foobar"}, {"bar": 42}, True),
-        ({"isUndefined": "bar"}, {"bar": 42}, False),
+        ({"isDefined": "foobar"}, {"bar": 42}, False),
+        ({"isDefined": "bar"}, {"bar": 42}, True),
     ],
 )
 def test_parse_expressions(ast, _locals, value):


### PR DESCRIPTION
The implementation of the `isUndefined` operator has been migrated to its negated form `isDefined` in the language spec. We update the implementation of the expression language accordingly.

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [ ] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
