### PR TITLE
chore(iast): validate iast_debug env var as bool

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -6,6 +6,7 @@ from typing import Tuple
 from typing import Union
 
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.utils.formats import asbool
 
 from ..._constants import IAST
 from .._metrics import _set_iast_error_metric
@@ -89,7 +90,7 @@ __all__ = [
 
 
 def iast_taint_log_error(msg):
-    if os.environ.get(IAST.ENV_DEBUG, False):
+    if asbool(os.environ.get(IAST.ENV_DEBUG, "false")):
         import inspect
 
         stack = inspect.stack()

--- a/tests/appsec/iast/aspects/test_add_aspect.py
+++ b/tests/appsec/iast/aspects/test_add_aspect.py
@@ -314,6 +314,8 @@ def test_taint_ranges_as_evidence_info_different_tainted_op1_and_op3_add():
     [
         (logging.DEBUG, "", "[IAST] Tainted Map"),
         (logging.WARNING, "", ""),
+        (logging.DEBUG, "false", "[IAST] Tainted Map"),
+        (logging.WARNING, "false", ""),
         (logging.DEBUG, "true", "_iast/_taint_tracking/__init__.py"),
         (logging.WARNING, "true", "_iast/_taint_tracking/__init__.py"),
     ],


### PR DESCRIPTION
Validate `_DD_IAST_DEBUG` as bool introduced in #8954

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
