### PR TITLE
chore(ci): add custom pypa_musllinux_1_2_i686 image with Rust compiler

### DIFF
--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -15,6 +15,10 @@ on:
       context:
         required: true
         type: string
+      file:
+        required: false
+        type: string
+        default: Dockerfile
     secrets:
       token:
         required: true
@@ -42,3 +46,4 @@ jobs:
         platforms: ${{ inputs.platforms }}
         build-args: ${{ inputs.build-args }}
         context: ${{ inputs.context }}
+        file: ${{ inputs.context }}/${{ inputs.file }}

--- a/.github/workflows/pypa_musllinux_1_2_i686.yml
+++ b/.github/workflows/pypa_musllinux_1_2_i686.yml
@@ -1,8 +1,7 @@
 name: PyPA i686 musl linux CI image
 
 on:
-  # TODO: REMOVE THIS AFTER TESTING
-  pull_request:
+  workflow_dispatch:
   push:
     branches:
       - 'main'

--- a/.github/workflows/pypa_musllinux_1_2_i686.yml
+++ b/.github/workflows/pypa_musllinux_1_2_i686.yml
@@ -1,0 +1,22 @@
+name: PyPA i686 musl linux CI image
+
+on:
+  # TODO: REMOVE THIS AFTER TESTING
+  pull_request:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'docker/**'
+
+jobs:
+  build-and-publish:
+    uses: ./.github/workflows/build-and-publish-image.yml
+    with:
+      tags: 'ghcr.io/datadog/dd-trace-py/pypa_musllinux_1_2_i686:${{ github.sha }},ghcr.io/datadog/dd-trace-py/pypa_musllinux_1_2_i686:latest'
+      platforms: 'linux/386'
+      build-args: ''
+      context: ./docker
+      file: Dockerfile.pypa_musllinux_1_2_i686
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/docker/Dockerfile.pypa_musllinux_1_2_i686
+++ b/docker/Dockerfile.pypa_musllinux_1_2_i686
@@ -1,0 +1,3 @@
+FROM quay.io/pypa/musllinux_1_2_i686:latest
+RUN apk add --no-cache gcc libgcc libstdc++ llvm15-libs musl musl-dev rust-stdlib && \
+    apk add --no-cache rust cargo


### PR DESCRIPTION
We need to get i686-unknown-linux-musl compatible rust compiler into the pypa i686 musl image for use with cibuildwheel in order to support compiler rust extensions.

## Testing

The PR originally built and published the image from this PR. This resulted in the following image being created: https://github.com/DataDog/dd-trace-py/pkgs/container/dd-trace-py%2Fpypa_musllinux_1_2_i686

This image was tested locally to ensure ddtrace would build properly:

```
$ docker run --rm -it ghcr.io/datadog/dd-trace-py/pypa_musllinux_1_2_i686:latest /bin/sh
> git clone https://github.com/DataDog/dd-trace-py.git
> cd ./dd-trace-py
# Check out branch which has a Rust extension
> git checkout brettlangdon/core.rate_limiter
> python3.12 -m pip install .
```

This was also tested by updating the `build` job for the PR #9232, showing it working as expected with cibuildwheel.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
