### PR TITLE
fix(iast): aes cipher functions break applications if iast is enabled

### DIFF
--- a/ddtrace/appsec/_iast/_ast/ast_patching.py
+++ b/ddtrace/appsec/_iast/_ast/ast_patching.py
@@ -23,8 +23,14 @@ from .visitor import AstVisitor
 
 # Prefixes for modules where IAST patching is allowed
 IAST_ALLOWLIST = ("tests.appsec.iast",)  # type: tuple[str, ...]
-IAST_DENYLIST = ("ddtrace", "pkg_resources")  # type: tuple[str, ...]
-
+IAST_DENYLIST = (
+    "ddtrace",
+    "pkg_resources",
+    "encodings",  # this package is used to load encodings when a module is imported, propagation is not needed
+    "inspect",  # this package is used to get the stack frames, propagation is not needed
+    "pycparser",  # this package is called when a module is imported, propagation is not needed
+    "Crypto",  # This module is patched by the IAST patch methods, propagation is not needed
+)  # type: tuple[str, ...]
 
 if IAST.PATCH_MODULES in os.environ:
     IAST_ALLOWLIST += tuple(os.environ[IAST.PATCH_MODULES].split(IAST.SEP_MODULES))

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
@@ -49,6 +49,12 @@ build_index_range_map(PyObject* text, TaintRangeRefs& ranges, PyObject* start, P
     }
     TaintRangeRefs index_range_map_result;
     long start_int = PyLong_AsLong(start);
+    if (start_int < 0) {
+        start_int = length_text + start_int;
+        if (start_int < 0) {
+            start_int = 0;
+        }
+    }
     long stop_int = length_text;
     if (stop != NULL) {
         stop_int = PyLong_AsLong(stop);
@@ -56,6 +62,9 @@ build_index_range_map(PyObject* text, TaintRangeRefs& ranges, PyObject* start, P
             stop_int = length_text;
         } else if (stop_int < 0) {
             stop_int = length_text + stop_int;
+            if (stop_int < 0) {
+                stop_int = 0;
+            }
         }
     }
     long step_int = 1;

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -157,6 +157,19 @@ def index_aspect(candidate_text, index) -> Any:
 
 
 def slice_aspect(candidate_text, start, stop, step) -> Any:
