### PR TITLE
feat(datastreams): change DSM encoding to use base64 and decoding to …

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -147,12 +147,12 @@ jobs:
       # even on failures, we want to have artifact to be able to investigate
       # The compress step speed up a lot the upload artifact process
       - name: Compress artifact
-        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        if: always() || github.event_name == 'schedule'
         run: tar -czvf artifact.tar.gz $(ls | grep logs)
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
-        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        if: always() || github.event_name == 'schedule'
         with:
           name: logs_${{ matrix.weblog-variant }}
           path: artifact.tar.gz

--- a/ddtrace/contrib/botocore/services/sqs.py
+++ b/ddtrace/contrib/botocore/services/sqs.py
@@ -130,7 +130,6 @@ def patched_sqs_api_call(original_func, instance, args, kwargs, function_vars):
             start_ns = time_ns()
             func_run = True
             # run the function before in order to extract possible parent context before starting span
-
             core.dispatch(f"botocore.{endpoint_name}.{operation}.pre", [params])
             result = original_func(*args, **kwargs)
             core.dispatch(f"botocore.{endpoint_name}.{operation}.post", [params, result])
@@ -162,7 +161,6 @@ def patched_sqs_api_call(original_func, instance, args, kwargs, function_vars):
             # we need to ensure the span start time is correct
             if start_ns is not None and func_run:
                 span.start_ns = start_ns
-
             if args and config.botocore["distributed_tracing"]:
                 try:
                     if endpoint_name == "sqs" and operation == "SendMessage":

--- a/ddtrace/internal/datastreams/botocore.py
+++ b/ddtrace/internal/datastreams/botocore.py
@@ -151,7 +151,6 @@ def record_data_streams_path_for_kinesis_stream(params, results):
         log.debug("Unable to determine StreamARN for request with params: ", params)
         return
 
-<<<<<<< HEAD
     pathway = processor().new_pathway()
     for record in results.get("Records", []):
         time_estimate = record.get("ApproximateArrivalTimestamp", datetime.now()).timestamp()
@@ -160,14 +159,6 @@ def record_data_streams_path_for_kinesis_stream(params, results):
             edge_start_sec_override=time_estimate,
             pathway_start_sec_override=time_estimate,
         )
-=======
-    ctx = DsmPathwayCodec.decode(context_json, processor())
-    ctx.set_checkpoint(
-        ["direction:in", "topic:" + stream, "type:kinesis"],
-        edge_start_sec_override=time_estimate,
-        pathway_start_sec_override=time_estimate,
-    )
->>>>>>> 3dd4c9d9c (feat(datastreams): change DSM encoding to use base64 and decoding to handle multiple encoding types (#8611))
 
 
 def handle_kinesis_receive(params, result):

--- a/releasenotes/notes/base64-encoding-for-DSM-context-propagation-efbfa76512224083.yaml
+++ b/releasenotes/notes/base64-encoding-for-DSM-context-propagation-efbfa76512224083.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    DSM: Adds base64 format for encoding and decoding DSM context hash. 

--- a/tests/.suitespec.json
+++ b/tests/.suitespec.json
@@ -437,6 +437,7 @@
             "@tracing",
             "@contrib",
             "@kafka",
+            "@datastreams",
             "tests/contrib/kafka/*",
             "tests/snapshots/tests.contrib.kafka.*"
         ],
@@ -673,6 +674,7 @@
             "@llmobs",
             "@botocore",
             "@llmobs",
+            "@datastreams",
             "tests/contrib/botocore/*",
             "tests/contrib/boto/*",
             "tests/snapshots/tests.contrib.botocore*"
@@ -1283,6 +1285,7 @@
             "@contrib",
             "@tracing",
             "@kombu",
+            "@datastreams",
             "tests/contrib/kombu/*"
         ],
         "jinja2": [

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -2970,6 +2970,7 @@ class BotocoreTest(TracerTestCase):
     @mock_kinesis
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_DATA_STREAMS_ENABLED="True"))
     @unittest.skipIf(BOTOCORE_VERSION < (1, 26, 31), "Kinesis didn't support streamARN till 1.26.31")
+    @mock.patch("time.time", mock.MagicMock(return_value=1642544540))
     def test_kinesis_data_streams_enabled_put_record(self):
         # (dict -> json string)[]
         with mock.patch(

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -16,7 +16,7 @@ from ddtrace.contrib.kafka.patch import patch
 from ddtrace.contrib.kafka.patch import unpatch
 from ddtrace.filters import TraceFilter
 import ddtrace.internal.datastreams  # noqa: F401 - used as part of mock patching
-from ddtrace.internal.datastreams.kafka import PROPAGATION_KEY
+from ddtrace.internal.datastreams.processor import PROPAGATION_KEY_BASE_64
 from ddtrace.internal.datastreams.processor import ConsumerPartitionKey
 from ddtrace.internal.datastreams.processor import DataStreamsCtx
 from ddtrace.internal.datastreams.processor import PartitionKey
@@ -31,7 +31,7 @@ GROUP_ID = "test_group"
 BOOTSTRAP_SERVERS = "localhost:{}".format(KAFKA_CONFIG["port"])
 KEY = "test_key"
 PAYLOAD = bytes("hueh hueh hueh", encoding="utf-8")
-DSM_TEST_PATH_HEADER_SIZE = 20
+DSM_TEST_PATH_HEADER_SIZE = 28
 
 
 class KafkaConsumerPollFilter(TraceFilter):
@@ -372,7 +372,7 @@ def test_data_streams_payload_size(dsm_processor, consumer, producer, kafka_topi
         test_header_size += len(k) + len(v)
     expected_payload_size = float(payload_length + key_length)
     expected_payload_size += test_header_size  # to account for headers we add here
-    expected_payload_size += len(PROPAGATION_KEY)  # Add in header key length
+    expected_payload_size += len(PROPAGATION_KEY_BASE_64)  # Add in header key length
     expected_payload_size += DSM_TEST_PATH_HEADER_SIZE  # to account for path header we add
 
     try:
@@ -701,8 +701,8 @@ def test_data_streams_default_context_propagation(consumer, producer, kafka_topi
     # message comes back with expected test string
     assert message.value() == b"context test"
 
-    # DSM header 'dd-pathway-ctx' was propagated in the headers
-    assert message.headers()[0][0] == PROPAGATION_KEY
+    # DSM header 'dd-pathway-ctx-base64' was propagated in the headers
+    assert message.headers()[0][0] == PROPAGATION_KEY_BASE_64
     assert message.headers()[0][1] is not None
 
 


### PR DESCRIPTION
…handle multiple encoding types (#8611)

Makes DSM pathway encoding/decoding more resilient, also adds a `DSMPathwayCodec` class that handles encoding / decoding DSM context. This makes future changes easier, since all integrations will now use this class instead of the actual encoding / decoding methods.

Encode using base64 only

Try to decode the following:
-    base64,
-    deprecated encoding of bytes
-    base64 encoding sent using deprecated key

Co-authored-by: Munir Abdinur <munir.abdinur@datadoghq.com>
(cherry picked from commit 3dd4c9d9cd0b479428e3b8aaaa4e48e8baae4085)

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
