### PR TITLE
chore(asm): remove WAF timeout & WAF error log metric

### DIFF
--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -346,6 +346,7 @@ class AppSecSpanProcessor(SpanProcessor):
             if info.errors:
                 errors = json.dumps(info.errors)
                 span.set_tag_str(APPSEC.EVENT_RULE_ERRORS, errors)
+                log.debug("Error in ASM In-App WAF: %s", errors)
             span.set_tag_str(APPSEC.EVENT_RULE_VERSION, info.version)
             from ddtrace.appsec._ddwaf import version
 

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -346,9 +346,6 @@ class AppSecSpanProcessor(SpanProcessor):
             if info.errors:
                 errors = json.dumps(info.errors)
                 span.set_tag_str(APPSEC.EVENT_RULE_ERRORS, errors)
-                _set_waf_error_metric("WAF run. Error", errors, info)
-            if waf_results.timeout:
-                _set_waf_error_metric("WAF run. Timeout errors", "", info)
             span.set_tag_str(APPSEC.EVENT_RULE_VERSION, info.version)
             from ddtrace.appsec._ddwaf import version
 

--- a/tests/appsec/appsec/test_telemetry.py
+++ b/tests/appsec/appsec/test_telemetry.py
@@ -126,10 +126,18 @@ def test_log_metric_error_ddwaf_timeout(telemetry_writer, tracer):
                 )
 
         list_metrics_logs = list(telemetry_writer._logs)
-        assert len(list_metrics_logs) == 1
-        assert list_metrics_logs[0]["message"] == "WAF run. Timeout errors"
-        assert list_metrics_logs[0].get("stack_trace") is None
-        assert "waf_version:{}".format(version()) in list_metrics_logs[0]["tags"]
+        assert len(list_metrics_logs) == 0
+
+        generate_metrics = telemetry_writer._namespace._metrics_data[TELEMETRY_TYPE_GENERATE_METRICS][
+            TELEMETRY_NAMESPACE_TAG_APPSEC
+        ]
+
+        timeout_found = False
+        for _metric_id, metric in generate_metrics.items():
+            if metric.name == "waf.requests":
+                assert ("waf_timeout", "true") in metric._tags
+                timeout_found = True
+        assert timeout_found
 
 
 def test_log_metric_error_ddwaf_update(telemetry_writer):


### PR DESCRIPTION
WAF timeouts create redundant and excessive noise.

Additionally, this log is redundant since that information is included within the span as `_dd.appsec.event_rules.errors` and as a tag within the `dd.instrumentation_telemetry_data.appsec.waf.requests` metric, under the tag `waf_timeout `.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
