### PR TITLE
fix(setuptools_scm): backport setuptools_scm version scheme to guess-next-dev [backport 2.8]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ Homepage = "https://github.com/DataDog/dd-trace-py"
 "Source Code" = "https://github.com/DataDog/dd-trace-py/"
 
 [tool.setuptools_scm]
-version_scheme = "release-branch-semver"  # Must be "release-branch-semver" for now in main, see https://github.com/DataDog/dd-trace-py/issues/8801
+version_scheme = "guess-next-dev"
 write_to = "ddtrace/_version.py"
 
 [tool.cython-lint]

--- a/releasenotes/notes/setuptools_scm-use-guess-next-dev-1e7754df76c78e94.yaml
+++ b/releasenotes/notes/setuptools_scm-use-guess-next-dev-1e7754df76c78e94.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    setuptools_scm version: Updates the setuptools_scm versioning method to "guess-next-dev" from "release-branch-semver", which was affecting the CI

--- a/releasenotes/notes/setuptools_scm-use-guess-next-dev-1e7754df76c78e94.yaml
+++ b/releasenotes/notes/setuptools_scm-use-guess-next-dev-1e7754df76c78e94.yaml
@@ -1,3 +1,0 @@
-fixes:
-  - |
-    setuptools_scm version: Updates the setuptools_scm versioning method to "guess-next-dev" from "release-branch-semver", which was affecting the CI


### PR DESCRIPTION
Prior to this change, setuptools_scm reported the version for patch releases as the next minor release. Afterwards, versions are patch releases (as expected).

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

(cherry picked from commit 1ffb660728e5b338c2381db9764d46fa5d12e62b)
