### PR TITLE
fix(openai): handle explicit n=None case for chat completions

### DIFF
--- a/ddtrace/contrib/openai/_endpoint_hooks.py
+++ b/ddtrace/contrib/openai/_endpoint_hooks.py
@@ -135,7 +135,7 @@ class _BaseCompletionHook(_EndpointHook):
             async def traced_streamed_response():
                 g = shared_gen()
                 g.send(None)
-                n = kwargs.get("n", 1)
+                n = kwargs.get("n", 1) or 1
                 if operation_id == _CompletionHook.OPERATION_ID:
                     prompts = kwargs.get("prompt", "")
                     if isinstance(prompts, list) and not isinstance(prompts[0], int):
@@ -158,7 +158,7 @@ class _BaseCompletionHook(_EndpointHook):
             def traced_streamed_response():
                 g = shared_gen()
                 g.send(None)
-                n = kwargs.get("n", 1)
+                n = kwargs.get("n", 1) or 1
                 if operation_id == _CompletionHook.OPERATION_ID:
                     prompts = kwargs.get("prompt", "")
                     if isinstance(prompts, list) and not isinstance(prompts[0], int):

--- a/releasenotes/notes/fix-openai-none-n-kwarg-04e0f81074a13191.yaml
+++ b/releasenotes/notes/fix-openai-none-n-kwarg-04e0f81074a13191.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    openai: This fix resolves an issue where specifying `n=None` for streamed chat completions resulted in a `TypeError`.

--- a/tests/contrib/openai/test_openai_v1.py
+++ b/tests/contrib/openai/test_openai_v1.py
@@ -1192,7 +1192,7 @@ def test_completion_stream(openai, openai_vcr, mock_metrics, mock_tracer):
             mock_encoding.return_value.encode.side_effect = lambda x: [1, 2]
             expected_completion = '! ... A page layouts page drawer? ... Interesting. The "Tools" is'
             client = openai.OpenAI()
-            resp = client.completions.create(model="ada", prompt="Hello world", stream=True)
+            resp = client.completions.create(model="ada", prompt="Hello world", stream=True, n=None)
             assert isinstance(resp, Generator)
             chunks = [c for c in resp]
 
@@ -1278,6 +1278,7 @@ def test_chat_completion_stream(openai, openai_vcr, mock_metrics, snapshot_trace
                 ],
                 stream=True,
                 user="ddtrace-test",
+                n=None,
             )
             assert isinstance(resp, Generator)
             prompt_tokens = 8


### PR DESCRIPTION
Fixes #9283.

If users explicitly pass in `n=None` as a kwarg for OpenAI's completion/chat endpoints, this will break our tracing as we rely on the value of the passed `n` to instantiate a list of `n` elements.

Normally if `n` is not passed into the chat/completion method we assume a default value of 1 via `kwargs.get("n", 1)` but if `n` is explicitly passed as None this breaks our check. This fix ensures we default to a `n=1` in this case.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
