### PR TITLE
ci: mark flaky test, verbose output on some suites

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -440,7 +440,7 @@ venv = Venv(
             env={
                 "DD_TRACE_AGENT_URL": "http://localhost:8126",
             },
-            command="pytest {cmdargs} tests/internal/",
+            command="pytest -v {cmdargs} tests/internal/",
             pkgs={
                 "httpretty": latest,
                 "gevent": latest,
@@ -1698,7 +1698,7 @@ venv = Venv(
         ),
         Venv(
             name="grpc",
-            command="python -m pytest {cmdargs} tests/contrib/grpc",
+            command="python -m pytest -v {cmdargs} tests/contrib/grpc",
             pkgs={
                 "googleapis-common-protos": latest,
                 "pytest-randomly": latest,

--- a/tests/contrib/celery/test_integration.py
+++ b/tests/contrib/celery/test_integration.py
@@ -704,6 +704,7 @@ class CeleryIntegrationTask(CeleryBaseTestCase):
         assert len(traces) == 2
         assert len(traces[0]) + len(traces[1]) == 3
 
+    @flaky(1720288420)
     def test_beat_scheduler_tracing(self):
         @self.app.task
         def fn_task():


### PR DESCRIPTION
This change adds verbose output to two suites to aid in catching unreliable tests like these:

https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/60831/workflows/1208499e-b0a0-4f81-a50d-ea38475a11dc/jobs/3816030
https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/60831/workflows/1208499e-b0a0-4f81-a50d-ea38475a11dc/jobs/3816040

It also marks an unreliable test in the `celery` suite.

https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/60798/workflows/7a11bd02-5a05-412e-9e07-c98dd0dd85ea/jobs/3813881

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
