### PR TITLE
chore(asm): add better support for recent versions of fastapi starlette httpx in unit tests

### DIFF
--- a/tests/appsec/contrib_appsec/test_fastapi.py
+++ b/tests/appsec/contrib_appsec/test_fastapi.py
@@ -12,7 +12,7 @@ from tests.appsec.contrib_appsec.fastapi_app.app import get_app
 
 FASTAPI_VERSION = tuple(int(v) for v in fastapi.__version__.split("."))
 STARLETTE_VERSION = tuple(int(v) for v in starlette.__version__.split("."))
-redirect_key = "allow_redirects" if STARLETTE_VERSION <= (0, 21, 0) else "follow_redirects"
+redirect_key = "allow_redirects" if STARLETTE_VERSION < (0, 21, 0) else "follow_redirects"
 HTTPX_VERSION = tuple(int(v) for v in httpx.__version__.split("."))
 
 

--- a/tests/appsec/contrib_appsec/test_fastapi.py
+++ b/tests/appsec/contrib_appsec/test_fastapi.py
@@ -46,7 +46,7 @@ class Test_FastAPI(utils.Contrib_TestClass_For_Threats):
                 # httpx does not accept unicode headers and is now used in the TestClient
                 if "headers" in kwargs and FASTAPI_VERSION >= (0, 87, 0):
                     kwargs["headers"] = {k.encode(): v.encode() for k, v in kwargs["headers"].items()}
-                if HTTPX_VERSION >= (0, 18, 0):
+                if HTTPX_VERSION >= (0, 18, 0) and STARLETTE_VERSION >= (0, 21, 0):
                     if "cookies" in kwargs:
                         client.cookies = kwargs["cookies"]
                         del kwargs["cookies"]
@@ -72,7 +72,7 @@ class Test_FastAPI(utils.Contrib_TestClass_For_Threats):
                 # httpx does not accept unicode headers and is now used in the TestClient
                 if "headers" in kwargs and FASTAPI_VERSION >= (0, 87, 0):
                     kwargs["headers"] = {k.encode(): v.encode() for k, v in kwargs["headers"].items()}
-                if HTTPX_VERSION >= (0, 18, 0):
+                if HTTPX_VERSION >= (0, 18, 0) and STARLETTE_VERSION >= (0, 21, 0):
                     if "cookies" in kwargs:
                         client.cookies = kwargs["cookies"]
                         del kwargs["cookies"]


### PR DESCRIPTION
Improve support and remove deprecation warnings for fastapi threat tests.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
