### PR TITLE
fix(falcon): resp.status parsing

### DIFF
--- a/ddtrace/contrib/falcon/middleware.py
+++ b/ddtrace/contrib/falcon/middleware.py
@@ -62,7 +62,11 @@ class TraceMiddleware(object):
         if not span:
             return  # unexpected
 
-        status = resp.status.partition(" ")[0]
+        if isinstance(resp.status, str):
+            status = resp.status.partition(" ")[0]
+
+        elif isinstance(resp.status, int):
+            status = str(resp.status)
 
         # falcon does not map errors or unmatched routes
         # to proper status codes, so we have to try to infer them


### PR DESCRIPTION
## Description

Starting with Falcon version 3.0, bare int codes can be assigned to resp.status.

As ddtrace expects the status to be a string, the following error is being raised:
`  File "falcon/app.py", line 375, in falcon.app.App.__call__
  File "/usr/local/lib/python3.8/site-packages/ddtrace/contrib/falcon/middleware.py", line 65, in process_response
    status = resp.status.partition(" ")[0]
AttributeError: 'int' object has no attribute 'partition'`

https://falcon.readthedocs.io/en/stable/api/status.html
![image](https://github.com/DataDog/dd-trace-py/assets/33765053/18018b1b-142a-4ea6-897d-d0b15caf8760)


## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- N/A If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- N/A If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
