### PR TITLE
feat(llmobs): add error.type to llmobs spans

### DIFF
--- a/ddtrace/llmobs/_trace_processor.py
+++ b/ddtrace/llmobs/_trace_processor.py
@@ -65,8 +65,9 @@ class LLMObsTraceProcessor(TraceProcessor):
         if span.get_tag(OUTPUT_VALUE):
             meta["output"]["value"] = span._meta.pop(OUTPUT_VALUE)
         if span.error:
-            meta["error.message"] = span.get_tag(ERROR_MSG)
-            meta["error.stack"] = span.get_tag(ERROR_STACK)
+            meta[ERROR_MSG] = span.get_tag(ERROR_MSG)
+            meta[ERROR_STACK] = span.get_tag(ERROR_STACK)
+            meta[ERROR_TYPE] = span.get_tag(ERROR_TYPE)
         if not meta["input"]:
             meta.pop("input")
         if not meta["output"]:

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -157,6 +157,7 @@ def _llmobs_base_span_event(
         "metrics": {},
     }
     if error:
+        span_event["meta"]["error.type"] = error
         span_event["meta"]["error.message"] = error_message
         span_event["meta"]["error.stack"] = error_stack
     return span_event


### PR DESCRIPTION
This PR adds `error.type` to LLMObs spans marked with error.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
