### PR TITLE
fix(asm): fix string aspects potentially being called on module aspects

### DIFF
--- a/ddtrace/appsec/_iast/_ast/visitor.py
+++ b/ddtrace/appsec/_iast/_ast/visitor.py
@@ -34,113 +34,115 @@ def _mark_avoid_convert_recursively(node):
             _mark_avoid_convert_recursively(child)
 
 
+_ASPECTS_SPEC = {
+    "definitions_module": "ddtrace.appsec._iast._taint_tracking.aspects",
+    "alias_module": "ddtrace_aspects",
+    "functions": {
+        "str": "ddtrace_aspects.str_aspect",
+        "bytes": "ddtrace_aspects.bytes_aspect",
+        "bytearray": "ddtrace_aspects.bytearray_aspect",
+        "ddtrace_iast_flask_patch": "ddtrace_aspects.empty_func",  # To avoid recursion
+    },
+    "stringalike_methods": {
+        "decode": "ddtrace_aspects.decode_aspect",
+        "join": "ddtrace_aspects.join_aspect",
+        "encode": "ddtrace_aspects.encode_aspect",
+        "extend": "ddtrace_aspects.bytearray_extend_aspect",
+        "upper": "ddtrace_aspects.upper_aspect",
+        "lower": "ddtrace_aspects.lower_aspect",
+        "replace": "ddtrace_aspects.replace_aspect",
+        "swapcase": "ddtrace_aspects.swapcase_aspect",
+        "title": "ddtrace_aspects.title_aspect",
+        "capitalize": "ddtrace_aspects.capitalize_aspect",
+        "casefold": "ddtrace_aspects.casefold_aspect",
+        "translate": "ddtrace_aspects.translate_aspect",
+        "format": "ddtrace_aspects.format_aspect",
+        "format_map": "ddtrace_aspects.format_map_aspect",
+        "zfill": "ddtrace_aspects.zfill_aspect",
+        "ljust": "ddtrace_aspects.ljust_aspect",
+        "split": "ddtrace_aspects.split_aspect",
+        "rsplit": "ddtrace_aspects.rsplit_aspect",
+        "splitlines": "ddtrace_aspects.splitlines_aspect",
+    },
+    # Replacement function for indexes and ranges
+    "slices": {
+        "index": "ddtrace_aspects.index_aspect",
+        "slice": "ddtrace_aspects.slice_aspect",
+    },
+    # Replacement functions for modules
+    "module_functions": {
+        "os.path": {
+            "basename": "ddtrace_aspects._aspect_ospathbasename",
+            "dirname": "ddtrace_aspects._aspect_ospathdirname",
+            "join": "ddtrace_aspects._aspect_ospathjoin",
+            "normcase": "ddtrace_aspects._aspect_ospathnormcase",
+            "split": "ddtrace_aspects._aspect_ospathsplit",
+            "splitext": "ddtrace_aspects._aspect_ospathsplitext",
+        }
+    },
+    "operators": {
+        ast.Add: "ddtrace_aspects.add_aspect",
+        "FORMAT_VALUE": "ddtrace_aspects.format_value_aspect",
+        ast.Mod: "ddtrace_aspects.modulo_aspect",
+        "BUILD_STRING": "ddtrace_aspects.build_string_aspect",
+    },
+    "excluded_from_patching": {
+        # Key: module being patched
+        # Value: dict with more info
+        "django.utils.formats": {
+            # Key: called functions that won't be patched. E.g.: for this module
+            # not a single call for format on any function will be patched.
+            #
+            # Value: function definitions. E.g.: we won't patch any Call node inside
+            # the iter_format_modules(). If we, for example, had 'foo': ('bar', 'baz')
+            # it would mean that we wouldn't patch any call to foo() done inside the
+            # bar() or baz() function definitions.
+            "format": ("",),
+            "": ("iter_format_modules",),
+        },
+        "django.utils.log": {
+            "": ("",),
+        },
+        "django.utils.html": {"": ("format_html", "format_html_join")},
+    },
+    # This is a set since all functions will be replaced by taint_sink_functions
+    "taint_sinks": {
+        "weak_randomness": DEFAULT_WEAK_RANDOMNESS_FUNCTIONS,
+        "path_traversal": DEFAULT_PATH_TRAVERSAL_FUNCTIONS,
+        "other": {
+            "load",
+            "run",
+            "path",
+            "exit",
+            "sleep",
+            "socket",
+        },
+        # These explicitly WON'T be replaced by taint_sink_function:
+        "disabled": {
+            "__new__",
+            "__init__",
+            "__dir__",
+            "__repr__",
+            "super",
+        },
+    },
+}
+
+
+if sys.version_info >= (3, 12):
+    _ASPECTS_SPEC["module_functions"]["os.path"]["splitroot"] = "ddtrace_aspects._aspect_ospathsplitroot"
+
+if sys.version_info >= (3, 12) or os.name == "nt":
+    _ASPECTS_SPEC["module_functions"]["os.path"]["splitdrive"] = "ddtrace_aspects._aspect_ospathsplitdrive"
+
+
 class AstVisitor(ast.NodeTransformer):
