### PR TITLE
fix(llmobs): format langchain schema inputs and outputs [backport #9194 to 2.9]

### DIFF
--- a/tests/contrib/langchain/cassettes/langchain/openai_chain_schema_io.yaml
+++ b/tests/contrib/langchain/cassettes/langchain/openai_chain_schema_io.yaml
@@ -1,0 +1,88 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "system", "content": "You''re an assistant who''s
+      good at world capitals. Respond in 20 words or fewer"}, {"role": "user", "content":
+      "Can you be my science teacher instead?"}, {"role": "assistant", "content":
+      "Yes"}, {"role": "user", "content": "What''s the powerhouse of the cell?"}],
+      "model": "gpt-3.5-turbo", "max_tokens": null, "stream": false, "n": 1, "temperature":
+      0.7}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '397'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAI/v1 PythonBindings/0.27.8
+      X-OpenAI-Client-User-Agent:
+      - '{"bindings_version": "0.27.8", "httplib": "requests", "lang": "python", "lang_version":
+        "3.10.13", "platform": "macOS-13.6.5-arm64-arm-64bit", "publisher": "openai",
+        "uname": "Darwin 22.6.0 Darwin Kernel Version 22.6.0: Mon Feb 19 19:45:09
+        PST 2024; root:xnu-8796.141.3.704.6~1/RELEASE_ARM64_T6000 arm64 arm"}'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-9MKlPkyelxszTnEysy4eeZihFwATX\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1715110059,\n  \"model\": \"gpt-3.5-turbo-0125\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"Mitochondria.\"\n      },\n      \"logprobs\":
+        null,\n      \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\":
+        54,\n    \"completion_tokens\": 4,\n    \"total_tokens\": 58\n  },\n  \"system_fingerprint\":
+        null\n}\n"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 88039bced98e1841-EWR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 May 2024 19:27:39 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=aG4mqwdLl6mtVHmUY1sni3SuU.qFBxanrCQAi0keMns-1715110059-1.0.1.1-q49zqtqqYOldKfp6LoZrV4xRF21gLaurG_WZtpCCQwxZkgKJfJgRMp5UzCBiwPlyxeQ4_OU81cwxx2_3QluxUw;
+        path=/; expires=Tue, 07-May-24 19:57:39 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=haGbmuprDHtB3GBdFJZDKT3WJMffTyEMnAhIgX__yro-1715110059674-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - user-vgqng3jybrjkfe7a1gf2l5ch
+      openai-processing-ms:
+      - '194'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '60000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '59941'
+      x-ratelimit-reset-requests:
+      - 8.64s
+      x-ratelimit-reset-tokens:
+      - 59ms
+      x-request-id:
+      - req_0d67fc7c57498b6f769c94d0e1b8ed94
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/contrib/langchain/cassettes/langchain_community/lcel_openai_chain_schema_io.yaml
+++ b/tests/contrib/langchain/cassettes/langchain_community/lcel_openai_chain_schema_io.yaml
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "system", "content": "You''re an assistant who''s
+      good at world capitals. Respond in 20 words or fewer"}, {"role": "user", "content":
+      "Can you be my science teacher instead?"}, {"role": "assistant", "content":
+      "Yes"}, {"role": "user", "content": "What''s the powerhouse of the cell?"}],
+      "model": "gpt-3.5-turbo", "n": 1, "stream": false, "temperature": 0.7}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '377'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.12.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.12.0
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.13
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA1SQy2rDMBBF9/4KMes42G1tJ16GQiElm2ZTKCXI8sRWKmuENIaWkH8vcl7tRou5
+        cy5ndEyEAN1CLUD1ktXgTLrcrMdteXit1PPby5bsat9lC910y7Zcv8MsEtQcUPGVmisanEHWZM+x
+        8igZY2te5UWelVVVTsFALZqIdY7Tx3mR8ugbSrP8obiQPWmFAWrxkQghxHF6o6Nt8Rtqkc2ukwFD
+        kB1CfVsSAjyZOAEZgg4sLcPsHiqyjHbS3mgm1ZNtvZZzuKycbt2GOuepiR52NOY232urQ7/zKAPZ
+        2BOY3Bk/JUJ8TjeM/7TAeRoc75i+0MbC4ulcB/dfu4fXjIml+cMskosehJ/AOOz22nbondfTPVEy
+        OSW/AAAA//8DAP/BSKLOAQAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 88034ba91f9132ee-EWR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 07 May 2024 18:32:56 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=tXnAARlh82B5PYxg8iwWtANjfsCqEVAPX9CNpGTnQlA-1715106776-1.0.1.1-Bgtuv8XOKJRrUkgcVrqMx771X7Ib6JMU509irL4q2Mw4kX12I9lvevhCOh3cWOFtC3ZeznyRxeOrvVe1g5JpKw;
+        path=/; expires=Tue, 07-May-24 19:02:56 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=4x6F.SrUVWZ6jyp1ltLrRzvWKvjujNgeIUIYDknJUuQ-1715106776974-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - user-vgqng3jybrjkfe7a1gf2l5ch
+      openai-processing-ms:
+      - '363'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '60000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '59941'
+      x-ratelimit-reset-requests:
+      - 8.64s
+      x-ratelimit-reset-tokens:
+      - 59ms
+      x-request-id:
+      - req_826f1c983f57bdccb2e5a88b97e35732
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/contrib/langchain/test_langchain.py
+++ b/tests/contrib/langchain/test_langchain.py
@@ -1296,10 +1296,11 @@ class TestLLMObsLangchain:
         )
 
     @staticmethod
