### PR TITLE
fix(asm): initializer rework and fix for segmentation faults [backport 2.8]

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectExtend.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectExtend.cpp
@@ -1,11 +1,18 @@
 #include "AspectExtend.h"
 
+/**
+ * @brief Taint candidate_text when bytearray extends is called.
+ *
+ * @param self
+ * @param args: 0: candidate text, 1: Bytearray or bytes to extend in candidate text
+ * @param nargs number of elements in args
+ * @return PyObject*: return None (Remember, Pyobject None isn't the same as nullptr)
+ */
 PyObject*
 api_extend_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 {
     if (nargs != 2 or !args) {
-        // TODO: any other more sane error handling?
-        return nullptr;
+        throw py::value_error(MSG_ERROR_N_PARAMS);
     }
 
     PyObject* candidate_text = args[0];
@@ -20,22 +27,28 @@ api_extend_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     }
 
     auto ctx_map = initializer->get_tainting_map();
-    const auto& to_candidate = get_tainted_object(candidate_text, ctx_map);
-    auto to_result = initializer->allocate_tainted_object_copy(to_candidate);
-    const auto& to_toadd = get_tainted_object(to_add, ctx_map);
+    if (not ctx_map or ctx_map->empty()) {
+        auto method_name = PyUnicode_FromString("extend");
+        PyObject_CallMethodObjArgs(candidate_text, method_name, to_add, nullptr);
+        Py_DecRef(method_name);
+    } else {
+        const auto& to_candidate = get_tainted_object(candidate_text, ctx_map);
+        auto to_result = initializer->allocate_tainted_object_copy(to_candidate);
+        const auto& to_toadd = get_tainted_object(to_add, ctx_map);
 
-    // Ensure no returns are done before this method call
-    auto method_name = PyUnicode_FromString("extend");
-    PyObject_CallMethodObjArgs(candidate_text, method_name, to_add, nullptr);
-    Py_DecRef(method_name);
+        // Ensure no returns are done before this method call
+        auto method_name = PyUnicode_FromString("extend");
+        PyObject_CallMethodObjArgs(candidate_text, method_name, to_add, nullptr);
+        Py_DecRef(method_name);
 
-    if (not ctx_map or ctx_map->empty() or to_result == nullptr) {
-        Py_RETURN_NONE;
+        if (to_result == nullptr) {
+            Py_RETURN_NONE;
+        }
+
+        if (to_toadd) {
+            to_result->add_ranges_shifted(to_toadd, (long)len_candidate_text);
+        }
+        set_tainted_object(candidate_text, to_result, ctx_map);
     }
-
-    if (to_toadd) {
-        to_result->add_ranges_shifted(to_toadd, (long)len_candidate_text);
-    }
-    set_tainted_object(candidate_text, to_result, ctx_map);
     Py_RETURN_NONE;
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.cpp
@@ -8,6 +8,12 @@ api_format_aspect(StrType& candidate_text,
                   const py::args& args,
                   const py::kwargs& kwargs)
 {
+    const auto tx_map = initializer->get_tainting_map();
+
+    if (not tx_map or tx_map->empty()) {
+        return py::getattr(candidate_text, "format")(*args, **kwargs);
+    }
+
     auto [ranges_orig, candidate_text_ranges] = are_all_text_all_ranges(candidate_text.ptr(), parameter_list);
 
     if (!ranges_orig.empty() or !candidate_text_ranges.empty()) {
@@ -40,7 +46,7 @@ api_format_aspect(StrType& candidate_text,
         StrType result_text = get<0>(result);
         TaintRangeRefs result_ranges = get<1>(result);
         PyObject* new_result = new_pyobject_id(result_text.ptr());
-        set_ranges(new_result, result_ranges);
+        set_ranges(new_result, result_ranges, tx_map);
         return py::reinterpret_steal<StrType>(new_result);
     }
     return py::getattr(candidate_text, "format")(*args, **kwargs);

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
@@ -1,7 +1,7 @@
 #include "AspectIndex.h"
 
 PyObject*
-index_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* idx, TaintRangeMapType* tx_taint_map)
+index_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* idx, const TaintRangeMapTypePtr& tx_taint_map)
 {
     auto idx_long = PyLong_AsLong(idx);
     TaintRangeRefs ranges_to_set;

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.h
@@ -3,6 +3,6 @@
 #include "TaintedOps/TaintedOps.h"
 
 PyObject*
-index_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* idx, TaintRangeMapType* tx_taint_map);
+index_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* idx, const TaintRangeMapTypePtr& tx_taint_map);
 PyObject*
 api_index_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs);

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
@@ -5,7 +5,7 @@ aspect_join_str(PyObject* sep,
                 PyObject* result,
                 PyObject* iterable_str,
                 size_t len_iterable,
-                TaintRangeMapType* tx_taint_map)
+                const TaintRangeMapTypePtr& tx_taint_map)
 {
     // This is the special case for unicode str and unicode iterable_str.
     // The iterable elements string will be split into 1 char-length strings.
@@ -58,7 +58,7 @@ aspect_join_str(PyObject* sep,
 }
 
 PyObject*
-aspect_join(PyObject* sep, PyObject* result, PyObject* iterable_elements, TaintRangeMapType* tx_taint_map)
+aspect_join(PyObject* sep, PyObject* result, PyObject* iterable_elements, const TaintRangeMapTypePtr& tx_taint_map)
 {
     const size_t& len_sep = get_pyobject_size(sep);
     // FIXME: bug. if the argument is a string instead of a tuple, it will enter
@@ -178,7 +178,9 @@ api_join_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
         result = result_ptr.ptr();
         Py_INCREF(result);
     }
-    if (get_pyobject_size(result) == 0) {
+
+    const auto ctx_map = initializer->get_tainting_map();
+    if (not ctx_map or ctx_map->empty() or get_pyobject_size(result) == 0) {
         // Empty result cannot have taint ranges
         if (decref_arg0) {
             Py_DecRef(arg0);

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
@@ -61,8 +61,7 @@ PyObject*
 aspect_join(PyObject* sep, PyObject* result, PyObject* iterable_elements, const TaintRangeMapTypePtr& tx_taint_map)
 {
     const size_t& len_sep = get_pyobject_size(sep);
-    // FIXME: bug. if the argument is a string instead of a tuple, it will enter
-    // into an infinite loop
+
     size_t len_iterable{ 0 };
     auto GetElement = PyList_GetItem;
     if (PyList_Check(iterable_elements)) {
@@ -142,7 +141,6 @@ PyObject*
 api_join_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 {
     if (nargs != 2) {
-        // TODO: any other more sane error handling?
         return nullptr;
     }
 
@@ -185,11 +183,6 @@ api_join_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
         if (decref_arg0) {
             Py_DecRef(arg0);
         }
-        return result;
-    }
-
-    auto ctx_map = initializer->get_tainting_map();
-    if (not ctx_map or ctx_map->empty()) {
         return result;
     }
     auto res = aspect_join(sep, result, arg0, ctx_map);

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
@@ -74,7 +74,6 @@ PyObject*
 api_add_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 {
     if (nargs != 2) {
-        // TODO: any other more sane error handling?
         return nullptr;
     }
     PyObject* candidate_text = args[0];
@@ -102,6 +101,6 @@ api_add_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     if (not tx_map or tx_map->empty()) {
         return result_o;
     }
-    auto res = add_aspect(result_o, candidate_text, text_to_add, ctx_map);
+    auto res = add_aspect(result_o, candidate_text, text_to_add, tx_map);
     return res;
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
@@ -11,7 +11,10 @@
  * @return A new result object with the taint information.
  */
 PyObject*
-add_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* text_to_add, TaintRangeMapType* tx_taint_map)
+add_aspect(PyObject* result_o,
+           PyObject* candidate_text,
+           PyObject* text_to_add,
+           const TaintRangeMapTypePtr& tx_taint_map)
 {
     size_t len_candidate_text{ get_pyobject_size(candidate_text) };
     size_t len_text_to_add{ get_pyobject_size(text_to_add) };
@@ -95,8 +98,8 @@ api_add_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
         return result_o;
     }
 
-    auto ctx_map = initializer->get_tainting_map();
-    if (not ctx_map or ctx_map->empty()) {
+    const auto tx_map = initializer->get_tainting_map();
+    if (not tx_map or tx_map->empty()) {
         return result_o;
     }
     auto res = add_aspect(result_o, candidate_text, text_to_add, ctx_map);

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
@@ -20,7 +20,7 @@ reduce_ranges_from_index_range_map(TaintRangeRefs index_range_map)
         if (taint_range != current_range) {
             if (current_range) {
                 new_ranges.emplace_back(
-                        initializer->allocate_taint_range(current_start, index - current_start, current_range->source));
+                  initializer->allocate_taint_range(current_start, index - current_start, current_range->source));
             }
             current_range = taint_range;
             current_start = index;
@@ -28,7 +28,7 @@ reduce_ranges_from_index_range_map(TaintRangeRefs index_range_map)
     }
     if (current_range != NULL) {
         new_ranges.emplace_back(
-                initializer->allocate_taint_range(current_start, index - current_start, current_range->source));
+          initializer->allocate_taint_range(current_start, index - current_start, current_range->source));
     }
     return new_ranges;
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.cpp
@@ -1,26 +1,42 @@
 #include "Helpers.h"
 #include "Initializer/Initializer.h"
+#include <algorithm>
 #include <ostream>
 #include <regex>
 
 using namespace pybind11::literals;
 namespace py = pybind11;
 
+/**
+ * @brief This function is used to get the taint ranges for the given text object.
+ *
+ * @param string_method The string method to be used.
+ * @param candidate_text The text object for which the taint ranges are to be built.
+ * @param args The arguments to be passed to the string method.
+ * @param kwargs The keyword arguments to be passed to the string method.
+ */
 template<class StrType>
 StrType
-common_replace(const py::str& string_method,
-               const StrType& candidate_text,
-               const py::args& args,
-               const py::kwargs& kwargs)
+api_common_replace(const py::str& string_method,
+                   const StrType& candidate_text,
+                   const py::args& args,
+                   const py::kwargs& kwargs)
 {
-    TaintRangeRefs candidate_text_ranges{ get_ranges(candidate_text.ptr()) };
-
+    bool ranges_error;
+    TaintRangeRefs candidate_text_ranges;
     StrType res = py::getattr(candidate_text, string_method)(*args, **kwargs);
-    if (candidate_text_ranges.empty()) {
+
+    const auto tx_map = initializer->get_tainting_map();
+    if (not tx_map or tx_map->empty()) {
+        return res;
+    }
+    std::tie(candidate_text_ranges, ranges_error) = get_ranges(candidate_text.ptr(), tx_map);
+
+    if (ranges_error or candidate_text_ranges.empty()) {
         return res;
     }
 
-    set_ranges(res.ptr(), shift_taint_ranges(candidate_text_ranges, 0, -1));
+    set_ranges(res.ptr(), shift_taint_ranges(candidate_text_ranges, 0, -1), tx_map);
     return res;
 }
 
@@ -177,11 +193,14 @@ split_taints(const string& str_to_split)
 py::bytearray
 api_convert_escaped_text_to_taint_text_ba(const py::bytearray& taint_escaped_text, TaintRangeRefs ranges_orig)
 {
+
+    const auto tx_map = initializer->get_tainting_map();
+
     py::bytes bytes_text = py::bytes() + taint_escaped_text;
 
     std::tuple result = _convert_escaped_text_to_taint_text<py::bytes>(bytes_text, std::move(ranges_orig));
     PyObject* new_result = new_pyobject_id((py::bytearray() + get<0>(result)).ptr());
-    set_ranges(new_result, get<1>(result));
+    set_ranges(new_result, get<1>(result), tx_map);
     return py::reinterpret_steal<py::bytearray>(new_result);
 }
 
@@ -189,11 +208,13 @@ template<class StrType>
 StrType
 api_convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, TaintRangeRefs ranges_orig)
 {
+    const auto tx_map = initializer->get_tainting_map();
+
     std::tuple result = _convert_escaped_text_to_taint_text<StrType>(taint_escaped_text, ranges_orig);
     StrType result_text = get<0>(result);
     TaintRangeRefs result_ranges = get<1>(result);
     PyObject* new_result = new_pyobject_id(result_text.ptr());
-    set_ranges(new_result, result_ranges);
+    set_ranges(new_result, result_ranges, tx_map);
     return py::reinterpret_steal<StrType>(new_result);
 }
 
@@ -308,6 +329,87 @@ _convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, TaintRang
     return { StrType(result), ranges };
 }
 
+/**
+ * @brief This function takes the ranges of a string splitted (as in string.split or rsplit or os.path.split) and
+ * applies the ranges of the original string to the splitted parts with updated offsets.
+ *
+ * @param source_str: The original string that was splitted.
+ * @param source_ranges: The ranges of the original string.
+ * @param split_result: The splitted parts of the original string.
+ * @param tx_map: The taint map to apply the ranges.
+ * @param include_separator: If the separator should be included in the splitted parts.
+ */
+template<class StrType>
+bool
+set_ranges_on_splitted(const StrType& source_str,
+                       const TaintRangeRefs& source_ranges,
+                       const py::list& split_result,
+                       const TaintRangeMapTypePtr& tx_map,
+                       bool include_separator)
+{
+    bool some_set = false;
+
+    // Some quick shortcuts
+    if (source_ranges.empty() or py::len(split_result) == 0 or py::len(source_str) == 0 or not tx_map or
+        tx_map->empty()) {
+        return false;
+    }
+
+    RANGE_START offset = 0;
+    std::string c_source_str = py::cast<std::string>(source_str);
+    auto separator_increase = (int)((not include_separator));
+
+    for (const auto& item : split_result) {
+        if (not is_text(item.ptr()) or py::len(item) == 0) {
+            continue;
+        }
+        auto c_item = py::cast<std::string>(item);
+        TaintRangeRefs item_ranges;
+
+        // Find the item in the source_str.
+        const auto start = static_cast<RANGE_START>(c_source_str.find(c_item, offset));
+        if (start == -1) {
+            continue;
+        }
+        const auto end = static_cast<RANGE_START>(start + c_item.length());
+
+        // Find what source_ranges match these positions and create a new range with the start and len updated.
+        for (const auto& range : source_ranges) {
+            auto range_end_abs = range->start + range->length;
+
+            if (range->start < end && range_end_abs > start) {
+                // Create a new range with the updated start
+                auto new_range_start = std::max(range->start - offset, 0L);
+                auto new_range_length = std::min(end - start, (range->length - std::max(0L, offset - range->start)));
+                item_ranges.emplace_back(
+                  initializer->allocate_taint_range(new_range_start, new_range_length, range->source));
+            }
+        }
+        if (not item_ranges.empty()) {
+            set_ranges(item.ptr(), item_ranges, tx_map);
+            some_set = true;
+        }
+
+        offset += py::len(item) + separator_increase;
+    }
+
+    return some_set;
+}
+
+template<class StrType>
+bool
+api_set_ranges_on_splitted(const StrType& source_str,
+                           const TaintRangeRefs& source_ranges,
+                           const py::list& split_result,
+                           bool include_separator)
+{
+    const auto tx_map = initializer->get_tainting_map();
+    if (not tx_map or tx_map->empty()) {
+        return false;
+    }
+    return set_ranges_on_splitted(source_str, source_ranges, split_result, tx_map, include_separator);
+}
+
 py::object
 parse_params(size_t position,
              const char* keyword_name,
@@ -326,9 +428,30 @@ parse_params(size_t position,
 void
 pyexport_aspect_helpers(py::module& m)
 {
-    m.def("common_replace", &common_replace<py::bytes>, "string_method"_a, "candidate_text"_a);
-    m.def("common_replace", &common_replace<py::str>, "string_method"_a, "candidate_text"_a);
-    m.def("common_replace", &common_replace<py::bytearray>, "string_method"_a, "candidate_text"_a);
+    m.def("common_replace", &api_common_replace<py::bytes>, "string_method"_a, "candidate_text"_a);
+    m.def("common_replace", &api_common_replace<py::str>, "string_method"_a, "candidate_text"_a);
+    m.def("common_replace", &api_common_replace<py::bytearray>, "string_method"_a, "candidate_text"_a);
+    m.def("set_ranges_on_splitted",
+          &api_set_ranges_on_splitted<py::bytes>,
+          "source_str"_a,
+          "source_ranges"_a,
+          "split_result"_a,
+          // cppcheck-suppress assignBoolToPointer
+          "include_separator"_a = false);
+    m.def("set_ranges_on_splitted",
+          &api_set_ranges_on_splitted<py::str>,
+          "source_str"_a,
+          "source_ranges"_a,
+          "split_result"_a,
+          // cppcheck-suppress assignBoolToPointer
+          "include_separator"_a = false);
+    m.def("set_ranges_on_splitted",
+          &api_set_ranges_on_splitted<py::bytearray>,
+          "source_str"_a,
+          "source_ranges"_a,
+          "split_result"_a,
+          // cppcheck-suppress assignBoolToPointer
+          "include_separator"_a = false);
     m.def("_all_as_formatted_evidence",
           &_all_as_formatted_evidence<py::str>,
           "text"_a,

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
@@ -14,10 +14,10 @@ namespace py = pybind11;
 // lower() and similar.
 template<class StrType>
 StrType
-common_replace(const py::str& string_method,
-               const StrType& candidate_text,
-               const py::args& args,
-               const py::kwargs& kwargs);
+api_common_replace(const py::str& string_method,
+                   const StrType& candidate_text,
+                   const py::args& args,
+                   const py::kwargs& kwargs);
 
 template<class StrType>
 StrType
@@ -51,6 +51,21 @@ api_convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, TaintR
 template<class StrType>
 std::tuple<StrType, TaintRangeRefs>
 _convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, TaintRangeRefs ranges_orig);
+
+template<class StrType>
+bool
+set_ranges_on_splitted(const StrType& source_str,
+                       const TaintRangeRefs& source_ranges,
+                       const py::list& split_result,
+                       const TaintRangeMapTypePtr& tx_map,
+                       bool include_separator = false);
+
+template<class StrType>
+bool
+api_set_ranges_on_splitted(const StrType& source_str,
+                           const TaintRangeRefs& source_ranges,
+                           const py::list& split_result,
+                           bool include_separator = false);
 
 void
 pyexport_aspect_helpers(py::module& m);

--- a/ddtrace/appsec/_iast/_taint_tracking/Constants.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Constants.h
@@ -2,3 +2,7 @@
 #define PY_MODULE_NAME "ddtrace.appsec._iast._taint_tracking._native"
 #define RANGE_START long
 #define RANGE_LENGTH long
+#define MSG_ERROR_N_PARAMS "[IAST] Invalid number of params"
+#define MSG_ERROR_SET_RANGES "[IAST] Set ranges error: Empty ranges or Tainted Map isn't initialized"
+#define MSG_ERROR_GET_RANGES_TYPE "[IAST] Get ranges error: Invalid type of candidate_text variable"
+#define MSG_ERROR_TAINT_MAP "[IAST] Tainted Map isn't initialized"

--- a/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
@@ -7,7 +7,7 @@ using namespace pybind11::literals;
 
 thread_local struct ThreadContextCache_
 {
-    size_t tx_id = 0;
+    TaintRangeMapTypePtr tx_map = nullptr;
 } ThreadContextCache;
 
 Initializer::Initializer()
@@ -23,23 +23,23 @@ Initializer::Initializer()
     }
 }
 
-TaintRangeMapType*
+TaintRangeMapTypePtr
 Initializer::create_tainting_map()
 {
-    auto map_ptr = new TaintRangeMapType();
-    active_map_addreses.insert(map_ptr);
+    auto map_ptr = make_shared<TaintRangeMapType>();
+    active_map_addreses[map_ptr.get()] = map_ptr;
     return map_ptr;
 }
 
 void
-Initializer::free_tainting_map(TaintRangeMapType* tx_map)
+Initializer::clear_tainting_map(const TaintRangeMapTypePtr& tx_map)
 {
     if (not tx_map)
         return;
 
-    auto it = active_map_addreses.find(tx_map);
+    auto it = active_map_addreses.find(tx_map.get());
     if (it == active_map_addreses.end()) {
-        // Map wasn't in the set, do nothing
+        // Map wasn't in the active addresses, do nothing
         return;
     }
 
@@ -48,24 +48,22 @@ Initializer::free_tainting_map(TaintRangeMapType* tx_map)
     }
 
     tx_map->clear();
-    delete tx_map;
-    active_map_addreses.erase(it);
 }
 
 // User must check for nullptr return
-TaintRangeMapType*
+TaintRangeMapTypePtr
 Initializer::get_tainting_map()
 {
-    return (TaintRangeMapType*)ThreadContextCache.tx_id;
+    return ThreadContextCache.tx_map;
 }
 
 void
 Initializer::clear_tainting_maps()
 {
     // Need to copy because free_tainting_map changes the set inside the iteration
-    auto map_addresses_copy = initializer->active_map_addreses;
-    for (auto map_ptr : map_addresses_copy) {
-        free_tainting_map((TaintRangeMapType*)map_ptr);
+    for (auto& [fst, snd] : initializer->active_map_addreses) {
+        clear_tainting_map(snd);
+        snd = nullptr;
     }
     active_map_addreses.clear();
 }
@@ -212,21 +210,14 @@ Initializer::release_taint_range(TaintRangePtr rangeptr)
 void
 Initializer::create_context()
 {
-    if (ThreadContextCache.tx_id != 0) {
-        // Destroy the current context
-        destroy_context();
+    if (ThreadContextCache.tx_map != nullptr) {
+        // Reset the current context
+        reset_context();
     }
 
     // Create a new taint_map
     auto map_ptr = create_tainting_map();
-    ThreadContextCache.tx_id = (size_t)map_ptr;
-}
-
-void
-Initializer::destroy_context()
-{
-    free_tainting_map((TaintRangeMapType*)ThreadContextCache.tx_id);
-    ThreadContextCache.tx_id = 0;
+    ThreadContextCache.tx_map = map_ptr;
 }
 
 size_t
@@ -238,9 +229,8 @@ Initializer::context_id()
 void
 Initializer::reset_context()
 {
-    //    lock_guard<recursive_mutex> lock(contexts_mutex);
-    ThreadContextCache.tx_id = 0;
     clear_tainting_maps();
+    ThreadContextCache.tx_map = nullptr;
 }
 
 // Created in the PYBIND11_MODULE in _native.cpp
@@ -259,5 +249,4 @@ pyexport_initializer(py::module& m)
     m.def(
       "create_context", []() { return initializer->create_context(); }, py::return_value_policy::reference);
     m.def("reset_context", [] { initializer->reset_context(); });
-    m.def("destroy_context", [] { initializer->destroy_context(); });
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
@@ -73,7 +73,7 @@ Initializer::num_objects_tainted()
 {
     auto ctx_map = initializer->get_tainting_map();
     if (ctx_map) {
-        return ctx_map->size();
+        return static_cast<int>(ctx_map->size());
     }
     return 0;
 }
@@ -106,7 +106,7 @@ Initializer::initializer_size()
 int
 Initializer::active_map_addreses_size()
 {
-    return active_map_addreses.size();
+    return static_cast<int>(active_map_addreses.size());
 }
 
 TaintedObjectPtr
@@ -127,15 +127,6 @@ Initializer::allocate_ranges_into_taint_object(TaintRangeRefs ranges)
     auto toptr = allocate_tainted_object();
     toptr->set_values(std::move(ranges));
     return toptr;
-}
-
-TaintedObjectPtr
-Initializer::allocate_tainted_object(TaintedObjectPtr from)
-{
-    if (!from) {
-        return allocate_tainted_object();
-    }
-    return allocate_ranges_into_taint_object(std::move(from->ranges_));
 }
 
 TaintedObjectPtr
@@ -220,12 +211,6 @@ Initializer::create_context()
     ThreadContextCache.tx_map = map_ptr;
 }
 
-size_t
-Initializer::context_id()
-{
-    return ThreadContextCache.tx_id;
-}
-
 void
 Initializer::reset_context()
 {
@@ -247,6 +232,6 @@ pyexport_initializer(py::module& m)
     m.def("active_map_addreses_size", [] { return initializer->active_map_addreses_size(); });
 
     m.def(
-      "create_context", []() { return initializer->create_context(); }, py::return_value_policy::reference);
+            "create_context", []() { return initializer->create_context(); }, py::return_value_policy::reference);
     m.def("reset_context", [] { initializer->reset_context(); });
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
@@ -232,6 +232,6 @@ pyexport_initializer(py::module& m)
     m.def("active_map_addreses_size", [] { return initializer->active_map_addreses_size(); });
 
     m.def(
-            "create_context", []() { return initializer->create_context(); }, py::return_value_policy::reference);
+      "create_context", []() { return initializer->create_context(); }, py::return_value_policy::reference);
     m.def("reset_context", [] { initializer->reset_context(); });
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.h
@@ -7,7 +7,6 @@
 
 #include <stack>
 #include <unordered_map>
-#include <unordered_set>
 
 using namespace std;
 
@@ -22,7 +21,9 @@ class Initializer
     static constexpr int TAINTEDOBJECTS_STACK_SIZE = 4096;
     stack<TaintedObjectPtr> available_taintedobjects_stack;
     stack<TaintRangePtr> available_ranges_stack;
-    unordered_set<TaintRangeMapType*> active_map_addreses;
+    // This is a map instead of a set so we can change the contents on iteration; otherwise
+    // keys and values are the same pointer.
+    unordered_map<TaintRangeMapType*, TaintRangeMapTypePtr> active_map_addreses;
 
   public:
     /**
@@ -35,21 +36,21 @@ class Initializer
      *
      * @return A pointer to the created taint range map.
      */
-    TaintRangeMapType* create_tainting_map();
+    TaintRangeMapTypePtr create_tainting_map();
 
     /**
-     * Frees a taint range map.
+     * Clears a taint range map.
      *
      * @param tx_map The taint range map to be freed.
      */
-    void free_tainting_map(TaintRangeMapType* tx_map);
+    void clear_tainting_map(const TaintRangeMapTypePtr& tx_map);
 
     /**
      * Gets the current taint range map.
      *
      * @return A pointer to the current taint range map.
      */
-    static TaintRangeMapType* get_tainting_map();
+    static TaintRangeMapTypePtr get_tainting_map();
 
     /**
      * Clears all active taint maps.
@@ -83,11 +84,6 @@ class Initializer
      * Creates a new taint tracking context.
      */
     void create_context();
-
-    /**
-     * Destroys the current taint tracking context.
-     */
-    void destroy_context();
 
     /**
      * Resets the current taint tracking context.

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
@@ -2,6 +2,8 @@
 #include "Initializer/Initializer.h"
 #include "Utils/StringUtils.h"
 
+namespace py = pybind11;
+
 void
 TaintRange::reset()
 {
@@ -36,7 +38,7 @@ TaintRange::get_hash() const
 };
 
 TaintRangePtr
-api_shift_taint_range(const TaintRangePtr& source_taint_range, RANGE_START offset, RANGE_LENGTH new_length = -1)
+shift_taint_range(const TaintRangePtr& source_taint_range, RANGE_START offset, RANGE_LENGTH new_length = -1)
 {
     if (new_length == -1) {
         new_length = source_taint_range->length;
@@ -54,7 +56,7 @@ shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, RANGE_START offset
     new_ranges.reserve(source_taint_ranges.size());
 
     for (const auto& trange : source_taint_ranges) {
-        new_ranges.emplace_back(api_shift_taint_range(trange, offset, new_length));
+        new_ranges.emplace_back(shift_taint_range(trange, offset, new_length));
     }
     return new_ranges;
 }
@@ -68,10 +70,10 @@ api_shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, RANGE_START of
 py::object
 api_set_ranges(py::object& str, const TaintRangeRefs& ranges)
 {
-    auto tx_map = initializer->get_tainting_map();
+    const auto tx_map = initializer->get_tainting_map();
 
     if (not tx_map) {
-        throw py::value_error("[IAST] Tainted Map isn't initialized");
+        throw py::value_error(MSG_ERROR_TAINT_MAP);
     }
     set_ranges(str.ptr(), ranges, tx_map);
     return py::none();
@@ -101,79 +103,78 @@ api_set_ranges(py::object& str, const TaintRangeRefs& ranges)
 PyObject*
 api_set_ranges_from_values(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 {
+    bool result = false;
+    const char* result_error_msg = MSG_ERROR_N_PARAMS;
+    PyObject* pyobject_n = nullptr;
 
-    if (nargs != 5) {
-        PyErr_SetString(
-          PyExc_TypeError,
-          "Invalid number of params: pyobject_newid, len(pyobject), source_name, source_value, source_origin");
-        throw std::runtime_error(
-          "Invalid number of params: pyobject_newid, len(pyobject), source_name, source_value, source_origin");
-    }
-    PyObject* tainted_object = args[0];
-    if (!PyUnicode_Check(tainted_object) and !PyByteArray_Check(tainted_object) and !PyBytes_Check(tainted_object)) {
-        return tainted_object;
-    }
-    auto ctx_map = initializer->get_tainting_map();
-    PyObject* pyobject_n = new_pyobject_id(tainted_object);
-    PyObject* len_pyobject_py = args[1];
+    if (nargs == 5) {
+        PyObject* tainted_object = args[0];
+        const auto tx_map = initializer->get_tainting_map();
+        if (not tx_map) {
+            py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
+            return nullptr;
+        }
 
-    long len_pyobject = PyLong_AsLong(len_pyobject_py);
-    string source_name = PyObjectToString(args[2]);
-    string source_value = PyObjectToString(args[3]);
-    auto source_origin = OriginType(PyLong_AsLong(args[4]));
-    auto source = Source(source_name, source_value, source_origin);
-    auto range = initializer->allocate_taint_range(0, len_pyobject, source);
-    TaintRangeRefs ranges = vector{ range };
-    set_ranges(pyobject_n, ranges, ctx_map);
+        pyobject_n = new_pyobject_id(tainted_object);
+        PyObject* len_pyobject_py = args[1];
+
+        long len_pyobject = PyLong_AsLong(len_pyobject_py);
+        string source_name = PyObjectToString(args[2]);
+        if (not source_name.empty()) {
+            string source_value = PyObjectToString(args[3]);
+            if (not source_value.empty()) {
+                auto source_origin = OriginType(PyLong_AsLong(args[4]));
+                auto source = Source(source_name, source_value, source_origin);
+                auto range = initializer->allocate_taint_range(0, len_pyobject, source);
+                TaintRangeRefs ranges = vector{ range };
+                result = set_ranges(pyobject_n, ranges, tx_map);
+                if (not result) {
+                    result_error_msg = MSG_ERROR_SET_RANGES;
+                }
+            } else {
+                result_error_msg = "[IAST] Invalid or empty source_value";
+            }
+        } else {
+            result_error_msg = "[IAST] Invalid or empty source_name";
+        }
+    }
+    if (not result) {
+        py::set_error(PyExc_ValueError, result_error_msg);
+        return nullptr;
+    }
+
     return pyobject_n;
 }
 
-TaintRangeRefs
-get_ranges(PyObject* string_input, TaintRangeMapType* tx_map)
+std::pair<TaintRangeRefs, bool>
+get_ranges(PyObject* string_input, const TaintRangeMapTypePtr& tx_map)
 {
+    TaintRangeRefs result;
     if (not is_text(string_input))
-        return {};
+        return std::make_pair(result, true);
 
-    if (not tx_map) {
-        tx_map = initializer->get_tainting_map();
+    if (tx_map->empty()) {
+        return std::make_pair(result, false);
     }
-    if (!tx_map or tx_map->empty()) {
-        // TODO: log something here: "no tx_map, maybe call create_context()?"
-        return {};
-    }
-
     const auto it = tx_map->find(get_unique_id(string_input));
     if (it == tx_map->end()) {
-        return {};
+        return std::make_pair(result, false);
     }
 
     if (get_internal_hash(string_input) != it->second.first) {
         tx_map->erase(it);
-        return {};
+        return std::make_pair(result, false);
     }
 
-    return it->second.second->get_ranges();
+    return std::make_pair(it->second.second->get_ranges(), false);
 }
 
-void
-set_ranges(PyObject* str, const TaintRangeRefs& ranges, TaintRangeMapType* tx_map)
+bool
+set_ranges(PyObject* str, const TaintRangeRefs& ranges, const TaintRangeMapTypePtr& tx_map)
 {
-    if (not is_text(str) or ranges.empty())
-        return;
-
-    if (not tx_map) {
-        tx_map = initializer->get_tainting_map();
-        if (not tx_map) {
-            // TODO: Log "Tainted Map isn't initialized. Call create_context() first";
-            return;
-        }
+    if (ranges.empty()) {
+        return false;
     }
-
-    auto tx_id = initializer->context_id();
-    if (tx_id == 0) {
-        return;
-    }
-
     auto obj_id = get_unique_id(str);
     auto it = tx_map->find(obj_id);
     auto new_tainted_object = initializer->allocate_ranges_into_taint_object(ranges);
@@ -183,14 +184,14 @@ set_ranges(PyObject* str, const TaintRangeRefs& ranges, TaintRangeMapType* tx_ma
     if (it != tx_map->end()) {
         it->second.second->decref();
         it->second = std::make_pair(get_internal_hash(str), new_tainted_object);
-        return;
+        return true;
     }
 
     tx_map->insert({ obj_id, std::make_pair(get_internal_hash(str), new_tainted_object) });
+    return true;
 }
 
 // Returns a tuple with (all ranges, ranges of candidate_text)
-// FIXME: add check that candidate_text is really some kind of string
 // FIXME: Take a PyList as parameter_list instead of a py::tuple (same for the
 // result)
 std::tuple<TaintRangeRefs, TaintRangeRefs>
@@ -198,29 +199,36 @@ are_all_text_all_ranges(PyObject* candidate_text, const py::tuple& parameter_lis
 {
     if (not is_text(candidate_text))
         return {};
-    // TODO: pass tx_map to the function
-    auto tx_map = initializer->get_tainting_map();
-    TaintRangeRefs candidate_text_ranges{ get_ranges(candidate_text, tx_map) };
-    TaintRangeRefs all_ranges;
 
-    for (const auto& param_handler : parameter_list) {
-        auto param = param_handler.cast<py::object>().ptr();
-
-        if (is_text(param)) {
-            // TODO: OPT
-            TaintRangeRefs ranges{ get_ranges(param, tx_map) };
-            all_ranges.insert(all_ranges.end(), ranges.begin(), ranges.end());
-        }
+    bool ranges_error;
+    TaintRangeRefs candidate_text_ranges, all_ranges;
+    const auto tx_map = initializer->get_tainting_map();
+    if (not tx_map or tx_map->empty()) {
+        return { {}, {} };
     }
 
-    all_ranges.insert(all_ranges.end(), candidate_text_ranges.begin(), candidate_text_ranges.end());
+    std::tie(candidate_text_ranges, ranges_error) = get_ranges(candidate_text, tx_map);
+    if (not ranges_error) {
+        for (const auto& param_handler : parameter_list) {
+            auto param = param_handler.cast<py::object>().ptr();
+
+            if (is_text(param)) {
+                TaintRangeRefs ranges;
+                std::tie(ranges, ranges_error) = get_ranges(param, tx_map);
+                if (not ranges_error) {
+                    all_ranges.insert(all_ranges.end(), ranges.begin(), ranges.end());
+                }
+            }
+        }
+        all_ranges.insert(all_ranges.end(), candidate_text_ranges.begin(), candidate_text_ranges.end());
+    }
     return { all_ranges, candidate_text_ranges };
 }
 
 TaintRangePtr
 get_range_by_hash(size_t range_hash, optional<TaintRangeRefs>& taint_ranges)
 {
-    if (!taint_ranges or taint_ranges->empty()) {
+    if (not taint_ranges or taint_ranges->empty()) {
         return nullptr;
     }
     // TODO: Replace this loop with a efficient function, vector.find() is O(n)
@@ -234,35 +242,75 @@ get_range_by_hash(size_t range_hash, optional<TaintRangeRefs>& taint_ranges)
     return null_range;
 }
 
-inline void
+TaintRangeRefs
+api_get_ranges(const py::object& string_input)
+{
+    bool ranges_error;
+    TaintRangeRefs ranges;
+    const auto tx_map = initializer->get_tainting_map();
+
+    if (not tx_map) {
+        throw py::value_error(MSG_ERROR_TAINT_MAP);
+    }
+
+    std::tie(ranges, ranges_error) = get_ranges(string_input.ptr(), tx_map);
+    if (ranges_error) {
+        throw py::value_error(MSG_ERROR_GET_RANGES_TYPE);
+    }
+    return ranges;
+}
+
+void
 api_copy_ranges_from_strings(py::object& str_1, py::object& str_2)
 {
-    auto tx_map = initializer->get_tainting_map();
-    auto ranges = get_ranges(str_1.ptr(), tx_map);
-    set_ranges(str_2.ptr(), ranges, tx_map);
+
+    bool ranges_error, result;
+    TaintRangeRefs ranges;
+    const auto tx_map = initializer->get_tainting_map();
+
+    if (not tx_map) {
+        py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
+        return;
+    }
+
+    std::tie(ranges, ranges_error) = get_ranges(str_1.ptr(), tx_map);
+    if (ranges_error) {
+        py::set_error(PyExc_TypeError, MSG_ERROR_TAINT_MAP);
+        return;
+    }
+    result = set_ranges(str_2.ptr(), ranges, tx_map);
+    if (not result) {
+        py::set_error(PyExc_TypeError, MSG_ERROR_SET_RANGES);
+    }
 }
 
 inline void
 api_copy_and_shift_ranges_from_strings(py::object& str_1, py::object& str_2, int offset, int new_length = -1)
 {
-    auto tx_map = initializer->get_tainting_map();
-    auto ranges = get_ranges(str_1.ptr(), tx_map);
-    set_ranges(str_2.ptr(), shift_taint_ranges(ranges, offset, new_length), tx_map);
+    bool ranges_error, result;
+    TaintRangeRefs ranges;
+    const auto tx_map = initializer->get_tainting_map();
+    if (not tx_map) {
+        py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
+        return;
+    }
+    std::tie(ranges, ranges_error) = get_ranges(str_1.ptr(), tx_map);
+    if (ranges_error) {
+        py::set_error(PyExc_TypeError, MSG_ERROR_TAINT_MAP);
+        return;
+    }
+    result = set_ranges(str_2.ptr(), shift_taint_ranges(ranges, offset, new_length), tx_map);
+    if (not result) {
+        py::set_error(PyExc_TypeError, MSG_ERROR_SET_RANGES);
+    }
 }
 
 TaintedObjectPtr
-get_tainted_object(PyObject* str, TaintRangeMapType* tx_map)
+get_tainted_object(PyObject* str, const TaintRangeMapTypePtr& tx_map)
 {
     if (not str)
         return nullptr;
 
-    if (not tx_map) {
-        tx_map = initializer->get_tainting_map();
-        if (not tx_map) {
-            // TODO: Log "Tainted Map isn't initialized. Call create_context() first";
-            return nullptr;
-        }
-    }
     if (is_notinterned_notfasttainted_unicode(str) or tx_map->empty()) {
         return nullptr;
     }
@@ -299,20 +347,11 @@ get_internal_hash(PyObject* obj)
 }
 
 void
-set_tainted_object(PyObject* str, TaintedObjectPtr tainted_object, TaintRangeMapType* tx_taint_map)
+set_tainted_object(PyObject* str, TaintedObjectPtr tainted_object, const TaintRangeMapTypePtr& tx_taint_map)
 {
     if (not str or not is_text(str)) {
         return;
     }
-
-    if (not tx_taint_map) {
-        tx_taint_map = initializer->get_tainting_map();
-        if (not tx_taint_map) {
-            // TODO: Log "Tainted Map isn't initialized. Call create_context() first";
-            return;
-        }
-    }
-
     auto obj_id = get_unique_id(str);
     set_fast_tainted_if_notinterned_unicode(str);
     auto it = tx_taint_map->find(obj_id);
@@ -375,8 +414,8 @@ pyexport_taintrange(py::module& m)
           "offset"_a,
           "new_length"_a = -1);
 
+    // m.def("set_ranges", py::overload_cast<PyObject*, const TaintRangeRefs&>(&api_set_ranges), "str"_a, "ranges"_a);
     m.def("set_ranges", &api_set_ranges, "str"_a, "ranges"_a);
-
     m.def("copy_ranges_from_strings", &api_copy_ranges_from_strings, "str_1"_a, "str_2"_a);
     m.def("copy_and_shift_ranges_from_strings",
           &api_copy_and_shift_ranges_from_strings,
@@ -385,10 +424,6 @@ pyexport_taintrange(py::module& m)
           "offset"_a,
           "new_length"_a = -1);
 
-    m.def("get_ranges",
-          py::overload_cast<PyObject*>(&get_ranges),
-          "string_input"_a,
-          py::return_value_policy::take_ownership);
     m.def("get_ranges", &api_get_ranges, "string_input"_a, py::return_value_policy::take_ownership);
 
     m.def("get_range_by_hash", &get_range_by_hash, "range_hash"_a, "taint_ranges"_a);

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
@@ -111,7 +111,6 @@ api_set_ranges_from_values(PyObject* self, PyObject* const* args, Py_ssize_t nar
         PyObject* tainted_object = args[0];
         const auto tx_map = initializer->get_tainting_map();
         if (not tx_map) {
-            py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
             return nullptr;
         }
 
@@ -139,7 +138,6 @@ api_set_ranges_from_values(PyObject* self, PyObject* const* args, Py_ssize_t nar
         }
     }
     if (not result) {
-        py::set_error(PyExc_ValueError, result_error_msg);
         return nullptr;
     }
 
@@ -250,12 +248,12 @@ api_get_ranges(const py::object& string_input)
     const auto tx_map = initializer->get_tainting_map();
 
     if (not tx_map) {
-        throw py::value_error(MSG_ERROR_TAINT_MAP);
+        return ranges;
     }
 
     std::tie(ranges, ranges_error) = get_ranges(string_input.ptr(), tx_map);
     if (ranges_error) {
-        throw py::value_error(MSG_ERROR_GET_RANGES_TYPE);
+        return ranges;
     }
     return ranges;
 }
@@ -269,18 +267,16 @@ api_copy_ranges_from_strings(py::object& str_1, py::object& str_2)
     const auto tx_map = initializer->get_tainting_map();
 
     if (not tx_map) {
-        py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
         return;
     }
 
     std::tie(ranges, ranges_error) = get_ranges(str_1.ptr(), tx_map);
     if (ranges_error) {
-        py::set_error(PyExc_TypeError, MSG_ERROR_TAINT_MAP);
         return;
     }
     result = set_ranges(str_2.ptr(), ranges, tx_map);
     if (not result) {
-        py::set_error(PyExc_TypeError, MSG_ERROR_SET_RANGES);
+        return;
     }
 }
 
@@ -291,17 +287,14 @@ api_copy_and_shift_ranges_from_strings(py::object& str_1, py::object& str_2, int
     TaintRangeRefs ranges;
     const auto tx_map = initializer->get_tainting_map();
     if (not tx_map) {
-        py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
         return;
     }
     std::tie(ranges, ranges_error) = get_ranges(str_1.ptr(), tx_map);
     if (ranges_error) {
-        py::set_error(PyExc_TypeError, MSG_ERROR_TAINT_MAP);
         return;
     }
     result = set_ranges(str_2.ptr(), shift_taint_ranges(ranges, offset, new_length), tx_map);
     if (not result) {
-        py::set_error(PyExc_TypeError, MSG_ERROR_SET_RANGES);
     }
 }
 

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
@@ -32,6 +32,9 @@ using TaintRangeMapType = std::map<uintptr_t, std::pair<Py_hash_t, TaintedObject
 
 #endif // NDEBUG
 
+using TaintRangeMapTypePtr = shared_ptr<TaintRangeMapType>;
+// using TaintRangeMapTypePtr = TaintRangeMapType*;
+
 struct TaintRange
 {
     RANGE_START start = 0;
@@ -73,7 +76,13 @@ using TaintRangePtr = shared_ptr<TaintRange>;
 using TaintRangeRefs = vector<TaintRangePtr>;
 
 TaintRangePtr
-api_shift_taint_range(const TaintRangePtr& source_taint_range, RANGE_START offset, RANGE_LENGTH new_length);
+shift_taint_range(const TaintRangePtr& source_taint_range, RANGE_START offset, RANGE_LENGTH new_length);
+
+inline TaintRangePtr
+api_shift_taint_range(const TaintRangePtr& source_taint_range, RANGE_START offset, RANGE_LENGTH new_length)
+{
+    return shift_taint_range(source_taint_range, offset, new_length);
+}
 
 TaintRangeRefs
 shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, RANGE_START offset, RANGE_LENGTH new_length);
@@ -81,32 +90,19 @@ shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, RANGE_START offset
 TaintRangeRefs
 api_shift_taint_ranges(const TaintRangeRefs&, RANGE_START offset, RANGE_LENGTH new_length);
 
-TaintRangeRefs
-get_ranges(PyObject* string_input, TaintRangeMapType* tx_map);
-inline TaintRangeRefs
-get_ranges(PyObject* string_input)
-{
-    return get_ranges(string_input, nullptr);
-}
-inline TaintRangeRefs
-api_get_ranges(py::object& string_input)
-{
-    return get_ranges(string_input.ptr());
-}
+std::pair<TaintRangeRefs, bool>
+get_ranges(PyObject* string_input, const TaintRangeMapTypePtr& tx_map);
 
-void
-set_ranges(PyObject* str, const TaintRangeRefs& ranges, TaintRangeMapType* tx_map);
-
-inline void
-set_ranges(PyObject* str, const TaintRangeRefs& ranges)
-{
-    set_ranges(str, ranges, nullptr);
-}
+bool
+set_ranges(PyObject* str, const TaintRangeRefs& ranges, const TaintRangeMapTypePtr& tx_map);
 
 py::object
 api_set_ranges(py::object& str, const TaintRangeRefs& ranges);
 
-inline void
+TaintRangeRefs
+api_get_ranges(const py::object& string_input);
+
+void
 api_copy_ranges_from_strings(py::object& str_1, py::object& str_2);
 
 inline void
@@ -140,7 +136,7 @@ api_is_unicode_and_not_fast_tainted(const py::object str)
 }
 
 TaintedObject*
-get_tainted_object(PyObject* str, TaintRangeMapType* tx_taint_map);
+get_tainted_object(PyObject* str, const TaintRangeMapTypePtr& tx_taint_map);
 
 Py_hash_t
 bytearray_hash(PyObject* bytearray);
@@ -149,7 +145,7 @@ Py_hash_t
 get_internal_hash(PyObject* obj);
 
 void
-set_tainted_object(PyObject* str, TaintedObjectPtr tainted_object, TaintRangeMapType* tx_taint_map);
+set_tainted_object(PyObject* str, TaintedObjectPtr tainted_object, const TaintRangeMapTypePtr& tx_taint_map);
 
 void
 pyexport_taintrange(py::module& m);

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.cpp
@@ -1,15 +1,17 @@
 #include "TaintedOps/TaintedOps.h"
 
 PyObject*
-api_new_pyobject_id(PyObject* Py_UNUSED(module), PyObject* args)
+api_new_pyobject_id(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 {
-    PyObject* tainted_object;
-    PyArg_ParseTuple(args, "O", &tainted_object);
+    if (nargs != 1 or !args) {
+        throw py::value_error(MSG_ERROR_N_PARAMS);
+    }
+    PyObject* tainted_object = args[0];
     return new_pyobject_id(tainted_object);
 }
 
 bool
-is_tainted(PyObject* tainted_object, TaintRangeMapType* tx_taint_map)
+is_tainted(PyObject* tainted_object, const TaintRangeMapTypePtr& tx_taint_map)
 {
     const auto& to_initial = get_tainted_object(tainted_object, tx_taint_map);
     if (to_initial and !to_initial->get_ranges().empty()) {
@@ -22,12 +24,12 @@ bool
 api_is_tainted(py::object tainted_object)
 {
     if (tainted_object) {
-        auto ctx_map = initializer->get_tainting_map();
-        if (not ctx_map or ctx_map->empty()) {
+        const auto tx_map = initializer->get_tainting_map();
+        if (not tx_map or tx_map->empty()) {
             return false;
         }
 
-        if (is_tainted(tainted_object.ptr(), ctx_map)) {
+        if (is_tainted(tainted_object.ptr(), tx_map)) {
             return true;
         }
     }

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.h
@@ -11,22 +11,13 @@ using namespace pybind11::literals;
 namespace py = pybind11;
 
 PyObject*
-api_new_pyobject_id(PyObject* Py_UNUSED(module), PyObject* args);
+api_new_pyobject_id(PyObject* self, PyObject* const* args, Py_ssize_t nargs);
 
 bool
-is_tainted(PyObject* Py_UNUSED(module), PyObject* args);
+is_tainted(PyObject* tainted_object, const TaintRangeMapTypePtr& tx_taint_map);
 
 bool
 api_is_tainted(py::object tainted_object);
 
 void
 pyexport_tainted_ops(py::module& m);
-// TODO
-// PyObject *api_add_taint_pyobject(PyObject* pyobject, PyObject* op1, PyObject*
-// op2); PyObject* api_taint_pyobject(PyObject* pyobject, Source source); bool
-// api_is_pyobject_tainted(PyObject* pyobject); void
-// api_set_tainted_ranges(PyObject* pyobject, TaintRangeRefs ranges);
-// TaintRangeRefs api_get_tainted_ranges(PyObject* pyobject); // can be already
-// implemented
-// XXX (Tuple[List[Dict[str, Union[Any, int]]], list[Source]])
-// api_taint_ranges_as_evidence_info(PyObject* pyobject);

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -18,7 +18,6 @@ if _is_python_version_supported():
     from ._native.initializer import active_map_addreses_size
     from ._native.initializer import create_context
     from ._native.initializer import debug_taint_map
-    from ._native.initializer import destroy_context
     from ._native.initializer import initializer_size
     from ._native.initializer import num_objects_tainted
     from ._native.initializer import reset_context
@@ -72,7 +71,6 @@ __all__ = [
     "set_fast_tainted_if_notinterned_unicode",
     "aspect_helpers",
     "reset_context",
-    "destroy_context",
     "initializer_size",
     "active_map_addreses_size",
     "create_context",

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -175,9 +175,8 @@ def slice_aspect(candidate_text, start, stop, step) -> Any:
     return result
 
 
-def bytearray_extend_aspect(orig_function, flag_added_args, *args, **kwargs):
-    # type: (Optional[Callable], int, Any, Any) -> Any
-    if orig_function and not isinstance(orig_function, BuiltinFunctionType):
+def bytearray_extend_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> Any:
+    if orig_function is not None and not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]
         return orig_function(*args, **kwargs)

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -175,7 +175,8 @@ def slice_aspect(candidate_text, start, stop, step) -> Any:
     return result
 
 
-def bytearray_extend_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> Any:
+def bytearray_extend_aspect(orig_function, flag_added_args, *args, **kwargs):
+    # type: (Optional[Callable], int, Any, Any) -> Any
     if orig_function is not None and not isinstance(orig_function, BuiltinFunctionType):
         if flag_added_args > 0:
             args = args[flag_added_args:]

--- a/releasenotes/notes/iast-segfaults-fix-d25c5c132dd8482e.yaml
+++ b/releasenotes/notes/iast-segfaults-fix-d25c5c132dd8482e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Code Security: fix a potential memory corruption when the context was reset.

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 
-cppcheck --error-exitcode=1 --std=c++17 --language=c++ --force \
+cppcheck --inline-suppr --error-exitcode=1 --std=c++17 --language=c++ --force \
     $(git ls-files '*.c' '*.cpp' '*.h' '*.hpp' '*.cc' '*.hh' | grep -E -v '^(ddtrace/(vendor|internal)|ddtrace/appsec/_iast/_taint_tracking/_vendor)/')

--- a/tests/appsec/iast/aspects/test_add_aspect.py
+++ b/tests/appsec/iast/aspects/test_add_aspect.py
@@ -1,25 +1,27 @@
 #!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
+import logging
+
 import pytest
 
+from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import create_context
-from ddtrace.appsec._iast._taint_tracking import destroy_context
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking import reset_context
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
-from ddtrace.appsec._iast._taint_tracking import taint_ranges_as_evidence_info
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import TaintRange_
 import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
 from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect
+from tests.utils import override_env
 
 
 @pytest.mark.parametrize(
     "obj1, obj2",
     [
         (3.5, 3.3),
-        # (complex(2, 1), complex(3, 4)),
+        (complex(2, 1), complex(3, 4)),
         ("Hello ", "world"),
         ("🙀", "🌝"),
         (b"Hi", b""),
@@ -230,82 +232,19 @@ def test_add_aspect_tainting_add_left_twice(obj1, obj2):
     assert ranges_result[0].length == 3
 
 
-def test_taint_ranges_as_evidence_info_nothing_tainted():
-    text = "nothing tainted"
-    value_parts, sources = taint_ranges_as_evidence_info(text)
-    assert value_parts == [{"value": text}]
-    assert sources == []
-
-
-def test_taint_ranges_as_evidence_info_all_tainted():
-    arg = "all tainted"
-    input_info = Source("request_body", arg, OriginType.PARAMETER)
-    tainted_text = taint_pyobject(arg, source_name="request_body", source_value=arg, source_origin=OriginType.PARAMETER)
-    value_parts, sources = taint_ranges_as_evidence_info(tainted_text)
-    assert value_parts == [{"value": tainted_text, "source": 0}]
-    assert sources == [input_info]
-
-
-def test_taint_ranges_as_evidence_info_tainted_op1_add():
-    arg = "tainted part"
-    input_info = Source("request_body", arg, OriginType.PARAMETER)
-    text = "|not tainted part|"
-    tainted_text = taint_pyobject(arg, source_name="request_body", source_value=arg, source_origin=OriginType.PARAMETER)
-    tainted_add_result = add_aspect(tainted_text, text)
-
-    value_parts, sources = taint_ranges_as_evidence_info(tainted_add_result)
-    assert value_parts == [{"value": tainted_text, "source": 0}, {"value": text}]
-    assert sources == [input_info]
-
-
-def test_taint_ranges_as_evidence_info_tainted_op2_add():
-    arg = "tainted part"
-    input_info = Source("request_body", arg, OriginType.PARAMETER)
-    text = "|not tainted part|"
-    tainted_text = taint_pyobject(arg, source_name="request_body", source_value=arg, source_origin=OriginType.PARAMETER)
-    tainted_add_result = add_aspect(text, tainted_text)
-
-    value_parts, sources = taint_ranges_as_evidence_info(tainted_add_result)
-    assert value_parts == [{"value": text}, {"value": tainted_text, "source": 0}]
-    assert sources == [input_info]
-
-
-def test_taint_ranges_as_evidence_info_same_tainted_op1_and_op3_add():
-    arg = "tainted part"
-    input_info = Source("request_body", arg, OriginType.PARAMETER)
-    text = "|not tainted part|"
-    tainted_text = taint_pyobject(arg, source_name="request_body", source_value=arg, source_origin=OriginType.PARAMETER)
-    tainted_add_result = add_aspect(tainted_text, add_aspect(text, tainted_text))
-
-    value_parts, sources = taint_ranges_as_evidence_info(tainted_add_result)
-    assert value_parts == [{"value": tainted_text, "source": 0}, {"value": text}, {"value": tainted_text, "source": 0}]
-    assert sources == [input_info]
-
-
-def test_taint_ranges_as_evidence_info_different_tainted_op1_and_op3_add():
-    arg1 = "tainted body"
-    arg2 = "tainted header"
-    input_info1 = Source("request_body", arg1, OriginType.PARAMETER)
-    input_info2 = Source("request_body", arg2, OriginType.PARAMETER)
-    text = "|not tainted part|"
-    tainted_text1 = taint_pyobject(
-        arg1, source_name="request_body", source_value=arg1, source_origin=OriginType.PARAMETER
-    )
-    tainted_text2 = taint_pyobject(
-        arg2, source_name="request_body", source_value=arg2, source_origin=OriginType.PARAMETER
-    )
-    tainted_add_result = add_aspect(tainted_text1, add_aspect(text, tainted_text2))
-
-    value_parts, sources = taint_ranges_as_evidence_info(tainted_add_result)
-    assert value_parts == [
-        {"value": tainted_text1, "source": 0},
-        {"value": text},
-        {"value": tainted_text2, "source": 1},
-    ]
-    assert sources == [input_info1, input_info2]
-
-
-def test_taint_object_error_with_no_context():
+@pytest.mark.skip_iast_check_logs
+@pytest.mark.parametrize(
+    "log_level, iast_debug, expected_log_msg",
+    [
+        (logging.DEBUG, "", ""),
+        (logging.WARNING, "", ""),
+        (logging.DEBUG, "false", ""),
+        (logging.WARNING, "false", ""),
+        (logging.DEBUG, "true", "_iast/_taint_tracking/__init__.py"),
+        (logging.WARNING, "true", ""),
+    ],
+)
+def test_taint_object_error_with_no_context(log_level, iast_debug, expected_log_msg, caplog):
     """Test taint_pyobject without context. This test is to ensure that the function does not raise an exception."""
     string_to_taint = "my_string"
     create_context()
@@ -319,16 +258,24 @@ def test_taint_object_error_with_no_context():
     ranges_result = get_tainted_ranges(result)
     assert len(ranges_result) == 1
 
-    destroy_context()
-    result = taint_pyobject(
-        pyobject=string_to_taint,
-        source_name="test_add_aspect_tainting_left_hand",
-        source_value=string_to_taint,
-        source_origin=OriginType.PARAMETER,
-    )
+    reset_context()
+    with override_env({IAST.ENV_DEBUG: iast_debug}), caplog.at_level(log_level):
+        result = taint_pyobject(
+            pyobject=string_to_taint,
+            source_name="test_add_aspect_tainting_left_hand",
+            source_value=string_to_taint,
+            source_origin=OriginType.PARAMETER,
+        )
 
     ranges_result = get_tainted_ranges(result)
     assert len(ranges_result) == 0
+
+    if expected_log_msg:
+        assert any(expected_log_msg in record.message for record in caplog.records), [
+            record.message for record in caplog.records
+        ]
+    else:
+        assert not any("[IAST] Tainted Map" in record.message for record in caplog.records)
 
     create_context()
     result = taint_pyobject(
@@ -342,6 +289,7 @@ def test_taint_object_error_with_no_context():
     assert len(ranges_result) == 1
 
 
+@pytest.mark.skip_iast_check_logs
 def test_get_ranges_from_object_with_no_context():
     """Test taint_pyobject without context. This test is to ensure that the function does not raise an exception."""
     string_to_taint = "my_string"
@@ -353,12 +301,13 @@ def test_get_ranges_from_object_with_no_context():
         source_origin=OriginType.PARAMETER,
     )
 
-    destroy_context()
+    reset_context()
     ranges_result = get_tainted_ranges(result)
     assert len(ranges_result) == 0
 
 
-def test_propagate_ranges_with_no_context():
+@pytest.mark.skip_iast_check_logs
+def test_propagate_ranges_with_no_context(caplog):
     """Test taint_pyobject without context. This test is to ensure that the function does not raise an exception."""
     string_to_taint = "my_string"
     create_context()
@@ -369,7 +318,12 @@ def test_propagate_ranges_with_no_context():
         source_origin=OriginType.PARAMETER,
     )
 
-    destroy_context()
-    result_2 = add_aspect(result, "another_string")
+    reset_context()
+    with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
+        result_2 = add_aspect(result, "another_string")
+
+    create_context()
     ranges_result = get_tainted_ranges(result_2)
+    log_messages = [record.message for record in caplog.get_records("call")]
+    assert not any("[IAST] " in message for message in log_messages), log_messages
     assert len(ranges_result) == 0

--- a/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
@@ -1,14 +1,23 @@
 # -*- encoding: utf-8 -*-
+from enum import Enum
+import logging
 import math
 from typing import Any
 from typing import NamedTuple
 
 import pytest
 
+from ddtrace.appsec._constants import IAST
+from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
+from ddtrace.appsec._iast._taint_tracking import create_context
+from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking import reset_context
+from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
 from tests.appsec.iast.aspects.aspect_utils import create_taint_range_with_format
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.utils import override_env
 
 
 mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.str_methods")
@@ -223,3 +232,56 @@ class TestOperatorFormatReplacement(BaseReplacement):
 
         list_metrics_logs = list(telemetry_writer._logs)
         assert len(list_metrics_logs) == 0
+
+
+@pytest.mark.skip_iast_check_logs
+def test_propagate_ranges_with_no_context(caplog):
+    """Test taint_pyobject without context. This test is to ensure that the function does not raise an exception."""
+    string_to_taint = "-1234 {} {} {} {test_kwarg} {test_var}"
+    create_context()
+    string_input = taint_pyobject(
+        pyobject=string_to_taint,
+        source_name="test_add_aspect_tainting_left_hand",
+        source_value=string_to_taint,
+        source_origin=OriginType.PARAMETER,
+    )
+    reset_context()
+    with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
+        result_2 = mod.do_args_kwargs_4(string_input, 6, test_var=1)
+
+    ranges_result = get_tainted_ranges(result_2)
+    log_messages = [record.message for record in caplog.get_records("call")]
+    assert not any("[IAST] " in message for message in log_messages), log_messages
+    assert len(ranges_result) == 0
+
+
+class ExportType(str, Enum):
+    USAGE = "Usage"
+    ACTUAL_COST = "ActualCost"
+
+
+def test_format_value_aspect_no_change_patched_unpatched():
+    # Issue: https://datadoghq.atlassian.net/jira/software/c/projects/APPSEC/boards/1141?selectedIssue=APPSEC-53155
+    fstr_unpatched = f"{ExportType.ACTUAL_COST}"
+    fstr_patched = mod.do_exporttype_member_format()
+    assert fstr_patched == fstr_unpatched
+
+
+class CustomSpec:
+    def __str__(self):
+        return "str"
+
+    def __repr__(self):
+        return "repr"
+
+    def __format__(self, format_spec):
+        return "format_" + format_spec
+
+
+def test_format_value_aspect_no_change_customspec():
+    c = CustomSpec()
+    assert f"{c}" == mod.do_customspec_simple()
+    assert f"{c!s}" == mod.do_customspec_cstr()
+    assert f"{c!r}" == mod.do_customspec_repr()
+    assert f"{c!a}" == mod.do_customspec_ascii()
+    assert f"{c!s:<20s}" == mod.do_customspec_formatspec()

--- a/tests/appsec/iast/aspects/test_index_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_index_aspect_fixtures.py
@@ -1,12 +1,16 @@
-# -*- encoding: utf-8 -*-
+import logging
 import sys
 
 import pytest
 
+from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._taint_tracking import OriginType
+from ddtrace.appsec._iast._taint_tracking import create_context
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking import reset_context
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.utils import override_env
 
 
 mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.str_methods")
@@ -72,3 +76,25 @@ def test_index_error_and_no_log_metric(telemetry_writer):
 
     list_metrics_logs = list(telemetry_writer._logs)
     assert len(list_metrics_logs) == 0
+
+
+@pytest.mark.skip_iast_check_logs
+@pytest.mark.skipif(sys.version_info < (3, 9, 0), reason="Python version not supported by IAST")
+def test_propagate_ranges_with_no_context(caplog):
+    """Test taint_pyobject without context. This test is to ensure that the function does not raise an exception."""
+    input_str = "abcde"
+    create_context()
+    string_input = taint_pyobject(
+        pyobject=input_str,
+        source_name="test_add_aspect_tainting_left_hand",
+        source_value="foo",
+        source_origin=OriginType.PARAMETER,
+    )
+    assert get_tainted_ranges(string_input)
+
+    reset_context()
+    with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
+        result = mod.do_index(string_input, 3)
+        assert result == "d"
+    log_messages = [record.message for record in caplog.get_records("call")]
+    assert not any("[IAST] " in message for message in log_messages), log_messages

--- a/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
+import logging
+
+import pytest
+
+from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._taint_tracking import OriginType
+from ddtrace.appsec._iast._taint_tracking import create_context
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking import reset_context
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.utils import override_env
 
 
 mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.str_methods")
@@ -16,6 +24,19 @@ class TestOperatorJoinReplacement(object):
             pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
         )
         it = ["a", "b", "c"]
+
+        result = mod.do_join(string_input, it)
+        assert result == "a-joiner-b-joiner-c"
+        ranges = get_tainted_ranges(result)
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "-joiner-"
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "-joiner-"
+
+    def test_string_join_tainted_joiner_and_string_iterator(self):  # type: () -> None
+        # taint "joi" from "-joiner-"
+        string_input = taint_pyobject(
+            pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
+        )
+        it = "abc"
 
         result = mod.do_join(string_input, it)
         assert result == "a-joiner-b-joiner-c"
@@ -415,3 +436,55 @@ class TestOperatorJoinReplacement(object):
         assert result[ranges[4].start : (ranges[4].start + ranges[4].length)] == "h"
         assert result[ranges[5].start : (ranges[5].start + ranges[5].length)] == "+abcde-"
         assert result[ranges[6].start : (ranges[6].start + ranges[6].length)] == "i"
+
+
+@pytest.mark.skip_iast_check_logs
+def test_propagate_ranges_with_no_context(caplog):
+    create_context()
+    string_input = taint_pyobject(
+        pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
+    )
+    it = ["a", "b", "c"]
+    reset_context()
+    with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
+        result = mod.do_join(string_input, it)
+        assert result == "a-joiner-b-joiner-c"
+    log_messages = [record.message for record in caplog.get_records("call")]
+    assert not any("[IAST] " in message for message in log_messages), log_messages
+
+
+@pytest.mark.skip_iast_check_logs
+def test_propagate_ranges_with_no_context_with_var(caplog):
+    create_context()
+    string_input = taint_pyobject(
+        pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
+    )
+    it = [
+        taint_pyobject(pyobject="a", source_name="joined", source_value="a", source_origin=OriginType.PARAMETER),
+        "b",
+        "c",
+    ]
+    reset_context()
+    with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
+        result = mod.do_join(string_input, it)
+        assert result == "a-joiner-b-joiner-c"
+    log_messages = [record.message for record in caplog.get_records("call")]
+    assert not any("[IAST] " in message for message in log_messages), log_messages
+
+
+@pytest.mark.skip_iast_check_logs
+def test_propagate_ranges_with_no_context_with_equal_var(caplog):
+    create_context()
+    string_input = taint_pyobject(
+        pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
+    )
+    a_tainted = taint_pyobject(
+        pyobject="abcdef", source_name="joined", source_value="abcdef", source_origin=OriginType.PARAMETER
+    )
+
+    reset_context()
+    with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
+        result = mod.do_join(string_input, [a_tainted, a_tainted, a_tainted])
+        assert result == "abcdef-joiner-abcdef-joiner-abcdef"
+    log_messages = [record.message for record in caplog.get_records("call")]
+    assert not any("[IAST] " in message for message in log_messages), log_messages

--- a/tests/appsec/iast/aspects/test_slice_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_slice_aspect_fixtures.py
@@ -1,12 +1,17 @@
 # -*- encoding: utf-8 -*-
+import logging
 import sys
 
 import pytest
 
+from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._taint_tracking import OriginType
+from ddtrace.appsec._iast._taint_tracking import create_context
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking import reset_context
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.utils import override_env
 
 
 mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.str_methods")
@@ -301,3 +306,21 @@ def test_string_slice_negative():
     )
     result = mod.do_slice_negative(tainted_input)
     assert result == expected_result
+
+
+@pytest.mark.skip_iast_check_logs
+def test_propagate_ranges_with_no_context(caplog):
+    create_context()
+    tainted_input = taint_pyobject(
+        pyobject="abcde",
+        source_name="input_str",
+        source_value="foo",
+        source_origin=OriginType.PARAMETER,
+    )
+
+    reset_context()
+    with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
+        result = mod.do_slice(tainted_input, 0, 3, None)
+        assert result == "abc"
+    log_messages = [record.message for record in caplog.get_records("call")]
+    assert not any("[IAST] " in message for message in log_messages), log_messages

--- a/tests/appsec/iast/taint_tracking/test_taint_tracking.py
+++ b/tests/appsec/iast/taint_tracking/test_taint_tracking.py
@@ -12,8 +12,8 @@ with override_env({"DD_IAST_ENABLED": "True"}):
     from ddtrace.appsec._iast._taint_tracking import OriginType
     from ddtrace.appsec._iast._taint_tracking import Source
     from ddtrace.appsec._iast._taint_tracking import TaintRange
-    from ddtrace.appsec._iast._taint_tracking import destroy_context
     from ddtrace.appsec._iast._taint_tracking import num_objects_tainted
+    from ddtrace.appsec._iast._taint_tracking import reset_context
     from ddtrace.appsec._iast._taint_tracking import set_ranges
     from ddtrace.appsec._iast._taint_tracking import taint_pyobject
     from ddtrace.appsec._iast._taint_tracking import taint_ranges_as_evidence_info
@@ -42,7 +42,7 @@ def test_taint_ranges_as_evidence_info_all_tainted():
 
 @pytest.mark.skip_iast_check_logs
 def test_taint_object_with_no_context_should_be_noop():
-    destroy_context()
+    reset_context()
     arg = "all tainted"
     tainted_text = taint_pyobject(arg, source_name="request_body", source_value=arg, source_origin=OriginType.PARAMETER)
     assert tainted_text == arg
@@ -51,7 +51,7 @@ def test_taint_object_with_no_context_should_be_noop():
 
 @pytest.mark.skip_iast_check_logs
 def test_propagate_ranges_with_no_context(caplog):
-    destroy_context()
+    reset_context()
     with override_env({IAST.ENV_DEBUG: "true"}), caplog.at_level(logging.DEBUG):
         string_input = taint_pyobject(
             pyobject="abcde", source_name="abcde", source_value="abcde", source_origin=OriginType.PARAMETER
@@ -63,7 +63,7 @@ def test_propagate_ranges_with_no_context(caplog):
 
 @pytest.mark.skip_iast_check_logs
 def test_call_to_set_ranges_directly_raises_a_exception(caplog):
-    destroy_context()
+    reset_context()
     input_str = "abcde"
     with pytest.raises(ValueError) as excinfo:
         set_ranges(


### PR DESCRIPTION
Backport #9284 to 2.8

## Description

Fix several segmentation faults (3 confirmed, probably more).

This is done by a small rework of the Initializer which includes:

- Moving `active_map_addreses` from `unordered_set` to `unordered_map` so we can iterate and change it without making a copy (making a copy was actually causing one of the segmentation faults because we were setting the `tx_map` pointer to `nullptr`, but on the copy, not the original, so `get_tainting_map` would return `not nullptr` but still garbage since it was deleted).

- Convert the `TaintRangeMapType` pointer to a `shared_ptr`. This fixed another segfault and makes the codebase more robust.

- Make `ThreadContextCache` not use a dangerously magical number-pointer but just a reference to the active `tx_map` so we only need to check if it's `nullptr` to see if we are in context (which is what functions did anyway).

- Removed `destroy_context`. Not needed anymore, `reset_context` will do the same in a safer way.

## Checklist

- [X] Change(s) are motivated and described in the PR description
- [X] Testing strategy is described if automated tests are not included in the PR
- [X] Risks are described (performance impact, potential for breakage, maintainability)
- [X] Change is maintainable (easy to change, telemetry, documentation)
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [X] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
