### PR TITLE
fix: support all valid package version specifiers in version checks

### DIFF
--- a/ddtrace/contrib/aioredis/patch.py
+++ b/ddtrace/contrib/aioredis/patch.py
@@ -8,6 +8,7 @@ from ddtrace import config
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.pin import Pin
+from ddtrace.vendor.packaging.version import parse as parse_version
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
@@ -46,7 +47,7 @@ config._add(
 )
 
 aioredis_version_str = getattr(aioredis, "__version__", "")
-aioredis_version = tuple([int(i) for i in aioredis_version_str.split(".")])
+aioredis_version = parse_version(aioredis_version_str)
 
 
 def get_version():
@@ -59,7 +60,7 @@ def patch():
         return
     aioredis._datadog_patch = True
     pin = Pin()
-    if aioredis_version >= (2, 0):
+    if aioredis_version >= parse_version("2.0"):
         _w("aioredis.client", "Redis.execute_command", traced_execute_command)
         _w("aioredis.client", "Redis.pipeline", traced_pipeline)
         _w("aioredis.client", "Pipeline.execute", traced_execute_pipeline)
@@ -76,7 +77,7 @@ def unpatch():
         return
 
     aioredis._datadog_patch = False
-    if aioredis_version >= (2, 0):
+    if aioredis_version >= parse_version("2.0"):
         _u(aioredis.client.Redis, "execute_command")
         _u(aioredis.client.Redis, "pipeline")
         _u(aioredis.client.Pipeline, "execute")

