### PR TITLE
fix(iast): improve header injection patching

### DIFF
--- a/ddtrace/appsec/_iast/taint_sinks/header_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/header_injection.py
@@ -1,5 +1,7 @@
+from ddtrace.contrib import trace_utils
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
+from ddtrace.vendor.wrapt.importer import when_imported
 
 from ..._common_module_patches import try_unwrap
 from ..._constants import IAST_SPAN_TAGS
@@ -8,7 +10,6 @@ from .._metrics import _set_metric_iast_instrumented_sink
 from .._metrics import increment_iast_span_metric
 from .._patch import set_and_check_module_is_patched
 from .._patch import set_module_unpatched
-from .._patch import try_wrap_function_wrapper
 from ..constants import HEADER_NAME_VALUE_SEPARATOR
 from ..constants import VULN_HEADER_INJECTION
 from ..processor import AppSecIastSpanProcessor
@@ -32,40 +33,23 @@ def patch():
     if not set_and_check_module_is_patched("django", default_attr="_datadog_header_injection_patch"):
         return
 
-    try_wrap_function_wrapper(
-        "wsgiref.headers",
-        "Headers.add_header",
-        _iast_h,
-    )
-    try_wrap_function_wrapper(
-        "wsgiref.headers",
-        "Headers.__setitem__",
-        _iast_h,
-    )
-    try_wrap_function_wrapper(
-        "werkzeug.datastructures",
-        "Headers.set",
-        _iast_h,
-    )
-    try_wrap_function_wrapper(
-        "werkzeug.datastructures",
-        "Headers.add",
-        _iast_h,
-    )
+    @when_imported("wsgiref.headers")
+    def _(m):
+        trace_utils.wrap(m, "Headers.add_header", _iast_h)
+        trace_utils.wrap(m, "Headers.__setitem__", _iast_h)
 
-    # Django
-    try_wrap_function_wrapper(
-        "django.http.response",
-        "HttpResponseBase.__setitem__",
-        _iast_h,
-    )
-    try_wrap_function_wrapper(
-        "django.http.response",
-        "ResponseHeaders.__setitem__",
-        _iast_h,
-    )
+    @when_imported("werkzeug.datastructures")
+    def _(m):
+        trace_utils.wrap(m, "Headers.add", _iast_h)
+        trace_utils.wrap(m, "Headers.set", _iast_h)
 
-    _set_metric_iast_instrumented_sink(VULN_HEADER_INJECTION, 1)
+    @when_imported("django.http.response")
+    def _(m):
+        trace_utils.wrap(m, "HttpResponse.__setitem__", _iast_h)
+        trace_utils.wrap(m, "ResponseHeaders.__setitem__", _iast_h)
+        trace_utils.wrap(m, "HttpResponseBase.__setitem__", _iast_h)
+
+    _set_metric_iast_instrumented_sink(VULN_HEADER_INJECTION)
 
 
 def unpatch():


### PR DESCRIPTION
In some cases, django patching doesn't work for header injection due to a circular import: https://github.com/DataDog/system-tests/pull/2437

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
