### PR TITLE
chore(ci): convert serverless slow import test to a subprocess test

### DIFF
--- a/tests/internal/test_serverless.py
+++ b/tests/internal/test_serverless.py
@@ -1,6 +1,5 @@
-import sys
-
 import mock
+import pytest
 
 from ddtrace.internal.serverless import in_azure_function_consumption_plan
 from ddtrace.internal.serverless import in_gcp_function
@@ -90,10 +89,22 @@ def test_not_azure_function_consumption_plan_wrong_sku():
         assert in_azure_function_consumption_plan() is False
 
 
-def test_slow_imports(monkeypatch):
+# DEV: Run this test in a subprocess to avoid messing with global sys.modules state
+@pytest.mark.subprocess()
+def test_slow_imports():
     # We should lazy load certain modules to avoid slowing down the startup
     # time when running in a serverless environment.  This test will fail if
     # any of those modules are imported during the import of ddtrace.
+    import os
+    import sys
+
+    os.environ.update(
+        {
+            "AWS_LAMBDA_FUNCTION_NAME": "foobar",
+            "DD_INSTRUMENTATION_TELEMETRY_ENABLED": "False",
+            "DD_API_SECURITY_ENABLED": "False",
+        }
+    )
 
     blocklist = [
         "ddtrace.appsec._api_security.api_manager",
@@ -106,9 +117,6 @@ def test_slow_imports(monkeypatch):
         "importlib.metadata",
         "importlib_metadata",
     ]
-    monkeypatch.setenv("DD_INSTRUMENTATION_TELEMETRY_ENABLED", False)
-    monkeypatch.setenv("DD_API_SECURITY_ENABLED", False)
-    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "foobar")
 
     class BlockListFinder:
         def find_spec(self, fullname, *args):
@@ -117,20 +125,8 @@ def test_slow_imports(monkeypatch):
                     raise ImportError(f"module {fullname} was imported!")
             return None
 
-    meta_path = [BlockListFinder()]
-    meta_path.extend(sys.meta_path)
+    sys.meta_path.insert(0, BlockListFinder())
 
-    deleted_modules = {}
-
-    for mod in sys.modules.copy():
-        if mod.startswith("ddtrace") or mod in blocklist:
-            deleted_modules[mod] = sys.modules[mod]
-            del sys.modules[mod]
-
-    with mock.patch("sys.meta_path", meta_path):
-        import ddtrace
-        import ddtrace.contrib.aws_lambda  # noqa:F401
-        import ddtrace.contrib.psycopg  # noqa:F401
-
-    for name, mod in deleted_modules.items():
-        sys.modules[name] = mod
+    import ddtrace
+    import ddtrace.contrib.aws_lambda  # noqa:F401
+    import ddtrace.contrib.psycopg  # noqa:F401


### PR DESCRIPTION
This test was messing with the global state of `sys.modules`. It was causing some modules to get unloaded causing them to get re-imported, which would cause issues.

Moving this test to a subprocess test will help isolate the behavior it is trying to test, and simplifies the test setup.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
