### PR TITLE
chore(iast): fix metrics log error format

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -119,9 +119,7 @@ def taint_pyobject(pyobject: Any, source_name: Any, source_value: Any, source_or
     try:
         pyobject_newid = set_ranges_from_values(pyobject, len(pyobject), source_name, source_value, source_origin)
     except ValueError as e:
-        iast_taint_log_error(
-            "IAST propagation error. Tainting object error (pyobject type %s): %s" % (type(pyobject), e)
-        )
+        iast_taint_log_error("Tainting object error (pyobject type %s): %s" % (type(pyobject), e))
         return pyobject
 
     _set_metric_iast_executed_source(source_origin)
@@ -132,16 +130,14 @@ def taint_pyobject_with_ranges(pyobject: Any, ranges: Tuple) -> None:
     try:
         set_ranges(pyobject, tuple(ranges))
     except ValueError as e:
-        iast_taint_log_error(
-            "IAST propagation error.Tainting object with ranges error (pyobject type %s): %s" % (type(pyobject), e)
-        )
+        iast_taint_log_error("Tainting object with ranges error (pyobject type %s): %s" % (type(pyobject), e))
 
 
 def get_tainted_ranges(pyobject: Any) -> Tuple:
     try:
         return get_ranges(pyobject)
     except ValueError as e:
-        iast_taint_log_error("IAST propagation error.Get ranges error (pyobject type %s): %s" % (type(pyobject), e))
+        iast_taint_log_error("Get ranges error (pyobject type %s): %s" % (type(pyobject), e))
     return tuple()
 
 

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -96,7 +96,7 @@ def iast_taint_log_error(msg):
         frame_info = "\n".join("%s %s" % (frame_info.filename, frame_info.lineno) for frame_info in stack[:7])
         log_message = "%s:\n%s", msg, frame_info
         log.warning(log_message)
-        _set_iast_error_metric("IAST propagation error. {}".format(msg))
+        _set_iast_error_metric("IAST propagation error. %s" % msg)
     else:
         log.debug(msg)
 
@@ -119,7 +119,9 @@ def taint_pyobject(pyobject: Any, source_name: Any, source_value: Any, source_or
     try:
         pyobject_newid = set_ranges_from_values(pyobject, len(pyobject), source_name, source_value, source_origin)
     except ValueError as e:
-        iast_taint_log_error(("Tainting object error (pyobject type %s): %s", (type(pyobject), e)))
+        iast_taint_log_error(
+            "IAST propagation error. Tainting object error (pyobject type %s): %s" % (type(pyobject), e)
+        )
         return pyobject
 
     _set_metric_iast_executed_source(source_origin)
@@ -130,14 +132,16 @@ def taint_pyobject_with_ranges(pyobject: Any, ranges: Tuple) -> None:
     try:
         set_ranges(pyobject, tuple(ranges))
     except ValueError as e:
-        iast_taint_log_error(("Tainting object with ranges error (pyobject type %s): %s", (type(pyobject), e)))
+        iast_taint_log_error(
+            "IAST propagation error.Tainting object with ranges error (pyobject type %s): %s" % (type(pyobject), e)
+        )
 
 
 def get_tainted_ranges(pyobject: Any) -> Tuple:
     try:
         return get_ranges(pyobject)
     except ValueError as e:
-        iast_taint_log_error(("Get ranges error (pyobject type %s): %s", (type(pyobject), e)))
+        iast_taint_log_error("IAST propagation error.Get ranges error (pyobject type %s): %s" % (type(pyobject), e))
     return tuple()
 
 


### PR DESCRIPTION
Fix IAST metrics log error format:
Before:
![image](https://github.com/DataDog/dd-trace-py/assets/6352942/7dd14ccc-26ba-4426-a0cb-50949d84c5b1)

After:
![image](https://github.com/DataDog/dd-trace-py/assets/6352942/ee31916d-34d9-443e-ac56-d850e0311d9d)

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)