### PR TITLE
chore(tracer): make tracer.sampler private and add tracer.sample()

### DIFF
--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -755,7 +755,7 @@ class Tracer(object):
             self._services.add(service)
 
         if not trace_id:
-            self._sampler.sample(span)
+            self.sample(span)
 
         # Only call span processors if the tracer is enabled
         if self.enabled:

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -228,7 +228,7 @@ class Tracer(object):
         self.enabled = config._tracing_enabled
         self.context_provider = context_provider or DefaultContextProvider()
         self._user_sampler: Optional[BaseSampler] = None
-        self.sampler: BaseSampler = DatadogSampler()
+        self._sampler: BaseSampler = DatadogSampler()
         self._dogstatsd_url = agent.get_stats_url() if dogstatsd_url is None else dogstatsd_url
         self._compute_stats = config._trace_compute_stats
         self._agent_url: str = agent.get_trace_url() if url is None else url
@@ -294,6 +294,9 @@ class Tracer(object):
             key,
         )
         self.shutdown(timeout=self.SHUTDOWN_TIMEOUT)
+
+    def sample(self, span):
+        self._sampler.sample(span)
 
     def on_start_span(self, func: Callable) -> Callable:
         """Register a function to execute when a span start.
@@ -415,8 +418,8 @@ class Tracer(object):
             self._iast_enabled = asm_config._iast_enabled = iast_enabled
 
         if sampler is not None:
-            self.sampler = sampler
-            self._user_sampler = self.sampler
+            self._sampler = sampler
+            self._user_sampler = self._sampler
 
         self._dogstatsd_url = dogstatsd_url or self._dogstatsd_url
 
@@ -519,8 +522,8 @@ class Tracer(object):
         The agent can return updated sample rates for the priority sampler.
         """
         try:
