### PR TITLE
ci: parametrized framework tests

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -570,10 +570,11 @@ jobs:
             profiling: 0
             iast: 1
             appsec: 0
-          - suffix: APPSEC
-            profiling: 0
-            iast: 0
-            appsec: 1
+          # Disabled while the bug is investigated: APPSEC-53221
+          # - suffix: APPSEC
+          #   profiling: 0
+          #   iast: 0
+          #   appsec: 1
     name: Starlette 0.37.1 (with ${{ matrix.suffix }})
     runs-on: "ubuntu-latest"
     needs: needs-run

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -26,11 +26,28 @@ jobs:
         continue-on-error: true
 
   bottle-testsuite-0_12_19:
+    strategy:
+      matrix:
+        include:
+          - suffix: Profiling
+            profiling: 1
+            iast: 0
+            appsec: 0
+          - suffix: IAST
+            profiling: 0
+            iast: 1
+            appsec: 0
+          - suffix: APPSEC
+            profiling: 0
+            iast: 0
+            appsec: 1
+    name: Bottle 0.12.19 (with ${{ matrix.suffix }})
     runs-on: ubuntu-latest
     needs: needs-run
     env:
-      DD_PROFILING_ENABLED: true
-      DD_IAST_ENABLED: true
+      DD_PROFILING_ENABLED: ${{ matrix.profiling }}
+      DD_IAST_ENABLED: ${{ matrix.iast }}
+      DD_APPSEC_ENABLED: ${{ matrix.appsec }}
       DD_TESTING_RAISE: true
       CMAKE_BUILD_PARALLEL_LEVEL: 12
       DD_DEBUGGER_EXPL_OUTPUT_FILE: debugger-expl.txt
@@ -121,16 +138,36 @@ jobs:
           - suffix: DI profiler
             expl_profiler: 1
             expl_coverage: 0
+            profiling: 1
+            iast: 0
+            appsec: 0
           - suffix: DI coverage
             expl_profiler: 0
             expl_coverage: 1
+            profiling: 1
+            iast: 0
+            appsec: 0
+          - suffix: IAST
+            expl_profiler: 0
+            expl_coverage: 0
+            profiling: 0
+            iast: 1
+            appsec: 0
+          - suffix: APPSEC
+            expl_profiler: 0
+            expl_coverage: 0
+            profiling: 0
+            iast: 0
+            appsec: 1
+
     runs-on: ubuntu-latest
     needs: needs-run
     timeout-minutes: 15
     name: Django 3.1 (with ${{ matrix.suffix }})
     env:
-      DD_PROFILING_ENABLED: true
-      DD_IAST_ENABLED: true
+      DD_PROFILING_ENABLED: ${{ matrix.profiling }}
+      DD_IAST_ENABLED: ${{ matrix.iast }}
+      DD_APPSEC_ENABLED: ${{ matrix.appsec }}
       DD_TESTING_RAISE: true
       DD_DEBUGGER_EXPL_ENCODE: 0  # Disabled to speed up
       DD_DEBUGGER_EXPL_PROFILER_ENABLED: ${{ matrix.expl_profiler }}
@@ -202,12 +239,28 @@ jobs:
         run: cat debugger-expl.txt
 
   graphene-testsuite-3_0:
+    strategy:
+      matrix:
+        include:
+          - suffix: Profiling
+            profiling: 1
+            iast: 0
+            appsec: 0
+          - suffix: IAST
+            profiling: 0
+            iast: 1
+            appsec: 0
+          - suffix: APPSEC
+            profiling: 0
+            iast: 0
+            appsec: 1
+    name: Graphene 3.0 (with ${{ matrix.suffix }})
     runs-on: ubuntu-latest
     needs: needs-run
     env:
-      DD_PROFILING_ENABLED: true
-      DD_IAST_ENABLED: true
-      DD_TESTING_RAISE: true
+      DD_PROFILING_ENABLED: ${{ matrix.profiling }}
+      DD_IAST_ENABLED: ${{ matrix.iast }}
+      DD_APPSEC_ENABLED: ${{ matrix.appsec }}
       PYTHONPATH: ../ddtrace/tests/debugging/exploration/:.
       DD_DEBUGGER_EXPL_OUTPUT_FILE: debugger-expl.txt
       CMAKE_BUILD_PARALLEL_LEVEL: 12
@@ -250,12 +303,29 @@ jobs:
         run: cat debugger-expl.txt
 
   fastapi-testsuite-0_92:
+    strategy:
+      matrix:
+        include:
+          - suffix: Profiling
+            profiling: 1
+            iast: 0
+            appsec: 0
+          - suffix: IAST
+            profiling: 0
+            iast: 1
+            appsec: 0
+          - suffix: APPSEC
+            profiling: 0
+            iast: 0
+            appsec: 1
+    name: FastAPI 0.92 (with ${{ matrix.suffix }})
     runs-on: ubuntu-latest
     needs: needs-run
     env:
       DD_TESTING_RAISE: true
-      DD_PROFILING_ENABLED: true
-      DD_IAST_ENABLED: true
+      DD_PROFILING_ENABLED: ${{ matrix.profiling }}
+      DD_IAST_ENABLED: ${{ matrix.iast }}
+      DD_APPSEC_ENABLED: ${{ matrix.appsec }}
       CMAKE_BUILD_PARALLEL_LEVEL: 12
       DD_DEBUGGER_EXPL_OUTPUT_FILE: debugger-expl.txt
     defaults:
@@ -297,13 +367,30 @@ jobs:
         run: cat debugger-expl.txt
 
   flask-testsuite-1_1_4:
+    strategy:
+      matrix:
+        include:
+          - suffix: Profiling
+            profiling: 1
+            iast: 0
+            appsec: 0
+          - suffix: IAST
+            profiling: 0
+            iast: 1
+            appsec: 0
+          - suffix: APPSEC
+            profiling: 0
+            iast: 0
+            appsec: 1
+    name: Flask 1.1.4 (with ${{ matrix.suffix }})
     runs-on: ubuntu-latest
     needs: needs-run
     env:
       TOX_TESTENV_PASSENV: DD_TESTING_RAISE DD_PROFILING_ENABLED
       DD_TESTING_RAISE: true
-      DD_PROFILING_ENABLED: true
-      DD_IAST_ENABLED: true
+      DD_PROFILING_ENABLED: ${{ matrix.profiling }}
+      DD_IAST_ENABLED: ${{ matrix.iast }}
+      DD_APPSEC_ENABLED: ${{ matrix.appsec }}
       PYTHONPATH: ../ddtrace/tests/debugging/exploration/
       DD_DEBUGGER_EXPL_OUTPUT_FILE: debugger-expl.txt
       CMAKE_BUILD_PARALLEL_LEVEL: 12
@@ -349,6 +436,16 @@ jobs:
         run: cat debugger-expl.txt
 
   httpx-testsuite-0_22_0:
+    strategy:
+      matrix:
+        include:
+          - suffix: IAST
+            iast: 1
+            appsec: 0
+          - suffix: APPSEC
+            iast: 0
+            appsec: 1
+    name: Httpx 0.22.0 (with ${{ matrix.suffix }})
     runs-on: ubuntu-latest
     needs: needs-run
     defaults:
@@ -385,17 +482,36 @@ jobs:
           DD_HTTPX_DISTRIBUTED_TRACING: "false"
           # Debugger exploration testing does not work in CI
           # PYTHONPATH: ../ddtrace/tests/debugging/exploration/
+          DD_IAST_ENABLED: ${{ matrix.iast }}
+          DD_APPSEC_ENABLED: ${{ matrix.appsec }}
         # test_pool_timeout raises RuntimeError: The connection pool was closed while 1 HTTP requests/responses were still in-flight
         run: pytest -k 'not test_pool_timeout'
 
   mako-testsuite-1_3_0:
+    strategy:
+      matrix:
+        include:
+          - suffix: Profiling
+            profiling: 1
+            iast: 0
+            appsec: 0
+          - suffix: IAST
+            profiling: 0
+            iast: 1
+            appsec: 0
+          - suffix: APPSEC
+            profiling: 0
+            iast: 0
+            appsec: 1
+    name: Mako 1.3.0 (with ${{ matrix.suffix }})
     runs-on: ubuntu-latest
     needs: needs-run
     env:
       TOX_TESTENV_PASSENV: DD_TESTING_RAISE DD_PROFILING_ENABLED
       DD_TESTING_RAISE: true
-      DD_PROFILING_ENABLED: true
-      DD_IAST_ENABLED: true
+      DD_PROFILING_ENABLED: ${{ matrix.profiling }}
+      DD_IAST_ENABLED: ${{ matrix.iast }}
+      DD_APPSEC_ENABLED: ${{ matrix.appsec }}
       PYTHONPATH: ../ddtrace/tests/debugging/exploration/
       DD_DEBUGGER_EXPL_OUTPUT_FILE: debugger-expl.txt
       CMAKE_BUILD_PARALLEL_LEVEL: 12
