### PR TITLE
fix(asm): ep cmdi patch error

### DIFF
--- a/ddtrace/appsec/_iast/taint_sinks/command_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/command_injection.py
@@ -24,6 +24,9 @@ def get_version() -> str:
 
 
 def patch():
+    if asm_config._ep_enabled:
+        core.dispatch("exploit.prevention.ssrf.patch.urllib")
+
     if not asm_config._iast_enabled:
         return
 
@@ -38,9 +41,6 @@ def patch():
 
         os._datadog_cmdi_patch = True
         subprocess._datadog_cmdi_patch = True
-
-    if asm_config._ep_enabled:
-        core.dispatch("exploit.prevention.ssrf.patch.urllib")
 
 
 def unpatch() -> None:


### PR DESCRIPTION
fix potential error on Exploit Prevention that EP for CMDi won't work if IAST_ENABLED is False

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
