### PR TITLE
fix: error parsing django cookies

### DIFF
--- a/ddtrace/contrib/django/utils.py
+++ b/ddtrace/contrib/django/utils.py
@@ -374,23 +374,24 @@ def _after_request_tags(pin, span: Span, request, response):
             response_cookies = {}
             if response.cookies:
                 for k, v in response.cookies.items():
-                    # `v` is a http.cookies.Morsel class instance:
+                    # `v` is a http.cookies.Morsel class instance in some scenarios:
                     # 'cookie_key=cookie_value; HttpOnly; Path=/; SameSite=Strict'
-                    # try:
-                    i = 0
-                    result = ""
-                    for element in v.OutputString().split(";"):
-                        if i == 0:
-                            # split cookie_key="cookie_value"
-                            key, value = element.split("=")
-                            # Remove quotes "cookie_value"
-                            result = value[1:-1] if value.startswith('"') and value[-1] == '"' else value
-                        else:
-                            result += "; " + element
-                        i += 1
-                    response_cookies[k] = result
-                    # except Exception:
-                    #     response_cookies[k] = v.OutputString()
+                    try:
+                        i = 0
+                        result = ""
+                        for element in v.OutputString().split(";"):
+                            if i == 0:
+                                # split cookie_key="cookie_value"
+                                key, value = element.split("=", 1)
+                                # Remove quotes "cookie_value"
+                                result = value[1:-1] if value.startswith('"') and value[-1] == '"' else value
+                            else:
+                                result += ";" + element
+                            i += 1
+                        response_cookies[k] = result
+                    except Exception:
+                        # parse cookies by the old way
+                        response_cookies[k] = v.OutputString()
 
             raw_uri = url
             if raw_uri and request.META.get("QUERY_STRING"):

--- a/tests/contrib/django/django_app/appsec_urls.py
+++ b/tests/contrib/django/django_app/appsec_urls.py
@@ -210,6 +210,24 @@ def sqli_http_request_body(request):
     return HttpResponse(value, status=200)
 
 
+def view_insecure_cookies_insecure(request):
+    res = HttpResponse("OK")
+    res.set_cookie("insecure", "cookie", secure=False, httponly=True, samesite="Strict")
+    return res
+
+
+def view_insecure_cookies_secure(request):
+    res = HttpResponse("OK")
+    res.set_cookie("secure2", "value", secure=True, httponly=True, samesite="Strict")
+    return res
+
+
+def view_insecure_cookies_empty(request):
+    res = HttpResponse("OK")
+    res.set_cookie("insecure", "", secure=False, httponly=True, samesite="Strict")
+    return res
+
+
 def command_injection(request):
     value = decode_aspect(bytes.decode, 1, request.body)
     # label iast_command_injection
