### PR TITLE
fix(tracer): ensure all metadata and configs are checked for flare + correct config file

### DIFF
--- a/ddtrace/internal/flare/handler.py
+++ b/ddtrace/internal/flare/handler.py
@@ -64,7 +64,7 @@ def _prepare_tracer_flare(flare: Flare, configs: List[dict]) -> bool:
             continue
 
         flare_log_level = c.get("config", {}).get("log_level").upper()
-        flare.prepare(c, flare_log_level)
+        flare.prepare(flare_log_level)
         return True
     return False
 

--- a/ddtrace/internal/flare/handler.py
+++ b/ddtrace/internal/flare/handler.py
@@ -51,7 +51,7 @@ def _handle_tracer_flare(flare: Flare, data: dict, cleanup: bool = False):
         log.warning("Received unexpected tracer flare product type: %s", product_type)
 
 
-def _prepare_tracer_flare(flare: Flare, configs: List[dict]):
+def _prepare_tracer_flare(flare: Flare, configs: List[dict]) -> bool:
     """
     Update configurations to start sending tracer logs to a file
     to be sent in a flare later.
@@ -65,10 +65,11 @@ def _prepare_tracer_flare(flare: Flare, configs: List[dict]):
 
         flare_log_level = c.get("config", {}).get("log_level").upper()
         flare.prepare(c, flare_log_level)
-        return
+        return True
+    return False
 
 
-def _generate_tracer_flare(flare: Flare, configs: List[Any]):
+def _generate_tracer_flare(flare: Flare, configs: List[Any]) -> bool:
     """
     Revert tracer flare configurations back to original state
     before sending the flare.
@@ -87,4 +88,5 @@ def _generate_tracer_flare(flare: Flare, configs: List[Any]):
         flare.revert_configs()
 
         flare.send(flare_request)
-        return
+        return True
+    return False

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -815,7 +815,7 @@ class Config(object):
         from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
 
         remoteconfig_pubsub = self._remoteconfigPubSub()(self._handle_remoteconfig)
-        flare = Flare(trace_agent_url=self._trace_agent_url, api_key=self._dd_api_key)
+        flare = Flare(trace_agent_url=self._trace_agent_url, api_key=self._dd_api_key, ddconfig=self.__dict__)
         tracerflare_pubsub = _tracerFlarePubSub()(_handle_tracer_flare, flare)
         remoteconfig_poller.register("APM_TRACING", remoteconfig_pubsub)
         remoteconfig_poller.register("AGENT_CONFIG", tracerflare_pubsub)

--- a/tests/internal/test_tracer_flare.py
+++ b/tests/internal/test_tracer_flare.py
@@ -33,7 +33,9 @@ class TracerFlareTests(unittest.TestCase):
     def setUp(self):
         self.flare_uuid = uuid.uuid4()
         self.flare_dir = f"{TRACER_FLARE_DIRECTORY}-{self.flare_uuid}"
-        self.flare = Flare(trace_agent_url=TRACE_AGENT_URL, flare_dir=pathlib.Path(self.flare_dir))
+        self.flare = Flare(
+            trace_agent_url=TRACE_AGENT_URL, flare_dir=pathlib.Path(self.flare_dir), ddconfig={"config": "testconfig"}
+        )
         self.pid = os.getpid()
         self.flare_file_path = f"{self.flare_dir}/tracer_python_{self.pid}.log"
         self.config_file_path = f"{self.flare_dir}/tracer_config_{self.pid}.json"
@@ -55,7 +57,7 @@ class TracerFlareTests(unittest.TestCase):
         """
         ddlogger = get_logger("ddtrace")
 
-        self.flare.prepare(self.mock_config_dict, "DEBUG")
+        self.flare.prepare("DEBUG")
 
         file_handler = self._get_handler()
         valid_logger_level = self.flare._get_valid_logger_level(DEBUG_LEVEL_INT)
@@ -81,7 +83,7 @@ class TracerFlareTests(unittest.TestCase):
         # Mock the partial failure
         with mock.patch("json.dump") as mock_json:
             mock_json.side_effect = Exception("this is an expected error")
-            self.flare.prepare(self.mock_config_dict, "DEBUG")
+            self.flare.prepare("DEBUG")
 
         file_handler = self._get_handler()
         assert file_handler is not None
@@ -101,7 +103,7 @@ class TracerFlareTests(unittest.TestCase):
         num_processes = 3
 
         def handle_agent_config():
-            self.flare.prepare(self.mock_config_dict, "DEBUG")
+            self.flare.prepare("DEBUG")
 
         def handle_agent_task():
             self.flare.send(self.mock_flare_send_request)
@@ -134,7 +136,7 @@ class TracerFlareTests(unittest.TestCase):
         processes = []
 
         def do_tracer_flare(prep_request, send_request):
-            self.flare.prepare(self.mock_config_dict, prep_request)
+            self.flare.prepare(prep_request)
             # Assert that only one process wrote its file successfully
             # We check for 2 files because it will generate a log file and a config file
             assert 2 == len(os.listdir(self.flare_dir))
@@ -157,7 +159,7 @@ class TracerFlareTests(unittest.TestCase):
         file, just the tracer logs
         """
         app_logger = Logger(name="my-app", level=DEBUG_LEVEL_INT)
-        self.flare.prepare(self.mock_config_dict, "DEBUG")
+        self.flare.prepare("DEBUG")
 
         app_log_line = "this is an app log"
         app_logger.debug(app_log_line)
@@ -195,7 +197,7 @@ class TracerFlareSubscriberTests(unittest.TestCase):
         self.tracer_flare_sub = TracerFlareSubscriber(
             data_connector=PublisherSubscriberConnector(),
             callback=_handle_tracer_flare,
-            flare=Flare(trace_agent_url=TRACE_AGENT_URL),
+            flare=Flare(trace_agent_url=TRACE_AGENT_URL, ddconfig={"config": "testconfig"}),
         )
 
     def generate_agent_config(self):


### PR DESCRIPTION
## Overview
This PR fixes two bugs with the tracer flare.

First, the RC poller behavior for the tracer flare. Prior to this PR, it would assume that the first product when polling the RC backend would be the target config/metadata we need. However, this is not a safe assumption as multiple products could be updated and polled at once. This, in addition to the fact that currently the tracer flare shares the `AGENT_CONFIG` and `AGENT_TASK` product with the **agent** flare, means that we need to check all products to ensure we don't accidentally skip a tracer flare product.

Second, we were passing in the RC config, not the actual ddtrace config when generating the config file for the flare. This is fixed, and the correct config is being generated now.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
