### PR TITLE
fix(asm): initializer rework and fix for segmentation faults [backport 2.9]

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.cpp
@@ -17,7 +17,7 @@ api_format_aspect(StrType& candidate_text,
                   const py::args& args,
                   const py::kwargs& kwargs)
 {
-    auto tx_map = initializer->get_tainting_map();
+    const auto tx_map = initializer->get_tainting_map();
 
     if (not tx_map or tx_map->empty()) {
         return py::getattr(candidate_text, "format")(*args, **kwargs);

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
@@ -10,7 +10,7 @@
  * @return PyObject*
  */
 PyObject*
-index_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* idx, TaintRangeMapType* tx_taint_map)
+index_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* idx, const TaintRangeMapTypePtr& tx_taint_map)
 {
     auto idx_long = PyLong_AsLong(idx);
     bool ranges_error;

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.h
@@ -3,6 +3,6 @@
 #include "TaintedOps/TaintedOps.h"
 
 PyObject*
-index_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* idx, TaintRangeMapType* tx_taint_map);
+index_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* idx, const TaintRangeMapTypePtr& tx_taint_map);
 PyObject*
 api_index_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs);

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
@@ -5,7 +5,7 @@ aspect_join_str(PyObject* sep,
                 PyObject* result,
                 PyObject* iterable_str,
                 size_t len_iterable,
-                TaintRangeMapType* tx_taint_map)
+                const TaintRangeMapTypePtr& tx_taint_map)
 {
     // This is the special case for unicode str and unicode iterable_str.
     // The iterable elements string will be split into 1 char-length strings.
@@ -58,7 +58,7 @@ aspect_join_str(PyObject* sep,
 }
 
 PyObject*
-aspect_join(PyObject* sep, PyObject* result, PyObject* iterable_elements, TaintRangeMapType* tx_taint_map)
+aspect_join(PyObject* sep, PyObject* result, PyObject* iterable_elements, const TaintRangeMapTypePtr& tx_taint_map)
 {
     const size_t& len_sep = get_pyobject_size(sep);
 
@@ -149,8 +149,6 @@ api_join_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     PyObject* arg0 = args[1];
     bool decref_arg0 = false;
 
-    auto ctx_map = initializer->get_tainting_map();
-
     if (PyIter_Check(arg0) or PySet_Check(arg0) or PyFrozenSet_Check(arg0)) {
         PyObject* iterator = PyObject_GetIter(arg0);
 
@@ -179,6 +177,8 @@ api_join_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
         result = result_ptr.ptr();
         Py_INCREF(result);
     }
+
+    const auto ctx_map = initializer->get_tainting_map();
     if (not ctx_map or ctx_map->empty() or get_pyobject_size(result) == 0) {
         // Empty result cannot have taint ranges
         if (decref_arg0) {

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
@@ -11,7 +11,10 @@
  * @return A new result object with the taint information.
  */
 PyObject*
-add_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* text_to_add, TaintRangeMapType* tx_taint_map)
+add_aspect(PyObject* result_o,
+           PyObject* candidate_text,
+           PyObject* text_to_add,
+           const TaintRangeMapTypePtr& tx_taint_map)
 {
     size_t len_candidate_text{ get_pyobject_size(candidate_text) };
     size_t len_text_to_add{ get_pyobject_size(text_to_add) };
@@ -95,7 +98,7 @@ api_add_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
         return result_o;
     }
 
-    TaintRangeMapType* tx_map = initializer->get_tainting_map();
+    const auto tx_map = initializer->get_tainting_map();
     if (not tx_map or tx_map->empty()) {
         return result_o;
     }

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSplit.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSplit.cpp
@@ -7,7 +7,8 @@ api_split_text(const StrType& text, const optional<StrType>& separator, const op
 {
     auto split = text.attr("split");
     auto split_result = split(separator, maxsplit);
-    TaintRangeMapType* tx_map = initializer->get_tainting_map();
+
+    const auto tx_map = initializer->get_tainting_map();
     if (not tx_map or tx_map->empty()) {
         return split_result;
     }
@@ -25,7 +26,7 @@ api_rsplit_text(const StrType& text, const optional<StrType>& separator, const o
 {
     auto rsplit = text.attr("rsplit");
     auto split_result = rsplit(separator, maxsplit);
-    TaintRangeMapType* tx_map = initializer->get_tainting_map();
+    const auto tx_map = initializer->get_tainting_map();
     if (not tx_map or tx_map->empty()) {
         return split_result;
     }
@@ -42,7 +43,7 @@ api_splitlines_text(const StrType& text, bool keepends)
 {
     auto splitlines = text.attr("splitlines");
     auto split_result = splitlines(keepends);
-    TaintRangeMapType* tx_map = initializer->get_tainting_map();
+    const auto tx_map = initializer->get_tainting_map();
     if (not tx_map or tx_map->empty()) {
         return split_result;
     }

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectsOsPath.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectsOsPath.cpp
@@ -18,7 +18,7 @@ api_ospathjoin_aspect(StrType& first_part, const py::args& args)
     auto join = ospath.attr("join");
     auto joined = join(first_part, *args);
 
-    auto tx_map = initializer->get_tainting_map();
+    const auto tx_map = initializer->get_tainting_map();
     if (not tx_map or tx_map->empty()) {
         return joined;
     }
@@ -106,11 +106,9 @@ api_ospathbasename_aspect(const StrType& path)
     auto ospath = py::module_::import("os.path");
     auto basename = ospath.attr("basename");
     auto basename_result = basename(path);
-    auto tx_map = initializer->get_tainting_map();
-    if (not tx_map or tx_map->empty()) {
-        return basename_result;
-    }
-    if (py::len(basename_result) == 0) {
+
+    const auto tx_map = initializer->get_tainting_map();
+    if (not tx_map or tx_map->empty() or py::len(basename_result) == 0) {
         return basename_result;
     }
 
@@ -141,12 +139,9 @@ api_ospathdirname_aspect(const StrType& path)
     auto ospath = py::module_::import("os.path");
     auto dirname = ospath.attr("dirname");
     auto dirname_result = dirname(path);
-    auto tx_map = initializer->get_tainting_map();
-    if (not tx_map or tx_map->empty()) {
-        return dirname_result;
-    }
 
-    if (py::len(dirname_result) == 0) {
+    const auto tx_map = initializer->get_tainting_map();
+    if (not tx_map or tx_map->empty() or py::len(dirname_result) == 0) {
         return dirname_result;
     }
 
@@ -177,11 +172,9 @@ _forward_to_set_ranges_on_splitted(const char* function_name, const StrType& pat
     auto ospath = py::module_::import("os.path");
     auto function = ospath.attr(function_name);
     auto function_result = function(path);
-    auto tx_map = initializer->get_tainting_map();
-    if (not tx_map or tx_map->empty()) {
-        return function_result;
-    }
-    if (py::len(function_result) == 0) {
+
+    const auto tx_map = initializer->get_tainting_map();
+    if (not tx_map or tx_map->empty() or py::len(function_result) == 0) {
         return function_result;
     }
 
@@ -231,7 +224,8 @@ api_ospathnormcase_aspect(const StrType& path)
     auto ospath = py::module_::import("os.path");
     auto normcase = ospath.attr("normcase");
     auto normcased = normcase(path);
-    auto tx_map = initializer->get_tainting_map();
+
+    const auto tx_map = initializer->get_tainting_map();
     if (not tx_map or tx_map->empty()) {
         return normcased;
     }

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
@@ -57,7 +57,7 @@ bool
 set_ranges_on_splitted(const StrType& source_str,
                        const TaintRangeRefs& source_ranges,
                        const py::list& split_result,
-                       TaintRangeMapType* tx_map,
+                       const TaintRangeMapTypePtr& tx_map,
                        bool include_separator = false);
 
 template<class StrType>

--- a/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
@@ -7,7 +7,7 @@ using namespace pybind11::literals;
 
 thread_local struct ThreadContextCache_
 {
-    size_t tx_id = 0;
+    TaintRangeMapTypePtr tx_map = nullptr;
 } ThreadContextCache;
 
 Initializer::Initializer()
@@ -23,23 +23,23 @@ Initializer::Initializer()
     }
 }
 
-TaintRangeMapType*
+TaintRangeMapTypePtr
 Initializer::create_tainting_map()
 {
-    auto map_ptr = new TaintRangeMapType();
-    active_map_addreses.insert(map_ptr);
+    auto map_ptr = make_shared<TaintRangeMapType>();
+    active_map_addreses[map_ptr.get()] = map_ptr;
     return map_ptr;
 }
 
 void
-Initializer::free_tainting_map(TaintRangeMapType* tx_map)
+Initializer::clear_tainting_map(const TaintRangeMapTypePtr& tx_map)
 {
     if (not tx_map)
         return;
 
-    auto it = active_map_addreses.find(tx_map);
+    auto it = active_map_addreses.find(tx_map.get());
     if (it == active_map_addreses.end()) {
-        // Map wasn't in the set, do nothing
+        // Map wasn't in the active addresses, do nothing
         return;
     }
 
@@ -48,24 +48,22 @@ Initializer::free_tainting_map(TaintRangeMapType* tx_map)
     }
 
     tx_map->clear();
-    delete tx_map;
-    active_map_addreses.erase(it);
 }
 
 // User must check for nullptr return
-TaintRangeMapType*
+TaintRangeMapTypePtr
 Initializer::get_tainting_map()
 {
-    return (TaintRangeMapType*)ThreadContextCache.tx_id;
+    return ThreadContextCache.tx_map;
 }
 
 void
 Initializer::clear_tainting_maps()
 {
     // Need to copy because free_tainting_map changes the set inside the iteration
-    auto map_addresses_copy = initializer->active_map_addreses;
-    for (auto map_ptr : map_addresses_copy) {
-        free_tainting_map((TaintRangeMapType*)map_ptr);
+    for (auto& [fst, snd] : initializer->active_map_addreses) {
+        clear_tainting_map(snd);
+        snd = nullptr;
     }
     active_map_addreses.clear();
 }
@@ -203,29 +201,21 @@ Initializer::release_taint_range(TaintRangePtr rangeptr)
 void
 Initializer::create_context()
 {
-    if (ThreadContextCache.tx_id != 0) {
-        // Destroy the current context
-        destroy_context();
+    if (ThreadContextCache.tx_map != nullptr) {
+        // Reset the current context
+        reset_context();
     }
 
     // Create a new taint_map
     auto map_ptr = create_tainting_map();
-    ThreadContextCache.tx_id = (size_t)map_ptr;
-}
-
-void
-Initializer::destroy_context()
-{
-    free_tainting_map((TaintRangeMapType*)ThreadContextCache.tx_id);
-    ThreadContextCache.tx_id = 0;
+    ThreadContextCache.tx_map = map_ptr;
 }
 
 void
 Initializer::reset_context()
 {
-    //    lock_guard<recursive_mutex> lock(contexts_mutex);
-    ThreadContextCache.tx_id = 0;
     clear_tainting_maps();
+    ThreadContextCache.tx_map = nullptr;
 }
 
 // Created in the PYBIND11_MODULE in _native.cpp
@@ -244,5 +234,4 @@ pyexport_initializer(py::module& m)
     m.def(
       "create_context", []() { return initializer->create_context(); }, py::return_value_policy::reference);
     m.def("reset_context", [] { initializer->reset_context(); });
-    m.def("destroy_context", [] { initializer->destroy_context(); });
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.h
@@ -7,7 +7,6 @@
 
 #include <stack>
 #include <unordered_map>
-#include <unordered_set>
 
 using namespace std;
 
@@ -22,7 +21,9 @@ class Initializer
     static constexpr int TAINTEDOBJECTS_STACK_SIZE = 4096;
     stack<TaintedObjectPtr> available_taintedobjects_stack;
     stack<TaintRangePtr> available_ranges_stack;
-    unordered_set<TaintRangeMapType*> active_map_addreses;
+    // This is a map instead of a set so we can change the contents on iteration; otherwise
+    // keys and values are the same pointer.
+    unordered_map<TaintRangeMapType*, TaintRangeMapTypePtr> active_map_addreses;
 
   public:
     /**
@@ -35,21 +36,21 @@ class Initializer
      *
      * @return A pointer to the created taint range map.
      */
-    TaintRangeMapType* create_tainting_map();
+    TaintRangeMapTypePtr create_tainting_map();
 
     /**
-     * Frees a taint range map.
+     * Clears a taint range map.
      *
      * @param tx_map The taint range map to be freed.
      */
-    void free_tainting_map(TaintRangeMapType* tx_map);
+    void clear_tainting_map(const TaintRangeMapTypePtr& tx_map);
 
     /**
      * Gets the current taint range map.
      *
      * @return A pointer to the current taint range map.
      */
-    static TaintRangeMapType* get_tainting_map();
+    static TaintRangeMapTypePtr get_tainting_map();
 
     /**
      * Clears all active taint maps.
@@ -83,11 +84,6 @@ class Initializer
      * Creates a new taint tracking context.
      */
     void create_context();
-
-    /**
-     * Destroys the current taint tracking context.
-     */
-    void destroy_context();
 
     /**
      * Resets the current taint tracking context.

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
@@ -70,7 +70,7 @@ api_shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, RANGE_START of
 py::object
 api_set_ranges(py::object& str, const TaintRangeRefs& ranges)
 {
-    auto tx_map = initializer->get_tainting_map();
+    const auto tx_map = initializer->get_tainting_map();
 
     if (not tx_map) {
         throw py::value_error(MSG_ERROR_TAINT_MAP);
@@ -109,7 +109,7 @@ api_set_ranges_from_values(PyObject* self, PyObject* const* args, Py_ssize_t nar
 
     if (nargs == 5) {
         PyObject* tainted_object = args[0];
-        TaintRangeMapType* tx_map = initializer->get_tainting_map();
+        const auto tx_map = initializer->get_tainting_map();
         if (not tx_map) {
             py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
             return nullptr;
@@ -147,7 +147,7 @@ api_set_ranges_from_values(PyObject* self, PyObject* const* args, Py_ssize_t nar
 }
 
 std::pair<TaintRangeRefs, bool>
-get_ranges(PyObject* string_input, TaintRangeMapType* tx_map)
+get_ranges(PyObject* string_input, const TaintRangeMapTypePtr& tx_map)
 {
     TaintRangeRefs result;
     if (not is_text(string_input))
@@ -170,7 +170,7 @@ get_ranges(PyObject* string_input, TaintRangeMapType* tx_map)
 }
 
 bool
-set_ranges(PyObject* str, const TaintRangeRefs& ranges, TaintRangeMapType* tx_map)
+set_ranges(PyObject* str, const TaintRangeRefs& ranges, const TaintRangeMapTypePtr& tx_map)
 {
     if (ranges.empty()) {
         return false;
@@ -202,7 +202,7 @@ are_all_text_all_ranges(PyObject* candidate_text, const py::tuple& parameter_lis
 
     bool ranges_error;
     TaintRangeRefs candidate_text_ranges, all_ranges;
-    TaintRangeMapType* tx_map = initializer->get_tainting_map();
+    const auto tx_map = initializer->get_tainting_map();
     if (not tx_map or tx_map->empty()) {
         return { {}, {} };
     }
@@ -247,7 +247,7 @@ api_get_ranges(const py::object& string_input)
 {
     bool ranges_error;
     TaintRangeRefs ranges;
-    TaintRangeMapType* tx_map = initializer->get_tainting_map();
+    const auto tx_map = initializer->get_tainting_map();
 
     if (not tx_map) {
         throw py::value_error(MSG_ERROR_TAINT_MAP);
@@ -266,7 +266,7 @@ api_copy_ranges_from_strings(py::object& str_1, py::object& str_2)
 
     bool ranges_error, result;
     TaintRangeRefs ranges;
-    TaintRangeMapType* tx_map = initializer->get_tainting_map();
+    const auto tx_map = initializer->get_tainting_map();
 
     if (not tx_map) {
         py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
@@ -289,7 +289,7 @@ api_copy_and_shift_ranges_from_strings(py::object& str_1, py::object& str_2, int
 {
     bool ranges_error, result;
     TaintRangeRefs ranges;
-    TaintRangeMapType* tx_map = initializer->get_tainting_map();
+    const auto tx_map = initializer->get_tainting_map();
     if (not tx_map) {
         py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
         return;
@@ -306,7 +306,7 @@ api_copy_and_shift_ranges_from_strings(py::object& str_1, py::object& str_2, int
 }
 
 TaintedObjectPtr
-get_tainted_object(PyObject* str, TaintRangeMapType* tx_map)
+get_tainted_object(PyObject* str, const TaintRangeMapTypePtr& tx_map)
 {
     if (not str)
         return nullptr;
@@ -347,7 +347,7 @@ get_internal_hash(PyObject* obj)
 }
 
 void
-set_tainted_object(PyObject* str, TaintedObjectPtr tainted_object, TaintRangeMapType* tx_taint_map)
+set_tainted_object(PyObject* str, TaintedObjectPtr tainted_object, const TaintRangeMapTypePtr& tx_taint_map)
 {
     if (not str or not is_text(str)) {
         return;

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
@@ -32,6 +32,9 @@ using TaintRangeMapType = std::map<uintptr_t, std::pair<Py_hash_t, TaintedObject
 
 #endif // NDEBUG
 
+using TaintRangeMapTypePtr = shared_ptr<TaintRangeMapType>;
+// using TaintRangeMapTypePtr = TaintRangeMapType*;
+
 struct TaintRange
 {
     RANGE_START start = 0;
@@ -88,10 +91,10 @@ TaintRangeRefs
 api_shift_taint_ranges(const TaintRangeRefs&, RANGE_START offset, RANGE_LENGTH new_length);
 
 std::pair<TaintRangeRefs, bool>
-get_ranges(PyObject* string_input, TaintRangeMapType* tx_map);
+get_ranges(PyObject* string_input, const TaintRangeMapTypePtr& tx_map);
 
 bool
-set_ranges(PyObject* str, const TaintRangeRefs& ranges, TaintRangeMapType* tx_map);
+set_ranges(PyObject* str, const TaintRangeRefs& ranges, const TaintRangeMapTypePtr& tx_map);
 
 py::object
 api_set_ranges(py::object& str, const TaintRangeRefs& ranges);
@@ -133,7 +136,7 @@ api_is_unicode_and_not_fast_tainted(const py::object str)
 }
 
 TaintedObject*
-get_tainted_object(PyObject* str, TaintRangeMapType* tx_taint_map);
+get_tainted_object(PyObject* str, const TaintRangeMapTypePtr& tx_taint_map);
 
 Py_hash_t
 bytearray_hash(PyObject* bytearray);
@@ -142,7 +145,7 @@ Py_hash_t
 get_internal_hash(PyObject* obj);
 
 void
-set_tainted_object(PyObject* str, TaintedObjectPtr tainted_object, TaintRangeMapType* tx_taint_map);
+set_tainted_object(PyObject* str, TaintedObjectPtr tainted_object, const TaintRangeMapTypePtr& tx_taint_map);
 
 void
 pyexport_taintrange(py::module& m);

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.cpp
@@ -11,7 +11,7 @@ api_new_pyobject_id(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 }
 
 bool
-is_tainted(PyObject* tainted_object, TaintRangeMapType* tx_taint_map)
+is_tainted(PyObject* tainted_object, const TaintRangeMapTypePtr& tx_taint_map)
 {
     const auto& to_initial = get_tainted_object(tainted_object, tx_taint_map);
     if (to_initial and !to_initial->get_ranges().empty()) {
@@ -24,7 +24,7 @@ bool
 api_is_tainted(py::object tainted_object)
 {
     if (tainted_object) {
-        TaintRangeMapType* tx_map = initializer->get_tainting_map();
+        const auto tx_map = initializer->get_tainting_map();
         if (not tx_map or tx_map->empty()) {
             return false;
         }

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.h
@@ -14,7 +14,7 @@ PyObject*
 api_new_pyobject_id(PyObject* self, PyObject* const* args, Py_ssize_t nargs);
 
 bool
-is_tainted(PyObject* tainted_object, TaintRangeMapType* tx_taint_map);
+is_tainted(PyObject* tainted_object, const TaintRangeMapTypePtr& tx_taint_map);
 
 bool
 api_is_tainted(py::object tainted_object);

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -38,7 +38,6 @@ if _is_python_version_supported():
     from ._native.initializer import active_map_addreses_size
     from ._native.initializer import create_context
     from ._native.initializer import debug_taint_map
-    from ._native.initializer import destroy_context
     from ._native.initializer import initializer_size
     from ._native.initializer import num_objects_tainted
     from ._native.initializer import reset_context
@@ -84,7 +83,6 @@ __all__ = [
     "set_fast_tainted_if_notinterned_unicode",
     "aspect_helpers",
     "reset_context",
-    "destroy_context",
     "initializer_size",
     "active_map_addreses_size",
     "create_context",

--- a/releasenotes/notes/iast-segfaults-fix-d25c5c132dd8482e.yaml
+++ b/releasenotes/notes/iast-segfaults-fix-d25c5c132dd8482e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Code Security: fix a potential memory corruption when the context was reset.

--- a/tests/appsec/iast/aspects/test_add_aspect.py
+++ b/tests/appsec/iast/aspects/test_add_aspect.py
@@ -8,9 +8,9 @@ from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import create_context
-from ddtrace.appsec._iast._taint_tracking import destroy_context
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking import reset_context
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking import taint_ranges_as_evidence_info
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import TaintRange_
@@ -335,7 +335,7 @@ def test_taint_object_error_with_no_context(log_level, iast_debug, expected_log_
     ranges_result = get_tainted_ranges(result)
     assert len(ranges_result) == 1
 
-    destroy_context()
+    reset_context()
     with override_env({IAST.ENV_DEBUG: iast_debug}), caplog.at_level(log_level):
         result = taint_pyobject(
             pyobject=string_to_taint,
@@ -378,7 +378,7 @@ def test_get_ranges_from_object_with_no_context():
         source_origin=OriginType.PARAMETER,
     )
 
-    destroy_context()
+    reset_context()
     ranges_result = get_tainted_ranges(result)
     assert len(ranges_result) == 0
 
@@ -395,7 +395,7 @@ def test_propagate_ranges_with_no_context(caplog):
         source_origin=OriginType.PARAMETER,
     )
 
-    destroy_context()
+    reset_context()
     with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
         result_2 = add_aspect(result, "another_string")
 

--- a/tests/appsec/iast/aspects/test_bytearray_extend_aspect.py
+++ b/tests/appsec/iast/aspects/test_bytearray_extend_aspect.py
@@ -8,8 +8,8 @@ from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
 from ddtrace.appsec._iast._taint_tracking import create_context
-from ddtrace.appsec._iast._taint_tracking import destroy_context
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking import reset_context
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
 from tests.utils import override_env
@@ -110,7 +110,7 @@ def test_propagate_ranges_with_no_context(caplog):
     ba2 = taint_pyobject(
         pyobject=bytearray(b"456"), source_name="test", source_value="foo", source_origin=OriginType.PARAMETER
     )
-    destroy_context()
+    reset_context()
     with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
         result = mod.do_bytearray_extend(ba1, ba2)
         assert result == bytearray(b"123456")

--- a/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
@@ -11,8 +11,8 @@ from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
 from ddtrace.appsec._iast._taint_tracking import create_context
-from ddtrace.appsec._iast._taint_tracking import destroy_context
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking import reset_context
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
 from tests.appsec.iast.aspects.aspect_utils import create_taint_range_with_format
@@ -245,7 +245,7 @@ def test_propagate_ranges_with_no_context(caplog):
         source_value=string_to_taint,
         source_origin=OriginType.PARAMETER,
     )
-    destroy_context()
+    reset_context()
     with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
         result_2 = mod.do_args_kwargs_4(string_input, 6, test_var=1)
 

--- a/tests/appsec/iast/aspects/test_index_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_index_aspect_fixtures.py
@@ -6,8 +6,8 @@ import pytest
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import create_context
-from ddtrace.appsec._iast._taint_tracking import destroy_context
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking import reset_context
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
 from tests.utils import override_env
@@ -92,7 +92,7 @@ def test_propagate_ranges_with_no_context(caplog):
     )
     assert get_tainted_ranges(string_input)
 
-    destroy_context()
+    reset_context()
     with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
         result = mod.do_index(string_input, 3)
         assert result == "d"

--- a/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
@@ -7,8 +7,8 @@ import pytest
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import create_context
-from ddtrace.appsec._iast._taint_tracking import destroy_context
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking import reset_context
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
 from tests.utils import override_env
@@ -445,7 +445,7 @@ def test_propagate_ranges_with_no_context(caplog):
         pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
     )
     it = ["a", "b", "c"]
-    destroy_context()
+    reset_context()
     with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
         result = mod.do_join(string_input, it)
         assert result == "a-joiner-b-joiner-c"
@@ -464,7 +464,7 @@ def test_propagate_ranges_with_no_context_with_var(caplog):
         "b",
         "c",
     ]
-    destroy_context()
+    reset_context()
     with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
         result = mod.do_join(string_input, it)
         assert result == "a-joiner-b-joiner-c"
@@ -482,7 +482,7 @@ def test_propagate_ranges_with_no_context_with_equal_var(caplog):
         pyobject="abcdef", source_name="joined", source_value="abcdef", source_origin=OriginType.PARAMETER
     )
 
-    destroy_context()
+    reset_context()
     with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
         result = mod.do_join(string_input, [a_tainted, a_tainted, a_tainted])
         assert result == "abcdef-joiner-abcdef-joiner-abcdef"

--- a/tests/appsec/iast/aspects/test_ospath_aspects_fixtures.py
+++ b/tests/appsec/iast/aspects/test_ospath_aspects_fixtures.py
@@ -10,8 +10,8 @@ from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
 from ddtrace.appsec._iast._taint_tracking import create_context
-from ddtrace.appsec._iast._taint_tracking import destroy_context
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking import reset_context
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
 from tests.utils import override_env
@@ -161,7 +161,7 @@ def test_propagate_ranges_with_no_context(caplog):
     )
     assert get_tainted_ranges(string_input)
 
-    destroy_context()
+    reset_context()
     with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
         result = mod.do_os_path_join(string_input, "bar")
         assert result == "abcde/bar"

--- a/tests/appsec/iast/aspects/test_slice_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_slice_aspect_fixtures.py
@@ -7,8 +7,8 @@ import pytest
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import create_context
-from ddtrace.appsec._iast._taint_tracking import destroy_context
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking import reset_context
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
 from tests.utils import override_env
@@ -318,7 +318,7 @@ def test_propagate_ranges_with_no_context(caplog):
         source_origin=OriginType.PARAMETER,
     )
 
-    destroy_context()
+    reset_context()
     with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
         result = mod.do_slice(tainted_input, 0, 3, None)
         assert result == "abc"

--- a/tests/appsec/iast/aspects/test_split_aspect.py
+++ b/tests/appsec/iast/aspects/test_split_aspect.py
@@ -9,7 +9,7 @@ from ddtrace.appsec._iast._taint_tracking import _aspect_rsplit
 from ddtrace.appsec._iast._taint_tracking import _aspect_split
 from ddtrace.appsec._iast._taint_tracking import _aspect_splitlines
 from ddtrace.appsec._iast._taint_tracking import create_context
-from ddtrace.appsec._iast._taint_tracking import destroy_context
+from ddtrace.appsec._iast._taint_tracking import reset_context
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import Source
@@ -169,7 +169,7 @@ def test_propagate_ranges_with_no_context(caplog):
     )
     assert get_ranges(string_input)
 
-    destroy_context()
+    reset_context()
     with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
         result = _aspect_split(string_input, "|")
         assert result == ["abc", "def"]

--- a/tests/appsec/iast/taint_tracking/test_taint_tracking.py
+++ b/tests/appsec/iast/taint_tracking/test_taint_tracking.py
@@ -12,8 +12,8 @@ with override_env({"DD_IAST_ENABLED": "True"}):
     from ddtrace.appsec._iast._taint_tracking import OriginType
     from ddtrace.appsec._iast._taint_tracking import Source
     from ddtrace.appsec._iast._taint_tracking import TaintRange
-    from ddtrace.appsec._iast._taint_tracking import destroy_context
     from ddtrace.appsec._iast._taint_tracking import num_objects_tainted
+    from ddtrace.appsec._iast._taint_tracking import reset_context
     from ddtrace.appsec._iast._taint_tracking import set_ranges
     from ddtrace.appsec._iast._taint_tracking import taint_pyobject
     from ddtrace.appsec._iast._taint_tracking import taint_ranges_as_evidence_info
@@ -42,7 +42,7 @@ def test_taint_ranges_as_evidence_info_all_tainted():
 
 @pytest.mark.skip_iast_check_logs
 def test_taint_object_with_no_context_should_be_noop():
-    destroy_context()
+    reset_context()
     arg = "all tainted"
     tainted_text = taint_pyobject(arg, source_name="request_body", source_value=arg, source_origin=OriginType.PARAMETER)
     assert tainted_text == arg
@@ -51,7 +51,7 @@ def test_taint_object_with_no_context_should_be_noop():
 
 @pytest.mark.skip_iast_check_logs
 def test_propagate_ranges_with_no_context(caplog):
-    destroy_context()
+    reset_context()
     with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
         string_input = taint_pyobject(
             pyobject="abcde", source_name="abcde", source_value="abcde", source_origin=OriginType.PARAMETER
@@ -63,7 +63,7 @@ def test_propagate_ranges_with_no_context(caplog):
 
 @pytest.mark.skip_iast_check_logs
 def test_call_to_set_ranges_directly_raises_a_exception(caplog):
-    destroy_context()
+    reset_context()
     input_str = "abcde"
     with pytest.raises(ValueError) as excinfo:
         set_ranges(


### PR DESCRIPTION
Backport #9284 to 2.9

## Description

Fix several segmentation faults (3 confirmed, probably more).

This is done by a small rework of the Initializer which includes:

- Moving `active_map_addreses` from `unordered_set` to `unordered_map` so we can iterate and change it without making a copy (making a copy was actually causing one of the segmentation faults because we were setting the `tx_map` pointer to `nullptr`, but on the copy, not the original, so `get_tainting_map` would return `not nullptr` but still garbage since it was deleted).

- Convert the `TaintRangeMapType` pointer to a `shared_ptr`. This fixed another segfault and makes the codebase more robust.

- Make `ThreadContextCache` not use a dangerously magical number-pointer but just a reference to the active `tx_map` so we only need to check if it's `nullptr` to see if we are in context (which is what functions did anyway).

- Removed `destroy_context`. Not needed anymore, `reset_context` will do the same in a safer way.

## Checklist

- [X] Change(s) are motivated and described in the PR description
- [X] Testing strategy is described if automated tests are not included in the PR
- [X] Risks are described (performance impact, potential for breakage, maintainability)
- [X] Change is maintainable (easy to change, telemetry, documentation)
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [X] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