-            if isinstance(self.sampler, BasePrioritySampler):
-                self.sampler.update_rate_by_service_sample_rates(
+            if isinstance(self._sampler, BasePrioritySampler):
+                self._sampler.update_rate_by_service_sample_rates(
                     resp.rate_by_service,
                 )
         except ValueError:
@@ -752,7 +755,7 @@ class Tracer(object):
             self._services.add(service)
 
         if not trace_id:
-            self.sampler.sample(span)
+            self._sampler.sample(span)
 
         # Only call span processors if the tracer is enabled
         if self.enabled:
@@ -1072,7 +1075,7 @@ class Tracer(object):
         if "_trace_sample_rate" in items:
             # Reset the user sampler if one exists
             if cfg._get_source("_trace_sample_rate") != "remote_config" and self._user_sampler:
-                self.sampler = self._user_sampler
+                self._sampler = self._user_sampler
                 return
 
             if cfg._get_source("_trace_sample_rate") != "default":
@@ -1080,7 +1083,7 @@ class Tracer(object):
             else:
                 sample_rate = None
             sampler = DatadogSampler(default_sample_rate=sample_rate)
-            self.sampler = sampler
+            self._sampler = sampler
 
         if "tags" in items:
             self._tags = cfg.tags.copy()

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -57,6 +57,7 @@ from ddtrace.internal.serverless import in_gcp_function
 from ddtrace.internal.serverless.mini_agent import maybe_start_serverless_mini_agent
 from ddtrace.internal.service import ServiceStatusError
 from ddtrace.internal.utils import _get_metas_to_propagate
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.internal.utils.http import verify_url
 from ddtrace.internal.writer import AgentWriter
 from ddtrace.internal.writer import LogWriter
@@ -66,6 +67,7 @@ from ddtrace.sampler import BaseSampler
 from ddtrace.sampler import DatadogSampler
 from ddtrace.settings.asm import config as asm_config
 from ddtrace.settings.peer_service import _ps_config
+from ddtrace.vendor.debtcollector import deprecate
 
 
 if TYPE_CHECKING:
@@ -297,6 +299,25 @@ class Tracer(object):
 
     def sample(self, span):
         self._sampler.sample(span)
+
+    @property
+    def sampler(self):
+        deprecate(
+            "tracer.sampler is deprecated and will be removed.",
+            message="To manually sample call tracer.sample(span) instead.",
+            category=DDTraceDeprecationWarning,
+        )
+        return self._sampler
+
+    @sampler.setter
+    def sampler(self, value):
+        deprecate(
+            "Setting a custom sampler is deprecated and will be removed.",
+            message="""Please use DD_TRACE_SAMPLING_RULES to configure the sampler instead:
+    https://ddtrace.readthedocs.io/en/stable/configuration.html#DD_TRACE_SAMPLING_RULES""",
+            category=DDTraceDeprecationWarning,
+        )
+        self._sampler = value
 
     def on_start_span(self, func: Callable) -> Callable:
         """Register a function to execute when a span start.

--- a/ddtrace/internal/debug.py
+++ b/ddtrace/internal/debug.py
@@ -73,8 +73,8 @@ def collect(tracer):
         agent_error = None
 
     sampler_rules = None
-    if isinstance(tracer.sampler, DatadogSampler):
-        sampler_rules = [str(rule) for rule in tracer.sampler.rules]
+    if isinstance(tracer._sampler, DatadogSampler):
+        sampler_rules = [str(rule) for rule in tracer._sampler.rules]
 
     is_venv = in_venv()
 
@@ -138,7 +138,7 @@ def collect(tracer):
         is_global_tracer=tracer == ddtrace.tracer,
         enabled_env_setting=os.getenv("DATADOG_TRACE_ENABLED"),
         tracer_enabled=tracer.enabled,
-        sampler_type=type(tracer.sampler).__name__ if tracer.sampler else "N/A",
+        sampler_type=type(tracer._sampler).__name__ if tracer._sampler else "N/A",
         priority_sampler_type="N/A",
         sampler_rules=sampler_rules,
         service=ddtrace.config.service or "",

--- a/releasenotes/notes/deprecate_tracer_sampler-69c81b7ccf8fb6f9.yaml
+++ b/releasenotes/notes/deprecate_tracer_sampler-69c81b7ccf8fb6f9.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    tracing: ``tracer.sampler`` is deprecated and will be removed in the next major version release.
+    To manually sample please call ``tracer.sample`` instead.

--- a/tests/tracer/test_sampler.py
+++ b/tests/tracer/test_sampler.py
@@ -95,7 +95,7 @@ class RateSamplerTest(unittest.TestCase):
 
             # Since RateSampler does not set the sampling priority on a span, we will use a DatadogSampler
             # with rate limiting disabled.
-            tracer.sampler = DatadogSampler(default_sample_rate=sample_rate, rate_limit=-1)
+            tracer._sampler = DatadogSampler(default_sample_rate=sample_rate, rate_limit=-1)
 
             iterations = int(1e4 / sample_rate)
 
@@ -124,7 +124,7 @@ class RateSamplerTest(unittest.TestCase):
         tracer = DummyTracer()
         # Since RateSampler does not set the sampling priority on a span, we will use a DatadogSampler
         # with rate limiting disabled.
-        tracer.sampler = DatadogSampler(default_sample_rate=0.5, rate_limit=-1)
+        tracer._sampler = DatadogSampler(default_sample_rate=0.5, rate_limit=-1)
 
         for i in range(10):
             span = tracer.trace(str(i))
@@ -137,20 +137,20 @@ class RateSamplerTest(unittest.TestCase):
             sampled = len(samples) == 1 and samples[0].context.sampling_priority > 0
             for _ in range(10):
                 other_span = Span(str(i), trace_id=span.trace_id)
-                assert sampled == tracer.sampler.sample(
+                assert sampled == tracer._sampler.sample(
                     other_span
                 ), "sampling should give the same result for a given trace_id"
 
     def test_negative_sample_rate_raises_error(self):
         tracer = DummyTracer()
         with pytest.raises(ValueError, match="sample_rate of -0.5 is negative"):
-            tracer.sampler = RateSampler(sample_rate=-0.5)
+            tracer._sampler = RateSampler(sample_rate=-0.5)
 
     def test_sample_rate_0_does_not_reset_to_1(self):
         tracer = DummyTracer()
-        tracer.sampler = RateSampler(sample_rate=0)
+        tracer._sampler = RateSampler(sample_rate=0)
         assert (
-            tracer.sampler.sample_rate == 0
+            tracer._sampler.sample_rate == 0
         ), "Setting the sample rate to zero should result in the sample rate being zero"
 
 
@@ -189,7 +189,7 @@ class RateByServiceSamplerTest(unittest.TestCase):
         for sample_rate in [0.1, 0.25, 0.5, 1]:
             tracer = DummyTracer()
             tracer.configure(sampler=RateByServiceSampler())
-            tracer.sampler.set_sample_rate(sample_rate)
+            tracer._sampler.set_sample_rate(sample_rate)
 
             iterations = int(1e4 / sample_rate)
 


### PR DESCRIPTION
## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
