### PR TITLE
docs: fix opentelemetry import

### DIFF
--- a/ddtrace/opentelemetry/__init__.py
+++ b/ddtrace/opentelemetry/__init__.py
@@ -38,10 +38,10 @@ Usage
 Datadog and OpenTelemetry APIs can be used interchangeably::
 
     # Sample Usage
-    import opentelemetry
+    from opentelemetry import trace
     import ddtrace
 
-    oteltracer = opentelemetry.trace.get_tracer(__name__)
+    oteltracer = trace.get_tracer(__name__)
 
     with oteltracer.start_as_current_span("otel-span") as parent_span:
         parent_span.set_attribute("otel_key", "otel_val")


### PR DESCRIPTION
The `opentelemetry` is a namespace package and as such the reference to `opentelemetry.trace` in the documentation is incorrect.

```
Python 3.11.4 (main, Jul 28 2023, 04:37:46) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import opentelemetry
>>> oteltracer = opentelemetry.trace.get_tracer(__name__)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'opentelemetry' has no attribute 'trace'
```

As an aside, the library code does exactly this in multiple places but it was not. My guess is that this has to do with the `opentelemetry.trace` working if the `trace` sub-package of the namespace package `opentelemetry` had already been imported.

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
