### PR TITLE
feat(iast): remove deprecated functions

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -1,9 +1,6 @@
 import os
 from typing import Any
-from typing import Dict
-from typing import List
 from typing import Tuple
-from typing import Union
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import asbool
@@ -180,35 +177,3 @@ def get_tainted_ranges(pyobject: Any) -> Tuple:
     except ValueError as e:
         iast_taint_log_error("Get ranges error (pyobject type %s): %s" % (type(pyobject), e))
     return tuple()
-
-
-def taint_ranges_as_evidence_info(pyobject: Any) -> Tuple[List[Dict[str, Union[Any, int]]], List[Source]]:
-    # TODO: This function is deprecated.
-    #  Redaction migrated to `ddtrace.appsec._iast._evidence_redaction._sensitive_handler` but we need to migrate
-    #  all vulnerabilities to use it first.
-    value_parts = []
-    sources = list()
-    current_pos = 0
-    tainted_ranges = get_tainted_ranges(pyobject)
-    if not len(tainted_ranges):
-        return ([{"value": pyobject}], list())
-
-    for _range in tainted_ranges:
-        if _range.start > current_pos:
-            value_parts.append({"value": pyobject[current_pos : _range.start]})
-
-        if _range.source not in sources:
-            sources.append(_range.source)
-
-        value_parts.append(
-            {
-                "value": pyobject[_range.start : _range.start + _range.length],
-                "source": sources.index(_range.source),
-            }
-        )
-        current_pos = _range.start + _range.length
-
-    if current_pos < len(pyobject):
-        value_parts.append({"value": pyobject[current_pos:]})
-
-    return value_parts, sources

--- a/ddtrace/appsec/_iast/reporter.py
+++ b/ddtrace/appsec/_iast/reporter.py
@@ -113,7 +113,8 @@ class IastSpanReporter(object):
         """
         return reduce(operator.xor, (hash(obj) for obj in set(self.sources) | self.vulnerabilities))
 
-    def taint_ranges_as_evidence_info(self, pyobject: Any) -> Tuple[List[Source], List[Dict]]:
+    @staticmethod
+    def taint_ranges_as_evidence_info(pyobject: Any) -> Tuple[List[Source], List[Dict]]:
         """
         Extracts tainted ranges as evidence information.
 

--- a/tests/appsec/iast/aspects/test_add_aspect.py
+++ b/tests/appsec/iast/aspects/test_add_aspect.py
@@ -12,10 +12,10 @@ from ddtrace.appsec._iast._taint_tracking import destroy_context
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
-from ddtrace.appsec._iast._taint_tracking import taint_ranges_as_evidence_info
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import TaintRange_
 import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
 from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect
+from ddtrace.appsec._iast.reporter import IastSpanReporter
 from tests.utils import override_env
 
 
@@ -236,7 +236,7 @@ def test_add_aspect_tainting_add_left_twice(obj1, obj2):
 
 def test_taint_ranges_as_evidence_info_nothing_tainted():
     text = "nothing tainted"
-    value_parts, sources = taint_ranges_as_evidence_info(text)
+    value_parts, sources = IastSpanReporter.taint_ranges_as_evidence_info(text)
     assert value_parts == [{"value": text}]
     assert sources == []
 
@@ -245,7 +245,7 @@ def test_taint_ranges_as_evidence_info_all_tainted():
     arg = "all tainted"
     input_info = Source("request_body", arg, OriginType.PARAMETER)
     tainted_text = taint_pyobject(arg, source_name="request_body", source_value=arg, source_origin=OriginType.PARAMETER)
-    value_parts, sources = taint_ranges_as_evidence_info(tainted_text)
+    value_parts, sources = IastSpanReporter.taint_ranges_as_evidence_info(tainted_text)
     assert value_parts == [{"value": tainted_text, "source": 0}]
     assert sources == [input_info]
 
@@ -257,7 +257,7 @@ def test_taint_ranges_as_evidence_info_tainted_op1_add():
     tainted_text = taint_pyobject(arg, source_name="request_body", source_value=arg, source_origin=OriginType.PARAMETER)
     tainted_add_result = add_aspect(tainted_text, text)
 
-    value_parts, sources = taint_ranges_as_evidence_info(tainted_add_result)
+    value_parts, sources = IastSpanReporter.taint_ranges_as_evidence_info(tainted_add_result)
     assert value_parts == [{"value": tainted_text, "source": 0}, {"value": text}]
     assert sources == [input_info]
 
@@ -269,7 +269,7 @@ def test_taint_ranges_as_evidence_info_tainted_op2_add():
     tainted_text = taint_pyobject(arg, source_name="request_body", source_value=arg, source_origin=OriginType.PARAMETER)
     tainted_add_result = add_aspect(text, tainted_text)
 
-    value_parts, sources = taint_ranges_as_evidence_info(tainted_add_result)
+    value_parts, sources = IastSpanReporter.taint_ranges_as_evidence_info(tainted_add_result)
     assert value_parts == [{"value": text}, {"value": tainted_text, "source": 0}]
     assert sources == [input_info]
 
@@ -281,7 +281,7 @@ def test_taint_ranges_as_evidence_info_same_tainted_op1_and_op3_add():
     tainted_text = taint_pyobject(arg, source_name="request_body", source_value=arg, source_origin=OriginType.PARAMETER)
     tainted_add_result = add_aspect(tainted_text, add_aspect(text, tainted_text))
 
-    value_parts, sources = taint_ranges_as_evidence_info(tainted_add_result)
+    value_parts, sources = IastSpanReporter.taint_ranges_as_evidence_info(tainted_add_result)
     assert value_parts == [{"value": tainted_text, "source": 0}, {"value": text}, {"value": tainted_text, "source": 0}]
     assert sources == [input_info]
 
@@ -300,7 +300,7 @@ def test_taint_ranges_as_evidence_info_different_tainted_op1_and_op3_add():
     )
     tainted_add_result = add_aspect(tainted_text1, add_aspect(text, tainted_text2))
 
-    value_parts, sources = taint_ranges_as_evidence_info(tainted_add_result)
+    value_parts, sources = IastSpanReporter.taint_ranges_as_evidence_info(tainted_add_result)
     assert value_parts == [
         {"value": tainted_text1, "source": 0},
         {"value": text},


### PR DESCRIPTION
Remove deprecated functions

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
