### PR TITLE
fix(iast): remove native exceptions [backport 2.4]

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
@@ -149,7 +149,8 @@ set_ranges(PyObject* str, const TaintRangeRefs& ranges, TaintRangeMapType* tx_ma
     if (not tx_map) {
         tx_map = initializer->get_tainting_map();
         if (not tx_map) {
-            throw py::value_error("Tainted Map isn't initialized. Call create_context() first");
+            // TODO: Log "Tainted Map isn't initialized. Call create_context() first";
+            return;
         }
     }
 
@@ -243,7 +244,8 @@ get_tainted_object(PyObject* str, TaintRangeMapType* tx_map)
     if (not tx_map) {
         tx_map = initializer->get_tainting_map();
         if (not tx_map) {
-            throw py::value_error("Tainted Map isn't initialized. Call create_context() first");
+            // TODO: Log "Tainted Map isn't initialized. Call create_context() first";
+            return nullptr;
         }
     }
     if (is_notinterned_notfasttainted_unicode(str) or tx_map->empty()) {
@@ -291,7 +293,8 @@ set_tainted_object(PyObject* str, TaintedObjectPtr tainted_object, TaintRangeMap
     if (not tx_taint_map) {
         tx_taint_map = initializer->get_tainting_map();
         if (not tx_taint_map) {
-            throw py::value_error("Tainted Map isn't initialized. Call create_context() first");
+            // TODO: Log "Tainted Map isn't initialized. Call create_context() first";
+            return;
         }
     }
 
@@ -343,9 +346,6 @@ pyexport_taintrange(py::module& m)
           "candidate_text"_a,
           "parameter_list"_a,
           py::return_value_policy::move);
-
-    // TODO: check return value policy
-    m.def("get_tainted_object", &get_tainted_object, "str"_a, "tx_taint_map"_a);
 
     m.def(
       "shift_taint_range", &api_shift_taint_range, py::return_value_policy::move, "source_taint_range"_a, "offset"_a);

--- a/releasenotes/notes/iast-fix-native-exceptions-e6299dc2b9ad54d3.yaml
+++ b/releasenotes/notes/iast-fix-native-exceptions-e6299dc2b9ad54d3.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Vulnerability Management for Code-level (IAST): Some native exceptions were not being caught correctly by the python tracer. 
+    This fix remove those exceptions to avoid fatal error executions.

--- a/tests/appsec/iast/aspects/test_add_aspect.py
+++ b/tests/appsec/iast/aspects/test_add_aspect.py
@@ -4,6 +4,8 @@ import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import Source
+from ddtrace.appsec._iast._taint_tracking import create_context
+from ddtrace.appsec._iast._taint_tracking import destroy_context
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
@@ -301,3 +303,73 @@ def test_taint_ranges_as_evidence_info_different_tainted_op1_and_op3_add():
         {"value": tainted_text2, "source": 1},
     ]
     assert sources == [input_info1, input_info2]
+
+
+def test_taint_object_error_with_no_context():
+    """Test taint_pyobject without context. This test is to ensure that the function does not raise an exception."""
+    string_to_taint = "my_string"
+    create_context()
+    result = taint_pyobject(
+        pyobject=string_to_taint,
+        source_name="test_add_aspect_tainting_left_hand",
+        source_value=string_to_taint,
+        source_origin=OriginType.PARAMETER,
+    )
+
+    ranges_result = get_tainted_ranges(result)
+    assert len(ranges_result) == 1
+
+    destroy_context()
+    result = taint_pyobject(
+        pyobject=string_to_taint,
+        source_name="test_add_aspect_tainting_left_hand",
+        source_value=string_to_taint,
+        source_origin=OriginType.PARAMETER,
+    )
+
+    ranges_result = get_tainted_ranges(result)
+    assert len(ranges_result) == 0
+
+    create_context()
+    result = taint_pyobject(
+        pyobject=string_to_taint,
+        source_name="test_add_aspect_tainting_left_hand",
+        source_value=string_to_taint,
+        source_origin=OriginType.PARAMETER,
+    )
+
+    ranges_result = get_tainted_ranges(result)
+    assert len(ranges_result) == 1
+
+
+def test_get_ranges_from_object_with_no_context():
+    """Test taint_pyobject without context. This test is to ensure that the function does not raise an exception."""
+    string_to_taint = "my_string"
+    create_context()
+    result = taint_pyobject(
+        pyobject=string_to_taint,
+        source_name="test_add_aspect_tainting_left_hand",
+        source_value=string_to_taint,
+        source_origin=OriginType.PARAMETER,
+    )
+
+    destroy_context()
+    ranges_result = get_tainted_ranges(result)
+    assert len(ranges_result) == 0
+
+
+def test_propagate_ranges_with_no_context():
+    """Test taint_pyobject without context. This test is to ensure that the function does not raise an exception."""
+    string_to_taint = "my_string"
+    create_context()
+    result = taint_pyobject(
+        pyobject=string_to_taint,
+        source_name="test_add_aspect_tainting_left_hand",
+        source_value=string_to_taint,
+        source_origin=OriginType.PARAMETER,
+    )
+
+    destroy_context()
+    result_2 = add_aspect(result, "another_string")
+    ranges_result = get_tainted_ranges(result_2)
+    assert len(ranges_result) == 0


### PR DESCRIPTION
Backport 79f99eff41dbc825c23e934152f9dd7ffc835972 from #8841 to 2.4.

Some native exceptions were not being caught correctly by the python tracer. This fix remove those exceptions to avoid fatal error executions like:

```
File "/usr/local/lib/python3.10/dist-packages/ddtrace/appsec/_iast/_taint_tracking/__init__.py", line 106 in taint_pyobject
Current thread 0x0000ffff83fbc420
Fatal Python error: g_initialstub: greenlet: Unhandled C++ exception: Tainted Map isn't initialized. Call create_context() first
```
```python
    destroy_context()
    try:
        result = taint_pyobject(
            pyobject=string_to_taint,
            source_name="test_add_aspect_tainting_left_hand",
            source_value=string_to_taint,
            source_origin=OriginType.PARAMETER,
        )
    except Exception:
        pass
```
```
Fatal Python error: Aborted

Thread 0x000078a301cc9700 (most recent call first):
  File "/home/alberto.vara/.pyenv/versions/3.9.1/lib/python3.9/threading.py", line 316 in wait
```


## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