@@ -441,12 +557,29 @@ jobs:
         run: cat debugger-expl.txt
 
   starlette-testsuite-0_37_1:
+    strategy:
+      matrix:
+        include:
+          - suffix: Profiling
+            profiling: 1
+            iast: 0
+            appsec: 0
+          - suffix: IAST
+            profiling: 0
+            iast: 1
+            appsec: 0
+          - suffix: APPSEC
+            profiling: 0
+            iast: 0
+            appsec: 1
+    name: Starlette 0.37.1 (with ${{ matrix.suffix }})
     runs-on: "ubuntu-latest"
     needs: needs-run
     env:
       DD_TESTING_RAISE: true
-      DD_PROFILING_ENABLED: true
-      DD_IAST_ENABLED: true
+      DD_PROFILING_ENABLED: ${{ matrix.profiling }}
+      DD_IAST_ENABLED: ${{ matrix.iast }}
+      DD_APPSEC_ENABLED: ${{ matrix.appsec }}
       PYTHONPATH: ../ddtrace/tests/debugging/exploration/
       DD_DEBUGGER_EXPL_OUTPUT_FILE: debugger-expl.txt
       CMAKE_BUILD_PARALLEL_LEVEL: 12
@@ -484,12 +617,29 @@ jobs:
         run: cat debugger-expl.txt
 
   requests-testsuite-2_26_0:
+    strategy:
+      matrix:
+        include:
+          - suffix: Profiling
+            profiling: 1
+            iast: 0
+            appsec: 0
+          - suffix: IAST
+            profiling: 0
+            iast: 1
+            appsec: 0
+          - suffix: APPSEC
+            profiling: 0
+            iast: 0
+            appsec: 1
+    name: Requests 2.26.0 (with ${{ matrix.suffix }})
     runs-on: "ubuntu-latest"
     needs: needs-run
     env:
       DD_TESTING_RAISE: true
-      DD_PROFILING_ENABLED: true
-      DD_IAST_ENABLED: true
+      DD_PROFILING_ENABLED: ${{ matrix.profiling }}
+      DD_IAST_ENABLED: ${{ matrix.iast }}
+      DD_APPSEC_ENABLED: ${{ matrix.appsec }}
       CMAKE_BUILD_PARALLEL_LEVEL: 12
       DD_DEBUGGER_EXPL_OUTPUT_FILE: debugger-expl.txt
     defaults:
@@ -528,12 +678,29 @@ jobs:
 
   asyncpg-testsuite-0_27_0:
     # https://github.com/MagicStack/asyncpg/blob/v0.25.0/.github/workflows/tests.yml#L125
+    strategy:
+      matrix:
+        include:
+          - suffix: Profiling
+            profiling: 1
+            iast: 0
+            appsec: 0
+          - suffix: IAST
+            profiling: 0
+            iast: 1
+            appsec: 0
+          - suffix: APPSEC
+            profiling: 0
+            iast: 0
+            appsec: 1
+    name: AsyncPG 0.27.0 (with ${{ matrix.suffix }})
     runs-on: "ubuntu-latest"
     needs: needs-run
     env:
       DD_TESTING_RAISE: true
-      DD_PROFILING_ENABLED: true
-      DD_IAST_ENABLED: true
+      DD_PROFILING_ENABLED: ${{ matrix.profiling }}
+      DD_IAST_ENABLED: ${{ matrix.iast }}
+      DD_APPSEC_ENABLED: ${{ matrix.appsec }}
       CMAKE_BUILD_PARALLEL_LEVEL: 12
     defaults:
       run:
@@ -569,12 +736,22 @@ jobs:
         run: ddtrace-run python -m pytest -k 'not test_record_gc and not test_record_get and not test_record_items and not test_record_iter' tests
 
   gunicorn-testsuite-20_1_0:
-    name: gunicorn 20.1.0
+    strategy:
+      matrix:
+        include:
+          - suffix: IAST
+            iast: 1
+            appsec: 0
+          - suffix: APPSEC
+            iast: 0
+            appsec: 1
+    name: gunicorn 20.1.0 (with ${{ matrix.suffix }})
     runs-on: "ubuntu-latest"
     needs: needs-run
     env:
       DD_TESTING_RAISE: true
