### PR TITLE
chore(tracing): remove span_links from context._with_span

### DIFF
--- a/ddtrace/_trace/context.py
+++ b/ddtrace/_trace/context.py
@@ -115,7 +115,6 @@ class Context(object):
             metrics=self._metrics,
             lock=self._lock,
             baggage=self._baggage,
-            span_links=self._span_links,
             is_remote=False,
         )
 

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -2153,7 +2153,7 @@ def test_span_links_set_on_root_span_not_child(fastapi_client, tracer, fastapi_t
         attributes={"reason": "terminated_context", "context_headers": "tracecontext"},
     )
     assert spans[0][1]._links == {}
-    assert spans[0][1].context._span_links == {}
+    assert spans[0][1].context._span_links == []
 
 
 VALID_DATADOG_CONTEXT = {

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -2153,6 +2153,7 @@ def test_span_links_set_on_root_span_not_child(fastapi_client, tracer, fastapi_t
         attributes={"reason": "terminated_context", "context_headers": "tracecontext"},
     )
     assert spans[0][1]._links == {}
+    assert spans[0][1].context._span_links == {}
 
 
 VALID_DATADOG_CONTEXT = {


### PR DESCRIPTION
`Context._spans_links` should only be set on local root spans. It does not make sense to copy this value to child spans. This is not a bug fix, it just removes an unnecessary and potentially confusing operation. 

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
