### PR TITLE
chore(iast): clean native code

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectExtend.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectExtend.cpp
@@ -1,5 +1,13 @@
 #include "AspectExtend.h"
 
+/**
+ * @brief Taint candidate_text when bytearray extends is called.
+ *
+ * @param self
+ * @param args: 0: candidate text, 1: Bytearray or bytes to extend in candidate text
+ * @param nargs number of elements in args
+ * @return PyObject*: return None (Remember, Pyobject None isn't the same as nullptr)
+ */
 PyObject*
 api_extend_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 {

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.cpp
@@ -1,6 +1,15 @@
-#pragma once
 #include "Aspects/AspectFormat.h"
 
+/**
+ * @brief This function is used to format the candidate_text with the given parameter_list, args and kwargs.
+ *
+ * @tparam StrType
+ * @param candidate_text
+ * @param parameter_list
+ * @param args
+ * @param kwargs
+ * @return StrType
+ */
 template<class StrType>
 StrType
 api_format_aspect(StrType& candidate_text,

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
@@ -1,5 +1,14 @@
 #include "AspectIndex.h"
 
+/**
+ * @brief Index aspect
+ *
+ * @param result_o
+ * @param candidate_text
+ * @param idx
+ * @param tx_taint_map
+ * @return PyObject*
+ */
 PyObject*
 index_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* idx, TaintRangeMapType* tx_taint_map)
 {

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
@@ -61,8 +61,7 @@ PyObject*
 aspect_join(PyObject* sep, PyObject* result, PyObject* iterable_elements, TaintRangeMapType* tx_taint_map)
 {
     const size_t& len_sep = get_pyobject_size(sep);
-    // FIXME: bug. if the argument is a string instead of a tuple, it will enter
-    // into an infinite loop
+
     size_t len_iterable{ 0 };
     auto GetElement = PyList_GetItem;
     if (PyList_Check(iterable_elements)) {

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
@@ -1,5 +1,12 @@
 #include "AspectSlice.h"
 
+/**
+ * This function reduces the taint ranges from the given index range map.
+ *
+ * @param index_range_map The index range map from which the taint ranges are to be reduced.
+ *
+ * @return A map of taint ranges for the given index range map.
+ */
 TaintRangeRefs
 reduce_ranges_from_index_range_map(TaintRangeRefs index_range_map)
 {
@@ -26,6 +33,14 @@ reduce_ranges_from_index_range_map(TaintRangeRefs index_range_map)
     return new_ranges;
 }
 
+/**
+ * This function builds a map of taint ranges for the given text object.
+ *
+ * @param text The text object for which the taint ranges are to be built.
+ * @param ranges The taint range map that stores taint information.
+ *
+ * @return A map of taint ranges for the given text object.
+ */
 TaintRangeRefs
 build_index_range_map(PyObject* text, TaintRangeRefs& ranges, PyObject* start, PyObject* stop, PyObject* step)
 {

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.cpp
@@ -6,6 +6,13 @@
 using namespace pybind11::literals;
 namespace py = pybind11;
 
+/**
+ * @brief This function is used to get the taint ranges for the given text object.
+ *
+ * @tparam StrType
+ * @param text
+ * @return TaintRangeRefs
+ */
 template<class StrType>
 StrType
 api_common_replace(const py::str& string_method,

--- a/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
@@ -75,7 +75,7 @@ Initializer::num_objects_tainted()
 {
     auto ctx_map = initializer->get_tainting_map();
     if (ctx_map) {
-        return (int)ctx_map->size();
+        return static_cast<int>(ctx_map->size());
     }
     return 0;
 }
@@ -108,7 +108,7 @@ Initializer::initializer_size()
 int
 Initializer::active_map_addreses_size()
 {
-    return (int)active_map_addreses.size();
+    return static_cast<int>(active_map_addreses.size());
 }
 
 TaintedObjectPtr

--- a/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
@@ -75,7 +75,7 @@ Initializer::num_objects_tainted()
 {
     auto ctx_map = initializer->get_tainting_map();
     if (ctx_map) {
-        return ctx_map->size();
+        return (int)ctx_map->size();
     }
     return 0;
 }
@@ -108,7 +108,7 @@ Initializer::initializer_size()
 int
 Initializer::active_map_addreses_size()
 {
-    return active_map_addreses.size();
+    return (int)active_map_addreses.size();
 }
 
 TaintedObjectPtr
@@ -129,15 +129,6 @@ Initializer::allocate_ranges_into_taint_object(TaintRangeRefs ranges)
     auto toptr = allocate_tainted_object();
     toptr->set_values(std::move(ranges));
     return toptr;
-}
-
-TaintedObjectPtr
-Initializer::allocate_tainted_object(TaintedObjectPtr from)
-{
-    if (!from) {
-        return allocate_tainted_object();
-    }
-    return allocate_ranges_into_taint_object(std::move(from->ranges_));
 }
 
 TaintedObjectPtr
@@ -227,12 +218,6 @@ Initializer::destroy_context()
 {
     free_tainting_map((TaintRangeMapType*)ThreadContextCache.tx_id);
     ThreadContextCache.tx_id = 0;
-}
-
-size_t
-Initializer::context_id()
-{
-    return ThreadContextCache.tx_id;
 }
 
 void

--- a/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.h
@@ -63,7 +63,7 @@ class Initializer
      */
     static int num_objects_tainted();
 
-    string debug_taint_map();
+    static string debug_taint_map();
 
     /**
      * Gets the size of the Initializer object.
@@ -95,13 +95,6 @@ class Initializer
     void reset_context();
 
     /**
-     * Gets the ID of the current taint tracking context.
-     *
-     * @return The ID of the current taint tracking context.
-     */
-    static size_t context_id();
-
-    /**
      * Allocates a new tainted object.
 
      * IMPORTANT: if the returned object is not assigned to the map, you have responsibility of calling
@@ -114,14 +107,6 @@ class Initializer
      * @return A pointer to the allocated tainted object.
      */
     TaintedObjectPtr allocate_tainted_object();
-
-    /**
-     * Allocates a new tainted object as a copy of an existing object.
-     *
-     * @param from The existing tainted object to copy.
-     * @return A pointer to the allocated tainted object.
-     */
-    TaintedObjectPtr allocate_tainted_object(TaintedObjectPtr from);
 
     /**
      * Allocates taint ranges into new tainted object.

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.cpp
@@ -5,8 +5,17 @@
 
 namespace py = pybind11;
 
+/**
+ * This function allocates a new taint range with the given offset and maximum length.
+ *
+ * @param source_taint_range The source taint range.
+ * @param offset The offset to be applied.
+ * @param max_length The maximum length of the taint range.
+ *
+ * @return A new taint range with the given offset and maximum length.
+ */
 TaintRangePtr
-reposition_and_limit_taint_range(const TaintRangePtr& source_taint_range, RANGE_START offset, RANGE_LENGTH max_length)
+allocate_limited_taint_range(const TaintRangePtr& source_taint_range, RANGE_START offset, RANGE_LENGTH max_length)
 {
     RANGE_LENGTH length;
     if (max_length != -1)
@@ -20,6 +29,10 @@ reposition_and_limit_taint_range(const TaintRangePtr& source_taint_range, RANGE_
     return tptr;
 }
 
+/**
+ * @brief Shifts the taint range by the given offset.
+ * @param offset The offset to be applied.
+ */
 TaintRangePtr
 shift_taint_range(const TaintRangePtr& source_taint_range, RANGE_START offset)
 {
@@ -29,6 +42,14 @@ shift_taint_range(const TaintRangePtr& source_taint_range, RANGE_START offset)
     return tptr;
 }
 
+/**
+ * This function shifts the taint ranges by the given offset.
+ *
+ * @param tainted_object The tainted object.
+ * @param offset The offset to be applied.
+ * @param max_length The maximum length of the taint range.
+ * @param orig_offset The offset to be applied at the beginning.
+ */
 void
 TaintedObject::add_ranges_shifted(TaintedObjectPtr tainted_object,
                                   RANGE_START offset,
@@ -39,6 +60,14 @@ TaintedObject::add_ranges_shifted(TaintedObjectPtr tainted_object,
     add_ranges_shifted(ranges, offset, max_length, orig_offset);
 }
 
+/**
+ * This function shifts the taint ranges by the given offset.
+ *
+ * @param ranges The taint ranges.
+ * @param offset The offset to be applied.
+ * @param max_length The maximum length of the taint range.
+ * @param orig_offset The offset to be applied at the beginning.
+ */
 void
 TaintedObject::add_ranges_shifted(TaintRangeRefs ranges,
                                   RANGE_START offset,
@@ -57,7 +86,7 @@ TaintedObject::add_ranges_shifted(TaintRangeRefs ranges,
                     // Make sure original position (orig_offset) is covered by the range
                     if (trange->start <= orig_offset and
                         ((trange->start + trange->length) >= orig_offset + max_length)) {
-                        ranges_.emplace_back(reposition_and_limit_taint_range(trange, offset, max_length));
+                        ranges_.emplace_back(allocate_limited_taint_range(trange, offset, max_length));
                         i++;
                     }
                 } else {

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.cpp
@@ -15,7 +15,9 @@ namespace py = pybind11;
  * @return A new taint range with the given offset and maximum length.
  */
 TaintRangePtr
-allocate_limited_taint_range(const TaintRangePtr& source_taint_range, RANGE_START offset, RANGE_LENGTH max_length)
+allocate_limited_taint_range_with_offset(const TaintRangePtr& source_taint_range,
+                                         RANGE_START offset,
+                                         RANGE_LENGTH max_length)
 {
     RANGE_LENGTH length;
     if (max_length != -1)
@@ -86,7 +88,7 @@ TaintedObject::add_ranges_shifted(TaintRangeRefs ranges,
                     // Make sure original position (orig_offset) is covered by the range
                     if (trange->start <= orig_offset and
                         ((trange->start + trange->length) >= orig_offset + max_length)) {
-                        ranges_.emplace_back(allocate_limited_taint_range(trange, offset, max_length));
+                        ranges_.emplace_back(allocate_limited_taint_range_with_offset(trange, offset, max_length));
                         i++;
                     }
                 } else {

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.cpp
@@ -1,10 +1,12 @@
 #include "TaintedOps/TaintedOps.h"
 
 PyObject*
-api_new_pyobject_id(PyObject* Py_UNUSED(module), PyObject* args)
+api_new_pyobject_id(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 {
-    PyObject* tainted_object;
-    PyArg_ParseTuple(args, "O", &tainted_object);
+    if (nargs != 1 or !args) {
+        throw py::value_error(MSG_ERROR_N_PARAMS);
+    }
+    PyObject* tainted_object = args[0];
     return new_pyobject_id(tainted_object);
 }
 

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.h
@@ -11,22 +11,13 @@ using namespace pybind11::literals;
 namespace py = pybind11;
 
 PyObject*
-api_new_pyobject_id(PyObject* Py_UNUSED(module), PyObject* args);
+api_new_pyobject_id(PyObject* self, PyObject* const* args, Py_ssize_t nargs);
 
 bool
-is_tainted(PyObject* Py_UNUSED(module), PyObject* args);
+is_tainted(PyObject* tainted_object, TaintRangeMapType* tx_taint_map);
 
 bool
 api_is_tainted(py::object tainted_object);
 
 void
 pyexport_tainted_ops(py::module& m);
-// TODO
-// PyObject *api_add_taint_pyobject(PyObject* pyobject, PyObject* op1, PyObject*
-// op2); PyObject* api_taint_pyobject(PyObject* pyobject, Source source); bool
-// api_is_pyobject_tainted(PyObject* pyobject); void
-// api_set_tainted_ranges(PyObject* pyobject, TaintRangeRefs ranges);
-// TaintRangeRefs api_get_tainted_ranges(PyObject* pyobject); // can be already
-// implemented
-// XXX (Tuple[List[Dict[str, Union[Any, int]]], list[Source]])
-// api_taint_ranges_as_evidence_info(PyObject* pyobject);

--- a/ddtrace/appsec/_iast/_taint_tracking/_native.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/_native.cpp
@@ -1,4 +1,4 @@
-/* *****
+/**
  * IAST Native Module
  * This C++ module contains IAST propagation features:
  * - Taint tracking: propagation of a tainted variable.
@@ -27,9 +27,6 @@ using namespace pybind11::literals;
 namespace py = pybind11;
 
 static PyMethodDef AspectsMethods[] = {
-    // We are using  METH_VARARGS because we need compatibility with
-    // python 3.5, 3.6. but METH_FASTCALL could be used instead for python
-    // >= 3.7
     { "add_aspect", ((PyCFunction)api_add_aspect), METH_FASTCALL, "aspect add" },
     { "extend_aspect", ((PyCFunction)api_extend_aspect), METH_FASTCALL, "aspect extend" },
     { "index_aspect", ((PyCFunction)api_index_aspect), METH_FASTCALL, "aspect index" },
@@ -45,10 +42,7 @@ static struct PyModuleDef aspects = { PyModuleDef_HEAD_INIT,
                                       .m_methods = AspectsMethods };
 
 static PyMethodDef OpsMethods[] = {
-    // We are using  METH_VARARGS because we need compatibility with
-    // python 3.5, 3.6. but METH_FASTCALL could be used instead for python
-    // >= 3.7
-    { "new_pyobject_id", (PyCFunction)api_new_pyobject_id, METH_VARARGS, "new pyobject id" },
+    { "new_pyobject_id", (PyCFunction)api_new_pyobject_id, METH_FASTCALL, "new pyobject id" },
     { "set_ranges_from_values", ((PyCFunction)api_set_ranges_from_values), METH_FASTCALL, "set_ranges_from_values" },
     { nullptr, nullptr, 0, nullptr }
 };
@@ -59,6 +53,9 @@ static struct PyModuleDef ops = { PyModuleDef_HEAD_INIT,
                                   .m_size = -1,
                                   .m_methods = OpsMethods };
 
+/**
+ * This function initializes the native module.
+ */
 PYBIND11_MODULE(_native, m)
 {
     const char* env_iast_enabled = std::getenv("DD_IAST_ENABLED");

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -3,8 +3,16 @@ from builtins import bytes as builtin_bytes
 from builtins import str as builtin_str
 import codecs
 from types import BuiltinFunctionType
-from typing import TYPE_CHECKING
 from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Text
+from typing import Tuple
+from typing import Union
+
+from ddtrace.appsec._constants import IAST
 
 from .._taint_tracking import TagMappingMode
 from .._taint_tracking import TaintRange
@@ -27,18 +35,7 @@ from .._taint_tracking import taint_pyobject_with_ranges
 from .._taint_tracking._native import aspects  # noqa: F401
 
 
-if TYPE_CHECKING:
-    from typing import Callable  # noqa:F401
-    from typing import Dict  # noqa:F401
-    from typing import List  # noqa:F401
-    from typing import Optional  # noqa:F401
-    from typing import Sequence  # noqa:F401
-    from typing import Tuple  # noqa:F401
-    from typing import Union  # noqa:F401
-
-    TEXT_TYPE = Union[str, bytes, bytearray]
-
-TEXT_TYPES = (str, bytes, bytearray)
+TEXT_TYPES = Union[str, bytes, bytearray]
 
 
 _add_aspect = aspects.add_aspect
@@ -51,7 +48,7 @@ __all__ = ["add_aspect", "str_aspect", "bytearray_extend_aspect", "decode_aspect
 
 
 def add_aspect(op1, op2):
-    if not isinstance(op1, TEXT_TYPES) or not isinstance(op2, TEXT_TYPES) or type(op1) != type(op2):
+    if not isinstance(op1, IAST.TEXT_TYPES) or not isinstance(op2, IAST.TEXT_TYPES) or type(op1) != type(op2):
         return op1 + op2
     try:
         return _add_aspect(op1, op2)
@@ -60,8 +57,7 @@ def add_aspect(op1, op2):
     return op1 + op2
 
 
-def str_aspect(orig_function, flag_added_args, *args, **kwargs):
-    # type: (Optional[Callable], int, Any, Any) -> str
+def str_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> str:
     if orig_function:
         if orig_function != builtin_str:
             if flag_added_args > 0:
@@ -86,8 +82,7 @@ def str_aspect(orig_function, flag_added_args, *args, **kwargs):
     return result
 
 
-def bytes_aspect(orig_function, flag_added_args, *args, **kwargs):
-    # type: (Optional[Callable], int, Any, Any) -> bytes
+def bytes_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> bytes:
     if orig_function:
         if orig_function != builtin_bytes:
             if flag_added_args > 0:
@@ -105,8 +100,7 @@ def bytes_aspect(orig_function, flag_added_args, *args, **kwargs):
     return result
 
 
-def bytearray_aspect(orig_function, flag_added_args, *args, **kwargs):
-    # type: (Optional[Callable], int, Any, Any) -> bytearray
+def bytearray_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> bytearray:
     if orig_function:
         if orig_function != builtin_bytearray:
             if flag_added_args > 0:
@@ -124,8 +118,7 @@ def bytearray_aspect(orig_function, flag_added_args, *args, **kwargs):
     return result
 
 
-def join_aspect(orig_function, flag_added_args, *args, **kwargs):
-    # type: (Optional[Callable], int, Any, Any) -> Any
+def join_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> Any:
     if not orig_function:
         orig_function = args[0].join
     if not isinstance(orig_function, BuiltinFunctionType):
@@ -138,7 +131,7 @@ def join_aspect(orig_function, flag_added_args, *args, **kwargs):
 
     joiner = args[0]
     args = args[flag_added_args:]
-    if not isinstance(joiner, TEXT_TYPES):
+    if not isinstance(joiner, IAST.TEXT_TYPES):
         return joiner.join(*args, **kwargs)
     try:
         return _join_aspect(joiner, *args, **kwargs)
@@ -147,10 +140,10 @@ def join_aspect(orig_function, flag_added_args, *args, **kwargs):
         return joiner.join(*args, **kwargs)
 
 
-def index_aspect(candidate_text, index) -> Any:
+def index_aspect(candidate_text: Text, index: int) -> Text:
     result = candidate_text[index]
 
-    if not isinstance(candidate_text, TEXT_TYPES) or not isinstance(index, int):
+    if not isinstance(candidate_text, IAST.TEXT_TYPES) or not isinstance(index, int):
         return result
 
     try:
@@ -160,9 +153,9 @@ def index_aspect(candidate_text, index) -> Any:
     return result
 
 
-def slice_aspect(candidate_text, start, stop, step) -> Any:
+def slice_aspect(candidate_text: Text, start: int, stop: int, step: int) -> Text:
     if (
-        not isinstance(candidate_text, TEXT_TYPES)
+        not isinstance(candidate_text, IAST.TEXT_TYPES)
         or (start is not None and not isinstance(start, int))
         or (stop is not None and not isinstance(stop, int))
         or (step is not None and not isinstance(step, int))
@@ -179,8 +172,7 @@ def slice_aspect(candidate_text, start, stop, step) -> Any:
     return result
 
 
-def bytearray_extend_aspect(orig_function, flag_added_args, *args, **kwargs):
-    # type: (Optional[Callable], int, Any, Any) -> Any
+def bytearray_extend_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> Any:
     if orig_function and not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
@@ -203,9 +195,8 @@ def bytearray_extend_aspect(orig_function, flag_added_args, *args, **kwargs):
         return op1.extend(op2)
 
 
-def modulo_aspect(candidate_text, candidate_tuple):
-    # type: (Any, Any) -> Any
-    if not isinstance(candidate_text, TEXT_TYPES):
+def modulo_aspect(candidate_text: Text, candidate_tuple: Any) -> Any:
+    if not isinstance(candidate_text, IAST.TEXT_TYPES):
         return candidate_text % candidate_tuple
 
     try:
@@ -229,7 +220,7 @@ def modulo_aspect(candidate_text, candidate_tuple):
                     parameter,
                     tag_mapping_function=TagMappingMode.Mapper,
                 )
-                if isinstance(parameter, TEXT_TYPES)
+                if isinstance(parameter, IAST.TEXT_TYPES)
                 else parameter
                 for parameter in parameter_list
             ),
@@ -240,12 +231,13 @@ def modulo_aspect(candidate_text, candidate_tuple):
         return candidate_text % candidate_tuple
 
 
-def build_string_aspect(*args):  # type: (List[Any]) -> str
+def build_string_aspect(*args: List[Any]) -> TEXT_TYPES:
     return join_aspect("".join, 1, "", args)
 
 
-def ljust_aspect(orig_function, flag_added_args, *args, **kwargs):
-    # type: (Optional[Callable], int, Any, Any) -> Union[str, bytes, bytearray]
+def ljust_aspect(
+    orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
+) -> Union[TEXT_TYPES]:
     if not orig_function:
         orig_function = args[0].ljust
     if not isinstance(orig_function, BuiltinFunctionType):
@@ -258,7 +250,7 @@ def ljust_aspect(orig_function, flag_added_args, *args, **kwargs):
 
     result = candidate_text.ljust(*args, **kwargs)
 
-    if not isinstance(candidate_text, TEXT_TYPES):
+    if not isinstance(candidate_text, IAST.TEXT_TYPES):
         return result
 
     try:
@@ -281,8 +273,9 @@ def ljust_aspect(orig_function, flag_added_args, *args, **kwargs):
     return result
 
 
-def zfill_aspect(orig_function, flag_added_args, *args, **kwargs):
-    # type: (Optional[Callable], int, Any, Any) -> Any
+def zfill_aspect(
+    orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
+) -> Union[TEXT_TYPES]:
     if orig_function and not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
@@ -293,7 +286,7 @@ def zfill_aspect(orig_function, flag_added_args, *args, **kwargs):
 
     result = candidate_text.zfill(*args, **kwargs)
 
-    if not isinstance(candidate_text, TEXT_TYPES):
+    if not isinstance(candidate_text, IAST.TEXT_TYPES):
         return result
 
     try:
@@ -325,11 +318,8 @@ def zfill_aspect(orig_function, flag_added_args, *args, **kwargs):
 
 
 def format_aspect(
-    orig_function,  # type: Optional[Callable]
-    flag_added_args,  # type: int
-    *args,  # type: Any
-    **kwargs,  # type: Dict[str, Any]
-):  # type: (...) -> str
+    orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
+) -> Union[TEXT_TYPES]:
     if not orig_function:
         orig_function = args[0].format
 
@@ -346,7 +336,7 @@ def format_aspect(
 
     result = candidate_text.format(*args, **kwargs)
 
-    if not isinstance(candidate_text, TEXT_TYPES):
+    if not isinstance(candidate_text, IAST.TEXT_TYPES):
         return result
 
     try:
@@ -362,8 +352,8 @@ def format_aspect(
 
 
 def format_map_aspect(
-    orig_function, flag_added_args, *args, **kwargs
-):  # type: (Optional[Callable], int, Any, Any) -> str
+    orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
+) -> Union[TEXT_TYPES]:
     if orig_function and not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
@@ -374,7 +364,7 @@ def format_map_aspect(
 
     candidate_text = args[0]  # type: str
     args = args[flag_added_args:]
-    if not isinstance(candidate_text, TEXT_TYPES):
+    if not isinstance(candidate_text, IAST.TEXT_TYPES):
         return candidate_text.format_map(*args, **kwargs)
 
     try:
@@ -393,7 +383,7 @@ def format_map_aspect(
             ).format_map(
                 {
                     key: as_formatted_evidence(value, tag_mapping_function=TagMappingMode.Mapper)
-                    if isinstance(value, TEXT_TYPES)
+                    if isinstance(value, IAST.TEXT_TYPES)
                     else value
                     for key, value in mapping.items()
                 }
@@ -405,9 +395,7 @@ def format_map_aspect(
         return candidate_text.format_map(*args, **kwargs)
 
 
-def repr_aspect(orig_function, flag_added_args, *args, **kwargs):
-    # type: (Optional[Callable], Any, Any, Any) -> Any
-
+def repr_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> Any:
     # DEV: We call this function directly passing None as orig_function
     if orig_function is not None and not (
         orig_function is repr or getattr(orig_function, "__name__", None) == "__repr__"
@@ -418,7 +406,7 @@ def repr_aspect(orig_function, flag_added_args, *args, **kwargs):
 
     result = repr(*args, **kwargs)
 
-    if args and isinstance(args[0], TEXT_TYPES) and is_pyobject_tainted(args[0]):
+    if args and isinstance(args[0], IAST.TEXT_TYPES) and is_pyobject_tainted(args[0]):
         try:
             if isinstance(args[0], bytes):
                 check_offset = ascii(args[0])[2:-1]
@@ -438,10 +426,10 @@ def repr_aspect(orig_function, flag_added_args, *args, **kwargs):
 
 
 def format_value_aspect(
-    element,  # type: Any
-    options=0,  # type: int
-    format_spec=None,  # type: Optional[str]
-):  # type: (...) -> str
+    element: Any,
+    options: int = 0,
+    format_spec: Optional[str] = None,
+) -> str:
     if options == 115:
         new_text = str_aspect(str, 0, element)
     elif options == 114:
@@ -451,7 +439,7 @@ def format_value_aspect(
         new_text = ascii(element)
     else:
         new_text = element
-    if not isinstance(new_text, TEXT_TYPES):
+    if not isinstance(new_text, IAST.TEXT_TYPES):
         return format(new_text)
 
     try:
@@ -531,7 +519,9 @@ def incremental_translation(self, incr_coder, funcode, empty):
     return result
 
 
-def decode_aspect(orig_function, flag_added_args, *args, **kwargs):
+def decode_aspect(
+    orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
+) -> Union[TEXT_TYPES]:
     if orig_function and (not flag_added_args or not args):
         # This patch is unexpected, so we fallback
         # to executing the original function
@@ -554,7 +544,9 @@ def decode_aspect(orig_function, flag_added_args, *args, **kwargs):
     return result
 
 
-def encode_aspect(orig_function, flag_added_args, *args, **kwargs):
+def encode_aspect(
+    orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
+) -> Union[TEXT_TYPES]:
     if orig_function and (not flag_added_args or not args):
         # This patch is unexpected, so we fallback
         # to executing the original function
@@ -578,8 +570,8 @@ def encode_aspect(orig_function, flag_added_args, *args, **kwargs):
 
 
 def upper_aspect(
-    orig_function, flag_added_args, *args, **kwargs
-):  # type: (Optional[Callable], int, Any, Any) -> TEXT_TYPE
+    orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
+) -> Union[TEXT_TYPES]:
     if orig_function and (not isinstance(orig_function, BuiltinFunctionType) or not args):
         if flag_added_args > 0:
             args = args[flag_added_args:]
@@ -587,7 +579,7 @@ def upper_aspect(
 
     candidate_text = args[0]
     args = args[flag_added_args:]
-    if not isinstance(candidate_text, TEXT_TYPES):
+    if not isinstance(candidate_text, IAST.TEXT_TYPES):
         return candidate_text.upper(*args, **kwargs)
 
     try:
@@ -598,8 +590,8 @@ def upper_aspect(
 
 
 def lower_aspect(
-    orig_function, flag_added_args, *args, **kwargs
-):  # type: (Optional[Callable], int, Any, Any) -> TEXT_TYPE
+    orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
+) -> Union[TEXT_TYPES]:
     if orig_function and (not isinstance(orig_function, BuiltinFunctionType) or not args):
         if flag_added_args > 0:
             args = args[flag_added_args:]
@@ -607,7 +599,7 @@ def lower_aspect(
 
     candidate_text = args[0]
     args = args[flag_added_args:]
-    if not isinstance(candidate_text, TEXT_TYPES):
+    if not isinstance(candidate_text, IAST.TEXT_TYPES):
         return candidate_text.lower(*args, **kwargs)
 
     try:
@@ -618,16 +610,16 @@ def lower_aspect(
 
 
 def _distribute_ranges_and_escape(
-    split_elements,  # type: List[Optional[TEXT_TYPE]]
-    len_separator,  # type: int
-    ranges,  # type: Tuple[TaintRange, ...]
-):  # type: (...) -> List[Optional[TEXT_TYPE]]
+    split_elements: List[Optional[TEXT_TYPES]],
+    len_separator: int,
+    ranges: Tuple[TaintRange, ...],
+) -> List[Optional[TEXT_TYPES]]:
     # FIXME: converts to set, and then to list again, probably to remove
     # duplicates. This should be removed once the ranges values on the
     # taint dictionary are stored in a set.
     range_set = set(ranges)
     range_set_remove = range_set.remove
-    formatted_elements = []  # type: List[Optional[TEXT_TYPE]]
+    formatted_elements: List[Optional[TEXT_TYPES]] = []
     formatted_elements_append = formatted_elements.append
     element_start = 0
     extra = 0
@@ -642,7 +634,7 @@ def _distribute_ranges_and_escape(
         else:
             len_element = len(element)
         element_end = element_start + len_element
-        new_ranges = {}  # type: Dict[TaintRange, TaintRange]
+        new_ranges: Dict[TaintRange, TaintRange] = {}
 
         for taint_range in ranges:
             if (taint_range.start + taint_range.length) <= (element_start + extra):
@@ -695,16 +687,16 @@ def _distribute_ranges_and_escape(
 
 
 def aspect_replace_api(
-    candidate_text, old_value, new_value, count, orig_result
-):  # type: (Any, Any, Any, int, Any) -> str
+    candidate_text: TEXT_TYPES, old_value: Any, new_value: Any, count: int, orig_result: Any
+) -> TEXT_TYPES:
     ranges_orig, candidate_text_ranges = are_all_text_all_ranges(candidate_text, (old_value, new_value))
     if not ranges_orig:  # Ranges in args/kwargs are checked
         return orig_result
 
-    empty = b"" if isinstance(candidate_text, (bytes, bytearray)) else ""  # type: TEXT_TYPE
+    empty = b"" if isinstance(candidate_text, (bytes, bytearray)) else ""
 
     if old_value:
-        elements = candidate_text.split(old_value, count)  # type: Sequence[TEXT_TYPE]
+        elements: List[Any] = candidate_text.split(old_value, count)
     else:
         if count == -1:
             elements = (
@@ -740,7 +732,7 @@ def aspect_replace_api(
                 if len(elements) == count and elements[-1] != b"":
                     elements.append(empty)
     i = 0
-    new_elements = []  # type: List[Optional[TEXT_TYPE]]
+    new_elements: List[Optional[TEXT_TYPES]] = []
     new_elements_append = new_elements.append
 
     # if new value is blank, _distribute_ranges_and_escape function doesn't
@@ -770,7 +762,7 @@ def aspect_replace_api(
                 new_elements_append(old_value)
             i += 1
     else:
-        new_elements = elements  # type: ignore
+        new_elements = elements
 
     if candidate_text_ranges:
         new_elements = _distribute_ranges_and_escape(
@@ -790,8 +782,8 @@ def aspect_replace_api(
 
 
 def replace_aspect(
-    orig_function, flag_added_args, *args, **kwargs
-):  # type: (Optional[Callable], int, Any, Any) -> TEXT_TYPE
+    orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
+) -> Union[TEXT_TYPES]:
     if orig_function and (not isinstance(orig_function, BuiltinFunctionType) or not args):
         if flag_added_args > 0:
             args = args[flag_added_args:]
@@ -800,7 +792,7 @@ def replace_aspect(
     candidate_text = args[0]
     args = args[flag_added_args:]
     orig_result = candidate_text.replace(*args, **kwargs)
-    if not isinstance(candidate_text, TEXT_TYPES):
+    if not isinstance(candidate_text, IAST.TEXT_TYPES):
         return orig_result
 
     ###
@@ -837,8 +829,8 @@ def replace_aspect(
 
 
 def swapcase_aspect(
-    orig_function, flag_added_args, *args, **kwargs
-):  # type: (Optional[Callable], int, Any, Any) -> TEXT_TYPE
+    orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
+) -> Union[TEXT_TYPES]:
     if orig_function and (not isinstance(orig_function, BuiltinFunctionType) or not args):
         if flag_added_args > 0:
             args = args[flag_added_args:]
@@ -846,7 +838,7 @@ def swapcase_aspect(
 
     candidate_text = args[0]
     args = args[flag_added_args:]
-    if not isinstance(candidate_text, TEXT_TYPES):
+    if not isinstance(candidate_text, IAST.TEXT_TYPES):
         return candidate_text.swapcase(*args, **kwargs)
     try:
         return common_replace("swapcase", candidate_text, *args, **kwargs)
@@ -856,8 +848,8 @@ def swapcase_aspect(
 
 
 def title_aspect(
-    orig_function, flag_added_args, *args, **kwargs
-):  # type: (Optional[Callable], int, Any, Any) -> TEXT_TYPE
+    orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
+) -> Union[TEXT_TYPES]:
     if orig_function and (not isinstance(orig_function, BuiltinFunctionType) or not args):
         if flag_added_args > 0:
             args = args[flag_added_args:]
@@ -865,7 +857,7 @@ def title_aspect(
 
     candidate_text = args[0]
     args = args[flag_added_args:]
-    if not isinstance(candidate_text, TEXT_TYPES):
+    if not isinstance(candidate_text, IAST.TEXT_TYPES):
         return candidate_text.title(*args, **kwargs)
     try:
         return common_replace("title", candidate_text, *args, **kwargs)
@@ -875,8 +867,8 @@ def title_aspect(
 
 
 def capitalize_aspect(
-    orig_function, flag_added_args, *args, **kwargs
-):  # type: (Optional[Callable], int, Any, Any) -> TEXT_TYPE
+    orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
+) -> Union[TEXT_TYPES]:
     if orig_function and (not isinstance(orig_function, BuiltinFunctionType) or not args):
         if flag_added_args > 0:
             args = args[flag_added_args:]
@@ -884,7 +876,7 @@ def capitalize_aspect(
 
     candidate_text = args[0]
     args = args[flag_added_args:]
-    if not isinstance(candidate_text, TEXT_TYPES):
+    if not isinstance(candidate_text, IAST.TEXT_TYPES):
         return candidate_text.capitalize(*args, **kwargs)
 
     try:
@@ -895,8 +887,8 @@ def capitalize_aspect(
 
 
 def casefold_aspect(
-    orig_function, flag_added_args, *args, **kwargs
-):  # type: (Optional[Callable], int, Any, Any) -> TEXT_TYPE
+    orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
+) -> Union[TEXT_TYPES]:
     if orig_function:
         if not isinstance(orig_function, BuiltinFunctionType) or not args:
             if flag_added_args > 0:
@@ -912,7 +904,7 @@ def casefold_aspect(
 
     candidate_text = args[0]
     args = args[flag_added_args:]
-    if not isinstance(candidate_text, TEXT_TYPES):
+    if not isinstance(candidate_text, IAST.TEXT_TYPES):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return candidate_text.casefold(*args, **kwargs)
@@ -924,8 +916,8 @@ def casefold_aspect(
 
 
 def translate_aspect(
-    orig_function, flag_added_args, *args, **kwargs
-):  # type: (Optional[Callable], int, Any, Any) -> TEXT_TYPE
+    orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
+) -> Union[TEXT_TYPES]:
     if orig_function and (not isinstance(orig_function, BuiltinFunctionType) or not args):
         if flag_added_args > 0:
             args = args[flag_added_args:]
@@ -933,7 +925,7 @@ def translate_aspect(
 
     candidate_text = args[0]
     args = args[flag_added_args:]
-    if not isinstance(candidate_text, TEXT_TYPES):
+    if not isinstance(candidate_text, IAST.TEXT_TYPES):
         return candidate_text.translate(*args, **kwargs)
     try:
         return common_replace("translate", candidate_text, *args, **kwargs)

--- a/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
@@ -31,6 +31,19 @@ class TestOperatorJoinReplacement(object):
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "-joiner-"
         assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "-joiner-"
 
+    def test_string_join_tainted_joiner_and_string_iterator(self):  # type: () -> None
+        # taint "joi" from "-joiner-"
+        string_input = taint_pyobject(
+            pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
+        )
+        it = "abc"
+
+        result = mod.do_join(string_input, it)
+        assert result == "a-joiner-b-joiner-c"
+        ranges = get_tainted_ranges(result)
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "-joiner-"
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "-joiner-"
+
     def test_string_join_tainted_joiner_bytes(self):  # type: () -> None
         # taint "joi" from "-joiner-"
         string_input = taint_pyobject(


### PR DESCRIPTION
Boy scout rule: "Always leave your code cleaner than you found it.":

- Remove narrowing conversion from unsigned long to int and cast manually
- Remove TODOs (and add test to verify the TODO was resolved)
- Add doc strings
- Remove unused functions (`context_id` and `allocate_tainted_object`)
- Update type hinting on Python aspect file


![image](https://github.com/DataDog/dd-trace-py/assets/6352942/fa5a7579-9221-40e9-8ab6-200789d1dce4)

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
