### PR TITLE
fix(botocore): add defaults for response types and exception handling [backport #9173 to 2.9]

### DIFF
--- a/ddtrace/contrib/botocore/services/bedrock.py
+++ b/ddtrace/contrib/botocore/services/bedrock.py
@@ -167,28 +167,34 @@ def _extract_text_and_response_reason(ctx: core.ExecutionContext, body: Dict[str
     provider = ctx["model_provider"]
     try:
         if provider == _AI21:
-            text = body.get("completions")[0].get("data").get("text")
-            finish_reason = body.get("completions")[0].get("finishReason")
+            completions = body.get("completions", [])
+            if completions:
+                data = completions[0].get("data", {})
+                text = data.get("text")
+                finish_reason = completions[0].get("finishReason")
         elif provider == _AMAZON and "embed" in model_name:
             text = [body.get("embedding", [])]
         elif provider == _AMAZON:
-            text = body.get("results")[0].get("outputText")
-            finish_reason = body.get("results")[0].get("completionReason")
+            results = body.get("results", [])
+            if results:
+                text = results[0].get("outputText")
+                finish_reason = results[0].get("completionReason")
         elif provider == _ANTHROPIC:
             text = body.get("completion", "") or body.get("content", "")
             finish_reason = body.get("stop_reason")
         elif provider == _COHERE and "embed" in model_name:
             text = body.get("embeddings", [[]])
         elif provider == _COHERE:
-            text = [generation["text"] for generation in body.get("generations")]
-            finish_reason = [generation["finish_reason"] for generation in body.get("generations")]
+            generations = body.get("generations", [])
+            text = [generation["text"] for generation in generations]
+            finish_reason = [generation["finish_reason"] for generation in generations]
         elif provider == _META:
             text = body.get("generation")
             finish_reason = body.get("stop_reason")
         elif provider == _STABILITY:
             # TODO: request/response formats are different for image-based models. Defer for now
             pass
-    except (IndexError, AttributeError):
+    except (IndexError, AttributeError, TypeError):
         log.warning("Unable to extract text/finish_reason from response body. Defaulting to empty text/finish_reason.")
 
     if not isinstance(text, list):

--- a/releasenotes/notes/bedrock-response-key-checking-845ef1f191fcc120.yaml
+++ b/releasenotes/notes/bedrock-response-key-checking-845ef1f191fcc120.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    botocore: This fix adds additional key name checking and appropriate defaults for responses from Cohere and Amazon models.


### PR DESCRIPTION
Backports #9173 to 2.9

## Changes Made
This PR adds some additional key name checking and adds defaults when `get`ing these attributes. Additionally, adds an additional exception type to catch as a fallback in the case if incorrect response handling.

## Motivation
This PR addresses app-crashing cases where different model versions have different key names for certain output fields.
Fixes #9135 

## Follow-up
A follow-up PR will address the discrepancies in more detail when we have time to go through the model providers and make sure our response parsing is up-to-date.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)