### PR TITLE
chore(ci): update GitHub Actions to latest version

### DIFF
--- a/.github/workflows/apm-transport-stress-test.yml
+++ b/.github/workflows/apm-transport-stress-test.yml
@@ -13,7 +13,7 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_SHARED_TESTS_API_KEY }}
       TRACER: python
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: DataDog/apm-transport-stress-tests
       - name: Build

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -23,7 +23,7 @@ jobs:
   build_push:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -84,7 +84,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
           path: dist
 
       - name: Install build dependencies
@@ -117,7 +116,6 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -54,12 +54,12 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         # Include all history and tags
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.7'
@@ -68,7 +68,7 @@ jobs:
         run: |
           pip install cython cmake
           python setup.py sdist
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
@@ -80,8 +80,8 @@ jobs:
     container:
       image: python:3.9-alpine
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     if: (github.event_name == 'release' && github.event.action == 'published')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -70,6 +70,7 @@ jobs:
           python setup.py sdist
       - uses: actions/upload-artifact@v4
         with:
+          name: source-dist
           path: dist/*.tar.gz
 
   test_alpine_sdist:

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -84,6 +84,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
+          name: source-dist
           path: dist
 
       - name: Install build dependencies
@@ -117,6 +118,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: dist
+          merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -120,8 +120,13 @@ jobs:
           # DEV: Uncomment to debug MacOS
           # CIBW_BUILD_VERBOSITY_MACOS: 3
 
-      - run: |
+      - if: runner.os != 'Windows'
+        run: |
           echo "ARTIFACT_NAME=${{ matrix.os }}-${{ matrix.archs }}-$(echo "${{ inputs.cibw_build }}" | tr -cd '[:alnum:]_-')" >> $GITHUB_ENV
+      - if: runner.os == 'Windows'
+        run: |
+          chcp 65001 #set code page to utf-8
+          echo ("ARTIFACT_NAME=${{ matrix.os }}-${{ matrix.archs }}-${{ inputs.cibw_build }}".replace('*', '').replace(' ', '_')) >> $env:GITHUB_ENV
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ env.ARTIFACT_NAME }}

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -122,4 +122,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: wheels-${{ matrix.os }}-${{ matrix.version }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -120,10 +120,8 @@ jobs:
           # DEV: Uncomment to debug MacOS
           # CIBW_BUILD_VERBOSITY_MACOS: 3
 
-      - run:
-          name: Generate artifact name
-          command: |
-            echo "artifact_name=${{ matrix.os }}-${{ matrix-archs }}-$(echo "${{ inputs.cibw_build }}" | tr -cd '[:alnum:]_-')" >> $GITHUB_OUTPUT
+      - run: |
+          echo "artifact_name=${{ matrix.os }}-${{ matrix-archs }}-$(echo "${{ inputs.cibw_build }}" | tr -cd '[:alnum:]_-')" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ steps.vars.outputs.artifact_name }}

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -121,7 +121,7 @@ jobs:
           # CIBW_BUILD_VERBOSITY_MACOS: 3
 
       - run: |
-          echo "artifact_name=${{ matrix.os }}-${{ matrix-archs }}-$(echo "${{ inputs.cibw_build }}" | tr -cd '[:alnum:]_-')" >> $GITHUB_OUTPUT
+          echo "artifact_name=${{ matrix.os }}-${{ matrix.archs }}-$(echo "${{ inputs.cibw_build }}" | tr -cd '[:alnum:]_-')" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ steps.vars.outputs.artifact_name }}

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -121,8 +121,8 @@ jobs:
           # CIBW_BUILD_VERBOSITY_MACOS: 3
 
       - run: |
-          echo "artifact_name=${{ matrix.os }}-${{ matrix.archs }}-$(echo "${{ inputs.cibw_build }}" | tr -cd '[:alnum:]_-')" >> $GITHUB_OUTPUT
+          echo "ARTIFACT_NAME=${{ matrix.os }}-${{ matrix.archs }}-$(echo "${{ inputs.cibw_build }}" | tr -cd '[:alnum:]_-')" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ steps.vars.outputs.artifact_name }}
+          name: wheels-${{ env.ARTIFACT_NAME }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -28,12 +28,12 @@ jobs:
          - os: macos-12
            archs: x86_64 universal2
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         # Include all history and tags
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: matrix.os != 'arm-4core-linux'
         name: Install Python
         with:
@@ -120,6 +120,6 @@ jobs:
           # DEV: Uncomment to debug MacOS
           # CIBW_BUILD_VERBOSITY_MACOS: 3
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -122,5 +122,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}-${{ matrix.version }}
+          name: wheels-${{ matrix.os }}-${{ matrix.archs }}-${{ matrix.version }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -122,5 +122,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}-${{ matrix.archs }}-${{ matrix.version }}
+          name: wheels-${{ matrix.os }}-${{ matrix.archs }}-${{ github.job }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -120,7 +120,11 @@ jobs:
           # DEV: Uncomment to debug MacOS
           # CIBW_BUILD_VERBOSITY_MACOS: 3
 
+      - run:
+          name: Generate artifact name
+          command: |
+            echo "artifact_name=${{ matrix.os }}-${{ matrix-archs }}-$(echo "${{ inputs.cibw_build }}" | tr -cd '[:alnum:]_-')" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}-${{ matrix.archs }}-${{ github.job }}
+          name: wheels-${{ steps.vars.outputs.artifact_name }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,7 +12,7 @@ jobs:
     name: Validate changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         # Include all history and tags
         with:
           fetch-depth: 0
@@ -25,7 +25,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: scripts/check-releasenotes
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.8'
@@ -42,7 +42,7 @@ jobs:
           rst2html.py CHANGELOG.rst CHANGELOG.html
 
       - name: Upload CHANGELOG.rst
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: changelog
           path: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/django-overhead-profile.yml
+++ b/.github/workflows/django-overhead-profile.yml
@@ -16,11 +16,11 @@ jobs:
       run:
         working-directory: ddtrace
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: ddtrace
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.8"
 
@@ -32,7 +32,7 @@ jobs:
         run: |
           bash scripts/profiles/django-simple/run.sh ${PREFIX}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: django-overhead-profile
           path: ${{ github.workspace }}/prefix/artifacts

--- a/.github/workflows/encoders-profile.yml
+++ b/.github/workflows/encoders-profile.yml
@@ -16,11 +16,11 @@ jobs:
       run:
         working-directory: ddtrace
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: ddtrace
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.8"
 
@@ -36,7 +36,7 @@ jobs:
             sed -i 's|${{ github.workspace }}/ddtrace/||g' ${PREFIX}/artifacts/$a
           done
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: encoders-profile
           path: ${{ github.workspace }}/prefix/artifacts

--- a/.github/workflows/flask-overhead-profile.yml
+++ b/.github/workflows/flask-overhead-profile.yml
@@ -16,11 +16,11 @@ jobs:
       run:
         working-directory: ddtrace
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: ddtrace
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
@@ -32,7 +32,7 @@ jobs:
         run: |
           bash scripts/profiles/flask-simple/run.sh ${PREFIX}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: flask-overhead-profile
           path: ${{ github.workspace }}/prefix/artifacts

--- a/.github/workflows/lib-inject-publish.yml
+++ b/.github/workflows/lib-inject-publish.yml
@@ -17,7 +17,7 @@ jobs:
   wait_for_package:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
     - name: Wait for package to be available from PyPI

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -37,7 +37,7 @@ jobs:
       BUILDX_PLATFORMS: linux/amd64
     steps:
       - name: Checkout system tests
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
             repository: 'DataDog/system-tests'
 
@@ -74,7 +74,7 @@ jobs:
         ]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build and run the app
         run: |
           SRC="$(pwd)"

--- a/.github/workflows/pr-name.yml
+++ b/.github/workflows/pr-name.yml
@@ -9,10 +9,10 @@ jobs:
   pr_name_lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         name: Install Node.js
         with:
           node-version: 16

--- a/.github/workflows/requirements-locks.yml
+++ b/.github/workflows/requirements-locks.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/datadog/dd-trace-py/testrunner:latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/set-target-milestone.yml
+++ b/.github/workflows/set-target-milestone.yml
@@ -12,11 +12,11 @@ jobs:
     name: Add milestone to merged pull requests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         # Include all history and tags
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.8'

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -80,7 +80,7 @@ jobs:
           docker image save system_tests/weblog:latest | gzip > ${{ matrix.weblog-variant}}_weblog_${{ github.sha }}.tar.gz
           docker image save system_tests/agent:latest | gzip > ${{ matrix.weblog-variant}}_agent_${{ github.sha }}.tar.gz
 
-      - uses: actions/upload-artifact@4
+      - uses: actions/upload-artifact@v4
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
         with:
           name: ${{ matrix.weblog-variant }}_${{ github.sha }}
@@ -120,7 +120,7 @@ jobs:
         with:
           repository: 'DataDog/system-tests'
 
-      - uses: actions/download-artifact@4
+      - uses: actions/download-artifact@v4
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
         with:
           name: ${{ matrix.weblog-variant }}_${{ github.sha }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -48,13 +48,13 @@ jobs:
     steps:
       - name: Setup python 3.9
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
       - name: Checkout system tests
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
 
@@ -80,7 +80,7 @@ jobs:
           docker image save system_tests/weblog:latest | gzip > ${{ matrix.weblog-variant}}_weblog_${{ github.sha }}.tar.gz
           docker image save system_tests/agent:latest | gzip > ${{ matrix.weblog-variant}}_agent_${{ github.sha }}.tar.gz
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@4
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
         with:
           name: ${{ matrix.weblog-variant }}_${{ github.sha }}
@@ -110,17 +110,17 @@ jobs:
     steps:
       - name: Setup python 3.9
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
       - name: Checkout system tests
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@4
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
         with:
           name: ${{ matrix.weblog-variant }}_${{ github.sha }}
@@ -229,7 +229,7 @@ jobs:
         run: tar -czvf artifact.tar.gz $(ls | grep logs)
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: steps.compress-artifact.outcome == 'success' || github.event_name == 'schedule'
         with:
           name: logs_${{ matrix.weblog-variant }}_${{ matrix.scenario }}
@@ -244,7 +244,7 @@ jobs:
     steps:
       - name: Checkout system tests
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'DataDog/system-tests'
       - name: Checkout dd-trace-py
@@ -254,7 +254,7 @@ jobs:
           path: 'binaries/dd-trace-py'
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
         with:
           python-version: '3.9'
@@ -272,7 +272,7 @@ jobs:
         run: tar -czvf artifact.tar.gz $(ls | grep logs)
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
         with:
           name: logs_parametric

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       outcome: ${{ steps.run_needed.outcome }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: run_needed
         name: Check if run is needed
         run:  |
@@ -39,15 +39,15 @@ jobs:
       run:
         working-directory: bottle
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.9'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: bottlepy/bottle
@@ -90,17 +90,17 @@ jobs:
 #       run:
 #         working-directory: sanic
 #     steps:
-#       - uses: actions/checkout@v3
+#       - uses: actions/checkout@v4
 #         if: needs.needs-run.outputs.outcome == 'success'
 #         with:
 #           path: ddtrace
-#       - uses: actions/checkout@v3
+#       - uses: actions/checkout@v4
 #         if: needs.needs-run.outputs.outcome == 'success'
 #         with:
 #           repository: sanic-org/sanic
 #           ref: v22.12.0
 #           path: sanic
-#       - uses: actions/setup-python@v4
+#       - uses: actions/setup-python@v5
 #         if: needs.needs-run.outputs.outcome == 'success'
 #         with:
 #           python-version: "3.11"
@@ -145,17 +145,17 @@ jobs:
       run:
         working-directory: django
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: django/django
           ref: stable/3.1.x
           path: django
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: "3.8"
@@ -215,11 +215,11 @@ jobs:
       run:
         working-directory: graphene
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: graphql-python/graphene
@@ -227,7 +227,7 @@ jobs:
           # Unreleased CI fix: https://github.com/graphql-python/graphene/pull/1412
           ref: 03277a55123fd2f8a8465c5fa671f7fb0d004c26
           path: graphene
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: "3.9"
@@ -262,15 +262,15 @@ jobs:
       run:
         working-directory: fastapi
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.9'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: tiangolo/fastapi
@@ -311,17 +311,17 @@ jobs:
       run:
         working-directory: flask
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: pallets/flask
           ref: 1.1.4
           path: flask
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.8'
@@ -355,17 +355,17 @@ jobs:
       run:
         working-directory: httpx
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: encode/httpx
           ref: 0.22.0
           path: httpx
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.9'
@@ -403,17 +403,17 @@ jobs:
       run:
         working-directory: mako
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: sqlalchemy/mako
           ref: rel_1_3_0
           path: mako
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.8'
@@ -454,7 +454,7 @@ jobs:
       run:
         working-directory: starlette
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.9'
@@ -496,15 +496,15 @@ jobs:
       run:
         working-directory: requests
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.9'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: psf/requests
@@ -539,15 +539,15 @@ jobs:
       run:
         working-directory: asyncpg
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.9'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: magicstack/asyncpg
@@ -581,15 +581,15 @@ jobs:
       run:
         working-directory: gunicorn
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.9'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: benoitc/gunicorn
@@ -618,15 +618,15 @@ jobs:
       run:
         working-directory: uwsgi
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           python-version: '3.9'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           path: ddtrace
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: unbit/uwsgi

--- a/.github/workflows/upstream-issues.yml
+++ b/.github/workflows/upstream-issues.yml
@@ -7,7 +7,7 @@ jobs:
   upstream-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: Kyle-Verhoog/upstream-issue-notifier@v0.1.3
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This helps to avoid 'Node.js 16 actions are deprecated.' messages

- checkout v3 -> v4
- setup-python v4 -> v5
- setup-node v3 -> v4
- upload-artifact v3 -> v4
- download-artifact v3 -> v4

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
