### PR TITLE
chore: native asm code linting

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectExtend.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectExtend.cpp
@@ -9,7 +9,7 @@
  * @return PyObject*: return None (Remember, Pyobject None isn't the same as nullptr)
  */
 PyObject*
-api_extend_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
+api_extend_aspect(PyObject* self, PyObject* const* args, const Py_ssize_t nargs)
 {
     if (nargs != 2 or !args) {
         throw py::value_error(MSG_ERROR_N_PARAMS);

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.cpp
@@ -27,14 +27,14 @@ api_format_aspect(StrType& candidate_text,
 
     if (!ranges_orig.empty() or !candidate_text_ranges.empty()) {
         auto new_template =
-          _int_as_formatted_evidence<StrType>(candidate_text, candidate_text_ranges, TagMappingMode::Mapper);
+          int_as_formatted_evidence<StrType>(candidate_text, candidate_text_ranges, TagMappingMode::Mapper);
 
         py::list new_args;
         py::dict new_kwargs;
         for (const auto arg : args) {
             if (is_text(arg.ptr())) {
                 auto str_arg = py::cast<py::str>(arg);
-                auto n_arg = _all_as_formatted_evidence<py::str>(str_arg, TagMappingMode::Mapper);
+                auto n_arg = all_as_formatted_evidence<py::str>(str_arg, TagMappingMode::Mapper);
                 new_args.append(n_arg);
             } else {
                 new_args.append(arg);
@@ -43,7 +43,7 @@ api_format_aspect(StrType& candidate_text,
         for (auto [key, value] : kwargs) {
             if (is_text(value.ptr())) {
                 auto str_value = py::cast<py::str>(value);
-                auto n_value = _all_as_formatted_evidence<py::str>(str_value, TagMappingMode::Mapper);
+                auto n_value = all_as_formatted_evidence<py::str>(str_value, TagMappingMode::Mapper);
                 new_kwargs[key] = n_value;
             } else {
                 new_kwargs[key] = value;
@@ -51,7 +51,7 @@ api_format_aspect(StrType& candidate_text,
         }
         StrType new_template_format =
           py::getattr(new_template, "format")(*(py::cast<py::tuple>(new_args)), **new_kwargs);
-        std::tuple result = _convert_escaped_text_to_taint_text<StrType>(new_template_format, ranges_orig);
+        std::tuple result = convert_escaped_text_to_taint_text<StrType>(new_template_format, ranges_orig);
         StrType result_text = get<0>(result);
         TaintRangeRefs result_ranges = get<1>(result);
         PyObject* new_result = new_pyobject_id(result_text.ptr());

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.h
@@ -1,9 +1,6 @@
 #pragma once
 #include "Aspects/Helpers.h"
 #include "Initializer/Initializer.h"
-#include "TaintTracking/Source.h"
-#include "TaintTracking/TaintRange.h"
-#include "TaintTracking/TaintedObject.h"
 
 template<class StrType>
 StrType

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
@@ -12,10 +12,9 @@
 PyObject*
 index_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* idx, const TaintRangeMapTypePtr& tx_taint_map)
 {
-    auto idx_long = PyLong_AsLong(idx);
-    bool ranges_error;
-    TaintRangeRefs ranges_to_set, ranges;
-    std::tie(ranges, ranges_error) = get_ranges(candidate_text, tx_taint_map);
+    const auto idx_long = PyLong_AsLong(idx);
+    TaintRangeRefs ranges_to_set;
+    auto [ranges, ranges_error] = get_ranges(candidate_text, tx_taint_map);
     if (ranges_error) {
         return result_o;
     }
@@ -38,7 +37,7 @@ index_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* idx, const 
 }
 
 PyObject*
-api_index_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
+api_index_aspect(PyObject* self, PyObject* const* args, const Py_ssize_t nargs)
 {
     if (nargs != 2) {
         py::set_error(PyExc_ValueError, MSG_ERROR_N_PARAMS);
@@ -49,9 +48,7 @@ api_index_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     PyObject* candidate_text = args[0];
     PyObject* idx = args[1];
 
-    PyObject* result_o;
-
-    result_o = PyObject_GetItem(candidate_text, idx);
+    PyObject* result_o = PyObject_GetItem(candidate_text, idx);
 
     if (not ctx_map or ctx_map->empty()) {
         return result_o;

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "Aspects/Helpers.h"
 #include "TaintedOps/TaintedOps.h"
 
 PyObject*

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
@@ -95,8 +95,7 @@ aspect_join(PyObject* sep, PyObject* result, PyObject* iterable_elements, const 
         // b"a".join(u"c", b"d") -> unicode
         const size_t& element_len = get_pyobject_size(element);
         if (element_len > 0) {
-            const auto& to_element = get_tainted_object(element, tx_taint_map);
-            if (to_element) {
+            if (const auto& to_element = get_tainted_object(element, tx_taint_map)) {
                 if (current_pos == 0 and !first_tainted_to) {
                     first_tainted_to = to_element;
                 } else {
@@ -138,7 +137,7 @@ aspect_join(PyObject* sep, PyObject* result, PyObject* iterable_elements, const 
 }
 
 PyObject*
-api_join_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
+api_join_aspect(PyObject* self, PyObject* const* args, const Py_ssize_t nargs)
 {
     if (nargs != 2) {
         py::set_error(PyExc_ValueError, MSG_ERROR_N_PARAMS);
@@ -152,7 +151,7 @@ api_join_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     if (PyIter_Check(arg0) or PySet_Check(arg0) or PyFrozenSet_Check(arg0)) {
         PyObject* iterator = PyObject_GetIter(arg0);
 
-        if (iterator != NULL) {
+        if (iterator != nullptr) {
             PyObject* item;
             PyObject* list_aux = PyList_New(0);
             while ((item = PyIter_Next(iterator))) {

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.h
@@ -1,7 +1,5 @@
 #pragma once
 #include "Initializer/Initializer.h"
-#include "TaintTracking/TaintRange.h"
-#include "TaintTracking/TaintedObject.h"
 
 namespace py = pybind11;
 

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
@@ -16,8 +16,8 @@ add_aspect(PyObject* result_o,
            PyObject* text_to_add,
            const TaintRangeMapTypePtr& tx_taint_map)
 {
-    size_t len_candidate_text{ get_pyobject_size(candidate_text) };
-    size_t len_text_to_add{ get_pyobject_size(text_to_add) };
+    const size_t len_candidate_text{ get_pyobject_size(candidate_text) };
+    const size_t len_text_to_add{ get_pyobject_size(text_to_add) };
 
     if (len_text_to_add == 0 and len_candidate_text > 0) {
         return candidate_text;
@@ -48,7 +48,7 @@ add_aspect(PyObject* result_o,
     }
 
     auto tainted = initializer->allocate_tainted_object_copy(to_candidate_text);
-    tainted->add_ranges_shifted(to_text_to_add, (RANGE_START)len_candidate_text);
+    tainted->add_ranges_shifted(to_text_to_add, static_cast<RANGE_START>(len_candidate_text));
     const auto res_new_id = new_pyobject_id(result_o);
     Py_DecRef(result_o);
     set_tainted_object(res_new_id, tainted, tx_taint_map);
@@ -80,7 +80,7 @@ api_add_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     PyObject* candidate_text = args[0];
     PyObject* text_to_add = args[1];
 
-    PyObject* result_o;
+    PyObject* result_o = nullptr;
     if (PyUnicode_Check(candidate_text)) {
         result_o = PyUnicode_Concat(candidate_text, text_to_add);
     } else if (PyBytes_Check(candidate_text)) {

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.h
@@ -1,7 +1,5 @@
 #pragma once
 #include "Initializer/Initializer.h"
-#include "TaintTracking/TaintRange.h"
-#include "TaintTracking/TaintedObject.h"
 
 PyObject*
 api_add_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs);

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
@@ -8,7 +8,7 @@
  * @return A map of taint ranges for the given index range map.
  */
 TaintRangeRefs
-reduce_ranges_from_index_range_map(TaintRangeRefs index_range_map)
+reduce_ranges_from_index_range_map(const TaintRangeRefs& index_range_map)
 {
     TaintRangeRefs new_ranges;
     TaintRangePtr current_range;
@@ -16,8 +16,7 @@ reduce_ranges_from_index_range_map(TaintRangeRefs index_range_map)
     size_t index;
 
     for (index = 0; index < index_range_map.size(); ++index) {
-        auto taint_range{ index_range_map.at(index) };
-        if (taint_range != current_range) {
+        if (const auto& taint_range{ index_range_map.at(index) }; taint_range != current_range) {
             if (current_range) {
                 new_ranges.emplace_back(
                   initializer->allocate_taint_range(current_start, index - current_start, current_range->source));
@@ -26,7 +25,7 @@ reduce_ranges_from_index_range_map(TaintRangeRefs index_range_map)
             current_start = index;
         }
     }
-    if (current_range != NULL) {
+    if (current_range != nullptr) {
         new_ranges.emplace_back(
           initializer->allocate_taint_range(current_start, index - current_start, current_range->source));
     }
@@ -38,6 +37,9 @@ reduce_ranges_from_index_range_map(TaintRangeRefs index_range_map)
  *
  * @param text The text object for which the taint ranges are to be built.
  * @param ranges The taint range map that stores taint information.
+ * @param start The start index of the text object.
+ * @param stop The stop index of the text object.
+ * @param step The step index of the text object.
  *
  * @return A map of taint ranges for the given text object.
  */
@@ -57,7 +59,7 @@ build_index_range_map(PyObject* text, TaintRangeRefs& ranges, PyObject* start, P
             index++;
         }
     }
-    long length_text = (long long)py::len(text);
+    long length_text = static_cast<long long>(py::len(text));
     while (index < length_text) {
         index_range_map.emplace_back(nullptr);
         index++;
@@ -71,7 +73,7 @@ build_index_range_map(PyObject* text, TaintRangeRefs& ranges, PyObject* start, P
         }
     }
     long stop_int = length_text;
-    if (stop != NULL) {
+    if (stop != nullptr) {
         stop_int = PyLong_AsLong(stop);
         if (stop_int > length_text) {
             stop_int = length_text;
@@ -83,7 +85,7 @@ build_index_range_map(PyObject* text, TaintRangeRefs& ranges, PyObject* start, P
         }
     }
     long step_int = 1;
-    if (step != NULL) {
+    if (step != nullptr) {
         step_int = PyLong_AsLong(step);
     }
     for (auto i = start_int; i < stop_int; i += step_int) {
@@ -101,9 +103,7 @@ slice_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* start, PyOb
     if (not ctx_map or ctx_map->empty()) {
         return result_o;
     }
-    bool ranges_error;
-    TaintRangeRefs ranges;
-    std::tie(ranges, ranges_error) = get_ranges(candidate_text, ctx_map);
+    auto [ranges, ranges_error] = get_ranges(candidate_text, ctx_map);
     if (ranges_error or ranges.empty()) {
         return result_o;
     }
@@ -117,7 +117,7 @@ PyObject*
 api_slice_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 {
     if (nargs < 3) {
-        return NULL;
+        return nullptr;
     }
     PyObject* candidate_text = args[0];
     PyObject* start = PyLong_FromLong(0);
@@ -125,7 +125,7 @@ api_slice_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     if (PyNumber_Check(args[1])) {
         start = PyNumber_Long(args[1]);
     }
-    PyObject* stop = NULL;
+    PyObject* stop = nullptr;
     if (PyNumber_Check(args[2])) {
         stop = PyNumber_Long(args[2]);
     }
@@ -137,30 +137,30 @@ api_slice_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     }
 
     PyObject* slice = PySlice_New(start, stop, step);
-    if (slice == NULL) {
+    if (slice == nullptr) {
         PyErr_Print();
-        if (start != NULL) {
+        if (start != nullptr) {
             Py_DecRef(start);
         }
-        if (stop != NULL) {
+        if (stop != nullptr) {
             Py_DecRef(stop);
         }
-        if (step != NULL) {
+        if (step != nullptr) {
             Py_DecRef(step);
         }
-        return NULL;
+        return nullptr;
     }
     PyObject* result = PyObject_GetItem(candidate_text, slice);
 
     auto res = slice_aspect(result, candidate_text, start, stop, step);
 
-    if (start != NULL) {
+    if (start != nullptr) {
         Py_DecRef(start);
     }
-    if (stop != NULL) {
+    if (stop != nullptr) {
         Py_DecRef(stop);
     }
-    if (step != NULL) {
+    if (step != nullptr) {
         Py_DecRef(step);
     }
     Py_DecRef(slice);

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "Aspects/Helpers.h"
 #include "TaintedOps/TaintedOps.h"
 
 PyObject*

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSplit.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSplit.cpp
@@ -5,16 +5,15 @@ template<class StrType>
 py::list
 api_split_text(const StrType& text, const optional<StrType>& separator, const optional<int> maxsplit)
 {
-    auto split = text.attr("split");
-    auto split_result = split(separator, maxsplit);
+    const auto split = text.attr("split");
+    const auto split_result = split(separator, maxsplit);
 
     const auto tx_map = initializer->get_tainting_map();
     if (not tx_map or tx_map->empty()) {
         return split_result;
     }
 
-    auto ranges = api_get_ranges(text);
-    if (not ranges.empty()) {
+    if (auto ranges = api_get_ranges(text); not ranges.empty()) {
         set_ranges_on_splitted(text, ranges, split_result, tx_map, false);
     }
 
@@ -25,15 +24,14 @@ template<class StrType>
 py::list
 api_rsplit_text(const StrType& text, const optional<StrType>& separator, const optional<int> maxsplit)
 {
-    auto rsplit = text.attr("rsplit");
-    auto split_result = rsplit(separator, maxsplit);
+    const auto rsplit = text.attr("rsplit");
+    const auto split_result = rsplit(separator, maxsplit);
     const auto tx_map = initializer->get_tainting_map();
     if (not tx_map or tx_map->empty()) {
         return split_result;
     }
 
-    auto ranges = api_get_ranges(text);
-    if (not ranges.empty()) {
+    if (auto ranges = api_get_ranges(text); not ranges.empty()) {
         set_ranges_on_splitted(text, ranges, split_result, tx_map, false);
     }
     return split_result;
@@ -43,15 +41,14 @@ template<class StrType>
 py::list
 api_splitlines_text(const StrType& text, bool keepends)
 {
-    auto splitlines = text.attr("splitlines");
-    auto split_result = splitlines(keepends);
+    const auto splitlines = text.attr("splitlines");
+    const auto split_result = splitlines(keepends);
     const auto tx_map = initializer->get_tainting_map();
     if (not tx_map or tx_map->empty()) {
         return split_result;
     }
 
-    auto ranges = api_get_ranges(text);
-    if (not ranges.empty()) {
+    if (auto ranges = api_get_ranges(text); not ranges.empty()) {
         set_ranges_on_splitted(text, ranges, split_result, tx_map, keepends);
     }
     return split_result;

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSplit.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSplit.h
@@ -4,11 +4,11 @@
 
 template<class StrType>
 py::list
-api_split_text(const StrType& text, const optional<StrType>& separator, const optional<int> maxsplit);
+api_split_text(const StrType& text, const optional<StrType>& separator, optional<int> maxsplit);
 
 template<class StrType>
 py::list
-api_rsplit_text(const StrType& text, const optional<StrType>& separator, const optional<int> maxsplit);
+api_rsplit_text(const StrType& text, const optional<StrType>& separator, optional<int> maxsplit);
 
 template<class StrType>
 py::list

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectsOsPath.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectsOsPath.cpp
@@ -74,7 +74,8 @@ api_ospathjoin_aspect(StrType& first_part, const py::args& args)
     for (unsigned long i = 0; i < args.size(); i++) {
         if (i >= unsigned_initial_arg_pos) {
             // Set the ranges from the corresponding argument
-            if (auto [ranges, ranges_error] = get_ranges(args[i].ptr(), tx_map); not ranges_error and not ranges.empty()) {
+            if (auto [ranges, ranges_error] = get_ranges(args[i].ptr(), tx_map);
+                not ranges_error and not ranges.empty()) {
                 const auto len_args_i = py::len(args[i]);
                 for (auto& range : ranges) {
                     result_ranges.emplace_back(shift_taint_range(range, current_offset, len_args_i));

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectsOsPath.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectsOsPath.cpp
@@ -6,7 +6,7 @@
 static bool
 starts_with_separator(const py::handle& arg, const std::string& separator)
 {
-    std::string carg = py::cast<std::string>(arg);
+    const auto carg = py::cast<std::string>(arg);
     return carg.substr(0, 1) == separator;
 }
 
@@ -14,7 +14,7 @@ template<class StrType>
 StrType
 api_ospathjoin_aspect(StrType& first_part, const py::args& args)
 {
-    auto ospath = py::module_::import("os.path");
+    const auto ospath = py::module_::import("os.path");
     auto join = ospath.attr("join");
     auto joined = join(first_part, *args);
 
@@ -23,8 +23,8 @@ api_ospathjoin_aspect(StrType& first_part, const py::args& args)
         return joined;
     }
 
-    std::string separator = ospath.attr("sep").cast<std::string>();
-    auto sepsize = separator.size();
+    const auto separator = ospath.attr("sep").cast<std::string>();
+    const auto sepsize = separator.size();
 
     // Find the initial iteration point. This will be the first argument that has the separator ("/foo")
     // as a first character or first_part (the first element) if no such argument is found.
@@ -53,9 +53,7 @@ api_ospathjoin_aspect(StrType& first_part, const py::args& args)
     if (not root_is_after_first) {
         // Get the ranges of first_part and set them to the result, skipping the first character position
         // if it's a separator
-        bool ranges_error;
-        TaintRangeRefs ranges;
-        std::tie(ranges, ranges_error) = get_ranges(first_part.ptr(), tx_map);
+        auto [ranges, ranges_error] = get_ranges(first_part.ptr(), tx_map);
         if (not ranges_error and not ranges.empty()) {
             for (auto& range : ranges) {
                 result_ranges.emplace_back(shift_taint_range(range, current_offset, first_part_len));
@@ -70,17 +68,14 @@ api_ospathjoin_aspect(StrType& first_part, const py::args& args)
         initial_arg_pos = 0;
     }
 
-    unsigned long unsigned_initial_arg_pos = max(0, initial_arg_pos);
+    const unsigned long unsigned_initial_arg_pos = max(0, initial_arg_pos);
 
     // Now go trough the arguments and do the same
     for (unsigned long i = 0; i < args.size(); i++) {
         if (i >= unsigned_initial_arg_pos) {
             // Set the ranges from the corresponding argument
-            bool ranges_error;
-            TaintRangeRefs ranges;
-            std::tie(ranges, ranges_error) = get_ranges(args[i].ptr(), tx_map);
-            if (not ranges_error and not ranges.empty()) {
-                auto len_args_i = py::len(args[i]);
+            if (auto [ranges, ranges_error] = get_ranges(args[i].ptr(), tx_map); not ranges_error and not ranges.empty()) {
+                const auto len_args_i = py::len(args[i]);
                 for (auto& range : ranges) {
                     result_ranges.emplace_back(shift_taint_range(range, current_offset, len_args_i));
                 }
@@ -103,7 +98,7 @@ template<class StrType>
 StrType
 api_ospathbasename_aspect(const StrType& path)
 {
-    auto ospath = py::module_::import("os.path");
+    const auto ospath = py::module_::import("os.path");
     auto basename = ospath.attr("basename");
     auto basename_result = basename(path);
 
@@ -112,9 +107,7 @@ api_ospathbasename_aspect(const StrType& path)
         return basename_result;
     }
 
-    bool ranges_error;
-    TaintRangeRefs ranges;
-    std::tie(ranges, ranges_error) = get_ranges(path.ptr(), tx_map);
+    auto [ranges, ranges_error] = get_ranges(path.ptr(), tx_map);
     if (ranges_error or ranges.empty()) {
         return basename_result;
     }
@@ -136,7 +129,7 @@ template<class StrType>
 StrType
 api_ospathdirname_aspect(const StrType& path)
 {
-    auto ospath = py::module_::import("os.path");
+    const auto ospath = py::module_::import("os.path");
     auto dirname = ospath.attr("dirname");
     auto dirname_result = dirname(path);
 
@@ -145,9 +138,7 @@ api_ospathdirname_aspect(const StrType& path)
         return dirname_result;
     }
 
-    bool ranges_error;
-    TaintRangeRefs ranges;
-    std::tie(ranges, ranges_error) = get_ranges(path.ptr(), tx_map);
+    auto [ranges, ranges_error] = get_ranges(path.ptr(), tx_map);
     if (ranges_error or ranges.empty()) {
         return dirname_result;
     }
@@ -167,9 +158,9 @@ api_ospathdirname_aspect(const StrType& path)
 
 template<class StrType>
 static py::tuple
-_forward_to_set_ranges_on_splitted(const char* function_name, const StrType& path, bool includeseparator = false)
+forward_to_set_ranges_on_splitted(const char* function_name, const StrType& path, bool includeseparator = false)
 {
-    auto ospath = py::module_::import("os.path");
+    const auto ospath = py::module_::import("os.path");
     auto function = ospath.attr(function_name);
     auto function_result = function(path);
 
@@ -178,9 +169,7 @@ _forward_to_set_ranges_on_splitted(const char* function_name, const StrType& pat
         return function_result;
     }
 
-    bool ranges_error;
-    TaintRangeRefs ranges;
-    std::tie(ranges, ranges_error) = get_ranges(path.ptr(), tx_map);
+    auto [ranges, ranges_error] = get_ranges(path.ptr(), tx_map);
     if (ranges_error or ranges.empty()) {
         return function_result;
     }
@@ -193,35 +182,35 @@ template<class StrType>
 py::tuple
 api_ospathsplit_aspect(const StrType& path)
 {
-    return _forward_to_set_ranges_on_splitted("split", path);
+    return forward_to_set_ranges_on_splitted("split", path);
 }
 
 template<class StrType>
 py::tuple
 api_ospathsplitext_aspect(const StrType& path)
 {
-    return _forward_to_set_ranges_on_splitted("splitext", path, true);
+    return forward_to_set_ranges_on_splitted("splitext", path, true);
 }
 
 template<class StrType>
 py::tuple
 api_ospathsplitdrive_aspect(const StrType& path)
 {
-    return _forward_to_set_ranges_on_splitted("splitdrive", path, true);
+    return forward_to_set_ranges_on_splitted("splitdrive", path, true);
 }
 
 template<class StrType>
 py::tuple
 api_ospathsplitroot_aspect(const StrType& path)
 {
-    return _forward_to_set_ranges_on_splitted("splitroot", path, true);
+    return forward_to_set_ranges_on_splitted("splitroot", path, true);
 }
 
 template<class StrType>
 StrType
 api_ospathnormcase_aspect(const StrType& path)
 {
-    auto ospath = py::module_::import("os.path");
+    const auto ospath = py::module_::import("os.path");
     auto normcase = ospath.attr("normcase");
     auto normcased = normcase(path);
 
@@ -230,16 +219,13 @@ api_ospathnormcase_aspect(const StrType& path)
         return normcased;
     }
 
-    bool ranges_error;
-    TaintRangeRefs ranges;
-    std::tie(ranges, ranges_error) = get_ranges(path.ptr(), tx_map);
+    auto [ranges, ranges_error] = get_ranges(path.ptr(), tx_map);
     if (ranges_error or ranges.empty()) {
         return normcased;
     }
 
-    TaintRangeRefs result_ranges = ranges;
-    PyObject* new_result = new_pyobject_id(normcased.ptr());
-    if (new_result) {
+    const TaintRangeRefs result_ranges = ranges;
+    if (PyObject* new_result = new_pyobject_id(normcased.ptr())) {
         set_ranges(new_result, result_ranges, tx_map);
         return py::reinterpret_steal<StrType>(new_result);
     }

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectsOsPath.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectsOsPath.h
@@ -1,7 +1,5 @@
 #pragma once
 #include "Initializer/Initializer.h"
-#include "TaintTracking/TaintRange.h"
-#include "TaintTracking/TaintedObject.h"
 
 namespace py = pybind11;
 

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.cpp
@@ -1,7 +1,6 @@
 #include "Helpers.h"
 #include "Initializer/Initializer.h"
 #include <algorithm>
-#include <ostream>
 #include <regex>
 
 using namespace pybind11::literals;
@@ -22,15 +21,13 @@ api_common_replace(const py::str& string_method,
                    const py::args& args,
                    const py::kwargs& kwargs)
 {
-    bool ranges_error;
-    TaintRangeRefs candidate_text_ranges;
-    StrType res = py::getattr(candidate_text, string_method)(*args, **kwargs);
+    const StrType res = py::getattr(candidate_text, string_method)(*args, **kwargs);
 
     const auto tx_map = initializer->get_tainting_map();
     if (not tx_map or tx_map->empty()) {
         return res;
     }
-    std::tie(candidate_text_ranges, ranges_error) = get_ranges(candidate_text.ptr(), tx_map);
+    auto [candidate_text_ranges, ranges_error] = get_ranges(candidate_text.ptr(), tx_map);
 
     if (ranges_error or candidate_text_ranges.empty()) {
         return res;
@@ -76,7 +73,7 @@ mapper_replace(const TaintRangePtr& taint_range, const optional<const py::dict>&
     if (!new_ranges->contains(o)) {
         return py::none{};
     }
-    TaintRange new_range = py::cast<TaintRange>((*new_ranges)[o]);
+    const TaintRange new_range = py::cast<TaintRange>((*new_ranges)[o]);
     return py::int_(new_range.get_hash());
 }
 
@@ -98,23 +95,23 @@ range_sort(const TaintRangePtr& t1, const TaintRangePtr& t2)
 
 template<class StrType>
 StrType
-_all_as_formatted_evidence(StrType& text, TagMappingMode tag_mapping_mode)
+all_as_formatted_evidence(StrType& text, TagMappingMode tag_mapping_mode)
 {
     TaintRangeRefs text_ranges = api_get_ranges(text);
-    return AsFormattedEvidence<StrType>(text, text_ranges, tag_mapping_mode, nullopt);
+    return as_formatted_evidence<StrType>(text, text_ranges, tag_mapping_mode, nullopt);
 }
 
 template<class StrType>
 StrType
-_int_as_formatted_evidence(StrType& text, TaintRangeRefs text_ranges, TagMappingMode tag_mapping_mode)
+int_as_formatted_evidence(StrType& text, TaintRangeRefs text_ranges, TagMappingMode tag_mapping_mode)
 {
-    return AsFormattedEvidence<StrType>(text, text_ranges, tag_mapping_mode, nullopt);
+    return as_formatted_evidence<StrType>(text, text_ranges, tag_mapping_mode, nullopt);
 }
 
 // TODO OPTIMIZATION: Remove py::types once this isn't used in Python
 template<class StrType>
 StrType
-AsFormattedEvidence(StrType& text,
+as_formatted_evidence(StrType& text,
                     TaintRangeRefs& text_ranges,
                     const optional<TagMappingMode>& tag_mapping_mode,
                     const optional<const py::dict>& new_ranges)
@@ -142,9 +139,9 @@ AsFormattedEvidence(StrType& text,
                     // Nothing
                 }
             }
-        auto tag = get_tag<StrType>(content);
+        const auto tag = get_tag<StrType>(content);
 
-        auto range_end = taint_range->start + taint_range->length;
+        const auto range_end = taint_range->start + taint_range->length;
 
         res_vector.push_back(text[py::slice(py::int_{ index }, py::int_{ taint_range->start }, nullptr)]);
         res_vector.push_back(StrType(EVIDENCE_MARKS::START_EVIDENCE));
@@ -161,7 +158,7 @@ AsFormattedEvidence(StrType& text,
 
 template<class StrType>
 StrType
-ApiAsFormattedEvidence(StrType& text,
+api_as_formatted_evidence(StrType& text,
                        optional<TaintRangeRefs>& text_ranges,
                        const optional<TagMappingMode>& tag_mapping_mode,
                        const optional<const py::dict>& new_ranges)
@@ -172,18 +169,17 @@ ApiAsFormattedEvidence(StrType& text,
     } else {
         _ranges = text_ranges.value();
     }
-    return AsFormattedEvidence<StrType>(text, _ranges, tag_mapping_mode, new_ranges);
+    return as_formatted_evidence<StrType>(text, _ranges, tag_mapping_mode, new_ranges);
 }
 
 vector<string>
 split_taints(const string& str_to_split)
 {
-    std::regex rgx(R"((:\+-(<[0-9.a-z\-]+>)?|(<[0-9.a-z\-]+>)?-\+:))");
+    const std::regex rgx(R"((:\+-(<[0-9.a-z\-]+>)?|(<[0-9.a-z\-]+>)?-\+:))");
     std::sregex_token_iterator iter(str_to_split.begin(), str_to_split.end(), rgx, { -1, 0 });
-    std::sregex_token_iterator end;
     vector<string> res;
 
-    for (; iter != end; ++iter) {
+    for (const std::sregex_token_iterator end; iter != end; ++iter) {
         res.push_back(*iter);
     }
 
@@ -196,9 +192,9 @@ api_convert_escaped_text_to_taint_text_ba(const py::bytearray& taint_escaped_tex
 
     const auto tx_map = initializer->get_tainting_map();
 
-    py::bytes bytes_text = py::bytes() + taint_escaped_text;
+    const py::bytes bytes_text = py::bytes() + taint_escaped_text;
 
-    std::tuple result = _convert_escaped_text_to_taint_text<py::bytes>(bytes_text, std::move(ranges_orig));
+    const std::tuple result = convert_escaped_text_to_taint_text<py::bytes>(bytes_text, std::move(ranges_orig));
     PyObject* new_result = new_pyobject_id((py::bytearray() + get<0>(result)).ptr());
     set_ranges(new_result, get<1>(result), tx_map);
     return py::reinterpret_steal<py::bytearray>(new_result);
@@ -210,16 +206,16 @@ api_convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, TaintR
 {
     const auto tx_map = initializer->get_tainting_map();
 
-    std::tuple result = _convert_escaped_text_to_taint_text<StrType>(taint_escaped_text, ranges_orig);
+    std::tuple result = convert_escaped_text_to_taint_text<StrType>(taint_escaped_text, ranges_orig);
     StrType result_text = get<0>(result);
-    TaintRangeRefs result_ranges = get<1>(result);
+    const TaintRangeRefs result_ranges = get<1>(result);
     PyObject* new_result = new_pyobject_id(result_text.ptr());
     set_ranges(new_result, result_ranges, tx_map);
     return py::reinterpret_steal<StrType>(new_result);
 }
 
 unsigned long int
-getNum(std::string s)
+getNum(const std::string& s)
 {
     unsigned int n = -1;
     try {
@@ -236,9 +232,9 @@ getNum(std::string s)
 
 template<class StrType>
 std::tuple<StrType, TaintRangeRefs>
-_convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, TaintRangeRefs ranges_orig)
+convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, TaintRangeRefs ranges_orig)
 {
-    string result{ u8"" };
+    string result;
     string startswith_element{ ":" };
 
     string taint_escaped_string = py::cast<string>(taint_escaped_text);
@@ -256,8 +252,7 @@ _convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, TaintRang
     string id_evidence;
 
     for (string const& element : texts_and_marks) {
-        bool is_content = index % 2 == 0;
-        if (is_content) {
+        if (index % 2 == 0) {
             result += element;
             length = py::len(StrType(element));
             end += length;
@@ -266,8 +261,7 @@ _convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, TaintRang
         }
         if (element.rfind(startswith_element, 0) == 0) {
             id_evidence = element.substr(4, element.length() - 5);
-            auto range_by_id = get_range_by_hash(getNum(id_evidence), optional_ranges_orig);
-            if (range_by_id == nullptr) {
+            if (auto range_by_id = get_range_by_hash(getNum(id_evidence), optional_ranges_orig); range_by_id == nullptr) {
                 result += element;
                 length = py::len(StrType(element));
                 end += length;
@@ -295,11 +289,10 @@ _convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, TaintRang
             }
             id_evidence = element.substr(4, element.length() - 5);
             start = end;
-            context_stack.push_back({ id_evidence, start });
+            context_stack.emplace_back( id_evidence, start );
         } else {
             id_evidence = element.substr(1, element.length() - 5);
-            auto range_by_id = get_range_by_hash(getNum(id_evidence), optional_ranges_orig);
-            if (range_by_id == nullptr) {
+            if (auto range_by_id = get_range_by_hash(getNum(id_evidence), optional_ranges_orig); range_by_id == nullptr) {
                 result += element;
                 length = py::len(StrType(element));
                 end += length;
@@ -357,7 +350,7 @@ set_ranges_on_splitted(const StrType& source_str,
 
     RANGE_START offset = 0;
     std::string c_source_str = py::cast<std::string>(source_str);
-    auto separator_increase = (int)((not include_separator));
+    const auto separator_increase = static_cast<int>(not include_separator);
 
     for (const auto& item : split_result) {
         if (not is_text(item.ptr()) or py::len(item) == 0) {
@@ -375,12 +368,10 @@ set_ranges_on_splitted(const StrType& source_str,
 
         // Find what source_ranges match these positions and create a new range with the start and len updated.
         for (const auto& range : source_ranges) {
-            auto range_end_abs = range->start + range->length;
-
-            if (range->start < end && range_end_abs > start) {
+            if (const auto range_end_abs = range->start + range->length; range->start < end && range_end_abs > start) {
                 // Create a new range with the updated start
-                auto new_range_start = std::max(range->start - offset, 0L);
-                auto new_range_length = std::min(end - start, (range->length - std::max(0L, offset - range->start)));
+                const auto new_range_start = std::max(range->start - offset, 0L);
+                const auto new_range_length = std::min(end - start, (range->length - std::max(0L, offset - range->start)));
                 item_ranges.emplace_back(
                   initializer->allocate_taint_range(new_range_start, new_range_length, range->source));
             }
@@ -419,7 +410,8 @@ parse_params(size_t position,
 {
     if (args.size() >= position + 1) {
         return args[position];
-    } else if (kwargs && kwargs.contains(keyword_name)) {
+    }
+    if (kwargs && kwargs.contains(keyword_name)) {
         return kwargs[keyword_name];
     }
     return default_value;
@@ -453,32 +445,32 @@ pyexport_aspect_helpers(py::module& m)
           // cppcheck-suppress assignBoolToPointer
           "include_separator"_a = false);
     m.def("_all_as_formatted_evidence",
-          &_all_as_formatted_evidence<py::str>,
+          &all_as_formatted_evidence<py::str>,
           "text"_a,
           "tag_mapping_function"_a = nullopt,
           py::return_value_policy::move);
     m.def("_int_as_formatted_evidence",
-          &_int_as_formatted_evidence<py::str>,
+          &int_as_formatted_evidence<py::str>,
           "text"_a,
           "text_ranges"_a = nullopt,
           "tag_mapping_function"_a = nullopt,
           py::return_value_policy::move);
     m.def("as_formatted_evidence",
-          &ApiAsFormattedEvidence<py::bytes>,
-          "text"_a,
-          "text_ranges"_a = nullopt,
-          "tag_mapping_function"_a = nullopt,
-          "new_ranges"_a = nullopt,
-          py::return_value_policy::move);
-    m.def("as_formatted_evidence",
-          &ApiAsFormattedEvidence<py::str>,
+          &api_as_formatted_evidence<py::bytes>,
           "text"_a,
           "text_ranges"_a = nullopt,
           "tag_mapping_function"_a = nullopt,
           "new_ranges"_a = nullopt,
           py::return_value_policy::move);
     m.def("as_formatted_evidence",
-          &ApiAsFormattedEvidence<py::bytearray>,
+          &api_as_formatted_evidence<py::str>,
+          "text"_a,
+          "text_ranges"_a = nullopt,
+          "tag_mapping_function"_a = nullopt,
+          "new_ranges"_a = nullopt,
+          py::return_value_policy::move);
+    m.def("as_formatted_evidence",
+          &api_as_formatted_evidence<py::bytearray>,
           "text"_a,
           "text_ranges"_a = nullopt,
           "tag_mapping_function"_a = nullopt,

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.cpp
@@ -112,9 +112,9 @@ int_as_formatted_evidence(StrType& text, TaintRangeRefs text_ranges, TagMappingM
 template<class StrType>
 StrType
 as_formatted_evidence(StrType& text,
-                    TaintRangeRefs& text_ranges,
-                    const optional<TagMappingMode>& tag_mapping_mode,
-                    const optional<const py::dict>& new_ranges)
+                      TaintRangeRefs& text_ranges,
+                      const optional<TagMappingMode>& tag_mapping_mode,
+                      const optional<const py::dict>& new_ranges)
 {
     if (text_ranges.empty()) {
         return text;
@@ -159,9 +159,9 @@ as_formatted_evidence(StrType& text,
 template<class StrType>
 StrType
 api_as_formatted_evidence(StrType& text,
-                       optional<TaintRangeRefs>& text_ranges,
-                       const optional<TagMappingMode>& tag_mapping_mode,
-                       const optional<const py::dict>& new_ranges)
+                          optional<TaintRangeRefs>& text_ranges,
+                          const optional<TagMappingMode>& tag_mapping_mode,
+                          const optional<const py::dict>& new_ranges)
 {
     TaintRangeRefs _ranges;
     if (!text_ranges) {
@@ -261,7 +261,8 @@ convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, TaintRange
         }
         if (element.rfind(startswith_element, 0) == 0) {
             id_evidence = element.substr(4, element.length() - 5);
-            if (auto range_by_id = get_range_by_hash(getNum(id_evidence), optional_ranges_orig); range_by_id == nullptr) {
+            if (auto range_by_id = get_range_by_hash(getNum(id_evidence), optional_ranges_orig);
+                range_by_id == nullptr) {
                 result += element;
                 length = py::len(StrType(element));
                 end += length;
@@ -289,10 +290,11 @@ convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, TaintRange
             }
             id_evidence = element.substr(4, element.length() - 5);
             start = end;
-            context_stack.emplace_back( id_evidence, start );
+            context_stack.emplace_back(id_evidence, start);
         } else {
             id_evidence = element.substr(1, element.length() - 5);
-            if (auto range_by_id = get_range_by_hash(getNum(id_evidence), optional_ranges_orig); range_by_id == nullptr) {
+            if (auto range_by_id = get_range_by_hash(getNum(id_evidence), optional_ranges_orig);
+                range_by_id == nullptr) {
                 result += element;
                 length = py::len(StrType(element));
                 end += length;
@@ -371,7 +373,8 @@ set_ranges_on_splitted(const StrType& source_str,
             if (const auto range_end_abs = range->start + range->length; range->start < end && range_end_abs > start) {
                 // Create a new range with the updated start
                 const auto new_range_start = std::max(range->start - offset, 0L);
-                const auto new_range_length = std::min(end - start, (range->length - std::max(0L, offset - range->start)));
+                const auto new_range_length =
+                  std::min(end - start, (range->length - std::max(0L, offset - range->start)));
                 item_ranges.emplace_back(
                   initializer->allocate_taint_range(new_range_start, new_range_length, range->source));
             }

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
@@ -29,16 +29,16 @@ int_as_formatted_evidence(StrType& text, TaintRangeRefs text_ranges, TagMappingM
 template<class StrType>
 StrType
 as_formatted_evidence(StrType& text,
-                    TaintRangeRefs& text_ranges,
-                    const optional<TagMappingMode>& tag_mapping_mode,
-                    const optional<const py::dict>& new_ranges);
+                      TaintRangeRefs& text_ranges,
+                      const optional<TagMappingMode>& tag_mapping_mode,
+                      const optional<const py::dict>& new_ranges);
 
 template<class StrType>
 StrType
 api_as_formatted_evidence(StrType& text,
-                       optional<TaintRangeRefs>& text_ranges,
-                       const optional<TagMappingMode>& tag_mapping_mode,
-                       const optional<const py::dict>& new_ranges);
+                          optional<TaintRangeRefs>& text_ranges,
+                          const optional<TagMappingMode>& tag_mapping_mode,
+                          const optional<const py::dict>& new_ranges);
 
 py::bytearray
 api_convert_escaped_text_to_taint_text_ba(const py::bytearray& taint_escaped_text, TaintRangeRefs ranges_orig);

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
@@ -3,7 +3,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include "TaintTracking/Source.h"
 #include "TaintTracking/TaintRange.h"
 
 using namespace pybind11::literals;
@@ -21,22 +20,22 @@ api_common_replace(const py::str& string_method,
 
 template<class StrType>
 StrType
-_all_as_formatted_evidence(StrType& text, TagMappingMode tag_mapping_mode);
+all_as_formatted_evidence(StrType& text, TagMappingMode tag_mapping_mode);
 
 template<class StrType>
 StrType
-_int_as_formatted_evidence(StrType& text, TaintRangeRefs text_ranges, TagMappingMode tag_mapping_mode);
+int_as_formatted_evidence(StrType& text, TaintRangeRefs text_ranges, TagMappingMode tag_mapping_mode);
 
 template<class StrType>
 StrType
-AsFormattedEvidence(StrType& text,
-                    optional<TaintRangeRefs>& text_ranges,
-                    const TagMappingMode& tag_mapping_mode,
+as_formatted_evidence(StrType& text,
+                    TaintRangeRefs& text_ranges,
+                    const optional<TagMappingMode>& tag_mapping_mode,
                     const optional<const py::dict>& new_ranges);
 
 template<class StrType>
 StrType
-ApiAsFormattedEvidence(StrType& text,
+api_as_formatted_evidence(StrType& text,
                        optional<TaintRangeRefs>& text_ranges,
                        const optional<TagMappingMode>& tag_mapping_mode,
                        const optional<const py::dict>& new_ranges);
@@ -50,7 +49,7 @@ api_convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, TaintR
 
 template<class StrType>
 std::tuple<StrType, TaintRangeRefs>
-_convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, TaintRangeRefs ranges_orig);
+convert_escaped_text_to_taint_text(const StrType& taint_escaped_text, TaintRangeRefs ranges_orig);
 
 template<class StrType>
 bool

--- a/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
@@ -34,17 +34,16 @@ Initializer::create_tainting_map()
 void
 Initializer::clear_tainting_map(const TaintRangeMapTypePtr& tx_map)
 {
-    if (not tx_map)
+    if (not tx_map or tx_map->empty())
         return;
 
-    auto it = active_map_addreses.find(tx_map.get());
-    if (it == active_map_addreses.end()) {
+    if (const auto it = active_map_addreses.find(tx_map.get()); it == active_map_addreses.end()) {
         // Map wasn't in the active addresses, do nothing
         return;
     }
 
-    for (auto& kv_taint_map : *tx_map) {
-        kv_taint_map.second.second->decref();
+    for (const auto& [fst, snd] : *tx_map) {
+        snd.second->decref();
     }
 
     tx_map->clear();
@@ -71,8 +70,7 @@ Initializer::clear_tainting_maps()
 int
 Initializer::num_objects_tainted()
 {
-    auto ctx_map = initializer->get_tainting_map();
-    if (ctx_map) {
+    if (const auto ctx_map = initializer->get_tainting_map()) {
         return static_cast<int>(ctx_map->size());
     }
     return 0;
@@ -81,16 +79,16 @@ Initializer::num_objects_tainted()
 string
 Initializer::debug_taint_map()
 {
-    auto ctx_map = initializer->get_tainting_map();
+    const auto ctx_map = initializer->get_tainting_map();
     if (!ctx_map) {
         return ("[]");
     }
 
     std::stringstream output;
     output << "[";
-    for (const auto& item : *ctx_map) {
-        output << "{ 'Id-Key': " << item.first << ",";
-        output << "'Value': { 'Hash': " << item.second.first << ", 'TaintedObject': '" << item.second.second->toString()
+    for (const auto& [fst, snd] : *ctx_map) {
+        output << "{ 'Id-Key': " << fst << ",";
+        output << "'Value': { 'Hash': " << snd.first << ", 'TaintedObject': '" << snd.second->toString()
                << "'}},";
     }
     output << "]";
@@ -98,13 +96,13 @@ Initializer::debug_taint_map()
 }
 
 int
-Initializer::initializer_size()
+Initializer::initializer_size() const
 {
     return sizeof(*this);
 }
 
 int
-Initializer::active_map_addreses_size()
+Initializer::active_map_addreses_size() const
 {
     return static_cast<int>(active_map_addreses.size());
 }
@@ -124,7 +122,7 @@ Initializer::allocate_tainted_object()
 TaintedObjectPtr
 Initializer::allocate_ranges_into_taint_object(TaintRangeRefs ranges)
 {
-    auto toptr = allocate_tainted_object();
+    const auto toptr = allocate_tainted_object();
     toptr->set_values(std::move(ranges));
     return toptr;
 }
@@ -132,7 +130,7 @@ Initializer::allocate_ranges_into_taint_object(TaintRangeRefs ranges)
 TaintedObjectPtr
 Initializer::allocate_ranges_into_taint_object_copy(const TaintRangeRefs& ranges)
 {
-    auto toptr = allocate_tainted_object();
+    const auto toptr = allocate_tainted_object();
     toptr->copy_values(ranges);
     return toptr;
 }
@@ -165,7 +163,7 @@ Initializer::release_tainted_object(TaintedObjectPtr tobj)
 }
 
 TaintRangePtr
-Initializer::allocate_taint_range(RANGE_START start, RANGE_LENGTH length, Source origin)
+Initializer::allocate_taint_range(const RANGE_START start, const RANGE_LENGTH length, const Source& origin)
 {
     if (!available_ranges_stack.empty()) {
         auto rptr = available_ranges_stack.top();

--- a/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
@@ -88,8 +88,7 @@ Initializer::debug_taint_map()
     output << "[";
     for (const auto& [fst, snd] : *ctx_map) {
         output << "{ 'Id-Key': " << fst << ",";
-        output << "'Value': { 'Hash': " << snd.first << ", 'TaintedObject': '" << snd.second->toString()
-               << "'}},";
+        output << "'Value': { 'Hash': " << snd.first << ", 'TaintedObject': '" << snd.second->toString() << "'}},";
     }
     output << "]";
     return output.str();

--- a/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.h
@@ -71,14 +71,14 @@ class Initializer
      *
      * @return The size of the Initializer object.
      */
-    int initializer_size();
+    int initializer_size() const;
 
     /**
      * Gets the size of active map addresses.
      *
      * @return The size of active map addresses.
      */
-    int active_map_addreses_size();
+    int active_map_addreses_size() const;
 
     /**
      * Creates a new taint tracking context.
@@ -133,7 +133,7 @@ class Initializer
     // FIXME: these should be static functions of TaintRange
     // IMPORTANT: if the returned object is not assigned to the map, you have
     // responsibility of calling release_taint_range on it or you'll have a leak.
-    TaintRangePtr allocate_taint_range(RANGE_START start, RANGE_LENGTH length, Source source);
+    TaintRangePtr allocate_taint_range(RANGE_START start, RANGE_LENGTH length, const Source& source);
 
     void release_taint_range(TaintRangePtr rangeptr);
 };

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/Source.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/Source.cpp
@@ -10,15 +10,13 @@ Source::Source(string name, string value, OriginType origin)
   : name(std::move(name))
   , value(std::move(value))
   , origin(origin)
-{
-}
+{}
 
 Source::Source(int name, string value, const OriginType origin)
   : name(origin_to_str(OriginType{ name }))
   , value(std::move(value))
   , origin(origin)
-{
-}
+{}
 
 string
 Source::toString() const

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/Source.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/Source.cpp
@@ -10,13 +10,15 @@ Source::Source(string name, string value, OriginType origin)
   : name(std::move(name))
   , value(std::move(value))
   , origin(origin)
-{}
+{
+}
 
 Source::Source(int name, string value, const OriginType origin)
   : name(origin_to_str(OriginType{ name }))
   , value(std::move(value))
   , origin(origin)
-{}
+{
+}
 
 string
 Source::toString() const
@@ -73,7 +75,9 @@ pyexport_source(py::module& m)
       .def_readonly("value", &Source::value)
       .def("to_string", &Source::toString)
       .def("__hash__",
-           [](const Source& self) { return hash<string>{}(self.name + self.value) * (33 + static_cast<int>(self.origin)); })
+           [](const Source& self) {
+               return hash<string>{}(self.name + self.value) * (33 + static_cast<int>(self.origin));
+           })
       .def("__str__", &Source::toString)
       .def("__repr__", &Source::toString)
       .def("__eq__", [](const Source* self, const Source* other) {

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/Source.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/Source.cpp
@@ -1,9 +1,5 @@
 #include <pybind11/pybind11.h>
 
-#include <sstream>
-#include <string>
-#include <utility>
-
 #include "Source.h"
 
 using namespace std;
@@ -16,7 +12,7 @@ Source::Source(string name, string value, OriginType origin)
   , origin(origin)
 {}
 
-Source::Source(int name, string value, OriginType origin)
+Source::Source(int name, string value, const OriginType origin)
   : name(origin_to_str(OriginType{ name }))
   , value(std::move(value))
   , origin(origin)
@@ -41,7 +37,7 @@ Source::operator std::string() const
 int
 Source::get_hash() const
 {
-    return std::hash<size_t>()(std::hash<string>()(name) ^ (long)origin ^ std::hash<string>()(value));
+    return std::hash<size_t>()(std::hash<string>()(name) ^ static_cast<long>(origin) ^ std::hash<string>()(value));
 };
 
 void
@@ -77,7 +73,7 @@ pyexport_source(py::module& m)
       .def_readonly("value", &Source::value)
       .def("to_string", &Source::toString)
       .def("__hash__",
-           [](const Source& self) { return hash<string>{}(self.name + self.value) * (33 + int(self.origin)); })
+           [](const Source& self) { return hash<string>{}(self.name + self.value) * (33 + static_cast<int>(self.origin)); })
       .def("__str__", &Source::toString)
       .def("__repr__", &Source::toString)
       .def("__eq__", [](const Source* self, const Source* other) {

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/Source.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/Source.h
@@ -1,10 +1,5 @@
 #pragma once
-#include "structmember.h"
-#include <Python.h>
-#include <iostream>
-#include <pybind11/pybind11.h>
 #include <sstream>
-#include <string.h>
 
 #include "../Constants.h"
 
@@ -46,14 +41,14 @@ struct Source
 
     [[nodiscard]] string toString() const;
 
-    inline void set_values(string name_ = "", string value_ = "", OriginType origin_ = OriginType())
+    void set_values(string name_ = "", string value_ = "", OriginType origin_ = OriginType())
     {
         name = std::move(name_);
         value = std::move(value_);
         origin = origin_;
     }
 
-    inline void reset()
+    void reset()
     {
         name = "";
         value = "";
@@ -62,7 +57,7 @@ struct Source
 
     [[nodiscard]] int get_hash() const;
 
-    static inline size_t hash(const string& name, const string& value, const OriginType origin)
+    static size_t hash(const string& name, const string& value, const OriginType origin)
     {
         return std::hash<size_t>()(std::hash<string>()(name + value) ^ (int)origin);
     };
@@ -71,7 +66,7 @@ struct Source
 };
 
 inline string
-origin_to_str(OriginType origin_type)
+origin_to_str(const OriginType origin_type)
 {
     switch (origin_type) {
         case OriginType::PARAMETER:

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
@@ -40,15 +40,17 @@ TaintRange::get_hash() const
 TaintRangePtr
 shift_taint_range(const TaintRangePtr& source_taint_range, const RANGE_START offset, const RANGE_LENGTH new_length = -1)
 {
-    const auto new_length_to_use = new_length == -1? source_taint_range->length : new_length;
+    const auto new_length_to_use = new_length == -1 ? source_taint_range->length : new_length;
     auto tptr = initializer->allocate_taint_range(source_taint_range->start + offset, // start
-                                                  new_length_to_use,                         // length
+                                                  new_length_to_use,                  // length
                                                   source_taint_range->source);        // origin
     return tptr;
 }
 
 TaintRangeRefs
-shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, const RANGE_START offset, const RANGE_LENGTH new_length = -1)
+shift_taint_ranges(const TaintRangeRefs& source_taint_ranges,
+                   const RANGE_START offset,
+                   const RANGE_LENGTH new_length = -1)
 {
     TaintRangeRefs new_ranges;
     new_ranges.reserve(source_taint_ranges.size());
@@ -60,7 +62,9 @@ shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, const RANGE_START 
 }
 
 TaintRangeRefs
-api_shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, const RANGE_START offset, const RANGE_LENGTH new_length = -1)
+api_shift_taint_ranges(const TaintRangeRefs& source_taint_ranges,
+                       const RANGE_START offset,
+                       const RANGE_LENGTH new_length = -1)
 {
     return shift_taint_ranges(source_taint_ranges, offset);
 }
@@ -270,7 +274,10 @@ api_copy_ranges_from_strings(py::object& str_1, py::object& str_2)
 }
 
 inline void
-api_copy_and_shift_ranges_from_strings(py::object& str_1, py::object& str_2, const int offset, const int new_length = -1)
+api_copy_and_shift_ranges_from_strings(py::object& str_1,
+                                       py::object& str_2,
+                                       const int offset,
+                                       const int new_length = -1)
 {
     const auto tx_map = initializer->get_tainting_map();
     if (not tx_map) {
@@ -282,7 +289,8 @@ api_copy_and_shift_ranges_from_strings(py::object& str_1, py::object& str_2, con
         py::set_error(PyExc_TypeError, MSG_ERROR_TAINT_MAP);
         return;
     }
-    if (const bool result = set_ranges(str_2.ptr(), shift_taint_ranges(ranges, offset, new_length), tx_map); not result) {
+    if (const bool result = set_ranges(str_2.ptr(), shift_taint_ranges(ranges, offset, new_length), tx_map);
+        not result) {
         py::set_error(PyExc_TypeError, MSG_ERROR_SET_RANGES);
     }
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
@@ -31,26 +31,24 @@ TaintRange::operator std::string() const
 uint
 TaintRange::get_hash() const
 {
-    uint hstart = hash<uint>()(this->start);
-    uint hlength = hash<uint>()(this->length);
-    uint hsource = hash<uint>()(this->source.get_hash());
+    const uint hstart = hash<uint>()(this->start);
+    const uint hlength = hash<uint>()(this->length);
+    const uint hsource = hash<uint>()(this->source.get_hash());
     return hstart ^ hlength ^ hsource;
 };
 
 TaintRangePtr
-shift_taint_range(const TaintRangePtr& source_taint_range, RANGE_START offset, RANGE_LENGTH new_length = -1)
+shift_taint_range(const TaintRangePtr& source_taint_range, const RANGE_START offset, const RANGE_LENGTH new_length = -1)
 {
-    if (new_length == -1) {
-        new_length = source_taint_range->length;
-    }
+    const auto new_length_to_use = new_length == -1? source_taint_range->length : new_length;
     auto tptr = initializer->allocate_taint_range(source_taint_range->start + offset, // start
-                                                  new_length,                         // length
+                                                  new_length_to_use,                         // length
                                                   source_taint_range->source);        // origin
     return tptr;
 }
 
 TaintRangeRefs
-shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, RANGE_START offset, RANGE_LENGTH new_length = -1)
+shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, const RANGE_START offset, const RANGE_LENGTH new_length = -1)
 {
     TaintRangeRefs new_ranges;
     new_ranges.reserve(source_taint_ranges.size());
@@ -62,7 +60,7 @@ shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, RANGE_START offset
 }
 
 TaintRangeRefs
-api_shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, RANGE_START offset, RANGE_LENGTH new_length = -1)
+api_shift_taint_ranges(const TaintRangeRefs& source_taint_ranges, const RANGE_START offset, const RANGE_LENGTH new_length = -1)
 {
     return shift_taint_ranges(source_taint_ranges, offset);
 }
@@ -101,7 +99,7 @@ api_set_ranges(py::object& str, const TaintRangeRefs& ranges)
  * @param nargs The number of arguments in the 'args' array.
  */
 PyObject*
-api_set_ranges_from_values(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
+api_set_ranges_from_values(PyObject* self, PyObject* const* args, const Py_ssize_t nargs)
 {
     bool result = false;
     const char* result_error_msg = MSG_ERROR_N_PARAMS;
@@ -118,15 +116,13 @@ api_set_ranges_from_values(PyObject* self, PyObject* const* args, Py_ssize_t nar
         pyobject_n = new_pyobject_id(tainted_object);
         PyObject* len_pyobject_py = args[1];
 
-        long len_pyobject = PyLong_AsLong(len_pyobject_py);
-        string source_name = PyObjectToString(args[2]);
-        if (not source_name.empty()) {
-            string source_value = PyObjectToString(args[3]);
-            if (not source_value.empty()) {
-                auto source_origin = OriginType(PyLong_AsLong(args[4]));
-                auto source = Source(source_name, source_value, source_origin);
-                auto range = initializer->allocate_taint_range(0, len_pyobject, source);
-                TaintRangeRefs ranges = vector{ range };
+        const long len_pyobject = PyLong_AsLong(len_pyobject_py);
+        if (const string source_name = PyObjectToString(args[2]); not source_name.empty()) {
+            if (const string source_value = PyObjectToString(args[3]); not source_value.empty()) {
+                const auto source_origin = static_cast<OriginType>(PyLong_AsLong(args[4]));
+                const auto source = Source(source_name, source_value, source_origin);
+                const auto range = initializer->allocate_taint_range(0, len_pyobject, source);
+                const auto ranges = vector{ range };
                 result = set_ranges(pyobject_n, ranges, tx_map);
                 if (not result) {
                     result_error_msg = MSG_ERROR_SET_RANGES;
@@ -176,7 +172,7 @@ set_ranges(PyObject* str, const TaintRangeRefs& ranges, const TaintRangeMapTypeP
         return false;
     }
     auto obj_id = get_unique_id(str);
-    auto it = tx_map->find(obj_id);
+    const auto it = tx_map->find(obj_id);
     auto new_tainted_object = initializer->allocate_ranges_into_taint_object(ranges);
 
     set_fast_tainted_if_notinterned_unicode(str);
@@ -200,22 +196,17 @@ are_all_text_all_ranges(PyObject* candidate_text, const py::tuple& parameter_lis
     if (not is_text(candidate_text))
         return {};
 
-    bool ranges_error;
-    TaintRangeRefs candidate_text_ranges, all_ranges;
+    TaintRangeRefs all_ranges;
     const auto tx_map = initializer->get_tainting_map();
     if (not tx_map or tx_map->empty()) {
         return { {}, {} };
     }
 
-    std::tie(candidate_text_ranges, ranges_error) = get_ranges(candidate_text, tx_map);
+    auto [candidate_text_ranges, ranges_error] = get_ranges(candidate_text, tx_map);
     if (not ranges_error) {
         for (const auto& param_handler : parameter_list) {
-            auto param = param_handler.cast<py::object>().ptr();
-
-            if (is_text(param)) {
-                TaintRangeRefs ranges;
-                std::tie(ranges, ranges_error) = get_ranges(param, tx_map);
-                if (not ranges_error) {
+            if (const auto param = param_handler.cast<py::object>().ptr(); is_text(param)) {
+                if (auto [ranges, ranges_error] = get_ranges(param, tx_map); not ranges_error) {
                     all_ranges.insert(all_ranges.end(), ranges.begin(), ranges.end());
                 }
             }
@@ -226,7 +217,7 @@ are_all_text_all_ranges(PyObject* candidate_text, const py::tuple& parameter_lis
 }
 
 TaintRangePtr
-get_range_by_hash(size_t range_hash, optional<TaintRangeRefs>& taint_ranges)
+get_range_by_hash(const size_t range_hash, optional<TaintRangeRefs>& taint_ranges)
 {
     if (not taint_ranges or taint_ranges->empty()) {
         return nullptr;
@@ -245,15 +236,13 @@ get_range_by_hash(size_t range_hash, optional<TaintRangeRefs>& taint_ranges)
 TaintRangeRefs
 api_get_ranges(const py::object& string_input)
 {
-    bool ranges_error;
-    TaintRangeRefs ranges;
     const auto tx_map = initializer->get_tainting_map();
 
     if (not tx_map) {
         throw py::value_error(MSG_ERROR_TAINT_MAP);
     }
 
-    std::tie(ranges, ranges_error) = get_ranges(string_input.ptr(), tx_map);
+    auto [ranges, ranges_error] = get_ranges(string_input.ptr(), tx_map);
     if (ranges_error) {
         throw py::value_error(MSG_ERROR_GET_RANGES_TYPE);
     }
@@ -263,9 +252,6 @@ api_get_ranges(const py::object& string_input)
 void
 api_copy_ranges_from_strings(py::object& str_1, py::object& str_2)
 {
-
-    bool ranges_error, result;
-    TaintRangeRefs ranges;
     const auto tx_map = initializer->get_tainting_map();
 
     if (not tx_map) {
@@ -273,34 +259,30 @@ api_copy_ranges_from_strings(py::object& str_1, py::object& str_2)
         return;
     }
 
-    std::tie(ranges, ranges_error) = get_ranges(str_1.ptr(), tx_map);
+    auto [ranges, ranges_error] = get_ranges(str_1.ptr(), tx_map);
     if (ranges_error) {
         py::set_error(PyExc_TypeError, MSG_ERROR_TAINT_MAP);
         return;
     }
-    result = set_ranges(str_2.ptr(), ranges, tx_map);
-    if (not result) {
+    if (const bool result = set_ranges(str_2.ptr(), ranges, tx_map); not result) {
         py::set_error(PyExc_TypeError, MSG_ERROR_SET_RANGES);
     }
 }
 
 inline void
-api_copy_and_shift_ranges_from_strings(py::object& str_1, py::object& str_2, int offset, int new_length = -1)
+api_copy_and_shift_ranges_from_strings(py::object& str_1, py::object& str_2, const int offset, const int new_length = -1)
 {
-    bool ranges_error, result;
-    TaintRangeRefs ranges;
     const auto tx_map = initializer->get_tainting_map();
     if (not tx_map) {
         py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
         return;
     }
-    std::tie(ranges, ranges_error) = get_ranges(str_1.ptr(), tx_map);
+    auto [ranges, ranges_error] = get_ranges(str_1.ptr(), tx_map);
     if (ranges_error) {
         py::set_error(PyExc_TypeError, MSG_ERROR_TAINT_MAP);
         return;
     }
-    result = set_ranges(str_2.ptr(), shift_taint_ranges(ranges, offset, new_length), tx_map);
-    if (not result) {
+    if (const bool result = set_ranges(str_2.ptr(), shift_taint_ranges(ranges, offset, new_length), tx_map); not result) {
         py::set_error(PyExc_TypeError, MSG_ERROR_SET_RANGES);
     }
 }
@@ -315,7 +297,7 @@ get_tainted_object(PyObject* str, const TaintRangeMapTypePtr& tx_map)
         return nullptr;
     }
 
-    auto it = tx_map->find(get_unique_id(str));
+    const auto it = tx_map->find(get_unique_id(str));
     if (it == tx_map->end()) {
         return nullptr;
     }
@@ -347,15 +329,14 @@ get_internal_hash(PyObject* obj)
 }
 
 void
-set_tainted_object(PyObject* str, TaintedObjectPtr tainted_object, const TaintRangeMapTypePtr& tx_taint_map)
+set_tainted_object(PyObject* str, TaintedObjectPtr tainted_object, const TaintRangeMapTypePtr& tx_map)
 {
     if (not str or not is_text(str)) {
         return;
     }
     auto obj_id = get_unique_id(str);
     set_fast_tainted_if_notinterned_unicode(str);
-    auto it = tx_taint_map->find(obj_id);
-    if (it != tx_taint_map->end()) {
+    if (const auto it = tx_map->find(obj_id); it != tx_map->end()) {
         // The same memory address was probably re-used for a different PyObject, so
         // we need to overwrite it.
         if (it->second.second != tainted_object) {
@@ -371,7 +352,7 @@ set_tainted_object(PyObject* str, TaintedObjectPtr tainted_object, const TaintRa
         return;
     }
     tainted_object->incref();
-    tx_taint_map->insert({ obj_id, std::make_pair(get_internal_hash(str), tainted_object) });
+    tx_map->insert({ obj_id, std::make_pair(get_internal_hash(str), tainted_object) });
 }
 
 // OPTIMIZATION TODO: export the variant of these functions taking a PyObject*
@@ -431,8 +412,8 @@ pyexport_taintrange(py::module& m)
     // Fake constructor, used to force calling allocate_taint_range for performance reasons
     m.def(
       "taint_range",
-      [](RANGE_START start, RANGE_LENGTH length, Source source) {
-          return initializer->allocate_taint_range(start, length, std::move(source));
+      [](const RANGE_START start, const RANGE_LENGTH length, const Source& source) {
+          return initializer->allocate_taint_range(start, length, source);
       },
       "start"_a,
       "length"_a,

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.h
@@ -1,6 +1,4 @@
 #pragma once
-#include <iostream>
-#include <sstream>
 #include <utility>
 
 #include <pybind11/stl.h>
@@ -43,7 +41,7 @@ struct TaintRange
 
     TaintRange() = default;
 
-    TaintRange(RANGE_START start, RANGE_LENGTH length, Source source)
+    TaintRange(const RANGE_START start, const RANGE_LENGTH length, Source source)
       : start(start)
       , length(length)
       , source(std::move(source))
@@ -53,7 +51,7 @@ struct TaintRange
         }
     }
 
-    inline void set_values(RANGE_START start_, RANGE_LENGTH length_, Source source_)
+    inline void set_values(const RANGE_START start_, const RANGE_LENGTH length_, Source source_)
     {
         if (length_ <= 0) {
             throw std::invalid_argument("Error: Length cannot be set to 0.");
@@ -79,7 +77,7 @@ TaintRangePtr
 shift_taint_range(const TaintRangePtr& source_taint_range, RANGE_START offset, RANGE_LENGTH new_length);
 
 inline TaintRangePtr
-api_shift_taint_range(const TaintRangePtr& source_taint_range, RANGE_START offset, RANGE_LENGTH new_length)
+api_shift_taint_range(const TaintRangePtr& source_taint_range, const RANGE_START offset, const RANGE_LENGTH new_length)
 {
     return shift_taint_range(source_taint_range, offset, new_length);
 }
@@ -130,7 +128,7 @@ api_set_fast_tainted_if_unicode(const py::object& obj)
 }
 
 inline bool
-api_is_unicode_and_not_fast_tainted(const py::object str)
+api_is_unicode_and_not_fast_tainted(const py::object& str)
 {
     return is_notinterned_notfasttainted_unicode(str.ptr());
 }
@@ -145,7 +143,7 @@ Py_hash_t
 get_internal_hash(PyObject* obj);
 
 void
-set_tainted_object(PyObject* str, TaintedObjectPtr tainted_object, const TaintRangeMapTypePtr& tx_taint_map);
+set_tainted_object(PyObject* str, TaintedObjectPtr tainted_object, const TaintRangeMapTypePtr& tx_map);
 
 void
 pyexport_taintrange(py::module& m);

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.cpp
@@ -74,12 +74,12 @@ TaintedObject::add_ranges_shifted(TaintRangeRefs ranges,
                                   const RANGE_LENGTH max_length,
                                   const RANGE_START orig_offset)
 {
-    if (const auto to_add = static_cast<long>(min(ranges.size(), TAINT_RANGE_LIMIT - ranges_.size())); !ranges.empty() and to_add > 0) {
+    if (const auto to_add = static_cast<long>(min(ranges.size(), TAINT_RANGE_LIMIT - ranges_.size()));
+        !ranges.empty() and to_add > 0) {
         ranges_.reserve(ranges_.size() + to_add);
         if (offset == 0 and max_length == -1) {
             ranges_.insert(ranges_.end(), ranges.begin(), ranges.end());
-        } else
-        {
+        } else {
             int i = 0;
             for (const auto& trange : ranges) {
                 if (max_length != -1 and orig_offset != -1) {

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.cpp
@@ -1,7 +1,4 @@
-#include "TaintTracking/TaintedObject.h"
 #include "Initializer/Initializer.h"
-#include "TaintTracking/TaintRange.h"
-#include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 
@@ -16,8 +13,8 @@ namespace py = pybind11;
  */
 TaintRangePtr
 allocate_limited_taint_range_with_offset(const TaintRangePtr& source_taint_range,
-                                         RANGE_START offset,
-                                         RANGE_LENGTH max_length)
+                                         const RANGE_START offset,
+                                         const RANGE_LENGTH max_length)
 {
     RANGE_LENGTH length;
     if (max_length != -1)
@@ -33,10 +30,11 @@ allocate_limited_taint_range_with_offset(const TaintRangePtr& source_taint_range
 
 /**
  * @brief Shifts the taint range by the given offset.
+ * @param source_taint_range The source taint range.
  * @param offset The offset to be applied.
  */
 TaintRangePtr
-shift_taint_range(const TaintRangePtr& source_taint_range, RANGE_START offset)
+shift_taint_range(const TaintRangePtr& source_taint_range, const RANGE_START offset)
 {
     auto tptr = initializer->allocate_taint_range(source_taint_range->start + offset, // start
                                                   source_taint_range->length,         // length
@@ -53,10 +51,10 @@ shift_taint_range(const TaintRangePtr& source_taint_range, RANGE_START offset)
  * @param orig_offset The offset to be applied at the beginning.
  */
 void
-TaintedObject::add_ranges_shifted(TaintedObjectPtr tainted_object,
-                                  RANGE_START offset,
-                                  RANGE_LENGTH max_length,
-                                  RANGE_START orig_offset)
+TaintedObject::add_ranges_shifted(const TaintedObjectPtr tainted_object,
+                                  const RANGE_START offset,
+                                  const RANGE_LENGTH max_length,
+                                  const RANGE_START orig_offset)
 {
     const auto& ranges = tainted_object->get_ranges();
     add_ranges_shifted(ranges, offset, max_length, orig_offset);
@@ -72,17 +70,17 @@ TaintedObject::add_ranges_shifted(TaintedObjectPtr tainted_object,
  */
 void
 TaintedObject::add_ranges_shifted(TaintRangeRefs ranges,
-                                  RANGE_START offset,
-                                  RANGE_LENGTH max_length,
-                                  RANGE_START orig_offset)
+                                  const RANGE_START offset,
+                                  const RANGE_LENGTH max_length,
+                                  const RANGE_START orig_offset)
 {
-    const auto to_add = (long)min(ranges.size(), TAINT_RANGE_LIMIT - ranges_.size());
-    if (!ranges.empty() and to_add > 0) {
+    if (const auto to_add = static_cast<long>(min(ranges.size(), TAINT_RANGE_LIMIT - ranges_.size())); !ranges.empty() and to_add > 0) {
         ranges_.reserve(ranges_.size() + to_add);
-        int i = 0;
         if (offset == 0 and max_length == -1) {
             ranges_.insert(ranges_.end(), ranges.begin(), ranges.end());
-        } else {
+        } else
+        {
+            int i = 0;
             for (const auto& trange : ranges) {
                 if (max_length != -1 and orig_offset != -1) {
                     // Make sure original position (orig_offset) is covered by the range
@@ -104,7 +102,7 @@ TaintedObject::add_ranges_shifted(TaintRangeRefs ranges,
 }
 
 std::string
-TaintedObject::toString()
+TaintedObject::toString() const
 {
     stringstream ss;
 
@@ -121,7 +119,7 @@ TaintedObject::toString()
     return ss.str();
 }
 
-TaintedObject::operator string()
+TaintedObject::operator string() const
 {
     return toString();
 }
@@ -166,12 +164,12 @@ void
 TaintedObject::release()
 {
     // If rc_ is negative, there is a bug.
-    assert(rc_ == 0);
+    // assert(rc_ == 0);
     initializer->release_tainted_object(this);
 }
 
 void
-pyexport_taintedobject(py::module& m)
+pyexport_taintedobject(const py::module& m)
 {
     py::class_<TaintedObject>(m, "TaintedObject").def(py::init<>());
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintedObject.h
@@ -46,9 +46,9 @@ class TaintedObject
                             RANGE_LENGTH max_length = -1,
                             RANGE_START orig_offset = -1);
 
-    std::string toString();
+    std::string toString() const;
 
-    explicit operator string();
+    explicit operator string() const;
 
     void move_ranges_to_stack();
 
@@ -62,4 +62,4 @@ class TaintedObject
 };
 
 void
-pyexport_taintedobject(py::module& m);
+pyexport_taintedobject(const py::module& m);

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/_taint_tracking.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/_taint_tracking.h
@@ -1,10 +1,6 @@
 #pragma once
 #include <pybind11/pybind11.h>
 
-#include "TaintTracking/Source.h"
-#include "TaintTracking/TaintRange.h"
-#include "TaintTracking/TaintedObject.h"
-
 inline void
 pyexport_m_taint_tracking(py::module& m)
 {

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.cpp
@@ -1,7 +1,7 @@
 #include "TaintedOps/TaintedOps.h"
 
 PyObject*
-api_new_pyobject_id(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
+api_new_pyobject_id(PyObject* self, PyObject* const* args, const Py_ssize_t nargs)
 {
     if (nargs != 1 or !args) {
         throw py::value_error(MSG_ERROR_N_PARAMS);

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintedOps/TaintedOps.h
@@ -1,10 +1,6 @@
 #pragma once
 #include "Initializer/Initializer.h"
-#include "TaintTracking/TaintRange.h"
-#include "TaintTracking/TaintedObject.h"
 #include "Utils/StringUtils.h"
-#include <Python.h>
-#include <pybind11/pybind11.h>
 
 using namespace std;
 using namespace pybind11::literals;

--- a/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
@@ -8,7 +8,7 @@ using namespace pybind11::literals;
 
 namespace py = pybind11;
 
-static uintptr_t
+inline static uintptr_t
 get_unique_id(const PyObject* str)
 {
     return reinterpret_cast<uintptr_t>(str);

--- a/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
@@ -8,10 +8,10 @@ using namespace pybind11::literals;
 
 namespace py = pybind11;
 
-inline static uintptr_t
+static uintptr_t
 get_unique_id(const PyObject* str)
 {
-    return uintptr_t(str);
+    return reinterpret_cast<uintptr_t>(str);
 }
 
 bool

--- a/ddtrace/appsec/_iast/_taint_tracking/_native.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/_native.cpp
@@ -61,7 +61,6 @@ PYBIND11_MODULE(_native, m)
     const char* env_iast_enabled = std::getenv("DD_IAST_ENABLED");
     if (env_iast_enabled == nullptr) {
         throw py::import_error("IAST not enabled");
-        return;
     }
 
     std::string iast_enabled = std::string(env_iast_enabled);
@@ -69,7 +68,6 @@ PYBIND11_MODULE(_native, m)
       iast_enabled.begin(), iast_enabled.end(), iast_enabled.begin(), [](unsigned char c) { return std::tolower(c); });
     if (iast_enabled != "true" && iast_enabled != "1") {
         throw py::import_error("IAST not enabled");
-        return;
     }
 
     initializer = make_unique<Initializer>();

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -278,7 +278,7 @@ def modulo_aspect(candidate_text: Text, candidate_tuple: Any) -> Any:
         if not ranges_orig:
             return candidate_text % candidate_tuple
 
-        return _convert_escaped_text_to_tainted_text(
+        return convert_escaped_text_to_tainted_text(
             as_formatted_evidence(
                 candidate_text,
                 candidate_text_ranges,
@@ -448,7 +448,7 @@ def format_map_aspect(
         if not ranges_orig:
             return candidate_text.format_map(*args, **kwargs)
 
-        return _convert_escaped_text_to_tainted_text(
+        return convert_escaped_text_to_tainted_text(
             as_formatted_evidence(
                 candidate_text, candidate_text_ranges, tag_mapping_function=TagMappingMode.Mapper
             ).format_map(

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -278,7 +278,7 @@ def modulo_aspect(candidate_text: Text, candidate_tuple: Any) -> Any:
         if not ranges_orig:
             return candidate_text % candidate_tuple
 
-        return convert_escaped_text_to_tainted_text(
+        return _convert_escaped_text_to_tainted_text(
             as_formatted_evidence(
                 candidate_text,
                 candidate_text_ranges,
@@ -448,7 +448,7 @@ def format_map_aspect(
         if not ranges_orig:
             return candidate_text.format_map(*args, **kwargs)
 
-        return convert_escaped_text_to_tainted_text(
+        return _convert_escaped_text_to_tainted_text(
             as_formatted_evidence(
                 candidate_text, candidate_text_ranges, tag_mapping_function=TagMappingMode.Mapper
             ).format_map(


### PR DESCRIPTION
## Description

This includes many small linting-style changes including:

- const correctness
- include header cleanup (which actually improves compile time).
- C++ conventions (no underscores, C++ casts).
- et cetera...

## Checklist

- [X] Change(s) are motivated and described in the PR description
- [X] Testing strategy is described if automated tests are not included in the PR
- [X] Risks are described (performance impact, potential for breakage, maintainability)
- [X] Change is maintainable (easy to change, telemetry, documentation)
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [X] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)