### PR TITLE
fix(langchain): addresses compatibility with vision API [backport #8681 to 2.7]

### DIFF
--- a/ddtrace/contrib/langchain/patch.py
+++ b/ddtrace/contrib/langchain/patch.py
@@ -283,10 +283,16 @@ def traced_chat_model_generate(langchain, pin, func, instance, args, kwargs):
         for message_set_idx, message_set in enumerate(chat_messages):
             for message_idx, message in enumerate(message_set):
                 if integration.is_pc_sampled_span(span):
-                    span.set_tag_str(
-                        "langchain.request.messages.%d.%d.content" % (message_set_idx, message_idx),
-                        integration.trunc(message.content),
-                    )
+                    if isinstance(message, dict):
+                        span.set_tag_str(
+                            "langchain.request.messages.%d.%d.content" % (message_set_idx, message_idx),
+                            integration.trunc(str(message.get("content", ""))),
+                        )
+                    else:
+                        span.set_tag_str(
+                            "langchain.request.messages.%d.%d.content" % (message_set_idx, message_idx),
+                            integration.trunc(str(getattr(message, "content", ""))),
+                        )
                 span.set_tag_str(
                     "langchain.request.messages.%d.%d.message_type" % (message_set_idx, message_idx),
                     message.__class__.__name__,
@@ -327,10 +333,7 @@ def traced_chat_model_generate(langchain, pin, func, instance, args, kwargs):
             else:
                 log_chat_completions = [
                     [
-                        {
-                            "content": message.text,
-                            "message_type": message.message.__class__.__name__,
-                        }
+                        {"content": message.text, "message_type": message.message.__class__.__name__}
                         for message in messages
                     ]
                     for messages in chat_completions.generations
@@ -343,7 +346,9 @@ def traced_chat_model_generate(langchain, pin, func, instance, args, kwargs):
                     "messages": [
                         [
                             {
-                                "content": message.content,
+                                "content": message.get("content", "")
+                                if isinstance(message, dict)
+                                else str(getattr(message, "content", "")),
                                 "message_type": message.__class__.__name__,
                             }
                             for message in messages
@@ -374,10 +379,16 @@ async def traced_chat_model_agenerate(langchain, pin, func, instance, args, kwar
         for message_set_idx, message_set in enumerate(chat_messages):
             for message_idx, message in enumerate(message_set):
                 if integration.is_pc_sampled_span(span):
-                    span.set_tag_str(
-                        "langchain.request.messages.%d.%d.content" % (message_set_idx, message_idx),
-                        integration.trunc(message.content),
-                    )
+                    if isinstance(message, dict):
+                        span.set_tag_str(
+                            "langchain.request.messages.%d.%d.content" % (message_set_idx, message_idx),
+                            integration.trunc(str(message.get("content", ""))),
+                        )
+                    else:
+                        span.set_tag_str(
+                            "langchain.request.messages.%d.%d.content" % (message_set_idx, message_idx),
+                            integration.trunc(str(getattr(message, "content", ""))),
+                        )
                 span.set_tag_str(
                     "langchain.request.messages.%d.%d.message_type" % (message_set_idx, message_idx),
                     message.__class__.__name__,
@@ -418,10 +429,7 @@ async def traced_chat_model_agenerate(langchain, pin, func, instance, args, kwar
             else:
                 log_chat_completions = [
                     [
-                        {
-                            "content": message.text,
-                            "message_type": message.message.__class__.__name__,
-                        }
+                        {"content": message.text, "message_type": message.message.__class__.__name__}
                         for message in messages
                     ]
                     for messages in chat_completions.generations
@@ -434,7 +442,9 @@ async def traced_chat_model_agenerate(langchain, pin, func, instance, args, kwar
                     "messages": [
                         [
                             {
-                                "content": message.content,
+                                "content": message.get("content", "")
+                                if isinstance(message, dict)
+                                else str(getattr(message, "content", "")),
                                 "message_type": message.__class__.__name__,
                             }
                             for message in messages

--- a/releasenotes/notes/fix-langchain-vision-apis-58e4de9b52198e43.yaml
+++ b/releasenotes/notes/fix-langchain-vision-apis-58e4de9b52198e43.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    langchain: Ensures langchain vision APIs are correctly instrumented


### PR DESCRIPTION
Backports https://github.com/DataDog/dd-trace-py/pull/8681 to 2.7.

Note that in 2.7 the test_langchain_community.py file is not yet present as there is no explicit support yet for langchain_community. The test added by https://github.com/DataDog/dd-trace-py/pull/8681 is based in the now-not-present test file, so we've just deleted it for now but the fix still applies for regular langchain.


## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
