### PR TITLE
fix(kafka): handle empty message lists [backport 2.7]

### DIFF
--- a/releasenotes/notes/kafka-empty-message-list-d4358af8f4b72567.yaml
+++ b/releasenotes/notes/kafka-empty-message-list-d4358af8f4b72567.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    kafka: This fix resolves an issue where an empty message list returned from consume calls could cause crashes in the Kafka integration.
+    Empty lists from consume can occur when the call times out.

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -12,6 +12,7 @@ import pytest
 
 from ddtrace import Pin
 from ddtrace import Tracer
+from ddtrace.contrib.kafka.patch import TracedConsumer
 from ddtrace.contrib.kafka.patch import patch
 from ddtrace.contrib.kafka.patch import unpatch
 from ddtrace.filters import TraceFilter
@@ -200,6 +201,26 @@ def test_consumer_created_with_logger_does_not_raise(tracer):
         logger=logger,
     )
     consumer.close()
+
+
+def test_empty_list_from_consume_does_not_raise():
+    # https://github.com/DataDog/dd-trace-py/issues/8846
+    patch()
+    consumer = confluent_kafka.Consumer(
+        {
+            "bootstrap.servers": BOOTSTRAP_SERVERS,
+            "group.id": GROUP_ID,
+            "auto.offset.reset": "earliest",
+            "request.timeout.ms": 1000,
+            "retry.backoff.ms": 10,
+        },
+    )
+    assert isinstance(consumer, TracedConsumer)
+    max_messages_per_batch = 1
+    timeout = 0
+    consumer.consume(max_messages_per_batch, timeout)
+    consumer.close()
+    unpatch()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This pull request fixes
https://github.com/DataDog/dd-trace-py/issues/8846 by handling the case where the list of messages is empty, which can happen when `consume` calls time out.

## Checklist

- [x] Change(s) are motivated and described in the PR description