### PR TITLE
chore(asm): enable rasp with iast

### DIFF
--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -25,15 +25,7 @@ _DD_ORIGINAL_ATTRIBUTES: Dict[Any, Any] = {}
 
 def patch_common_modules():
     try_wrap_function_wrapper("builtins", "open", wrapped_open_CFDDB7ABBA9081B6)
-
-    # due to incompatibilities with gevent, delay the patching if IAST is enabled
-    if asm_config._iast_enabled:
-        core.on(
-            "exploit.prevention.ssrf.patch.urllib",
-            lambda: try_wrap_function_wrapper("urllib.request", "OpenerDirector.open", wrapped_open_ED4CF71136E15EBF),
-        )
-    else:
-        try_wrap_function_wrapper("urllib.request", "OpenerDirector.open", wrapped_open_ED4CF71136E15EBF)
+    try_wrap_function_wrapper("urllib.request", "OpenerDirector.open", wrapped_open_ED4CF71136E15EBF)
 
 
 def unpatch_common_modules():

--- a/ddtrace/appsec/_iast/taint_sinks/command_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/command_injection.py
@@ -4,7 +4,6 @@ from typing import List
 from typing import Union
 
 from ddtrace.contrib import trace_utils
-from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
 
@@ -41,9 +40,6 @@ def patch():
         subprocess._datadog_cmdi_patch = True
 
     _set_metric_iast_instrumented_sink(VULN_CMDI)
-
-    if asm_config._ep_enabled:
-        core.dispatch("exploit.prevention.ssrf.patch.urllib")
 
 
 def unpatch() -> None:

--- a/tests/appsec/contrib_appsec/utils.py
+++ b/tests/appsec/contrib_appsec/utils.py
@@ -1222,8 +1222,6 @@ class Contrib_TestClass_For_Threats:
         rule_file,
         blocking,
     ):
-        if asm_config._iast_enabled:
-            raise pytest.xfail("iast and exploit prevention not working yet together")
         from unittest.mock import patch as mock_patch
 
         from ddtrace.appsec._constants import APPSEC
@@ -1246,8 +1244,8 @@ class Contrib_TestClass_For_Threats:
                 for trace in self.check_for_stack_trace(root_span):
                     assert "frames" in trace
                     function = trace["frames"][0]["function"]
-                    assert any(
-                        function.endswith(top_function) for top_function in top_functions
+                    assert any(function.endswith(top_function) for top_function in top_functions) or (
+                        asm_config._iast_enabled and function.endswith("ast_function")
                     ), f"unknown top function {function}"
                 # assert mocked.call_args_list == []
                 telemetry_calls = {(c.__name__, f"{ns}.{nm}", t): v for (c, ns, nm, v, t), _ in mocked.call_args_list}


### PR DESCRIPTION
- remove delayed patching for rasp/iast as now rasp patching is always lazy.
- enable rasp threat tests with iast

APPSEC-51853

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
