### PR TITLE
ci: fetch main branch when not in a pull request build

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - id: run_needed
         name: Check if run is needed
         run:  |
-          git fetch origin main
+          git fetch origin ${{ github.event.pull_request.base.sha || "main" }}
           export PATHS=$(git diff --name-only HEAD ${{ github.event.pull_request.base.sha }})
           python -c "import os,sys,fnmatch;sys.exit(not bool([_ for pattern in {'ddtrace/*', 'setup*', 'pyproject.toml', '.github/workflows/system-tests.yml'} for _ in fnmatch.filter(os.environ['PATHS'].splitlines(), pattern)]))"
         continue-on-error: true

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - id: run_needed
         name: Check if run is needed
         run:  |
-          git fetch origin ${{ github.event.pull_request.base.sha }}
+          git fetch origin ${{ "" || "main" }}
           export PATHS=$(git diff --name-only HEAD ${{ github.event.pull_request.base.sha }})
           python -c "import os,sys,fnmatch;sys.exit(not bool([_ for pattern in {'ddtrace/*', 'setup*', 'pyproject.toml', '.github/workflows/system-tests.yml'} for _ in fnmatch.filter(os.environ['PATHS'].splitlines(), pattern)]))"
         continue-on-error: true
@@ -50,7 +50,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-  
+
       - name: Checkout system tests
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
         uses: actions/checkout@v3
@@ -69,13 +69,13 @@ jobs:
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
         run: ./build.sh
 
-      - name: Run INTEGRATIONS 
+      - name: Run INTEGRATIONS
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        run: ./run.sh INTEGRATIONS 
+        run: ./run.sh INTEGRATIONS
 
-      - name: Run CROSSED_TRACING_LIBRARIES 
+      - name: Run CROSSED_TRACING_LIBRARIES
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        run: ./run.sh CROSSED_TRACING_LIBRARIES 
+        run: ./run.sh CROSSED_TRACING_LIBRARIES
 
       - name: Run
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - id: run_needed
         name: Check if run is needed
         run:  |
-          git fetch origin ${{ '' || "main" }}
+          git fetch origin main
           export PATHS=$(git diff --name-only HEAD ${{ github.event.pull_request.base.sha }})
           python -c "import os,sys,fnmatch;sys.exit(not bool([_ for pattern in {'ddtrace/*', 'setup*', 'pyproject.toml', '.github/workflows/system-tests.yml'} for _ in fnmatch.filter(os.environ['PATHS'].splitlines(), pattern)]))"
         continue-on-error: true

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - id: run_needed
         name: Check if run is needed
         run:  |
-          git fetch origin ${{ "" || "main" }}
+          git fetch origin ${{ '' || "main" }}
           export PATHS=$(git diff --name-only HEAD ${{ github.event.pull_request.base.sha }})
           python -c "import os,sys,fnmatch;sys.exit(not bool([_ for pattern in {'ddtrace/*', 'setup*', 'pyproject.toml', '.github/workflows/system-tests.yml'} for _ in fnmatch.filter(os.environ['PATHS'].splitlines(), pattern)]))"
         continue-on-error: true

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - id: run_needed
         name: Check if run is needed
         run:  |
-          git fetch origin ${{ github.event.pull_request.base.sha || "main" }}
+          git fetch origin ${{ github.event.pull_request.base.sha || 'main' }}
           export PATHS=$(git diff --name-only HEAD ${{ github.event.pull_request.base.sha }})
           python -c "import os,sys,fnmatch;sys.exit(not bool([_ for pattern in {'ddtrace/*', 'setup*', 'pyproject.toml', '.github/workflows/system-tests.yml'} for _ in fnmatch.filter(os.environ['PATHS'].splitlines(), pattern)]))"
         continue-on-error: true


### PR DESCRIPTION
This pull request fixes main-branch CI failures like [this one](https://github.com/DataDog/dd-trace-py/actions/runs/8362741898/job/22894090313) that resulted from attempting to fetch all of the repo's hundreds of branches and tags during system tests. The root cause is visible [here](https://github.com/DataDog/dd-trace-py/actions/runs/8362741898/job/22894073563) in the "check if run is needed" step. The fix applied in this pull request is to only fetch the `main` branch when running on a merge or schedule, instead of fetching all branches and tags due to an empty pull request hash variable as in the previous behavior.

The whitespace changes are something I noticed while in this file and are not directly related to the bugfix.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
