### PR TITLE
feat(llmobs): make DD_LLMOBS_APP_NAME required

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -1,4 +1,3 @@
-DEFAULT_ML_APP_NAME = "unnamed-ml-app"
 SPAN_KIND = "_ml_obs.meta.span.kind"
 SESSION_ID = "_ml_obs.session_id"
 METRICS = "_ml_obs.metrics"

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -552,6 +552,7 @@ class Config(object):
 
         self._llmobs_enabled = asbool(os.getenv("DD_LLMOBS_ENABLED", False))
         self._llmobs_sample_rate = float(os.getenv("DD_LLMOBS_SAMPLE_RATE", 1.0))
+        self._llmobs_ml_app = os.getenv("DD_LLMOBS_APP_NAME")
 
     def __getattr__(self, name) -> Any:
         if name in self._config:

--- a/tests/contrib/botocore/test_bedrock.py
+++ b/tests/contrib/botocore/test_bedrock.py
@@ -398,7 +398,9 @@ def test_readlines_error(bedrock_client, request_vcr):
                 response.get("body").readlines()
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0)])
+@pytest.mark.parametrize(
+    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
+)
 class TestLLMObsBedrock:
     @staticmethod
     def _expected_llmobs_calls(span, n_output):
@@ -422,7 +424,7 @@ class TestLLMObsBedrock:
                         "completion_tokens": completion_tokens,
                         "total_tokens": prompt_tokens + completion_tokens,
                     },
-                    tags={"service": "aws.bedrock-runtime", "ml_app": "aws.bedrock-runtime"},
+                    tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>"},
                 )
             )
         ]
@@ -579,7 +581,7 @@ class TestLLMObsBedrock:
                     error=span.get_tag("error.type"),
                     error_message=span.get_tag("error.message"),
                     error_stack=span.get_tag("error.stack"),
-                    tags={"service": "aws.bedrock-runtime", "ml_app": "aws.bedrock-runtime"},
+                    tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>"},
                 )
             ),
         ]

--- a/tests/contrib/openai/test_openai_v0.py
+++ b/tests/contrib/openai/test_openai_v0.py
@@ -2183,7 +2183,9 @@ with get_openai_vcr(subdirectory_name="v0").use_cassette("completion.yaml"):
         assert err == b""
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0)])
+@pytest.mark.parametrize(
+    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
+)
 def test_llmobs_completion(openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer):
     """Ensure llmobs records are emitted for completion endpoints when configured.
 
@@ -2208,13 +2210,16 @@ def test_llmobs_completion(openai_vcr, openai, ddtrace_global_config, mock_llmob
                     output_messages=[{"content": ", relax!” I said to my laptop"}, {"content": " (1"}],
                     parameters={"temperature": 0.8, "max_tokens": 10},
                     token_metrics={"prompt_tokens": 2, "completion_tokens": 12, "total_tokens": 14},
+                    tags={"ml_app": "<ml-app-name>"},
                 )
             ),
         ]
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0)])
+@pytest.mark.parametrize(
+    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
+)
 def test_llmobs_completion_stream(openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer):
     with openai_vcr.use_cassette("completion_streamed.yaml"):
         model = "ada"
@@ -2236,13 +2241,16 @@ def test_llmobs_completion_stream(openai_vcr, openai, ddtrace_global_config, moc
                     output_messages=[{"content": expected_completion}],
                     parameters={"temperature": 0},
                     token_metrics={"prompt_tokens": 2, "completion_tokens": 16, "total_tokens": 18},
+                    tags={"ml_app": "<ml-app-name>"},
                 ),
             ),
         ]
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0)])
+@pytest.mark.parametrize(
+    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
+)
 def test_llmobs_chat_completion(openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer):
     """Ensure llmobs records are emitted for chat completion endpoints when configured.
 
@@ -2281,13 +2289,16 @@ def test_llmobs_chat_completion(openai_vcr, openai, ddtrace_global_config, mock_
                     ],
                     parameters={"temperature": 0},
                     token_metrics={"prompt_tokens": 57, "completion_tokens": 34, "total_tokens": 91},
+                    tags={"ml_app": "<ml-app-name>"},
                 )
             ),
         ]
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0)])
+@pytest.mark.parametrize(
+    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
+)
 async def test_llmobs_chat_completion_stream(
     openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer
 ):
