### PR TITLE
chore(debugger): consolidate pii redaction keys for all libraries

### DIFF
--- a/ddtrace/debugging/_redaction.py
+++ b/ddtrace/debugging/_redaction.py
@@ -15,6 +15,7 @@ REDACTED_IDENTIFIERS = (
         {
             "2fa",
             "accesstoken",
+            "address",
             "aiohttpsession",
             "apikey",
             "apisecret",
@@ -30,6 +31,7 @@ REDACTED_IDENTIFIERS = (
             "clientid",
             "clientsecret",
             "config",
+            "connectionstring",
             "connectsid",
             "cookie",
             "credentials",
@@ -42,7 +44,9 @@ REDACTED_IDENTIFIERS = (
             "encryptionkey",
             "encryptionkeyid",
             "env",
+            "geolocation",
             "gpgkey",
+            "ipaddress",
             "jti",
             "jwt",
             "licensekey",
@@ -62,9 +66,6 @@ REDACTED_IDENTIFIERS = (
             "pin",
             "pincode",
             "pkcs8",
-            "plateno",
-            "platenum",
-            "platenumber",
             "privatekey",
             "publickey",
             "pwd",
@@ -98,7 +99,8 @@ REDACTED_IDENTIFIERS = (
             "xcsrftoken",
             "xforwardedfor",
             "xrealip",
-            "xsrftoken",
+            "xsrf",
+            "xsrftoken"
         }
     )
     | config.redacted_identifiers

--- a/ddtrace/debugging/_redaction.py
+++ b/ddtrace/debugging/_redaction.py
@@ -100,7 +100,7 @@ REDACTED_IDENTIFIERS = (
             "xforwardedfor",
             "xrealip",
             "xsrf",
-            "xsrftoken"
+            "xsrftoken",
         }
     )
     | config.redacted_identifiers

--- a/tests/debugging/exception/test_auto_instrument.py
+++ b/tests/debugging/exception/test_auto_instrument.py
@@ -109,7 +109,8 @@ class ExceptionDebuggingTestCase(TracerTestCase):
 
         with exception_debugging() as d:
             rate_limiter = RateLimiter(
-                limit_rate=1,  # one trace per second
+                limit_rate=0.1,  # one trace per second
+                tau=10,
                 raise_on_exceed=False,
             )
             with with_rate_limiter(rate_limiter):
@@ -155,7 +156,7 @@ class ExceptionDebuggingTestCase(TracerTestCase):
             exc_ids = set(span.get_tag("_dd.debug.error.exception_id") for span in self.spans)
             assert len(exc_ids) == number_of_exc_ids
 
-            # invoke again (should be in less then 1 sec)
+            # invoke again (should be in less than 1 sec)
             with with_rate_limiter(rate_limiter):
                 with pytest.raises(KeyError):
                     c()


### PR DESCRIPTION
## Checklist
Consolidate PII redaction keys for all libraries.

## Notes
Related PRs:
`dotnet` - https://github.com/DataDog/dd-trace-dotnet/pull/5522
`java` - https://github.com/DataDog/dd-trace-java/pull/6980

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
