### PR TITLE
chore(iast): sqli and ssrf instrumented sink metric

### DIFF
--- a/ddtrace/contrib/mysql/patch.py
+++ b/ddtrace/contrib/mysql/patch.py
@@ -4,7 +4,10 @@ import mysql.connector
 
 from ddtrace import Pin
 from ddtrace import config
+from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
+from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.contrib.dbapi import TracedConnection
+from ddtrace.settings.asm import config as asm_config
 from ddtrace.vendor import wrapt
 
 from ...ext import db
@@ -46,6 +49,9 @@ def patch():
     # `Connect` is an alias for `connect`, patch it too
     if hasattr(mysql.connector, "Connect"):
         mysql.connector.Connect = mysql.connector.connect
+
+    if asm_config._iast_enabled:
+        _set_metric_iast_instrumented_sink(VULN_SQL_INJECTION)
 
 
 def unpatch():

--- a/ddtrace/contrib/mysqldb/patch.py
+++ b/ddtrace/contrib/mysqldb/patch.py
@@ -4,12 +4,15 @@ import MySQLdb
 
 from ddtrace import Pin
 from ddtrace import config
+from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
+from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.constants import SPAN_KIND
 from ddtrace.constants import SPAN_MEASURED_KEY
 from ddtrace.contrib.dbapi import TracedConnection
 from ddtrace.contrib.trace_utils import ext_service
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_database_operation
+from ddtrace.settings.asm import config as asm_config
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from ...ext import SpanKind
@@ -62,6 +65,9 @@ def patch():
         _w("MySQLdb", "Connection", _connect)
     if hasattr(MySQLdb, "connect"):
         _w("MySQLdb", "connect", _connect)
+
+    if asm_config._iast_enabled:
+        _set_metric_iast_instrumented_sink(VULN_SQL_INJECTION)
 
 
 def unpatch():

--- a/ddtrace/contrib/requests/patch.py
+++ b/ddtrace/contrib/requests/patch.py
@@ -4,6 +4,9 @@ import requests
 
 from ddtrace import config
 from ddtrace.appsec._common_module_patches import wrapped_request_D8CB81E472AF98A2 as _wrap_request
+from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
+from ddtrace.appsec._iast.constants import VULN_SSRF
+from ddtrace.settings.asm import config as asm_config
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from ...internal.schema import schematize_service_name
@@ -40,6 +43,9 @@ def patch():
     # IAST needs to wrap this function because `Session.send` is too late
     _w("requests", "Session.request", _wrap_request)
     Pin(_config=config.requests).onto(requests.Session)
+
+    if asm_config._iast_enabled:
+        _set_metric_iast_instrumented_sink(VULN_SSRF)
 
 
 def unpatch():

--- a/ddtrace/contrib/sqlalchemy/patch.py
+++ b/ddtrace/contrib/sqlalchemy/patch.py
@@ -1,5 +1,8 @@
 import sqlalchemy
 
+from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
+from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
+from ddtrace.settings.asm import config as asm_config
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from ..trace_utils import unwrap
@@ -19,6 +22,9 @@ def patch():
     # patch the engine creation function
     _w("sqlalchemy", "create_engine", _wrap_create_engine)
     _w("sqlalchemy.engine", "create_engine", _wrap_create_engine)
+
+    if asm_config._iast_enabled:
+        _set_metric_iast_instrumented_sink(VULN_SQL_INJECTION)
 
 
 def unpatch():

--- a/ddtrace/contrib/sqlite3/patch.py
+++ b/ddtrace/contrib/sqlite3/patch.py
@@ -4,6 +4,9 @@ import sqlite3.dbapi2
 import sys
 
 from ddtrace import config
+from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
+from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
+from ddtrace.settings.asm import config as asm_config
 from ddtrace.vendor import wrapt
 
 from ...contrib.dbapi import FetchTracedCursor
@@ -40,6 +43,9 @@ def patch():
 
     sqlite3.connect = wrapped
     sqlite3.dbapi2.connect = wrapped
+
+    if asm_config._iast_enabled:
+        _set_metric_iast_instrumented_sink(VULN_SQL_INJECTION)
 
 
 def unpatch():

--- a/ddtrace/contrib/urllib3/patch.py
+++ b/ddtrace/contrib/urllib3/patch.py
@@ -4,9 +4,12 @@ import urllib3
 
 from ddtrace import config
 from ddtrace.appsec._common_module_patches import wrapped_request_D8CB81E472AF98A2 as _wrap_request
+from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
+from ddtrace.appsec._iast.constants import VULN_SSRF
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.pin import Pin
+from ddtrace.settings.asm import config as asm_config
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
@@ -57,6 +60,9 @@ def patch():
         # Old version before https://github.com/urllib3/urllib3/pull/2398
         _w("urllib3.request", "RequestMethods.request", _wrap_request)
     Pin().onto(urllib3.connectionpool.HTTPConnectionPool)
+
+    if asm_config._iast_enabled:
+        _set_metric_iast_instrumented_sink(VULN_SSRF)
 
 
 def unpatch():


### PR DESCRIPTION
Enable SQLi and SSRF instrumented sink metric

This PR continues #9214

APPSEC-52863 & APPSEC-52863

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
