### PR TITLE
chore(lib-inject): use slim images in CI

### DIFF
--- a/tests/lib-injection/dd-lib-python-init-test-django-gunicorn/Dockerfile
+++ b/tests/lib-injection/dd-lib-python-init-test-django-gunicorn/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.10-slim
 
 ENV PYTHONUNBUFFERED 1
 ENV DJANGO_SETTINGS_MODULE django_app

--- a/tests/lib-injection/dd-lib-python-init-test-django-pre-installed/Dockerfile
+++ b/tests/lib-injection/dd-lib-python-init-test-django-pre-installed/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.9-slim
 
 ENV PYTHONUNBUFFERED 1
 ENV DJANGO_SETTINGS_MODULE django_app

--- a/tests/lib-injection/dd-lib-python-init-test-django-unsupported-python/Dockerfile
+++ b/tests/lib-injection/dd-lib-python-init-test-django-unsupported-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6-slim
 
 ENV PYTHONUNBUFFERED 1
 ENV DJANGO_SETTINGS_MODULE django_app

--- a/tests/lib-injection/dd-lib-python-init-test-django-uvicorn/Dockerfile
+++ b/tests/lib-injection/dd-lib-python-init-test-django-uvicorn/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.12-slim
 
 ENV PYTHONUNBUFFERED 1
 ENV DJANGO_SETTINGS_MODULE django_app

--- a/tests/lib-injection/dd-lib-python-init-test-django/Dockerfile
+++ b/tests/lib-injection/dd-lib-python-init-test-django/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.11-slim
 
 ENV PYTHONUNBUFFERED 1
 ENV DJANGO_SETTINGS_MODULE django_app


### PR DESCRIPTION
This should speed up CI and save resources without any drawback since the slim images should contain everything required for our purposes.

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [ ] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
