### PR TITLE
ci: temporarily disable vertica test suite

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -14,7 +14,7 @@ mysql_image: &mysql_image mysql:5.7@sha256:03b6dcedf5a2754da00e119e2cc6094ed3c88
 postgres_image: &postgres_image postgres:12-alpine@sha256:c6704f41eb84be53d5977cb821bf0e5e876064b55eafef1e260c2574de40ad9a
 mongo_image: &mongo_image mongo:3.6@sha256:19c11a8f1064fd2bb713ef1270f79a742a184cd57d9bb922efdd2a8eca514af8
 httpbin_image: &httpbin_image kennethreitz/httpbin@sha256:2c7abc4803080c22928265744410173b6fea3b898872c01c5fd0f0f9df4a59fb
-vertica_image: &vertica_image sumitchawla/vertica:latest
+vertica_image: &vertica_image vertica/vertica-ce:latest
 rabbitmq_image: &rabbitmq_image rabbitmq:3.7-alpine
 testagent_image: &testagent_image ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.16.0
 

--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -1227,21 +1227,6 @@ jobs:
           snapshot: true
           docker_services: "httpbin_local"
 
-  vertica:
-    <<: *contrib_job
-    docker:
-      - image: *ddtrace_dev_image
-      - *testagent
-      - image: *vertica_image
-        environment:
-          - VP_TEST_USER=dbadmin
-          - VP_TEST_PASSWORD=abc123
-          - VP_TEST_DATABASE=docker
-    steps:
-      - run_test:
-          wait: vertica
-          pattern: 'vertica'
-
   wsgi:
     <<: *machine_executor
     steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
             - ENABLED_CHECKS=trace_content_length,trace_stall,meta_tracer_version_header,trace_count_header,trace_peer_service,trace_dd_service
             - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,metrics.system.process_id,metrics.process_id,meta.runtime-id,meta._dd.p.tid,meta.pathway.hash,metrics._dd.tracer_kr,meta._dd.parent_id
     vertica:
-        image: sumitchawla/vertica
+        image: vertica/vertica-ce
         environment:
           - VP_TEST_USER=dbadmin
           - VP_TEST_PASSWORD=abc123
@@ -195,7 +195,7 @@ services:
             - DD_REMOTE_CONFIGURATION_ENABLED=true
             - DD_AGENT_PORT=8126
             - DD_TRACE_AGENT_URL=http://testagent:8126
-            - _DD_APPSEC_DEDUPLICATION_ENABLED=false 
+            - _DD_APPSEC_DEDUPLICATION_ENABLED=false
 
 volumes:
     ddagent:

--- a/tests/contrib/config.py
+++ b/tests/contrib/config.py
@@ -75,7 +75,7 @@ VERTICA_CONFIG = {
     "port": os.getenv("TEST_VERTICA_PORT", 5433),
     "user": os.getenv("TEST_VERTICA_USER", "dbadmin"),
     "password": os.getenv("TEST_VERTICA_PASSWORD", "abc123"),
-    "database": os.getenv("TEST_VERTICA_DATABASE", "vtdb"),
+    "database": os.getenv("TEST_VERTICA_DATABASE", "docker"),
 }
 
 RABBITMQ_CONFIG = {

--- a/tests/contrib/config.py
+++ b/tests/contrib/config.py
@@ -75,7 +75,7 @@ VERTICA_CONFIG = {
     "port": os.getenv("TEST_VERTICA_PORT", 5433),
     "user": os.getenv("TEST_VERTICA_USER", "dbadmin"),
     "password": os.getenv("TEST_VERTICA_PASSWORD", "abc123"),
-    "database": os.getenv("TEST_VERTICA_DATABASE", "docker"),
+    "database": os.getenv("TEST_VERTICA_DATABASE", "vtdb"),
 }
 
 RABBITMQ_CONFIG = {


### PR DESCRIPTION
This pull request disables the reliably-failing `vertica` test suite to unblock CI while we figure out how to resolve the failure.

[This](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/60382/workflows/959242f7-9615-4cb8-a324-3a1e829071ef/jobs/3792168) is the failure currently happening on main. My attempts to use the [official image](https://hub.docker.com/r/vertica/vertica-ce) have failed so far.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
