### PR TITLE
chore: fix grpc contrib codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@ ddtrace/internal/schema/            @DataDog/apm-core-python @DataDog/apm-framew
 tests/contrib/                      @DataDog/apm-core-python @DataDog/apm-framework-integrations
 tests/internal/peer_service         @DataDog/apm-core-python @DataDog/apm-framework-integrations
 tests/internal/service_name         @DataDog/apm-core-python @DataDog/apm-framework-integrations
+tests/contrib/grpc                  @DataDog/apm-framework-integrations @DataDog/asm-python
 
 # Files which can be approved by anyone
 # DEV: This helps not requiring apm-core-python to review new files added
@@ -33,7 +34,6 @@ ddtrace/contrib/pytest_bdd          @DataDog/ci-app-libraries
 ddtrace/contrib/unittest            @DataDog/ci-app-libraries
 tests/contrib/pytest                @DataDog/ci-app-libraries
 tests/contrib/pytest_bdd            @DataDog/ci-app-libraries
-tests/contrib/grpc                  @DataDog/ci-app-libraries @DataDog/asm-python
 tests/contrib/unittest_plugin       @DataDog/ci-app-libraries
 ddtrace/ext/ci.py                   @DataDog/ci-app-libraries
 ddtrace/ext/ci_visibility           @DataDog/ci-app-libraries


### PR DESCRIPTION
## Checklist

- [X] Change(s) are motivated and described in the PR description
- [X] Testing strategy is described if automated tests are not included in the PR
- [X] Risks are described (performance impact, potential for breakage, maintainability)
- [X] Change is maintainable (easy to change, telemetry, documentation)
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [X] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
