### PR TITLE
chore: third-party include/exclude settings

### DIFF
--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -8,6 +8,7 @@ from ddtrace.internal.compat import Path
 from ddtrace.internal.module import origin
 from ddtrace.internal.utils.cache import cached
 from ddtrace.internal.utils.cache import callonce
+from ddtrace.settings.third_party import config as tp_config
 
 
 LOG = logging.getLogger(__name__)
@@ -140,7 +141,10 @@ def _third_party_packages() -> set:
     from gzip import decompress
     from importlib.resources import read_binary
 
-    return set(decompress(read_binary("ddtrace.internal", "third-party.tar.gz")).decode("utf-8").splitlines())
+    return (
+        set(decompress(read_binary("ddtrace.internal", "third-party.tar.gz")).decode("utf-8").splitlines())
+        | tp_config.excludes
+    ) - tp_config.includes
 
 
 def filename_to_package(filename):

--- a/ddtrace/settings/third_party.py
+++ b/ddtrace/settings/third_party.py
@@ -1,0 +1,23 @@
+from envier import En
+
+
+class ThirdPartyDetectionConfig(En):
+    __prefix__ = "dd.third_party_detection"
+
+    excludes = En.v(
+        set,
+        "excludes",
+        help="Additional packages to treat as third-party",
+        help_type="List",
+        default=set(),
+    )
+    includes = En.v(
+        set,
+        "includes",
+        help="List of packages that should not be treated as third-party",
+        help_type="List",
+        default=set(),
+    )
+
+
+config = ThirdPartyDetectionConfig()

--- a/tests/internal/test_packages.py
+++ b/tests/internal/test_packages.py
@@ -94,3 +94,16 @@ def test_third_party_packages():
 
     assert "requests" in _third_party_packages()
     assert "nota3rdparty" not in _third_party_packages()
+
+
+@pytest.mark.subprocess(
+    env={
+        "DD_THIRD_PARTY_DETECTION_EXCLUDES": "myfancypackage,myotherfancypackage",
+        "DD_THIRD_PARTY_DETECTION_INCLUDES": "requests",
+    }
+)
+def test_third_party_packages_excludes_includes():
+    from ddtrace.internal.packages import _third_party_packages
+
+    assert {"myfancypackage", "myotherfancypackage"} < _third_party_packages()
+    assert "requests" not in _third_party_packages()


### PR DESCRIPTION
We introduce environment variables for controlling the behaviour of the new third-party detection logic. In particular, we provide two variables that allow modifying the built-in list of package names. The exclude list adds to the built-in list, while the include list does the opposite.

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