-      DD_IAST_ENABLED: true
+      DD_IAST_ENABLED: ${{ matrix.iast }}
+      DD_APPSEC_ENABLED: ${{ matrix.appsec }}
       # PYTHONPATH: ../ddtrace/tests/debugging/exploration/
       CMAKE_BUILD_PARALLEL_LEVEL: 12
     defaults:
@@ -604,13 +781,29 @@ jobs:
           pytest -p no:warnings -k "not test_import" tests/
 
   uwsgi-testsuite-2_0_21:
-    name: uwsgi 2.0.21
+    strategy:
+      matrix:
+        include:
+          - suffix: Profiling
+            profiling: 1
+            iast: 0
+            appsec: 0
+          - suffix: IAST
+            profiling: 0
+            iast: 1
+            appsec: 0
+          - suffix: APPSEC
+            profiling: 0
+            iast: 0
+            appsec: 1
+    name: uwsgi 2.0.21 (with ${{ matrix.suffix }})
     runs-on: "ubuntu-latest"
     needs: needs-run
     env:
       DD_TESTING_RAISE: true
-      DD_PROFILING_ENABLED: true
-      DD_IAST_ENABLED: true
+      DD_PROFILING_ENABLED: ${{ matrix.profiling }}
+      DD_IAST_ENABLED: ${{ matrix.iast }}
+      DD_APPSEC_ENABLED: ${{ matrix.appsec }}
       PYTHONPATH: ../ddtrace/tests/debugging/exploration/
       DD_DEBUGGER_EXPL_OUTPUT_FILE: debugger-expl.txt
       CMAKE_BUILD_PARALLEL_LEVEL: 12

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -147,12 +147,13 @@ jobs:
             profiling: 1
             iast: 0
             appsec: 0
-          - suffix: IAST
-            expl_profiler: 0
-            expl_coverage: 0
-            profiling: 0
-            iast: 1
-            appsec: 0
+          # Disabled while the bug is investigated: APPSEC-53222
+          # - suffix: IAST
+          #   expl_profiler: 0
+          #   expl_coverage: 0
+          #   profiling: 0
+          #   iast: 1
+          #   appsec: 0
           - suffix: APPSEC
             expl_profiler: 0
             expl_coverage: 0

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -147,13 +147,12 @@ jobs:
             profiling: 1
             iast: 0
             appsec: 0
-          # Disabled while the bug is investigated: APPSEC-53222
-          # - suffix: IAST
-          #   expl_profiler: 0
-          #   expl_coverage: 0
-          #   profiling: 0
-          #   iast: 1
-          #   appsec: 0
+          - suffix: IAST
+            expl_profiler: 0
+            expl_coverage: 0
+            profiling: 0
+            iast: 1
+            appsec: 0
           - suffix: APPSEC
             expl_profiler: 0
             expl_coverage: 0

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -235,7 +235,7 @@ jobs:
       - name: Run tests
         if: needs.needs-run.outputs.outcome == 'success'
         # django.tests.requests module interferes with requests library patching in the tracer -> disable requests patch
-        run: DD_PATCH_MODULES=unittest:no DD_TRACE_REQUESTS_ENABLED=0 ddtrace-run tests/runtests.py
+        run: DD_PATCH_MODULES=unittest:no DD_TRACE_REQUESTS_ENABLED=0 ddtrace-run tests/runtests.py --parallel 1
 
       - name: Debugger exploration results
         if: needs.needs-run.outputs.outcome == 'success'

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -208,7 +208,9 @@ jobs:
         run: pip install -r tests/requirements/py3.txt
       - name: Install ddtrace
         if: needs.needs-run.outputs.outcome == 'success'
-        run: pip install ../ddtrace
+        run: |
+          pip install envier Cython cmake
+          pip install ../ddtrace
       - name: Install django
         if: needs.needs-run.outputs.outcome == 'success'
         run: pip install -e .
@@ -603,7 +605,9 @@ jobs:
           path: starlette
       - name: Install ddtrace
         if: needs.needs-run.outputs.outcome == 'success'
-        run: pip install ../ddtrace
+        run: |
+          pip install envier Cython cmake
+          pip install ../ddtrace
       - name: Install dependencies
         if: needs.needs-run.outputs.outcome == 'success'
         run: scripts/install


### PR DESCRIPTION
CI: parametrize framework tests to run them separately with Profiling, IAST or Appsec enabled

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
