### PR TITLE
ci: Revert "ci: parallel system tests (#8791)"

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -24,7 +24,7 @@ jobs:
           python -c "import os,sys,fnmatch;sys.exit(not bool([_ for pattern in {'ddtrace/*', 'setup*', 'pyproject.toml', '.github/workflows/system-tests.yml'} for _ in fnmatch.filter(os.environ['PATHS'].splitlines(), pattern)]))"
         continue-on-error: true
 
-  system-tests-build:
+  system-tests:
     runs-on: ubuntu-latest
     needs: needs-run
     strategy:
@@ -34,7 +34,7 @@ jobs:
           - weblog-variant: uwsgi-poc
           - weblog-variant: django-poc
           - weblog-variant: fastapi
-          # runs django-poc for 3.12
+        #   runs django-poc for 3.12
           - weblog-variant: python3.12
       fail-fast: false
     env:
@@ -69,105 +69,98 @@ jobs:
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
         run: ./build.sh
 
-      - name: Save
-        id: save
+      - name: Run INTEGRATIONS
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        run: |
-          docker image save system_tests/weblog:latest | gzip > ${{ matrix.weblog-variant}}_weblog_${{ github.sha }}.tar.gz
-          docker image save system_tests/agent:latest | gzip > ${{ matrix.weblog-variant}}_agent_${{ github.sha }}.tar.gz
+        run: ./run.sh INTEGRATIONS
 
-      - uses: actions/upload-artifact@master
+      - name: Run CROSSED_TRACING_LIBRARIES
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        with:
-          name: ${{ matrix.weblog-variant }}_${{ github.sha }}
-          path: |
-            ${{ matrix.weblog-variant}}_weblog_${{ github.sha }}.tar.gz
-            ${{ matrix.weblog-variant}}_agent_${{ github.sha }}.tar.gz
-            venv
-          retention-days: 2
+        run: ./run.sh CROSSED_TRACING_LIBRARIES
 
-  system-tests-run:
-    runs-on: ubuntu-latest
-    needs: [needs-run, system-tests-build]
-    strategy:
-      matrix:
-        weblog-variant: [flask-poc, uwsgi-poc , django-poc, fastapi, python3.12]
-        scenario: [
-          INTEGRATIONS,
-          CROSSED_TRACING_LIBRARIES,
-          DEFAULT,
-          SAMPLING
-          REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES,
-          REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES,
-          REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING, REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD,
-          APPSEC_MISSING_RULES,
-          APPSEC_CUSTOM_RULES,
-          APPSEC_CORRUPTED_RULES,
-          APPSEC_RULES_MONITORING_WITH_ERRORS,
-          APPSEC_BLOCKING,
-          APPSEC_DISABLED,
-          APPSEC_LOW_WAF_TIMEOUT,
-          APPSEC_CUSTOM_OBFUSCATION,
-          APPSEC_RATE_LIMITER,
-          APPSEC_BLOCKING_FULL_DENYLIST, APPSEC_REQUEST_BLOCKING,
-          APPSEC_RUNTIME_ACTIVATION,
-          APPSEC_WAF_TELEMETRY,
-        ]
-
-      fail-fast: false
-    env:
-      TEST_LIBRARY: python
-      WEBLOG_VARIANT: ${{ matrix.weblog-variant }}
-      # system-tests requires an API_KEY, but it does not have to be a valid key, as long as we don't run a scenario
-      # that make assertion on backend data. Using a fake key allow to run system tests on PR originating from forks.
-      # If ever it's needed, a valid key exists in the repo, using ${{ secrets.DD_API_KEY }}
-      DD_API_KEY: 1234567890abcdef1234567890abcdef
-      CMAKE_BUILD_PARALLEL_LEVEL: 12
-    steps:
-      - name: Setup python 3.9
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-
-      - name: Checkout system tests
+      - name: Run
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        uses: actions/checkout@v3
-        with:
-          repository: 'DataDog/system-tests'
+        run: ./run.sh
 
-      - uses: actions/download-artifact@master
+      - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        with:
-          name: ${{ matrix.weblog-variant }}_${{ github.sha }}
-          path: ${{ matrix.weblog-variant}}_${{ github.sha }}.tar.gz
+        run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES
 
