### PR TITLE
chore(internal): add ``time_window`` parameter to rate limiter

### DIFF
--- a/tests/tracer/test_rate_limiter.py
+++ b/tests/tracer/test_rate_limiter.py
@@ -9,46 +9,50 @@ from ddtrace.internal.rate_limiter import RateLimiter
 from ddtrace.internal.rate_limiter import RateLimitExceeded
 
 
-def nanoseconds(x):
-    # Helper to iterate over x seconds in nanosecond steps
-    return range(0, int(1e9 * x), int(1e9))
+def nanoseconds(x, time_window):
+    # Helper to iterate over x time windows in nanosecond steps
+    return range(0, int(time_window * x), int(time_window))
 
 
-def test_rate_limiter_init():
-    limiter = RateLimiter(rate_limit=100)
+@pytest.mark.parametrize("time_window", [1e3, 1e6, 1e9])
+def test_rate_limiter_init(time_window):
+    limiter = RateLimiter(rate_limit=100, time_window=time_window)
     assert limiter.rate_limit == 100
     assert limiter.tokens == 100
     assert limiter.max_tokens == 100
     assert limiter.last_update_ns <= compat.monotonic_ns()
 
 
-def test_rate_limiter_rate_limit_0():
-    limiter = RateLimiter(rate_limit=0)
+@pytest.mark.parametrize("time_window", [1e3, 1e6, 1e9])
+def test_rate_limiter_rate_limit_0(time_window):
+    limiter = RateLimiter(rate_limit=0, time_window=time_window)
     assert limiter.rate_limit == 0
     assert limiter.tokens == 0
     assert limiter.max_tokens == 0
 
     now_ns = compat.monotonic_ns()
-    for i in nanoseconds(10000):
+    for i in nanoseconds(10000, time_window):
         # Make sure the time is different for every check
         assert limiter.is_allowed(now_ns + i) is False
 
 
-def test_rate_limiter_rate_limit_negative():
-    limiter = RateLimiter(rate_limit=-1)
+@pytest.mark.parametrize("time_window", [1e3, 1e6, 1e9])
+def test_rate_limiter_rate_limit_negative(time_window):
+    limiter = RateLimiter(rate_limit=-1, time_window=time_window)
     assert limiter.rate_limit == -1
     assert limiter.tokens == -1
     assert limiter.max_tokens == -1
 
     now_ns = compat.monotonic_ns()
-    for i in nanoseconds(10000):
+    for i in nanoseconds(10000, time_window):
         # Make sure the time is different for every check
         assert limiter.is_allowed(now_ns + i) is True
 
 
 @pytest.mark.parametrize("rate_limit", [1, 10, 50, 100, 500, 1000])
-def test_rate_limiter_is_allowed(rate_limit):
-    limiter = RateLimiter(rate_limit=rate_limit)
+@pytest.mark.parametrize("time_window", [1e3, 1e6, 1e9])
+def test_rate_limiter_is_allowed(rate_limit, time_window):
+    limiter = RateLimiter(rate_limit=rate_limit, time_window=time_window)
 
     def check_limit(time_ns):
         # Up to the allowed limit is allowed
@@ -63,13 +67,14 @@ def test_rate_limiter_is_allowed(rate_limit):
     now = compat.monotonic_ns()
 
     # Check the limit for 5 time frames
-    for i in nanoseconds(5):
+    for i in nanoseconds(5, time_window):
         # Keep the same timeframe
         check_limit(now + i)
 
 
-def test_rate_limiter_is_allowed_large_gap():
-    limiter = RateLimiter(rate_limit=100)
+@pytest.mark.parametrize("time_window", [1e3, 1e6, 1e9])
+def test_rate_limiter_is_allowed_large_gap(time_window):
+    limiter = RateLimiter(rate_limit=100, time_window=time_window)
 
     # Start time
     now_ns = compat.monotonic_ns()
@@ -79,25 +84,27 @@ def test_rate_limiter_is_allowed_large_gap():
 
     # Large gap before next call to `is_allowed()`
     for _ in range(100):