--- a/ddtrace/contrib/aioredis/patch.py
+++ b/ddtrace/contrib/aioredis/patch.py
@@ -48,6 +48,7 @@ config._add(
 
 aioredis_version_str = getattr(aioredis, "__version__", "")
 aioredis_version = parse_version(aioredis_version_str)
+V2 = parse_version("2.0")
 
 
 def get_version():
@@ -60,7 +61,7 @@ def patch():
         return
     aioredis._datadog_patch = True
     pin = Pin()
-    if aioredis_version >= parse_version("2.0"):
+    if aioredis_version >= V2:
         _w("aioredis.client", "Redis.execute_command", traced_execute_command)
         _w("aioredis.client", "Redis.pipeline", traced_pipeline)
         _w("aioredis.client", "Pipeline.execute", traced_execute_pipeline)
@@ -77,7 +78,7 @@ def unpatch():
         return
 
     aioredis._datadog_patch = False
-    if aioredis_version >= parse_version("2.0"):
+    if aioredis_version >= V2:
         _u(aioredis.client.Redis, "execute_command")
         _u(aioredis.client.Redis, "pipeline")
         _u(aioredis.client.Pipeline, "execute")

--- a/ddtrace/contrib/algoliasearch/patch.py
+++ b/ddtrace/contrib/algoliasearch/patch.py
@@ -6,6 +6,7 @@ from ddtrace.internal.schema import schematize_cloud_api_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.pin import Pin
+from ddtrace.vendor.packaging.version import parse as parse_version
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from ...constants import SPAN_KIND
@@ -17,18 +18,22 @@ DD_PATCH_ATTR = "_datadog_patch"
 
 SERVICE_NAME = schematize_service_name("algoliasearch")
 APP_NAME = "algoliasearch"
+V0 = parse_version("0.0")
+V1 = parse_version("1.0")
+V2 = parse_version("2.0")
+V3 = parse_version("3.0")
 
 try:
     VERSION = "0.0.0"
     import algoliasearch
     from algoliasearch.version import VERSION
 
-    algoliasearch_version = tuple([int(i) for i in VERSION.split(".")])
+    algoliasearch_version = parse_version(VERSION)
 
     # Default configuration
     config._add("algoliasearch", dict(_default_service=SERVICE_NAME, collect_query_text=False))
 except ImportError:
-    algoliasearch_version = (0, 0)
+    algoliasearch_version = V0
 
 
 def get_version():
@@ -37,7 +42,7 @@ def get_version():
 
 
 def patch():
-    if algoliasearch_version == (0, 0):
+    if algoliasearch_version == V0:
         return
 
     if getattr(algoliasearch, DD_PATCH_ATTR, False):
@@ -47,10 +52,10 @@ def patch():
 
     pin = Pin()
 
-    if algoliasearch_version < (2, 0) and algoliasearch_version >= (1, 0):
+    if algoliasearch_version < V2 and algoliasearch_version >= V1:
         _w(algoliasearch.index, "Index.search", _patched_search)
         pin.onto(algoliasearch.index.Index)
-    elif algoliasearch_version >= (2, 0) and algoliasearch_version < (3, 0):
+    elif algoliasearch_version >= V2 and algoliasearch_version < V3:
         from algoliasearch import search_index
 
         _w(algoliasearch, "search_index.SearchIndex.search", _patched_search)
@@ -60,15 +65,15 @@ def patch():
 
 
 def unpatch():
-    if algoliasearch_version == (0, 0):
+    if algoliasearch_version == V0:
         return
 
     if getattr(algoliasearch, DD_PATCH_ATTR, False):
         setattr(algoliasearch, DD_PATCH_ATTR, False)
 
-        if algoliasearch_version < (2, 0) and algoliasearch_version >= (1, 0):
+        if algoliasearch_version < V2 and algoliasearch_version >= V1:
             _u(algoliasearch.index.Index, "search")
-        elif algoliasearch_version >= (2, 0) and algoliasearch_version < (3, 0):
+        elif algoliasearch_version >= V2 and algoliasearch_version < V3:
             from algoliasearch import search_index
 
             _u(search_index.SearchIndex, "search")
@@ -103,9 +108,9 @@ def _patched_search(func, instance, wrapt_args, wrapt_kwargs):
     argument to the algoliasearch.index.Index.search() method.
     """
 
-    if algoliasearch_version < (2, 0) and algoliasearch_version >= (1, 0):
+    if algoliasearch_version < V2 and algoliasearch_version >= V1:
         function_query_arg_name = "args"
-    elif algoliasearch_version >= (2, 0) and algoliasearch_version < (3, 0):
+    elif algoliasearch_version >= V2 and algoliasearch_version < V3:
         function_query_arg_name = "request_options"
     else:
         return func(*wrapt_args, **wrapt_kwargs)

--- a/ddtrace/contrib/django/patch.py
+++ b/ddtrace/contrib/django/patch.py
@@ -37,6 +37,7 @@ from ddtrace.internal.utils.formats import asbool
 from ddtrace.settings.asm import config as asm_config
 from ddtrace.settings.integration import IntegrationConfig
 from ddtrace.vendor import wrapt
+from ddtrace.vendor.packaging.version import parse as parse_version
 from ddtrace.vendor.wrapt.importer import when_imported
 
 from ...appsec._utils import _UserInfoRetriever
@@ -817,8 +818,8 @@ def _patch(django):
     def _(m):
         import channels
 
-        channels_version = tuple(int(x) for x in channels.__version__.split("."))
-        if channels_version >= (3, 0):
+        channels_version = parse_version(channels.__version__)
+        if channels_version >= parse_version("3.0"):
             # ASGI3 is only supported in channels v3.0+
             trace_utils.wrap(m, "URLRouter.__init__", unwrap_views)
 

--- a/ddtrace/contrib/starlette/patch.py
+++ b/ddtrace/contrib/starlette/patch.py
@@ -45,10 +45,10 @@ config._add(
 
 def get_version():
     # type: () -> str
-    return parse_version(getattr(starlette, "__version__", ""))
+    return getattr(starlette, "__version__", "")
 
 
-_STARLETTE_VERSION = get_version()
+_STARLETTE_VERSION = parse_version(get_version())
 
 
 def traced_init(wrapped, instance, args, kwargs):

--- a/ddtrace/contrib/starlette/patch.py
+++ b/ddtrace/contrib/starlette/patch.py
@@ -21,6 +21,7 @@ from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils import set_argument_value
 from ddtrace.internal.utils.wrappers import unwrap as _u
+from ddtrace.vendor.packaging.version import parse as parse_version
 from ddtrace.vendor.wrapt import ObjectProxy
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
@@ -44,10 +45,10 @@ config._add(
 
 def get_version():
     # type: () -> str
-    return getattr(starlette, "__version__", "")
+    return parse_version(getattr(starlette, "__version__", ""))
 
 
-_STARLETTE_VERSION = tuple(map(int, get_version().split(".")))
+_STARLETTE_VERSION = get_version()
 
 
 def traced_init(wrapped, instance, args, kwargs):
@@ -167,7 +168,7 @@ def traced_handler(wrapped, instance, args, kwargs):
         raise trace_utils.InterruptException("starlette")
 
     # https://github.com/encode/starlette/issues/1336
-    if _STARLETTE_VERSION <= (0, 33, 0) and len(request_spans) > 1:
+    if _STARLETTE_VERSION <= parse_version("0.33.0") and len(request_spans) > 1:
         request_spans[-1].set_tag(http.URL, request_spans[0].get_tag(http.URL))
 
     return wrapped(*args, **kwargs)

--- a/releasenotes/notes/versions-arent-just-ints-909349433f58b79b.yaml
+++ b/releasenotes/notes/versions-arent-just-ints-909349433f58b79b.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    instrumentation: fixes crashses that could occur in certain integrations with packages that use non-integer components
+    in their version specifiers

--- a/tests/contrib/algoliasearch/test.py
+++ b/tests/contrib/algoliasearch/test.py
@@ -4,8 +4,13 @@ from ddtrace.contrib.algoliasearch.patch import algoliasearch_version
 from ddtrace.contrib.algoliasearch.patch import patch
 from ddtrace.contrib.algoliasearch.patch import unpatch
 from ddtrace.pin import Pin
+from ddtrace.vendor.packaging.version import parse as parse_version
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
+
+
+V1 = parse_version("1.0")
+V2 = parse_version("2.0")
 
 
 class AlgoliasearchTest(TracerTestCase):
@@ -29,7 +34,7 @@ class AlgoliasearchTest(TracerTestCase):
         # Algolia search is a non free SaaS application, it isn't possible to add it to the
         # docker environment to enable a full-fledged integration test. The next best option
         # is to mock out the search method to prevent it from making server requests
-        if algoliasearch_version < (2, 0) and algoliasearch_version >= (1, 0):
+        if algoliasearch_version < V2 and algoliasearch_version >= V1:
             import algoliasearch
             import algoliasearch.index as index_module
 
@@ -56,7 +61,7 @@ class AlgoliasearchTest(TracerTestCase):
             self.reset()
 
     def perform_search(self, query_text, query_args=None):
-        if algoliasearch_version < (2, 0) and algoliasearch_version >= (1, 0):
+        if algoliasearch_version < V2 and algoliasearch_version >= V1:
             self.index.search(query_text, args=query_args)
         else:
             self.index.search(query_text, request_options=query_args)


### PR DESCRIPTION
This pull request fixes https://github.com/DataDog/dd-trace-py/issues/8823 by updating package version checks that used `int()` and `split('.')` to use the spec-compliant version specifier parsing implementation from `vendor.packaging`.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
