### PR TITLE
fix(asm): fix receive wrapper for asgi (#8696)

### DIFF
--- a/releasenotes/notes/fix_asgi_receive_wrapper-685522a1af75d59d.yaml
+++ b/releasenotes/notes/fix_asgi_receive_wrapper-685522a1af75d59d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ASM: This fix resolves an issue where the asgi middleware could crash with a RuntimeError "Unexpected message received".

--- a/tests/appsec/contrib_appsec/fastapi_app/app.py
+++ b/tests/appsec/contrib_appsec/fastapi_app/app.py
@@ -1,9 +1,11 @@
+import asyncio
 from typing import Optional
 
 from fastapi import FastAPI
 from fastapi import Request
 from fastapi.responses import HTMLResponse
 from fastapi.responses import JSONResponse
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 
@@ -82,5 +84,14 @@ def get_app():
 
         ddtrace.Pin.override(app, service=service_name, tracer=ddtrace.tracer)
         return HTMLResponse(service_name, 200)
+
+    async def slow_numbers(minimum, maximum):
+        for number in range(minimum, maximum):
+            yield "%d" % number
+            await asyncio.sleep(0.25)
+
+    @app.get("/stream/")
+    async def stream():
+        return StreamingResponse(slow_numbers(0, 10), media_type="text/html")
 
     return app

--- a/tests/appsec/contrib_appsec/utils.py
+++ b/tests/appsec/contrib_appsec/utils.py
@@ -659,6 +659,12 @@ class Contrib_TestClass_For_Threats:
                 assert get_tag(http.STATUS_CODE) == "200"
                 assert get_tag(APPSEC.JSON) is None
 
+    LARGE_BODY = {
+        f"key_{i}": {f"key_{i}_{j}": {f"key_{i}_{j}_{k}": f"value_{i}_{j}_{k}" for k in range(4)} for j in range(4)}
+        for i in range(254)
+    }
+    LARGE_BODY["attack"] = "yqrweytqwreasldhkuqwgervflnmlnli"
+
     @pytest.mark.parametrize("asm_enabled", [True, False])
     @pytest.mark.parametrize(
         ("body", "content_type", "blocked"),
@@ -666,6 +672,7 @@ class Contrib_TestClass_For_Threats:
             # json body must be blocked
             ('{"attack": "yqrweytqwreasldhkuqwgervflnmlnli"}', "application/json", "tst-037-003"),
             ('{"attack": "yqrweytqwreasldhkuqwgervflnmlnli"}', "text/json", "tst-037-003"),
+            (json.dumps(LARGE_BODY), "text/json", "tst-037-003"),
             # xml body must be blocked
             (
                 '<?xml version="1.0" encoding="UTF-8"?><attack>yqrweytqwreasldhkuqwgervflnmlnli</attack>',
@@ -686,6 +693,7 @@ class Contrib_TestClass_For_Threats:
             # other values must not be blocked
             ('{"attack": "zqrweytqwreasldhkuqxgervflnmlnli"}', "application/json", False),
         ],
+        ids=["json", "text_json", "json_large", "xml", "form", "form_multipart", "text", "no_attack"],
     )
     def test_request_suspicious_request_block_match_request_body(
         self, interface: Interface, get_tag, asm_enabled, root_span, body, content_type, blocked
@@ -999,6 +1007,25 @@ class Contrib_TestClass_For_Threats:
             assert self.body(response) == "awesome_test"
             # only two global callbacks are expected for API Security and Nested Events
             assert len(_asm_request_context.GLOBAL_CALLBACKS.get(_asm_request_context._CONTEXT_CALL, [])) == 2
+
+    @pytest.mark.parametrize("asm_enabled", [True, False])
+    @pytest.mark.parametrize("metastruct", [True, False])
+    def test_stream_response(
+        self,
+        interface: Interface,
+        get_tag,
+        asm_enabled,
+        metastruct,
+        root_span,
+    ):
+        if interface.name != "fastapi":
+            raise pytest.skip("only fastapi tests have support for stream response")
+        with override_global_config(
+            dict(_asm_enabled=asm_enabled, _use_metastruct_for_triggers=metastruct)
+        ), override_env(dict(DD_APPSEC_RULES=rules.RULES_SRB)):
+            self.update_tracer(interface)
+            response = interface.client.get("/stream/")
+            assert self.body(response) == "0123456789"
 
 
 @contextmanager


### PR DESCRIPTION
- Fix receive wrapper for asynchronous requests with more than one message received.
- Add a test_streaming (only for FastAPI) to cover the fix
- Add one other possible large request body for threat blocking tests on request body

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

(cherry picked from commit 28a03cc093b3e5c4582a71fd2d0347be88ee3195)