@@ -252,6 +270,9 @@ urlpatterns = [
     handler("sqli_http_request_cookie_name/$", sqli_http_request_cookie_name, name="sqli_http_request_cookie_name"),
     handler("sqli_http_request_cookie_value/$", sqli_http_request_cookie_value, name="sqli_http_request_cookie_value"),
     handler("sqli_http_request_body/$", sqli_http_request_body, name="sqli_http_request_body"),
+    handler("insecure-cookie/test_insecure", view_insecure_cookies_insecure),
+    handler("insecure-cookie/test_secure", view_insecure_cookies_secure),
+    handler("insecure-cookie/test_empty_cookie", view_insecure_cookies_empty),
     path(
         "sqli_http_path_parameter/<str:q_http_path_parameter>/",
         sqli_http_path_parameter,

--- a/tests/contrib/django/django_app/appsec_urls.py
+++ b/tests/contrib/django/django_app/appsec_urls.py
@@ -228,6 +228,20 @@ def view_insecure_cookies_empty(request):
     return res
 
 
+def view_insecure_cookies_two_insecure_one_secure(request):
+    res = HttpResponse("OK")
+    res.set_cookie("insecure1", "cookie1", secure=False, httponly=True, samesite="Strict")
+    res.set_cookie("insecure2", "cookie2", secure=True, httponly=False, samesite="Strict")
+    res.set_cookie("secure3", "cookie3", secure=True, httponly=True, samesite="Strict")
+    return res
+
+
+def view_insecure_cookies_insecure_special_chars(request):
+    res = HttpResponse("OK")
+    res.set_cookie("insecure", "cookie?()43jfM;;;===value", secure=False, httponly=True, samesite="Strict")
+    return res
+
+
 def command_injection(request):
     value = decode_aspect(bytes.decode, 1, request.body)
     # label iast_command_injection
@@ -270,9 +284,11 @@ urlpatterns = [
     handler("sqli_http_request_cookie_name/$", sqli_http_request_cookie_name, name="sqli_http_request_cookie_name"),
     handler("sqli_http_request_cookie_value/$", sqli_http_request_cookie_value, name="sqli_http_request_cookie_value"),
     handler("sqli_http_request_body/$", sqli_http_request_body, name="sqli_http_request_body"),
-    handler("insecure-cookie/test_insecure", view_insecure_cookies_insecure),
-    handler("insecure-cookie/test_secure", view_insecure_cookies_secure),
-    handler("insecure-cookie/test_empty_cookie", view_insecure_cookies_empty),
+    handler("insecure-cookie/test_insecure_2_1/$", view_insecure_cookies_two_insecure_one_secure),
+    handler("insecure-cookie/test_insecure_special/$", view_insecure_cookies_insecure_special_chars),
+    handler("insecure-cookie/test_insecure/$", view_insecure_cookies_insecure),
+    handler("insecure-cookie/test_secure/$", view_insecure_cookies_secure),
+    handler("insecure-cookie/test_empty_cookie/$", view_insecure_cookies_empty),
     path(
         "sqli_http_path_parameter/<str:q_http_path_parameter>/",
         sqli_http_path_parameter,

--- a/tests/contrib/django/test_django_appsec_iast.py
+++ b/tests/contrib/django/test_django_appsec_iast.py
@@ -9,6 +9,7 @@ from ddtrace.appsec._iast._patch_modules import patch_iast
 from ddtrace.appsec._iast._utils import _is_python_version_supported as python_supported_by_iast
 from ddtrace.appsec._iast.constants import VULN_CMDI
 from ddtrace.appsec._iast.constants import VULN_HEADER_INJECTION
+from ddtrace.appsec._iast.constants import VULN_INSECURE_COOKIE
 from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.internal.compat import urlencode
 from ddtrace.settings.asm import config as asm_config
@@ -580,3 +581,60 @@ def test_django_header_injection(client, test_spans, tracer):
         }
         assert loaded["vulnerabilities"][0]["location"]["line"] == line
         assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
+
+
+@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+def test_django_insecure_cookie(client, test_spans, tracer):
+    with override_global_config(dict(_iast_enabled=True, _deduplication_enabled=False)):
+        oce.reconfigure()
+        root_span, _ = _aux_appsec_get_root_span(
+            client,
+            test_spans,
+            tracer,
+            url="/appsec/insecure-cookie/test_insecure/",
+        )
+
+        assert root_span.get_metric(IAST.ENABLED) == 1.0
+
+        loaded = json.loads(root_span.get_tag(IAST.JSON))
+        assert loaded["sources"] == []
+        assert len(loaded["vulnerabilities"]) == 1
+        vulnerability = loaded["vulnerabilities"][0]
+        assert vulnerability["type"] == VULN_INSECURE_COOKIE
+        assert vulnerability["evidence"] == {"valueParts": [{"value": "insecure"}]}
+        assert "path" not in vulnerability["location"].keys()
+        assert "line" not in vulnerability["location"].keys()
+        assert vulnerability["location"]["spanId"]
+        assert vulnerability["hash"]
+
+
+@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+def test_django_insecure_cookie_secure(client, test_spans, tracer):
+    with override_global_config(dict(_iast_enabled=True, _deduplication_enabled=False)):
+        oce.reconfigure()
+        root_span, _ = _aux_appsec_get_root_span(
+            client,
+            test_spans,
+            tracer,
+            url="/appsec/insecure-cookie/test_secure/",
+        )
+
+        assert root_span.get_metric(IAST.ENABLED) == 1.0
+
+        assert root_span.get_tag(IAST.JSON) is None
+
+
+@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+def test_django_insecure_cookie_empty_cookie(client, test_spans, tracer):
+    with override_global_config(dict(_iast_enabled=True, _deduplication_enabled=False)):
+        oce.reconfigure()
+        root_span, _ = _aux_appsec_get_root_span(
+            client,
+            test_spans,
+            tracer,
+            url="/appsec/insecure-cookie/test_empty_cookie/",
+        )
+
+        assert root_span.get_metric(IAST.ENABLED) == 1.0
+
+        assert root_span.get_tag(IAST.JSON) is None

--- a/tests/contrib/django/test_django_appsec_iast.py
+++ b/tests/contrib/django/test_django_appsec_iast.py
@@ -638,3 +638,46 @@ def test_django_insecure_cookie_empty_cookie(client, test_spans, tracer):
         assert root_span.get_metric(IAST.ENABLED) == 1.0
 
         assert root_span.get_tag(IAST.JSON) is None
+
+
+@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+def test_django_insecure_cookie_2_insecure_1_secure(client, test_spans, tracer):
+    with override_global_config(dict(_iast_enabled=True, _deduplication_enabled=False)):
+        oce.reconfigure()
+        root_span, _ = _aux_appsec_get_root_span(
+            client,
+            test_spans,
+            tracer,
+            url="/appsec/insecure-cookie/test_insecure_2_1/",
+        )
+
+        assert root_span.get_metric(IAST.ENABLED) == 1.0
+
+        loaded = json.loads(root_span.get_tag(IAST.JSON))
+        assert loaded["sources"] == []
+        assert len(loaded["vulnerabilities"]) == 2
+
+
+@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+def test_django_insecure_cookie_special_characters(client, test_spans, tracer):
+    with override_global_config(dict(_iast_enabled=True, _deduplication_enabled=False)):
+        oce.reconfigure()
+        root_span, _ = _aux_appsec_get_root_span(
+            client,
+            test_spans,
+            tracer,
+            url="/appsec/insecure-cookie/test_insecure_special/",
+        )
+
+        assert root_span.get_metric(IAST.ENABLED) == 1.0
+
+        loaded = json.loads(root_span.get_tag(IAST.JSON))
+        assert loaded["sources"] == []
+        assert len(loaded["vulnerabilities"]) == 1
+        vulnerability = loaded["vulnerabilities"][0]
+        assert vulnerability["type"] == VULN_INSECURE_COOKIE
+        assert vulnerability["evidence"] == {"valueParts": [{"value": "insecure"}]}
+        assert "path" not in vulnerability["location"].keys()
+        assert "line" not in vulnerability["location"].keys()
+        assert vulnerability["location"]["spanId"]
+        assert vulnerability["hash"]


### PR DESCRIPTION
core.dispatch("django.after_request_headers.post") built a invalid cookie payload

```python
def view_insecure_cookies_insecure(request):
    res = HttpResponse("OK")
    res.set_cookie("insecure_cookie", "cookie_value", secure=False, httponly=True, samesite="Strict")
```
:x: Before:  `{"insecure_cookie": "insecure_cookie=cookie_value; HttpOnly; Path=/; SameSite=Strict"}`
:white_check_mark: After: `{"insecure_cookie": "cookie_value; HttpOnly; Path=/; SameSite=Strict"}`

 or if the cookie was empty
```
def view_insecure_cookies_insecure(request):
    res = HttpResponse("OK")
    res.set_cookie("insecure_cookie", "", secure=False, httponly=True, samesite="Strict")
```
:x: Before:  `{"insecure_cookie": "insecure_cookie=""; HttpOnly; Path=/; SameSite=Strict"}`
:white_check_mark: After: `{"insecure_cookie": "; HttpOnly; Path=/; SameSite=Strict"}`

APPSEC-53206

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
- [x] If change touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
