### PR TITLE
fix(propagation): never clobber extracted decisionmaker tags... [backport 2.5]

### DIFF
--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -39,6 +39,8 @@ from ..internal.constants import PROPAGATION_STYLE_DATADOG
 from ..internal.constants import W3C_TRACEPARENT_KEY
 from ..internal.constants import W3C_TRACESTATE_KEY
 from ..internal.logger import get_logger
+from ..internal.sampling import SAMPLING_DECISION_TRACE_TAG_KEY
+from ..internal.sampling import SamplingMechanism
 from ..internal.sampling import validate_sampling_decision
 from ..span import _get_64_highest_order_bits_as_hex
 from ..span import _get_64_lowest_order_bits_as_int
@@ -320,6 +322,12 @@ class _DatadogMultiHeader:
                 meta["_dd.propagation_error"] = "malformed_tid {}".format(trace_id_hob_hex)
                 del meta[_HIGHER_ORDER_TRACE_ID_BITS]
                 log.warning("malformed_tid: %s. Failed to decode trace id from http headers", trace_id_hob_hex)
+
+        if not meta:
+            meta = {}
+
+        if not meta.get(SAMPLING_DECISION_TRACE_TAG_KEY):
+            meta[SAMPLING_DECISION_TRACE_TAG_KEY] = f"-{SamplingMechanism.TRACE_SAMPLING_RULE}"
 
         # Try to parse values into their expected types
         try:

--- a/releasenotes/notes/clobber-dm-b494dc48a3217371.yaml
+++ b/releasenotes/notes/clobber-dm-b494dc48a3217371.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    propagation: This fix resolves an issue where the sampling decision-maker tag in tracestate propagation headers
+    was clobbered by a default value.

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_distributed_tracing_nested.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_distributed_tracing_nested.json
@@ -10,6 +10,7 @@
     "error": 0,
     "meta": {
       "_dd.base_service": "",
+      "_dd.p.dm": "-3",
       "_dd.p.tid": "654a694400000000",
       "component": "wsgi",
       "http.method": "GET",

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -284,6 +284,7 @@ def test_extract(tracer):  # noqa: F811
         assert span.context.dd_origin == "synthetics"
         assert span.context._meta == {
             "_dd.origin": "synthetics",
+            "_dd.p.dm": "-3",
             "_dd.p.test": "value",
         }
         with tracer.trace("child_span") as child_span:
@@ -293,6 +294,7 @@ def test_extract(tracer):  # noqa: F811
             assert child_span.context.dd_origin == "synthetics"
             assert child_span.context._meta == {
                 "_dd.origin": "synthetics",
+                "_dd.p.dm": "-3",
                 "_dd.p.test": "value",
             }
 
@@ -464,6 +466,7 @@ def test_extract_unicode(tracer):  # noqa: F811
 
         assert span.context._meta == {
             "_dd.origin": "synthetics",
+            "_dd.p.dm": "-3",
             "_dd.p.test": "value",
         }
         with tracer.trace("child_span") as child_span:
@@ -473,6 +476,7 @@ def test_extract_unicode(tracer):  # noqa: F811
             assert child_span.context.dd_origin == "synthetics"
             assert child_span.context._meta == {
                 "_dd.origin": "synthetics",
+                "_dd.p.dm": "-3",
                 "_dd.p.test": "value",
             }
 
@@ -526,6 +530,7 @@ def test_WSGI_extract(tracer):  # noqa: F811
         assert span.context._meta == {
             "_dd.origin": "synthetics",
             "_dd.p.test": "value",
+            "_dd.p.dm": "-3",
         }
 
 
@@ -549,6 +554,7 @@ def test_extract_invalid_tags(tracer):  # noqa: F811
         assert span.context.dd_origin == "synthetics"
         assert span.context._meta == {
             "_dd.origin": "synthetics",
+            "_dd.p.dm": "-3",
             "_dd.propagation_error": "decoding_error",
         }
 
@@ -573,6 +579,7 @@ def test_extract_tags_large(tracer):  # noqa: F811
         assert span.context.dd_origin == "synthetics"
         assert span.context._meta == {
             "_dd.origin": "synthetics",
+            "_dd.p.dm": "-3",
             "_dd.propagation_error": "extract_max_size",
         }
 
@@ -1124,6 +1131,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
+            "meta": {"_dd.p.dm": "-3"},
         },
     ),
     (
@@ -1135,6 +1143,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
+            "meta": {"_dd.p.dm": "-3"},
         },
     ),
     (
@@ -1152,6 +1161,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
+            "meta": {"_dd.p.dm": "-3"},
         },
     ),
     (
@@ -1174,6 +1184,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
+            "meta": {"_dd.p.dm": "-3"},
         },
     ),
     (
@@ -1185,6 +1196,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
+            "meta": {"_dd.p.dm": "-3"},
         },
     ),
     (
@@ -1420,7 +1432,7 @@ EXTRACT_FIXTURES = [
             "meta": {
                 "traceparent": TRACECONTEXT_HEADERS_VALID[_HTTP_HEADER_TRACEPARENT],
                 "tracestate": TRACECONTEXT_HEADERS_VALID[_HTTP_HEADER_TRACESTATE],
-                "_dd.p.dm": "-4",
+                "_dd.p.dm": "-3",
                 "_dd.p.usr.id": "baz64",
             },
             "span_links": [
@@ -1450,6 +1462,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
+            "meta": {"_dd.p.dm": "-3"},
             "span_links": [
                 SpanLink(
                     trace_id=TRACE_ID,
@@ -1489,6 +1502,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
+            "meta": {"_dd.p.dm": "-3"},
             "span_links": [
                 SpanLink(
                     trace_id=TRACE_ID,
@@ -1523,6 +1537,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
+            "meta": {"_dd.p.dm": "-3"},
         },
     ),
     (
@@ -1534,6 +1549,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
+            "meta": {"_dd.p.dm": "-3"},
         },
     ),
     (
@@ -1602,6 +1618,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
+            "meta": {"_dd.p.dm": "-3"},
         },
     ),
     # Testing that order matters
@@ -1670,7 +1687,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
-            "meta": {"tracestate": TRACECONTEXT_HEADERS_VALID[_HTTP_HEADER_TRACESTATE]},
+            "meta": {"tracestate": TRACECONTEXT_HEADERS_VALID[_HTTP_HEADER_TRACESTATE], "_dd.p.dm": "-3"},
         },
     ),
     # testing that tracestate is not added when tracecontext style comes later and does not match first style's trace-id
@@ -1683,6 +1700,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
+            "meta": {"_dd.p.dm": "-3"},
             "span_links": [
                 SpanLink(
                     trace_id=TRACE_ID,
@@ -1963,7 +1981,7 @@ FULL_CONTEXT_EXTRACT_FIXTURES = [
         Context(
             trace_id=13088165645273925489,
             span_id=5678,
-            meta={"_dd.origin": "synthetics"},
+            meta={"_dd.origin": "synthetics", "_dd.p.dm": "-3"},
             metrics={"_sampling_priority_v1": 1},
             span_links=[
                 SpanLink(
@@ -2006,7 +2024,14 @@ FULL_CONTEXT_EXTRACT_FIXTURES = [
         Context(
             trace_id=7277407061855694839,
             span_id=5678,
-            meta={"_dd.origin": "synthetics", "tracestate": "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE"},
+            # it's weird that both _dd.p.dm and tracestate.t.dm are set here. as far as i know, this is the expected
+            # behavior for this chaotic set of headers, specifically when STYLE_DATADOG precedes STYLE_W3C_TRACECONTEXT
+            # in the styles configuration
+            meta={
+                "_dd.p.dm": "-3",
+                "_dd.origin": "synthetics",
+                "tracestate": "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE",
+            },
             metrics={"_sampling_priority_v1": 1},
             span_links=[
                 SpanLink(
@@ -2023,7 +2048,7 @@ FULL_CONTEXT_EXTRACT_FIXTURES = [
 
 
 @pytest.mark.parametrize("name,styles,headers,expected_context", FULL_CONTEXT_EXTRACT_FIXTURES)
-def test_mutliple_context_interactions(name, styles, headers, expected_context):
+def test_multiple_context_interactions(name, styles, headers, expected_context):
     with override_global_config(dict(_propagation_style_extract=styles)):
         context = HTTPPropagator.extract(headers)
         assert context == expected_context


### PR DESCRIPTION
This pull request resolves [AIT-9945] by removing the condition gating the logic that avoids clobbering the `_dd.p.dm` tag when it's present on propagated headers.

## Checklist

- [x] Change(s) are motivated and described in the PR description

[AIT-9945]: https://datadoghq.atlassian.net/browse/AIT-9945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