### PR TITLE
chore(asm): avoid importing when patching with import hook

### DIFF
--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -12,6 +12,7 @@ from ddtrace.appsec._constants import WAF_CONTEXT_NAMES
 from ddtrace.internal import core
 from ddtrace.internal._exceptions import BlockingException
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.settings.asm import config as asm_config
 from ddtrace.vendor.wrapt import FunctionWrapper
 from ddtrace.vendor.wrapt import resolve_path
@@ -154,11 +155,13 @@ def try_unwrap(module, name):
         pass
 
 
-def try_wrap_function_wrapper(module: str, name: str, wrapper: Callable) -> None:
-    try:
-        wrap_object(module, name, FunctionWrapper, (wrapper,))
-    except (ImportError, AttributeError):
-        log.debug("ASM patching. Module %s.%s does not exist", module, name)
+def try_wrap_function_wrapper(module_name: str, name: str, wrapper: Callable) -> None:
+    @ModuleWatchdog.after_module_imported(module_name)
+    def _(module):
+        try:
+            wrap_object(module, name, FunctionWrapper, (wrapper,))
+        except (ImportError, AttributeError):
+            log.debug("ASM patching. Module %s.%s does not exist", module_name, name)
 
 
 def wrap_object(module, name, factory, args=(), kwargs=None):


### PR DESCRIPTION
We register an import hook to perform the patching of objects to prevent force-loading modules during bootstrap.

This fix a regression introduced by https://github.com/DataDog/dd-trace-py/pull/9246

APPSEC-53121

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
