### PR TITLE
Revert "chore(iast): improve taint tracking logs II (#9035)"

### DIFF
--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -84,7 +84,6 @@ class IAST(metaclass=Constant_Class):
     DENY_MODULES = "_DD_IAST_DENY_MODULES"
     SEP_MODULES = ","
     REQUEST_IAST_ENABLED = "_dd.iast.request_enabled"
-    TEXT_TYPES = (str, bytes, bytearray)
 
 
 class IAST_SPAN_TAGS(metaclass=Constant_Class):

--- a/ddtrace/appsec/_iast/_metrics.py
+++ b/ddtrace/appsec/_iast/_metrics.py
@@ -59,6 +59,7 @@ def metric_verbosity(lvl):
 def _set_iast_error_metric(msg):
     # type: (str) -> None
     # Due to format_exc and format_exception returns the error and the last frame
+    log.debug("IAST Error: %s", msg)
     try:
         exception_type, exception_instance, _traceback_list = sys.exc_info()
         res = []

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectExtend.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectExtend.cpp
@@ -4,7 +4,8 @@ PyObject*
 api_extend_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 {
     if (nargs != 2 or !args) {
-        throw py::value_error(MSG_ERROR_N_PARAMS);
+        // TODO: any other more sane error handling?
+        return nullptr;
     }
 
     PyObject* candidate_text = args[0];

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.cpp
@@ -8,12 +8,6 @@ api_format_aspect(StrType& candidate_text,
                   const py::args& args,
                   const py::kwargs& kwargs)
 {
-    auto tx_map = initializer->get_tainting_map();
-
-    if (not tx_map or tx_map->empty()) {
-        return py::getattr(candidate_text, "format")(*args, **kwargs);
-    }
-
     auto [ranges_orig, candidate_text_ranges] = are_all_text_all_ranges(candidate_text.ptr(), parameter_list);
 
     if (!ranges_orig.empty() or !candidate_text_ranges.empty()) {
@@ -46,7 +40,7 @@ api_format_aspect(StrType& candidate_text,
         StrType result_text = get<0>(result);
         TaintRangeRefs result_ranges = get<1>(result);
         PyObject* new_result = new_pyobject_id(result_text.ptr());
-        set_ranges(new_result, result_ranges, tx_map);
+        set_ranges(new_result, result_ranges);
         return py::reinterpret_steal<StrType>(new_result);
     }
     return py::getattr(candidate_text, "format")(*args, **kwargs);

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
@@ -23,7 +23,7 @@ index_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* idx, TaintR
     if (ranges_to_set.empty()) {
         return res_new_id;
     }
-    set_ranges(res_new_id, ranges_to_set, tx_taint_map);
+    set_ranges(res_new_id, ranges_to_set);
 
     return res_new_id;
 }
@@ -32,18 +32,15 @@ PyObject*
 api_index_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 {
     if (nargs != 2) {
-        py::set_error(PyExc_ValueError, MSG_ERROR_N_PARAMS);
         return nullptr;
     }
-    auto ctx_map = initializer->get_tainting_map();
-
     PyObject* candidate_text = args[0];
     PyObject* idx = args[1];
 
     PyObject* result_o;
 
     result_o = PyObject_GetItem(candidate_text, idx);
-
+    auto ctx_map = initializer->get_tainting_map();
     if (not ctx_map or ctx_map->empty()) {
         return result_o;
     }

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
@@ -142,15 +142,13 @@ PyObject*
 api_join_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 {
     if (nargs != 2) {
-        py::set_error(PyExc_ValueError, MSG_ERROR_N_PARAMS);
+        // TODO: any other more sane error handling?
         return nullptr;
     }
 
     PyObject* sep = args[0];
     PyObject* arg0 = args[1];
     bool decref_arg0 = false;
-
-    auto ctx_map = initializer->get_tainting_map();
 
     if (PyIter_Check(arg0) or PySet_Check(arg0) or PyFrozenSet_Check(arg0)) {
         PyObject* iterator = PyObject_GetIter(arg0);
@@ -180,11 +178,16 @@ api_join_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
         result = result_ptr.ptr();
         Py_INCREF(result);
     }
-    if (not ctx_map or ctx_map->empty() or get_pyobject_size(result) == 0) {
+    if (get_pyobject_size(result) == 0) {
         // Empty result cannot have taint ranges
         if (decref_arg0) {
             Py_DecRef(arg0);
         }
+        return result;
+    }
+
+    auto ctx_map = initializer->get_tainting_map();
+    if (not ctx_map or ctx_map->empty()) {
         return result;
     }
     auto res = aspect_join(sep, result, arg0, ctx_map);

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
@@ -71,7 +71,7 @@ PyObject*
 api_add_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 {
     if (nargs != 2) {
-        py::set_error(PyExc_ValueError, MSG_ERROR_N_PARAMS);
+        // TODO: any other more sane error handling?
         return nullptr;
     }
     PyObject* candidate_text = args[0];
@@ -95,10 +95,10 @@ api_add_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
         return result_o;
     }
 
-    TaintRangeMapType* tx_map = initializer->get_tainting_map();
-    if (not tx_map or tx_map->empty()) {
+    auto ctx_map = initializer->get_tainting_map();
+    if (not ctx_map or ctx_map->empty()) {
         return result_o;
     }
-    auto res = add_aspect(result_o, candidate_text, text_to_add, tx_map);
+    auto res = add_aspect(result_o, candidate_text, text_to_add, ctx_map);
     return res;
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
@@ -82,7 +82,6 @@ PyObject*
 slice_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* start, PyObject* stop, PyObject* step)
 {
     auto ctx_map = initializer->get_tainting_map();
-
     if (not ctx_map or ctx_map->empty()) {
         return result_o;
     }
@@ -93,8 +92,7 @@ slice_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* start, PyOb
         return result_o;
     }
     set_ranges(result_o,
-               reduce_ranges_from_index_range_map(build_index_range_map(candidate_text, ranges, start, stop, step)),
-               ctx_map);
+               reduce_ranges_from_index_range_map(build_index_range_map(candidate_text, ranges, start, stop, step)));
     return result_o;
 }
 

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.cpp
@@ -8,26 +8,21 @@ namespace py = pybind11;
 
 template<class StrType>
 StrType
-api_common_replace(const py::str& string_method,
-                   const StrType& candidate_text,
-                   const py::args& args,
-                   const py::kwargs& kwargs)
+common_replace(const py::str& string_method,
+               const StrType& candidate_text,
+               const py::args& args,
+               const py::kwargs& kwargs)
 {
     bool ranges_error;
     TaintRangeRefs candidate_text_ranges;
-    TaintRangeMapType* tx_map = initializer->get_tainting_map();
+    std::tie(candidate_text_ranges, ranges_error) = get_ranges(candidate_text.ptr());
+
     StrType res = py::getattr(candidate_text, string_method)(*args, **kwargs);
-
-    if (not tx_map or tx_map->empty()) {
-        return res;
-    }
-    std::tie(candidate_text_ranges, ranges_error) = get_ranges(candidate_text.ptr(), tx_map);
-
     if (ranges_error or candidate_text_ranges.empty()) {
         return res;
     }
 
-    set_ranges(res.ptr(), shift_taint_ranges(candidate_text_ranges, 0, -1), tx_map);
+    set_ranges(res.ptr(), shift_taint_ranges(candidate_text_ranges, 0, -1));
     return res;
 }
 
@@ -184,14 +179,11 @@ split_taints(const string& str_to_split)
 py::bytearray
 api_convert_escaped_text_to_taint_text_ba(const py::bytearray& taint_escaped_text, TaintRangeRefs ranges_orig)
 {
-
-    auto tx_map = initializer->get_tainting_map();
-
     py::bytes bytes_text = py::bytes() + taint_escaped_text;
 
     std::tuple result = _convert_escaped_text_to_taint_text<py::bytes>(bytes_text, std::move(ranges_orig));
     PyObject* new_result = new_pyobject_id((py::bytearray() + get<0>(result)).ptr());
-    set_ranges(new_result, get<1>(result), tx_map);
+    set_ranges(new_result, get<1>(result));
     return py::reinterpret_steal<py::bytearray>(new_result);
 }
 
@@ -199,13 +191,11 @@ template<class StrType>
 StrType
 api_convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, TaintRangeRefs ranges_orig)
 {
-    auto tx_map = initializer->get_tainting_map();
-
     std::tuple result = _convert_escaped_text_to_taint_text<StrType>(taint_escaped_text, ranges_orig);
     StrType result_text = get<0>(result);
     TaintRangeRefs result_ranges = get<1>(result);
     PyObject* new_result = new_pyobject_id(result_text.ptr());
-    set_ranges(new_result, result_ranges, tx_map);
+    set_ranges(new_result, result_ranges);
     return py::reinterpret_steal<StrType>(new_result);
 }
 
@@ -338,9 +328,9 @@ parse_params(size_t position,
 void
 pyexport_aspect_helpers(py::module& m)
 {
-    m.def("common_replace", &api_common_replace<py::bytes>, "string_method"_a, "candidate_text"_a);
-    m.def("common_replace", &api_common_replace<py::str>, "string_method"_a, "candidate_text"_a);
-    m.def("common_replace", &api_common_replace<py::bytearray>, "string_method"_a, "candidate_text"_a);
+    m.def("common_replace", &common_replace<py::bytes>, "string_method"_a, "candidate_text"_a);
+    m.def("common_replace", &common_replace<py::str>, "string_method"_a, "candidate_text"_a);
+    m.def("common_replace", &common_replace<py::bytearray>, "string_method"_a, "candidate_text"_a);
     m.def("_all_as_formatted_evidence",
           &_all_as_formatted_evidence<py::str>,
           "text"_a,

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
@@ -14,10 +14,10 @@ namespace py = pybind11;
 // lower() and similar.
 template<class StrType>
 StrType
-api_common_replace(const py::str& string_method,
-                   const StrType& candidate_text,
-                   const py::args& args,
-                   const py::kwargs& kwargs);
+common_replace(const py::str& string_method,
+               const StrType& candidate_text,
+               const py::args& args,
+               const py::kwargs& kwargs);
 
 template<class StrType>
 StrType

--- a/ddtrace/appsec/_iast/_taint_tracking/Constants.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Constants.h
@@ -2,7 +2,5 @@
 #define PY_MODULE_NAME "ddtrace.appsec._iast._taint_tracking._native"
 #define RANGE_START long
 #define RANGE_LENGTH long
-#define MSG_ERROR_N_PARAMS "[IAST] Invalid number of params"
 #define MSG_ERROR_SET_RANGES "[IAST] Set ranges error: Empty ranges or Tainted Map isn't initialized"
-#define MSG_ERROR_GET_RANGES_TYPE "[IAST] Get ranges error: Invalid type of candidate_text variable"
 #define MSG_ERROR_TAINT_MAP "[IAST] Tainted Map isn't initialized"

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
@@ -67,18 +67,6 @@ api_shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, RANGE_START of
     return shift_taint_ranges(source_taint_ranges, offset);
 }
 
-void
-api_set_ranges(py::object& str, const TaintRangeRefs& ranges)
-{
-    auto tx_map = initializer->get_tainting_map();
-
-    if (not tx_map) {
-        py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
-        return;
-    }
-    set_ranges(str.ptr(), ranges, tx_map);
-}
-
 /**
  * set_ranges_from_values.
  *
@@ -104,17 +92,13 @@ PyObject*
 api_set_ranges_from_values(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 {
     bool result = false;
-    const char* result_error_msg = MSG_ERROR_N_PARAMS;
+    const char* result_error_msg =
+      "[IAST] Invalid number of params: pyobject_newid, len(pyobject), source_name, source_value, source_origin";
     PyObject* pyobject_n = nullptr;
 
     if (nargs == 5) {
         PyObject* tainted_object = args[0];
-        TaintRangeMapType* tx_map = initializer->get_tainting_map();
-        if (not tx_map) {
-            py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
-            return nullptr;
-        }
-
+        auto ctx_map = initializer->get_tainting_map();
         pyobject_n = new_pyobject_id(tainted_object);
         PyObject* len_pyobject_py = args[1];
 
@@ -127,7 +111,7 @@ api_set_ranges_from_values(PyObject* self, PyObject* const* args, Py_ssize_t nar
                 auto source = Source(source_name, source_value, source_origin);
                 auto range = initializer->allocate_taint_range(0, len_pyobject, source);
                 TaintRangeRefs ranges = vector{ range };
-                result = set_ranges(pyobject_n, ranges, tx_map);
+                result = set_ranges(pyobject_n, ranges, ctx_map);
                 if (not result) {
                     result_error_msg = MSG_ERROR_SET_RANGES;
                 }
@@ -151,8 +135,14 @@ get_ranges(PyObject* string_input, TaintRangeMapType* tx_map)
 {
     TaintRangeRefs result;
     if (not is_text(string_input))
-        return std::make_pair(result, true);
+        return std::make_pair(result, false);
 
+    if (not tx_map) {
+        tx_map = initializer->get_tainting_map();
+        if (not tx_map) {
+            return std::make_pair(result, true);
+        }
+    }
     if (tx_map->empty()) {
         return std::make_pair(result, false);
     }
@@ -172,9 +162,21 @@ get_ranges(PyObject* string_input, TaintRangeMapType* tx_map)
 bool
 set_ranges(PyObject* str, const TaintRangeRefs& ranges, TaintRangeMapType* tx_map)
 {
-    if (ranges.empty()) {
+    if (ranges.empty())
         return false;
+
+    if (not tx_map) {
+        tx_map = initializer->get_tainting_map();
+        if (not tx_map) {
+            return false;
+        }
     }
+
+    auto tx_id = initializer->context_id();
+    if (tx_id == 0) {
+        return true;
+    }
+
     auto obj_id = get_unique_id(str);
     auto it = tx_map->find(obj_id);
     auto new_tainted_object = initializer->allocate_ranges_into_taint_object(ranges);
@@ -200,13 +202,9 @@ are_all_text_all_ranges(PyObject* candidate_text, const py::tuple& parameter_lis
     if (not is_text(candidate_text))
         return {};
 
+    auto tx_map = initializer->get_tainting_map();
     bool ranges_error;
     TaintRangeRefs candidate_text_ranges, all_ranges;
-    TaintRangeMapType* tx_map = initializer->get_tainting_map();
-    if (not tx_map or tx_map->empty()) {
-        return { {}, {} };
-    }
-
     std::tie(candidate_text_ranges, ranges_error) = get_ranges(candidate_text, tx_map);
     if (not ranges_error) {
         for (const auto& param_handler : parameter_list) {
@@ -242,37 +240,13 @@ get_range_by_hash(size_t range_hash, optional<TaintRangeRefs>& taint_ranges)
     return null_range;
 }
 
-TaintRangeRefs
-api_get_ranges(py::object& string_input)
-{
-    bool ranges_error;
-    TaintRangeRefs ranges;
-    TaintRangeMapType* tx_map = initializer->get_tainting_map();
-
-    if (not tx_map) {
-        throw py::value_error(MSG_ERROR_TAINT_MAP);
-    }
-
-    std::tie(ranges, ranges_error) = get_ranges(string_input.ptr(), tx_map);
-    if (ranges_error) {
-        throw py::value_error(MSG_ERROR_GET_RANGES_TYPE);
-    }
-    return ranges;
-}
-
-void
+inline void
 api_copy_ranges_from_strings(py::object& str_1, py::object& str_2)
 {
 
+    auto tx_map = initializer->get_tainting_map();
     bool ranges_error, result;
     TaintRangeRefs ranges;
-    TaintRangeMapType* tx_map = initializer->get_tainting_map();
-
-    if (not tx_map) {
-        py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
-        return;
-    }
-
     std::tie(ranges, ranges_error) = get_ranges(str_1.ptr(), tx_map);
     if (ranges_error) {
         py::set_error(PyExc_TypeError, MSG_ERROR_TAINT_MAP);
@@ -289,11 +263,7 @@ api_copy_and_shift_ranges_from_strings(py::object& str_1, py::object& str_2, int
 {
     bool ranges_error, result;
     TaintRangeRefs ranges;
-    TaintRangeMapType* tx_map = initializer->get_tainting_map();
-    if (not tx_map) {
-        py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
-        return;
-    }
+    auto tx_map = initializer->get_tainting_map();
     std::tie(ranges, ranges_error) = get_ranges(str_1.ptr(), tx_map);
     if (ranges_error) {
         py::set_error(PyExc_TypeError, MSG_ERROR_TAINT_MAP);
@@ -311,6 +281,13 @@ get_tainted_object(PyObject* str, TaintRangeMapType* tx_map)
     if (not str)
         return nullptr;
 
+    if (not tx_map) {
+        tx_map = initializer->get_tainting_map();
+        if (not tx_map) {
+            // TODO: Log "Tainted Map isn't initialized. Call create_context() first";
+            return nullptr;
+        }
+    }
     if (is_notinterned_notfasttainted_unicode(str) or tx_map->empty()) {
         return nullptr;
     }
@@ -352,6 +329,15 @@ set_tainted_object(PyObject* str, TaintedObjectPtr tainted_object, TaintRangeMap
     if (not str or not is_text(str)) {
         return;
     }
+
+    if (not tx_taint_map) {
+        tx_taint_map = initializer->get_tainting_map();
+        if (not tx_taint_map) {
+            // TODO: Log "Tainted Map isn't initialized. Call create_context() first";
+            return;
+        }
+    }
+
     auto obj_id = get_unique_id(str);
     set_fast_tainted_if_notinterned_unicode(str);
     auto it = tx_taint_map->find(obj_id);
@@ -414,8 +400,9 @@ pyexport_taintrange(py::module& m)
           "offset"_a,
           "new_length"_a = -1);
 
-    // m.def("set_ranges", py::overload_cast<PyObject*, const TaintRangeRefs&>(&api_set_ranges), "str"_a, "ranges"_a);
+    m.def("set_ranges", py::overload_cast<PyObject*, const TaintRangeRefs&>(&set_ranges), "str"_a, "ranges"_a);
     m.def("set_ranges", &api_set_ranges, "str"_a, "ranges"_a);
+
     m.def("copy_ranges_from_strings", &api_copy_ranges_from_strings, "str_1"_a, "str_2"_a);
     m.def("copy_and_shift_ranges_from_strings",
           &api_copy_and_shift_ranges_from_strings,
@@ -424,6 +411,10 @@ pyexport_taintrange(py::module& m)
           "offset"_a,
           "new_length"_a = -1);
 
+    m.def("get_ranges",
+          py::overload_cast<PyObject*>(&get_ranges),
+          "string_input"_a,
+          py::return_value_policy::take_ownership);
     m.def("get_ranges", &api_get_ranges, "string_input"_a, py::return_value_policy::take_ownership);
 
     m.def("get_range_by_hash", &get_range_by_hash, "range_hash"_a, "taint_ranges"_a);

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
@@ -84,16 +84,39 @@ api_shift_taint_ranges(const TaintRangeRefs&, RANGE_START offset, RANGE_LENGTH n
 std::pair<TaintRangeRefs, bool>
 get_ranges(PyObject* string_input, TaintRangeMapType* tx_map);
 
+inline std::pair<TaintRangeRefs, bool>
+get_ranges(PyObject* string_input)
+{
+    return get_ranges(string_input, nullptr);
+}
+
+inline TaintRangeRefs
+api_get_ranges(py::object& string_input)
+{
+    bool ranges_error;
+    TaintRangeRefs ranges;
+    std::tie(ranges, ranges_error) = get_ranges(string_input.ptr());
+    if (ranges_error) {
+        throw py::value_error(MSG_ERROR_TAINT_MAP);
+    }
+    return ranges;
+}
+
 bool
 set_ranges(PyObject* str, const TaintRangeRefs& ranges, TaintRangeMapType* tx_map);
 
-void
-api_set_ranges(py::object& str, const TaintRangeRefs& ranges);
+inline bool
+set_ranges(PyObject* str, const TaintRangeRefs& ranges)
+{
+    return set_ranges(str, ranges, nullptr);
+}
+inline void
+api_set_ranges(py::object& str, const TaintRangeRefs& ranges)
+{
+    set_ranges(str.ptr(), ranges);
+}
 
-TaintRangeRefs
-api_get_ranges(py::object& string_input);
-
-void
+inline void
 api_copy_ranges_from_strings(py::object& str_1, py::object& str_2);
 
 inline void

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.cpp
@@ -22,12 +22,12 @@ bool
 api_is_tainted(py::object tainted_object)
 {
     if (tainted_object) {
-        TaintRangeMapType* tx_map = initializer->get_tainting_map();
-        if (not tx_map or tx_map->empty()) {
+        auto ctx_map = initializer->get_tainting_map();
+        if (not ctx_map or ctx_map->empty()) {
             return false;
         }
 
-        if (is_tainted(tainted_object.ptr(), tx_map)) {
+        if (is_tainted(tainted_object.ptr(), ctx_map)) {
             return true;
         }
     }

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -50,6 +50,7 @@ if _is_python_version_supported():
 
     new_pyobject_id = ops.new_pyobject_id
     set_ranges_from_values = ops.set_ranges_from_values
+    is_pyobject_tainted = is_tainted
 
 
 __all__ = [
@@ -94,24 +95,15 @@ def iast_taint_log_error(msg):
 
         stack = inspect.stack()
         frame_info = "\n".join("%s %s" % (frame_info.filename, frame_info.lineno) for frame_info in stack[:7])
-        log.debug("%s:\n%s", msg, frame_info)
+        log.warning("%s:\n%s", msg, frame_info)
         _set_iast_error_metric("IAST propagation error. %s" % msg)
-
-
-def is_pyobject_tainted(pyobject: Any) -> bool:
-    if not pyobject or not isinstance(pyobject, IAST.TEXT_TYPES):
-        return False
-
-    try:
-        return is_tainted(pyobject)
-    except ValueError as e:
-        iast_taint_log_error("Checking tainted object error: %s" % e)
-    return False
+    else:
+        log.debug(msg)
 
 
 def taint_pyobject(pyobject: Any, source_name: Any, source_value: Any, source_origin=None) -> Any:
     # Pyobject must be Text with len > 1
-    if not pyobject or not isinstance(pyobject, IAST.TEXT_TYPES):
+    if not pyobject or not isinstance(pyobject, (str, bytes, bytearray)):
         return pyobject
 
     if isinstance(source_name, (bytes, bytearray)):
@@ -126,25 +118,22 @@ def taint_pyobject(pyobject: Any, source_name: Any, source_value: Any, source_or
 
     try:
         pyobject_newid = set_ranges_from_values(pyobject, len(pyobject), source_name, source_value, source_origin)
-        _set_metric_iast_executed_source(source_origin)
-        return pyobject_newid
     except ValueError as e:
         iast_taint_log_error("Tainting object error (pyobject type %s): %s" % (type(pyobject), e))
-    return pyobject
+        return pyobject
+
+    _set_metric_iast_executed_source(source_origin)
+    return pyobject_newid
 
 
 def taint_pyobject_with_ranges(pyobject: Any, ranges: Tuple) -> None:
-    if not pyobject or not isinstance(pyobject, IAST.TEXT_TYPES):
-        return None
     try:
-        set_ranges(pyobject, ranges)
+        set_ranges(pyobject, tuple(ranges))
     except ValueError as e:
         iast_taint_log_error("Tainting object with ranges error (pyobject type %s): %s" % (type(pyobject), e))
 
 
 def get_tainted_ranges(pyobject: Any) -> Tuple:
-    if not pyobject or not isinstance(pyobject, IAST.TEXT_TYPES):
-        return tuple()
     try:
         return get_ranges(pyobject)
     except ValueError as e:

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -53,11 +53,7 @@ __all__ = ["add_aspect", "str_aspect", "bytearray_extend_aspect", "decode_aspect
 def add_aspect(op1, op2):
     if not isinstance(op1, TEXT_TYPES) or not isinstance(op2, TEXT_TYPES) or type(op1) != type(op2):
         return op1 + op2
-    try:
-        return _add_aspect(op1, op2)
-    except Exception as e:
-        iast_taint_log_error("IAST propagation error. add_aspect. {}".format(e))
-    return op1 + op2
+    return _add_aspect(op1, op2)
 
 
 def str_aspect(orig_function, flag_added_args, *args, **kwargs):
@@ -71,7 +67,7 @@ def str_aspect(orig_function, flag_added_args, *args, **kwargs):
     else:
         result = args[0].str(*args[1:], **kwargs)
 
-    if args and is_pyobject_tainted(args[0]):
+    if args and isinstance(args[0], TEXT_TYPES) and is_pyobject_tainted(args[0]):
         try:
             if isinstance(args[0], (bytes, bytearray)):
                 encoding = parse_params(1, "encoding", "utf-8", *args, **kwargs)
@@ -97,7 +93,7 @@ def bytes_aspect(orig_function, flag_added_args, *args, **kwargs):
     else:
         result = args[0].bytes(*args[1:], **kwargs)
 
-    if args and is_pyobject_tainted(args[0]):
+    if args and isinstance(args[0], TEXT_TYPES) and is_pyobject_tainted(args[0]):
         try:
             copy_ranges_from_strings(args[0], result)
         except Exception as e:
@@ -116,7 +112,7 @@ def bytearray_aspect(orig_function, flag_added_args, *args, **kwargs):
     else:
         result = args[0].bytearray(*args[1:], **kwargs)
 
-    if args and is_pyobject_tainted(args[0]):
+    if args and isinstance(args[0], TEXT_TYPES) and is_pyobject_tainted(args[0]):
         try:
             copy_ranges_from_strings(args[0], result)
         except Exception as e:

--- a/tests/appsec/iast/aspects/conftest.py
+++ b/tests/appsec/iast/aspects/conftest.py
@@ -1,7 +1,11 @@
+import logging
+
 import pytest
 
+from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast import oce
 from ddtrace.appsec._iast._ast.ast_patching import astpatch_module
+from tests.utils import override_env
 
 
 def _iast_patched_module(module_name):
@@ -18,3 +22,12 @@ def _enable_oce():
     oce._enabled = True
     yield
     oce._enabled = False
+
+
+@pytest.fixture(autouse=True)
+def check_native_code_exception_in_each_python_aspect_test(caplog):
+    with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
+        yield
+    assert not any("[IAST] " in record.message for record in caplog.records), [
+        record.message for record in caplog.records
+    ]

--- a/tests/appsec/iast/aspects/test_bytearray_extend_aspect.py
+++ b/tests/appsec/iast/aspects/test_bytearray_extend_aspect.py
@@ -1,18 +1,10 @@
 # -*- encoding: utf-8 -*-
-import logging
-
-import pytest
-
-from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
-from ddtrace.appsec._iast._taint_tracking import create_context
-from ddtrace.appsec._iast._taint_tracking import destroy_context
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
-from tests.utils import override_env
 
 
 mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.str_methods")
@@ -101,18 +93,3 @@ class TestByteArrayExtendAspect(object):
         ]
         assert get_tainted_ranges(ba1) == ranges
         assert get_tainted_ranges(ba2) == [TaintRange(0, 3, Source("test2", "bar", OriginType.BODY))]
-
-
-@pytest.mark.skip_iast_check_logs
-def test_propagate_ranges_with_no_context(caplog):
-    create_context()
-    ba1 = bytearray(b"123")
-    ba2 = taint_pyobject(
-        pyobject=bytearray(b"456"), source_name="test", source_value="foo", source_origin=OriginType.PARAMETER
-    )
-    destroy_context()
-    with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
-        result = mod.do_bytearray_extend(ba1, ba2)
-        assert result == bytearray(b"123456")
-    log_messages = [record.message for record in caplog.get_records("call")]
-    assert len(log_messages) == 0

--- a/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
@@ -1,22 +1,14 @@
 # -*- encoding: utf-8 -*-
-import logging
 import math
 from typing import Any
 from typing import NamedTuple
 
 import pytest
 
-from ddtrace.appsec._constants import IAST
-from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
-from ddtrace.appsec._iast._taint_tracking import create_context
-from ddtrace.appsec._iast._taint_tracking import destroy_context
-from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
-from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
 from tests.appsec.iast.aspects.aspect_utils import create_taint_range_with_format
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
-from tests.utils import override_env
 
 
 mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.str_methods")
@@ -231,24 +223,3 @@ class TestOperatorFormatReplacement(BaseReplacement):
 
         list_metrics_logs = list(telemetry_writer._logs)
         assert len(list_metrics_logs) == 0
-
-
-@pytest.mark.skip_iast_check_logs
-def test_propagate_ranges_with_no_context(caplog):
-    """Test taint_pyobject without context. This test is to ensure that the function does not raise an exception."""
-    string_to_taint = "-1234 {} {} {} {test_kwarg} {test_var}"
-    create_context()
-    string_input = taint_pyobject(
-        pyobject=string_to_taint,
-        source_name="test_add_aspect_tainting_left_hand",
-        source_value=string_to_taint,
-        source_origin=OriginType.PARAMETER,
-    )
-    destroy_context()
-    with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
-        result_2 = mod.do_args_kwargs_4(string_input, 6, test_var=1)
-
-    ranges_result = get_tainted_ranges(result_2)
-    log_messages = [record.message for record in caplog.get_records("call")]
-    assert not any("[IAST] " in message for message in log_messages), log_messages
-    assert len(ranges_result) == 0

--- a/tests/appsec/iast/aspects/test_index_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_index_aspect_fixtures.py
@@ -1,16 +1,11 @@
-import logging
 import sys
 
 import pytest
 
-from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking import create_context
-from ddtrace.appsec._iast._taint_tracking import destroy_context
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
-from tests.utils import override_env
 
 
 mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.str_methods")
@@ -76,25 +71,3 @@ def test_index_error_and_no_log_metric(telemetry_writer):
 
     list_metrics_logs = list(telemetry_writer._logs)
     assert len(list_metrics_logs) == 0
-
-
-@pytest.mark.skip_iast_check_logs
-@pytest.mark.skipif(sys.version_info < (3, 9, 0), reason="Python version not supported by IAST")
-def test_propagate_ranges_with_no_context(caplog):
-    """Test taint_pyobject without context. This test is to ensure that the function does not raise an exception."""
-    input_str = "abcde"
-    create_context()
-    string_input = taint_pyobject(
-        pyobject=input_str,
-        source_name="test_add_aspect_tainting_left_hand",
-        source_value="foo",
-        source_origin=OriginType.PARAMETER,
-    )
-    assert get_tainted_ranges(string_input)
-
-    destroy_context()
-    with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
-        result = mod.do_index(string_input, 3)
-        assert result == "d"
-    log_messages = [record.message for record in caplog.get_records("call")]
-    assert not any("[IAST] " in message for message in log_messages), log_messages

--- a/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
@@ -1,17 +1,9 @@
 #!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
-import logging
-
-import pytest
-
-from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking import create_context
-from ddtrace.appsec._iast._taint_tracking import destroy_context
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
-from tests.utils import override_env
 
 
 mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.str_methods")
@@ -423,55 +415,3 @@ class TestOperatorJoinReplacement(object):
         assert result[ranges[4].start : (ranges[4].start + ranges[4].length)] == "h"
         assert result[ranges[5].start : (ranges[5].start + ranges[5].length)] == "+abcde-"
         assert result[ranges[6].start : (ranges[6].start + ranges[6].length)] == "i"
-
-
-@pytest.mark.skip_iast_check_logs
-def test_propagate_ranges_with_no_context(caplog):
-    create_context()
-    string_input = taint_pyobject(
-        pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
-    )
-    it = ["a", "b", "c"]
-    destroy_context()
-    with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
-        result = mod.do_join(string_input, it)
-        assert result == "a-joiner-b-joiner-c"
-    log_messages = [record.message for record in caplog.get_records("call")]
-    assert not any("[IAST] " in message for message in log_messages), log_messages
-
-
-@pytest.mark.skip_iast_check_logs
-def test_propagate_ranges_with_no_context_with_var(caplog):
-    create_context()
-    string_input = taint_pyobject(
-        pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
-    )
-    it = [
-        taint_pyobject(pyobject="a", source_name="joined", source_value="a", source_origin=OriginType.PARAMETER),
-        "b",
-        "c",
-    ]
-    destroy_context()
-    with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
-        result = mod.do_join(string_input, it)
-        assert result == "a-joiner-b-joiner-c"
-    log_messages = [record.message for record in caplog.get_records("call")]
-    assert not any("[IAST] " in message for message in log_messages), log_messages
-
-
-@pytest.mark.skip_iast_check_logs
-def test_propagate_ranges_with_no_context_with_equal_var(caplog):
-    create_context()
-    string_input = taint_pyobject(
-        pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
-    )
-    a_tainted = taint_pyobject(
-        pyobject="abcdef", source_name="joined", source_value="abcdef", source_origin=OriginType.PARAMETER
-    )
-
-    destroy_context()
-    with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
-        result = mod.do_join(string_input, [a_tainted, a_tainted, a_tainted])
-        assert result == "abcdef-joiner-abcdef-joiner-abcdef"
-    log_messages = [record.message for record in caplog.get_records("call")]
-    assert not any("[IAST] " in message for message in log_messages), log_messages

--- a/tests/appsec/iast/aspects/test_slice_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_slice_aspect_fixtures.py
@@ -1,17 +1,12 @@
 # -*- encoding: utf-8 -*-
-import logging
 import sys
 
 import pytest
 
-from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking import create_context
-from ddtrace.appsec._iast._taint_tracking import destroy_context
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
-from tests.utils import override_env
 
 
 mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.str_methods")
@@ -306,21 +301,3 @@ def test_string_slice_negative():
     )
     result = mod.do_slice_negative(tainted_input)
     assert result == expected_result
-
-
-@pytest.mark.skip_iast_check_logs
-def test_propagate_ranges_with_no_context(caplog):
-    create_context()
-    tainted_input = taint_pyobject(
-        pyobject="abcde",
-        source_name="input_str",
-        source_value="foo",
-        source_origin=OriginType.PARAMETER,
-    )
-
-    destroy_context()
-    with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
-        result = mod.do_slice(tainted_input, 0, 3, None)
-        assert result == "abc"
-    log_messages = [record.message for record in caplog.get_records("call")]
-    assert not any("[IAST] " in message for message in log_messages), log_messages

--- a/tests/appsec/iast/aspects/test_str_aspect.py
+++ b/tests/appsec/iast/aspects/test_str_aspect.py
@@ -251,11 +251,10 @@ def test_str_aspect_kwargs(obj, expected_result, encoding, errors):
 def test_str_aspect_decode_error(obj):
     import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
 
-    source_name = str(obj, "utf-8", errors="ignore")
     obj = taint_pyobject(
         obj,
         source_name="test_str_aspect_tainting",
-        source_value=source_name if source_name else "invalid",
+        source_value=str(obj, "utf-8", errors="ignore"),
         source_origin=OriginType.PARAMETER,
     )
     with pytest.raises(UnicodeDecodeError) as e:

--- a/tests/appsec/iast/conftest.py
+++ b/tests/appsec/iast/conftest.py
@@ -1,9 +1,7 @@
 from contextlib import contextmanager
-import logging
 
 import pytest
 
-from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast import oce
 from ddtrace.appsec._iast._patches.json_tainting import patch as json_patch
 from ddtrace.appsec._iast._patches.json_tainting import unpatch_iast as json_unpatch
@@ -151,16 +149,3 @@ def iast_context():
     _ = create_context()
     yield
     reset_context()
-
-
-@pytest.fixture(autouse=True)
-def check_native_code_exception_in_each_python_aspect_test(request, caplog):
-    if "skip_iast_check_logs" in request.keywords:
-        yield
-    else:
-        caplog.set_level(logging.DEBUG)
-        with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
-            yield
-
-        log_messages = [record.message for record in caplog.get_records("call")]
-        assert not any("[IAST] " in message for message in log_messages), log_messages

--- a/tests/appsec/iast/taint_tracking/test_native_taint_range.py
+++ b/tests/appsec/iast/taint_tracking/test_native_taint_range.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 from ast import literal_eval
 import random
-import re
 import sys
-
-import pytest
 
 from ddtrace.appsec._iast import oce
 from tests.utils import override_env
@@ -318,11 +315,8 @@ def test_set_get_ranges_other():
     s2 = None
     set_ranges(s1, [_RANGE1, _RANGE2])
     set_ranges(s2, [_RANGE1, _RANGE2])
-    with pytest.raises(ValueError, match=re.escape("[IAST] Get ranges error: Invalid type of candidate_text variable")):
-        get_ranges(s1)
-
-    with pytest.raises(ValueError, match=re.escape("[IAST] Get ranges error: Invalid type of candidate_text variable")):
-        get_ranges(s2)
+    assert not get_ranges(s1)
+    assert not get_ranges(s2)
 
 
 def test_set_get_ranges_bytes():

--- a/tests/appsec/iast/taint_tracking/test_taint_tracking.py
+++ b/tests/appsec/iast/taint_tracking/test_taint_tracking.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-import logging
 
-import pytest
-
-from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast import oce
 from tests.utils import override_env
 
@@ -11,8 +7,6 @@ from tests.utils import override_env
 with override_env({"DD_IAST_ENABLED": "True"}):
     from ddtrace.appsec._iast._taint_tracking import OriginType
     from ddtrace.appsec._iast._taint_tracking import Source
-    from ddtrace.appsec._iast._taint_tracking import destroy_context
-    from ddtrace.appsec._iast._taint_tracking import num_objects_tainted
     from ddtrace.appsec._iast._taint_tracking import taint_pyobject
     from ddtrace.appsec._iast._taint_tracking import taint_ranges_as_evidence_info
     from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect
@@ -36,27 +30,6 @@ def test_taint_ranges_as_evidence_info_all_tainted():
     value_parts, sources = taint_ranges_as_evidence_info(tainted_text)
     assert value_parts == [{"value": tainted_text, "source": 0}]
     assert sources == [input_info]
-
-
-@pytest.mark.skip_iast_check_logs
-def test_taint_object_with_no_context_should_be_noop():
-    destroy_context()
-    arg = "all tainted"
-    tainted_text = taint_pyobject(arg, source_name="request_body", source_value=arg, source_origin=OriginType.PARAMETER)
-    assert tainted_text == arg
-    assert num_objects_tainted() == 0
-
-
-@pytest.mark.skip_iast_check_logs
-def test_propagate_ranges_with_no_context(caplog):
-    destroy_context()
-    with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
-        string_input = taint_pyobject(
-            pyobject="abcde", source_name="abcde", source_value="abcde", source_origin=OriginType.PARAMETER
-        )
-        assert string_input == "abcde"
-    log_messages = [record.message for record in caplog.get_records("call")]
-    assert any("[IAST] " in message for message in log_messages), log_messages
 
 
 def test_taint_ranges_as_evidence_info_tainted_op1_add():


### PR DESCRIPTION
This reverts commit 51d71f397d45c336f302285cf247b33066338685.

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
