### PR TITLE
chore(serverless): lazy load slow package imports

### DIFF
--- a/ddtrace/_logger.py
+++ b/ddtrace/_logger.py
@@ -76,6 +76,7 @@ def _add_file_handler(
         log_path = os.path.abspath(log_path)
         num_backup = 1
         from logging.handlers import RotatingFileHandler
+
         ddtrace_file_handler = RotatingFileHandler(
             filename=log_path, mode="a", maxBytes=max_file_bytes, backupCount=num_backup
         )

--- a/ddtrace/_logger.py
+++ b/ddtrace/_logger.py
@@ -1,5 +1,4 @@
 import logging
-from logging.handlers import RotatingFileHandler
 import os
 from typing import Optional
 
@@ -76,6 +75,7 @@ def _add_file_handler(
     if log_path is not None:
         log_path = os.path.abspath(log_path)
         num_backup = 1
+        from logging.handlers import RotatingFileHandler
         ddtrace_file_handler = RotatingFileHandler(
             filename=log_path, mode="a", maxBytes=max_file_bytes, backupCount=num_backup
         )

--- a/ddtrace/_logger.py
+++ b/ddtrace/_logger.py
@@ -70,7 +70,7 @@ def _add_file_handler(
     log_level: int,
     handler_name: Optional[str] = None,
     max_file_bytes: int = DEFAULT_FILE_SIZE_BYTES,
-) -> Optional[RotatingFileHandler]:
+):
     ddtrace_file_handler = None
     if log_path is not None:
         log_path = os.path.abspath(log_path)

--- a/ddtrace/internal/compat.py
+++ b/ddtrace/internal/compat.py
@@ -6,7 +6,6 @@ import functools
 from inspect import iscoroutinefunction
 from inspect import isgeneratorfunction
 import ipaddress
-import multiprocessing
 import os
 import platform
 import re
@@ -477,4 +476,5 @@ else:
 
 
 def get_mp_context():
+    import multiprocessing
     return multiprocessing.get_context("fork" if sys.platform != "win32" else "spawn")

--- a/ddtrace/internal/compat.py
+++ b/ddtrace/internal/compat.py
@@ -477,4 +477,5 @@ else:
 
 def get_mp_context():
     import multiprocessing
+
     return multiprocessing.get_context("fork" if sys.platform != "win32" else "spawn")

--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -437,6 +437,7 @@ class FormData:
 def multipart(parts: List[FormData]) -> Tuple[bytes, dict]:
     from email.mime.application import MIMEApplication
     from email.mime.multipart import MIMEMultipart
+
     msg = MIMEMultipart("form-data")
     del msg["MIME-Version"]
 

--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -1,7 +1,5 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
-from email.mime.application import MIMEApplication
-from email.mime.multipart import MIMEMultipart
 from json import loads
 import logging
 import os
@@ -437,6 +435,8 @@ class FormData:
 
 
 def multipart(parts: List[FormData]) -> Tuple[bytes, dict]:
+    from email.mime.application import MIMEApplication
+    from email.mime.multipart import MIMEMultipart
     msg = MIMEMultipart("form-data")
     del msg["MIME-Version"]
 

--- a/tests/internal/test_serverless.py
+++ b/tests/internal/test_serverless.py
@@ -129,8 +129,8 @@ def test_slow_imports(monkeypatch):
 
     with mock.patch("sys.meta_path", meta_path):
         import ddtrace
-        import ddtrace.contrib.psycopg  # noqa:F401
         import ddtrace.contrib.aws_lambda  # noqa:F401
+        import ddtrace.contrib.psycopg  # noqa:F401
 
     for name, mod in deleted_modules.items():
         sys.modules[name] = mod

--- a/tests/internal/test_serverless.py
+++ b/tests/internal/test_serverless.py
@@ -96,9 +96,11 @@ def test_slow_imports(monkeypatch):
     # any of those modules are imported during the import of ddtrace.
 
     blocklist = [
+        "ddtrace.appsec._api_security.api_manager",
         "ddtrace.appsec._iast._ast.ast_patching",
         "ddtrace.internal.telemetry.telemetry_writer",
-        "ddtrace.appsec._api_security.api_manager",
+        "email.mime.application",
+        "email.mime.multipart",
         "logging.handlers",
     ]
     monkeypatch.setenv("DD_INSTRUMENTATION_TELEMETRY_ENABLED", False)

--- a/tests/internal/test_serverless.py
+++ b/tests/internal/test_serverless.py
@@ -102,6 +102,7 @@ def test_slow_imports(monkeypatch):
         "email.mime.application",
         "email.mime.multipart",
         "logging.handlers",
+        "multiprocessing",
     ]
     monkeypatch.setenv("DD_INSTRUMENTATION_TELEMETRY_ENABLED", False)
     monkeypatch.setenv("DD_API_SECURITY_ENABLED", False)

--- a/tests/internal/test_serverless.py
+++ b/tests/internal/test_serverless.py
@@ -103,6 +103,8 @@ def test_slow_imports(monkeypatch):
         "email.mime.multipart",
         "logging.handlers",
         "multiprocessing",
+        "importlib.metadata",
+        "importlib_metadata",
     ]
     monkeypatch.setenv("DD_INSTRUMENTATION_TELEMETRY_ENABLED", False)
     monkeypatch.setenv("DD_API_SECURITY_ENABLED", False)

--- a/tests/internal/test_serverless.py
+++ b/tests/internal/test_serverless.py
@@ -128,6 +128,7 @@ def test_slow_imports(monkeypatch):
     with mock.patch("sys.meta_path", meta_path):
         import ddtrace
         import ddtrace.contrib.psycopg  # noqa:F401
+        import ddtrace.contrib.aws_lambda  # noqa:F401
 
     for name, mod in deleted_modules.items():
         sys.modules[name] = mod

--- a/tests/internal/test_serverless.py
+++ b/tests/internal/test_serverless.py
@@ -99,6 +99,7 @@ def test_slow_imports(monkeypatch):
         "ddtrace.appsec._iast._ast.ast_patching",
         "ddtrace.internal.telemetry.telemetry_writer",
         "ddtrace.appsec._api_security.api_manager",
+        "logging.handlers",
     ]
     monkeypatch.setenv("DD_INSTRUMENTATION_TELEMETRY_ENABLED", False)
     monkeypatch.setenv("DD_API_SECURITY_ENABLED", False)
@@ -117,7 +118,7 @@ def test_slow_imports(monkeypatch):
     deleted_modules = {}
 
     for mod in sys.modules.copy():
-        if mod.startswith("ddtrace"):
+        if mod.startswith("ddtrace") or mod in blocklist:
             deleted_modules[mod] = sys.modules[mod]
             del sys.modules[mod]
 


### PR DESCRIPTION
Lazy loads
+ `logging.handlers`
+ `multiprocessing`
+ `email.mime.application`
+ `email.mime.multipart`

All of which are slow to import and not needed when run in aws lambda. This improves cold start time.

Also, updates tests to ensure the code is not accidentally updated in the future to import these packages.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x]  [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x]  Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
