### PR TITLE
fix(asm): remove datadog.api_security metrics

### DIFF
--- a/releasenotes/notes/removing_api_security_metrics-4b6a6ba8643b5ab3.yaml
+++ b/releasenotes/notes/removing_api_security_metrics-4b6a6ba8643b5ab3.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ASM: This fix removes unrequired API security metrics.


### PR DESCRIPTION
Metrics were added during R&D phase on API Security. This PR removes them.
It prevents to send unneeded data to DD backend.

APPSEC-52415

https://github.com/DataDog/dd-analytics/pull/30330 is also put in place to ensure no additional charges for customers using non updated tracers.

This PR is backported to all versions containing api security.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
