### PR TITLE
ci: native arm64 build

### DIFF
--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -46,7 +46,7 @@ jobs:
           sudo apt install -y python3-pip
           python3 -m pip install --user pipx
           python3 -m pipx ensurepath
-          sudo pipx ensurepath --global
+          #sudo pipx ensurepath --global
 
       - name: Set up QEMU
         if: runner.os == 'Linux' && matrix.os != 'arm-4core-linux'

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -42,14 +42,14 @@ jobs:
       - name: Install pipx
         if: matrix.os == 'arm-4core-linux'
         run: |
-          sudo apt install -y acl
+          sudo apt install -y acl python3.10-venv
           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
           sudo python3 get-pip.py
           curl -fsSL https://get.docker.com -o get-docker.sh
           sudo sh get-docker.sh
           sudo usermod -a -G docker $USER
           sudo setfacl --modify user:runner:rw /var/run/docker.sock
-          python3 -m pip install pipx virtualenv
+          python3 -m pip install pipx
           python3 -m pipx ensurepath
 
       - name: Set up QEMU

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -54,9 +54,10 @@ jobs:
         with:
           platforms: all
 
-      - name: Build wheels
+      - name: Build wheels Other
+        if: matrix.os != 'windows-latest'
         run: |
-          if [[${{ matrix.os }} == 'arm-4core-linux']]; then
+          if [['${{ matrix.os }}' == 'arm-4core-linux']]; then
             export PATH=$PATH:/home/runner/.local/bin
           fi
           pipx run cibuildwheel==2.16.5
@@ -81,12 +82,27 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
             zip -d {wheel} \*.c \*.cpp \*.cc \*.h \*.hpp \*.pyx &&
             delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+          # DEV: Uncomment to debug MacOS
+          # CIBW_BUILD_VERBOSITY_MACOS: 3
+          #
+      - name: Build wheels Windows
+        if: matrix.os == 'windows-latest'
+        run: pipx run cibuildwheel==2.16.5
+        env:
+          # configure cibuildwheel to build native archs ('auto'), and some
+          # emulated ones
+          CIBW_ARCHS: ${{ matrix.archs }}
+          CIBW_BUILD: ${{ inputs.cibw_build }}
+          CIBW_SKIP: ${{ inputs.cibw_skip }}
+          CIBW_PRERELEASE_PYTHONS: ${{ inputs.cibw_prerelease_pythons }}
+          CMAKE_BUILD_PARALLEL_LEVEL: 12
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS:
             choco install -y 7zip &&
             7z d -r "{wheel}" *.c *.cpp *.cc *.h *.hpp *.pyx &&
             move "{wheel}" "{dest_dir}"
           # DEV: Uncomment to debug MacOS
           # CIBW_BUILD_VERBOSITY_MACOS: 3
+
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -39,10 +39,10 @@ jobs:
         with:
           python-version: '3.8'
 
-      - name: Install python
+      - name: Install pipx
         if: matrix.os == 'arm-4core-linux'
         run: |
-          sudo apt-get install python3
+          sudo apt-get install pipx
 
       - name: Set up QEMU
         if: runner.os == 'Linux' && matrix.os != 'arm-4core-linux'

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -56,13 +56,33 @@ jobs:
         with:
           platforms: all
 
-      - name: Build wheels Other
-        if: matrix.os != 'windows-latest'
+      - name: Build wheels arm64
+        if: matrix.os == 'arm-4core-linux'
         run: |
