### PR TITLE
feat(llmobs): change error field to status

### DIFF
--- a/ddtrace/llmobs/_trace_processor.py
+++ b/ddtrace/llmobs/_trace_processor.py
@@ -85,7 +85,7 @@ class LLMObsTraceProcessor(TraceProcessor):
             "tags": tags,
             "start_ns": span.start_ns,
             "duration": span.duration_ns,
-            "error": span.error,
+            "status": "error" if span.error else "ok",
             "meta": meta,
             "metrics": metrics,
         }

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -29,7 +29,6 @@ class LLMObsEvent(TypedDict):
     tags: List[str]
     service: str
     name: str
-    error: int
     start_ns: int
     duration: float
     status: str

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -153,7 +153,7 @@ def _llmobs_base_span_event(
         "tags": _expected_llmobs_tags(span, tags=tags, error=error, session_id=session_id),
         "start_ns": span.start_ns,
         "duration": span.duration_ns,
-        "error": 1 if error else 0,
+        "status": "error" if error else "ok",
         "meta": {"span.kind": span_kind},
         "metrics": {},
     }


### PR DESCRIPTION
This PR changes the `span.error` field to `span.status`, with the possible values being `'ok', 'error'` replacing `0, 1` respectively.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
