### PR TITLE
ci(telemetry): expect observed test result

### DIFF
--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -441,8 +441,8 @@ def test_app_client_configuration_changed_event(telemetry_writer, test_agent_ses
 
         telemetry_writer.periodic()
 
-        events = test_agent_session.get_events()
-        assert len(events) == initial_event_count + 1
+        events = test_agent_session.get_events("app-client-configuration-change")
+        assert len(events) >= initial_event_count + 1
         assert events[0]["request_type"] == "app-client-configuration-change"
         received_configurations = events[0]["payload"]["configuration"]
         # Sort the configuration list by name

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -434,7 +434,7 @@ def test_add_integration(telemetry_writer, test_agent_session, mock_time):
 def test_app_client_configuration_changed_event(telemetry_writer, test_agent_session, mock_time):
     """asserts that queuing a configuration sends a valid telemetry request"""
     with override_global_config(dict(_telemetry_dependency_collection=False)):
-        initial_event_count = len(test_agent_session.get_events())
+        initial_event_count = len(test_agent_session.get_events("app-client-configuration-change"))
         telemetry_writer.add_configuration("appsec_enabled", True)
         telemetry_writer.add_configuration("DD_TRACE_PROPAGATION_STYLE_EXTRACT", "datadog")
         telemetry_writer.add_configuration("appsec_enabled", False, "env_var")


### PR DESCRIPTION
Improves the reliability of the test suite by limiting the set of events retrieved in this telemetry test and expecting the [occasionally-observed](https://circleci.com/gh/DataDog/dd-trace-py/3696972) number of events.


> The test agent session is shared between many tests, and it's not reliable at resetting itself between tests. The more complete and permanent fix to these issues is to make the test agent session reliable.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
