### PR TITLE
chore(di): fix infinite loop in exception replay

### DIFF
--- a/tests/debugging/exception/test_auto_instrument.py
+++ b/tests/debugging/exception/test_auto_instrument.py
@@ -4,6 +4,7 @@ import pytest
 
 import ddtrace
 import ddtrace.debugging._exception.auto_instrument as auto_instrument
+from ddtrace.internal.packages import _third_party_packages
 from ddtrace.internal.rate_limiter import BudgetRateLimiterWithJitter as RateLimiter
 from tests.debugging.mocking import exception_debugging
 from tests.utils import TracerTestCase
@@ -24,8 +25,10 @@ class ExceptionDebuggingTestCase(TracerTestCase):
         super(ExceptionDebuggingTestCase, self).setUp()
         self.backup_tracer = ddtrace.tracer
         ddtrace.tracer = self.tracer
+        _third_party_packages().remove("ddtrace")
 
     def tearDown(self):
+        _third_party_packages().add("ddtrace")
         ddtrace.tracer = self.backup_tracer
         super(ExceptionDebuggingTestCase, self).tearDown()
 


### PR DESCRIPTION
The change that added third-party code detection to exception replay introduced a potential infinite loop. We change the coding to avoid that scenario.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
