### PR TITLE
fix(iast): empty insecure cookies

### DIFF
--- a/ddtrace/appsec/_iast/taint_sinks/insecure_cookie.py
+++ b/ddtrace/appsec/_iast/taint_sinks/insecure_cookie.py
@@ -36,6 +36,9 @@ def asm_check_cookies(cookies: Optional[Dict[str, str]]) -> None:
 
     for cookie_key, cookie_value in cookies.items():
         lvalue = cookie_value.lower().replace(" ", "")
+        # If lvalue starts with ";" means that the cookie is empty, like ';httponly;path=/;samesite=strict'
+        if lvalue == "" or lvalue.startswith(";"):
+            continue
 
         if ";secure" not in lvalue:
             increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, InsecureCookie.vulnerability_type)

--- a/tests/contrib/flask/test_flask_appsec_iast.py
+++ b/tests/contrib/flask/test_flask_appsec_iast.py
@@ -868,9 +868,8 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             root_span = self.pop_spans()[0]
             assert root_span.get_metric(IAST.ENABLED) == 1.0
 
-            loaded = json.loads(root_span.get_tag(IAST.JSON))
-            assert loaded["sources"] == []
-            assert len(loaded["vulnerabilities"]) == 0
+            loaded = root_span.get_tag(IAST.JSON)
+            assert loaded is None
 
 
 class FlaskAppSecIASTDisabledTestCase(BaseFlaskTestCase):

--- a/tests/contrib/flask/test_flask_appsec_iast.py
+++ b/tests/contrib/flask/test_flask_appsec_iast.py
@@ -8,6 +8,9 @@ from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast import oce
 from ddtrace.appsec._iast._utils import _is_python_version_supported as python_supported_by_iast
 from ddtrace.appsec._iast.constants import VULN_HEADER_INJECTION
+from ddtrace.appsec._iast.constants import VULN_INSECURE_COOKIE
+from ddtrace.appsec._iast.constants import VULN_NO_HTTPONLY_COOKIE
+from ddtrace.appsec._iast.constants import VULN_NO_SAMESITE_COOKIE
 from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.appsec._iast.taint_sinks.header_injection import patch as patch_header_injection
 from ddtrace.contrib.sqlite3.patch import patch as patch_sqlite_sqli
@@ -635,6 +638,239 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             # assert vulnerability["location"]["path"] == TEST_FILE_PATH
             # assert vulnerability["location"]["line"] == line
             # assert vulnerability["hash"] == hash_value