-    def _expected_llmobs_llm_call(span, provider="openai", input_role=None, output_role=None):
-        input_meta = {"content": mock.ANY}
-        if input_role is not None:
-            input_meta["role"] = input_role
+    def _expected_llmobs_llm_call(span, provider="openai", input_roles=[None], output_role=None):
+        input_meta = [{"content": mock.ANY} for _ in input_roles]
+        for idx, role in enumerate(input_roles):
+            if role is not None:
+                input_meta[idx]["role"] = role
 
         output_meta = {"content": mock.ANY}
         if output_role is not None:
@@ -1326,7 +1327,7 @@ class TestLLMObsLangchain:
             span,
             model_name=span.get_tag("langchain.request.model"),
             model_provider=span.get_tag("langchain.request.provider"),
-            input_messages=[input_meta],
+            input_messages=input_meta,
             output_messages=[output_meta],
             metadata=metadata,
             token_metrics={},
@@ -1344,7 +1345,7 @@ class TestLLMObsLangchain:
         mock_llmobs_span_writer,
         mock_tracer,
         cassette_name,
-        input_role=None,
+        input_roles=[None],
         output_role=None,
         different_py39_cassette=False,
     ):
@@ -1363,7 +1364,7 @@ class TestLLMObsLangchain:
                 cls._expected_llmobs_llm_call(
                     span,
                     provider=provider,
-                    input_role=input_role,
+                    input_roles=input_roles,
                     output_role=output_role,
                 )
             ),
@@ -1380,7 +1381,7 @@ class TestLLMObsLangchain:
         mock_llmobs_span_writer,
         mock_tracer,
         cassette_name,
-        expected_spans_data=[("llm", {"provider": "openai", "input_role": None, "output_role": None})],
+        expected_spans_data=[("llm", {"provider": "openai", "input_roles": [None], "output_role": None})],
         different_py39_cassette=False,
     ):
         # disable the service before re-enabling it, as it was enabled in another test
@@ -1463,7 +1464,7 @@ class TestLLMObsLangchain:
             mock_tracer=mock_tracer,
             cassette_name="openai_chat_completion_sync_call.yaml",
             provider="openai",
-            input_role="user",
+            input_roles=["user"],
             output_role="assistant",
             different_py39_cassette=True,
         )
@@ -1478,7 +1479,7 @@ class TestLLMObsLangchain:
             mock_tracer=mock_tracer,
             cassette_name="openai_chat_completion_sync_call.yaml",
             provider="openai",
-            input_role="custom",
+            input_roles=["custom"],
             output_role="assistant",
             different_py39_cassette=True,
         )
@@ -1523,7 +1524,7 @@ class TestLLMObsLangchain:
                         ),
                     },
                 ),
-                ("llm", {"provider": "openai", "input_role": None, "output_role": None}),
+                ("llm", {"provider": "openai", "input_roles": [None], "output_role": None}),
             ],
             different_py39_cassette=True,
         )
@@ -1585,7 +1586,7 @@ class TestLLMObsLangchain:
                         "output_value": mock.ANY,
                     },
                 ),
-                ("llm", {"provider": "openai", "input_role": None, "output_role": None}),
+                ("llm", {"provider": "openai", "input_roles": [None], "output_role": None}),
                 (
                     "chain",
                     {
@@ -1593,6 +1594,68 @@ class TestLLMObsLangchain:
                         "output_value": mock.ANY,
                     },
                 ),