-        assert limiter.is_allowed(now_ns + (1e9 * 100)) is True
+        assert limiter.is_allowed(now_ns + (time_window * 100)) is True
 
 
-def test_rate_limiter_is_allowed_small_gaps():
-    limiter = RateLimiter(rate_limit=100)
+@pytest.mark.parametrize("time_window", [1e3, 1e6, 1e9])
+def test_rate_limiter_is_allowed_small_gaps(time_window):
+    limiter = RateLimiter(rate_limit=100, time_window=time_window)
 
     # Start time
     now_ns = compat.monotonic_ns()
     gap = 1e9 / 100
     # Keep incrementing by a gap to keep us at our rate limit
-    for i in nanoseconds(10000):
+    for i in nanoseconds(10000, time_window):
         # Keep the same timeframe
         time_ns = now_ns + (gap * i)
 
         assert limiter.is_allowed(time_ns) is True
 
 
-def test_rate_liimter_effective_rate_rates():
-    limiter = RateLimiter(rate_limit=100)
+@pytest.mark.parametrize("time_window", [1e3, 1e6, 1e9])
+def test_rate_liimter_effective_rate_rates(time_window):
+    limiter = RateLimiter(rate_limit=100, time_window=time_window)
 
     # Static rate limit window
     starting_window_ns = compat.monotonic_ns()
@@ -113,7 +120,7 @@ def test_rate_liimter_effective_rate_rates():
         assert limiter.current_window_ns == starting_window_ns
 
     prev_rate = 0.5
-    window_ns = starting_window_ns + 1e9
+    window_ns = starting_window_ns + time_window
 
     for _ in range(100):
         assert limiter.is_allowed(window_ns) is True
@@ -127,8 +134,9 @@ def test_rate_liimter_effective_rate_rates():
         assert limiter.current_window_ns == window_ns
 
 
-def test_rate_limiter_effective_rate_starting_rate():
-    limiter = RateLimiter(rate_limit=1)
+@pytest.mark.parametrize("time_window", [1e3, 1e6, 1e9])
+def test_rate_limiter_effective_rate_starting_rate(time_window):
+    limiter = RateLimiter(rate_limit=1, time_window=time_window)
 
     now_ns = compat.monotonic_ns()
 
@@ -148,7 +156,7 @@ def test_rate_limiter_effective_rate_starting_rate():
     assert limiter.prev_window_rate is None
 
     # Gap of 0.9999 seconds, same window
-    time_ns = now_ns + (0.9999 * 1e9)
+    time_ns = now_ns + (0.9999 * time_window)
     assert limiter.is_allowed(time_ns) is False
     # DEV: We have rate_limit=1 set
     assert limiter.effective_rate == 0.5
@@ -156,24 +164,24 @@ def test_rate_limiter_effective_rate_starting_rate():
     assert limiter.prev_window_rate is None
 
     # Gap of 1.0 seconds, new window
-    time_ns = now_ns + 1e9
+    time_ns = now_ns + time_window
     assert limiter.is_allowed(time_ns) is True
     assert limiter.effective_rate == 0.75
-    assert limiter.current_window_ns == (now_ns + 1e9)
+    assert limiter.current_window_ns == (now_ns + time_window)
     assert limiter.prev_window_rate == 0.5
 
     # Gap of 1.9999 seconds, same window
-    time_ns = now_ns + (1.9999 * 1e9)
+    time_ns = now_ns + (1.9999 * time_window)
     assert limiter.is_allowed(time_ns) is False
     assert limiter.effective_rate == 0.5
-    assert limiter.current_window_ns == (now_ns + 1e9)  # Same as old window
+    assert limiter.current_window_ns == (now_ns + time_window)  # Same as old window
     assert limiter.prev_window_rate == 0.5
 
     # Large gap of 100 seconds, new window
-    time_ns = now_ns + (100.0 * 1e9)
+    time_ns = now_ns + (100.0 * time_window)
     assert limiter.is_allowed(time_ns) is True
     assert limiter.effective_rate == 0.75
-    assert limiter.current_window_ns == (now_ns + (100.0 * 1e9))
+    assert limiter.current_window_ns == (now_ns + (100.0 * time_window))
     assert limiter.prev_window_rate == 0.5
 
 


### PR DESCRIPTION
## Description
This pull request introduces a new feature to the rate limiter module by adding a time_window parameter. The end goal is to make the rate limiter configurable, allowing for rate limiting at different time periods such as 1 minute, 1 hour, or the default of 1 second.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
