### PR TITLE
feat(llmobs): submit span events for chains from langchain

### DIFF
--- a/tests/contrib/langchain/cassettes/langchain/chain_openai_completion_sync.yaml
+++ b/tests/contrib/langchain/cassettes/langchain/chain_openai_completion_sync.yaml
@@ -1,0 +1,100 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": "Can you explain what an LLM
+      chain is?"}], "model": "gpt-3.5-turbo", "max_tokens": 256, "stream": false,
+      "n": 1, "temperature": 0.0}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '174'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.8
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.8", "httplib": "requests", "lang": "python", "lang_version":
+        "3.10.13", "platform": "macOS-13.6.5-arm64-arm-64bit", "publisher": "openai",
+        "uname": "Darwin 22.6.0 Darwin Kernel Version 22.6.0: Mon Feb 19 19:45:09
+        PST 2024; root:xnu-8796.141.3.704.6~1/RELEASE_ARM64_T6000 arm64 arm"}'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-9C8PFrPeDGqajEgFLZaqgkzXID7Px\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1712679277,\n  \"model\": \"gpt-3.5-turbo-0125\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"An LLM chain, also known as a Limited
+        Liability Master Limited Partnership (LLM), is a type of business structure
+        that combines the benefits of a master limited partnership (MLP) with the
+        limited liability protection of a limited liability company (LLC). In an LLM
+        chain, the general partner is typically an LLC, which provides limited liability
+        protection to the owners or partners of the business. This structure allows
+        for the flow-through tax benefits of an MLP, while also shielding the owners
+        from personal liability for the debts and obligations of the business. LLM
+        chains are commonly used in the energy and natural resources industries, where
+        they can help to attract investment and manage risk.\"\n      },\n      \"logprobs\":
+        null,\n      \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\":
+        17,\n    \"completion_tokens\": 134,\n    \"total_tokens\": 151\n  },\n  \"system_fingerprint\":
+        \"fp_b28b39ffa8\"\n}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 871bca881ceb176c-EWR
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 09 Apr 2024 16:14:40 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=P_A3eEpwJvlwNo_lYI5KnWC8I3YCpFU9NLmtseZcxHU-1712679280-1.0.1.1-H_Q93FobYi5ChT1UdnaLy5SqSrXRzslzmbM0G3OtXew9Fa5kjch7zUWAmQwq5mbB3TYMWNHV5yRpOuzTTyQQLA;
+        path=/; expires=Tue, 09-Apr-24 16:44:40 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=w7KNhheJeVoLvTJtbGGRMdAw698oHGYkvMTRO6Y_PE4-1712679280070-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - gpt-3.5-turbo-0125
+      openai-organization:
+      - user-vgqng3jybrjkfe7a1gf2l5ch
+      openai-processing-ms:
+      - '3144'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '200'
+      x-ratelimit-limit-tokens:
+      - '40000'
+      x-ratelimit-remaining-requests:
+      - '194'
+      x-ratelimit-remaining-tokens:
+      - '39733'
+      x-ratelimit-reset-requests:
+      - 40m32.016s
+      x-ratelimit-reset-tokens:
+      - 400ms
+      x-request-id:
+      - req_f05f797b55ec8ff19b979b928dcbb377
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/contrib/langchain/cassettes/langchain/squential_chain_nested.yaml
+++ b/tests/contrib/langchain/cassettes/langchain/squential_chain_nested.yaml
@@ -1,0 +1,180 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": "what is the city Sponegog Squarepants
+      is from?"}], "model": "gpt-3.5-turbo", "max_tokens": 256, "stream": false, "n":
+      1, "temperature": 0.0}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '183'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.8
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.8", "httplib": "requests", "lang": "python", "lang_version":
+        "3.10.13", "platform": "macOS-13.6.5-arm64-arm-64bit", "publisher": "openai",
+        "uname": "Darwin 22.6.0 Darwin Kernel Version 22.6.0: Mon Feb 19 19:45:09
+        PST 2024; root:xnu-8796.141.3.704.6~1/RELEASE_ARM64_T6000 arm64 arm"}'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-9CAI07PG14SFGrnvGA8fMLYdMgUpK\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1712686516,\n  \"model\": \"gpt-3.5-turbo-0125\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"SpongeBob SquarePants is from the fictional
+        underwater city of Bikini Bottom.\"\n      },\n      \"logprobs\": null,\n
+        \     \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\":
+        20,\n    \"completion_tokens\": 17,\n    \"total_tokens\": 37\n  },\n  \"system_fingerprint\":
+        \"fp_b28b39ffa8\"\n}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 871c7b46aac50fa8-EWR
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 09 Apr 2024 18:15:16 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=nVSik.HpqeKrsvD0ZqZAbyBflIT2fEVYDbaV5PhTonA-1712686516-1.0.1.1-AArGAzH8NhmtUxarWPiMGmUD69x5DDU0h0ZtXd3yEbBWTAFIwXRMufBh3obcnsU91asL6Da5YM_mc.zvwU9KhA;
+        path=/; expires=Tue, 09-Apr-24 18:45:16 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=XodN.YfZTnYY3RLJGblTP43lZk_31akP6_F1R86YWhQ-1712686516778-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - gpt-3.5-turbo-0125
+      openai-organization:
+      - user-vgqng3jybrjkfe7a1gf2l5ch
+      openai-processing-ms:
+      - '408'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '200'
+      x-ratelimit-limit-tokens:
+      - '40000'
+      x-ratelimit-remaining-requests:
+      - '198'
+      x-ratelimit-remaining-tokens:
+      - '39731'
+      x-ratelimit-reset-requests:
+      - 13m29.656s
+      x-ratelimit-reset-tokens:
+      - 403ms
+      x-request-id:
+      - req_92de730952a141d5e8df0fb46ca6e935
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"role": "user", "content": "what country is the city SpongeBob
+      SquarePants is from the fictional underwater city of Bikini Bottom. in? respond
+      in Spanish"}], "model": "gpt-3.5-turbo", "max_tokens": 256, "stream": false,
+      "n": 1, "temperature": 0.0}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '262'
+      Content-Type:
+      - application/json
+      Cookie:
+      - __cf_bm=nVSik.HpqeKrsvD0ZqZAbyBflIT2fEVYDbaV5PhTonA-1712686516-1.0.1.1-AArGAzH8NhmtUxarWPiMGmUD69x5DDU0h0ZtXd3yEbBWTAFIwXRMufBh3obcnsU91asL6Da5YM_mc.zvwU9KhA;
+        _cfuvid=XodN.YfZTnYY3RLJGblTP43lZk_31akP6_F1R86YWhQ-1712686516778-0.0.1.1-604800000
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.8
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.8", "httplib": "requests", "lang": "python", "lang_version":
+        "3.10.13", "platform": "macOS-13.6.5-arm64-arm-64bit", "publisher": "openai",
+        "uname": "Darwin 22.6.0 Darwin Kernel Version 22.6.0: Mon Feb 19 19:45:09
+        PST 2024; root:xnu-8796.141.3.704.6~1/RELEASE_ARM64_T6000 arm64 arm"}'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-9CAI0f0V19DHszbs0d1DXBOgS1fhI\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1712686516,\n  \"model\": \"gpt-3.5-turbo-0125\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"La ciudad de SpongeBob SquarePants
+        es de la ficticia ciudad submarina de Fondo de Bikini.\"\n      },\n      \"logprobs\":
+        null,\n      \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\":
+        33,\n    \"completion_tokens\": 23,\n    \"total_tokens\": 56\n  },\n  \"system_fingerprint\":
+        \"fp_b28b39ffa8\"\n}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 871c7b4a492878df-EWR
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 09 Apr 2024 18:15:17 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - gpt-3.5-turbo-0125
+      openai-organization:
+      - user-vgqng3jybrjkfe7a1gf2l5ch
+      openai-processing-ms:
+      - '378'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '200'
+      x-ratelimit-limit-tokens:
+      - '40000'
+      x-ratelimit-remaining-requests:
+      - '197'
+      x-ratelimit-remaining-tokens:
+      - '39711'
+      x-ratelimit-reset-requests:
+      - 20m41.081s
+      x-ratelimit-reset-tokens:
+      - 433ms
+      x-request-id:
+      - req_2cc4e3569e8c4113f3aa7758f4e9cc9f
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -147,7 +147,7 @@ def _llmobs_base_span_event(
     span_event = {
         "span_id": str(span.span_id),
         "trace_id": "{:x}".format(span.trace_id),
-        "parent_id": "undefined",
+        "parent_id": str(span.parent_id or "undefined"),
         "session_id": session_id or "{:x}".format(span.trace_id),
         "name": span.name,
         "tags": _expected_llmobs_tags(span, tags=tags, error=error, session_id=session_id),


### PR DESCRIPTION
## Summary
Follow-up to #8695 

This PR adds support for submitting LLMObs span events from the LangChain integration automatically if LLMObs is enabled, and if the LLMObs span is sampled. This is accomplished by:

- Setting the span type `SpanTypes.LLM` on `langchain` chain APM spans so they are properly processed by the trace processor service in the LLMObs service
- Tagging each chain span with additional _ml_obs.* tags, which get popped from the trace when submitting the data they represent to LLMObs intake through the LLMObs writer

## For Reviewers

Most of the LOC are test changes to account for the change in test structure when dealing with variable amounts of expected calls to the LLMObs writer. Otherwise, the important files changed are:

1. `ddtrace/contrib/langchain/patch.py`
2. `ddtrace/llmobs/_integrations/langchain.py`

Additionally, no release notes/changelog, as this is an internal change for submitting span events to LLMObs intake.

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
