### PR TITLE
Fix kafka instrumentation crash when consume returns an empty list

### DIFF
--- a/ddtrace/contrib/kafka/patch.py
+++ b/ddtrace/contrib/kafka/patch.py
@@ -224,8 +224,8 @@ def traced_poll_or_consume(func, instance, args, kwargs):
             # poll returns a single message
             _instrument_message([result], pin, start_ns, instance, err)
         elif isinstance(result, list):
-            # consume returns a list of messages,
-            _instrument_message(result, pin, start_ns, instance, err)
+            # consume returns a list of messages, possibly empty
+            _instrument_message(result if result else [None], pin, start_ns, instance, err)
         elif config.kafka.trace_empty_poll_enabled:
             _instrument_message([None], pin, start_ns, instance, err)
 

--- a/ddtrace/contrib/kafka/patch.py
+++ b/ddtrace/contrib/kafka/patch.py
@@ -225,7 +225,7 @@ def traced_poll_or_consume(func, instance, args, kwargs):
             _instrument_message([result], pin, start_ns, instance, err)
         elif isinstance(result, list):
             # consume returns a list of messages, possibly empty
-            _instrument_message(result if result else [None], pin, start_ns, instance, err)
+            _instrument_message(result or [None], pin, start_ns, instance, err)
         elif config.kafka.trace_empty_poll_enabled:
             _instrument_message([None], pin, start_ns, instance, err)
 

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -295,6 +295,12 @@ def test_commit_with_consume_with_multiple_messages(producer, consumer, kafka_to
         assert len(messages) == 2
 
 
+def test_consume_with_no_message(dummy_tracer, consumer):
+    Pin.override(consumer, tracer=dummy_tracer)
+    messages = consumer.consume(timeout=0)
+    assert len(messages) == 0
+
+
 @pytest.mark.snapshot(ignores=["metrics.kafka.message_offset", "meta.error.stack"])
 @pytest.mark.parametrize("should_filter_empty_polls", [False])
 def test_commit_with_consume_with_error(producer, consumer, kafka_topic):

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -299,6 +299,14 @@ def test_consume_with_no_message(dummy_tracer, consumer):
     Pin.override(consumer, tracer=dummy_tracer)
     messages = consumer.consume(timeout=0)
     assert len(messages) == 0
+    traces = dummy_tracer.pop_traces()
+    assert len(traces) == 1
+    with override_config("kafka", dict(trace_empty_consume_enabled=False)):
+        messages = consumer.consume(timeout=0)
+        traces = dummy_tracer.pop_traces()
+        assert len(traces) == 0
+
+
 
 
 @pytest.mark.snapshot(ignores=["metrics.kafka.message_offset", "meta.error.stack"])


### PR DESCRIPTION
Fixes https://github.com/DataDog/dd-trace-py/issues/8873

Bug introduced here : https://github.com/DataDog/dd-trace-py/pull/8511
Bug introduced to 2.7 here : https://github.com/DataDog/dd-trace-py/pull/8757

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
