### PR TITLE
chore(di): implement instanceof operator

### DIFF
--- a/ddtrace/debugging/_expressions.py
+++ b/ddtrace/debugging/_expressions.py
@@ -58,6 +58,24 @@ IN_OPERATOR_INSTR = Instr("COMPARE_OP", Compare.IN) if PY < (3, 9) else Instr("C
 NOT_IN_OPERATOR_INSTR = Instr("COMPARE_OP", Compare.NOT_IN) if PY < (3, 9) else Instr("CONTAINS_OP", 1)
 
 
+def instanceof(value: Any, type_qname: str) -> bool:
+    try:
+        # Try with a built-in type first
+        return isinstance(value, __builtins__[type_qname])  # type: ignore[index]
+    except KeyError:
+        # Otherwise we expect a fully qualified name
+        try:
+            for c in object.__getattribute__(type(value), "__mro__"):
+                module = object.__getattribute__(c, "__module__")
+                qualname = object.__getattribute__(c, "__qualname__")
+                if f"{module}.{qualname}" == type_qname:
+                    return True
+        except AttributeError:
+            log.debug("Failed to check instanceof %s for value of type %s", type_qname, type(value))
+
+    return False
+
+
 class DDCompiler:
     @classmethod
     def __getmember__(cls, o, a):
@@ -228,13 +246,13 @@ class DDCompiler:
 
     def _compile_arg_operation(self, ast: DDASTType) -> Optional[List[Instr]]:
         # arg_operation  =>  {"<arg_op_type>": [<argument_list>]}
-        # arg_op_type    =>  filter | substring
+        # arg_op_type    =>  filter | substring | getmember | index | instanceof
         if not isinstance(ast, dict):
             return None
 
         _type, args = next(iter(ast.items()))
 
-        if _type not in {"filter", "substring", "getmember", "index"}:
+        if _type not in {"filter", "substring", "getmember", "index", "instanceof"}:
             return None
 
         if _type == "substring":
@@ -282,6 +300,16 @@ class DDCompiler:
             if not ci:
                 return None
             return self._call_function(self.__index__, cv, ci)
+
+        if _type == "instanceof":
+            v, t = args
+            cv = self._compile_predicate(v)
+            if not cv:
+                return None
+            ct = self._compile_predicate(t)
+            if not ct:
+                return None
+            return self._call_function(instanceof, cv, ct)
 
         return None
 

--- a/tests/debugging/test_expressions.py
+++ b/tests/debugging/test_expressions.py
@@ -104,6 +104,13 @@ class CustomDict(dict):
         (True, {}, True),
         ({"isUndefined": "foobar"}, {"bar": 42}, True),
         ({"isUndefined": "bar"}, {"bar": 42}, False),
+        ({"instanceof": [{"ref": "bar"}, "int"]}, {"bar": 42}, True),
+        ({"instanceof": [{"ref": "bar"}, "BaseException"]}, {"bar": RuntimeError()}, True),
+        (
+            {"instanceof": [{"ref": "bar"}, f"{CustomObject.__module__}.{CustomObject.__qualname__}"]},
+            {"bar": CustomObject("foo")},
+            True,
+        ),
     ],
 )
 def test_parse_expressions(ast, _locals, value):


### PR DESCRIPTION
We implement the instanceof operator for the DI expression language to determine if a value is of a given type.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
