### PR TITLE
ci: mark some flaky tests

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -133,7 +133,7 @@ venv = Venv(
         Venv(
             name="appsec_iast",
             pys=select_pys(),
-            command="pytest {cmdargs} tests/appsec/iast/",
+            command="pytest -v {cmdargs} tests/appsec/iast/",
             pkgs={
                 "requests": latest,
                 "pycryptodome": latest,

--- a/tests/contrib/celery/test_integration.py
+++ b/tests/contrib/celery/test_integration.py
@@ -17,6 +17,7 @@ from ddtrace.contrib.celery import unpatch
 import ddtrace.internal.forksafe as forksafe
 from ddtrace.propagation.http import HTTPPropagator
 from tests.opentracer.utils import init_tracer
+from tests.utils import flaky
 
 from ...utils import override_global_config
 from .base import CeleryBaseTestCase
@@ -209,6 +210,7 @@ class CeleryIntegrationTask(CeleryBaseTestCase):
         assert run_span.get_tag("component") == "celery"
         assert run_span.get_tag("span.kind") == "consumer"
 
+    @flaky(1722529274)
     def test_fn_task_delay(self):
         # using delay shorthand must preserve arguments
         @self.app.task

--- a/tests/internal/test_tracer_flare.py
+++ b/tests/internal/test_tracer_flare.py
@@ -13,6 +13,7 @@ from ddtrace.internal.flare import TRACER_FLARE_FILE_HANDLER_NAME
 from ddtrace.internal.flare import Flare
 from ddtrace.internal.flare import FlareSendRequest
 from ddtrace.internal.logger import get_logger
+from tests.utils import flaky
 
 
 DEBUG_LEVEL_INT = logging.DEBUG
@@ -118,6 +119,7 @@ class TracerFlareTests(unittest.TestCase):
         for p in processes:
             p.join()
 
+    @flaky(1722529274)
     def test_multiple_process_partial_failure(self):
         """
         Validte that even if the tracer flare fails for one process, we should


### PR DESCRIPTION
This change marks these two ephemeral CI failures as flaky:

https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/60664/workflows/e6f953d9-721e-4a27-8064-5209f7ac3a15/jobs/3805647 last touched by @zarirhamza 
https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/60685/workflows/c25bae04-8827-4893-ac67-f239b2226774/jobs/3806940 last touched by @erikayasuda 

It also adds verbose output to the `appsec_iast` test suite to aid in figuring out which test or tests generates this ephemeral segfault: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/60686/workflows/21d8cecd-9345-4e16-9157-71425bd65ccb/jobs/3807035

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
