### PR TITLE
feat(iast): ensure no side-effects in IAST aspects [backport to 2.9]

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -135,7 +135,11 @@ def is_pyobject_tainted(pyobject: Any) -> bool:
 
 def taint_pyobject(pyobject: Any, source_name: Any, source_value: Any, source_origin=None) -> Any:
     # Pyobject must be Text with len > 1
-    if not pyobject or not isinstance(pyobject, IAST.TEXT_TYPES):
+    if not isinstance(pyobject, IAST.TEXT_TYPES):
+        return pyobject
+    # We need this validation in different contition if pyobject is not a text type and creates a side-effect such as
+    # __len__ magic method call.
+    if len(pyobject) == 0:
         return pyobject
 
     if isinstance(source_name, (bytes, bytearray)):
@@ -157,17 +161,19 @@ def taint_pyobject(pyobject: Any, source_name: Any, source_value: Any, source_or
     return pyobject
 
 
-def taint_pyobject_with_ranges(pyobject: Any, ranges: Tuple) -> None:
-    if not pyobject or not isinstance(pyobject, IAST.TEXT_TYPES):
-        return None
+def taint_pyobject_with_ranges(pyobject: Any, ranges: Tuple) -> bool:
+    if not isinstance(pyobject, IAST.TEXT_TYPES):
+        return False
     try:
         set_ranges(pyobject, ranges)
+        return True
     except ValueError as e:
         iast_taint_log_error("Tainting object with ranges error (pyobject type %s): %s" % (type(pyobject), e))
+    return False
 
 
 def get_tainted_ranges(pyobject: Any) -> Tuple:
-    if not pyobject or not isinstance(pyobject, IAST.TEXT_TYPES):
+    if not isinstance(pyobject, IAST.TEXT_TYPES):
         return tuple()
     try:
         return get_ranges(pyobject)

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -88,7 +88,7 @@ def add_aspect(op1, op2):
 
 
 def split_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> str:
-    if orig_function:
+    if orig_function is not None:
         if orig_function != builtin_str:
             if flag_added_args > 0:
                 args = args[flag_added_args:]
@@ -101,7 +101,7 @@ def split_aspect(orig_function: Optional[Callable], flag_added_args: int, *args:
 
 
 def rsplit_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> str:
-    if orig_function:
+    if orig_function is not None:
         if orig_function != builtin_str:
             if flag_added_args > 0:
                 args = args[flag_added_args:]
@@ -127,7 +127,7 @@ def splitlines_aspect(orig_function: Optional[Callable], flag_added_args: int, *
 
 
 def str_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> str:
-    if orig_function:
+    if orig_function is not None:
         if orig_function != builtin_str:
             if flag_added_args > 0:
                 args = args[flag_added_args:]
@@ -152,7 +152,7 @@ def str_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: A
 
 
 def bytes_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> bytes:
-    if orig_function:
+    if orig_function is not None:
         if orig_function != builtin_bytes:
             if flag_added_args > 0:
                 args = args[flag_added_args:]
@@ -170,7 +170,7 @@ def bytes_aspect(orig_function: Optional[Callable], flag_added_args: int, *args:
 
 
 def bytearray_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> bytearray:
-    if orig_function:
+    if orig_function is not None:
         if orig_function != builtin_bytearray:
             if flag_added_args > 0:
                 args = args[flag_added_args:]
@@ -242,7 +242,7 @@ def slice_aspect(candidate_text: Text, start: int, stop: int, step: int) -> Text
 
 
 def bytearray_extend_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> Any:
-    if orig_function and not isinstance(orig_function, BuiltinFunctionType):
+    if orig_function is not None and not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
@@ -347,7 +347,7 @@ def ljust_aspect(
 def zfill_aspect(
     orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
 ) -> Union[TEXT_TYPES]:
-    if orig_function and not isinstance(orig_function, BuiltinFunctionType):
+    if orig_function is not None and not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
@@ -425,12 +425,12 @@ def format_aspect(
 def format_map_aspect(
     orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
 ) -> Union[TEXT_TYPES]:
-    if orig_function and not isinstance(orig_function, BuiltinFunctionType):
+    if orig_function is not None and not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
 
-    if orig_function and not args:
+    if orig_function is not None and not args:
         return orig_function(*args, **kwargs)
 
     candidate_text = args[0]  # type: str
@@ -597,7 +597,7 @@ def incremental_translation(self, incr_coder, funcode, empty):
 def decode_aspect(
     orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
 ) -> Union[TEXT_TYPES]:
-    if orig_function and (not flag_added_args or not args):
+    if orig_function is not None and (not flag_added_args or not args):
         # This patch is unexpected, so we fallback
         # to executing the original function
         return orig_function(*args, **kwargs)
@@ -622,7 +622,7 @@ def decode_aspect(
 def encode_aspect(
     orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
 ) -> Union[TEXT_TYPES]:
-    if orig_function and (not flag_added_args or not args):
+    if orig_function is not None and (not flag_added_args or not args):
         # This patch is unexpected, so we fallback
         # to executing the original function
         return orig_function(*args, **kwargs)
@@ -647,7 +647,7 @@ def encode_aspect(
 def upper_aspect(
     orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
 ) -> Union[TEXT_TYPES]:
-    if orig_function and (not isinstance(orig_function, BuiltinFunctionType) or not args):
+    if orig_function is not None and (not isinstance(orig_function, BuiltinFunctionType) or not args):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
@@ -667,7 +667,7 @@ def upper_aspect(
 def lower_aspect(
     orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
 ) -> Union[TEXT_TYPES]:
-    if orig_function and (not isinstance(orig_function, BuiltinFunctionType) or not args):
+    if orig_function is not None and (not isinstance(orig_function, BuiltinFunctionType) or not args):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
@@ -859,7 +859,7 @@ def aspect_replace_api(
 def replace_aspect(
     orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
 ) -> Union[TEXT_TYPES]:
-    if orig_function and (not isinstance(orig_function, BuiltinFunctionType) or not args):
+    if orig_function is not None and (not isinstance(orig_function, BuiltinFunctionType) or not args):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
@@ -906,7 +906,7 @@ def replace_aspect(
 def swapcase_aspect(
     orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
 ) -> Union[TEXT_TYPES]:
-    if orig_function and (not isinstance(orig_function, BuiltinFunctionType) or not args):
+    if orig_function is not None and (not isinstance(orig_function, BuiltinFunctionType) or not args):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
@@ -925,7 +925,7 @@ def swapcase_aspect(
 def title_aspect(
     orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
 ) -> Union[TEXT_TYPES]:
-    if orig_function and (not isinstance(orig_function, BuiltinFunctionType) or not args):
+    if orig_function is not None and (not isinstance(orig_function, BuiltinFunctionType) or not args):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
@@ -944,7 +944,7 @@ def title_aspect(
 def capitalize_aspect(
     orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
 ) -> Union[TEXT_TYPES]:
-    if orig_function and (not isinstance(orig_function, BuiltinFunctionType) or not args):
+    if orig_function is not None and (not isinstance(orig_function, BuiltinFunctionType) or not args):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
@@ -964,7 +964,7 @@ def capitalize_aspect(
 def casefold_aspect(
     orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
 ) -> Union[TEXT_TYPES]:
-    if orig_function:
+    if orig_function is not None:
         if not isinstance(orig_function, BuiltinFunctionType) or not args:
             if flag_added_args > 0:
                 args = args[flag_added_args:]
@@ -972,7 +972,11 @@ def casefold_aspect(
     else:
         orig_function = getattr(args[0], "casefold", None)
 
-    if orig_function and orig_function.__qualname__ not in ("str.casefold", "bytes.casefold", "bytearray.casefold"):
+    if orig_function is not None and getattr(orig_function, "__qualname__") not in (
+        "str.casefold",
+        "bytes.casefold",
+        "bytearray.casefold",
+    ):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)
@@ -993,7 +997,7 @@ def casefold_aspect(
 def translate_aspect(
     orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
 ) -> Union[TEXT_TYPES]:
-    if orig_function and (not isinstance(orig_function, BuiltinFunctionType) or not args):
+    if orig_function is not None and (not isinstance(orig_function, BuiltinFunctionType) or not args):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)

--- a/releasenotes/notes/iast-fix-side-effects-aad844523a335cae.yaml
+++ b/releasenotes/notes/iast-fix-side-effects-aad844523a335cae.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Code Security: Ensure IAST propagation does not raise side effects related to Magic methods.

--- a/tests/appsec/iast/aspects/test_add_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_add_aspect_fixtures.py
@@ -78,7 +78,6 @@ class TestOperatorAddReplacement(unittest.TestCase):
         result = mod.do_add_and_uppercase(prefix, suffix)
 
         assert result == "AB"
-        # TODO: migrate aspect title
         assert len(get_tainted_ranges(result)) == 2
 
     def test_string_operator_add_one_tainted_mixed_bytearray_bytes(self):  # type: () -> None
@@ -89,13 +88,7 @@ class TestOperatorAddReplacement(unittest.TestCase):
         bar = bytearray("bar", encoding="utf-8")
         result = mod.do_operator_add_params(string_input, bar)
         assert result == b"foobar"
-        # TODO: error
-        #     def add_aspect(op1, op2):
-        #         if not isinstance(op1, TEXT_TYPES) or not isinstance(op2, TEXT_TYPES):
-        #             return op1 + op2
-        # >       return _add_aspect(op1, op2)
-        # E       SystemError: <method 'join' of 'bytes' objects> returned a result with an exception set
-        # assert len(get_tainted_ranges(result)) == 2
+        assert len(get_tainted_ranges(result)) == 0
 
     def test_string_operator_add_two_mixed_bytearray_bytes(self):  # type: () -> None
         string_input = taint_pyobject(
@@ -105,10 +98,4 @@ class TestOperatorAddReplacement(unittest.TestCase):
 
         result = mod.do_operator_add_params(string_input, bar)
         assert result == bytearray(b"foobar")
-        # TODO: error
-        #     def add_aspect(op1, op2):
-        #         if not isinstance(op1, TEXT_TYPES) or not isinstance(op2, TEXT_TYPES):
-        #             return op1 + op2
-        # >       return _add_aspect(op1, op2)
-        # E       SystemError: <method 'join' of 'bytes' objects> returned a result with an exception set
-        # assert len(get_tainted_ranges(result)) == 2
+        assert len(get_tainted_ranges(result)) == 0

--- a/tests/appsec/iast/aspects/test_side_effects.py
+++ b/tests/appsec/iast/aspects/test_side_effects.py
@@ -1,5 +1,11 @@
+import sys
+
 import pytest
 
+from ddtrace.appsec._iast._taint_tracking import OriginType
+from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking import taint_pyobject_with_ranges
 import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
 from tests.appsec.iast.iast_utils_side_effects import MagicMethodsException
@@ -7,20 +13,19 @@ from tests.appsec.iast.iast_utils_side_effects import MagicMethodsException
 
 mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.str_methods")
 
+STRING_TO_TAINT = "abc"
+
 
 def test_radd_aspect_side_effects():
-    string_to_taint = "abc"
-    object_with_side_effects = MagicMethodsException(string_to_taint)
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
 
     def __radd__(self, a):
-        print(self)
-        print(a)
         return self._data + a
 
     _old_method = getattr(MagicMethodsException, "__radd__", None)
     setattr(MagicMethodsException, "__radd__", __radd__)
     result = "123" + object_with_side_effects
-    assert result == string_to_taint + "123"
+    assert result == STRING_TO_TAINT + "123"
 
     result_tainted = ddtrace_aspects.add_aspect("123", object_with_side_effects)
 
@@ -30,8 +35,7 @@ def test_radd_aspect_side_effects():
 
 
 def test_add_aspect_side_effects():
-    string_to_taint = "abc"
-    object_with_side_effects = MagicMethodsException(string_to_taint)
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
 
     def __add__(self, a):
         return self._data + a
@@ -48,9 +52,128 @@ def test_add_aspect_side_effects():
     setattr(MagicMethodsException, "__radd__", _old_method)
 
 
+def test_split_side_effects():
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+
+    result = mod.do_split_no_args(object_with_side_effects)
+    assert result == ["abc"]
+
+
+def test_split_side_effects_none():
+    with pytest.raises(AttributeError, match="'NoneType' object has no attribute 'split'"):
+        mod.do_split_no_args(None)
+
+
+def test_rsplit_side_effects():
+    def __call__(self):
+        return self._data
+
+    _old_method = getattr(MagicMethodsException, "__call__", None)
+    setattr(MagicMethodsException, "__call__", __call__)
+
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+    object_with_side_effects.rsplit = MagicMethodsException(STRING_TO_TAINT)
+
+    result = object_with_side_effects.rsplit()
+    assert result
+    assert mod.do_rsplit_no_args(object_with_side_effects) == result
+
+    setattr(MagicMethodsException, "__call__", _old_method)
+
+
+def test_rsplit_side_effects_none():
+    with pytest.raises(AttributeError, match="'NoneType' object has no attribute 'rsplit'"):
+        mod.do_rsplit_no_args(None)
+
+
+def test_splitlines_side_effects():
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+
+    with pytest.raises(AttributeError, match="'MagicMethodsException' object has no attribute 'splitlines'"):
+        mod.do_splitlines_no_arg(object_with_side_effects)
+
+
+def test_splitlines_side_effects_none():
+    with pytest.raises(AttributeError, match="'NoneType' object has no attribute 'splitlines'"):
+        mod.do_splitlines_no_arg(None)
+
+
+def test_str_side_effects():
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+
+    with pytest.raises(Exception, match="side effect"):
+        str(object_with_side_effects)
+
+    with pytest.raises(Exception, match="side effect"):
+        mod.do_str(object_with_side_effects)
+
+
+def test_str_side_effects_none():
+    result = mod.do_str(None)
+    assert result == "None"
+
+
+def test_bytes_side_effects():
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+
+    with pytest.raises(Exception, match="side effect"):
+        bytes(object_with_side_effects)
+
+    with pytest.raises(Exception, match="side effect"):
+        mod.do_bytes(object_with_side_effects)
+
+
+def test_bytes_side_effects_none():
+    with pytest.raises(TypeError, match="cannot convert 'NoneType' object to bytes"):
+        bytes(None)
+
+    with pytest.raises(TypeError, match="cannot convert 'NoneType' object to bytes"):
+        mod.do_bytes(None)
+
+
+def test_bytes_with_encoding_side_effects():
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+
+    with pytest.raises(TypeError, match="encoding without a string argument"):
+        bytes(object_with_side_effects, encoding="utf-8")
+
+    with pytest.raises(TypeError, match="encoding without a string argument"):
+        mod.do_str_to_bytes(object_with_side_effects)
+
+
+def test_bytes_with_encoding_side_effects_none():
+    with pytest.raises(TypeError, match="encoding without a string argument"):
+        bytes(None, encoding="utf-8")
+
+    with pytest.raises(TypeError, match="encoding without a string argument"):
+        mod.do_str_to_bytes(None)
+
+
+def test_bytearray_side_effects():
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+
+    with pytest.raises(Exception, match="side effect"):
+        bytearray(object_with_side_effects)
+
+    with pytest.raises(Exception, match="side effect"):
+        mod.do_bytes_to_bytearray(object_with_side_effects)
+
+
+def test_bytearray_side_effects_none():
+    if sys.version_info < (3, 8):
+        msg = "'NoneType' object is not iterable"
+    else:
+        msg = "cannot convert 'NoneType' object to bytearray"
+
+    with pytest.raises(TypeError, match=msg):
+        bytearray(None)
+
+    with pytest.raises(TypeError, match=msg):
+        mod.do_bytes_to_bytearray(None)
+
+
 def test_join_aspect_side_effects():
-    string_to_taint = "abc"
-    object_with_side_effects = MagicMethodsException(string_to_taint)
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
 
     it = ["a", "b", "c"]
 
@@ -58,9 +181,203 @@ def test_join_aspect_side_effects():
     assert result == "abcabc"
 
 
+def test_join_aspect_side_effects_iterables():
+    it = [MagicMethodsException("a"), MagicMethodsException("b"), MagicMethodsException("c")]
+
+    with pytest.raises(TypeError, match="sequence item 0: expected str instance, MagicMethodsException found"):
+        STRING_TO_TAINT.join(it)
+    with pytest.raises(TypeError, match="sequence item 0: expected str instance, MagicMethodsException found"):
+        mod.do_join(STRING_TO_TAINT, it)
+
+
+def test_index_aspect_side_effects():
+    def __getitem__(self, a):
+        return self._data[a]
+
+    _old_method = getattr(MagicMethodsException, "__getitem__", None)
+    setattr(MagicMethodsException, "__getitem__", __getitem__)
+
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+    result = object_with_side_effects[1]
+    assert result == "b"
+
+    result_tainted = mod.do_index(object_with_side_effects, 1)
+    assert result_tainted == result
+    setattr(MagicMethodsException, "__getitem__", _old_method)
+
+
+def test_slice_aspect_side_effects():
+    def __getitem__(self, a):
+        return self._data[a]
+
+    _old_method = getattr(MagicMethodsException, "__getitem__", None)
+    setattr(MagicMethodsException, "__getitem__", __getitem__)
+
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+    result = object_with_side_effects[:2]
+    assert result == "ab"
+
+    result_tainted = mod.do_slice(object_with_side_effects, None, 2, None)
+    assert result_tainted == result
+    setattr(MagicMethodsException, "__getitem__", _old_method)
+
+
+def test_bytearray_extend_side_effects():
+    _old_method = getattr(MagicMethodsException, "__getitem__", None)
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+    result = object_with_side_effects.extend(bytearray(b"abc"))
+    assert result == bytearray(b"abcabc")
+
+    mod.do_bytearray_extend(object_with_side_effects, bytearray(b"abc"))
+
+
+def test_modulo_aspect_side_effects():
+    def __str__(self):
+        return self._data
+
+    _old_method = getattr(MagicMethodsException, "__str__", None)
+    setattr(MagicMethodsException, "__str__", __str__)
+
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+    result = "aa %s ss" % object_with_side_effects
+    assert result == "aa %s ss" % "abc"
+
+    result_tainted = mod.do_modulo("aa %s ss", object_with_side_effects)
+    assert result_tainted == result
+
+    setattr(MagicMethodsException, "__str__", _old_method)
+
+
+def test_modulo_aspect_template_side_effects():
+    def __str__(self):
+        return self._data
+
+    def __mod__(self, a):
+        return self._data % a
+
+    _old_method_str = getattr(MagicMethodsException, "__str__", None)
+    _old_method_mod = getattr(MagicMethodsException, "__mod__", None)
+    setattr(MagicMethodsException, "__str__", __str__)
+    setattr(MagicMethodsException, "__mod__", __mod__)
+
+    object_with_side_effects = MagicMethodsException("aa %s ss")
+    result = object_with_side_effects % STRING_TO_TAINT
+    assert result == "aa %s ss" % "abc"
+
+    result_tainted = mod.do_modulo(object_with_side_effects, STRING_TO_TAINT)
+    assert result_tainted == result
+
+    setattr(MagicMethodsException, "__str__", _old_method_str)
+    setattr(MagicMethodsException, "__mod__", _old_method_mod)
+
+
+def test_ljust_aspect_side_effects():
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+    result = object_with_side_effects.ljust(10)
+    assert result == "abc       "
+
+    result_tainted = mod.do_ljust(object_with_side_effects, 10)
+    assert result_tainted == result
+
+
+def test_ljust_aspect_fill_char_side_effects():
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+    result = object_with_side_effects.ljust(10, "d")
+    assert result == "abcddddddd"
+
+    result_tainted = mod.do_ljust_2(object_with_side_effects, 10, "d")
+    assert result_tainted == result
+
+
+def test_zfill_aspect_side_effects():
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+    result = object_with_side_effects.zfill(10)
+    assert result == "0000000abc"
+
+    result_tainted = mod.do_zfill(object_with_side_effects, 10)
+    assert result_tainted == result
+
+
+def test_format_aspect_side_effects():
+    object_with_side_effects = MagicMethodsException("d: {}, e: {}")
+    result = object_with_side_effects.format("f", STRING_TO_TAINT)
+    assert result == "d: f, e: abc"
+
+    result_tainted = mod.do_format(object_with_side_effects, "f", STRING_TO_TAINT)
+    assert result_tainted == result
+
+
+def test_format_not_str_side_effects():
+    object_with_side_effects = MagicMethodsException("aaaa")
+
+    result_tainted = mod.do_format_not_str(object_with_side_effects)
+    assert result_tainted == "output"
+
+
+def test_format_map_aspect_side_effects():
+    object_with_side_effects = MagicMethodsException("d: {data1}, e: {data2}")
+    result = object_with_side_effects.format_map(dict(data1=STRING_TO_TAINT, data2=STRING_TO_TAINT))
+    assert result == "d: abc, e: abc"
+
+    result_tainted = mod.do_format_map(object_with_side_effects, dict(data1=STRING_TO_TAINT, data2=STRING_TO_TAINT))
+    assert result_tainted == result
+
+
+def test_taint_pyobject():
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+
+    result = taint_pyobject(
+        pyobject=object_with_side_effects,
+        source_name="test_ospath",
+        source_value="foo",
+        source_origin=OriginType.PARAMETER,
+    )
+    assert result._data == STRING_TO_TAINT
+
+
+def test_repr_aspect_side_effects():
+    def __repr__(self):
+        return self._data
+
+    _old_method_repr = getattr(MagicMethodsException, "__repr__", None)
+    setattr(MagicMethodsException, "__repr__", __repr__)
+
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+    result = repr(object_with_side_effects)
+    assert result == STRING_TO_TAINT
+
+    result_tainted = mod.do_repr(object_with_side_effects)
+    assert result_tainted == result
+
+    setattr(MagicMethodsException, "__repr__", _old_method_repr)
+
+
+def test_format_value_aspect_side_effects():
+    def __format__(self, *args, **kwargs):
+        print(args)
+        print(kwargs)
+        return self._data
+
+    def __add__(self, b):
+        return self._data + b
+
+    _old_method_format = getattr(MagicMethodsException, "__format__", None)
+    setattr(MagicMethodsException, "__format__", __format__)
+    setattr(MagicMethodsException, "__add__", __add__)
+
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+    b = "bar"
+    result = f"{object_with_side_effects} + {b} = {object_with_side_effects + b}"
+    assert result == "abc + bar = abcbar"
+
+    result_tainted = mod.do_fstring(object_with_side_effects, b)
+    assert result_tainted == result
+
+    setattr(MagicMethodsException, "__format__", _old_method_format)
+
+
 def test_encode_aspect_side_effects():
-    string_to_taint = "abc"
-    object_with_side_effects = MagicMethodsException(string_to_taint)
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
 
     result = mod.do_encode(object_with_side_effects)
     assert result == b"abc"
@@ -69,3 +386,110 @@ def test_encode_aspect_side_effects():
 def test_encode_aspect_side_effects_none():
     with pytest.raises(AttributeError, match="'NoneType' object has no attribute 'encode'"):
         mod.do_encode(None)
+
+
+def test_decode_aspect_side_effects():
+    object_with_side_effects = MagicMethodsException(b"abc")
+
+    result = mod.do_decode(object_with_side_effects)
+    assert result == STRING_TO_TAINT
+
+
+def test_decode_aspect_side_effects_none():
+    with pytest.raises(AttributeError, match="'NoneType' object has no attribute 'decode'"):
+        mod.do_decode(None)
+
+
+def test_replace_aspect_side_effects():
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+    old_text = "b"
+    new_text = "fgh"
+    result = mod.do_replace(object_with_side_effects, old_text, new_text)
+    assert result == "afghc"
+
+
+def test_replace_aspect_side_effects_none():
+    with pytest.raises(AttributeError, match="'NoneType' object has no attribute 'replace'"):
+        old_text = "b"
+        new_text = "fgh"
+        mod.do_replace(None, old_text, new_text)
+
+
+@pytest.mark.parametrize(
+    "method",
+    (
+        "upper",
+        "lower",
+        "swapcase",
+        "title",
+        "capitalize",
+        "casefold",
+    ),
+)
+def test_common_aspect_side_effects(method):
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+
+    result = getattr(mod, f"do_{method}")(object_with_side_effects)
+    assert result == STRING_TO_TAINT
+
+
+@pytest.mark.parametrize(
+    "method",
+    (
+        "upper",
+        "lower",
+        "swapcase",
+        "title",
+        "capitalize",
+        "casefold",
+    ),
+)
+def test_common_aspect_side_effects_none(method):
+    with pytest.raises(AttributeError, match=f"'NoneType' object has no attribute '{method}'"):
+        getattr(mod, f"do_{method}")(None)
+
+
+def test_translate_aspect_side_effects():
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+
+    result = mod.do_translate(object_with_side_effects, {"a"})
+    assert result == STRING_TO_TAINT
+
+
+def test_translate_aspect_side_effects_none():
+    with pytest.raises(AttributeError, match="'NoneType' object has no attribute 'translate'"):
+        mod.do_translate(None, {"a"})
+
+
+def test_taint_pyobject_none():
+    result = taint_pyobject(
+        pyobject=None,
+        source_name="test_ospath",
+        source_value="foo",
+        source_origin=OriginType.PARAMETER,
+    )
+    assert result is None
+
+
+def test_taint_pyobject_with_ranges():
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+
+    result = taint_pyobject_with_ranges(pyobject=object_with_side_effects, ranges=tuple())
+    assert result is False
+
+
+def test_taint_pyobject_with_ranges_none():
+    result = taint_pyobject_with_ranges(pyobject=None, ranges=tuple())
+    assert result is False
+
+
+def test_get_tainted_ranges():
+    object_with_side_effects = MagicMethodsException(STRING_TO_TAINT)
+
+    result = get_tainted_ranges(pyobject=object_with_side_effects)
+    assert result == ()
+
+
+def test_get_tainted_ranges_none():
+    result = get_tainted_ranges(None)
+    assert result == ()

--- a/tests/appsec/iast/fixtures/aspects/str_methods.py
+++ b/tests/appsec/iast/fixtures/aspects/str_methods.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from enum import Enum
 import functools
 from http.client import HTTPConnection
 from http.server import HTTPServer as HTTPServer
@@ -214,9 +215,21 @@ def do_bytearray_append(ba):  # type: (bytearray) -> bytes
     return ba
 
 
-def do_bytearray_extend(ba, b):  # type: (bytearray, bytearray) -> None
+def do_bytearray_extend(ba: bytearray, b: bytearray) -> bytearray:
     ba.extend(b)
     return ba
+
+
+def do_repr(b: Any) -> str:
+    return repr(b)
+
+
+def do_str(b: Any) -> str:
+    return str(b)
+
+
+def do_bytes(b: Any) -> bytes:
+    return bytes(b)
 
 
 def do_bytes_to_str(b):  # type: (bytes) -> str
@@ -391,6 +404,10 @@ def do_replace_not_str(c):  # type: (str) -> str
     return my_str.replace(c)
 
 
+def do_format(a: Text, *args: Text) -> Text:
+    return a.format(*args)
+
+
 def do_format_not_str(c):  # type: (str) -> str
     class MyStr(object):
         @staticmethod
@@ -399,6 +416,10 @@ def do_format_not_str(c):  # type: (str) -> str
 
     my_str = MyStr()
     return my_str.format(c)
+
+
+def do_format_map(a: Text, *args: Text) -> Text:
+    return a.format_map(*args)
 
 
 def do_format_map_not_str(c):  # type: (str) -> str
@@ -846,10 +867,6 @@ def do_args_kwargs_4(format_string, *args_safe, **kwargs_safe):  # type: (str, A
     return format_string.format("1", "2", test_kwarg=3, *args_safe, **kwargs_safe)
 
 
-def do_format_map(template, mapping):  # type: (str, Dict[str, Any]) -> str
-    return template.format_map(mapping)
-
-
 def do_format_key_error(param1):  # type: (str, Dict[str, Any]) -> str
     return "Test {param1}, {param2}".format(param1=param1)  # noqa:F524
 
@@ -1154,3 +1171,52 @@ def do_stringio_init_param(StringIO, string_input):
 def do_stringio_init_and_getvalue_param(StringIO, string_input):
     xxx = StringIO(string_input)
     return xxx.getvalue()
+
+
+class ExportType(str, Enum):
+    USAGE = "Usage"
+    ACTUAL_COST = "ActualCost"
+
+
+def do_exporttype_member_format():
+    return f"{ExportType.ACTUAL_COST}"
+
+
+class CustomSpec:
+    def __str__(self):
+        return "str"
+
+    def __repr__(self):
+        return "repr"
+
+    def __format__(self, format_spec):
+        return "format_" + format_spec
+
+
+def do_customspec_simple():
+    c = CustomSpec()
+    return f"{c}"
+
+
+def do_customspec_cstr():
+    c = CustomSpec()
+    return f"{c!s}"
+
+
+def do_customspec_repr():
+    c = CustomSpec()
+    return f"{c!r}"
+
+
+def do_customspec_ascii():
+    c = CustomSpec()
+    return f"{c!a}"
+
+
+def do_customspec_formatspec():
+    c = CustomSpec()
+    return f"{c!s:<20s}"
+
+
+def do_fstring(a, b):
+    return f"{a} + {b} = {a + b}"

--- a/tests/appsec/iast/iast_utils_side_effects.py
+++ b/tests/appsec/iast/iast_utils_side_effects.py
@@ -7,6 +7,53 @@ class MagicMethodsException:
     def encode(self, *args, **kwargs):
         return self._data.encode(*args, **kwargs)
 
+    def decode(self, *args, **kwargs):
+        return self._data.decode(*args, **kwargs)
+
+    def split(self, *args, **kwargs):
+        return self._data.split(*args, **kwargs)
+
+    def extend(self, a):
+        ba = bytearray(self._data, encoding="utf-8")
+        ba.extend(a)
+        return ba
+
+    def ljust(self, width, fill_char=" "):
+        return self._data.ljust(width, fill_char)
+
+    def zfill(self, width):
+        return self._data.zfill(width)
+
+    def format(self, *args, **kwargs):
+        return self._data.format(*args, **kwargs)
+
+    def format_map(self, *args, **kwargs):
+        return self._data.format_map(*args, **kwargs)
+
+    def upper(self, *args, **kwargs):
+        return self._data
+
+    def lower(self, *args, **kwargs):
+        return self._data
+
+    def replace(self, *args, **kwargs):
+        return self._data.replace(*args, **kwargs)
+
+    def swapcase(self, *args, **kwargs):
+        return self._data
+
+    def title(self, *args, **kwargs):
+        return self._data
+
+    def capitalize(self, *args, **kwargs):
+        return self._data
+
+    def casefold(self, *args, **kwargs):
+        return self._data
+
+    def translate(self, *args, **kwargs):
+        return self._data
+
     def __init__(self, data):
         self._data = data
 
@@ -15,14 +62,16 @@ class MagicMethodsException:
     #     return cls
     # def __setattr__(self, name, value):
     #     raise Exception("side effect")
-    # def __str__(self):
-    #     raise Exception("side effect")
-    # def __repr__(self):
-    #     raise Exception("side effect")
     # def __getattribute__(self, name):
     #     raise Exception("side effect")
     # def __getattr__(self, name):
     #     raise Exception("side effect")
+
+    def __repr__(self):
+        raise Exception("side effect")
+
+    def __str__(self):
+        raise Exception("side effect")
 
     def __delattr__(self, name):
         raise Exception("side effect")


### PR DESCRIPTION
Backport #https://github.com/DataDog/dd-trace-py/pull/9257 to 2.9
Ensure IAST propagations do not raise side effects related to Magic methods.
This PR continues this #9244


## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
