### PR TITLE
fix(iast): fstring int formatting [backport 2.8]

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -448,6 +448,8 @@ def format_value_aspect(
     else:
         new_text = element
     if not isinstance(new_text, TEXT_TYPES):
+        if format_spec:
+            return format(new_text, format_spec)
         return format(new_text)
 
     try:

--- a/releasenotes/notes/fix-fstring-zeropadding-e8e463a4d8623040.yaml
+++ b/releasenotes/notes/fix-fstring-zeropadding-e8e463a4d8623040.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Code Security: This fix solves an issue with fstrings where formatting was not applied to int parameters

--- a/tests/appsec/iast/aspects/test_str_py3.py
+++ b/tests/appsec/iast/aspects/test_str_py3.py
@@ -52,6 +52,11 @@ class TestOperatorsReplacement(BaseReplacement):
         result = mod_py3.do_repr_fstring_with_format(string_input)  # pylint: disable=no-member
         assert as_formatted_evidence(result) == "':+-foo-+:'     "
 
+    def test_int_fstring_zero_padding_tainted(self):
+        int_input = 5
+        result = mod_py3.do_zero_padding_fstring(int_input)  # pylint: disable=no-member
+        assert result == "00005"
+
     def test_string_fstring_repr_str_twice_tainted(self):
         # type: () -> None
         string_input = "foo"

--- a/tests/appsec/iast/fixtures/aspects/str_methods_py3.py
+++ b/tests/appsec/iast/fixtures/aspects/str_methods_py3.py
@@ -9,6 +9,10 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Tuple  # noqa:F401
 
 
+def do_zero_padding_fstring(a):  # type: (int) -> str
+    return f"{a:05d}"
+
+
 def do_fmt_value(a):  # type: (str) -> str
     return f"{a:<8s}bar"
 


### PR DESCRIPTION
IAST: This fixes an issue where f-strings receiving int parameters were not properly formatted.

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

(cherry picked from commit 5e6184cc9782eb40a4eee307abc144653e5ff7d7)
