### PR TITLE
fix(kafka): do identity checks on kafka messages to work around… [backport 2.5]

### DIFF
--- a/ddtrace/contrib/kafka/patch.py
+++ b/ddtrace/contrib/kafka/patch.py
@@ -209,9 +209,9 @@ def traced_poll(func, instance, args, kwargs):
     except Exception as e:
         err = e
     ctx = None
-    if message and config.kafka.distributed_tracing_enabled and message.headers():
+    if message is not None and config.kafka.distributed_tracing_enabled and message.headers():
         ctx = Propagator.extract(dict(message.headers()))
-    if message or config.kafka.trace_empty_poll_enabled:
+    if message is not None or config.kafka.trace_empty_poll_enabled:
         with pin.tracer.start_span(
             name=schematize_messaging_operation(kafkax.CONSUME, provider="kafka", direction=SpanDirection.PROCESSING),
             service=trace_utils.ext_service(pin, config.kafka),

--- a/releasenotes/notes/kafka-none-2-4f9e600e115eb44c.yaml
+++ b/releasenotes/notes/kafka-none-2-4f9e600e115eb44c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    kafka: This fix resolves an issue where ``None`` messages from confluent-kafka could cause crashes in the Kafka integration.


### PR DESCRIPTION
This pull request fixes
https://github.com/DataDog/dd-trace-py/issues/8602 by changing `if message` tests in the Kafka contrib to `if message is not None`. This avoids the runtime calling `__len__` on the message object, which is not guaranteed by confluent-kafka to be defined.

## Checklist

- [x] Change(s) are motivated and described in the PR description
