### PR TITLE
chore: ignore django test for patching

### DIFF
--- a/ddtrace/appsec/_iast/_ast/ast_patching.py
+++ b/ddtrace/appsec/_iast/_ast/ast_patching.py
@@ -37,6 +37,7 @@ IAST_DENYLIST: Tuple[Text, ...] = (
     "pytest",  # Testing framework
     "freezegun",  # Testing utilities for time manipulation
     "sklearn",  # Machine learning library
+    "urlpatterns_reverse.tests",  # assertRaises eat exceptions in native code, so we don't call the original function
 )
 
 


### PR DESCRIPTION
## Description

While a new PR with a fix for the `terminate` calls caused by uncatched exceptions coming from pybind11 is coming, this adds the urlreverse Django's test to the ignore list (which is needed anyway because the `assertRaises` of a testcase eats any exceptions so the `join_aspect` can't catch it and call the original function).

## Checklist

- [X] Change(s) are motivated and described in the PR description
- [X] Testing strategy is described if automated tests are not included in the PR
- [X] Risks are described (performance impact, potential for breakage, maintainability)
- [X] Change is maintainable (easy to change, telemetry, documentation)
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [X] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
