### PR TITLE
refactor: compress the packages index [backport #9047 to 2.8]

### DIFF
--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 import sysconfig
 from types import ModuleType
 import typing as t
@@ -12,8 +13,6 @@ from ddtrace.internal.utils.cache import callonce
 
 LOG = logging.getLogger(__name__)
 
-if t.TYPE_CHECKING:
-    import pathlib  # noqa
 
 try:
     fspath = os.fspath
@@ -50,10 +49,6 @@ except AttributeError:
         )
 
 
-# We don't store every file of every package but filter commonly used extensions
-SUPPORTED_EXTENSIONS = (".py", ".so", ".dll", ".pyc")
-
-
 Distribution = t.NamedTuple("Distribution", [("name", str), ("version", str), ("path", t.Optional[str])])
 
 
@@ -81,33 +76,85 @@ def get_distributions():
     return pkgs
 
 
-def _is_python_source_file(path):
-    # type: (pathlib.PurePath) -> bool
-    return os.path.splitext(path.name)[-1].lower() in SUPPORTED_EXTENSIONS
+def _effective_root(rel_path: Path, parent: Path) -> str:
+    base = rel_path.parts[0]
+    root = parent / base
+    return base if root.is_dir() and (root / "__init__.py").exists() else "/".join(rel_path.parts[:2])
+
+
+def _root_module(path: Path) -> str:
+    # Try the most likely prefixes first
+    for parent_path in (purelib_path, platlib_path):
+        try:
+            return _effective_root(path.relative_to(parent_path), parent_path)
+        except ValueError:
+            # Not relative to this path
+            pass
+
+    # Try to resolve the root module using sys.path. We keep the shortest
+    # relative path as the one more likely to give us the root module.
+    min_relative_path = max_parent_path = None
+    for parent_path in (Path(_).resolve() for _ in sys.path):
+        try:
+            relative = path.relative_to(parent_path)
+            if min_relative_path is None or len(relative.parents) < len(min_relative_path.parents):
+                min_relative_path, max_parent_path = relative, parent_path
+        except ValueError:
+            pass
+
+    if min_relative_path is not None:
+        try:
+            return _effective_root(min_relative_path, t.cast(Path, max_parent_path))
+        except IndexError:
+            pass
+
+    msg = f"Could not find root module for path {path}"
+    raise ValueError(msg)
 
 
 @callonce
-def _package_file_mapping():
-    # type: (...) -> t.Optional[t.Dict[str, Distribution]]
+def _package_for_root_module_mapping() -> t.Optional[t.Dict[str, Distribution]]:
     try:
-        import importlib.metadata as il_md
+        import importlib.metadata as metadata
     except ImportError:
-        import importlib_metadata as il_md  # type: ignore[no-redef]
+        import importlib_metadata as metadata  # type: ignore[no-redef]
+
+    namespaces: t.Dict[str, bool] = {}
+
+    def is_namespace(f: metadata.PackagePath):
+        root = f.parts[0]
+        try:
+            return namespaces[root]
+        except KeyError:
+            pass
+
+        if len(f.parts) < 2:
+            namespaces[root] = False
+            return False
+
+        located_f = t.cast(Path, f.locate())
+        parent = located_f.parents[len(f.parts) - 2]
+        if parent.is_dir() and not (parent / "__init__.py").exists():
+            namespaces[root] = True
+            return True
+
+        namespaces[root] = False
+        return False
 
     try:
         mapping = {}
 