-                ("llm", {"provider": "openai", "input_role": None, "output_role": None}),
+                ("llm", {"provider": "openai", "input_roles": [None], "output_role": None}),
+            ],
+        )
+
+    @pytest.mark.skipif(sys.version_info < (3, 10, 0), reason="Requires unnecessary cassette file for Python 3.9")
+    def test_llmobs_chain_schema_io(self, langchain, mock_llmobs_span_writer, mock_tracer, request_vcr):
+        model = langchain.chat_models.ChatOpenAI(temperature=0, max_tokens=256)
+        prompt = langchain.prompts.ChatPromptTemplate.from_messages(
+            [
+                langchain.prompts.SystemMessagePromptTemplate.from_template(
+                    "You're an assistant who's good at {ability}. Respond in 20 words or fewer"
+                ),
+                langchain.prompts.MessagesPlaceholder(variable_name="history"),
+                langchain.prompts.HumanMessagePromptTemplate.from_template("{input}"),
+            ]
+        )
+
+        chain = langchain.chains.LLMChain(prompt=prompt, llm=model)
+
+        self._test_llmobs_chain_invoke(
+            generate_trace=lambda input_text: chain.run(
+                {
+                    "ability": "world capitals",
+                    "history": [
+                        langchain.schema.HumanMessage(content="Can you be my science teacher instead?"),
+                        langchain.schema.AIMessage(content="Yes"),
+                    ],
+                    "input": "What's the powerhouse of the cell?",
+                }
+            ),
+            request_vcr=request_vcr,
+            mock_llmobs_span_writer=mock_llmobs_span_writer,
+            mock_tracer=mock_tracer,
+            cassette_name="openai_chain_schema_io.yaml",
+            expected_spans_data=[
+                (
+                    "chain",
+                    {
+                        "input_value": json.dumps(
+                            {
+                                "ability": "world capitals",
+                                "history": [["user", "Can you be my science teacher instead?"], ["assistant", "Yes"]],
+                                "input": "What's the powerhouse of the cell?",
+                            }
+                        ),
+                        "output_value": json.dumps(
+                            {
+                                "ability": "world capitals",
+                                "history": [["user", "Can you be my science teacher instead?"], ["assistant", "Yes"]],
+                                "input": "What's the powerhouse of the cell?",
+                                "text": "Mitochondria.",
+                            }
+                        ),
+                    },
+                ),
+                (
+                    "llm",
+                    {
+                        "provider": "openai",
+                        "input_roles": ["system", "user", "assistant", "user"],
+                        "output_role": "assistant",
+                    },
+                ),
             ],
         )

--- a/tests/contrib/langchain/test_langchain_community.py
+++ b/tests/contrib/langchain/test_langchain_community.py
@@ -1284,10 +1284,11 @@ class TestLLMObsLangchain:
         )
 
     @staticmethod
-    def _expected_llmobs_llm_call(span, provider="openai", input_role=None, output_role=None):
-        input_meta = {"content": mock.ANY}
-        if input_role is not None:
-            input_meta["role"] = input_role
+    def _expected_llmobs_llm_call(span, provider="openai", input_roles=[None], output_role=None):
+        input_meta = [{"content": mock.ANY} for _ in input_roles]
+        for idx, role in enumerate(input_roles):
+            if role is not None:
+                input_meta[idx]["role"] = role
 
         output_meta = {"content": mock.ANY}
         if output_role is not None:
@@ -1314,7 +1315,7 @@ class TestLLMObsLangchain:
             span,
             model_name=span.get_tag("langchain.request.model"),
             model_provider=span.get_tag("langchain.request.provider"),
-            input_messages=[input_meta],
+            input_messages=input_meta,
             output_messages=[output_meta],
             metadata=metadata,
             token_metrics={},
@@ -1332,7 +1333,7 @@ class TestLLMObsLangchain:
         mock_llmobs_span_writer,
         mock_tracer,
         cassette_name,
-        input_role=None,
+        input_roles=[None],
         output_role=None,
     ):
         LLMObs.disable()
@@ -1348,7 +1349,7 @@ class TestLLMObsLangchain:
                 cls._expected_llmobs_llm_call(
                     span,
                     provider=provider,
-                    input_role=input_role,
+                    input_roles=input_roles,
                     output_role=output_role,
                 )
             ),
@@ -1365,7 +1366,7 @@ class TestLLMObsLangchain:
         mock_llmobs_span_writer,
         mock_tracer,
         cassette_name,
-        expected_spans_data=[("llm", {"provider": "openai", "input_role": None, "output_role": None})],
+        expected_spans_data=[("llm", {"provider": "openai", "input_roles": [None], "output_role": None})],
     ):
         # disable the service before re-enabling it, as it was enabled in another test
         LLMObs.disable()
@@ -1429,7 +1430,7 @@ class TestLLMObsLangchain:
             mock_tracer=mock_tracer,
             cassette_name="openai_chat_completion_sync_call.yaml",
             provider="openai",
-            input_role="user",
+            input_roles=["user"],
             output_role="assistant",
         )
 
@@ -1446,7 +1447,7 @@ class TestLLMObsLangchain:
             mock_tracer=mock_tracer,
             cassette_name="openai_chat_completion_sync_call.yaml",
             provider="openai",
