### PR TITLE
ci: add greenlet dependency to riot lockfiles

### DIFF
--- a/.riot/requirements/1185813.txt
+++ b/.riot/requirements/1185813.txt
@@ -13,6 +13,7 @@ charset-normalizer==3.3.2
 coverage[toml]==7.4.3
 databases==0.8.0
 exceptiongroup==1.2.0
+greenlet==3.0.3
 h11==0.14.0
 httpcore==1.0.4
 httpx==0.27.0

--- a/.riot/requirements/135e6d3.txt
+++ b/.riot/requirements/135e6d3.txt
@@ -12,6 +12,7 @@ certifi==2024.2.2
 charset-normalizer==3.3.2
 coverage[toml]==7.4.3
 databases==0.8.0
+greenlet==3.0.3
 h11==0.14.0
 httpcore==1.0.4
 httpx==0.27.0

--- a/.riot/requirements/1420734.txt
+++ b/.riot/requirements/1420734.txt
@@ -7,6 +7,7 @@
 attrs==23.2.0
 coverage[toml]==7.4.3
 exceptiongroup==1.2.0
+greenlet==3.0.3
 hypothesis==6.45.0
 importlib-metadata==7.0.1
 iniconfig==2.0.0

--- a/.riot/requirements/16653b8.txt
+++ b/.riot/requirements/16653b8.txt
@@ -6,6 +6,7 @@
 #
 attrs==23.2.0
 coverage[toml]==7.4.3
+greenlet==3.0.3
 hypothesis==6.45.0
 iniconfig==2.0.0
 mock==5.1.0

--- a/.riot/requirements/16711f6.txt
+++ b/.riot/requirements/16711f6.txt
@@ -6,6 +6,7 @@
 #
 attrs==23.2.0
 coverage[toml]==7.4.3
+greenlet==3.0.3
 hypothesis==6.45.0
 iniconfig==2.0.0
 mock==5.1.0

--- a/.riot/requirements/16c5a53.txt
+++ b/.riot/requirements/16c5a53.txt
@@ -12,6 +12,7 @@ certifi==2024.2.2
 charset-normalizer==3.3.2
 coverage[toml]==7.4.3
 databases==0.8.0
+greenlet==3.0.3
 h11==0.14.0
 httpcore==1.0.4
 httpx==0.27.0

--- a/.riot/requirements/17ed83b.txt
+++ b/.riot/requirements/17ed83b.txt
@@ -13,6 +13,7 @@ charset-normalizer==3.3.2
 coverage[toml]==7.4.3
 databases==0.8.0
 exceptiongroup==1.2.0
+greenlet==3.0.3
 h11==0.14.0
 httpcore==1.0.4
 httpx==0.27.0

--- a/.riot/requirements/1b75c2c.txt
+++ b/.riot/requirements/1b75c2c.txt
@@ -7,6 +7,7 @@
 attrs==23.2.0
 coverage[toml]==7.4.3
 exceptiongroup==1.2.0
+greenlet==3.0.3
 hypothesis==6.45.0
 importlib-metadata==7.0.1
 iniconfig==2.0.0

--- a/.riot/requirements/1ef0c35.txt
+++ b/.riot/requirements/1ef0c35.txt
@@ -13,6 +13,7 @@ charset-normalizer==3.3.2
 coverage[toml]==7.4.3
 databases==0.8.0
 exceptiongroup==1.2.0
+greenlet==3.0.3
 h11==0.14.0
 httpcore==1.0.4
 httpx==0.27.0

--- a/.riot/requirements/36231be.txt
+++ b/.riot/requirements/36231be.txt
@@ -13,6 +13,7 @@ charset-normalizer==3.3.2
 coverage[toml]==7.4.3
 databases==0.8.0
 exceptiongroup==1.2.0
+greenlet==3.0.3
 h11==0.14.0
 httpcore==1.0.4
 httpx==0.27.0

--- a/.riot/requirements/3cdaaae.txt
+++ b/.riot/requirements/3cdaaae.txt
@@ -7,6 +7,7 @@
 attrs==23.2.0
 coverage[toml]==7.4.3
 exceptiongroup==1.2.0
+greenlet==3.0.3
 hypothesis==6.45.0
 iniconfig==2.0.0
 mock==5.1.0

--- a/.riot/requirements/60ac461.txt
+++ b/.riot/requirements/60ac461.txt
@@ -13,6 +13,7 @@ charset-normalizer==3.3.2
 coverage[toml]==7.4.3
 databases==0.8.0
 exceptiongroup==1.2.0
+greenlet==3.0.3
 h11==0.14.0
 httpcore==1.0.4
 httpx==0.27.0

--- a/.riot/requirements/7a59aa8.txt
+++ b/.riot/requirements/7a59aa8.txt
@@ -13,6 +13,7 @@ charset-normalizer==3.3.2
 coverage[toml]==7.4.3
 databases==0.8.0
 exceptiongroup==1.2.0
+greenlet==3.0.3
 h11==0.14.0
 httpcore==1.0.4
 httpx==0.27.0

--- a/.riot/requirements/9c022dd.txt
+++ b/.riot/requirements/9c022dd.txt
@@ -13,6 +13,7 @@ charset-normalizer==3.3.2
 coverage[toml]==7.4.3
 databases==0.8.0
 exceptiongroup==1.2.0
+greenlet==3.0.3
 h11==0.14.0
 httpcore==1.0.4
 httpx==0.27.0

--- a/.riot/requirements/dc69f1e.txt
+++ b/.riot/requirements/dc69f1e.txt
@@ -7,6 +7,7 @@
 attrs==23.2.0
 coverage[toml]==7.2.7
 exceptiongroup==1.2.0
+greenlet==3.0.3
 hypothesis==6.45.0
 importlib-metadata==6.7.0
 iniconfig==2.0.0


### PR DESCRIPTION
CI: Nightly job on main is failing due to missing greenlet dependency in some lockfiles:

- https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/57791/workflows/0f925a1b-c165-4275-94fd-28cf36976e7b/jobs/3660780
- https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/57791/workflows/0f925a1b-c165-4275-94fd-28cf36976e7b/jobs/3660814

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
