### PR TITLE
fix: botocore bedrock integration breaks for command R requests

### DIFF
--- a/ddtrace/contrib/botocore/services/bedrock.py
+++ b/ddtrace/contrib/botocore/services/bedrock.py
@@ -180,8 +180,8 @@ def _extract_text_and_response_reason(ctx: core.ExecutionContext, body: Dict[str
         elif provider == _COHERE and "embed" in model_name:
             text = body.get("embeddings", [[]])
         elif provider == _COHERE:
-            text = [generation["text"] for generation in body.get("generations")]
-            finish_reason = [generation["finish_reason"] for generation in body.get("generations")]
+            text = [generation["text"] for generation in body.get("generations", [])]
+            finish_reason = [generation["finish_reason"] for generation in body.get("generations", [])]
         elif provider == _META:
             text = body.get("generation")
             finish_reason = body.get("stop_reason")


### PR DESCRIPTION
fixes: https://github.com/DataDog/dd-trace-py/issues/9135

This PR does not add support for Command R models as this is more complex and would require:
- distingiushing Command models from Command R models
- trace inputs of Command R models
- trace outputs of Command R models

Instead this PR just ensures that ddtrace doesn't break Command R invocation.