-            input_role="custom",
+            input_roles=["custom"],
             output_role="assistant",
         )
 
@@ -1484,7 +1485,7 @@ class TestLLMObsLangchain:
                         "output_value": expected_output,
                     },
                 ),
-                ("llm", {"provider": "openai", "input_role": None, "output_role": None}),
+                ("llm", {"provider": "openai", "input_roles": [None], "output_role": None}),
             ],
         )
 
@@ -1526,8 +1527,8 @@ class TestLLMObsLangchain:
                         "output_value": mock.ANY,
                     },
                 ),
-                ("llm", {"provider": "openai", "input_role": "user", "output_role": "assistant"}),
-                ("llm", {"provider": "openai", "input_role": "user", "output_role": "assistant"}),
+                ("llm", {"provider": "openai", "input_roles": ["user"], "output_role": "assistant"}),
+                ("llm", {"provider": "openai", "input_roles": ["user"], "output_role": "assistant"}),
             ],
         )
 
@@ -1554,7 +1555,67 @@ class TestLLMObsLangchain:
                         "output_value": mock.ANY,
                     },
                 ),
-                ("llm", {"provider": "openai", "input_role": "user", "output_role": "assistant"}),
-                ("llm", {"provider": "openai", "input_role": "user", "output_role": "assistant"}),
+                ("llm", {"provider": "openai", "input_roles": ["user"], "output_role": "assistant"}),
+                ("llm", {"provider": "openai", "input_roles": ["user"], "output_role": "assistant"}),
+            ],
+        )
+
+    @flaky(1735812000)
+    def test_llmobs_chain_schema_io(
+        self, langchain_core, langchain_openai, mock_llmobs_span_writer, mock_tracer, request_vcr
+    ):
+        model = langchain_openai.ChatOpenAI()
+        prompt = langchain_core.prompts.ChatPromptTemplate.from_messages(
+            [
+                ("system", "You're an assistant who's good at {ability}. Respond in 20 words or fewer"),
+                langchain_core.prompts.MessagesPlaceholder(variable_name="history"),
+                ("human", "{input}"),
+            ]
+        )
+
+        chain = prompt | model
+
+        self._test_llmobs_chain_invoke(
+            generate_trace=lambda inputs: chain.invoke(
+                {
+                    "ability": "world capitals",
+                    "history": [
+                        langchain.schema.HumanMessage(content="Can you be my science teacher instead?"),
+                        langchain.schema.AIMessage(content="Yes"),
+                    ],
+                    "input": "What's the powerhouse of the cell?",
+                }
+            ),
+            request_vcr=request_vcr,
+            mock_llmobs_span_writer=mock_llmobs_span_writer,
+            mock_tracer=mock_tracer,
+            cassette_name="lcel_openai_chain_schema_io.yaml",
+            expected_spans_data=[
+                (
+                    "chain",
+                    {
+                        "input_value": json.dumps(
+                            [
+                                {
+                                    "ability": "world capitals",
+                                    "history": [
+                                        ["user", "Can you be my science teacher instead?"],
+                                        ["assistant", "Yes"],
+                                    ],
+                                    "input": "What's the powerhouse of the cell?",
+                                }
+                            ]
+                        ),
+                        "output_value": json.dumps(["assistant", "Mitochondria."]),
+                    },
+                ),
+                (
+                    "llm",
+                    {
+                        "provider": "openai",
+                        "input_roles": ["system", "user", "assistant", "user"],
+                        "output_role": "assistant",
+                    },
+                ),
             ],
         )


### PR DESCRIPTION
Backports #9194 to 2.9

## Changes Made
Changes the parsing of input/output from chain calls using LangChain. Previously, if a `langchain.schema` type was present in the input or output and was passed into a `json.dumps` call, we would catch a "non-serializable JSON" exception, and log it, not appending the message appropriately to the span event.

This changes the parsing to go over all attributes of input/outputs, and in the case of a non-string, attempts to map it to a string by accessing its content.

## Motivation
Make sure input and output are appropriately tagged on LLMObs span events (fix) for LangChain chains, which are in a readable format (feat, as before it would've read something like `content=xyz` by just stringifying the schema object)

## Notes for Reviewers
* No release note included as this is an internal bug fix for LLMObs span event submission.
* Most LOC are a couple cassette files added that were needed to test chat model message history in a chain, which we did not have before.

## Testing
Some manual verification in the UI was done in addition to the unit tests done. For the LCEL unit test case added, it produces the following in the LLMObs UI:
<img width="973" alt="Screenshot 2024-05-07 at 4 16 13 PM" src="https://github.com/DataDog/dd-trace-py/assets/106700075/716fa4f0-5007-4adb-8c93-596844cce01b">

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)