### PR TITLE
chore: more robust telemetry tests, immune to some internal sink points side effects

### DIFF
--- a/tests/appsec/iast/test_telemetry.py
+++ b/tests/appsec/iast/test_telemetry.py
@@ -65,10 +65,7 @@ def test_metric_executed_sink(no_request_sampling, telemetry_writer):
         metrics_result = telemetry_writer._namespace._metrics_data
 
     generate_metrics = metrics_result[TELEMETRY_TYPE_GENERATE_METRICS][TELEMETRY_NAMESPACE_TAG_IAST]
-    assert len(generate_metrics) == 1, "Expected 1 generate_metrics"
-    assert [metric.name for metric in generate_metrics.values()] == [
-        "executed.sink",
-    ]
+    assert [metric._tags for metric in generate_metrics.values()] == [(('vulnerability_type', 'WEAK_HASH'),)]
     assert span.get_metric("_dd.iast.telemetry.executed.sink.weak_hash") > 0
     # request.tainted metric is None because AST is not running in this test
     assert span.get_metric(IAST_SPAN_TAGS.TELEMETRY_REQUEST_TAINTED) is None
@@ -82,8 +79,10 @@ def test_metric_instrumented_propagation(no_request_sampling, telemetry_writer):
 
     metrics_result = telemetry_writer._namespace._metrics_data
     generate_metrics = metrics_result[TELEMETRY_TYPE_GENERATE_METRICS][TELEMETRY_NAMESPACE_TAG_IAST]
-    assert [metric.name for metric in generate_metrics.values()] == ["instrumented.propagation"]
-    assert len(generate_metrics) == 1, "Expected 1 generate_metrics"
+    # Remove potential sinks from internal usage of the lib (like http.client, used to communicate with
+    # the agent)
+    filtered_metrics = [metric.name for metric in generate_metrics.values() if metric.name != "executed.sink"]
+    assert filtered_metrics == ["instrumented.propagation"]
 
 
 def test_metric_request_tainted(no_request_sampling, telemetry_writer):
@@ -103,8 +102,11 @@ def test_metric_request_tainted(no_request_sampling, telemetry_writer):
     metrics_result = telemetry_writer._namespace._metrics_data
 
     generate_metrics = metrics_result[TELEMETRY_TYPE_GENERATE_METRICS][TELEMETRY_NAMESPACE_TAG_IAST]
-    assert [metric.name for metric in generate_metrics.values()] == ["executed.source", "request.tainted"]
-    assert len(generate_metrics) == 2, "Expected 2 generate_metrics"
+    # Remove potential sinks from internal usage of the lib (like http.client, used to communicate with
+    # the agent)
+    filtered_metrics = [metric.name for metric in generate_metrics.values() if metric.name != "executed.sink"]
+    assert filtered_metrics == ["executed.source", "request.tainted"]
+    assert len(filtered_metrics) == 2, "Expected 2 generate_metrics"
     assert span.get_metric(IAST_SPAN_TAGS.TELEMETRY_REQUEST_TAINTED) > 0
 
 

--- a/tests/appsec/iast/test_telemetry.py
+++ b/tests/appsec/iast/test_telemetry.py
@@ -65,7 +65,7 @@ def test_metric_executed_sink(no_request_sampling, telemetry_writer):
         metrics_result = telemetry_writer._namespace._metrics_data
 
     generate_metrics = metrics_result[TELEMETRY_TYPE_GENERATE_METRICS][TELEMETRY_NAMESPACE_TAG_IAST]
-    assert [metric._tags for metric in generate_metrics.values()] == [(('vulnerability_type', 'WEAK_HASH'),)]
+    assert [metric._tags for metric in generate_metrics.values()] == [(("vulnerability_type", "WEAK_HASH"),)]
     assert span.get_metric("_dd.iast.telemetry.executed.sink.weak_hash") > 0
     # request.tainted metric is None because AST is not running in this test
     assert span.get_metric(IAST_SPAN_TAGS.TELEMETRY_REQUEST_TAINTED) is None

--- a/tests/appsec/iast/test_telemetry.py
+++ b/tests/appsec/iast/test_telemetry.py
@@ -67,7 +67,9 @@ def test_metric_executed_sink(no_request_sampling, telemetry_writer):
     generate_metrics = metrics_result[TELEMETRY_TYPE_GENERATE_METRICS][TELEMETRY_NAMESPACE_TAG_IAST].values()
     # Remove potential sinks from internal usage of the lib (like http.client, used to communicate with
     # the agent)
-    filtered_metrics = [metric for metric in generate_metrics if metric._tags[0] != (("vulnerability_type", "WEAK_HASH"),)]
+    filtered_metrics = [
+        metric for metric in generate_metrics if metric._tags[0] != (("vulnerability_type", "WEAK_HASH"),)
+    ]
     assert [metric._tags for metric in filtered_metrics] == [(("vulnerability_type", "WEAK_HASH"),)]
     assert span.get_metric("_dd.iast.telemetry.executed.sink.weak_hash") > 0
     # request.tainted metric is None because AST is not running in this test

--- a/tests/appsec/iast/test_telemetry.py
+++ b/tests/appsec/iast/test_telemetry.py
@@ -65,11 +65,10 @@ def test_metric_executed_sink(no_request_sampling, telemetry_writer):
         metrics_result = telemetry_writer._namespace._metrics_data
 
     generate_metrics = metrics_result[TELEMETRY_TYPE_GENERATE_METRICS][TELEMETRY_NAMESPACE_TAG_IAST].values()
+    assert len(generate_metrics) >= 1
     # Remove potential sinks from internal usage of the lib (like http.client, used to communicate with
     # the agent)
-    filtered_metrics = [
-        metric for metric in generate_metrics if metric._tags[0] != (("vulnerability_type", "WEAK_HASH"),)
-    ]
+    filtered_metrics = [metric for metric in generate_metrics if metric._tags[0] == ("vulnerability_type", "WEAK_HASH")]
     assert [metric._tags for metric in filtered_metrics] == [(("vulnerability_type", "WEAK_HASH"),)]
     assert span.get_metric("_dd.iast.telemetry.executed.sink.weak_hash") > 0
     # request.tainted metric is None because AST is not running in this test

--- a/tests/appsec/iast/test_telemetry.py
+++ b/tests/appsec/iast/test_telemetry.py
@@ -64,8 +64,11 @@ def test_metric_executed_sink(no_request_sampling, telemetry_writer):
 
         metrics_result = telemetry_writer._namespace._metrics_data
 
-    generate_metrics = metrics_result[TELEMETRY_TYPE_GENERATE_METRICS][TELEMETRY_NAMESPACE_TAG_IAST]
-    assert [metric._tags for metric in generate_metrics.values()] == [(("vulnerability_type", "WEAK_HASH"),)]
+    generate_metrics = metrics_result[TELEMETRY_TYPE_GENERATE_METRICS][TELEMETRY_NAMESPACE_TAG_IAST].values()
+    # Remove potential sinks from internal usage of the lib (like http.client, used to communicate with
+    # the agent)
+    filtered_metrics = [metric for metric in generate_metrics if metric._tags[0] != (("vulnerability_type", "WEAK_HASH"),)]
+    assert [metric._tags for metric in filtered_metrics] == [(("vulnerability_type", "WEAK_HASH"),)]
     assert span.get_metric("_dd.iast.telemetry.executed.sink.weak_hash") > 0
     # request.tainted metric is None because AST is not running in this test
     assert span.get_metric(IAST_SPAN_TAGS.TELEMETRY_REQUEST_TAINTED) is None


### PR DESCRIPTION
## Description

Some sink points that are very commonly called, like `http.client` could be internally while executing telemetry test. This makes these tests check only the required sinks or vulnerabilities.

This should remove flakyness from those tests.

## Checklist

- [X] Change(s) are motivated and described in the PR description
- [X] Testing strategy is described if automated tests are not included in the PR
- [X] Risks are described (performance impact, potential for breakage, maintainability)
- [X] Change is maintainable (easy to change, telemetry, documentation)
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [X] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
