### PR TITLE
ci: add timeout to django framework tests [backport 2.8]

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -124,6 +124,7 @@ jobs:
             expl_coverage: 1
     runs-on: ubuntu-latest
     needs: needs-run
+    timeout-minutes: 15
     name: Django 3.1 (with ${{ matrix.suffix }})
     env:
       DD_PROFILING_ENABLED: true


### PR DESCRIPTION
CI: Add a timeout to Django framework tests so it doesn't hang.

When these tests pass (not often), it takes almost 10 minutes, so a 15 minute timeout should be good enough. When it hangs it can take hours.

It's safe to timeout as it is not a "required for merge" job.

Hang example:
https://github.com/DataDog/dd-trace-py/actions/runs/8813403580/job/24191102553

Proper run example:
https://github.com/DataDog/dd-trace-py/actions/runs/8813298346/job/24190769113

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

(cherry picked from commit 7c6be310b5f129af0fa6b5b9c2f43d0507c08871)
