### PR TITLE
fix(iast): ensure context is created for current span

### DIFF
--- a/ddtrace/appsec/_iast/processor.py
+++ b/ddtrace/appsec/_iast/processor.py
@@ -48,12 +48,13 @@ class AppSecIastSpanProcessor(SpanProcessor):
         if not _is_iast_enabled():
             return
 
+        from ._taint_tracking import create_context
+
+        create_context()
+
         request_iast_enabled = False
         if oce.acquire_request(span):
-            from ._taint_tracking import create_context
-
             request_iast_enabled = True
-            create_context()
 
         core.set_item(IAST.REQUEST_IAST_ENABLED, request_iast_enabled, span=span)
 

--- a/releasenotes/notes/iast-fix-context-creation-2d0dee033723514c.yaml
+++ b/releasenotes/notes/iast-fix-context-creation-2d0dee033723514c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Vulnerability Management for Code-level (IAST): This fix addresses an issue where tainting objects may fail due to context not being created in the current span.


### PR DESCRIPTION
IAST: Ensure context is created in the current span, as some tainting operations occur regardless of `oce.acquire_request`. 

Note: The bug was introduce in this PR: https://github.com/DataDog/dd-trace-py/pull/8452

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
