### PR TITLE
fix(iast): fix `api_set_ranges` return type [backport 2.8]

### DIFF
--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -84,6 +84,7 @@ class IAST(metaclass=Constant_Class):
     DENY_MODULES = "_DD_IAST_DENY_MODULES"
     SEP_MODULES = ","
     REQUEST_IAST_ENABLED = "_dd.iast.request_enabled"
+    TEXT_TYPES = (str, bytes, bytearray)
 
 
 class IAST_SPAN_TAGS(metaclass=Constant_Class):

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
@@ -65,6 +65,18 @@ api_shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, RANGE_START of
     return shift_taint_ranges(source_taint_ranges, offset);
 }
 
+py::object
+api_set_ranges(py::object& str, const TaintRangeRefs& ranges)
+{
+    auto tx_map = initializer->get_tainting_map();
+
+    if (not tx_map) {
+        throw py::value_error(MSG_ERROR_TAINT_MAP);
+    }
+    set_ranges(str.ptr(), ranges, tx_map);
+    return py::none();
+}
+
 /**
  * set_ranges_from_values.
  *
@@ -363,7 +375,6 @@ pyexport_taintrange(py::module& m)
           "offset"_a,
           "new_length"_a = -1);
 
-    m.def("set_ranges", py::overload_cast<PyObject*, const TaintRangeRefs&>(&set_ranges), "str"_a, "ranges"_a);
     m.def("set_ranges", &api_set_ranges, "str"_a, "ranges"_a);
 
     m.def("copy_ranges_from_strings", &api_copy_ranges_from_strings, "str_1"_a, "str_2"_a);

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
@@ -71,7 +71,7 @@ api_set_ranges(py::object& str, const TaintRangeRefs& ranges)
     auto tx_map = initializer->get_tainting_map();
 
     if (not tx_map) {
-        throw py::value_error(MSG_ERROR_TAINT_MAP);
+        throw py::value_error("[IAST] Tainted Map isn't initialized");
     }
     set_ranges(str.ptr(), ranges, tx_map);
     return py::none();

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
@@ -97,6 +97,7 @@ api_get_ranges(py::object& string_input)
 void
 set_ranges(PyObject* str, const TaintRangeRefs& ranges, TaintRangeMapType* tx_map);
 
+inline void
 set_ranges(PyObject* str, const TaintRangeRefs& ranges)
 {
     set_ranges(str, ranges, nullptr);

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
@@ -97,16 +97,14 @@ api_get_ranges(py::object& string_input)
 void
 set_ranges(PyObject* str, const TaintRangeRefs& ranges, TaintRangeMapType* tx_map);
 
-inline void
+
 set_ranges(PyObject* str, const TaintRangeRefs& ranges)
 {
     set_ranges(str, ranges, nullptr);
 }
-inline void
-api_set_ranges(py::object& str, const TaintRangeRefs& ranges)
-{
-    set_ranges(str.ptr(), ranges);
-}
+
+py::object
+api_set_ranges(py::object& str, const TaintRangeRefs& ranges);
 
 inline void
 api_copy_ranges_from_strings(py::object& str_1, py::object& str_2);

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
@@ -97,7 +97,6 @@ api_get_ranges(py::object& string_input)
 void
 set_ranges(PyObject* str, const TaintRangeRefs& ranges, TaintRangeMapType* tx_map);
 
-
 set_ranges(PyObject* str, const TaintRangeRefs& ranges)
 {
     set_ranges(str, ranges, nullptr);

--- a/tests/appsec/iast/taint_tracking/test_taint_tracking.py
+++ b/tests/appsec/iast/taint_tracking/test_taint_tracking.py
@@ -58,7 +58,7 @@ def test_propagate_ranges_with_no_context(caplog):
         )
         assert string_input == "abcde"
     log_messages = [record.message for record in caplog.get_records("call")]
-    assert any("[IAST] " in message for message in log_messages), log_messages
+    assert not any("[IAST] " in message for message in log_messages), log_messages
 
 
 @pytest.mark.skip_iast_check_logs

--- a/tests/appsec/iast/taint_tracking/test_taint_tracking.py
+++ b/tests/appsec/iast/taint_tracking/test_taint_tracking.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
+import logging
 
+import pytest
+
+from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast import oce
 from tests.utils import override_env
 
@@ -7,6 +11,10 @@ from tests.utils import override_env
 with override_env({"DD_IAST_ENABLED": "True"}):
     from ddtrace.appsec._iast._taint_tracking import OriginType
     from ddtrace.appsec._iast._taint_tracking import Source
+    from ddtrace.appsec._iast._taint_tracking import TaintRange
+    from ddtrace.appsec._iast._taint_tracking import destroy_context
+    from ddtrace.appsec._iast._taint_tracking import num_objects_tainted
+    from ddtrace.appsec._iast._taint_tracking import set_ranges
     from ddtrace.appsec._iast._taint_tracking import taint_pyobject
     from ddtrace.appsec._iast._taint_tracking import taint_ranges_as_evidence_info
     from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect
@@ -30,6 +38,39 @@ def test_taint_ranges_as_evidence_info_all_tainted():
     value_parts, sources = taint_ranges_as_evidence_info(tainted_text)
     assert value_parts == [{"value": tainted_text, "source": 0}]
     assert sources == [input_info]
+
+
+@pytest.mark.skip_iast_check_logs
+def test_taint_object_with_no_context_should_be_noop():
+    destroy_context()
+    arg = "all tainted"
+    tainted_text = taint_pyobject(arg, source_name="request_body", source_value=arg, source_origin=OriginType.PARAMETER)
+    assert tainted_text == arg
+    assert num_objects_tainted() == 0
+
+
+@pytest.mark.skip_iast_check_logs
+def test_propagate_ranges_with_no_context(caplog):
+    destroy_context()
+    with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
+        string_input = taint_pyobject(
+            pyobject="abcde", source_name="abcde", source_value="abcde", source_origin=OriginType.PARAMETER
+        )
+        assert string_input == "abcde"
+    log_messages = [record.message for record in caplog.get_records("call")]
+    assert any("[IAST] " in message for message in log_messages), log_messages
+
+
+@pytest.mark.skip_iast_check_logs
+def test_call_to_set_ranges_directly_raises_a_exception(caplog):
+    destroy_context()
+    input_str = "abcde"
+    with pytest.raises(ValueError) as excinfo:
+        set_ranges(
+            input_str,
+            [TaintRange(0, len(input_str), Source(input_str, "sample_value", OriginType.PARAMETER))],
+        )
+    assert str(excinfo.value).startswith("[IAST] Tainted Map isn't initialized")
 
 
 def test_taint_ranges_as_evidence_info_tainted_op1_add():


### PR DESCRIPTION
Backport f9fbc36f6d193d1d7a5b09c45101efb55daa23a7 from #9067 to 2.8.

`api_set_ranges` threw  an unexpected error if we're out of context

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

