### PR TITLE
feat(asm): telemetry sends appsec sca env var

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -455,6 +455,9 @@ class TelemetryWriter(PeriodicService):
             ]
         )
 
+        if config._config["_sca_enabled"] is not None:
+            self.add_configuration("DD_APPSEC_SCA_ENABLED", config._config["_sca_enabled"].value(), "env_var")
+
         payload = {
             "configuration": self._flush_configuration_queue(),
             "error": {

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -312,6 +312,11 @@ def _default_config():
             default=False,
             envs=[("DD_APPSEC_ENABLED", asbool)],
         ),
+        "_sca_enabled": _ConfigItem(
+            name="sca_enabled",
+            default=None,
+            envs=[("DD_APPSEC_ENABLED", asbool)],
+        ),
         "_dsm_enabled": _ConfigItem(
             name="dsm_enabled",
             default=False,

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -418,6 +418,11 @@ The following environment variables for the tracer are supported:
      default: False
      description: Whether to enable AppSec monitoring.
 
+   DD_APPSEC_SCA_ENABLED:
+     type: Boolean
+     default: None
+     description: Wheter to enable/disable SCA (Software Composition Analysis).
+
    DD_APPSEC_RULES:
      type: String
      description: Path to a json file containing AppSec rules.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -421,7 +421,7 @@ The following environment variables for the tracer are supported:
    DD_APPSEC_SCA_ENABLED:
      type: Boolean
      default: None
-     description: Wheter to enable/disable SCA (Software Composition Analysis).
+     description: Whether to enable/disable SCA (Software Composition Analysis).
 
    DD_APPSEC_RULES:
      type: String

--- a/releasenotes/notes/appsec-sca-env-var-telemetry-1f46bea88a86fc39.yaml
+++ b/releasenotes/notes/appsec-sca-env-var-telemetry-1f46bea88a86fc39.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    ASM: This introduces the capability to enable or disable SCA using the environment variable DD_APPSEC_SCA_ENABLED. By default this env var is unset and in that case it doesn't affect the product.

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -481,9 +481,13 @@ from ddtrace.settings import _config
 
 _config._telemetry_dependency_collection = False
 
+class FailingFilture(TraceFilter):
+    def process_trace(self, trace):
+       raise Exception("Exception raised in trace filter")
+
 tracer.configure(
     settings={
-        "FILTERS": [],
+        "FILTERS": [FailingFilture()],
     }
 )
 
@@ -498,7 +502,8 @@ tracer.trace("hello").finish()
 
     app_started_events = [event for event in events if event["request_type"] == "app-started"]
     assert len(app_started_events) == 1
-    assert app_started_events[0]["payload"]["configuration"]["DD_APPSEC_SCA_ENABLED"] == "true"
+    configuration = app_started_events[0]["payload"]["configuration"]
+    assert {"name": "DD_APPSEC_SCA_ENABLED", "origin": "env_var", "value": "true"} in configuration
 
 
 @pytest.mark.parametrize("env_var_value", ["False", "false", "0"])
@@ -513,9 +518,13 @@ from ddtrace.settings import _config
 
 _config._telemetry_dependency_collection = False
 
+class FailingFilture(TraceFilter):
+    def process_trace(self, trace):
+       raise Exception("Exception raised in trace filter")
+
 tracer.configure(
     settings={
-        "FILTERS": [],
+        "FILTERS": [FailingFilture()],
     }
 )
 
@@ -530,7 +539,8 @@ tracer.trace("hello").finish()
 
     app_started_events = [event for event in events if event["request_type"] == "app-started"]
     assert len(app_started_events) == 1
-    assert app_started_events[0]["payload"]["configuration"]["DD_APPSEC_SCA_ENABLED"] == "false"
+    configuration = app_started_events[0]["payload"]["configuration"]
+    assert {"name": "DD_APPSEC_SCA_ENABLED", "origin": "env_var", "value": "false"} in configuration
 
 
 def test_app_started_sca_missing(test_agent_session, run_python_code_in_subprocess):
@@ -544,9 +554,13 @@ from ddtrace.settings import _config
 
 _config._telemetry_dependency_collection = False
 
+class FailingFilture(TraceFilter):
+    def process_trace(self, trace):
+       raise Exception("Exception raised in trace filter")
+
 tracer.configure(
     settings={
-        "FILTERS": [],
+        "FILTERS": [FailingFilture()],
     }
 )
 
@@ -561,4 +575,7 @@ tracer.trace("hello").finish()
 
     app_started_events = [event for event in events if event["request_type"] == "app-started"]
     assert len(app_started_events) == 1
-    assert "DD_APPSEC_SCA_ENABLED" not in app_started_events[0]["payload"]["configuration"].keys()
+
+    configuration = app_started_events[0]["payload"]["configuration"]
+    for entry in configuration:
+        assert entry["name"] != "DD_APPSEC_SCA_ENABLED"


### PR DESCRIPTION
## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [ ] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