+
     def __init__(
         self,
         filename="",
         module_name="",
     ):
-        # Offset caused by inserted lines. Will be adjusted in visit_Generic
-        self._aspects_spec = {
-            "definitions_module": "ddtrace.appsec._iast._taint_tracking.aspects",
-            "alias_module": "ddtrace_aspects",
-            "functions": {
-                "str": "ddtrace_aspects.str_aspect",
-                "bytes": "ddtrace_aspects.bytes_aspect",
-                "bytearray": "ddtrace_aspects.bytearray_aspect",
-                "ddtrace_iast_flask_patch": "ddtrace_aspects.empty_func",  # To avoid recursion
-            },
-            "stringalike_methods": {
-                "decode": "ddtrace_aspects.decode_aspect",
-                "join": "ddtrace_aspects.join_aspect",
-                "encode": "ddtrace_aspects.encode_aspect",
-                "extend": "ddtrace_aspects.bytearray_extend_aspect",
-                "upper": "ddtrace_aspects.upper_aspect",
-                "lower": "ddtrace_aspects.lower_aspect",
-                "replace": "ddtrace_aspects.replace_aspect",
-                "swapcase": "ddtrace_aspects.swapcase_aspect",
-                "title": "ddtrace_aspects.title_aspect",
-                "capitalize": "ddtrace_aspects.capitalize_aspect",
-                "casefold": "ddtrace_aspects.casefold_aspect",
-                "translate": "ddtrace_aspects.translate_aspect",
-                "format": "ddtrace_aspects.format_aspect",
-                "format_map": "ddtrace_aspects.format_map_aspect",
-                "zfill": "ddtrace_aspects.zfill_aspect",
-                "ljust": "ddtrace_aspects.ljust_aspect",
-                "split": "ddtrace_aspects.split_aspect",
-                "rsplit": "ddtrace_aspects.rsplit_aspect",
-                "splitlines": "ddtrace_aspects.splitlines_aspect",
-            },
-            # Replacement function for indexes and ranges
-            "slices": {
-                "index": "ddtrace_aspects.index_aspect",
-                "slice": "ddtrace_aspects.slice_aspect",
-            },
-            # Replacement functions for modules
-            "module_functions": {
-                "os.path": {
-                    "basename": "ddtrace_aspects._aspect_ospathbasename",
-                    "dirname": "ddtrace_aspects._aspect_ospathdirname",
-                    "join": "ddtrace_aspects._aspect_ospathjoin",
-                    "normcase": "ddtrace_aspects._aspect_ospathnormcase",
-                    "split": "ddtrace_aspects._aspect_ospathsplit",
-                    "splitext": "ddtrace_aspects._aspect_ospathsplitext",
-                }
-            },
-            "operators": {
-                ast.Add: "ddtrace_aspects.add_aspect",
-                "FORMAT_VALUE": "ddtrace_aspects.format_value_aspect",
-                ast.Mod: "ddtrace_aspects.modulo_aspect",
-                "BUILD_STRING": "ddtrace_aspects.build_string_aspect",
-            },
-            "excluded_from_patching": {
-                # Key: module being patched
-                # Value: dict with more info
-                "django.utils.formats": {
-                    # Key: called functions that won't be patched. E.g.: for this module
-                    # not a single call for format on any function will be patched.
-                    #
-                    # Value: function definitions. E.g.: we won't patch any Call node inside
-                    # the iter_format_modules(). If we, for example, had 'foo': ('bar', 'baz')
-                    # it would mean that we wouldn't patch any call to foo() done inside the
-                    # bar() or baz() function definitions.
-                    "format": ("",),
-                    "": ("iter_format_modules",),
-                },
-                "django.utils.log": {
-                    "": ("",),
-                },
-                "django.utils.html": {"": ("format_html", "format_html_join")},
-            },
-            # This is a set since all functions will be replaced by taint_sink_functions
-            "taint_sinks": {
-                "weak_randomness": DEFAULT_WEAK_RANDOMNESS_FUNCTIONS,
-                "path_traversal": DEFAULT_PATH_TRAVERSAL_FUNCTIONS,
-                "other": {
-                    "load",
-                    "run",
-                    "path",
-                    "exit",
-                    "sleep",
-                    "socket",
-                },
-                # These explicitly WON'T be replaced by taint_sink_function:
-                "disabled": {
-                    "__new__",
-                    "__init__",
-                    "__dir__",
-                    "__repr__",
-                    "super",
-                },
-            },
-        }
-
-        if sys.version_info >= (3, 12):
-            self._aspects_spec["module_functions"]["os.path"]["splitroot"] = "ddtrace_aspects._aspect_ospathsplitroot"
-
-        if sys.version_info >= (3, 12) or os.name == "nt":
-            self._aspects_spec["module_functions"]["os.path"]["splitdrive"] = "ddtrace_aspects._aspect_ospathsplitdrive"
-
         self._sinkpoints_spec = {
             "definitions_module": "ddtrace.appsec._iast.taint_sinks",
             "alias_module": "ddtrace_taint_sinks",
@@ -154,23 +156,23 @@ class AstVisitor(ast.NodeTransformer):
         self.filename = filename
         self.module_name = module_name
 
-        self._aspect_index = self._aspects_spec["slices"]["index"]
-        self._aspect_slice = self._aspects_spec["slices"]["slice"]
-        self._aspect_functions = self._aspects_spec["functions"]
-        self._aspect_operators = self._aspects_spec["operators"]
-        self._aspect_methods = self._aspects_spec["stringalike_methods"]
-        self._aspect_modules = self._aspects_spec["module_functions"]
-        self._aspect_format_value = self._aspects_spec["operators"]["FORMAT_VALUE"]
-        self._aspect_build_string = self._aspects_spec["operators"]["BUILD_STRING"]
-        self.excluded_functions = self._aspects_spec["excluded_from_patching"].get(self.module_name, {})
+        self._aspect_index = _ASPECTS_SPEC["slices"]["index"]
+        self._aspect_slice = _ASPECTS_SPEC["slices"]["slice"]
+        self._aspect_functions = _ASPECTS_SPEC["functions"]
+        self._aspect_operators = _ASPECTS_SPEC["operators"]
+        self._aspect_methods = _ASPECTS_SPEC["stringalike_methods"]
+        self._aspect_modules = _ASPECTS_SPEC["module_functions"]
+        self._aspect_format_value = _ASPECTS_SPEC["operators"]["FORMAT_VALUE"]
+        self._aspect_build_string = _ASPECTS_SPEC["operators"]["BUILD_STRING"]
+        self.excluded_functions = _ASPECTS_SPEC["excluded_from_patching"].get(self.module_name, {})
 
         # Sink points
         self._taint_sink_replace_any = self._merge_taint_sinks(
-            self._aspects_spec["taint_sinks"]["other"],
-            self._aspects_spec["taint_sinks"]["weak_randomness"],
-            *[functions for module, functions in self._aspects_spec["taint_sinks"]["path_traversal"].items()],
+            _ASPECTS_SPEC["taint_sinks"]["other"],
+            _ASPECTS_SPEC["taint_sinks"]["weak_randomness"],
+            *[functions for module, functions in _ASPECTS_SPEC["taint_sinks"]["path_traversal"].items()],
         )
-        self._taint_sink_replace_disabled = self._aspects_spec["taint_sinks"]["disabled"]
+        self._taint_sink_replace_disabled = _ASPECTS_SPEC["taint_sinks"]["disabled"]
 
         self.dont_patch_these_functionsdefs = set()
         for _, v in self.excluded_functions.items():
@@ -397,7 +399,7 @@ class AstVisitor(ast.NodeTransformer):
         """
         insert_position = self.find_insert_position(module_node)
 
-        definitions_module = self._aspects_spec["definitions_module"]
+        definitions_module = _ASPECTS_SPEC["definitions_module"]
         replacements_import = self._node(
             ast.Import,
             module_node,
@@ -406,7 +408,7 @@ class AstVisitor(ast.NodeTransformer):
                     lineno=1,
                     col_offset=0,
                     name=definitions_module,
-                    asname=self._aspects_spec["alias_module"],
+                    asname=_ASPECTS_SPEC["alias_module"],
                 )
             ],
         )
@@ -517,6 +519,8 @@ class AstVisitor(ast.NodeTransformer):
             func_value_attr = getattr(func_value, "attr", None) if func_value else None
             func_attr = getattr(func_member, "attr", None)
             aspect = None
+            is_module_symbol = False
+
             if func_value_value_id or func_attr:
                 if func_value_value_id and func_value_attr:
                     # e.g. "os.path" or "one.two.three.whatever" (all dotted previous tokens with be in the id)
@@ -529,14 +533,23 @@ class AstVisitor(ast.NodeTransformer):
 
                 if key:
                     module_dict = self._aspect_modules.get(key, None)
-                    aspect = module_dict.get(func_attr, None) if module_dict else None
-                if aspect:
-                    # Create a new Name node for the replacement and set it as node.func
-                    call_node.func = self._attr_node(call_node, aspect)
-                    self.ast_modified = call_modified = True
+                    # using "is not None" here because we want to mark is_module_symbol even if the dict is
+                    # empty (e.g. we don't have an aspect for this specific function but we plan to, or we create
+                    # empty dicts for some modules to avoid checking for string methods on their symbols)
+                    if module_dict is not None:
+                        aspect = module_dict.get(func_attr, None)
+                        # since this is a module symbol, even if we don't have an aspect for this specific function,
+                        # set this, so we don't try to replace as a string method
+                        is_module_symbol = True
+                        if aspect:
+                            # Create a new Name node for the replacement and set it as node.func
+                            call_node.func = self._attr_node(call_node, aspect)
+                            self.ast_modified = call_modified = True
+                    else:
+                        aspect = None
 
-            if not aspect:
-                # Not a module symbol, check if it's a known method
+            if (not is_module_symbol) and (not aspect):
+                # Not a module symbol, check if it's a known string method
                 aspect = self._aspect_methods.get(method_name)
 
                 if aspect:

--- a/ddtrace/appsec/_iast/_ast/visitor.py
+++ b/ddtrace/appsec/_iast/_ast/visitor.py
@@ -137,7 +137,6 @@ if sys.version_info >= (3, 12) or os.name == "nt":
 
 
 class AstVisitor(ast.NodeTransformer):
-
     def __init__(
         self,
         filename="",

--- a/ddtrace/appsec/_iast/_ast/visitor.py
+++ b/ddtrace/appsec/_iast/_ast/visitor.py
@@ -130,7 +130,7 @@ _ASPECTS_SPEC = {
 
 
 if sys.version_info >= (3, 12):
-    _ASPECTS_SPEC["module_functions"]["os.path"]["splitroot"] = "ddtrace_aspects._aspect_ospathsplitroot"  # type: ignore[index]
+    _ASPECTS_SPEC["module_functions"]["os.path"]["splitroot"] = "ddtrace_aspects._aspect_ospathsplitroot"
 
 if sys.version_info >= (3, 12) or os.name == "nt":
     _ASPECTS_SPEC["module_functions"]["os.path"]["splitdrive"] = "ddtrace_aspects._aspect_ospathsplitdrive"  # type: ignore[index]

--- a/ddtrace/appsec/_iast/_ast/visitor.py
+++ b/ddtrace/appsec/_iast/_ast/visitor.py
@@ -130,10 +130,10 @@ _ASPECTS_SPEC = {
 
 
 if sys.version_info >= (3, 12):
-    _ASPECTS_SPEC["module_functions"]["os.path"]["splitroot"] = "ddtrace_aspects._aspect_ospathsplitroot"
+    _ASPECTS_SPEC["module_functions"]["os.path"]["splitroot"] = "ddtrace_aspects._aspect_ospathsplitroot"  # type: ignore[index]
 
 if sys.version_info >= (3, 12) or os.name == "nt":
-    _ASPECTS_SPEC["module_functions"]["os.path"]["splitdrive"] = "ddtrace_aspects._aspect_ospathsplitdrive"
+    _ASPECTS_SPEC["module_functions"]["os.path"]["splitdrive"] = "ddtrace_aspects._aspect_ospathsplitdrive"  # type: ignore[index]
 
 
 class AstVisitor(ast.NodeTransformer):

--- a/tests/appsec/iast/aspects/test_ospath_aspects_fixtures.py
+++ b/tests/appsec/iast/aspects/test_ospath_aspects_fixtures.py
@@ -74,8 +74,9 @@ def test_ospathsplit_noaspect_dont_call_string_aspect():
     global mod
 
     with mock.patch("ddtrace.appsec._iast._taint_tracking.aspects.split_aspect") as str_split_aspect:
-         with mock.patch("ddtrace.appsec._iast._taint_tracking.aspects._aspect_ospathsplit") as os_split_aspect:
+        with mock.patch("ddtrace.appsec._iast._taint_tracking.aspects._aspect_ospathsplit") as os_split_aspect:
             import ddtrace.appsec._iast._ast.visitor as visitor
+
             old_aspect = visitor._ASPECTS_SPEC["module_functions"]["os.path"]["split"]
             try:
                 del visitor._ASPECTS_SPEC["module_functions"]["os.path"]["split"]
@@ -83,7 +84,10 @@ def test_ospathsplit_noaspect_dont_call_string_aspect():
                 del sys.modules["tests.appsec.iast.fixtures.aspects.module_functions"]
                 mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.module_functions")
                 string_input = taint_pyobject(
-                    pyobject="/foo/bar", source_name="first_element", source_value="/foo/bar", source_origin=OriginType.PARAMETER
+                    pyobject="/foo/bar",
+                    source_name="first_element",
+                    source_value="/foo/bar",
+                    source_origin=OriginType.PARAMETER,
                 )
                 result = mod.do_os_path_split(string_input)
                 assert result == ("/foo", "bar")

--- a/tests/appsec/iast/aspects/test_ospath_aspects_fixtures.py
+++ b/tests/appsec/iast/aspects/test_ospath_aspects_fixtures.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 
+import mock
 import pytest
 
 from ddtrace.appsec._constants import IAST
@@ -67,6 +68,33 @@ def test_ospathsplit_tainted():
     assert get_tainted_ranges(result[1]) == [
         TaintRange(0, 3, Source("first_element", "/foo/bar", OriginType.PARAMETER))
     ]
+
+
+def test_ospathsplit_noaspect_dont_call_string_aspect():
+    global mod
+
+    with mock.patch("ddtrace.appsec._iast._taint_tracking.aspects.split_aspect") as str_split_aspect:
+         with mock.patch("ddtrace.appsec._iast._taint_tracking.aspects._aspect_ospathsplit") as os_split_aspect:
+            import ddtrace.appsec._iast._ast.visitor as visitor
+            old_aspect = visitor._ASPECTS_SPEC["module_functions"]["os.path"]["split"]
+            try:
+                del visitor._ASPECTS_SPEC["module_functions"]["os.path"]["split"]
+                del mod
+                del sys.modules["tests.appsec.iast.fixtures.aspects.module_functions"]
+                mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.module_functions")
+                string_input = taint_pyobject(
+                    pyobject="/foo/bar", source_name="first_element", source_value="/foo/bar", source_origin=OriginType.PARAMETER
+                )
+                result = mod.do_os_path_split(string_input)
+                assert result == ("/foo", "bar")
+                assert get_tainted_ranges(result[0]) == []
+                assert get_tainted_ranges(result[1]) == []
+                assert not str_split_aspect.called
+                assert not os_split_aspect.called
+            finally:
+                visitor._ASPECTS_SPEC["module_functions"]["os.path"]["split"] = old_aspect
+                del sys.modules["tests.appsec.iast.fixtures.aspects.module_functions"]
+                mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.module_functions")
 
 
 def test_ospathsplitext_tainted():


### PR DESCRIPTION
## Description

In some corner cases, modules with a function like `split` that are also string methods, could call the string method instead of the module function, which could even cause a segmentation fault with the to-be-fixed-on-another-PR `Initializer`.

This also changes the `aspects_specs` from being creating on each instantiation of the `AstVisitor` to being a module constant. This was done mostly for making it easier to test but as a nice side-effect it should improve performance.

## Checklist

- [X] Change(s) are motivated and described in the PR description
- [X] Testing strategy is described if automated tests are not included in the PR
- [X] Risks are described (performance impact, potential for breakage, maintainability)
- [X] Change is maintainable (easy to change, telemetry, documentation)
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [X] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
