### PR TITLE
fix(langchain): safely check if instance is openai llm/chat [backport #8896 to 2.8]

### DIFF
--- a/releasenotes/notes/fix-langchain-openai-submodule-check-ea81685e31cb9720.yaml
+++ b/releasenotes/notes/fix-langchain-openai-submodule-check-ea81685e31cb9720.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    langchain: This fix adds error handling for checking if a traced LLM or chat model is an OpenAI instance, as the 
+    langchain_community package does not allow automatic submodule importing. 


### PR DESCRIPTION
Backport of #8896 to 2.8.

Fixes #8889.

This PR adds a safe check for if a traced LLM/Chat model instance is an OpenAI instance by adding try/catch and reversing the order of the type checks. Previously we were checking directly against the installed langchain package, i.e.
```python
if isinstance(instance, BASE_LANGCHAIN_MODULE.chat_models.ChatOpenAI) or (
            langchain_openai and isinstance(instance, langchain_openai.ChatOpenAI)
        ):
# BASE_LANGCHAIN_MODULE can be either `langchain` or `langchain_community`
```
But `langchain_community` does not allow automatically accessing its submodules, i.e. `langchain_community.chat_models.ChatOpenAI` will result in an error unless `from langchain_community import chat_models` is performed already.

With this fix, there are three scenarios for
`langchain_community/langchain_openai` users:
1. They use `langchain_openai` --> we perform the type check using `langchain_openai` first which will always be available, and will never hit the `BASE_LANGCHAIN_MODULE` type check.
2. They use `langchain_community` --> since users are using `langchain_community.chat_models` they must have already imported this in their code and it should not result in any errors. Regardless, we will safely try type checking against the submodule.
3. They use `langchain` --> `langchain` allows automatically accessing submodules without directly importing, so this should also not result in any errors.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
