### PR TITLE
fix(iast): unexpected Import error catching

### DIFF
--- a/ddtrace/appsec/_iast/_loader.py
+++ b/ddtrace/appsec/_iast/_loader.py
@@ -32,10 +32,7 @@ def _exec_iast_patched_module(module_watchdog, module):
 
     if compiled_code:
         # Patched source is executed instead of original module
-        try:
-            exec(compiled_code, module.__dict__)  # nosec B102
-        except ImportError:
-            log.debug("Unexpected exception while executing patched code", exc_info=True)
+        exec(compiled_code, module.__dict__)  # nosec B102
     elif module_watchdog.loader is not None:
         try:
             module_watchdog.loader.exec_module(module)

--- a/releasenotes/notes/iast-fix-iast-import-error-2eedea126bb9d92d.yaml
+++ b/releasenotes/notes/iast-fix-iast-import-error-2eedea126bb9d92d.yaml
@@ -1,6 +1,4 @@
 ---
 fixes:
   - |
-    Code Security (IAST): When loading a Python module, AST patching was catching the ImportError exception and not 
-    propagating it correctly, causing if one wanted to catch this exception, it couldn't be done, 
-    generating unexpected effects as in the BeautifulSoup4 package."
+    Code Security: This fixes a bug in the AST patching process where ``ImportError`` exceptions were being caught, interfering with the proper application cycle if an ``ImportError`` was expected."

--- a/releasenotes/notes/iast-fix-iast-import-error-2eedea126bb9d92d.yaml
+++ b/releasenotes/notes/iast-fix-iast-import-error-2eedea126bb9d92d.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Code Security (IAST): When loading a Python module, AST patching was catching the ImportError exception and not 
+    propagating it correctly, causing if one wanted to catch this exception, it couldn't be done, 
+    generating unexpected effects as in the BeautifulSoup4 package."

--- a/tests/appsec/app.py
+++ b/tests/appsec/app.py
@@ -17,6 +17,7 @@ from tests.appsec.iast_packages.packages.pkg_python_dateutil import pkg_python_d
 from tests.appsec.iast_packages.packages.pkg_pyyaml import pkg_pyyaml
 from tests.appsec.iast_packages.packages.pkg_requests import pkg_requests
 from tests.appsec.iast_packages.packages.pkg_urllib3 import pkg_urllib3
+import tests.appsec.integrations.module_with_import_errors as module_with_import_errors
 
 
 app = Flask(__name__)
@@ -57,6 +58,11 @@ def iast_cmdi_vulnerability():
     resp = Response("OK")
     resp.set_cookie("insecure", "cookie", secure=True, httponly=True, samesite="None")
     return resp
+
+
+@app.route("/iast-ast-patching-import-error", methods=["GET"])
+def iast_ast_patching_import_error():
+    return Response(str(module_with_import_errors.verbal_kint_is_keyser_soze))
 
 
 if __name__ == "__main__":

--- a/tests/appsec/app.py
+++ b/tests/appsec/app.py
@@ -9,6 +9,7 @@ from flask import request
 
 
 import ddtrace.auto  # noqa: F401  # isort: skip
+from tests.appsec.iast_packages.packages.pkg_beautifulsoup4 import pkg_beautifulsoup4
 from tests.appsec.iast_packages.packages.pkg_chartset_normalizer import pkg_chartset_normalizer
 from tests.appsec.iast_packages.packages.pkg_google_api_core import pkg_google_api_core
 from tests.appsec.iast_packages.packages.pkg_idna import pkg_idna
@@ -21,6 +22,7 @@ import tests.appsec.integrations.module_with_import_errors as module_with_import
 
 
 app = Flask(__name__)
+app.register_blueprint(pkg_beautifulsoup4)
 app.register_blueprint(pkg_chartset_normalizer)
 app.register_blueprint(pkg_google_api_core)
 app.register_blueprint(pkg_idna)

