### PR TITLE
feat(botocore): add support for tagging bedrock message input/outputs

### DIFF
--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -4,6 +4,7 @@ from typing import Dict
 from typing import Optional
 
 from ddtrace._trace.span import Span
+from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._constants import INPUT_MESSAGES
 from ddtrace.llmobs._constants import INPUT_PARAMETERS
 from ddtrace.llmobs._constants import METRICS
@@ -12,6 +13,9 @@ from ddtrace.llmobs._constants import MODEL_PROVIDER
 from ddtrace.llmobs._constants import OUTPUT_MESSAGES
 from ddtrace.llmobs._constants import SPAN_KIND
 from ddtrace.llmobs._integrations import BaseLLMIntegration
+
+
+log = get_logger(__name__)
 
 
 class BedrockIntegration(BaseLLMIntegration):
@@ -64,6 +68,7 @@ class BedrockIntegration(BaseLLMIntegration):
         if isinstance(prompt, str):
             return [{"content": prompt}]
         if not isinstance(prompt, list):
+            log.warning("Bedrock input is not a list of messages or a string.")
             return [{"content": ""}]
         input_messages = []
         for p in prompt:
@@ -71,12 +76,12 @@ class BedrockIntegration(BaseLLMIntegration):
             if isinstance(content, list) and isinstance(content[0], dict):
                 for entry in content:
                     if entry.get("type") == "text":
-                        input_messages.append({"content": entry.get("text"), "role": str(p.get("role"))})
+                        input_messages.append({"content": entry.get("text", ""), "role": str(p.get("role", ""))})
                     elif entry.get("type") == "image":
                         # Store a placeholder for potentially enormous binary image data.
-                        input_messages.append({"content": "{IMAGE DETECTED}", "role": str(p.get("role"))})
+                        input_messages.append({"content": "([IMAGE DETECTED])", "role": str(p.get("role", ""))})
             else:
-                input_messages.append({"content": content, "role": str(p.get("role"))})
+                input_messages.append({"content": content, "role": str(p.get("role", ""))})
         return input_messages
 
     @staticmethod

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -31,18 +31,18 @@ class BedrockIntegration(BaseLLMIntegration):
         max_tokens = int(span.get_tag("bedrock.request.max_tokens") or 0)
         if max_tokens:
             parameters["max_tokens"] = max_tokens
+        input_messages = self._extract_input_message(prompt)
 
         span.set_tag_str(SPAN_KIND, "llm")
         span.set_tag_str(MODEL_NAME, span.get_tag("bedrock.request.model") or "")
         span.set_tag_str(MODEL_PROVIDER, span.get_tag("bedrock.request.model_provider") or "")
-        span.set_tag_str(INPUT_MESSAGES, json.dumps([{"content": prompt}]))
+        span.set_tag_str(INPUT_MESSAGES, json.dumps(input_messages))
         span.set_tag_str(INPUT_PARAMETERS, json.dumps(parameters))
         if err or formatted_response is None:
             span.set_tag_str(OUTPUT_MESSAGES, json.dumps([{"content": ""}]))
         else:
-            span.set_tag_str(
-                OUTPUT_MESSAGES, json.dumps([{"content": completion} for completion in formatted_response["text"]])
-            )
+            output_messages = self._extract_output_message(formatted_response)
+            span.set_tag_str(OUTPUT_MESSAGES, json.dumps(output_messages))
         span.set_tag_str(METRICS, json.dumps(self._llmobs_metrics(span, formatted_response)))
 
     @staticmethod
@@ -55,3 +55,39 @@ class BedrockIntegration(BaseLLMIntegration):
             metrics["completion_tokens"] = completion_tokens
             metrics["total_tokens"] = prompt_tokens + completion_tokens
         return metrics
