### PR TITLE
chore(iast): update type checking

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -1,18 +1,19 @@
-# #!/usr/bin/env python3
-# flake8: noqa
-from typing import TYPE_CHECKING
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import Union
 
 from .._metrics import _set_metric_iast_executed_source
 from .._utils import _is_python_version_supported
 
 
 if _is_python_version_supported():
-    from .. import oce
     from ._native import ops
+    from ._native.aspect_format import _format_aspect
     from ._native.aspect_helpers import _convert_escaped_text_to_tainted_text
     from ._native.aspect_helpers import as_formatted_evidence
     from ._native.aspect_helpers import common_replace
-    from ._native.aspect_format import _format_aspect
     from ._native.aspect_helpers import parse_params
     from ._native.initializer import active_map_addreses_size
     from ._native.initializer import create_context
@@ -25,6 +26,8 @@ if _is_python_version_supported():
     from ._native.taint_tracking import Source
     from ._native.taint_tracking import TagMappingMode
     from ._native.taint_tracking import are_all_text_all_ranges
+    from ._native.taint_tracking import copy_and_shift_ranges_from_strings
+    from ._native.taint_tracking import copy_ranges_from_strings
     from ._native.taint_tracking import get_range_by_hash
     from ._native.taint_tracking import get_ranges
     from ._native.taint_tracking import is_notinterned_notfasttainted_unicode
@@ -32,8 +35,6 @@ if _is_python_version_supported():
     from ._native.taint_tracking import origin_to_str
     from ._native.taint_tracking import set_fast_tainted_if_notinterned_unicode
     from ._native.taint_tracking import set_ranges
-    from ._native.taint_tracking import copy_ranges_from_strings
-    from ._native.taint_tracking import copy_and_shift_ranges_from_strings
     from ._native.taint_tracking import shift_taint_range
     from ._native.taint_tracking import shift_taint_ranges
     from ._native.taint_tracking import str_to_origin
@@ -42,13 +43,6 @@ if _is_python_version_supported():
     new_pyobject_id = ops.new_pyobject_id
     set_ranges_from_values = ops.set_ranges_from_values
     is_pyobject_tainted = is_tainted
-
-if TYPE_CHECKING:
-    from typing import Any
-    from typing import Dict
-    from typing import List
-    from typing import Tuple
-    from typing import Union
 
 
 __all__ = [
@@ -86,9 +80,7 @@ __all__ = [
 ]
 
 
-def taint_pyobject(pyobject, source_name, source_value, source_origin=None):
-    # type: (Any, Any, Any, OriginType) -> Any
-
+def taint_pyobject(pyobject: Any, source_name: Any, source_value: Any, source_origin=None) -> Any:
     # Pyobject must be Text with len > 1
     if not pyobject or not isinstance(pyobject, (str, bytes, bytearray)):
         return pyobject
@@ -108,16 +100,15 @@ def taint_pyobject(pyobject, source_name, source_value, source_origin=None):
     return pyobject_newid
 
 
-def taint_pyobject_with_ranges(pyobject, ranges):  # type: (Any, tuple) -> None
+def taint_pyobject_with_ranges(pyobject: Any, ranges: Tuple) -> None:
     set_ranges(pyobject, tuple(ranges))
 
 
-def get_tainted_ranges(pyobject):  # type: (Any) -> tuple
+def get_tainted_ranges(pyobject: Any) -> Tuple:
     return get_ranges(pyobject)
 
 
-def taint_ranges_as_evidence_info(pyobject):
-    # type: (Any) -> Tuple[List[Dict[str, Union[Any, int]]], list[Source]]
+def taint_ranges_as_evidence_info(pyobject: Any) -> Tuple[List[Dict[str, Union[Any, int]]], list[Source]]:
     value_parts = []
     sources = []
     current_pos = 0

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -108,7 +108,7 @@ def get_tainted_ranges(pyobject: Any) -> Tuple:
     return get_ranges(pyobject)
 
 
-def taint_ranges_as_evidence_info(pyobject: Any) -> Tuple[List[Dict[str, Union[Any, int]]], list[Source]]:
+def taint_ranges_as_evidence_info(pyobject: Any) -> Tuple[List[Dict[str, Union[Any, int]]], List[Source]]:
     value_parts = []
     sources = []
     current_pos = 0


### PR DESCRIPTION
## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
