### PR TITLE
ci: ensure coverage cli doesn't exit with code 1

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -438,7 +438,7 @@ jobs:
       # DEV: "--ignore-errors" to skip over files that are missing
       - run: coverage report --ignore-errors --omit=ddtrace/ || true
       # Print diff-cover report to stdout (compares against origin/1.x)
-      - run: diff-cover --compare-branch $(git rev-parse --abbrev-ref origin/HEAD) coverage.xml
+      - run: diff-cover --compare-branch $(git rev-parse --abbrev-ref origin/HEAD) coverage.xml || true
 
 
   build_base_venvs:

--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -423,20 +423,20 @@ jobs:
       - run: codecov
       # Generate and save xml report
       # DEV: "--ignore-errors" to skip over files that are missing
-      - run: coverage xml --ignore-errors
+      - run: coverage xml --ignore-errors || true
       - store_artifacts:
           path: coverage.xml
       # Generate and save JSON report
       # DEV: "--ignore-errors" to skip over files that are missing
-      - run: coverage json --ignore-errors
+      - run: coverage json --ignore-errors || true
       - store_artifacts:
           path: coverage.json
       # Print ddtrace/ report to stdout
       # DEV: "--ignore-errors" to skip over files that are missing
-      - run: coverage report --ignore-errors --omit=tests/
+      - run: coverage report --ignore-errors --omit=tests/ || true
       # Print tests/ report to stdout
       # DEV: "--ignore-errors" to skip over files that are missing
-      - run: coverage report --ignore-errors --omit=ddtrace/
+      - run: coverage report --ignore-errors --omit=ddtrace/ || true
       # Print diff-cover report to stdout (compares against origin/1.x)
       - run: diff-cover --compare-branch $(git rev-parse --abbrev-ref origin/HEAD) coverage.xml
 


### PR DESCRIPTION
CI: coverage upload job is failing when there is nothing to upload. This PR should fix the issue

[Sample failure](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/60069/workflows/225951f3-212d-4877-9186-64214d02c2b5/jobs/3777882)

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