--- a/tests/appsec/iast_packages/packages/pkg_beautifulsoup4.py
+++ b/tests/appsec/iast_packages/packages/pkg_beautifulsoup4.py
@@ -1,0 +1,26 @@
+"""
+beautifulsoup4==4.12.3
+
+https://pypi.org/project/beautifulsoup4/
+"""
+from flask import Blueprint
+from flask import request
+
+from .utils import ResultResponse
+
+
+pkg_beautifulsoup4 = Blueprint("package_beautifulsoup4", __name__)
+
+
+@pkg_beautifulsoup4.route("/beautifulsoup4")
+def pkg_beautifusoup4_view():
+    from bs4 import BeautifulSoup
+
+    response = ResultResponse(request.args.get("package_param"))
+
+    try:
+        html = response.package_param
+        "".join(BeautifulSoup(html, features="lxml").findAll(string=True)).lstrip()
+    except Exception:
+        pass
+    return response.json()

--- a/tests/appsec/iast_packages/test_packages.py
+++ b/tests/appsec/iast_packages/test_packages.py
@@ -87,6 +87,7 @@ PACKAGES = [
         ["https", None, "www.datadoghq.com", None, "/", None, None],
         "www.datadoghq.com",
     ),
+    PackageForTesting("beautifulsoup4", "4.12.3", "<html></html>", "", ""),
 ]
 
 

--- a/tests/appsec/integrations/module_with_import_errors.py
+++ b/tests/appsec/integrations/module_with_import_errors.py
@@ -1,0 +1,11 @@
+try:
+    from . import _keyser_soze  # noqa: F401
+
+    verbal_kint_is_keyser_soze = True
+except ImportError:
+    verbal_kint_is_keyser_soze = False
+
+
+def func():
+    VARIABLE_TO_FORCE_AST_PATCHINT = "a" + "b"
+    return VARIABLE_TO_FORCE_AST_PATCHINT

--- a/tests/appsec/integrations/test_flask_iast_patching.py
+++ b/tests/appsec/integrations/test_flask_iast_patching.py
@@ -1,0 +1,22 @@
+from tests.appsec.appsec_utils import flask_server
+
+
+def test_flask_iast_ast_patching_import_error():
+    """this is a regression test for a bug with IAST + BeautifulSoup4, we were catching the ImportError exception in
+    ddtrace.appsec._iast._loader
+    try:
+        from . import _html5lib
+        register_treebuilders_from(_html5lib)
+    except ImportError:
+        # They don't have html5lib installed.
+        pass
+    """
+    with flask_server(
+        app="/home/alberto.vara/projects/dd-python/dd-trace-py/tests/appsec/app.py", iast_enabled="true", token=None
+    ) as context:
+        _, flask_client, pid = context
+
+        response = flask_client.get("/iast-ast-patching-import-error")
+
+        assert response.status_code == 200
+        assert response.content == b"False"

--- a/tests/appsec/integrations/test_flask_iast_patching.py
+++ b/tests/appsec/integrations/test_flask_iast_patching.py
@@ -11,9 +11,7 @@ def test_flask_iast_ast_patching_import_error():
         # They don't have html5lib installed.
         pass
     """
-    with flask_server(
-        app="/home/alberto.vara/projects/dd-python/dd-trace-py/tests/appsec/app.py", iast_enabled="true", token=None
-    ) as context:
+    with flask_server(iast_enabled="true", token=None) as context:
         _, flask_client, pid = context
 
         response = flask_client.get("/iast-ast-patching-import-error")


### PR DESCRIPTION
When loading a Python module, AST patching was catching the ImportError exception and not propagating it correctly, causing if one wanted to catch this exception, it couldn't be done, generating unexpected effects as in the BeautifulSoup4 package. In Example:

```python
try:
    from . import _html5lib
    register_treebuilders_from(_html5lib)
except ImportError:
    # They don't have html5lib installed.
    pass
```

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)