### PR TITLE
fix(kafka): handle empty message lists

### DIFF
--- a/ddtrace/contrib/kafka/patch.py
+++ b/ddtrace/contrib/kafka/patch.py
@@ -257,10 +257,10 @@ def _instrument_message(messages, pin, start_ns, instance, err):
         span.set_tag_str(SPAN_KIND, SpanKind.CONSUMER)
         span.set_tag_str(kafkax.RECEIVED_MESSAGE, str(first_message is not None))
         span.set_tag_str(kafkax.GROUP_ID, instance._group_id)
-        if messages[0] is not None:
-            message_key = messages[0].key() or ""
-            message_offset = messages[0].offset() or -1
-            span.set_tag_str(kafkax.TOPIC, messages[0].topic())
+        if first_message is not None:
+            message_key = first_message.key() or ""
+            message_offset = first_message.offset() or -1
+            span.set_tag_str(kafkax.TOPIC, first_message.topic())
 
             # If this is a deserializing consumer, do not set the key as a tag since we
             # do not have the serialization function
@@ -270,10 +270,10 @@ def _instrument_message(messages, pin, start_ns, instance, err):
                 or isinstance(message_key, bytes)
             ):
                 span.set_tag_str(kafkax.MESSAGE_KEY, message_key)
-            span.set_tag(kafkax.PARTITION, messages[0].partition())
+            span.set_tag(kafkax.PARTITION, first_message.partition())
             is_tombstone = False
             try:
-                is_tombstone = len(messages[0]) == 0
+                is_tombstone = len(first_message) == 0
             except TypeError:  # https://github.com/confluentinc/confluent-kafka-python/issues/1192
                 pass
             span.set_tag_str(kafkax.TOMBSTONE, str(is_tombstone))

--- a/ddtrace/contrib/kafka/patch.py
+++ b/ddtrace/contrib/kafka/patch.py
@@ -234,7 +234,7 @@ def _instrument_message(messages, pin, start_ns, instance, err):
     ctx = None
     # First message is used to extract context and enrich datadog spans
     # This approach aligns with the opentelemetry confluent kafka semantics
-    first_message = messages[0]
+    first_message = messages[0] if len(messages) else None
     if first_message is not None and config.kafka.distributed_tracing_enabled and first_message.headers():
         ctx = Propagator.extract(dict(first_message.headers()))
     with pin.tracer.start_span(

--- a/releasenotes/notes/kafka-empty-message-list-d4358af8f4b72567.yaml
+++ b/releasenotes/notes/kafka-empty-message-list-d4358af8f4b72567.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    kafka: This fix resolves an issue where an empty message list returned from consume calls could cause crashes in the Kafka integration.
+    Empty lists from consume can occur when the call times out.

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -12,6 +12,7 @@ import pytest
 
 from ddtrace import Pin
 from ddtrace import Tracer
+from ddtrace.contrib.kafka.patch import TracedConsumer
 from ddtrace.contrib.kafka.patch import patch
 from ddtrace.contrib.kafka.patch import unpatch
 from ddtrace.filters import TraceFilter
@@ -200,6 +201,26 @@ def test_consumer_created_with_logger_does_not_raise(tracer):
         logger=logger,
     )
     consumer.close()
+
+
+def test_empty_list_from_consume_does_not_raise():
+    # https://github.com/DataDog/dd-trace-py/issues/8846
+    patch()
+    consumer = confluent_kafka.Consumer(
+        {
+            "bootstrap.servers": BOOTSTRAP_SERVERS,
+            "group.id": GROUP_ID,
+            "auto.offset.reset": "earliest",
+            "request.timeout.ms": 1000,
+            "retry.backoff.ms": 10,
+        },
+    )
+    assert isinstance(consumer, TracedConsumer)
+    max_messages_per_batch = 1
+    timeout = 1
+    consumer.consume(max_messages_per_batch, timeout)
+    consumer.close()
+    unpatch()
 
 
 @pytest.mark.parametrize(

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -217,7 +217,7 @@ def test_empty_list_from_consume_does_not_raise():
     )
     assert isinstance(consumer, TracedConsumer)
     max_messages_per_batch = 1
-    timeout = 1
+    timeout = 0
     consumer.consume(max_messages_per_batch, timeout)
     consumer.close()
     unpatch()


### PR DESCRIPTION
This pull request fixes https://github.com/DataDog/dd-trace-py/issues/8846 by handling the case where the list of messages is empty, which can happen when `consume` calls time out.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