+
+    @staticmethod
+    def _extract_input_message(prompt):
+        """Extract input messages from the stored prompt.
+        Anthropic allows for messages and multiple texts in a message, which requires some special casing.
+        """
+        if isinstance(prompt, str):
+            return [{"content": prompt}]
+        if not isinstance(prompt, list):
+            return [{"content": ""}]
+        input_messages = []
+        for p in prompt:
+            content = p.get("content", "")
+            if isinstance(content, list) and isinstance(content[0], dict):
+                for entry in content:
+                    if entry.get("type") == "text":
+                        input_messages.append({"content": entry.get("text"), "role": str(p.get("role"))})
+                    elif entry.get("type") == "image":
+                        # Store a placeholder for potentially enormous binary image data.
+                        input_messages.append({"content": "{IMAGE DETECTED}", "role": str(p.get("role"))})
+            else:
+                input_messages.append({"content": content, "role": str(p.get("role"))})
+        return input_messages
+
+    @staticmethod
+    def _extract_output_message(formatted_response):
+        """Extract output messages from the stored response.
+        Anthropic allows for chat messages, which requires some special casing.
+        """
+        if isinstance(formatted_response["text"], str):
+            return [{"content": formatted_response["text"]}]
+        if isinstance(formatted_response["text"], list):
+            if isinstance(formatted_response["text"][0], str):
+                return [{"content": str(resp)} for resp in formatted_response["text"]]
+            if isinstance(formatted_response["text"][0], dict):
+                return [{"content": formatted_response["text"][0].get("text", "")}]

--- a/releasenotes/notes/feat-bedrock-message-api-673e527cb1b0befd.yaml
+++ b/releasenotes/notes/feat-bedrock-message-api-673e527cb1b0befd.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    botocore: Adds support to the bedrock integration for tagging input and output messages.