-        for ilmd_d in il_md.distributions():
-            if ilmd_d is not None and ilmd_d.files is not None:
-                d = Distribution(name=ilmd_d.metadata["name"], version=ilmd_d.version, path=None)
-                for f in ilmd_d.files:
-                    if _is_python_source_file(f):
-                        # mapping[fspath(f.locate())] = d
-                        _path = fspath(f.locate())
-                        mapping[_path] = d
-                        _realp = os.path.realpath(_path)
-                        if _realp != _path:
-                            mapping[_realp] = d
+        for dist in metadata.distributions():
+            if dist is not None and dist.files is not None:
+                d = Distribution(name=dist.metadata["name"], version=dist.version, path=None)
+                for f in dist.files:
+                    root = f.parts[0]
+                    if root.endswith(".dist-info") or root.endswith(".egg-info") or root == "..":
+                        continue
+                    if is_namespace(f):
+                        root = "/".join(f.parts[:2])
+                    if root not in mapping:
+                        mapping[root] = d
 
         return mapping
 
@@ -120,23 +167,24 @@ def _package_file_mapping():
         return None
 
 
-def filename_to_package(filename):
-    # type: (str) -> t.Optional[Distribution]
-
-    mapping = _package_file_mapping()
+@cached()
+def filename_to_package(filename: t.Union[str, Path]) -> t.Optional[Distribution]:
+    mapping = _package_for_root_module_mapping()
     if mapping is None:
         return None
 
-    if filename not in mapping and filename.endswith(".pyc"):
-        # Replace .pyc by .py
-        filename = filename[:-1]
+    try:
+        path = Path(filename) if isinstance(filename, str) else filename
+        return mapping.get(_root_module(path.resolve()))
+    except ValueError:
+        return None
 
-    return mapping.get(filename)
 
-
+@cached()
 def module_to_package(module: ModuleType) -> t.Optional[Distribution]:
     """Returns the package distribution for a module"""
-    return filename_to_package(str(origin(module)))
+    module_origin = origin(module)
+    return filename_to_package(module_origin) if module_origin is not None else None
 
 
 stdlib_path = Path(sysconfig.get_path("stdlib")).resolve()

--- a/tests/internal/test_packages.py
+++ b/tests/internal/test_packages.py
@@ -1,11 +1,35 @@
 import os
-import pathlib
 
-import mock
 import pytest
 
-from ddtrace.internal import packages
 from ddtrace.internal.packages import get_distributions
+from ddtrace.internal.utils.cache import cached
+
+
+@cached()
+def _cached_sentinel():
+    pass
+
+
+@pytest.fixture
+def packages():
+    from ddtrace.internal import packages as _p
+
+    yield _p
+
+    # Clear caches
+
+    try:
+        del _p._package_for_root_module_mapping.__closure__[0].cell_contents.__callonce_result__
+    except AttributeError:
+        pass
+
+    for f in _p.__dict__.values():
+        try:
+            if f.__code__ is _cached_sentinel.__code__:
+                f.invalidate()
+        except AttributeError:
+            pass
 
 
 def test_get_distributions():
@@ -34,55 +58,19 @@ def test_get_distributions():
     assert pkg_resources_ws == importlib_pkgs
 
 
-@pytest.mark.parametrize(
-    "filename,result",
-    (
-        ("toto.py", True),
-        ("blabla/toto.py", True),
-        ("/usr/blabla/toto.py", True),
-        ("foo.pyc", True),
-        ("/usr/foo.pyc", True),
-        ("something", False),
-        ("/something/", False),
-        ("/something/nop", False),
-        ("/something/yes.DLL", True),
-    ),
-)
-def test_is_python_source_file(
-    filename,  # type: str
-    result,  # type: bool
-):
-    # type: (...) -> None
-    assert packages._is_python_source_file(pathlib.Path(filename)) == result
-
-
-@mock.patch.object(packages, "_is_python_source_file")
-def test_filename_to_package_failure(_is_python_source_file):
-    # type: (mock.MagicMock) -> None
-    def _raise():
-        raise RuntimeError("boom")
-
-    _is_python_source_file.side_effect = _raise
-
-    # type: (...) -> None
-    assert packages.filename_to_package(packages.__file__) is None
-
-
-def test_filename_to_package():
+def test_filename_to_package(packages):
     # type: (...) -> None
     package = packages.filename_to_package(packages.__file__)
     assert package is None or package.name == "ddtrace"
     package = packages.filename_to_package(pytest.__file__)