+    import inspect
+
+    stack = inspect.stack()
+    print(stack[1:3])
+    print("slice!!!!!!!!!!!!!")
+    print(candidate_text)
+    print(type(candidate_text))
+    print(start)
+    print(type(start))
+    print(stop)
+    print(type(stop))
+    print(step)
+
     if (
         not isinstance(candidate_text, TEXT_TYPES)
         or (start is not None and not isinstance(start, int))

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -157,19 +157,6 @@ def index_aspect(candidate_text, index) -> Any:
 
 
 def slice_aspect(candidate_text, start, stop, step) -> Any:
-    import inspect
-
-    stack = inspect.stack()
-    print(stack[1:3])
-    print("slice!!!!!!!!!!!!!")
-    print(candidate_text)
-    print(type(candidate_text))
-    print(start)
-    print(type(start))
-    print(stop)
-    print(type(stop))
-    print(step)
-
     if (
         not isinstance(candidate_text, TEXT_TYPES)
         or (start is not None and not isinstance(start, int))

--- a/releasenotes/notes/iast-fix-cipher-error-48882bb289eb4353.yaml
+++ b/releasenotes/notes/iast-fix-cipher-error-48882bb289eb4353.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Code Security (IAST): Fixed an issue with AES functions from the pycryptodome package that caused the 
+    application to crash and stop.

--- a/tests/appsec/iast/aspects/test_slice_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_slice_aspect_fixtures.py
@@ -262,3 +262,42 @@ def test_string_slice_with_none_params(input_str, start_pos, end_pos, step, expe
         assert len(tainted_ranges) == 1
         assert tainted_ranges[0].start == 0
         assert tainted_ranges[0].length == len(expected_result)
+
+
+def test_string_slice_and_unpack():
+    """This test verify that site-packages/Crypto/Util/number.py:bytes_to_long is correctly instrumented with no
+    errors.
+    """
+    for _ in range(10):
+        input_str = b"\xcch\x08A\x93;\xa9:\xa9*\n\xeaA]\x13\xec"
+        expected_result = 271702677468084275015420463885508744172
+        result = mod.do_slice_complex(input_str)
+        assert result == expected_result
+
+        tainted_input = taint_pyobject(
+            pyobject=input_str,
+            source_name="input_str",
+            source_value="foo",
+            source_origin=OriginType.PARAMETER,
+        )
+        result = mod.do_slice_complex(tainted_input)
+        assert result == expected_result
+
+
+def test_string_slice_negative():
+    """This test verify that site-packages/Crypto/Util/number.py:bytes_to_long is correctly instrumented with no
+    errors.
+    """
+    input_str = b"\xc1\xd6/q\x85\n\xd40\xb6\x93\xbd* {\xb3\xaa"
+    expected_result = b"\xc1\xd6/q\x85\n\xd40\xb6\x93\xbd* {\xb3\xaa"
+    result = mod.do_slice_negative(input_str)
+    assert result == expected_result
+
+    tainted_input = taint_pyobject(
+        pyobject=input_str,
+        source_name="input_str",
+        source_value="foo",
+        source_origin=OriginType.PARAMETER,
+    )
+    result = mod.do_slice_negative(tainted_input)
+    assert result == expected_result

--- a/tests/appsec/iast/fixtures/aspects/str_methods.py
+++ b/tests/appsec/iast/fixtures/aspects/str_methods.py
@@ -927,6 +927,30 @@ def do_slice(
     return key_lambda_map[cases_key](text)
 
 
+def do_slice_complex(
+    s,  # type: str
+):
+    import struct
+
+    unpack = struct.unpack
+
+    length = len(s)
+    acc = 0
+    if length % 4:
+        extra = 4 - length % 4
+        s = b"\x00" * extra + s
+        length = length + extra
+    for i in range(0, length, 4):
+        acc = (acc << 32) + unpack(">I", s[i : i + 4])[0]
+    return acc
+
+
+def do_slice_negative(
+    s,  # type: str
+):
+    return s[-16:]
+
+
 def mult_two(a, b):  # type: (Any, Any) -> Any
     return a * b
 

--- a/tests/appsec/iast/fixtures/propagation_path.py
+++ b/tests/appsec/iast/fixtures/propagation_path.py
@@ -8,6 +8,17 @@ import os
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
+def propagation_no_path(origin_string):
+    from Crypto.Cipher import AES
+
+    key = b"Sixteen byte key"
+    data = b"abcdefgh"
+    crypt_obj = AES.new(key, AES.MODE_EAX)
+    # label propagation_no_path
+    result = crypt_obj.encrypt(data)
+    return result
+
+
 def propagation_path_1_source_1_prop(origin_string):
     if type(origin_string) is str:
         string1 = str(origin_string)  # 1 Range

--- a/tests/appsec/iast/fixtures/taint_sinks/weak_algorithms.py
+++ b/tests/appsec/iast/fixtures/taint_sinks/weak_algorithms.py
@@ -89,3 +89,13 @@ def cryptography_algorithm(algorithm):
     ct = encryptor.update(data)
 
     return ct
+
+
+def cipher_secure():
+    from Crypto.Cipher import AES
+
+    key = b"Sixteen byte key"
+    data = b"abcdefgh"
+    crypt_obj = AES.new(key, AES.MODE_EAX)
+    result = crypt_obj.encrypt(data)
+    return result

--- a/tests/appsec/iast/taint_sinks/test_weak_cipher.py
+++ b/tests/appsec/iast/taint_sinks/test_weak_cipher.py
@@ -8,6 +8,7 @@ from tests.appsec.iast.fixtures.taint_sinks.weak_algorithms import cipher_arc2
 from tests.appsec.iast.fixtures.taint_sinks.weak_algorithms import cipher_arc4
 from tests.appsec.iast.fixtures.taint_sinks.weak_algorithms import cipher_blowfish
 from tests.appsec.iast.fixtures.taint_sinks.weak_algorithms import cipher_des
+from tests.appsec.iast.fixtures.taint_sinks.weak_algorithms import cipher_secure
 from tests.appsec.iast.fixtures.taint_sinks.weak_algorithms import cryptography_algorithm
 from tests.appsec.iast.iast_utils import get_line_and_hash
 
@@ -180,3 +181,18 @@ def test_weak_cipher_deduplication(num_vuln_expected, iast_span_deduplication_en
         assert span_report
 
         assert len(span_report.vulnerabilities) == num_vuln_expected
+
+
+def test_weak_cipher_secure(iast_span_defaults):
+    cipher_secure()
+    span_report = core.get_item(IAST.CONTEXT_KEY, span=iast_span_defaults)
+
+    assert span_report is None
+
+
+def test_weak_cipher_secure_multiple_calls_error(iast_span_defaults):
+    for _ in range(50):
+        cipher_secure()
+    span_report = core.get_item(IAST.CONTEXT_KEY, span=iast_span_defaults)
+
+    assert span_report is None

--- a/tests/appsec/iast/test_iast_propagation_path.py
+++ b/tests/appsec/iast/test_iast_propagation_path.py
@@ -27,6 +27,18 @@ def _assert_vulnerability(span_report, value_parts, file_line_label):
     assert vulnerability.hash == hash_value
 
 
+def test_propagation_no_path(iast_span_defaults):
+    mod = _iast_patched_module("tests.appsec.iast.fixtures.propagation_path")
+    origin1 = "taintsource"
+    tainted_string = taint_pyobject(origin1, source_name="path", source_value=origin1, source_origin=OriginType.PATH)
+    for i in range(100):
+        mod.propagation_no_path(tainted_string)
+
+    span_report = core.get_item(IAST.CONTEXT_KEY, span=iast_span_defaults)
+
+    assert span_report is None
+
+
 @pytest.mark.parametrize(
     "origin1",
     [

--- a/tests/appsec/iast_tdd_propagation/flask_orm_app.py
+++ b/tests/appsec/iast_tdd_propagation/flask_orm_app.py
@@ -13,7 +13,7 @@ from flask import request
 
 from ddtrace import tracer
 from ddtrace.appsec._constants import IAST
-from ddtrace.appsec._iast import ddtrace_iast_flask_patch
+from ddtrace.appsec.iast import ddtrace_iast_flask_patch
 from ddtrace.internal import core
 from tests.utils import override_env
 

--- a/tests/appsec/iast_tdd_propagation/flask_taint_sinks_app.py
+++ b/tests/appsec/iast_tdd_propagation/flask_taint_sinks_app.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+""" This Flask application is imported on tests.appsec.appsec_utils.gunicorn_server
+"""
+from flask_taint_sinks_views import create_app
+
+from ddtrace import auto  # noqa: F401
+
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run(debug=False, port=8000)

--- a/tests/appsec/iast_tdd_propagation/flask_taint_sinks_views.py
+++ b/tests/appsec/iast_tdd_propagation/flask_taint_sinks_views.py
@@ -1,0 +1,73 @@
+import sys
+
+from Crypto.Cipher import AES
+from Crypto.Cipher import ARC4
+from flask import Flask
+from flask import request
+
+from ddtrace import tracer
+from ddtrace.appsec._constants import IAST
+from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
+from ddtrace.internal import core
+
+
+class ResultResponse:
+    param = ""
+    sources = ""
+    vulnerabilities = ""
+
+    def __init__(self, param):
+        self.param = param
+
+    def json(self):
+        return {
+            "param": self.param,
+            "sources": self.sources,
+            "vulnerabilities": self.vulnerabilities,
+            "params_are_tainted": is_pyobject_tainted(self.param),
+        }
+
+
+def create_app():
+    app = Flask(__name__)
+
+    @app.route("/shutdown")
+    def shutdown():
+        tracer.shutdown()
+        sys.exit(0)
+
+    @app.route("/")
+    def secure_weak_cipher():
+        param = request.args.get("param", "param")
+
+        key = b"Sixteen byte key"
+        data = b"abcdefgh"
+        crypt_obj = AES.new(key, AES.MODE_EAX)
+        crypt_obj.encrypt(data)
+
+        response = ResultResponse(param)
+        report = core.get_items([IAST.CONTEXT_KEY], tracer.current_root_span())
+        if report and report[0]:
+            response.sources = report[0].sources[0].value
+            response.vulnerabilities = list(report[0].vulnerabilities)[0].type
+
+        return response.json()
+
+    @app.route("/weak_cipher")
+    def insecure_weak_cipher():
+        param = request.args.get("param", "param")
+
+        password = b"12345678"
+        data = b"abcdefgh"
+        crypt_obj = ARC4.new(password)
+        crypt_obj.encrypt(data)
+
+        response = ResultResponse(param)
+        report = core.get_items([IAST.CONTEXT_KEY], tracer.current_root_span())
+        if report and report[0]:
+            response.sources = report[0].sources[0].value if report[0].sources else ""
+            response.vulnerabilities = list(report[0].vulnerabilities)[0].type
+
+        return response.json()
+
+    return app

--- a/tests/appsec/iast_tdd_propagation/test_flask.py
+++ b/tests/appsec/iast_tdd_propagation/test_flask.py
@@ -49,3 +49,37 @@ def test_iast_flask_orm(orm, xfail):
             assert content["sources"] == "my-bytes-string"
             assert content["vulnerabilities"] == "SQL_INJECTION"
         assert content["params_are_tainted"] is True
+
+
+def test_iast_flask_weak_cipher():
+    with flask_server(
+        iast_enabled="true",
+        tracer_enabled="true",
+        remote_configuration_enabled="false",
+        token=None,
+        app="flask_taint_sinks_app.py",
+    ) as context:
+        server_process, client, pid = context
+        for i in range(10):
+            try:
+                tainted_response = client.get("/?param=my-bytes-string")
+            except Exception:
+                pytest.fail(
+                    "Server FAILED, see stdout and stderr logs"
+                    "\n=== Captured STDOUT ===\n%s=== End of captured STDOUT ==="
+                    "\n=== Captured STDERR ===\n%s=== End of captured STDERR ==="
+                    % (server_process.stdout, server_process.stderr)
+                )
+            assert tainted_response.status_code == 200
+            content = json.loads(tainted_response.content)
+            assert content["param"] == "my-bytes-string"
+            assert content["sources"] == ""
+            assert content["vulnerabilities"] == ""
+            assert content["params_are_tainted"] is True
+
+            weak_response = client.get("/weak_cipher?param=my-bytes-string")
+            assert weak_response.status_code == 200
+            content = json.loads(weak_response.content)
+            assert content["sources"] == ""
+            assert content["vulnerabilities"] == "WEAK_CIPHER"
+            assert content["params_are_tainted"] is True


### PR DESCRIPTION
This PR fix an issue with AES functions from the pycryptodome package that caused the application to crash and stop.

The problem was a negative start variable of a slice operation in the `pycryptodome` package.

```python
# site-packages/Crypto/Hash/CMAC.py
def update(self, msg):
	"""Authenticate the next chunk of message.

	Args:
	    data (byte string/byte array/memoryview): The next chunk of data
	"""

```
C++ slice aspect function was fixed an Crypto package skipped from AST patching


## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)