### PR TITLE
perf(iast): improve performance for patching decision [backport 2.9]

### DIFF
--- a/ddtrace/appsec/_iast/_ast/ast_patching.py
+++ b/ddtrace/appsec/_iast/_ast/ast_patching.py
@@ -33,6 +33,9 @@ IAST_DENYLIST = (
     "api_pb2",  # Patching crashes with these auto-generated modules, propagation is not needed
     "api_pb2_grpc",  # ditto
     "unittest.mock",
+    "pytest",  # Testing framework
+    "freezegun",  # Testing utilities for time manipulation
+    "sklearn",  # Machine learning library
 )  # type: tuple[str, ...]
 
 
@@ -88,10 +91,16 @@ def _should_iast_patch(module_name):  # type: (str) -> bool
     select if module_name should be patch from the longuest prefix that match in allow or deny list.
     if a prefix is in both list, deny is selected.
     """
-    max_allow = max((len(prefix) for prefix in IAST_ALLOWLIST if module_name.startswith(prefix)), default=-1)
-    max_deny = max((len(prefix) for prefix in IAST_DENYLIST if module_name.startswith(prefix)), default=-1)
-    diff = max_allow - max_deny
-    return diff > 0 or (diff == 0 and not _in_python_stdlib_or_third_party(module_name))
+    # TODO: A better solution would be to migrate the original algorithm to C++:
+    # max_allow = max((len(prefix) for prefix in IAST_ALLOWLIST if module_name.startswith(prefix)), default=-1)
+    # max_deny = max((len(prefix) for prefix in IAST_DENYLIST if module_name.startswith(prefix)), default=-1)
+    # diff = max_allow - max_deny
+    # return diff > 0 or (diff == 0 and not _in_python_stdlib_or_third_party(module_name))
+    if module_name.startswith(IAST_ALLOWLIST):
+        return True
+    if module_name.startswith(IAST_DENYLIST):
+        return False
+    return not _in_python_stdlib_or_third_party(module_name)
 
 
 def visit_ast(

--- a/tests/appsec/iast/test_env_var.py
+++ b/tests/appsec/iast/test_env_var.py
@@ -95,7 +95,7 @@ def test_A_env_var_iast_modules_to_patch(capfd):
         gc.collect()
 
     os.environ[IAST.PATCH_MODULES] = IAST.SEP_MODULES.join(
-        ["please_patch", "also.that", "ddtrace", "please_patch.do_not.but_yes"]
+        ["ddtrace.allowed", "please_patch", "also.that", "please_patch.do_not.but_yes"]
     )
     os.environ[IAST.DENY_MODULES] = IAST.SEP_MODULES.join(["please_patch.do_not", "also.that.but.not.that"])
     import ddtrace.appsec._iast._ast.ast_patching as ap
@@ -112,6 +112,7 @@ def test_A_env_var_iast_modules_to_patch(capfd):
         "also.that.but.not",
         "tests.appsec.iast",
         "tests.appsec.iast.sub",
+        "ddtrace.allowed",
     ]:
         assert ap._should_iast_patch(module_name), module_name
 
@@ -120,9 +121,5 @@ def test_A_env_var_iast_modules_to_patch(capfd):
         "ddtrace.sub",
         "hypothesis",
         "pytest",
-        "please_patch.do_not",
-        "please_patch.do_not.any",
-        "also.that.but.not.that",
-        "also.that.but.not.that.never",
     ]:
         assert not ap._should_iast_patch(module_name), module_name


### PR DESCRIPTION
IAST: Performance optimization. Chages logic for IAST allowlist and denylist, now allowlist has precedence over denylist.

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

---------

Co-authored-by: Alberto Vara <alberto.vara@datadoghq.com>
(cherry picked from commit d0811139d2d101043f7fd20b4c97a9b83a806e22)