### PR TITLE
fix(iast): fix `api_set_ranges` return type

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
@@ -67,16 +67,16 @@ api_shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, RANGE_START of
     return shift_taint_ranges(source_taint_ranges, offset);
 }
 
-void
+py::object
 api_set_ranges(py::object& str, const TaintRangeRefs& ranges)
 {
     auto tx_map = initializer->get_tainting_map();
 
     if (not tx_map) {
-        py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
-        return;
+        throw py::value_error(MSG_ERROR_TAINT_MAP);
     }
     set_ranges(str.ptr(), ranges, tx_map);
+    return py::none();
 }
 
 /**

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
@@ -87,7 +87,7 @@ get_ranges(PyObject* string_input, TaintRangeMapType* tx_map);
 bool
 set_ranges(PyObject* str, const TaintRangeRefs& ranges, TaintRangeMapType* tx_map);
 
-void
+py::object
 api_set_ranges(py::object& str, const TaintRangeRefs& ranges);
 
 TaintRangeRefs

--- a/tests/appsec/iast/taint_tracking/test_taint_tracking.py
+++ b/tests/appsec/iast/taint_tracking/test_taint_tracking.py
@@ -11,8 +11,10 @@ from tests.utils import override_env
 with override_env({"DD_IAST_ENABLED": "True"}):
     from ddtrace.appsec._iast._taint_tracking import OriginType
     from ddtrace.appsec._iast._taint_tracking import Source
+    from ddtrace.appsec._iast._taint_tracking import TaintRange
     from ddtrace.appsec._iast._taint_tracking import destroy_context
     from ddtrace.appsec._iast._taint_tracking import num_objects_tainted
+    from ddtrace.appsec._iast._taint_tracking import set_ranges
     from ddtrace.appsec._iast._taint_tracking import taint_pyobject
     from ddtrace.appsec._iast._taint_tracking import taint_ranges_as_evidence_info
     from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect
@@ -57,6 +59,18 @@ def test_propagate_ranges_with_no_context(caplog):
         assert string_input == "abcde"
     log_messages = [record.message for record in caplog.get_records("call")]
     assert any("[IAST] " in message for message in log_messages), log_messages
+
+
+@pytest.mark.skip_iast_check_logs
+def test_call_to_set_ranges_directly_raises_a_exception(caplog):
+    destroy_context()
+    input_str = "abcde"
+    with pytest.raises(ValueError) as excinfo:
+        set_ranges(
+            input_str,
+            [TaintRange(0, len(input_str), Source(input_str, "sample_value", OriginType.PARAMETER))],
+        )
+    assert str(excinfo.value).startswith("[IAST] Tainted Map isn't initialized")
 
 
 def test_taint_ranges_as_evidence_info_tainted_op1_add():


### PR DESCRIPTION
`api_set_ranges` threw  an unexpected error if we're out of context

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
