### PR TITLE
chore(asm): improve logic of api security manager

### DIFF
--- a/ddtrace/appsec/_api_security/api_manager.py
+++ b/ddtrace/appsec/_api_security/api_manager.py
@@ -150,7 +150,7 @@ class APIManager(Service):
         except Exception:
             log.debug("Failed to enrich request span with headers", exc_info=True)
 
-        waf_payload = {}
+        waf_payload = {"PROCESSOR_SETTINGS": {"extract-schema": True}}
         for address, _, transform in self.COLLECTED:
             if not asm_config._api_security_parse_response_body and address == "RESPONSE_BODY":
                 continue
@@ -161,28 +161,27 @@ class APIManager(Service):
             if transform is not None:
                 value = transform(value)
             waf_payload[address] = value
-        if waf_payload:
-            waf_payload["PROCESSOR_SETTINGS"] = {"extract-schema": True}
-            result = call_waf_callback(waf_payload)
-            if result is None:
-                return
-            for meta, schema in result.derivatives.items():
-                b64_gzip_content = b""
-                try:
-                    b64_gzip_content = base64.b64encode(
-                        gzip.compress(json.dumps(schema, separators=",:").encode())
-                    ).decode()
-                    if len(b64_gzip_content) >= MAX_SPAN_META_VALUE_LEN:
-                        raise TooLargeSchemaException
-                    root._meta[meta] = b64_gzip_content
-                except Exception as e:
-                    self._schema_meter.increment("errors", tags={"exc": e.__class__.__name__, "address": address})
-                    self._log_limiter.limit(
-                        log.warning,
-                        "Failed to get schema from %r [schema length=%d]:\n%s",
-                        address,
-                        len(b64_gzip_content),
-                        repr(value)[:256],
-                        exc_info=True,
-                    )
+
+        result = call_waf_callback(waf_payload)
+        if result is None:
+            return
+        for meta, schema in result.derivatives.items():
+            b64_gzip_content = b""
+            try:
+                b64_gzip_content = base64.b64encode(
+                    gzip.compress(json.dumps(schema, separators=",:").encode())
+                ).decode()
+                if len(b64_gzip_content) >= MAX_SPAN_META_VALUE_LEN:
+                    raise TooLargeSchemaException
+                root._meta[meta] = b64_gzip_content
+            except Exception as e:
+                self._schema_meter.increment("errors", tags={"exc": e.__class__.__name__, "address": address})
+                self._log_limiter.limit(
+                    log.warning,
+                    "Failed to get schema from %r [schema length=%d]:\n%s",
+                    address,
+                    len(b64_gzip_content),
+                    repr(value)[:256],
+                    exc_info=True,
+                )
         self._schema_meter.increment("spans")


### PR DESCRIPTION
We moved from a "maybe we need" to "we always need" in the api security schema computation in the api security manager, the logic should reflect that.

- ensure that we always do the computation, even if all addresses are already in the context.

(This PR does not change the default behaviour of the tracer, but, later,  if we use response body in the waf context for another feature before api security, we don't want api security to be disabled because of that).

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
