### PR TITLE
fix(redis): added back tracer_utils_redis with deprecation warn

### DIFF
--- a/ddtrace/contrib/trace_utils_redis.py
+++ b/ddtrace/contrib/trace_utils_redis.py
@@ -5,7 +5,7 @@ from ddtrace.vendor.debtcollector import deprecate
 
 
 deprecate(
-    "The ddtrace.contrib.tracer_utils_redis module is deprecated and will be removed.",
+    "The ddtrace.contrib.trace_utils_redis module is deprecated and will be removed.",
     message="A new interface will be provided by the ddtrace.contrib.redis_utils.",
     category=DDTraceDeprecationWarning,
 )

--- a/ddtrace/contrib/trace_utils_redis.py
+++ b/ddtrace/contrib/trace_utils_redis.py
@@ -1,0 +1,18 @@
+from ddtrace.contrib.redis_utils import determine_row_count
+from ddtrace.contrib.redis_utils import stringify_cache_args
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+from ddtrace.vendor.debtcollector import deprecate
+
+
+deprecate(
+    "The ddtrace.contrib.tracer_utils_redis module is deprecated and will be removed.",
+    message="A new interface will be provided by the ddtrace.contrib.redis_utils.",
+    category=DDTraceDeprecationWarning,
+)
+
+
+format_command_args = stringify_cache_args
+
+
+def determine_row_count(redis_command, span, result):  # noqa: F811
+    determine_row_count(redis_command=redis_command, result=result)

--- a/ddtrace/contrib/trace_utils_redis.py
+++ b/ddtrace/contrib/trace_utils_redis.py
@@ -6,7 +6,7 @@ from ddtrace.vendor.debtcollector import deprecate
 
 deprecate(
     "The ddtrace.contrib.trace_utils_redis module is deprecated and will be removed.",
-    message="A new interface will be provided by the ddtrace.contrib.redis_utils.",
+    message="A new interface will be provided by the ddtrace.contrib.redis_utils module",
     category=DDTraceDeprecationWarning,
 )
 

--- a/tests/.suitespec.json
+++ b/tests/.suitespec.json
@@ -141,6 +141,7 @@
             "ddtrace/contrib/yaaredis/*",
             "ddtrace/_trace/utils_redis.py",
             "ddtrace/contrib/redis_utils.py",
+            "ddtrace/contrib/trace_utils_redis.py",
             "ddtrace/ext/redis.py"
         ],
         "mongo": [


### PR DESCRIPTION
## Checklist
Adds back and deprecates old `tracer_utils_redis` module with public method and variables.

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
