### PR TITLE
fix(asm): fix cpu leak (#8629) [APMS-11823] [backport 1.20]

### DIFF
--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -127,7 +127,7 @@ class _DataHandler:
             env = self.execution_context.get_item("asm_env")
             callbacks = GLOBAL_CALLBACKS.get(_CONTEXT_CALL, [])
             if env is not None and env.callbacks is not None and env.callbacks.get(_CONTEXT_CALL):
-                callbacks += env.callbacks.get(_CONTEXT_CALL)
+                callbacks = callbacks + env.callbacks.get(_CONTEXT_CALL)
             if callbacks:
                 if env is not None:
                     for function in callbacks:

--- a/releasenotes/notes/fix_incident_25768-043ae458e46c9620.yaml
+++ b/releasenotes/notes/fix_incident_25768-043ae458e46c9620.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    ASM: This fix resolves an issue with Flask instrumentation causing CPU leak with ASM, 
+    API Security and Telemetry enabled.


### PR DESCRIPTION
This PR fixes a cpu leak in ASM instrumentation, that would add additional overhead to all requests if ASM, API Security and Telemetry were enabled on Flask instrumentation.

Related to incident 25768.

- [x] e