### PR TITLE
ci: resolve failing flask framework tests [backport 2.5]

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -332,6 +332,7 @@ jobs:
         # test_exception_propagation is broken upstream
         run: |
           source .tox/py38/bin/activate
+          pip install "pytest<8.1"
           pip install ../ddtrace
           pip install -e .
           pip install --upgrade MarkupSafe==2.0.1


### PR DESCRIPTION
Pytest v8.1.1 updated how warnings are validated and this breaks the flask v1.1.4 test suite:
https://docs.pytest.org/en/stable/changelog.html#pytest-8-1-1-2024-03-08

This PR pins pytest to a compatible version.

TODO: Upgrade the flask version used in framework tests

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

---------

Co-authored-by: Christophe Papazian <114495376+christophe-papazian@users.noreply.github.com>
(cherry picked from commit 699f92678db2a7d35e6b5968ec8d106e02c4466a)