--- a/tests/contrib/botocore/bedrock_cassettes/anthropic_message_invoke.yaml
+++ b/tests/contrib/botocore/bedrock_cassettes/anthropic_message_invoke.yaml
@@ -1,0 +1,49 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": [{"type": "text", "text": "summarize
+      the plot to the lord of the rings in a dozen words"}]}], "anthropic_version":
+      "bedrock-2023-05-31", "max_tokens": 50, "temperature": 0}'
+    headers:
+      Content-Length:
+      - '214'
+      User-Agent:
+      - !!binary |
+        Qm90bzMvMS4zNC40OSBtZC9Cb3RvY29yZSMxLjM0LjQ5IHVhLzIuMCBvcy9tYWNvcyMyMy4zLjAg
+        bWQvYXJjaCNhcm02NCBsYW5nL3B5dGhvbiMzLjEwLjUgbWQvcHlpbXBsI0NQeXRob24gY2ZnL3Jl
+        dHJ5LW1vZGUjbGVnYWN5IEJvdG9jb3JlLzEuMzQuNDk=
+      X-Amz-Date:
+      - !!binary |
+        MjAyNDAzMjdUMjMwODA4Wg==
+      amz-sdk-invocation-id:
+      - !!binary |
+        MGZmOGJmYzktODE2My00NGFkLTk0NjEtNmExZGRiNGY0NmVl
+      amz-sdk-request:
+      - !!binary |
+        YXR0ZW1wdD0x
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-sonnet-20240229-v1%3A0/invoke
+  response:
+    body:
+      string: '{"id":"msg_01E6sPP1ksqicYCaBrkvzna8","type":"message","role":"assistant","content":[{"type":"text","text":"Hobbits
+        embark on epic quest to destroy powerful ring, battling dark forces."}],"model":"claude-3-sonnet-28k-20240229","stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":21,"output_tokens":22}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '319'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 27 Mar 2024 23:08:09 GMT
+      X-Amzn-Bedrock-Input-Token-Count:
+      - '21'
+      X-Amzn-Bedrock-Invocation-Latency:
+      - '886'
+      X-Amzn-Bedrock-Output-Token-Count:
+      - '22'
+      x-amzn-RequestId:
+      - cfb79f63-67cf-45b5-8a3c-9f5bf02064f5
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/contrib/botocore/bedrock_cassettes/anthropic_message_invoke_stream.yaml
+++ b/tests/contrib/botocore/bedrock_cassettes/anthropic_message_invoke_stream.yaml
@@ -1,0 +1,137 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": [{"type": "text", "text": "summarize
+      the plot to the lord of the rings in a dozen words"}]}], "anthropic_version":
+      "bedrock-2023-05-31", "max_tokens": 50, "temperature": 0}'
+    headers:
+      Content-Length:
+      - '214'
+      User-Agent:
+      - !!binary |
+        Qm90bzMvMS4zNC40OSBtZC9Cb3RvY29yZSMxLjM0LjQ5IHVhLzIuMCBvcy9tYWNvcyMyMy4zLjAg
+        bWQvYXJjaCNhcm02NCBsYW5nL3B5dGhvbiMzLjEwLjUgbWQvcHlpbXBsI0NQeXRob24gY2ZnL3Jl
+        dHJ5LW1vZGUjbGVnYWN5IEJvdG9jb3JlLzEuMzQuNDk=
+      X-Amz-Date:
+      - !!binary |
+        MjAyNDAzMjdUMjMyNTUyWg==
+      amz-sdk-invocation-id:
+      - !!binary |
+        OTAzOWQ0M2YtMjI1Yy00MTg1LTk2ZmYtNjAxNjgxNmRlNWRi
+      amz-sdk-request:
+      - !!binary |
+        YXR0ZW1wdD0x
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-sonnet-20240229-v1%3A0/invoke-with-response-stream
+  response:
+    body:
+      string: !!binary |
+        AAABrwAAAEu9B5yTCzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0
+        aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaWJXVnpj
+        MkZuWlY5emRHRnlkQ0lzSW0xbGMzTmhaMlVpT25zaWFXUWlPaUp0YzJkZk1ERXpUVlp2Y1dWU2NH
+        VnJiemxGYUVoV1kwSmtTblpySWl3aWRIbHdaU0k2SW0xbGMzTmhaMlVpTENKeWIyeGxJam9pWVhO
+        emFYTjBZVzUwSWl3aVkyOXVkR1Z1ZENJNlcxMHNJbTF2WkdWc0lqb2lZMnhoZFdSbExUTXRjMjl1
+        Ym1WMExUSTRheTB5TURJME1ESXlPU0lzSW5OMGIzQmZjbVZoYzI5dUlqcHVkV3hzTENKemRHOXdY
+        M05sY1hWbGJtTmxJanB1ZFd4c0xDSjFjMkZuWlNJNmV5SnBibkIxZEY5MGIydGxibk1pT2pJeExD
+        SnZkWFJ3ZFhSZmRHOXJaVzV6SWpveWZYMTkifXGngnUAAADXAAAAS7/55DgLOmV2ZW50LXR5cGUH
+        AAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAF
+        ZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pWTI5dWRHVnVkRjlpYkc5amExOXpkR0Z5ZENJc0lt
+        bHVaR1Y0SWpvd0xDSmpiMjUwWlc1MFgySnNiMk5ySWpwN0luUjVjR1VpT2lKMFpYaDBJaXdpZEdW
+        NGRDSTZJaUo5ZlE9PSJ9zb9mHQAAANcAAABLv/nkOAs6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250
+        ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMi
+        OiJleUowZVhCbElqb2lZMjl1ZEdWdWRGOWliRzlqYTE5a1pXeDBZU0lzSW1sdVpHVjRJam93TENK
+        a1pXeDBZU0k2ZXlKMGVYQmxJam9pZEdWNGRGOWtaV3gwWVNJc0luUmxlSFFpT2lKSWJ5SjlmUT09
+        In23ZierAAAA1wAAAEu/+eQ4CzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFw
+        cGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpv
+        aVkyOXVkR1Z1ZEY5aWJHOWphMTlrWld4MFlTSXNJbWx1WkdWNElqb3dMQ0prWld4MFlTSTZleUow
+        ZVhCbElqb2lkR1Y0ZEY5a1pXeDBZU0lzSW5SbGVIUWlPaUppWWlKOWZRPT0ifQ0pk8IAAADXAAAA
+        S7/55DgLOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNv
+        bg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pWTI5dWRHVnVkRjlp
+        Ykc5amExOWtaV3gwWVNJc0ltbHVaR1Y0SWpvd0xDSmtaV3gwWVNJNmV5SjBlWEJsSWpvaWRHVjRk
+        RjlrWld4MFlTSXNJblJsZUhRaU9pSnBkSE1pZlgwPSJ9Bn+s5gAAANcAAABLv/nkOAs6ZXZlbnQt
+        dHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5
+        cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhCbElqb2lZMjl1ZEdWdWRGOWliRzlqYTE5a1pXeDBZ
+        U0lzSW1sdVpHVjRJam93TENKa1pXeDBZU0k2ZXlKMGVYQmxJam9pZEdWNGRGOWtaV3gwWVNJc0lu
+        UmxlSFFpT2lJZ1pXMWlJbjE5In1vviHWAAAA1wAAAEu/+eQ4CzpldmVudC10eXBlBwAFY2h1bmsN
+        OmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJi
+        eXRlcyI6ImV5SjBlWEJsSWpvaVkyOXVkR1Z1ZEY5aWJHOWphMTlrWld4MFlTSXNJbWx1WkdWNElq
+        b3dMQ0prWld4MFlTSTZleUowZVhCbElqb2lkR1Y0ZEY5a1pXeDBZU0lzSW5SbGVIUWlPaUpoY21z
+        aWZYMD0ifai3FLIAAADXAAAAS7/55DgLOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBl
+        BwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVY
+        QmxJam9pWTI5dWRHVnVkRjlpYkc5amExOWtaV3gwWVNJc0ltbHVaR1Y0SWpvd0xDSmtaV3gwWVNJ
+        NmV5SjBlWEJsSWpvaWRHVjRkRjlrWld4MFlTSXNJblJsZUhRaU9pSWdiMjRpZlgwPSJ9LaAc6QAA
+        ANsAAABLegkJOQs6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlv
+        bi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhCbElqb2lZMjl1ZEdW
+        dWRGOWliRzlqYTE5a1pXeDBZU0lzSW1sdVpHVjRJam93TENKa1pXeDBZU0k2ZXlKMGVYQmxJam9p
+        ZEdWNGRGOWtaV3gwWVNJc0luUmxlSFFpT2lJZ1pYQnBZeUo5ZlE9PSJ9r7TlKAAAANsAAABLegkJ
+        OQs6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTpt
+        ZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhCbElqb2lZMjl1ZEdWdWRGOWliRzlq
+        YTE5a1pXeDBZU0lzSW1sdVpHVjRJam93TENKa1pXeDBZU0k2ZXlKMGVYQmxJam9pZEdWNGRGOWta
+        V3gwWVNJc0luUmxlSFFpT2lJZ2NYVmxjM1FpZlgwPSJ9yNU7XQAAANcAAABLv/nkOAs6ZXZlbnQt
+        dHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5
+        cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhCbElqb2lZMjl1ZEdWdWRGOWliRzlqYTE5a1pXeDBZ
+        U0lzSW1sdVpHVjRJam93TENKa1pXeDBZU0k2ZXlKMGVYQmxJam9pZEdWNGRGOWtaV3gwWVNJc0lu
+        UmxlSFFpT2lJZ2RHOGlmWDA9In3NJf97AAAA3wAAAEuPia/5CzpldmVudC10eXBlBwAFY2h1bmsN
+        OmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJi
+        eXRlcyI6ImV5SjBlWEJsSWpvaVkyOXVkR1Z1ZEY5aWJHOWphMTlrWld4MFlTSXNJbWx1WkdWNElq
+        b3dMQ0prWld4MFlTSTZleUowZVhCbElqb2lkR1Y0ZEY5a1pXeDBZU0lzSW5SbGVIUWlPaUlnWkdW
+        emRISnZlU0o5ZlE9PSJ9GVDMeAAAAN8AAABLj4mv+Qs6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250
+        ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMi
+        OiJleUowZVhCbElqb2lZMjl1ZEdWdWRGOWliRzlqYTE5a1pXeDBZU0lzSW1sdVpHVjRJam93TENK
+        a1pXeDBZU0k2ZXlKMGVYQmxJam9pZEdWNGRGOWtaV3gwWVNJc0luUmxlSFFpT2lJZ2NHOTNaWEpt
+        ZFd3aWZYMD0ifbBAbfYAAADbAAAAS3oJCTkLOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10
+        eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlK
+        MGVYQmxJam9pWTI5dWRHVnVkRjlpYkc5amExOWtaV3gwWVNJc0ltbHVaR1Y0SWpvd0xDSmtaV3gw
+        WVNJNmV5SjBlWEJsSWpvaWRHVjRkRjlrWld4MFlTSXNJblJsZUhRaU9pSWdjbWx1WnlKOWZRPT0i
+        fdsCH0cAAADTAAAAS0p5QvgLOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBw
+        bGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9p
+        WTI5dWRHVnVkRjlpYkc5amExOWtaV3gwWVNJc0ltbHVaR1Y0SWpvd0xDSmtaV3gwWVNJNmV5SjBl
+        WEJsSWpvaWRHVjRkRjlrWld4MFlTSXNJblJsZUhRaU9pSXNJbjE5In1IR0aCAAAA2wAAAEt6CQk5
+        CzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1l
+        c3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaVkyOXVkR1Z1ZEY5aWJHOWph
+        MTlrWld4MFlTSXNJbWx1WkdWNElqb3dMQ0prWld4MFlTSTZleUowZVhCbElqb2lkR1Y0ZEY5a1pX
+        eDBZU0lzSW5SbGVIUWlPaUlnWW1GMGRDSjlmUT09In063/+bAAAA1wAAAEu/+eQ4CzpldmVudC10
+        eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlw
+        ZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaVkyOXVkR1Z1ZEY5aWJHOWphMTlrWld4MFlT
+        SXNJbWx1WkdWNElqb3dMQ0prWld4MFlTSTZleUowZVhCbElqb2lkR1Y0ZEY5a1pXeDBZU0lzSW5S
+        bGVIUWlPaUpzYVc1bkluMTkifdfxDdQAAADbAAAAS3oJCTkLOmV2ZW50LXR5cGUHAAVjaHVuaw06
+        Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5
+        dGVzIjoiZXlKMGVYQmxJam9pWTI5dWRHVnVkRjlpYkc5amExOWtaV3gwWVNJc0ltbHVaR1Y0SWpv
+        d0xDSmtaV3gwWVNJNmV5SjBlWEJsSWpvaWRHVjRkRjlrWld4MFlTSXNJblJsZUhRaU9pSWdaR0Z5
+        YXlKOWZRPT0ifT+sUfEAAADbAAAAS3oJCTkLOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10
+        eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlK
+        MGVYQmxJam9pWTI5dWRHVnVkRjlpYkc5amExOWtaV3gwWVNJc0ltbHVaR1Y0SWpvd0xDSmtaV3gw
+        WVNJNmV5SjBlWEJsSWpvaWRHVjRkRjlrWld4MFlTSXNJblJsZUhRaU9pSWdabTl5WTJWekluMTki
+        fQET+eEAAADTAAAAS0p5QvgLOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBw
+        bGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9p
+        WTI5dWRHVnVkRjlpYkc5amExOWtaV3gwWVNJc0ltbHVaR1Y0SWpvd0xDSmtaV3gwWVNJNmV5SjBl
+        WEJsSWpvaWRHVjRkRjlrWld4MFlTSXNJblJsZUhRaU9pSXVJbjE5In0rl3O4AAAAmwAAAEsi+lFw
+        CzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1l
+        c3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaVkyOXVkR1Z1ZEY5aWJHOWph
+        MTl6ZEc5d0lpd2lhVzVrWlhnaU9qQjkifcBWfr4AAAD7AAAAS7vIJj0LOmV2ZW50LXR5cGUHAAVj
+        aHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZl
+        bnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pYldWemMyRm5aVjlrWld4MFlTSXNJbVJsYkhSaElqcDdJ
+        bk4wYjNCZmNtVmhjMjl1SWpvaVpXNWtYM1IxY200aUxDSnpkRzl3WDNObGNYVmxibU5sSWpwdWRX
+        eHNmU3dpZFhOaFoyVWlPbnNpYjNWMGNIVjBYM1J2YTJWdWN5STZNako5ZlE9PSJ9Dr54mgAAATMA
+        AABLqfFWggs6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9q
+        c29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhCbElqb2liV1Z6YzJGblpW
+        OXpkRzl3SWl3aVlXMWhlbTl1TFdKbFpISnZZMnN0YVc1MmIyTmhkR2x2YmsxbGRISnBZM01pT25z
+        aWFXNXdkWFJVYjJ0bGJrTnZkVzUwSWpveU1Td2liM1YwY0hWMFZHOXJaVzVEYjNWdWRDSTZNaklz
+        SW1sdWRtOWpZWFJwYjI1TVlYUmxibU41SWpveU1ETXpMQ0ptYVhKemRFSjVkR1ZNWVhSbGJtTjVJ
+        am94TWpJNWZYMD0ifdb/Fzc=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/vnd.amazon.eventstream
+      Date:
+      - Wed, 27 Mar 2024 23:25:53 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Amzn-Bedrock-Content-Type:
+      - application/json
+      x-amzn-RequestId:
+      - 1708c260-6ca9-46ce-8799-1ce6c03cae0d
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/contrib/botocore/test_bedrock.py
+++ b/tests/contrib/botocore/test_bedrock.py
@@ -264,6 +264,14 @@ def test_anthropic_invoke(bedrock_client, request_vcr):
 
 
 @pytest.mark.snapshot
