### PR TITLE
chore(iast): fix metrics log error typo

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/Constants.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Constants.h
@@ -3,4 +3,4 @@
 #define RANGE_START long
 #define RANGE_LENGTH long
 #define MSG_ERROR_SET_RANGES "[IAST] Set ranges error: Empty ranges or Tainted Map isn't initialized"
-#define MSG_ERROR_TAINT_MAP "[IAST] Tainted Map is isn't initialized"
+#define MSG_ERROR_TAINT_MAP "[IAST] Tainted Map isn't initialized"

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -94,8 +94,7 @@ def iast_taint_log_error(msg):
 
         stack = inspect.stack()
         frame_info = "\n".join("%s %s" % (frame_info.filename, frame_info.lineno) for frame_info in stack[:7])
-        log_message = "%s:\n%s" % (msg, frame_info)
-        log.warning(log_message)
+        log.warning("%s:\n%s", msg, frame_info)
         _set_iast_error_metric("IAST propagation error. %s" % msg)
     else:
         log.debug(msg)

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -94,7 +94,7 @@ def iast_taint_log_error(msg):
 
         stack = inspect.stack()
         frame_info = "\n".join("%s %s" % (frame_info.filename, frame_info.lineno) for frame_info in stack[:7])
-        log_message = "%s:\n%s", msg, frame_info
+        log_message = "%s:\n%s" % (msg, frame_info)
         log.warning(log_message)
         _set_iast_error_metric("IAST propagation error. %s" % msg)
     else:


### PR DESCRIPTION
Fix IAST metrics log error typo

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)