### PR TITLE
chore(telemetry): add item for instrumentation config id

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -422,6 +422,11 @@ class TelemetryWriter(PeriodicService):
         if register_app_shutdown:
             atexit.register(self.app_shutdown)
 
+        package_source_entry = ["instrumentation_config_id", "", "default"]
+        if "DD_INSTRUMENTATION_CONFIG_ID" in os.environ:
+            package_source_entry[1] = os.environ["DD_INSTRUMENTATION_CONFIG_ID"]
+            package_source_entry[2] = "environment"
+
         self.add_configurations(
             [
                 self._telemetry_entry("_trace_enabled"),
@@ -435,6 +440,7 @@ class TelemetryWriter(PeriodicService):
                 self._telemetry_entry("trace_http_header_tags"),
                 self._telemetry_entry("tags"),
                 self._telemetry_entry("_tracing_enabled"),
+                package_source_entry,
                 (TELEMETRY_STARTUP_LOGS_ENABLED, config._startup_logs_enabled, "unknown"),
                 (TELEMETRY_DYNAMIC_INSTRUMENTATION_ENABLED, di_config.enabled, "unknown"),
                 (TELEMETRY_EXCEPTION_DEBUGGING_ENABLED, ed_config.enabled, "unknown"),

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -4,7 +4,6 @@ import os
 import sys
 import time
 from types import ModuleType
-from typing import cast
 from typing import TYPE_CHECKING  # noqa:F401
 from typing import Any  # noqa:F401
 from typing import Dict  # noqa:F401
@@ -423,11 +422,13 @@ class TelemetryWriter(PeriodicService):
         if register_app_shutdown:
             atexit.register(self.app_shutdown)
 
-        package_source_entry = ["instrumentation_config_id", "", "default"]
+        inst_config_id_entry = ("instrumentation_config_id", "", "default")
         if "DD_INSTRUMENTATION_CONFIG_ID" in os.environ:
-            package_source_entry[1] = os.environ["DD_INSTRUMENTATION_CONFIG_ID"]
-            package_source_entry[2] = "environment"
-        package_source_entry_t = cast(Tuple[str, str, str], tuple(package_source_entry))
+            inst_config_id_entry = (
+                "instrumentation_config_id",
+                os.environ["DD_INSTRUMENTATION_CONFIG_ID"],
+                "environment",
+            )
 
         self.add_configurations(
             [
@@ -442,7 +443,7 @@ class TelemetryWriter(PeriodicService):
                 self._telemetry_entry("trace_http_header_tags"),
                 self._telemetry_entry("tags"),
                 self._telemetry_entry("_tracing_enabled"),
-                package_source_entry_t,
+                inst_config_id_entry,
                 (TELEMETRY_STARTUP_LOGS_ENABLED, config._startup_logs_enabled, "unknown"),
                 (TELEMETRY_DYNAMIC_INSTRUMENTATION_ENABLED, di_config.enabled, "unknown"),
                 (TELEMETRY_EXCEPTION_DEBUGGING_ENABLED, ed_config.enabled, "unknown"),

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -427,7 +427,7 @@ class TelemetryWriter(PeriodicService):
             inst_config_id_entry = (
                 "instrumentation_config_id",
                 os.environ["DD_INSTRUMENTATION_CONFIG_ID"],
-                "environment",
+                "env_var",
             )
 
         self.add_configurations(

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 from types import ModuleType
+from typing import cast
 from typing import TYPE_CHECKING  # noqa:F401
 from typing import Any  # noqa:F401
 from typing import Dict  # noqa:F401
@@ -426,6 +427,7 @@ class TelemetryWriter(PeriodicService):
         if "DD_INSTRUMENTATION_CONFIG_ID" in os.environ:
             package_source_entry[1] = os.environ["DD_INSTRUMENTATION_CONFIG_ID"]
             package_source_entry[2] = "environment"
+        package_source_entry_t = cast(Tuple[str, str, str], tuple(package_source_entry))
 
         self.add_configurations(
             [
@@ -440,7 +442,7 @@ class TelemetryWriter(PeriodicService):
                 self._telemetry_entry("trace_http_header_tags"),
                 self._telemetry_entry("tags"),
                 self._telemetry_entry("_tracing_enabled"),
-                package_source_entry,
+                package_source_entry_t,
                 (TELEMETRY_STARTUP_LOGS_ENABLED, config._startup_logs_enabled, "unknown"),
                 (TELEMETRY_DYNAMIC_INSTRUMENTATION_ENABLED, di_config.enabled, "unknown"),
                 (TELEMETRY_EXCEPTION_DEBUGGING_ENABLED, ed_config.enabled, "unknown"),

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -146,6 +146,7 @@ def test_app_started_event(telemetry_writer, test_agent_session, mock_time):
                     {"name": "logs_injection_enabled", "origin": "default", "value": "false"},
                     {"name": "trace_tags", "origin": "default", "value": ""},
                     {"name": "tracing_enabled", "origin": "default", "value": "true"},
+                    {"name": "instrumentation_config_id", "origin": "default", "value": ""},
                 ],
                 key=lambda x: x["name"],
             ),
@@ -229,6 +230,7 @@ import ddtrace.auto
     env["DD_TRACE_WRITER_INTERVAL_SECONDS"] = "30"
     env["DD_TRACE_WRITER_REUSE_CONNECTIONS"] = "True"
     env["DD_TAGS"] = "team:apm,component:web"
+    env["DD_INSTRUMENTATION_CONFIG_ID"] = "abcedf123"
     env[env_var] = value
 
     file = tmpdir.join("moon_ears.json")
@@ -314,6 +316,7 @@ import ddtrace.auto
             {"name": "trace_header_tags", "origin": "default", "value": ""},
             {"name": "trace_tags", "origin": "env_var", "value": "team:apm,component:web"},
             {"name": "tracing_enabled", "origin": "env_var", "value": "false"},
+            {"name": "instrumentation_config_id", "origin": "env_var", "value": "abcedf123"},
         ],
         key=lambda x: x["name"],
     )


### PR DESCRIPTION
When enabling library injection remotely through the UI, we'd like to show which
services have been instrumented as a result. To do this we are proposing
to submit the remote configuration ID that was used to instrument the service.


[](https://datadoghq.atlassian.net/browse/APMON-887)

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
