### PR TITLE
fix(iast): ensure no side-effects in IAST encode aspect [backport 2.7]

### DIFF
--- a/tests/appsec/iast/aspects/test_side_effects.py
+++ b/tests/appsec/iast/aspects/test_side_effects.py
@@ -1,0 +1,71 @@
+import pytest
+
+import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
+from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils_side_effects import MagicMethodsException
+
+
+mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.str_methods")
+
+
+def test_radd_aspect_side_effects():
+    string_to_taint = "abc"
+    object_with_side_effects = MagicMethodsException(string_to_taint)
+
+    def __radd__(self, a):
+        print(self)
+        print(a)
+        return self._data + a
+
+    _old_method = getattr(MagicMethodsException, "__radd__", None)
+    setattr(MagicMethodsException, "__radd__", __radd__)
+    result = "123" + object_with_side_effects
+    assert result == string_to_taint + "123"
+
+    result_tainted = ddtrace_aspects.add_aspect("123", object_with_side_effects)
+
+    assert result_tainted == result
+
+    setattr(MagicMethodsException, "__radd__", _old_method)
+
+
+def test_add_aspect_side_effects():
+    string_to_taint = "abc"
+    object_with_side_effects = MagicMethodsException(string_to_taint)
+
+    def __add__(self, a):
+        return self._data + a
+
+    _old_method = getattr(MagicMethodsException, "__add__", None)
+    setattr(MagicMethodsException, "__add__", __add__)
+    result = object_with_side_effects + "123"
+    assert result == "abc123"
+
+    result_tainted = ddtrace_aspects.add_aspect(object_with_side_effects, "123")
+
+    assert result_tainted == result
+
+    setattr(MagicMethodsException, "__radd__", _old_method)
+
+
+def test_join_aspect_side_effects():
+    string_to_taint = "abc"
+    object_with_side_effects = MagicMethodsException(string_to_taint)
+
+    it = ["a", "b", "c"]
+
+    result = mod.do_join(object_with_side_effects, it)
+    assert result == "abcabc"
+
+
+def test_encode_aspect_side_effects():
+    string_to_taint = "abc"
+    object_with_side_effects = MagicMethodsException(string_to_taint)
+
+    result = mod.do_encode(object_with_side_effects)
+    assert result == b"abc"
+
+
+def test_encode_aspect_side_effects_none():
+    with pytest.raises(AttributeError, match="'NoneType' object has no attribute 'encode'"):
+        mod.do_encode(None)