@@ -2326,13 +2337,16 @@ async def test_llmobs_chat_completion_stream(
                     output_messages=[{"content": expected_completion, "role": "assistant"}],
                     parameters={"temperature": 0},
                     token_metrics={"prompt_tokens": 8, "completion_tokens": 12, "total_tokens": 20},
+                    tags={"ml_app": "<ml-app-name>"},
                 )
             ),
         ]
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0)])
+@pytest.mark.parametrize(
+    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
+)
 def test_llmobs_chat_completion_function_call(
     openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer
 ):
@@ -2362,13 +2376,16 @@ def test_llmobs_chat_completion_function_call(
                     output_messages=[{"content": resp.choices[0].message.function_call.arguments, "role": "assistant"}],
                     parameters={"temperature": 0},
                     token_metrics={"prompt_tokens": 157, "completion_tokens": 57, "total_tokens": 214},
+                    tags={"ml_app": "<ml-app-name>"},
                 )
             ),
         ]
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0)])
+@pytest.mark.parametrize(
+    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
+)
 def test_llmobs_chat_completion_function_call_stream(
     openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer
 ):
@@ -2405,13 +2422,16 @@ def test_llmobs_chat_completion_function_call_stream(
                     output_messages=[{"content": expected_output, "role": "assistant"}],
                     parameters={"temperature": 0},
                     token_metrics={"prompt_tokens": 63, "completion_tokens": 33, "total_tokens": 96},
+                    tags={"ml_app": "<ml-app-name>"},
                 )
             ),
         ]
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0)])
+@pytest.mark.parametrize(
+    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
+)
 def test_llmobs_completion_error(openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer):
     """Ensure erroneous llmobs records are emitted for completion endpoints when configured."""
     with pytest.raises(Exception):
@@ -2437,13 +2457,16 @@ def test_llmobs_completion_error(openai_vcr, openai, ddtrace_global_config, mock
                     error="openai.error.AuthenticationError",
                     error_message="Incorrect API key provided: <not-a-r****key>. You can find your API key at https://platform.openai.com/account/api-keys.",  # noqa: E501
                     error_stack=span.get_tag("error.stack"),
+                    tags={"ml_app": "<ml-app-name>"},
                 )
             ),
         ]
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0)])
+@pytest.mark.parametrize(
+    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
+)
 def test_llmobs_chat_completion_error(openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer):
     """Ensure erroneous llmobs records are emitted for chat completion endpoints when configured."""
     if not hasattr(openai, "ChatCompletion"):
@@ -2481,6 +2504,7 @@ def test_llmobs_chat_completion_error(openai_vcr, openai, ddtrace_global_config,
                     error="openai.error.AuthenticationError",
                     error_message="Incorrect API key provided: <not-a-r****key>. You can find your API key at https://platform.openai.com/account/api-keys.",  # noqa: E501
                     error_stack=span.get_tag("error.stack"),
+                    tags={"ml_app": "<ml-app-name>"},
                 )
             ),
         ]

--- a/tests/contrib/openai/test_openai_v1.py
+++ b/tests/contrib/openai/test_openai_v1.py
@@ -1859,7 +1859,9 @@ with get_openai_vcr(subdirectory_name="v1").use_cassette("completion.yaml"):
         assert err == b""
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0)])
+@pytest.mark.parametrize(
+    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
+)
 def test_llmobs_completion(openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer):
     """Ensure llmobs records are emitted for completion endpoints when configured.
 
@@ -1891,13 +1893,16 @@ def test_llmobs_completion(openai_vcr, openai, ddtrace_global_config, mock_llmob
                     output_messages=[{"content": ", relax!” I said to my laptop"}, {"content": " (1"}],
                     parameters={"temperature": 0.8, "max_tokens": 10},
                     token_metrics={"prompt_tokens": 2, "completion_tokens": 12, "total_tokens": 14},
+                    tags={"ml_app": "<ml-app-name>"},
                 )
             ),
         ]
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0)])
+@pytest.mark.parametrize(
+    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
+)
 def test_llmobs_completion_stream(openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer):
     with openai_vcr.use_cassette("completion_streamed.yaml"):
         with mock.patch("ddtrace.contrib.openai.utils.encoding_for_model", create=True) as mock_encoding:
@@ -1924,13 +1929,16 @@ def test_llmobs_completion_stream(openai_vcr, openai, ddtrace_global_config, moc
                     output_messages=[{"content": expected_completion}],
                     parameters={"temperature": 0},
                     token_metrics={"prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4},
+                    tags={"ml_app": "<ml-app-name>"},
                 ),
             ),
         ]
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0)])
+@pytest.mark.parametrize(
+    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
+)
 def test_llmobs_chat_completion(openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer):
     """Ensure llmobs records are emitted for chat completion endpoints when configured.
 
