### PR TITLE
fix(starlette): don't crash on functions without `__name__`

### DIFF
--- a/ddtrace/contrib/starlette/patch.py
+++ b/ddtrace/contrib/starlette/patch.py
@@ -177,10 +177,12 @@ def traced_handler(wrapped, instance, args, kwargs):
 def _trace_background_tasks(module, pin, wrapped, instance, args, kwargs):
     task = get_argument_value(args, kwargs, 0, "func")
     current_span = pin.tracer.current_span()
+    module_name = getattr(module, "__name__", "<unknown>")
+    task_name = getattr(task, "__name__", "<unknown>")
 
     async def traced_task(*args, **kwargs):
         with pin.tracer.start_span(
-            f"{module.__name__}.background_task", resource=task.__name__, child_of=None, activate=True
+            f"{module_name}.background_task", resource=task_name, child_of=None, activate=True
         ) as span:
             if current_span:
                 span.link_span(current_span.context)

--- a/releasenotes/notes/fix-starlette-background-67d4822042028d6b.yaml
+++ b/releasenotes/notes/fix-starlette-background-67d4822042028d6b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    starlette: Fix a bug that crashed background tasks started from functions without a `__name__` attribute

--- a/tests/contrib/starlette/app.py
+++ b/tests/contrib/starlette/app.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 from tempfile import NamedTemporaryFile
 import time
 
@@ -118,6 +119,10 @@ def get_app(engine):
 
         tasks = BackgroundTasks()
         tasks.add_task(custom_task, task_arg="hi")
+
+        anonymous = functools.partial(custom_task, task_arg="hi")
+        tasks.add_task(anonymous)
+
         return JSONResponse(jsonmsg, background=tasks)
 
     routes = [

--- a/tests/snapshots/tests.contrib.starlette.test_starlette.test_background_task.json
+++ b/tests/snapshots/tests.contrib.starlette.test_starlette.test_background_task.json
@@ -2,7 +2,7 @@
   {
     "name": "starlette.background_task",
     "service": "",
-    "resource": "custom_task",
+    "resource": "<unknown>",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
@@ -10,26 +10,52 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "65e7e28000000000",
-      "_dd.span_links": "[{\"trace_id\": \"65e7e27f0000000002d19f6cebbac350\", \"span_id\": \"61fccfc1f9d153b9\", \"tracestate\": \"dd=s:1;t.dm:-0\", \"flags\": 1}]",
+      "_dd.p.tid": "660a332900000000",
+      "_dd.span_links": "[{\"trace_id\": \"660a3327000000008449256363f198a8\", \"span_id\": \"92db06edf6ed92a6\", \"tracestate\": \"dd=s:1;t.dm:-0\", \"flags\": 1}]",
       "language": "python",
-      "runtime-id": "5444022027b74fcead7ac4f888aaa621"
+      "runtime-id": "2c92a35bf98a4b02af66c1340b9fc3bc"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 85074
+      "process_id": 7548
     },
-    "duration": 2001259000,
-    "start": 1709695616000325000
+    "duration": 2004714626,
+    "start": 1711944489796649052
+  }],
+[
+  {
+    "name": "starlette.background_task",
+    "service": "",
+    "resource": "custom_task",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "660a332700000000",
+      "_dd.span_links": "[{\"trace_id\": \"660a3327000000008449256363f198a8\", \"span_id\": \"92db06edf6ed92a6\", \"tracestate\": \"dd=s:1;t.dm:-0\", \"flags\": 1}]",
+      "language": "python",
+      "runtime-id": "2c92a35bf98a4b02af66c1340b9fc3bc"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 7548
+    },
+    "duration": 2003761042,
+    "start": 1711944487791773926
   }],
 [
   {
     "name": "starlette.request",
     "service": "starlette",
     "resource": "GET /backgroundtask",
-    "trace_id": 1,
+    "trace_id": 2,
     "span_id": 1,
     "parent_id": 0,
     "type": "web",
@@ -37,7 +63,7 @@
     "meta": {
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "65e7e27f00000000",
+      "_dd.p.tid": "660a332700000000",
       "component": "starlette",
       "http.method": "GET",
       "http.route": "/backgroundtask",
@@ -46,15 +72,15 @@
       "http.useragent": "testclient",
       "http.version": "1.1",
       "language": "python",
-      "runtime-id": "5444022027b74fcead7ac4f888aaa621",
+      "runtime-id": "2c92a35bf98a4b02af66c1340b9fc3bc",
       "span.kind": "server"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 85074
+      "process_id": 7548
     },
-    "duration": 314000,
-    "start": 1709695615999912000
+    "duration": 501334,
+    "start": 1711944487791160467
   }]]


### PR DESCRIPTION
Don't crash when encountering functions without `__name__` or `__module__` attributes.

Starlette background tasks can be started with any `callable`, and not all `callable`s (annoyingly) are guaranteed to have `__name__` attributes. Specifically, `functools.partial` generates a function without a `__name__`. There is some debate (see https://github.com/python/cpython/issues/91002) about whether this is the right behavior (it's clearly confusing, since it caused a bug here!) but right now, this makes the whole background task crash due to an attribute error.

This PR just tries to get the name/module, and if not available, replaces them with the string `<unknown>` rather than crashing the whole task. (Happy to switch to a different string here, `<unknown>` is just a placeholder that kind of matches python's `__name__` for lambdas (`<lambda>`)

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
