### PR TITLE
chore(iast): ast Visitor as singleton

### DIFF
--- a/ddtrace/appsec/_iast/_ast/ast_patching.py
+++ b/ddtrace/appsec/_iast/_ast/ast_patching.py
@@ -19,6 +19,9 @@ from ddtrace.internal.module import origin
 from .visitor import AstVisitor
 
 
+VISITOR = AstVisitor()
+
+
 # Prefixes for modules where IAST patching is allowed
 IAST_ALLOWLIST: Tuple[Text, ...] = ("tests.appsec.iast",)
 IAST_DENYLIST: Tuple[Text, ...] = (
@@ -99,13 +102,10 @@ def visit_ast(
 ) -> Optional[str]:
     parsed_ast = ast.parse(source_text, module_path)
 
-    visitor = AstVisitor(
-        filename=module_path,
-        module_name=module_name,
-    )
-    modified_ast = visitor.visit(parsed_ast)
+    VISITOR.update_location(filename=module_path, module_name=module_name)
+    modified_ast = VISITOR.visit(parsed_ast)
 
-    if not visitor.ast_modified:
+    if not VISITOR.ast_modified:
         return None
 
     ast.fix_missing_locations(modified_ast)

--- a/ddtrace/appsec/_iast/_ast/ast_patching.py
+++ b/ddtrace/appsec/_iast/_ast/ast_patching.py
@@ -19,7 +19,7 @@ from ddtrace.internal.module import origin
 from .visitor import AstVisitor
 
 
-VISITOR = AstVisitor()
+_VISITOR = AstVisitor()
 
 
 # Prefixes for modules where IAST patching is allowed
@@ -102,10 +102,10 @@ def visit_ast(
 ) -> Optional[str]:
     parsed_ast = ast.parse(source_text, module_path)
 
-    VISITOR.update_location(filename=module_path, module_name=module_name)
-    modified_ast = VISITOR.visit(parsed_ast)
+    _VISITOR.update_location(filename=module_path, module_name=module_name)
+    modified_ast = _VISITOR.visit(parsed_ast)
 
-    if not VISITOR.ast_modified:
+    if not _VISITOR.ast_modified:
         return None
 
     ast.fix_missing_locations(modified_ast)

--- a/ddtrace/appsec/_iast/_ast/visitor.py
+++ b/ddtrace/appsec/_iast/_ast/visitor.py
@@ -36,7 +36,7 @@ def _mark_avoid_convert_recursively(node):
             _mark_avoid_convert_recursively(child)
 
 
-_ASPECTS_SPEC = {
+_ASPECTS_SPEC: Dict[Text, Any] = {
     "definitions_module": "ddtrace.appsec._iast._taint_tracking.aspects",
     "alias_module": "ddtrace_aspects",
     "functions": {
@@ -128,7 +128,7 @@ _ASPECTS_SPEC = {
             "super",
         },
     },
-}  # type: Dict
+}
 
 
 if sys.version_info >= (3, 12):
@@ -178,7 +178,7 @@ class AstVisitor(ast.NodeTransformer):
         self.module_name = module_name
         self.ast_modified = False
 
-        excluded_from_patching = _ASPECTS_SPEC["excluded_from_patching"]  # type: Dict[str, Dict[str, Tuple[str]]]
+        excluded_from_patching: Dict[str, Dict[str, Tuple[str]]] = _ASPECTS_SPEC["excluded_from_patching"]
         self.excluded_functions = excluded_from_patching.get(self.module_name, {})
         self.dont_patch_these_functionsdefs = set()
         for _, v in self.excluded_functions.items():


### PR DESCRIPTION
IAST: Performance improvement: Reuse AST Visitor object.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