-          if [[ '${{ matrix.os }}' == 'arm-4core-linux' ]]; then
-            export PATH=$PATH:/home/runner/.local/bin
-          fi
-          pipx run cibuildwheel==2.16.5
+          export PATH=$PATH:/home/runner/.local/bin
+          sudo pipx run cibuildwheel==2.16.5
+        env:
+          # configure cibuildwheel to build native archs ('auto'), and some
+          # emulated ones
+          CIBW_ARCHS: ${{ matrix.archs }}
+          CIBW_BUILD: ${{ inputs.cibw_build }}
+          CIBW_SKIP: ${{ inputs.cibw_skip }}
+          CIBW_PRERELEASE_PYTHONS: ${{ inputs.cibw_prerelease_pythons }}
+          CMAKE_BUILD_PARALLEL_LEVEL: 12
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: |
+            mkdir ./tempwheelhouse &&
+            unzip -l {wheel} | grep '\.so' &&
+            auditwheel repair -w ./tempwheelhouse {wheel} &&
+            (yum install -y zip || apk add zip) &&
+            for w in ./tempwheelhouse/*.whl; do
+              zip -d $w \*.c \*.cpp \*.cc \*.h \*.hpp \*.pyx
+              mv $w {dest_dir}
+            done &&
+            rm -rf ./tempwheelhouse
+
+      - name: Build wheels Other
+        if: matrix.os != 'arm-4core-linux'
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
@@ -84,20 +104,6 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
             zip -d {wheel} \*.c \*.cpp \*.cc \*.h \*.hpp \*.pyx &&
             delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
-          # DEV: Uncomment to debug MacOS
-          # CIBW_BUILD_VERBOSITY_MACOS: 3
-          #
-      - name: Build wheels Windows
-        if: matrix.os == 'windows-latest'
-        run: pipx run cibuildwheel==2.16.5
-        env:
-          # configure cibuildwheel to build native archs ('auto'), and some
-          # emulated ones
-          CIBW_ARCHS: ${{ matrix.archs }}
-          CIBW_BUILD: ${{ inputs.cibw_build }}
-          CIBW_SKIP: ${{ inputs.cibw_skip }}
-          CIBW_PRERELEASE_PYTHONS: ${{ inputs.cibw_prerelease_pythons }}
-          CMAKE_BUILD_PARALLEL_LEVEL: 12
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS:
             choco install -y 7zip &&
             7z d -r "{wheel}" *.c *.cpp *.cc *.h *.hpp *.pyx &&

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -42,15 +42,14 @@ jobs:
       - name: Install pipx
         if: matrix.os == 'arm-4core-linux'
         run: |
-          sudo apt install -y acl python3.10-venv
           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
           sudo python3 get-pip.py
           curl -fsSL https://get.docker.com -o get-docker.sh
           sudo sh get-docker.sh
           sudo usermod -a -G docker $USER
+          sudo apt install -y acl python3.10-venv
           sudo setfacl --modify user:runner:rw /var/run/docker.sock
           python3 -m pip install pipx
-          python3 -m pipx ensurepath
 
       - name: Set up QEMU
         if: runner.os == 'Linux' && matrix.os != 'arm-4core-linux'

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -50,7 +50,6 @@ jobs:
           sudo usermod -a -G docker $USER
           python3 -m pip install pipx
           python3 -m pipx ensurepath
-          sudo /home/runner/.local/bin/pipx ensurepath --global
           sudo cat /etc/sudoers
 
       - name: Set up QEMU

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -43,7 +43,7 @@ jobs:
         if: matrix.os == 'arm-4core-linux'
         run: |
           sudo apt update
-          sudo apt install -y python3-pip python3.10-venv cmake g++-12 git make curl
+          sudo apt install -y python3-pip python3.10-venv python-is-python3 cmake g++-12 git make curl
           curl -fsSL https://get.docker.com -o get-docker.sh
           sudo sh get-docker.sh
           sudo python3 -m pip install pipx

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -46,8 +46,8 @@ jobs:
           sudo apt install -y python3-pip python3.10-venv cmake g++-12 git make curl
           curl -fsSL https://get.docker.com -o get-docker.sh
           sudo sh get-docker.sh
-          python3 -m pip install --user pipx "cibuildwheel==2.16.5"
-          python3 -m pipx ensurepath
+          sudo python3 -m pip install pipx
+          sudo python3 -m pipx ensurepath
           #sudo pipx ensurepath --global
 
       - name: Set up QEMU
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build wheels arm64
         if: matrix.os == 'arm-4core-linux'
-        run: sudo /home/runner/.local/bin/pipx run cibuildwheel==2.16.5
+        run: sudo pipx run cibuildwheel==2.16.5
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           echo $USER' ALL=(ALL) NOPASSWD: ALL' | sudo EDITOR='tee -a' visudo
           sudo apt update
-          sudo apt install -y python3-pip python3.10-venv python-is-python3 cmake g++-12 git make curl
+          sudo apt install -y python3-pip python3.10-venv python-is-python3 cmake g++-12 git make curl acl
           curl -fsSL https://get.docker.com -o get-docker.sh
           sudo sh get-docker.sh
           sudo usermod -a -G docker $USER

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build wheels arm64
         if: matrix.os == 'arm-4core-linux'
-        run: sudo pipx run cibuildwheel==2.16.5
+        run: sudo pipx run cibuildwheel==2.16.5 --platform linux
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -39,15 +39,16 @@ jobs:
         with:
           python-version: '3.8'
 
-      - name: Install pipx
+      - name: Install docker and pipx
         if: matrix.os == 'arm-4core-linux'
+        # The ARM64 Ubuntu has less things installed by default
+        # We need docker, pip and venv for cibuildwheel
+        # acl allows us to use docker in the same session
         run: |
-          curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-          sudo python3 get-pip.py
           curl -fsSL https://get.docker.com -o get-docker.sh
           sudo sh get-docker.sh
           sudo usermod -a -G docker $USER
-          sudo apt install -y acl python3.10-venv
+          sudo apt install -y acl python3.10-venv python3.10-pip
           sudo setfacl --modify user:runner:rw /var/run/docker.sock
           python3 -m pip install pipx
 
@@ -60,30 +61,7 @@ jobs:
       - name: Build wheels arm64
         if: matrix.os == 'arm-4core-linux'
         run: /home/runner/.local/bin/pipx run cibuildwheel==2.16.5 --platform linux
-        env:
-          # configure cibuildwheel to build native archs ('auto'), and some
-          # emulated ones
-          CIBW_BUILD_VERBOSITY: 1
-          CIBW_ARCHS: ${{ matrix.archs }}
-          CIBW_BUILD: ${{ inputs.cibw_build }}
-          CIBW_SKIP: ${{ inputs.cibw_skip }}
-          CIBW_PRERELEASE_PYTHONS: ${{ inputs.cibw_prerelease_pythons }}
-          CMAKE_BUILD_PARALLEL_LEVEL: 12
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: |
-            mkdir ./tempwheelhouse &&
-            unzip -l {wheel} | grep '\.so' &&
-            auditwheel repair -w ./tempwheelhouse {wheel} &&
-            (yum install -y zip || apk add zip) &&
-            for w in ./tempwheelhouse/*.whl; do
-              zip -d $w \*.c \*.cpp \*.cc \*.h \*.hpp \*.pyx
-              mv $w {dest_dir}
-            done &&
-            rm -rf ./tempwheelhouse
-
-      - name: Build wheels Other
-        if: matrix.os != 'arm-4core-linux'
-        uses: pypa/cibuildwheel@v2.16.5
-        env:
+        env: &cibuildwheel_opts
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
           CIBW_ARCHS: ${{ matrix.archs }}
@@ -110,6 +88,11 @@ jobs:
             move "{wheel}" "{dest_dir}"
           # DEV: Uncomment to debug MacOS
           # CIBW_BUILD_VERBOSITY_MACOS: 3
+
+      - name: Build wheels
+        if: matrix.os != 'arm-4core-linux'
+        uses: pypa/cibuildwheel@v2.16.5
+        env: *cibuildwheel_opts
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -47,9 +47,10 @@ jobs:
           sudo apt install -y python3-pip python3.10-venv python-is-python3 cmake g++-12 git make curl
           curl -fsSL https://get.docker.com -o get-docker.sh
           sudo sh get-docker.sh
-          sudo python3 -m pip install pipx
-          sudo python3 -m pipx ensurepath
-          #sudo pipx ensurepath --global
+          sudo usermod -a -G docker $USER
+          python3 -m pip install pipx
+          python3 -m pipx ensurepath
+          sudo pipx ensurepath --global
 
       - name: Set up QEMU
         if: runner.os == 'Linux' && matrix.os != 'arm-4core-linux'
@@ -59,7 +60,7 @@ jobs:
 
       - name: Build wheels arm64
         if: matrix.os == 'arm-4core-linux'
-        run: sudo /root/.local/bin/pipx run cibuildwheel==2.16.5 --platform linux
+        run: /home/runner/.local/bin/pipx run cibuildwheel==2.16.5 --platform linux
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Install pipx
         if: matrix.os == 'arm-4core-linux'
         run: |
+          sudo apt-get update
           sudo apt install python3-pip
           python3 -m pip install --user pipx
           python3 -m pipx ensurepath

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Build wheels arm64
         if: matrix.os == 'arm-4core-linux'
-        run: /home/runner/.local/bin/pipx run cibuildwheel==2.16.5 --platform linux
+        run: pipx run cibuildwheel==2.16.5
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -42,13 +42,14 @@ jobs:
       - name: Install pipx
         if: matrix.os == 'arm-4core-linux'
         run: |
-          sudo apt update
-          sudo apt install -y python3-pip python3.10-venv curl acl
+          sudo apt install -y acl
+          curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+          sudo python3 get-pip.py
           curl -fsSL https://get.docker.com -o get-docker.sh
           sudo sh get-docker.sh
           sudo usermod -a -G docker $USER
           sudo setfacl --modify user:runner:rw /var/run/docker.sock
-          python3 -m pip install pipx
+          python3 -m pip install pipx virtualenv
           python3 -m pipx ensurepath
 
       - name: Set up QEMU

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -50,7 +50,8 @@ jobs:
           sudo usermod -a -G docker $USER
           python3 -m pip install pipx
           python3 -m pipx ensurepath
-          sudo pipx ensurepath --global
+          sudo /home/runner/.local/bin/pipx ensurepath --global
+          sudo cat /etc/sudoers
 
       - name: Set up QEMU
         if: runner.os == 'Linux' && matrix.os != 'arm-4core-linux'

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -40,13 +40,12 @@ jobs:
           python-version: '3.8'
 
       - name: Install pipx
-        if: matrix.os == 'NOarm-4core-linux'
+        if: matrix.os == 'arm-4core-linux'
         run: |
           sudo apt update
           sudo apt install -y python3-pip cmake g++-12 git make curl
           python3 -m pip install --user pipx "cibuildwheel==2.16.5"
           python3 -m pipx ensurepath
-          export PATH=$PATH:/home/runner/.local/bin
           #sudo pipx ensurepath --global
 
       - name: Set up QEMU
@@ -56,8 +55,11 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        if: matrix.os != 'arm-4core-linux'
-        run: pipx run cibuildwheel==2.16.5
+        run: |
+          if [[${{ matrix.os }} == 'arm-4core-linux']]; then
+            export PATH=$PATH:/home/runner/.local/bin
+          fi
+          pipx run cibuildwheel==2.16.5
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -21,7 +21,7 @@ jobs:
         include:
          - os: ubuntu-latest
            archs: x86_64 i686
-         - os: ubuntu-latest
+         - os: arm-4core-linux
            archs: aarch64
          - os: windows-latest
            archs: AMD64 x86
@@ -45,7 +45,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        run: pipx run cibuildwheel==2.16.5
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -58,10 +58,12 @@ jobs:
 
       - name: Build wheels arm64
         if: matrix.os == 'arm-4core-linux'
-        run: sudo pipx run cibuildwheel==2.16.5 --platform linux
+        run: sudo /root/.local/bin/pipx run cibuildwheel==2.16.5 --platform linux
+
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
+          CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD: ${{ inputs.cibw_build }}
           CIBW_SKIP: ${{ inputs.cibw_skip }}

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Install pipx
         if: matrix.os == 'arm-4core-linux'
         run: |
-          sudo apt-get install pipx
+          python3 -m pip install --user pipx
+          python3 -m pipx ensurepath
+          sudo pipx ensurepath --global
 
       - name: Set up QEMU
         if: runner.os == 'Linux' && matrix.os != 'arm-4core-linux'

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -58,14 +58,11 @@ jobs:
 
       - name: Build wheels arm64
         if: matrix.os == 'arm-4core-linux'
-        run: |
-          sudo bash << EOF
-          /root/.local/bin/pipx run cibuildwheel==2.16.5 --platform linux
-          EOF
+        run: sudo /root/.local/bin/pipx run cibuildwheel==2.16.5 --platform linux
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
-          CIBW_BUILD_VERBOSITY: 3
+          CIBW_BUILD_VERBOSITY: 1
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD: ${{ inputs.cibw_build }}
           CIBW_SKIP: ${{ inputs.cibw_skip }}

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: '3.8'
 
       - name: Install pipx
-        if: matrix.os == 'arm-4core-linux'
+        if: matrix.os == 'NOarm-4core-linux'
         run: |
           sudo apt update
           sudo apt install -y python3-pip cmake g++-12 git make curl
@@ -56,6 +56,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
+        if: matrix.os != 'arm-4core-linux'
         run: pipx run cibuildwheel==2.16.5
         env:
           # configure cibuildwheel to build native archs ('auto'), and some

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -46,6 +46,7 @@ jobs:
           sudo apt install -y python3-pip
           python3 -m pip install --user pipx
           python3 -m pipx ensurepath
+          export PATH=$PATH:/home/runner/.local/bin
           #sudo pipx ensurepath --global
 
       - name: Set up QEMU
@@ -55,7 +56,9 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        run: pipx run cibuildwheel==2.16.5
+        run: |
+          export PATH=$PATH:/home/runner/.local/bin
+          pipx run cibuildwheel==2.16.5
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -42,15 +42,14 @@ jobs:
       - name: Install pipx
         if: matrix.os == 'arm-4core-linux'
         run: |
-          echo $USER' ALL=(ALL) NOPASSWD: ALL' | sudo EDITOR='tee -a' visudo
           sudo apt update
-          sudo apt install -y python3-pip python3.10-venv python-is-python3 cmake g++-12 git make curl acl
+          sudo apt install -y python3-pip python3.10-venv curl acl
           curl -fsSL https://get.docker.com -o get-docker.sh
           sudo sh get-docker.sh
           sudo usermod -a -G docker $USER
+          sudo setfacl --modify user:runner:rw /var/run/docker.sock
           python3 -m pip install pipx
           python3 -m pipx ensurepath
-          sudo setfacl --modify user:runner:rw /var/run/docker.sock
 
       - name: Set up QEMU
         if: runner.os == 'Linux' && matrix.os != 'arm-4core-linux'

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Build wheels Other
         if: matrix.os != 'windows-latest'
         run: |
-          if [['${{ matrix.os }}' == 'arm-4core-linux']]; then
+          if [[ '${{ matrix.os }}' == 'arm-4core-linux' ]]; then
             export PATH=$PATH:/home/runner/.local/bin
           fi
           pipx run cibuildwheel==2.16.5

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -43,7 +43,7 @@ jobs:
         if: matrix.os == 'arm-4core-linux'
         run: |
           sudo apt-get update
-          sudo apt install python3-pip
+          sudo apt install -y python3-pip
           python3 -m pip install --user pipx
           python3 -m pipx ensurepath
           sudo pipx ensurepath --global

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -92,7 +92,8 @@ jobs:
       - name: Build wheels
         if: matrix.os != 'arm-4core-linux'
         uses: pypa/cibuildwheel@v2.16.5
-        env: *cibuildwheel_opts
+        env:
+          <<: *cibuildwheel_opts
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -50,7 +50,7 @@ jobs:
           sudo usermod -a -G docker $USER
           python3 -m pip install pipx
           python3 -m pipx ensurepath
-          sudo cat /etc/sudoers
+          sudo setfacl --modify user:runner:rw /var/run/docker.sock
 
       - name: Set up QEMU
         if: runner.os == 'Linux' && matrix.os != 'arm-4core-linux'

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -43,7 +43,7 @@ jobs:
         if: matrix.os == 'arm-4core-linux'
         run: |
           sudo apt update
-          sudo apt install -y python3-pip cmake g++-12 git make curl
+          sudo apt install -y python3-pip python3.10-venv cmake g++-12 git make curl
           python3 -m pip install --user pipx "cibuildwheel==2.16.5"
           python3 -m pipx ensurepath
           #sudo pipx ensurepath --global

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build wheels arm64
         if: matrix.os == 'arm-4core-linux'
         run: /home/runner/.local/bin/pipx run cibuildwheel==2.16.5 --platform linux
-        env: &cibuildwheel_opts
+        env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
           CIBW_ARCHS: ${{ matrix.archs }}
@@ -93,7 +93,32 @@ jobs:
         if: matrix.os != 'arm-4core-linux'
         uses: pypa/cibuildwheel@v2.16.5
         env:
-          <<: *cibuildwheel_opts
+          # configure cibuildwheel to build native archs ('auto'), and some
+          # emulated ones
+          CIBW_ARCHS: ${{ matrix.archs }}
+          CIBW_BUILD: ${{ inputs.cibw_build }}
+          CIBW_SKIP: ${{ inputs.cibw_skip }}
+          CIBW_PRERELEASE_PYTHONS: ${{ inputs.cibw_prerelease_pythons }}
+          CMAKE_BUILD_PARALLEL_LEVEL: 12
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: |
+            mkdir ./tempwheelhouse &&
+            unzip -l {wheel} | grep '\.so' &&
+            auditwheel repair -w ./tempwheelhouse {wheel} &&
+            (yum install -y zip || apk add zip) &&
+            for w in ./tempwheelhouse/*.whl; do
+              zip -d $w \*.c \*.cpp \*.cc \*.h \*.hpp \*.pyx
+              mv $w {dest_dir}
+            done &&
+            rm -rf ./tempwheelhouse
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
+            zip -d {wheel} \*.c \*.cpp \*.cc \*.h \*.hpp \*.pyx &&
+            delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS:
+            choco install -y 7zip &&
+            7z d -r "{wheel}" *.c *.cpp *.cc *.h *.hpp *.pyx &&
+            move "{wheel}" "{dest_dir}"
+          # DEV: Uncomment to debug MacOS
+          # CIBW_BUILD_VERBOSITY_MACOS: 3
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -34,12 +34,18 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/setup-python@v4
+        if: matrix.os != 'arm-4core-linux'
         name: Install Python
         with:
           python-version: '3.8'
 
+      - name: Install python
+        if: matrix.os == 'arm-4core-linux'
+        run: |
+          sudo apt-get install python3
+
       - name: Set up QEMU
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.os != 'arm-4core-linux'
         uses: docker/setup-qemu-action@v2
         with:
           platforms: all

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -58,9 +58,7 @@ jobs:
 
       - name: Build wheels arm64
         if: matrix.os == 'arm-4core-linux'
-        run: |
-          export PATH=$PATH:/home/runner/.local/bin
-          sudo pipx run cibuildwheel==2.16.5
+        run: sudo /home/runner/.local/bin/pipx run cibuildwheel==2.16.5
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Install pipx
         if: matrix.os == 'arm-4core-linux'
         run: |
+          echo $USER' ALL=(ALL) NOPASSWD: ALL' | sudo EDITOR='tee -a' visudo
           sudo apt update
           sudo apt install -y python3-pip python3.10-venv python-is-python3 cmake g++-12 git make curl
           curl -fsSL https://get.docker.com -o get-docker.sh

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -48,7 +48,7 @@ jobs:
           curl -fsSL https://get.docker.com -o get-docker.sh
           sudo sh get-docker.sh
           sudo usermod -a -G docker $USER
-          sudo apt install -y acl python3.10-venv python3.10-pip
+          sudo apt install -y acl python3.10-venv python3-pip
           sudo setfacl --modify user:runner:rw /var/run/docker.sock
           python3 -m pip install pipx
 

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -43,7 +43,9 @@ jobs:
         if: matrix.os == 'arm-4core-linux'
         run: |
           sudo apt update
-          sudo apt install -y python3-pip python3.10-venv cmake g++-12 git make curl docker
+          sudo apt install -y python3-pip python3.10-venv cmake g++-12 git make curl
+          curl -fsSL https://get.docker.com -o get-docker.sh
+          sudo sh get-docker.sh
           python3 -m pip install --user pipx "cibuildwheel==2.16.5"
           python3 -m pipx ensurepath
           #sudo pipx ensurepath --global

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Build wheels arm64
         if: matrix.os == 'arm-4core-linux'
-        run: pipx run cibuildwheel==2.16.5
+        run: /home/runner/.local/bin/pipx run cibuildwheel==2.16.5 --platform linux
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -59,8 +59,9 @@ jobs:
       - name: Build wheels arm64
         if: matrix.os == 'arm-4core-linux'
         run: |
-          sudo -i
+          sudo bash << EOF
           /root/.local/bin/pipx run cibuildwheel==2.16.5 --platform linux
+          EOF
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Install pipx
         if: matrix.os == 'arm-4core-linux'
         run: |
+          sudo apt install python3-pip
           python3 -m pip install --user pipx
           python3 -m pipx ensurepath
           sudo pipx ensurepath --global

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -58,8 +58,9 @@ jobs:
 
       - name: Build wheels arm64
         if: matrix.os == 'arm-4core-linux'
-        run: sudo /root/.local/bin/pipx run cibuildwheel==2.16.5 --platform linux
-
+        run: |
+          sudo -i
+          /root/.local/bin/pipx run cibuildwheel==2.16.5 --platform linux
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -42,9 +42,9 @@ jobs:
       - name: Install pipx
         if: matrix.os == 'arm-4core-linux'
         run: |
-          sudo apt-get update
-          sudo apt install -y python3-pip
-          python3 -m pip install --user pipx
+          sudo apt update
+          sudo apt install -y python3-pip cmake g++-12 git make curl
+          python3 -m pip install --user pipx "cibuildwheel==2.16.5"
           python3 -m pipx ensurepath
           export PATH=$PATH:/home/runner/.local/bin
           #sudo pipx ensurepath --global

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -43,7 +43,7 @@ jobs:
         if: matrix.os == 'arm-4core-linux'
         run: |
           sudo apt update
-          sudo apt install -y python3-pip python3.10-venv cmake g++-12 git make curl
+          sudo apt install -y python3-pip python3.10-venv cmake g++-12 git make curl docker
           python3 -m pip install --user pipx "cibuildwheel==2.16.5"
           python3 -m pipx ensurepath
           #sudo pipx ensurepath --global

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -56,9 +56,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        run: |
-          export PATH=$PATH:/home/runner/.local/bin
-          pipx run cibuildwheel==2.16.5
+        run: pipx run cibuildwheel==2.16.5
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones


### PR DESCRIPTION
CI: Use native arm64 github runners to build arm64 wheels

## Caveats:

The usual nice things are not ready yet in arm64 runners, things like pip or docker have to be installed separately, so the `acl` trick is intented to use docker in the same session where it's installed.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
