### PR TITLE
ci: checkout PR head instead of merge branch when running system tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -60,10 +60,13 @@ jobs:
 
       - name: Checkout dd-trace-py
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'binaries/dd-trace-py'
           fetch-depth: 0
+          # NB this ref is necessary to keep the checkout out of detached HEAD state, which setuptools_scm requires for
+          # proper version guessing
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Build
         id: build
@@ -242,10 +245,11 @@ jobs:
           repository: 'DataDog/system-tests'
       - name: Checkout dd-trace-py
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: 'binaries/dd-trace-py'
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-python@v4
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
         with:


### PR DESCRIPTION
This pull request attempts to fix #8801 by setting the git ref used during system-tests' library checkout to one that corresponds to a real commit in the history. The [theory](https://github.com/DataDog/dd-trace-py/issues/8801#issuecomment-2038091563) is that this allows the version specifier to be guessed accurately by setuptools_scm.

This approach has been tested on a pull request #8879 with 2.7 as a base. In that test, the [observed version string](https://github.com/DataDog/dd-trace-py/actions/runs/8560819851/job/23460660021?pr=8879#step:3:36) was `2.7.7.dev13+<hash>`, as opposed to the string observed in #8801 `2.8.0.dev0`.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
