### PR TITLE
fix(telemetry): always send heartbeats [backport 2.6]

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -706,9 +706,8 @@ class TelemetryWriter(PeriodicService):
             if newly_imported_deps:
                 self._update_dependencies_event(newly_imported_deps)
 
-        if not self._events_queue:
-            # Optimization: only queue heartbeat if no other events are queued
-            self._app_heartbeat_event()
+        # Send a heartbeat event to the agent, this is required to keep RC connections alive
+        self._app_heartbeat_event()
 
         telemetry_events = self._flush_events_queue()
         for telemetry_event in telemetry_events:

--- a/releasenotes/notes/elemetry-always-send-heartbeats-a133f02ba2f5bb6e.yaml
+++ b/releasenotes/notes/elemetry-always-send-heartbeats-a133f02ba2f5bb6e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    internal telemetry: Ensures heartbeat events are sent at regular intervals even when no other events are being sent.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -390,6 +390,11 @@ def remote_config_worker():
 
 
 @pytest.fixture
+def filter_heartbeat_events():
+    yield True
+
+
+@pytest.fixture
 def telemetry_writer():
     telemetry_writer = TelemetryWriter(is_periodic=False)
     telemetry_writer.enable()
@@ -397,7 +402,6 @@ def telemetry_writer():
     # main telemetry_writer must be disabled to avoid conflicts with the test telemetry_writer
     try:
         ddtrace.internal.telemetry.telemetry_writer.disable()
-
         with mock.patch("ddtrace.internal.telemetry.telemetry_writer", telemetry_writer):
             yield telemetry_writer
 
@@ -408,9 +412,10 @@ def telemetry_writer():
 
 
 class TelemetryTestSession(object):
-    def __init__(self, token, telemetry_writer) -> None:
+    def __init__(self, token, telemetry_writer, filter_heartbeats) -> None:
         self.token = token
         self.telemetry_writer = telemetry_writer
+        self.filter_heartbeats = filter_heartbeats
 
     def create_connection(self):
         parsed = parse.urlparse(self.telemetry_writer._client._agent_url)
@@ -439,7 +444,7 @@ class TelemetryTestSession(object):
             pytest.fail("Failed to clear session: %s" % self.token)
         return True
 
-    def get_requests(self):
+    def get_requests(self, request_type=None):
         """Get a list of the requests sent to the test agent
 
         Results are in reverse order by ``seq_id``
@@ -448,14 +453,19 @@ class TelemetryTestSession(object):
 
         if status != 200:
             pytest.fail("Failed to fetch session requests: %s %s %s" % (self.create_connection(), status, self.token))
-        requests = json.loads(body.decode("utf-8"))
-        for req in requests:
+        requests = []
+        for req in json.loads(body.decode("utf-8")):
             body_str = base64.b64decode(req["body"]).decode("utf-8")
             req["body"] = json.loads(body_str)
+            # filter heartbeat requests to reduce noise
+            if req["body"]["request_type"] == "app-heartbeat" and self.filter_heartbeats:
+                continue
+            if request_type is None or req["body"]["request_type"] == request_type:
+                requests.append(req)
 
         return sorted(requests, key=lambda r: r["body"]["seq_id"], reverse=True)
 
-    def get_events(self):
+    def get_events(self, event_type=None):
         """Get a list of the event payloads sent to the test agent
 
         Results are in reverse order by ``seq_id``
@@ -463,17 +473,25 @@ class TelemetryTestSession(object):
         status, body = self._request("GET", "/test/session/apmtelemetry?test_session_token=%s" % self.token)
         if status != 200:
             pytest.fail("Failed to fetch session events: %s" % self.token)
-        return sorted(json.loads(body.decode("utf-8")), key=lambda e: e["seq_id"], reverse=True)
+
+        requests = []
+        for req in json.loads(body.decode("utf-8")):
+            # filter heartbeat events to reduce noise
+            if req.get("request_type") == "app-heartbeat" and self.filter_heartbeats:
+                continue
+            if event_type is None or req["request_type"] == event_type:
+                requests.append(req)
+        return sorted(requests, key=lambda e: e["seq_id"], reverse=True)
 
 
 @pytest.fixture
-def test_agent_session(telemetry_writer, request):
-    # type: (TelemetryWriter, Any) -> Generator[TelemetryTestSession, None, None]
+def test_agent_session(telemetry_writer, filter_heartbeat_events, request):
+    # type: (TelemetryWriter, bool, Any) -> Generator[TelemetryTestSession, None, None]
     token = request_token(request) + "".join(random.choices("abcdefghijklmnopqrstuvwxyz", k=32))
     telemetry_writer._restart_sequence()
     telemetry_writer._client._headers["X-Datadog-Test-Session-Token"] = token
 
-    requests = TelemetryTestSession(token, telemetry_writer)
+    requests = TelemetryTestSession(token, telemetry_writer, filter_heartbeat_events)
 
     conn = requests.create_connection()
     MAX_RETRY = 9

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -129,6 +129,7 @@ else:
     assert requests[1]["body"]["request_type"] == "app-started"
 
 
+@flaky(1735812000)
 def test_enable_fork_heartbeat(test_agent_session, run_python_code_in_subprocess):
     """assert app-heartbeat events are only sent in parent process when no other events are queued"""
     code = """


### PR DESCRIPTION
The python instrumentation telemetry client only sends heartbeats events if no other telemetry events are queued. This behavior does not align with other client libraries. Heartbeat events should be sent every 60 seconds.

This keeps the service active in the Datadog UI.

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

---------

Co-authored-by: Federico Mon <federico.mon@datadoghq.com>
(cherry picked from commit 18a7e49dd44706dbf4f3b5d2f27194dc629755eb)