### PR TITLE
chore(asm): use unpatched open for asm [backport 2.9]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -109,4 +109,5 @@ mypy.ini                            @DataDog/python-guild  @DataDog/apm-core-pyt
 .github/ISSUE_TEMPLATE.md           @DataDog/python-guild  @DataDog/apm-core-python
 .github/CODEOWNERS                  @DataDog/python-guild  @DataDog/apm-core-python
 .github/workflows/system-tests.yml  @DataDog/python-guild  @DataDog/apm-core-python
+ddtrace/internal/_unpatched.py      @DataDog/python-guild
 ddtrace/internal/compat.py          @DataDog/python-guild  @DataDog/apm-core-python

--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -7,13 +7,8 @@ from ddtrace.internal.module import ModuleWatchdog
 
 ModuleWatchdog.install()
 
-# Acquire a reference to the threading module. Some parts of the library (e.g.
-# the profiler) might be enabled programmatically and therefore might end up
-# getting a reference to the tracee's threading module. By storing a reference
-# to the threading module used by ddtrace here, we make it easy for those parts
-# to get a reference to the right threading module.
-import threading as _threading
-
+# Ensure we capture references to unpatched modules as early as possible
+import ddtrace.internal._unpatched  # noqa
 from ._logger import configure_ddtrace_logger
 
 

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -38,6 +38,7 @@ from ddtrace.constants import ORIGIN_KEY
 from ddtrace.constants import RUNTIME_FAMILY
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
+from ddtrace.internal._unpatched import unpatched_open as open  # noqa: A001
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.rate_limiter import RateLimiter
 from ddtrace.settings.asm import config as asm_config

--- a/ddtrace/internal/_unpatched.py
+++ b/ddtrace/internal/_unpatched.py
@@ -1,0 +1,10 @@
+# Acquire a reference to the open function from the builtins module. This is
+# necessary to ensure that the open function can be used unpatched when required.
+from builtins import open as unpatched_open  # noqa
+
+# Acquire a reference to the threading module. Some parts of the library (e.g.
+# the profiler) might be enabled programmatically and therefore might end up
+# getting a reference to the tracee's threading module. By storing a reference
+# to the threading module used by ddtrace here, we make it easy for those parts
+# to get a reference to the right threading module.
+import threading as _threading  # noqa

--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -17,6 +17,7 @@ from typing import Union  # noqa:F401
 
 from ddtrace.constants import USER_ID_KEY
 from ddtrace.internal import compat
+from ddtrace.internal._unpatched import unpatched_open as open  # noqa: A001
 from ddtrace.internal.compat import parse
 from ddtrace.internal.constants import BLOCKED_RESPONSE_HTML
 from ddtrace.internal.constants import BLOCKED_RESPONSE_JSON

--- a/ddtrace/profiling/_threading.pyx
+++ b/ddtrace/profiling/_threading.pyx
@@ -7,7 +7,7 @@ import weakref
 import attr
 from six.moves import _thread
 
-from ddtrace import _threading as ddtrace_threading
+from ddtrace.internal._unpatched import _threading as ddtrace_threading
 
 
 from cpython cimport PyLong_FromLong

--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -8,7 +8,7 @@ import typing
 import attr
 import six
 
-from ddtrace import _threading as ddtrace_threading
+from ddtrace.internal._unpatched import _threading as ddtrace_threading
 from ddtrace._trace import context
 from ddtrace._trace import span as ddspan
 from ddtrace.internal import compat

--- a/tests/.suitespec.json
+++ b/tests/.suitespec.json
@@ -38,6 +38,7 @@
             "ddtrace/internal/_rand.pyi",
             "ddtrace/internal/_rand.pyx",
             "ddtrace/internal/_stdint.h",
+            "ddtrace/internal/_unpatched.py",
             "ddtrace/internal/agent.py",
             "ddtrace/internal/assembly.py",
             "ddtrace/internal/atexit.py",


### PR DESCRIPTION
Backport of https://github.com/DataDog/dd-trace-py/pull/9326
## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