@@ -1968,13 +1976,16 @@ def test_llmobs_chat_completion(openai_vcr, openai, ddtrace_global_config, mock_
                     ],
                     parameters={"temperature": 0},
                     token_metrics={"prompt_tokens": 57, "completion_tokens": 34, "total_tokens": 91},
+                    tags={"ml_app": "<ml-app-name>"},
                 )
             ),
         ]
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0)])
+@pytest.mark.parametrize(
+    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
+)
 def test_llmobs_chat_completion_stream(openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer):
     """Ensure llmobs records are emitted for chat completion endpoints when configured.
 
@@ -2012,13 +2023,16 @@ def test_llmobs_chat_completion_stream(openai_vcr, openai, ddtrace_global_config
                     output_messages=[{"content": expected_completion, "role": "assistant"}],
                     parameters={"temperature": 0},
                     token_metrics={"prompt_tokens": 8, "completion_tokens": 8, "total_tokens": 16},
+                    tags={"ml_app": "<ml-app-name>"},
                 )
             ),
         ]
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0)])
+@pytest.mark.parametrize(
+    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
+)
 def test_llmobs_chat_completion_function_call(
     openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer
 ):
@@ -2047,13 +2061,16 @@ def test_llmobs_chat_completion_function_call(
                     output_messages=[{"content": resp.choices[0].message.function_call.arguments, "role": "assistant"}],
                     parameters={"temperature": 0},
                     token_metrics={"prompt_tokens": 157, "completion_tokens": 57, "total_tokens": 214},
+                    tags={"ml_app": "<ml-app-name>"},
                 )
             ),
         ]
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0)])
+@pytest.mark.parametrize(
+    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
+)
 def test_llmobs_completion_error(openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer):
     """Ensure erroneous llmobs records are emitted for completion endpoints when configured."""
     with pytest.raises(Exception):
@@ -2086,13 +2103,16 @@ def test_llmobs_completion_error(openai_vcr, openai, ddtrace_global_config, mock
                     error="openai.AuthenticationError",
                     error_message="Error code: 401 - {'error': {'message': 'Incorrect API key provided: <not-a-r****key>. You can find your API key at https://platform.openai.com/account/api-keys.', 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_api_key'}}",  # noqa: E501
                     error_stack=span.get_tag("error.stack"),
+                    tags={"ml_app": "<ml-app-name>"},
                 )
             ),
         ]
     )
 
 
-@pytest.mark.parametrize("ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0)])
+@pytest.mark.parametrize(
+    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
+)
 def test_llmobs_chat_completion_error(openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer):
     """Ensure erroneous llmobs records are emitted for chat completion endpoints when configured."""
     with pytest.raises(Exception):
@@ -2129,6 +2149,7 @@ def test_llmobs_chat_completion_error(openai_vcr, openai, ddtrace_global_config,
                     error="openai.AuthenticationError",
                     error_message="Error code: 401 - {'error': {'message': 'Incorrect API key provided: <not-a-r****key>. You can find your API key at https://platform.openai.com/account/api-keys.', 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_api_key'}}",  # noqa: E501
                     error_stack=span.get_tag("error.stack"),
+                    tags={"ml_app": "<ml-app-name>"},
                 )
             ),
         ]

--- a/tests/llmobs/conftest.py
+++ b/tests/llmobs/conftest.py
@@ -44,7 +44,7 @@ def ddtrace_global_config():
 
 
 def default_global_config():
-    return {"_dd_api_key": "<not-a-real-api_key>"}
+    return {"_dd_api_key": "<not-a-real-api_key>", "_llmobs_ml_app": "<ml-app-name>"}
 
 
 @pytest.fixture


### PR DESCRIPTION
Previously DD_LLMOBS_APP_NAME was a strongly recommended (but not required) config for LLMObs users. However, in the case users do not specify the env var, the ML Obs product will not be able to differentiate between spans from potentially different ML applications and show clustering/prompt data all together under the previous default `unnamed-ml-app` name.

By making this a required configuration, we will avoid this behavior. However we need to ensure that this is documented clearly for user setup docs.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
