### PR TITLE
ci: use v2 command for docker-compose

### DIFF
--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -79,20 +79,20 @@ jobs:
           chmod 777 $TEMP_DIR
           # Start the lib_inject to get the files copied. This avoids a race condition with the startup of the
           # application.
-          docker-compose up --build lib_inject
-          docker-compose up --build -d
+          docker compose up --build lib_inject
+          docker compose up --build -d
           # Wait for the app to start
           sleep 60
-          docker-compose logs
+          docker compose logs
       - name: Check Permissions on ddtrace pkgs
         run: |
            cd lib-injection
            # Ensure /datadog-lib/ddtrace_pkgs is a valid directory that is not empty
-           docker-compose run lib_inject find /datadog-init/ddtrace_pkgs -maxdepth 0 -empty | wc -l && if [ $? -ne 0 ]; then exit 1; fi
+           docker compose run lib_inject find /datadog-init/ddtrace_pkgs -maxdepth 0 -empty | wc -l && if [ $? -ne 0 ]; then exit 1; fi
            # Ensure files are not world writeable
-           docker-compose run lib_inject find /datadog-init/ddtrace_pkgs ! -perm /o+w | wc -l && if [ $? -ne 0 ]; then exit 1; fi
+           docker compose run lib_inject find /datadog-init/ddtrace_pkgs ! -perm /o+w | wc -l && if [ $? -ne 0 ]; then exit 1; fi
            # Ensure all users have read and execute permissions to files stored in /datadog-lib/ddtrace_pkgs
-           docker-compose run lib_inject find /datadog-init/ddtrace_pkgs ! -perm u=rwx,o=rx | wc -l && if [ $? -ne 0 ]; then exit 1; fi
+           docker compose run lib_inject find /datadog-init/ddtrace_pkgs ! -perm u=rwx,o=rx | wc -l && if [ $? -ne 0 ]; then exit 1; fi
       - name: Test the app
         run: |
           curl http://localhost:18080
@@ -106,4 +106,4 @@ jobs:
       - name: Output app logs (LOOK HERE IF THE JOB FAILS)
         if: success() || failure()
         run: |
-          docker-compose logs
+          docker compose logs


### PR DESCRIPTION
This change updates the Github Action that uses docker-compose to call the appropriate command given the recent upgrade of that software on the ubuntu Action image described in https://github.com/actions/runner-images/issues/9557. This had been leading to CI failures like [this](https://github.com/DataDog/dd-trace-py/actions/runs/8527626997/job/23359466946#step:3:1).

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
