### PR TITLE
ci(tracer): mark unreliable test as flaky

### DIFF
--- a/tests/tracer/runtime/test_metric_collectors.py
+++ b/tests/tracer/runtime/test_metric_collectors.py
@@ -32,7 +32,7 @@ class TestPSUtilRuntimeMetricCollector(BaseTestCase):
         for _, value in collector.collect(PSUTIL_RUNTIME_METRICS):
             self.assertIsNotNone(value)
 
-    @flaky(1717343326000)
+    @flaky(1717343326)
     def test_static_metrics(self):
         import os
         import threading

--- a/tests/tracer/runtime/test_metric_collectors.py
+++ b/tests/tracer/runtime/test_metric_collectors.py
@@ -8,6 +8,7 @@ from ddtrace.internal.runtime.metric_collectors import GCRuntimeMetricCollector
 from ddtrace.internal.runtime.metric_collectors import PSUtilRuntimeMetricCollector
 from ddtrace.internal.runtime.metric_collectors import RuntimeMetricCollector
 from tests.utils import BaseTestCase
+from tests.utils import flaky
 
 
 class TestRuntimeMetricCollector(BaseTestCase):
@@ -31,6 +32,7 @@ class TestPSUtilRuntimeMetricCollector(BaseTestCase):
         for _, value in collector.collect(PSUTIL_RUNTIME_METRICS):
             self.assertIsNotNone(value)
 
+    @flaky(1717343326000)
     def test_static_metrics(self):
         import os
         import threading


### PR DESCRIPTION
Marks a test that has failed occasionally recently ([example](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/58597/workflows/b57ad60b-d526-46d5-a383-7ed9c4dfe46b/jobs/3701995))

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
