### PR TITLE
fix(asm): workaround disabling builtins.open aspects [backport 2.9]

### DIFF
--- a/ddtrace/appsec/_iast/_ast/ast_patching.py
+++ b/ddtrace/appsec/_iast/_ast/ast_patching.py
@@ -32,6 +32,7 @@ IAST_DENYLIST = (
     "Crypto",  # This module is patched by the IAST patch methods, propagation is not needed
     "api_pb2",  # Patching crashes with these auto-generated modules, propagation is not needed
     "api_pb2_grpc",  # ditto
+    "unittest.mock",
 )  # type: tuple[str, ...]
 
 

--- a/ddtrace/appsec/_iast/_ast/visitor.py
+++ b/ddtrace/appsec/_iast/_ast/visitor.py
@@ -129,7 +129,8 @@ class AstVisitor(ast.NodeTransformer):
             "definitions_module": "ddtrace.appsec._iast.taint_sinks",
             "alias_module": "ddtrace_taint_sinks",
             "functions": {
-                "open": "ddtrace_taint_sinks.open_path_traversal",
+                # FIXME: disabled to unblock release 2.9
+                # "open": "ddtrace_taint_sinks.open_path_traversal",
             },
         }
         self._sinkpoints_functions = self._sinkpoints_spec["functions"]

--- a/releasenotes/notes/asm-open-disabled-090eefa08b8b69a4.yaml
+++ b/releasenotes/notes/asm-open-disabled-090eefa08b8b69a4.yaml
@@ -1,0 +1,4 @@
+---
+issues:
+  - |
+    Code Security: Security tracing for the ``builtins.open`` function is experimental and may not be stable. This aspect is not replaced by default.

--- a/tests/appsec/iast/taint_sinks/test_path_traversal.py
+++ b/tests/appsec/iast/taint_sinks/test_path_traversal.py
@@ -23,6 +23,8 @@ def _get_path_traversal_module_functions():
                 yield module, function
 
 
+# FIXME: enable once the mock + open issue is fixed
+@pytest.mark.skip
 def test_path_traversal_open(iast_span_defaults):
     mod = _iast_patched_module("tests.appsec.iast.fixtures.taint_sinks.path_traversal")
 
@@ -49,6 +51,8 @@ def test_path_traversal_open(iast_span_defaults):
     assert vulnerability["evidence"].get("redacted") is None
 
 
+# FIXME: enable once the mock + open issue is fixed
+@pytest.mark.skip
 @pytest.mark.parametrize(
     "file_path",
     (
@@ -70,6 +74,8 @@ def test_path_traversal_open_secure(file_path, iast_span_defaults):
     assert span_report is None
 
 
+# FIXME: enable once the mock + open issue is fixed
+@pytest.mark.skip
 @pytest.mark.parametrize(
     "module, function",
     _get_path_traversal_module_functions(),
@@ -103,6 +109,8 @@ def test_path_traversal(module, function, iast_span_defaults):
     assert vulnerability["evidence"].get("redacted") is None
 
 
+# FIXME: enable once the mock + open issue is fixed
+@pytest.mark.skip
 @pytest.mark.parametrize("num_vuln_expected", [1, 0, 0])
 def test_path_traversal_deduplication(num_vuln_expected, iast_span_deduplication_enabled):
     mod = _iast_patched_module("tests.appsec.iast.fixtures.taint_sinks.path_traversal")

--- a/tests/appsec/iast/test_iast_propagation_path.py
+++ b/tests/appsec/iast/test_iast_propagation_path.py
@@ -27,6 +27,8 @@ def _assert_vulnerability(data, value_parts, file_line_label):
     assert vulnerability["hash"] == hash_value
 
 
+# FIXME: enable once the mock + open issue is fixed
+@pytest.mark.skip
 def test_propagation_no_path(iast_span_defaults):
     mod = _iast_patched_module("tests.appsec.iast.fixtures.propagation_path")
     origin1 = "taintsource"
@@ -39,6 +41,8 @@ def test_propagation_no_path(iast_span_defaults):
     assert span_report is None
 
 
+# FIXME: enable once the mock + open issue is fixed
+@pytest.mark.skip
 @pytest.mark.parametrize(
     "origin1",
     [
@@ -73,6 +77,8 @@ def test_propagation_path_1_origin_1_propagation(origin1, iast_span_defaults):
     _assert_vulnerability(data, value_parts, "propagation_path_1_source_1_prop")
 
 
+# FIXME: enable once the mock + open issue is fixed
+@pytest.mark.skip
 @pytest.mark.parametrize(
     "origin1",
     [
@@ -109,6 +115,8 @@ def test_propagation_path_1_origins_2_propagations(origin1, iast_span_defaults):
     _assert_vulnerability(data, value_parts, "propagation_path_1_source_2_prop")
 
 
+# FIXME: enable once the mock + open issue is fixed
+@pytest.mark.skip
 @pytest.mark.parametrize(
     "origin1, origin2",
     [
@@ -159,6 +167,8 @@ def test_propagation_path_2_origins_2_propagations(origin1, origin2, iast_span_d
     _assert_vulnerability(data, value_parts, "propagation_path_2_source_2_prop")
 
 
+# FIXME: enable once the mock + open issue is fixed
+@pytest.mark.skip
 @pytest.mark.parametrize(
     "origin1, origin2",
     [
@@ -217,6 +227,8 @@ def test_propagation_path_2_origins_3_propagation(origin1, origin2, iast_span_de
     _assert_vulnerability(data, value_parts, "propagation_path_3_prop")
 
 
+# FIXME: enable once the mock + open issue is fixed
+@pytest.mark.skip
 @pytest.mark.parametrize(
     "origin1, origin2",
     [


### PR DESCRIPTION
## Checklist

- [X] Change(s) are motivated and described in the PR description
- [X] Testing strategy is described if automated tests are not included in the PR
- [X] Risks are described (performance impact, potential for breakage, maintainability)
- [X] Change is maintainable (easy to change, telemetry, documentation)
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [X] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