+
+    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    def test_flask_insecure_cookie(self):
+        @self.app.route("/insecure_cookie/", methods=["GET", "POST"])
+        def insecure_cookie():
+            from flask import Response
+            from flask import request
+
+            from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
+
+            tainted_string = request.form.get("name")
+            assert is_pyobject_tainted(tainted_string)
+            resp = Response("OK")
+            resp.set_cookie("insecure", "cookie", secure=False, httponly=True, samesite="Strict")
+            return resp
+
+        with override_global_config(
+            dict(
+                _iast_enabled=True,
+                _deduplication_enabled=False,
+            )
+        ):
+            resp = self.client.post("/insecure_cookie/", data={"name": "test"})
+            assert resp.status_code == 200
+
+            root_span = self.pop_spans()[0]
+            assert root_span.get_metric(IAST.ENABLED) == 1.0
+
+            loaded = json.loads(root_span.get_tag(IAST.JSON))
+            assert loaded["sources"] == []
+            assert len(loaded["vulnerabilities"]) == 1
+            vulnerability = loaded["vulnerabilities"][0]
+            assert vulnerability["type"] == VULN_INSECURE_COOKIE
+            assert vulnerability["evidence"] == {"valueParts": [{"value": "insecure"}]}
+            assert "path" not in vulnerability["location"].keys()
+            assert "line" not in vulnerability["location"].keys()
+            assert vulnerability["location"]["spanId"]
+            assert vulnerability["hash"]
+
+    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    def test_flask_insecure_cookie_empty(self):
+        @self.app.route("/insecure_cookie_empty/", methods=["GET", "POST"])
+        def insecure_cookie_empty():
+            from flask import Response
+            from flask import request
+
+            from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
+
+            tainted_string = request.form.get("name")
+            assert is_pyobject_tainted(tainted_string)
+            resp = Response("OK")
+            resp.set_cookie("insecure", "", secure=False, httponly=True, samesite="Strict")
+            return resp
+
+        with override_global_config(
+            dict(
+                _iast_enabled=True,
+                _deduplication_enabled=False,
+            )
+        ):
+            resp = self.client.post("/insecure_cookie_empty/", data={"name": "test"})
+            assert resp.status_code == 200
+
+            root_span = self.pop_spans()[0]
+            assert root_span.get_metric(IAST.ENABLED) == 1.0
+
+            loaded = root_span.get_tag(IAST.JSON)
+            assert loaded is None
+
+    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    def test_flask_no_http_only_cookie(self):
+        @self.app.route("/no_http_only_cookie/", methods=["GET", "POST"])
+        def no_http_only_cookie():
+            from flask import Response
+            from flask import request
+
+            from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
+
+            tainted_string = request.form.get("name")
+            assert is_pyobject_tainted(tainted_string)
+            resp = Response("OK")
+            resp.set_cookie("insecure", "cookie", secure=True, httponly=False, samesite="Strict")
+            return resp
+
+        with override_global_config(
+            dict(
+                _iast_enabled=True,
+                _deduplication_enabled=False,
+            )
+        ):
+            resp = self.client.post("/no_http_only_cookie/", data={"name": "test"})
+            assert resp.status_code == 200
+
+            root_span = self.pop_spans()[0]
+            assert root_span.get_metric(IAST.ENABLED) == 1.0
+
+            loaded = json.loads(root_span.get_tag(IAST.JSON))
+            assert loaded["sources"] == []
+            assert len(loaded["vulnerabilities"]) == 1
+            vulnerability = loaded["vulnerabilities"][0]
+            assert vulnerability["type"] == VULN_NO_HTTPONLY_COOKIE
+            assert vulnerability["evidence"] == {"valueParts": [{"value": "insecure"}]}
+            assert "path" not in vulnerability["location"].keys()
+            assert "line" not in vulnerability["location"].keys()
+            assert vulnerability["location"]["spanId"]
+            assert vulnerability["hash"]
+
+    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    def test_flask_no_http_only_cookie_empty(self):
+        @self.app.route("/no_http_only_cookie_empty/", methods=["GET", "POST"])
+        def no_http_only_cookie_empty():
+            from flask import Response
+            from flask import request
+
+            from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
+
+            tainted_string = request.form.get("name")
+            assert is_pyobject_tainted(tainted_string)
+            resp = Response("OK")
+            resp.set_cookie("insecure", "", secure=True, httponly=False, samesite="Strict")
+            return resp
+
+        with override_global_config(
+            dict(
+                _iast_enabled=True,
+                _deduplication_enabled=False,
+            )
+        ):
+            resp = self.client.post("/no_http_only_cookie_empty/", data={"name": "test"})
+            assert resp.status_code == 200
+
+            root_span = self.pop_spans()[0]
+            assert root_span.get_metric(IAST.ENABLED) == 1.0
+
+            loaded = root_span.get_tag(IAST.JSON)
+            assert loaded is None
+
+    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    def test_flask_no_samesite_cookie(self):
+        @self.app.route("/no_samesite_cookie/", methods=["GET", "POST"])
+        def no_samesite_cookie():
+            from flask import Response
+            from flask import request
+
+            from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
+
+            tainted_string = request.form.get("name")
+            assert is_pyobject_tainted(tainted_string)
+            resp = Response("OK")
+            resp.set_cookie("insecure", "cookie", secure=True, httponly=True, samesite="None")
+            return resp
+
+        with override_global_config(
+            dict(
+                _iast_enabled=True,
+                _deduplication_enabled=False,
+            )
+        ):
+            resp = self.client.post("/no_samesite_cookie/", data={"name": "test"})
+            assert resp.status_code == 200
+
+            root_span = self.pop_spans()[0]
+            assert root_span.get_metric(IAST.ENABLED) == 1.0
+
+            loaded = json.loads(root_span.get_tag(IAST.JSON))
+            assert loaded["sources"] == []
+            assert len(loaded["vulnerabilities"]) == 1
+            vulnerability = loaded["vulnerabilities"][0]
+            assert vulnerability["type"] == VULN_NO_SAMESITE_COOKIE
+            assert vulnerability["evidence"] == {"valueParts": [{"value": "insecure"}]}
+            assert "path" not in vulnerability["location"].keys()
+            assert "line" not in vulnerability["location"].keys()
+            assert vulnerability["location"]["spanId"]
+            assert vulnerability["hash"]
+
+    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    def test_flask_no_samesite_cookie_empty(self):
+        @self.app.route("/no_samesite_cookie_empty/", methods=["GET", "POST"])
+        def no_samesite_cookie_empty():
+            from flask import Response
+            from flask import request
+
+            from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
+
+            tainted_string = request.form.get("name")
+            assert is_pyobject_tainted(tainted_string)
+            resp = Response("OK")
+            resp.set_cookie("insecure", "", secure=True, httponly=True, samesite="None")
+            return resp
+
+        with override_global_config(
+            dict(
+                _iast_enabled=True,
+                _deduplication_enabled=False,
+            )
+        ):
+            resp = self.client.post("/no_samesite_cookie_empty/", data={"name": "test"})
+            assert resp.status_code == 200
+
+            root_span = self.pop_spans()[0]
+            loaded = root_span.get_tag(IAST.JSON)
+            assert loaded is None
+
+    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    def test_flask_cookie_secure(self):
+        @self.app.route("/cookie_secure/", methods=["GET", "POST"])
+        def cookie_secure():
+            from flask import Response
+            from flask import request
+
+            from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
+
+            tainted_string = request.form.get("name")
+            assert is_pyobject_tainted(tainted_string)
+            resp = Response("OK")
+            resp.set_cookie("insecure", "cookie", secure=True, httponly=True, samesite="Strict")
+            return resp
+
+        with override_global_config(
+            dict(
+                _iast_enabled=True,
+                _deduplication_enabled=False,
+            )
+        ):
+            resp = self.client.post("/cookie_secure/", data={"name": "test"})
+            assert resp.status_code == 200
+
+            root_span = self.pop_spans()[0]
+            assert root_span.get_metric(IAST.ENABLED) == 1.0
+
+            loaded = json.loads(root_span.get_tag(IAST.JSON))
+            assert loaded["sources"] == []
+            assert len(loaded["vulnerabilities"]) == 0
 
 
 class FlaskAppSecIASTDisabledTestCase(BaseFlaskTestCase):


### PR DESCRIPTION
Not report empty cookies vulnerabilities
## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
