### PR TITLE
ci: temporarily disable vertica test suite [backport 1.20]

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -14,7 +14,7 @@ mysql_image: &mysql_image mysql:5.7@sha256:03b6dcedf5a2754da00e119e2cc6094ed3c88
 postgres_image: &postgres_image postgres:12-alpine@sha256:c6704f41eb84be53d5977cb821bf0e5e876064b55eafef1e260c2574de40ad9a
 mongo_image: &mongo_image mongo:3.6@sha256:19c11a8f1064fd2bb713ef1270f79a742a184cd57d9bb922efdd2a8eca514af8
 httpbin_image: &httpbin_image kennethreitz/httpbin@sha256:2c7abc4803080c22928265744410173b6fea3b898872c01c5fd0f0f9df4a59fb
-vertica_image: &vertica_image sumitchawla/vertica:latest
+vertica_image: &vertica_image vertica/vertica-ce:latest
 rabbitmq_image: &rabbitmq_image rabbitmq:3.7-alpine
 testagent_image: &testagent_image ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.11.0
 
@@ -993,21 +993,6 @@ jobs:
           pattern: 'urllib3'
           snapshot: true
           docker_services: "httpbin_local"
-
-  vertica:
-    <<: *contrib_job
-    docker:
-      - image: *ddtrace_dev_image
-      - *testagent
-      - image: *vertica_image
-        environment:
-          - VP_TEST_USER=dbadmin
-          - VP_TEST_PASSWORD=abc123
-          - VP_TEST_DATABASE=docker
-    steps:
-      - run_test:
-          wait: vertica
-          pattern: 'vertica'
 
   wsgi:
     <<: *machine_executor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
             - ENABLED_CHECKS=trace_content_length,trace_stall,meta_tracer_version_header,trace_count_header,trace_peer_service,trace_dd_service
             - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,metrics.system.process_id,metrics.process_id,meta.runtime-id,meta._dd.p.tid,meta.pathway.hash,metrics._dd.tracer_kr
     vertica:
-        image: sumitchawla/vertica
+        image: vertica/vertica-ce
         environment:
           - VP_TEST_USER=dbadmin
           - VP_TEST_PASSWORD=abc123
@@ -185,6 +185,21 @@ services:
       ports:
         - "127.0.0.1:8001:80"
 
+    pygoat:
+        build:
+            context: tests/appsec/integrations/pygoat_tests
+            dockerfile: Dockerfile.pygoat.2.0.1
+        ports:
+            - "127.0.0.1:8321:8321"
+        environment:
+            - DD_APPSEC_ENABLED=true
+            - DD_IAST_ENABLED=true
+            - DD_IAST_REQUEST_SAMPLING=100
+            - DD_IAST_VULNERABILITIES_PER_REQUEST=100
+            - DD_REMOTE_CONFIGURATION_ENABLED=true
+            - DD_AGENT_PORT=8126
+            - DD_TRACE_AGENT_URL=http://testagent:8126
+            - _DD_APPSEC_DEDUPLICATION_ENABLED=false
 
 volumes:
     ddagent:


### PR DESCRIPTION
This pull request disables the reliably-failing `vertica` test suite to unblock CI while we figure out how to resolve the failure.

[This](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/60382/workflows/959242f7-9615-4cb8-a324-3a1e829071ef/jobs/3792168) is the failure currently happening on main. My attempts to use the [official image](https://hub.docker.com/r/vertica/vertica-ce) have failed so far.

- [x] Change(s) are motivated and described in the PR description