-      - name: docker load
+      - name: Run REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        run: |
-          docker load < ${{ matrix.weblog-variant}}_${{ github.sha }}.tar.gz/${{ matrix.weblog-variant}}_weblog_${{ github.sha }}.tar.gz
-          docker load < ${{ matrix.weblog-variant}}_${{ github.sha }}.tar.gz/${{ matrix.weblog-variant}}_agent_${{ github.sha }}.tar.gz
+        run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING
 
-      - name: move venv
+      - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        run: |
-          mv ${{ matrix.weblog-variant}}_${{ github.sha }}.tar.gz/venv venv
-          chmod -R +x venv/bin/*
+        run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD
 
-      - name: Run ${{ matrix.scenario }}
+      - name: Run APPSEC_MISSING_RULES
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        run: ./run.sh ${{ matrix.scenario }}
+        run: ./run.sh APPSEC_MISSING_RULES
+
+      - name: Run APPSEC_CUSTOM_RULES
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        run: ./run.sh APPSEC_CUSTOM_RULES
+
+      - name: Run APPSEC_CORRUPTED_RULES
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        run: ./run.sh APPSEC_CORRUPTED_RULES
+
+      - name: Run APPSEC_RULES_MONITORING_WITH_ERRORS
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        run: ./run.sh APPSEC_RULES_MONITORING_WITH_ERRORS
+
+      - name: Run APPSEC_BLOCKING
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        run: ./run.sh APPSEC_BLOCKING
+
+      - name: Run APPSEC_DISABLED
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        run: ./run.sh APPSEC_DISABLED
+
+      - name: Run APPSEC_LOW_WAF_TIMEOUT
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        run: ./run.sh APPSEC_LOW_WAF_TIMEOUT
+
+      - name: Run APPSEC_CUSTOM_OBFUSCATION
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        run: ./run.sh APPSEC_CUSTOM_OBFUSCATION
+
+      - name: Run APPSEC_RATE_LIMITER
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        run: ./run.sh APPSEC_RATE_LIMITER
+
+      - name: Run APPSEC_BLOCKING_FULL_DENYLIST
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        run: ./run.sh APPSEC_BLOCKING_FULL_DENYLIST
+
+      - name: Run APPSEC_REQUEST_BLOCKING
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        run: ./run.sh APPSEC_REQUEST_BLOCKING
+
+      - name: Run APPSEC_RUNTIME_ACTIVATION
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        run: ./run.sh APPSEC_RUNTIME_ACTIVATION
+
+      - name: Run APPSEC_WAF_TELEMETRY
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        run: ./run.sh APPSEC_WAF_TELEMETRY
+
+      - name: Run SAMPLING
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        run: ./run.sh SAMPLING
 
       # even on failures, we want to have artifact to be able to investigate, so run if build was a success
       # The compress step speed up a lot the upload artifact process
       - name: Compress artifact
         id: compress-artifact
+        if: steps.build.outcome == 'success' || github.event_name == 'schedule'
         run: tar -czvf artifact.tar.gz $(ls | grep logs)
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         if: steps.compress-artifact.outcome == 'success' || github.event_name == 'schedule'
         with:
-          name: logs_${{ matrix.weblog-variant }}_${{ matrix.scenario }}
+          name: logs_${{ matrix.weblog-variant }}
           path: artifact.tar.gz
 
   parametric:
@@ -210,14 +203,3 @@ jobs:
         with:
           name: logs_parametric
           path: artifact.tar.gz
-
-  system-tests:
-    runs-on: ubuntu-latest
-    needs: [needs-run, system-tests-run]
-    strategy:
-      matrix:
-        weblog-variant: [flask-poc, uwsgi-poc, django-poc, fastapi, python3.12]
-    steps:
-      - name: success
-        if: needs.system-tests-run.outputs.outcome == 'success'
-        run: echo "success"


### PR DESCRIPTION
This reverts commit ef4d80459a594b8c70610b03b74593c6c997133c from #8791, which broke CI on the main branch.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