+def test_anthropic_message_invoke(bedrock_client, request_vcr):
+    body, model = json.dumps(_REQUEST_BODIES["anthropic_message"]), _MODELS["anthropic_message"]
+    with request_vcr.use_cassette("anthropic_message_invoke.yaml"):
+        response = bedrock_client.invoke_model(body=body, modelId=model)
+        json.loads(response.get("body").read())
+
+
+@pytest.mark.snapshot
 def test_cohere_invoke_single_output(bedrock_client, request_vcr):
     body, model = json.dumps(_REQUEST_BODIES["cohere"]), _MODELS["cohere"]
     with request_vcr.use_cassette("cohere_invoke_single_output.yaml"):
@@ -311,6 +319,15 @@ def test_amazon_invoke_stream(bedrock_client, request_vcr):
 def test_anthropic_invoke_stream(bedrock_client, request_vcr):
     body, model = json.dumps(_REQUEST_BODIES["anthropic"]), _MODELS["anthropic"]
     with request_vcr.use_cassette("anthropic_invoke_stream.yaml"):
+        response = bedrock_client.invoke_model_with_response_stream(body=body, modelId=model)
+        for _ in response.get("body"):
+            pass
+
+
+@pytest.mark.snapshot
+def test_anthropic_message_invoke_stream(bedrock_client, request_vcr):
+    body, model = json.dumps(_REQUEST_BODIES["anthropic_message"]), _MODELS["anthropic_message"]
+    with request_vcr.use_cassette("anthropic_message_invoke_stream.yaml"):
         response = bedrock_client.invoke_model_with_response_stream(body=body, modelId=model)
         for _ in response.get("body"):
             pass

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_message_invoke.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_message_invoke.json
@@ -1,0 +1,40 @@
+[[
+  {
+    "name": "bedrock-runtime.command",
+    "service": "aws.bedrock-runtime",
+    "resource": "InvokeModel",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "llm",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6604ae4600000000",
+      "bedrock.request.max_tokens": "",
+      "bedrock.request.model": "claude-3-sonnet-20240229-v1:0",
+      "bedrock.request.model_provider": "anthropic",
+      "bedrock.request.prompt": "[{'role': 'user', 'content': [{'type': 'text', 'text': 'summarize the plot to the lord of the rings in a dozen words'}]}]",
+      "bedrock.request.stop_sequences": "[]",
+      "bedrock.request.temperature": "0",
+      "bedrock.request.top_k": "",
+      "bedrock.request.top_p": "",
+      "bedrock.response.choices.0.finish_reason": "end_turn",
+      "bedrock.response.choices.0.text": "{'type': 'text', 'text': 'Hobbits embark on epic quest to destroy powerful ring, battling dark forces.'}",
+      "bedrock.response.duration": "886",
+      "bedrock.response.id": "cfb79f63-67cf-45b5-8a3c-9f5bf02064f5",
+      "bedrock.usage.completion_tokens": "22",
+      "bedrock.usage.prompt_tokens": "21",
+      "language": "python",
+      "runtime-id": "d2a21cfa56b94b50bae2ca63f83c50f9"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 40705
+    },
+    "duration": 2160000,
+    "start": 1711582790110771000
+  }]]

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_message_invoke_stream.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_message_invoke_stream.json
@@ -1,0 +1,40 @@
+[[
+  {
+    "name": "bedrock-runtime.command",
+    "service": "aws.bedrock-runtime",
+    "resource": "InvokeModelWithResponseStream",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "llm",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6604ae8300000000",
+      "bedrock.request.max_tokens": "",
+      "bedrock.request.model": "claude-3-sonnet-20240229-v1:0",
+      "bedrock.request.model_provider": "anthropic",
+      "bedrock.request.prompt": "[{'role': 'user', 'content': [{'type': 'text', 'text': 'summarize the plot to the lord of the rings in a dozen words'}]}]",
+      "bedrock.request.stop_sequences": "[]",
+      "bedrock.request.temperature": "0",
+      "bedrock.request.top_k": "",
+      "bedrock.request.top_p": "",
+      "bedrock.response.choices.0.finish_reason": "end_turn",
+      "bedrock.response.choices.0.text": "Hobbits embark on epic quest to destroy powerful ring, battling dark forces.",
+      "bedrock.response.duration": "2033",
+      "bedrock.response.id": "1708c260-6ca9-46ce-8799-1ce6c03cae0d",
+      "bedrock.usage.completion_tokens": "22",
+      "bedrock.usage.prompt_tokens": "21",
+      "language": "python",
+      "runtime-id": "7cf2c8f7bcae407886c63c657123594f"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 40896
+    },
+    "duration": 2950000,
+    "start": 1711582851111829000
+  }]]


### PR DESCRIPTION
This PR adds support to the botocore integration's bedrock service to correctly tag input/output messages from Anthropic calls.

Previously bedrock's models only supported raw text prompts and returned text outputs. However, Anthropic's newest claude 3 supports a chat message API, which means we need to support that as well.

This change also switches to using `tracer.trace()` instead of `tracer.start_span(..., activate=False)` for bedrock spans, because the latter meant that bedrock spans would always be root spans (messing up parenting for traces containing non-root bedrock spans). 
Additionally by getting rid of the `activate=False` argument, this means that bedrock spans will now continue to be the active span until the stream/body is completely consumed. Previously we allowed bedrock spans to not be active, but if other downstream operations happen in the bedrock span then they would not correctly be child spans of the bedrock spans.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [X] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
