### PR TITLE
fix(structlog): Ensures processor injection is not duplicated

### DIFF
--- a/tests/contrib/structlog/test_structlog_logging.py
+++ b/tests/contrib/structlog/test_structlog_logging.py
@@ -345,3 +345,9 @@ def test_no_configured_processor():
 
     cf.logger.calls.clear()
     unpatch()
+
+# write a test with two loggers and confirm there is only processor per logger
+
+# write a test with a get_logger then new configure call and confirm there is only processor
+
+# write a test with an empty configure block and confirm there is no processor injected

--- a/tests/contrib/structlog/test_structlog_patch.py
+++ b/tests/contrib/structlog/test_structlog_patch.py
@@ -24,11 +24,14 @@ class TestStructlogPatch(PatchTestCase.Base):
     def assert_module_patched(self, structlog):
         self.assert_wrapped(structlog.get_logger)
         self.assert_wrapped(structlog.getLogger)
+        self.assert_wrapped(structlog.configure)
 
     def assert_not_module_patched(self, structlog):
         self.assert_not_wrapped(structlog.get_logger)
         self.assert_not_wrapped(structlog.getLogger)
+        self.assert_not_wrapped(structlog.configure)
 
     def assert_not_module_double_patched(self, structlog):
         self.assert_not_double_wrapped(structlog.get_logger)
         self.assert_not_double_wrapped(structlog.getLogger)
+        self.assert_not_double_wrapped(structlog.configure)


### PR DESCRIPTION
Fixes #8699 

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [ ] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
