### PR TITLE
ci: native arm64 build [backport 2.6]

### DIFF
--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -21,7 +21,7 @@ jobs:
         include:
          - os: ubuntu-latest
            archs: x86_64 i686
-         - os: ubuntu-latest
+         - os: arm-4core-linux
            archs: aarch64
          - os: windows-latest
            archs: AMD64 x86
@@ -34,17 +34,63 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/setup-python@v4
+        if: matrix.os != 'arm-4core-linux'
         name: Install Python
         with:
           python-version: '3.8'
 
+      - name: Install docker and pipx
+        if: matrix.os == 'arm-4core-linux'
+        # The ARM64 Ubuntu has less things installed by default
+        # We need docker, pip and venv for cibuildwheel
+        # acl allows us to use docker in the same session
+        run: |
+          curl -fsSL https://get.docker.com -o get-docker.sh
+          sudo sh get-docker.sh
+          sudo usermod -a -G docker $USER
+          sudo apt install -y acl python3.10-venv python3-pip
+          sudo setfacl --modify user:runner:rw /var/run/docker.sock
+          python3 -m pip install pipx
+
       - name: Set up QEMU
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.os != 'arm-4core-linux'
         uses: docker/setup-qemu-action@v2
         with:
           platforms: all
 
+      - name: Build wheels arm64
+        if: matrix.os == 'arm-4core-linux'
+        run: /home/runner/.local/bin/pipx run cibuildwheel==2.16.5 --platform linux
+        env:
+          # configure cibuildwheel to build native archs ('auto'), and some
+          # emulated ones
+          CIBW_ARCHS: ${{ matrix.archs }}
+          CIBW_BUILD: ${{ inputs.cibw_build }}
+          CIBW_SKIP: ${{ inputs.cibw_skip }}
+          CIBW_PRERELEASE_PYTHONS: ${{ inputs.cibw_prerelease_pythons }}
+          CMAKE_BUILD_PARALLEL_LEVEL: 12
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: |
+            mkdir ./tempwheelhouse &&
+            unzip -l {wheel} | grep '\.so' &&
+            auditwheel repair -w ./tempwheelhouse {wheel} &&
+            (yum install -y zip || apk add zip) &&
+            for w in ./tempwheelhouse/*.whl; do
+              zip -d $w \*.c \*.cpp \*.cc \*.h \*.hpp \*.pyx
+              mv $w {dest_dir}
+            done &&
+            rm -rf ./tempwheelhouse
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
+            zip -d {wheel} \*.c \*.cpp \*.cc \*.h \*.hpp \*.pyx &&
+            delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS:
+            choco install -y 7zip &&
+            7z d -r "{wheel}" *.c *.cpp *.cc *.h *.hpp *.pyx &&
+            move "{wheel}" "{dest_dir}"
+          # DEV: Uncomment to debug MacOS
+          # CIBW_BUILD_VERBOSITY_MACOS: 3
+
       - name: Build wheels
+        if: matrix.os != 'arm-4core-linux'
         uses: pypa/cibuildwheel@v2.16.5
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
@@ -72,6 +118,7 @@ jobs:
             move "{wheel}" "{dest_dir}"
           # DEV: Uncomment to debug MacOS
           # CIBW_BUILD_VERBOSITY_MACOS: 3
+
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
CI: Use native arm64 github runners to build arm64 wheels

## Caveats:

The usual nice things are not ready yet in arm64 runners, things like pip or docker have to be installed separately, so the `acl` trick is intented to use docker in the same session where it's installed.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

(cherry picked from commit 7c65a286ed500e9da03ce0be60d4f4423f6df102)