-    assert package is None or package.name == "pytest"
+    assert package.name == "pytest"
 
     import six
 
     package = packages.filename_to_package(six.__file__)
-    assert package is None or package.name == "six"
+    assert package.name == "six"
 
     import google.protobuf.internal as gp
 
     package = packages.filename_to_package(gp.__file__)
-    assert package is None or package.name == "protobuf"
-
-    del packages._package_file_mapping.__closure__[0].cell_contents.__callonce_result__
+    assert package.name == "protobuf"


### PR DESCRIPTION
Backport of #9047 to 2.8

We refactor the implementation of the mapping that allows us to convert a file path to the corresponding distribution. Instead of mapping each individual file path to the containing distribution, we extract the root modules and map those to the distribution instead. This leads to a significant compression of the in-memory mapping. Part of the saved memory can thus be used to cache the result of the conversions to avoid repeating unnecessary mapping work.

## Example

The following is an example for the mapping built for a sample Django application

<details><summary>Previous mapping</summary>
<pre>
{'.../sample-django/.venv310/bin/__pycache__/django-admin.cpython-310.pyc': Distribution(name='Django', version='3.1.13', path=None),
 '.../sample-django/.venv310/bin/django-admin.py': Distribution(name='Django', version='3.1.13', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/../../../bin/__pycache__/django-admin.cpython-310.pyc': Distribution(name='Django', version='3.1.13', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/../../../bin/django-admin.py': Distribution(name='Django', version='3.1.13', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/__editable___ddtrace_2_8_0_dev43_gc72cbe3c0_d20240308_finder.py': Distribution(name='ddtrace', version='2.8.0.dev43+gc72cbe3c0.d20240308', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/__pycache__/__editable___ddtrace_2_8_0_dev43_gc72cbe3c0_d20240308_finder.cpython-310.pyc': Distribution(name='ddtrace', version='2.8.0.dev43+gc72cbe3c0.d20240308', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/__pycache__/_pyrsistent_version.cpython-310.pyc': Distribution(name='pyrsistent', version='0.19.3', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/__pycache__/dj_database_url.cpython-310.pyc': Distribution(name='dj-database-url', version='0.5.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/__pycache__/six.cpython-310.pyc': Distribution(name='six', version='1.16.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/__pycache__/typing_extensions.cpython-310.pyc': Distribution(name='typing_extensions', version='4.5.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/__pycache__/xmltodict.cpython-310.pyc': Distribution(name='xmltodict', version='0.13.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/_distutils_hack/__init__.py': Distribution(name='setuptools', version='63.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/_distutils_hack/__pycache__/__init__.cpython-310.pyc': Distribution(name='setuptools', version='63.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/_distutils_hack/__pycache__/override.cpython-310.pyc': Distribution(name='setuptools', version='63.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/_distutils_hack/override.py': Distribution(name='setuptools', version='63.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/_pyrsistent_version.py': Distribution(name='pyrsistent', version='0.19.3', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/__init__.py': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/__pycache__/__init__.cpython-310.pyc': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/__pycache__/compatibility.cpython-310.pyc': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/__pycache__/current_thread_executor.cpython-310.pyc': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/__pycache__/local.cpython-310.pyc': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/__pycache__/server.cpython-310.pyc': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/__pycache__/sync.cpython-310.pyc': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/__pycache__/testing.cpython-310.pyc': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/__pycache__/timeout.cpython-310.pyc': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/__pycache__/wsgi.cpython-310.pyc': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/compatibility.py': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/current_thread_executor.py': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/local.py': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/server.py': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/sync.py': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/testing.py': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/timeout.py': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/asgiref/wsgi.py': Distribution(name='asgiref', version='3.2.10', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/__init__.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/__pycache__/__init__.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/__pycache__/_cmp.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/__pycache__/_compat.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/__pycache__/_config.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/__pycache__/_funcs.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/__pycache__/_make.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/__pycache__/_next_gen.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/__pycache__/_version_info.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/__pycache__/converters.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/__pycache__/exceptions.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/__pycache__/filters.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/__pycache__/setters.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/__pycache__/validators.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/_cmp.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/_compat.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/_config.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/_funcs.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/_make.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/_next_gen.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/_version_info.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/converters.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/exceptions.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/filters.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/setters.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attr/validators.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attrs/__init__.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attrs/__pycache__/__init__.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attrs/__pycache__/converters.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attrs/__pycache__/exceptions.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attrs/__pycache__/filters.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attrs/__pycache__/setters.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attrs/__pycache__/validators.cpython-310.pyc': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attrs/converters.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attrs/exceptions.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attrs/filters.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attrs/setters.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/attrs/validators.py': Distribution(name='attrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/bytecode/__init__.py': Distribution(name='bytecode', version='0.14.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/bytecode/__pycache__/__init__.cpython-310.pyc': Distribution(name='bytecode', version='0.14.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/bytecode/__pycache__/bytecode.cpython-310.pyc': Distribution(name='bytecode', version='0.14.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/bytecode/__pycache__/cfg.cpython-310.pyc': Distribution(name='bytecode', version='0.14.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/bytecode/__pycache__/concrete.cpython-310.pyc': Distribution(name='bytecode', version='0.14.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/bytecode/__pycache__/flags.cpython-310.pyc': Distribution(name='bytecode', version='0.14.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/bytecode/__pycache__/instr.cpython-310.pyc': Distribution(name='bytecode', version='0.14.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/bytecode/__pycache__/version.cpython-310.pyc': Distribution(name='bytecode', version='0.14.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/bytecode/bytecode.py': Distribution(name='bytecode', version='0.14.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/bytecode/cfg.py': Distribution(name='bytecode', version='0.14.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/bytecode/concrete.py': Distribution(name='bytecode', version='0.14.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/bytecode/flags.py': Distribution(name='bytecode', version='0.14.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/bytecode/instr.py': Distribution(name='bytecode', version='0.14.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/bytecode/version.py': Distribution(name='bytecode', version='0.14.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/cattr/__init__.py': Distribution(name='cattrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/cattr/__pycache__/__init__.cpython-310.pyc': Distribution(name='cattrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/cattr/__pycache__/converters.cpython-310.pyc': Distribution(name='cattrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/cattr/__pycache__/disambiguators.cpython-310.pyc': Distribution(name='cattrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/cattr/__pycache__/dispatch.cpython-310.pyc': Distribution(name='cattrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/cattr/__pycache__/errors.cpython-310.pyc': Distribution(name='cattrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/cattr/__pycache__/gen.cpython-310.pyc': Distribution(name='cattrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/cattr/converters.py': Distribution(name='cattrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/cattr/disambiguators.py': Distribution(name='cattrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/cattr/dispatch.py': Distribution(name='cattrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/cattr/errors.py': Distribution(name='cattrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/cattr/gen.py': Distribution(name='cattrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/cattr/preconf/__init__.py': Distribution(name='cattrs', version='22.2.0', path=None),
 '.../sample-django/.venv310/lib/python3.10/site-packages/cattr/preconf/__pycache__/__init__.cpython-310.pyc': Distribution(name='cattrs', version='22.2.0', path=None),
 # 5026 more entries
}
</pre>
</details>

<details><summary>New mapping</summary>
<pre>
{'AUTHORS': Distribution(name='psycopg2-binary', version='2.8.6', path=None),
 'INSTALL': Distribution(name='psycopg2-binary', version='2.8.6', path=None),
 'LICENSE': Distribution(name='uWSGI', version='2.0.22', path=None),
 'MANIFEST.in': Distribution(name='psycopg2-binary', version='2.8.6', path=None),
 'Makefile': Distribution(name='psycopg2-binary', version='2.8.6', path=None),
 'NEWS': Distribution(name='psycopg2-binary', version='2.8.6', path=None),
 'README': Distribution(name='uWSGI', version='2.0.22', path=None),
 'README.rst': Distribution(name='psycopg2-binary', version='2.8.6', path=None),
 '__editable__.ddtrace-2.8.0.dev43+gc72cbe3c0.d20240308.pth': Distribution(name='ddtrace', version='2.8.0.dev43+gc72cbe3c0.d20240308', path=None),
 '__editable___ddtrace_2_8_0_dev43_gc72cbe3c0_d20240308_finder.py': Distribution(name='ddtrace', version='2.8.0.dev43+gc72cbe3c0.d20240308', path=None),
 '__pycache__/__editable___ddtrace_2_8_0_dev43_gc72cbe3c0_d20240308_finder.cpython-310.pyc': Distribution(name='ddtrace', version='2.8.0.dev43+gc72cbe3c0.d20240308', path=None),
 '__pycache__/_pyrsistent_version.cpython-310.pyc': Distribution(name='pyrsistent', version='0.19.3', path=None),
 '__pycache__/dj_database_url.cpython-310.pyc': Distribution(name='dj-database-url', version='0.5.0', path=None),
 '__pycache__/six.cpython-310.pyc': Distribution(name='six', version='1.16.0', path=None),
 '__pycache__/typing_extensions.cpython-310.pyc': Distribution(name='typing_extensions', version='4.5.0', path=None),
 '__pycache__/xmltodict.cpython-310.pyc': Distribution(name='xmltodict', version='0.13.0', path=None),
 '_distutils_hack': Distribution(name='setuptools', version='63.2.0', path=None),
 '_pyrsistent_version.py': Distribution(name='pyrsistent', version='0.19.3', path=None),
 'asgiref': Distribution(name='asgiref', version='3.2.10', path=None),
 'attr': Distribution(name='attrs', version='22.2.0', path=None),
 'attrs': Distribution(name='attrs', version='22.2.0', path=None),
 'bytecode': Distribution(name='bytecode', version='0.14.0', path=None),
 'cattr': Distribution(name='cattrs', version='22.2.0', path=None),
 'cattrs': Distribution(name='cattrs', version='22.2.0', path=None),
 'certifi': Distribution(name='certifi', version='2022.12.7', path=None),
 'charset_normalizer': Distribution(name='charset-normalizer', version='3.1.0', path=None),
 'click': Distribution(name='click', version='8.1.3', path=None),
 'ddsketch': Distribution(name='ddsketch', version='2.0.4', path=None),
 'deprecated': Distribution(name='Deprecated', version='1.2.13', path=None),
 'distutils-precedence.pth': Distribution(name='setuptools', version='63.2.0', path=None),
 'dj_database_url.py': Distribution(name='dj-database-url', version='0.5.0', path=None),
 'django': Distribution(name='Django', version='3.1.13', path=None),
 'doc': Distribution(name='psycopg2-binary', version='2.8.6', path=None),
 'envier': Distribution(name='envier', version='0.5.0', path=None),
 'exceptiongroup': Distribution(name='exceptiongroup', version='1.1.1', path=None),
 'google/_upb': Distribution(name='protobuf', version='4.22.1', path=None),
 'google/protobuf': Distribution(name='protobuf', version='4.22.1', path=None),
 'gunicorn': Distribution(name='gunicorn', version='20.0.4', path=None),
 'h11': Distribution(name='h11', version='0.14.0', path=None),
 'idna': Distribution(name='idna', version='3.4', path=None),
 'importlib_metadata': Distribution(name='importlib-metadata', version='6.0.1', path=None),
 'jsonschema': Distribution(name='jsonschema', version='4.17.3', path=None),
 'lib': Distribution(name='psycopg2-binary', version='2.8.6', path=None),
 'numpy': Distribution(name='numpy', version='1.22.4', path=None),
 'opentelemetry/__pycache__': Distribution(name='opentelemetry-api', version='1.17.0', path=None),
 'opentelemetry/_logs': Distribution(name='opentelemetry-api', version='1.17.0', path=None),
 'opentelemetry/attributes': Distribution(name='opentelemetry-api', version='1.17.0', path=None),
 'opentelemetry/baggage': Distribution(name='opentelemetry-api', version='1.17.0', path=None),
 'opentelemetry/context': Distribution(name='opentelemetry-api', version='1.17.0', path=None),
 'opentelemetry/environment_variables.py': Distribution(name='opentelemetry-api', version='1.17.0', path=None),
 'opentelemetry/metrics': Distribution(name='opentelemetry-api', version='1.17.0', path=None),
 'opentelemetry/propagate': Distribution(name='opentelemetry-api', version='1.17.0', path=None),
 'opentelemetry/propagators': Distribution(name='opentelemetry-api', version='1.17.0', path=None),
 'opentelemetry/py.typed': Distribution(name='opentelemetry-api', version='1.17.0', path=None),
 'opentelemetry/trace': Distribution(name='opentelemetry-api', version='1.17.0', path=None),
 'opentelemetry/util': Distribution(name='opentelemetry-api', version='1.17.0', path=None),
 'opentelemetry/version.py': Distribution(name='opentelemetry-api', version='1.17.0', path=None),
 'packaging': Distribution(name='packaging', version='23.0', path=None),
 'pip': Distribution(name='pip', version='22.2.2', path=None),
 'pkg_resources': Distribution(name='setuptools', version='63.2.0', path=None),
 'psutil': Distribution(name='psutil', version='5.6.7', path=None),
 'psycopg': Distribution(name='psycopg2-binary', version='2.8.6', path=None),
 'pvectorc.cpython-310-darwin.so': Distribution(name='pyrsistent', version='0.19.3', path=None),
 'pyrsistent': Distribution(name='pyrsistent', version='0.19.3', path=None),
 'pytz': Distribution(name='pytz', version='2020.1', path=None),
 'requests': Distribution(name='requests', version='2.28.2', path=None),
 'scripts': Distribution(name='psycopg2-binary', version='2.8.6', path=None),
 'setup.cfg': Distribution(name='psycopg2-binary', version='2.8.6', path=None),
 'setup.py': Distribution(name='uWSGI', version='2.0.22', path=None),
 'setuptools': Distribution(name='setuptools', version='63.2.0', path=None),
 'six.py': Distribution(name='six', version='1.16.0', path=None),
 'sqlparse': Distribution(name='sqlparse', version='0.3.1', path=None),
 'tenacity': Distribution(name='tenacity', version='8.2.2', path=None),
 'tests': Distribution(name='psycopg2-binary', version='2.8.6', path=None),
 'typing_extensions.py': Distribution(name='typing_extensions', version='4.5.0', path=None),
 'urllib3': Distribution(name='urllib3', version='1.26.15', path=None),
 'uvicorn': Distribution(name='uvicorn', version='0.21.0', path=None),
 'uwsgidecorators.py': Distribution(name='uWSGI', version='2.0.22', path=None),
 'whitenoise': Distribution(name='whitenoise', version='5.2.0', path=None),
 'wrapt': Distribution(name='wrapt', version='1.15.0', path=None),
 'xmltodict.py': Distribution(name='xmltodict', version='0.13.0', path=None),
 'zipp': Distribution(name='zipp', version='3.15.0', path=None)}
</pre>
</details>

## Performance

This is a comparison between two runs of the command `austin -sbo /tmp/startup.mojo python -c "import os;os.environ['DD_PROFILING_ENABLED']='1';import ddtrace.auto`, before and after the change. The run time is measured on the same local development machine

### Before

Total run time: 1.89s

![image](https://github.com/DataDog/dd-trace-py/assets/20231758/9841ad37-a15e-49ad-8dcc-47a3e2a49f49)


### After

Total run time: 1.19s

![image](https://github.com/DataDog/dd-trace-py/assets/20231758/20f26c5c-2473-4645-bd4a-8143d921256a)


## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
