### PR TITLE
ci: skip forkserver multiprocessing profiling test because it is unreliable

### DIFF
--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -85,7 +85,7 @@ methods = multiprocessing.get_all_start_methods()
 
 @pytest.mark.parametrize(
     "method",
-    methods,
+    set(methods) - {"forkserver"},  # flaky
 )
 def test_multiprocessing(method, tmp_path, monkeypatch):
     filename = str(tmp_path / "pprof")


### PR DESCRIPTION
This change fixes CI failures like [this one](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/58472/workflows/ecbc60dd-6972-4246-ad54-fee72c9adef8/jobs/3695968) by skipping the test.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
