### PR TITLE
fix(asm): remove datadog.api_security metrics [backport 2.7]

### DIFF
--- a/ddtrace/appsec/_api_security/api_manager.py
+++ b/ddtrace/appsec/_api_security/api_manager.py
@@ -13,7 +13,6 @@ from ddtrace.appsec._constants import API_SECURITY
 from ddtrace.appsec._constants import SPAN_DATA_NAMES
 import ddtrace.constants as constants
 from ddtrace.internal.logger import get_logger
-from ddtrace.internal.metrics import Metrics
 from ddtrace.internal.service import Service
 from ddtrace.settings.asm import config as asm_config
 
@@ -23,7 +22,6 @@ if TYPE_CHECKING:
 
 
 log = get_logger(__name__)
-metrics = Metrics(namespace="datadog.api_security")
 _sentinel = object()
 
 
@@ -55,7 +53,6 @@ class APIManager(Service):
 
         asm_config._api_security_active = True
         log.debug("Enabling %s", cls.__name__)
-        metrics.enable()
         cls._instance = cls()
         cls._instance.start()
         log.debug("%s enabled", cls.__name__)
@@ -71,7 +68,6 @@ class APIManager(Service):
         log.debug("Disabling %s", cls.__name__)
         cls._instance.stop()
         cls._instance = None
-        metrics.disable()
         log.debug("%s disabled", cls.__name__)
 
     def __init__(self):
@@ -79,7 +75,6 @@ class APIManager(Service):
         super(APIManager, self).__init__()
 
         self.current_sampling_value = self.SAMPLE_START_VALUE
-        self._schema_meter = metrics.get_meter("schema")
         log.debug("%s initialized", self.__class__.__name__)
 
     def _stop_service(self):
@@ -155,8 +150,7 @@ class APIManager(Service):
                     if len(b64_gzip_content) >= MAX_SPAN_META_VALUE_LEN:
                         raise TooLargeSchemaException
                     root._meta[meta] = b64_gzip_content
-                except Exception as e:
-                    self._schema_meter.increment("errors", tags={"exc": e.__class__.__name__, "address": address})
+                except Exception:
                     self._log_limiter.limit(
                         log.warning,
                         "Failed to get schema from %r [schema length=%d]:\n%s",
@@ -165,4 +159,3 @@ class APIManager(Service):
                         repr(value)[:256],
                         exc_info=True,
                     )
-        self._schema_meter.increment("spans")

--- a/releasenotes/notes/removing_api_security_metrics-4b6a6ba8643b5ab3.yaml
+++ b/releasenotes/notes/removing_api_security_metrics-4b6a6ba8643b5ab3.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ASM: This fix removes unrequired API security metrics.


### PR DESCRIPTION
https://github.com/DataDog/dd-trace-py/pull/8906

Backport https://github.com/DataDog/dd-trace-py/commit/616c5a93ad26647a6b9cb98f45e9bc4a35687d83 from https://github.com/DataDog/dd-trace-py/pull/8906 to 2.7.

Metrics were added during R&D phase on API Security. This PR removes them.
It prevents to send unneeded data to DD backend.

APPSEC-52415

https://github.com/DataDog/dd-analytics/pull/30330 is also put in place to ensure no additional charges for customers using non updated tracers.

This PR is backported to all versions containing api security.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