--- a/tests/appsec/iast/iast_utils_side_effects.py
+++ b/tests/appsec/iast/iast_utils_side_effects.py
@@ -1,0 +1,310 @@
+class MagicMethodsException:
+    _data = "abc"
+
+    def join(self, iterable):
+        return self._data + "".join(iterable)
+
+    def encode(self, *args, **kwargs):
+        return self._data.encode(*args, **kwargs)
+
+    def __init__(self, data):
+        self._data = data
+
+    # We need those magic methods to verify the test with assert result = XXX
+    # def __new__(cls, *args, **kwargs):
+    #     return cls
+    # def __setattr__(self, name, value):
+    #     raise Exception("side effect")
+    # def __str__(self):
+    #     raise Exception("side effect")
+    # def __repr__(self):
+    #     raise Exception("side effect")
+    # def __getattribute__(self, name):
+    #     raise Exception("side effect")
+    # def __getattr__(self, name):
+    #     raise Exception("side effect")
+
+    def __delattr__(self, name):
+        raise Exception("side effect")
+
+    def __getitem__(self, key):
+        raise Exception("side effect")
+
+    def __setitem__(self, key, value):
+        raise Exception("side effect")
+
+    def __delitem__(self, key):
+        raise Exception("side effect")
+
+    def __iter__(self):
+        raise Exception("side effect")
+
+    def __next__(self):
+        raise Exception("side effect")
+
+    def __contains__(self, item):
+        raise Exception("side effect")
+
+    def __len__(self):
+        raise Exception("side effect")
+
+    def __call__(self, *args, **kwargs):
+        raise Exception("side effect")
+
+    def __enter__(self):
+        raise Exception("side effect")
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        raise Exception("side effect")
+
+    def __await__(self):
+        raise Exception("side effect")
+
+    def __aiter__(self):
+        raise Exception("side effect")
+
+    async def __anext__(self):
+        raise Exception("side effect")
+
+    def __bytes__(self):
+        raise Exception("side effect")
+
+    def __format__(self, format_spec):
+        raise Exception("side effect")
+
+    def __lt__(self, other):
+        raise Exception("side effect")
+
+    def __le__(self, other):
+        raise Exception("side effect")
+
+    def __eq__(self, other):
+        raise Exception("side effect")
+
+    def __ne__(self, other):
+        raise Exception("side effect")
+
+    def __gt__(self, other):
+        raise Exception("side effect")
+
+    def __ge__(self, other):
+        raise Exception("side effect")
+
+    def __hash__(self):
+        raise Exception("side effect")
+
+    def __bool__(self):
+        raise Exception("side effect")
+
+    def __reversed__(self):
+        raise Exception("side effect")
+
+    def __abs__(self):
+        raise Exception("side effect")
+
+    def __neg__(self):
+        raise Exception("side effect")
+
+    def __pos__(self):
+        raise Exception("side effect")
+
+    def __invert__(self):
+        raise Exception("side effect")
+
+    def __round__(self, n=None):
+        raise Exception("side effect")
+
+    def __floor__(self):
+        raise Exception("side effect")
+
+    def __ceil__(self):
+        raise Exception("side effect")
+
+    def __trunc__(self):
+        raise Exception("side effect")
+
+    def __sub__(self, other):
+        raise Exception("side effect")
+
+    def __mul__(self, other):
+        raise Exception("side effect")
+
+    def __matmul__(self, other):
+        raise Exception("side effect")
+
+    def __truediv__(self, other):
+        raise Exception("side effect")
+
+    def __floordiv__(self, other):
+        raise Exception("side effect")
+
+    def __mod__(self, other):
+        raise Exception("side effect")
+
+    def __divmod__(self, other):
+        raise Exception("side effect")
+
+    def __pow__(self, other, modulo=None):
+        raise Exception("side effect")
+
+    def __lshift__(self, other):
+        raise Exception("side effect")
+
+    def __rshift__(self, other):
+        raise Exception("side effect")
+
+    def __and__(self, other):
+        raise Exception("side effect")
+
+    def __xor__(self, other):
+        raise Exception("side effect")
+
+    def __or__(self, other):
+        raise Exception("side effect")
+
+    def __radd__(self, other):
+        raise Exception("side effect")
+
+    def __rsub__(self, other):
+        raise Exception("side effect")
+
+    def __rmul__(self, other):
+        raise Exception("side effect")
+
+    def __rmatmul__(self, other):
+        raise Exception("side effect")
+
+    def __rtruediv__(self, other):
+        raise Exception("side effect")
+
+    def __rfloordiv__(self, other):
+        raise Exception("side effect")
+
+    def __rmod__(self, other):
+        raise Exception("side effect")
+
+    def __rdivmod__(self, other):
+        raise Exception("side effect")
+
+    def __rpow__(self, other):
+        raise Exception("side effect")
+
+    def __rlshift__(self, other):
+        raise Exception("side effect")
+
+    def __rrshift__(self, other):
+        raise Exception("side effect")
+
+    def __rand__(self, other):
+        raise Exception("side effect")
+
+    def __rxor__(self, other):
+        raise Exception("side effect")
+
+    def __ror__(self, other):
+        raise Exception("side effect")
+
+    def __iadd__(self, other):
+        raise Exception("side effect")
+
+    def __isub__(self, other):
+        raise Exception("side effect")
+
+    def __imul__(self, other):
+        raise Exception("side effect")
+
+    def __imatmul__(self, other):
+        raise Exception("side effect")
+
+    def __itruediv__(self, other):
+        raise Exception("side effect")
+
+    def __ifloordiv__(self, other):
+        raise Exception("side effect")
+
+    def __imod__(self, other):
+        raise Exception("side effect")
+
+    def __ipow__(self, other):
+        raise Exception("side effect")
+
+    def __ilshift__(self, other):
+        raise Exception("side effect")
+
+    def __irshift__(self, other):
+        raise Exception("side effect")
+
+    def __iand__(self, other):
+        raise Exception("side effect")
+
+    def __ixor__(self, other):
+        raise Exception("side effect")
+
+    def __ior__(self, other):
+        raise Exception("side effect")
+
+    def __dir__(self):
+        raise Exception("side effect")
+
+    def __copy__(self):
+        raise Exception("side effect")
+
+    def __deepcopy__(self, memo):
+        raise Exception("side effect")
+
+    def __subclasshook__(self, subclass):
+        raise Exception("side effect")
+
+    def __instancecheck__(self, instance):
+        raise Exception("side effect")
+
+    def __subclasscheck__(self, subclass):
+        raise Exception("side effect")
+
+    def __prepare__(cls, name, bases):
+        raise Exception("side effect")
+
+    def __class_getitem__(self, item):
+        raise Exception("side effect")
+
+    def __subclass_prepare__(self, cls):
+        raise Exception("side effect")
+
+    def __init_subclass__(self, *args, **kwargs):
+        raise Exception("side effect")
+
+    def __length_hint__(self):
+        raise Exception("side effect")
+
+    def __missing__(self, key):
+        raise Exception("side effect")
+
+    def __complex__(self):
+        raise Exception("side effect")
+
+    def __int__(self):
+        raise Exception("side effect")
+
+    def __float__(self):
+        raise Exception("side effect")
+
+    def __index__(self):
+        raise Exception("side effect")
+
+    def __del__(self):
+        raise Exception("side effect")
+
+    def __getnewargs_ex__(self):
+        raise Exception("side effect")
+
+    def __getnewargs__(self):
+        raise Exception("side effect")
+
+    def __setstate__(self, state):
+        raise Exception("side effect")
+
+    def __dict__(self):
+        raise Exception("side effect")
+
+    def __weakref__(self):
+        raise Exception("side effect")


### PR DESCRIPTION
Backport 069d81003a680381911cc052f5e729714dfd4e4c from #9244 to 2.8.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
