### PR TITLE
revert(distributed_tracing): ensure last datadog parent id tag is always set

### DIFF
--- a/ddtrace/internal/constants.py
+++ b/ddtrace/internal/constants.py
@@ -25,7 +25,6 @@ W3C_TRACESTATE_SAMPLING_PRIORITY_KEY = "s"
 DEFAULT_SAMPLING_RATE_LIMIT = 100
 SAMPLING_DECISION_TRACE_TAG_KEY = "_dd.p.dm"
 LAST_DD_PARENT_ID_KEY = "_dd.parent_id"
-DEFAULT_LAST_PARENT_ID = "0000000000000000"
 DEFAULT_SERVICE_NAME = "unnamed-python-service"
 # Used to set the name of an integration on a span
 COMPONENT = "component"

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -38,7 +38,6 @@ from ..internal._tagset import encode_tagset_values
 from ..internal.compat import ensure_text
 from ..internal.constants import _PROPAGATION_STYLE_NONE
 from ..internal.constants import _PROPAGATION_STYLE_W3C_TRACECONTEXT
-from ..internal.constants import DEFAULT_LAST_PARENT_ID
 from ..internal.constants import HIGHER_ORDER_TRACE_ID_BITS as _HIGHER_ORDER_TRACE_ID_BITS
 from ..internal.constants import LAST_DD_PARENT_ID_KEY
 from ..internal.constants import MAX_UINT_64BITS as _MAX_UINT_64BITS
@@ -701,7 +700,7 @@ class _TraceContext:
 
     @staticmethod
     def _get_tracestate_values(ts_l):
-        # type: (List[str]) -> Tuple[Optional[int], Dict[str, str], Optional[str], str]
+        # type: (List[str]) -> Tuple[Optional[int], Dict[str, str], Optional[str], Optional[str]]
 
         # tracestate list parsing example: ["dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64","congo=t61rcWkgMzE"]
         # -> 2, {"_dd.p.dm":"-4","_dd.p.usr.id":"baz64"}, "rum"
@@ -728,7 +727,7 @@ class _TraceContext:
                 origin = _TraceContext.decode_tag_val(origin)
 
             # Get last datadog parent id, this field is used to reconnect traces with missing spans
-            lpid = dd.get("p", DEFAULT_LAST_PARENT_ID)
+            lpid = dd.get("p", "0000000000000000")
 
             # need to convert from t. to _dd.p.
             other_propagated_tags = {
@@ -737,7 +736,7 @@ class _TraceContext:
 
             return sampling_priority_ts_int, other_propagated_tags, origin, lpid
         else:
-            return None, {}, None, DEFAULT_LAST_PARENT_ID
+            return None, {}, None, None
 
     @staticmethod
     def _get_sampling_priority(
@@ -821,7 +820,8 @@ class _TraceContext:
                 if tracestate_values:
                     sampling_priority_ts, other_propagated_tags, origin, lpid = tracestate_values
                     meta.update(other_propagated_tags.items())
-                    meta[LAST_DD_PARENT_ID_KEY] = lpid
+                    if lpid:
+                        meta[LAST_DD_PARENT_ID_KEY] = lpid
 
                     sampling_priority = _TraceContext._get_sampling_priority(trace_flag, sampling_priority_ts, origin)
                 else:
@@ -921,10 +921,6 @@ class HTTPPropagator(object):
                 ts = _extract_header_value(_POSSIBLE_HTTP_HEADER_TRACESTATE, normalized_headers)
                 if ts:
                     primary_context._meta[W3C_TRACESTATE_KEY] = ts
-                # Ensure the last datadog parent id is always set on the primary context
-                primary_context._meta[LAST_DD_PARENT_ID_KEY] = context._meta.get(
-                    LAST_DD_PARENT_ID_KEY, DEFAULT_LAST_PARENT_ID
-                )
         primary_context._span_links = links
         return primary_context
 

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -692,7 +692,7 @@ TRACECONTEXT_HEADERS_VALID = {
 
 TRACECONTEXT_HEADERS_VALID_64_bit = {
     _HTTP_HEADER_TRACEPARENT: "00-000000000000000064fe8b2a57d3eff7-00f067aa0ba902b7-01",
-    _HTTP_HEADER_TRACESTATE: "dd=s:2;o:rum;p:00f067aa0ba902b7;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE",
+    _HTTP_HEADER_TRACESTATE: "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE",
 }
 
 
@@ -937,7 +937,7 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
         (
             "congo=t61rcWkgMzE,mako=s:2;o:rum;",
             # sampling_priority_ts, other_propagated_tags, origin, parent id
-            (None, {}, None, "0000000000000000"),
+            (None, {}, None, None),
             None,
             None,
         ),
@@ -1754,11 +1754,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
-            "meta": {
-                "tracestate": DATADOG_TRACECONTEXT_MATCHING_TRACE_ID_HEADERS[_HTTP_HEADER_TRACESTATE],
-                "_dd.p.dm": "-3",
-                LAST_DD_PARENT_ID_KEY: "00f067aa0ba902b7",
-            },
+            "meta": {"tracestate": TRACECONTEXT_HEADERS_VALID[_HTTP_HEADER_TRACESTATE], "_dd.p.dm": "-3"},
         },
     ),
     # testing that tracestate is not added when tracecontext style comes later and does not match first style's trace-id
@@ -2006,11 +2002,11 @@ FULL_CONTEXT_EXTRACT_FIXTURES = [
             span_id=67667974448284343,
             meta={
                 "traceparent": "00-000000000000000064fe8b2a57d3eff7-00f067aa0ba902b7-01",
-                "tracestate": ALL_HEADERS_CHAOTIC_2[_HTTP_HEADER_TRACESTATE],
+                "tracestate": TRACECONTEXT_HEADERS_VALID[_HTTP_HEADER_TRACESTATE],
                 "_dd.p.dm": "-4",
                 "_dd.p.usr.id": "baz64",
                 "_dd.origin": "rum",
-                LAST_DD_PARENT_ID_KEY: "00f067aa0ba902b7",
+                LAST_DD_PARENT_ID_KEY: "0000000000000000",
             },
             metrics={"_sampling_priority_v1": 2},
             span_links=[
@@ -2121,8 +2117,7 @@ FULL_CONTEXT_EXTRACT_FIXTURES = [
             meta={
                 "_dd.p.dm": "-3",
                 "_dd.origin": "synthetics",
-                "tracestate": ALL_HEADERS_CHAOTIC_1[_HTTP_HEADER_TRACESTATE],
-                LAST_DD_PARENT_ID_KEY: "00f067aa0ba902b7",
+                "tracestate": "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE",
             },
             metrics={"_sampling_priority_v1": 1},
             span_links=[


### PR DESCRIPTION
This reverts commit 22302147a2ac3baa03727c73085fd6575fba60e9.

W3C-Datadog header specification has significant gaps and needs to be revised. This change is unreleased so a release note is not required.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
