### PR TITLE
fix(grpc): include missing args in error call

### DIFF
--- a/ddtrace/contrib/grpc/aio_client_interceptor.py
+++ b/ddtrace/contrib/grpc/aio_client_interceptor.py
@@ -199,7 +199,7 @@ class _ClientInterceptor:
                 yield response
         except StopAsyncIteration:
             # Callback will handle span finishing
-            _handle_cancelled_error()
+            _handle_cancelled_error(call, span)
             raise
         except aio.AioRpcError as rpc_error:
             # NOTE: We can also handle the error in done callbacks,


### PR DESCRIPTION
Small pr to fix some missing arguments in a grpc error call. No backports necessary.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
