### PR TITLE
fix(asm): avoid terminate being called on native aspect [backport 2.9]

### DIFF
--- a/ddtrace/appsec/_iast/_ast/visitor.py
+++ b/ddtrace/appsec/_iast/_ast/visitor.py
@@ -71,12 +71,12 @@ _ASPECTS_SPEC = {
     # Replacement functions for modules
     "module_functions": {
         "os.path": {
-            "basename": "ddtrace_aspects._aspect_ospathbasename",
-            "dirname": "ddtrace_aspects._aspect_ospathdirname",
-            "join": "ddtrace_aspects._aspect_ospathjoin",
-            "normcase": "ddtrace_aspects._aspect_ospathnormcase",
-            "split": "ddtrace_aspects._aspect_ospathsplit",
-            "splitext": "ddtrace_aspects._aspect_ospathsplitext",
+            "basename": "ddtrace_aspects.ospathbasename_aspect",
+            "dirname": "ddtrace_aspects.ospathdirname_aspect",
+            "join": "ddtrace_aspects.ospathjoin_aspect",
+            "normcase": "ddtrace_aspects.ospathnormcase_aspect",
+            "split": "ddtrace_aspects.ospathsplit_aspect",
+            "splitext": "ddtrace_aspects.ospathsplitext_aspect",
         }
     },
     "operators": {
@@ -129,10 +129,10 @@ _ASPECTS_SPEC = {
 
 
 if sys.version_info >= (3, 12):
-    _ASPECTS_SPEC["module_functions"]["os.path"]["splitroot"] = "ddtrace_aspects._aspect_ospathsplitroot"
+    _ASPECTS_SPEC["module_functions"]["os.path"]["splitroot"] = "ddtrace_aspects.ospathsplitroot_aspect"
 
 if sys.version_info >= (3, 12) or os.name == "nt":
-    _ASPECTS_SPEC["module_functions"]["os.path"]["splitdrive"] = "ddtrace_aspects._aspect_ospathsplitdrive"  # type: ignore[index]
+    _ASPECTS_SPEC["module_functions"]["os.path"]["splitdrive"] = "ddtrace_aspects.ospathsplitdrive_aspect"  # type: ignore[index]
 
 
 class AstVisitor(ast.NodeTransformer):

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectExtend.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectExtend.cpp
@@ -1,4 +1,5 @@
 #include "AspectExtend.h"
+#include "Helpers.h"
 
 /**
  * @brief Taint candidate_text when bytearray extends is called.
@@ -17,12 +18,14 @@ api_extend_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 
     PyObject* candidate_text = args[0];
     if (!PyByteArray_Check(candidate_text)) {
+        py::set_error(PyExc_TypeError, "The candidate text must be a bytearray.");
         return nullptr;
     }
     auto len_candidate_text = PyByteArray_Size(candidate_text);
     PyObject* to_add = args[1];
 
     if (!PyByteArray_Check(to_add) and !PyBytes_Check(to_add)) {
+        py::set_error(PyExc_TypeError, "The text to add must be a bytearray or bytes.");
         return nullptr;
     }
 
@@ -30,6 +33,10 @@ api_extend_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     if (not ctx_map or ctx_map->empty()) {
         auto method_name = PyUnicode_FromString("extend");
         PyObject_CallMethodObjArgs(candidate_text, method_name, to_add, nullptr);
+        if (has_pyerr()) {
+            Py_DecRef(method_name);
+            return nullptr;
+        }
         Py_DecRef(method_name);
     } else {
         const auto& to_candidate = get_tainted_object(candidate_text, ctx_map);
@@ -39,6 +46,10 @@ api_extend_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
         // Ensure no returns are done before this method call
         auto method_name = PyUnicode_FromString("extend");
         PyObject_CallMethodObjArgs(candidate_text, method_name, to_add, nullptr);
+        if (has_pyerr()) {
+            Py_DecRef(method_name);
+            return nullptr;
+        }
         Py_DecRef(method_name);
 
         if (to_result == nullptr) {

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectJoin.cpp
@@ -1,4 +1,5 @@
 #include "AspectJoin.h"
+#include "Helpers.h"
 
 PyObject*
 aspect_join_str(PyObject* sep,
@@ -176,6 +177,13 @@ api_join_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
           py::reinterpret_borrow<py::bytearray>(sep).attr("join")(py::reinterpret_borrow<py::object>(arg0));
         result = result_ptr.ptr();
         Py_INCREF(result);
+    }
+
+    if (has_pyerr()) {
+        if (decref_arg0) {
+            Py_DecRef(arg0);
+        }
+        return nullptr;
     }
 
     const auto ctx_map = initializer->get_tainting_map();

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.cpp
@@ -425,6 +425,24 @@ parse_params(size_t position,
     return default_value;
 }
 
+bool
+has_pyerr()
+{
+    if (const auto exception = PyErr_Occurred()) {
+        PyObject *extype, *value, *traceback;
+        PyErr_Fetch(&extype, &value, &traceback);
+        PyErr_NormalizeException(&extype, &value, &traceback);
+        const auto exception_msg = py::str(PyObject_Str(value));
+        py::set_error(extype, exception_msg);
+        Py_DecRef(extype);
+        Py_DecRef(value);
+        Py_DecRef(traceback);
+        return true;
+    }
+
+    return false;
+}
+
 void
 pyexport_aspect_helpers(py::module& m)
 {
@@ -497,4 +515,5 @@ pyexport_aspect_helpers(py::module& m)
           "taint_escaped_text"_a,
           "ranges_orig"_a);
     m.def("parse_params", &parse_params);
+    m.def("has_pyerr", &has_pyerr);
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
@@ -67,5 +67,8 @@ api_set_ranges_on_splitted(const StrType& source_str,
                            const py::list& split_result,
                            bool include_separator = false);
 
+bool
+has_pyerr();
+
 void
 pyexport_aspect_helpers(py::module& m);

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -541,6 +541,86 @@ def format_value_aspect(
         return new_text
 
 
+def ospathjoin_aspect(*args, **kwargs):
+    try:
+        return _aspect_ospathjoin(*args, **kwargs)
+    except Exception as e:
+        iast_taint_log_error("IAST propagation error. ospathjoin_aspect. {}".format(e))
+        import os.path
+
+        return os.path.join(*args, **kwargs)
+
+
+def ospathbasename_aspect(*args, **kwargs):
+    try:
+        return _aspect_ospathbasename(*args, **kwargs)
+    except Exception as e:
+        iast_taint_log_error("IAST propagation error. ospathbasename_aspect. {}".format(e))
+        import os.path
+
+        return os.path.basename(*args, **kwargs)
+
+
+def ospathdirname_aspect(*args, **kwargs):
+    try:
+        return _aspect_ospathdirname(*args, **kwargs)
+    except Exception as e:
+        iast_taint_log_error("IAST propagation error. ospathdirname_aspect. {}".format(e))
+        import os.path
+
+        return os.path.dirname(*args, **kwargs)
+
+
+def ospathsplit_aspect(*args, **kwargs):
+    try:
+        return _aspect_ospathsplit(*args, **kwargs)
+    except Exception as e:
+        iast_taint_log_error("IAST propagation error. ospathsplit_aspect. {}".format(e))
+        import os.path
+
+        return os.path.split(*args, **kwargs)
+
+
+def ospathsplitext_aspect(*args, **kwargs):
+    try:
+        return _aspect_ospathsplitext(*args, **kwargs)
+    except Exception as e:
+        iast_taint_log_error("IAST propagation error. ospathsplitext_aspect. {}".format(e))
+        import os.path
+
+        return os.path.splitext(*args, **kwargs)
+
+
+def ospathsplitroot_aspect(*args, **kwargs):
+    try:
+        return _aspect_ospathsplitroot(*args, **kwargs)
+    except Exception as e:
+        iast_taint_log_error("IAST propagation error. ospathsplitroot_aspect. {}".format(e))
+        import os.path
+
+        return os.path.splitroot(*args, **kwargs)
+
+
+def ospathnormcase_aspect(*args, **kwargs):
+    try:
+        return _aspect_ospathnormcase(*args, **kwargs)
+    except Exception as e:
+        iast_taint_log_error("IAST propagation error. ospathnormcase_aspect. {}".format(e))
+        import os.path
+
+        return os.path.normcase(*args, **kwargs)
+
+
+def ospathsplitdrive_aspect(*args, **kwargs):
+    try:
+        return _aspect_ospathsplitdrive(*args, **kwargs)
+    except Exception as e:
+        iast_taint_log_error("IAST propagation error. ospathsplitdrive_aspect. {}".format(e))
+        import os.path
+
+        return os.path.splitdrive(*args, **kwargs)
+
+
 def incremental_translation(self, incr_coder, funcode, empty):
     tainted_ranges = iter(get_tainted_ranges(self))
     result_list, new_ranges = [], []

--- a/releasenotes/notes/no-terminate-on-extend-join-aspects-0cf5ddcaaf836168.yaml
+++ b/releasenotes/notes/no-terminate-on-extend-join-aspects-0cf5ddcaaf836168.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Code Security: avoid calling terminate on the extend and join aspect when an exception is raised.

--- a/tests/appsec/iast/aspects/test_bytearray_extend_aspect.py
+++ b/tests/appsec/iast/aspects/test_bytearray_extend_aspect.py
@@ -35,6 +35,14 @@ class TestByteArrayExtendAspect(object):
         assert result == bytearray(b"123456")
         assert not get_tainted_ranges(result)
 
+    def test_extend_native_exception_no_crash(self):
+        from ddtrace.appsec._iast._taint_tracking.aspects import _extend_aspect
+
+        ba1 = bytearray(b"123")
+        b2 = 456
+        with pytest.raises(TypeError):
+            _extend_aspect(ba1, b2)
+
     def test_extend_first_tainted(self):
         ba1 = taint_pyobject(
             pyobject=bytearray(b"123"), source_name="test", source_value="foo", source_origin=OriginType.PARAMETER

--- a/tests/appsec/iast/aspects/test_ospath_aspects.py
+++ b/tests/appsec/iast/aspects/test_ospath_aspects.py
@@ -6,18 +6,20 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
-from ddtrace.appsec._iast._taint_tracking import _aspect_ospathbasename
-from ddtrace.appsec._iast._taint_tracking import _aspect_ospathdirname
-from ddtrace.appsec._iast._taint_tracking import _aspect_ospathjoin
-from ddtrace.appsec._iast._taint_tracking import _aspect_ospathnormcase
-from ddtrace.appsec._iast._taint_tracking import _aspect_ospathsplit
-from ddtrace.appsec._iast._taint_tracking import _aspect_ospathsplitext
+from ddtrace.appsec._iast._taint_tracking.aspects import ospathbasename_aspect
+from ddtrace.appsec._iast._taint_tracking.aspects import ospathdirname_aspect
+from ddtrace.appsec._iast._taint_tracking.aspects import ospathjoin_aspect
+from ddtrace.appsec._iast._taint_tracking.aspects import ospathnormcase_aspect
+from ddtrace.appsec._iast._taint_tracking.aspects import ospathsplit_aspect
+from ddtrace.appsec._iast._taint_tracking.aspects import ospathsplitdrive_aspect
+from ddtrace.appsec._iast._taint_tracking.aspects import ospathsplitext_aspect
+from ddtrace.appsec._iast._taint_tracking.aspects import ospathsplitroot_aspect
 
 
 if sys.version_info >= (3, 12) or os.name == "nt":
-    from ddtrace.appsec._iast._taint_tracking import _aspect_ospathsplitdrive
+    pass
 if sys.version_info >= (3, 12):
-    from ddtrace.appsec._iast._taint_tracking import _aspect_ospathsplitroot
+    pass
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
 
@@ -36,7 +38,7 @@ def test_ospathjoin_first_arg_nottainted_noslash():
         source_value="bar",
         source_origin=OriginType.PARAMETER,
     )
-    res = _aspect_ospathjoin("root", tainted_foo, "nottainted", tainted_bar, "alsonottainted")
+    res = ospathjoin_aspect("root", tainted_foo, "nottainted", tainted_bar, "alsonottainted")
     assert res == "root/foo/nottainted/bar/alsonottainted"
     assert get_tainted_ranges(res) == [
         TaintRange(5, 3, Source("test_ospath", "foo", OriginType.PARAMETER)),
@@ -59,7 +61,7 @@ def test_ospathjoin_later_arg_tainted_with_slash_then_ignore_previous():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathjoin("ignored", ignored_tainted_foo, "ignored_nottainted", tainted_slashbar, "alsonottainted")
+    res = ospathjoin_aspect("ignored", ignored_tainted_foo, "ignored_nottainted", tainted_slashbar, "alsonottainted")
     assert res == "/bar/alsonottainted"
     assert get_tainted_ranges(res) == [
         TaintRange(0, 4, Source("test_ospath", "/bar", OriginType.PARAMETER)),
@@ -81,7 +83,7 @@ def test_ospathjoin_first_arg_tainted_no_slash():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathjoin(tainted_foo, "nottainted", tainted_bar, "alsonottainted")
+    res = ospathjoin_aspect(tainted_foo, "nottainted", tainted_bar, "alsonottainted")
     assert res == "foo/nottainted/bar/alsonottainted"
     assert get_tainted_ranges(res) == [
         TaintRange(0, 3, Source("test_ospath", "foo", OriginType.PARAMETER)),
@@ -104,7 +106,7 @@ def test_ospathjoin_first_arg_tainted_with_slash():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathjoin(tainted_slashfoo, "nottainted", tainted_bar, "alsonottainted")
+    res = ospathjoin_aspect(tainted_slashfoo, "nottainted", tainted_bar, "alsonottainted")
     assert res == "/foo/nottainted/bar/alsonottainted"
     assert get_tainted_ranges(res) == [
         TaintRange(0, 4, Source("test_ospath", "/foo", OriginType.PARAMETER)),
@@ -113,11 +115,11 @@ def test_ospathjoin_first_arg_tainted_with_slash():
 
 
 def test_ospathjoin_single_arg_nottainted():
-    res = _aspect_ospathjoin("nottainted")
+    res = ospathjoin_aspect("nottainted")
     assert res == "nottainted"
     assert not get_tainted_ranges(res)
 
-    res = _aspect_ospathjoin("/nottainted")
+    res = ospathjoin_aspect("/nottainted")
     assert res == "/nottainted"
     assert not get_tainted_ranges(res)
 
@@ -129,7 +131,7 @@ def test_ospathjoin_single_arg_tainted():
         source_value="foo",
         source_origin=OriginType.PARAMETER,
     )
-    res = _aspect_ospathjoin(tainted_foo)
+    res = ospathjoin_aspect(tainted_foo)
     assert res == "foo"
     assert get_tainted_ranges(res) == [TaintRange(0, 3, Source("test_ospath", "/foo", OriginType.PARAMETER))]
 
@@ -139,7 +141,7 @@ def test_ospathjoin_single_arg_tainted():
         source_value="/foo",
         source_origin=OriginType.PARAMETER,
     )
-    res = _aspect_ospathjoin(tainted_slashfoo)
+    res = ospathjoin_aspect(tainted_slashfoo)
     assert res == "/foo"
     assert get_tainted_ranges(res) == [TaintRange(0, 4, Source("test_ospath", "/foo", OriginType.PARAMETER))]
 
@@ -152,7 +154,7 @@ def test_ospathjoin_last_slash_nottainted():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathjoin("root", tainted_foo, "/nottainted")
+    res = ospathjoin_aspect("root", tainted_foo, "/nottainted")
     assert res == "/nottainted"
     assert not get_tainted_ranges(res)
 
@@ -171,18 +173,18 @@ def test_ospathjoin_last_slash_tainted():
         source_value="/bar",
         source_origin=OriginType.PARAMETER,
     )
-    res = _aspect_ospathjoin("root", tainted_foo, "nottainted", tainted_slashbar)
+    res = ospathjoin_aspect("root", tainted_foo, "nottainted", tainted_slashbar)
     assert res == "/bar"
     assert get_tainted_ranges(res) == [TaintRange(0, 4, Source("test_ospath", "/bar", OriginType.PARAMETER))]
 
 
 def test_ospathjoin_wrong_arg():
     with pytest.raises(TypeError):
-        _ = _aspect_ospathjoin("root", 42, "foobar")
+        _ = ospathjoin_aspect("root", 42, "foobar")
 
 
 def test_ospathjoin_bytes_nottainted():
-    res = _aspect_ospathjoin(b"nottainted", b"alsonottainted")
+    res = ospathjoin_aspect(b"nottainted", b"alsonottainted")
     assert res == b"nottainted/alsonottainted"
 
 
@@ -193,7 +195,7 @@ def test_ospathjoin_bytes_tainted():
         source_value=b"foo",
         source_origin=OriginType.PARAMETER,
     )
-    res = _aspect_ospathjoin(tainted_foo, b"nottainted")
+    res = ospathjoin_aspect(tainted_foo, b"nottainted")
     assert res == b"foo/nottainted"
     assert get_tainted_ranges(res) == [TaintRange(0, 3, Source("test_ospath", b"foo", OriginType.PARAMETER))]
 
@@ -204,23 +206,23 @@ def test_ospathjoin_bytes_tainted():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathjoin(tainted_slashfoo, b"nottainted")
+    res = ospathjoin_aspect(tainted_slashfoo, b"nottainted")
     assert res == b"/foo/nottainted"
     assert get_tainted_ranges(res) == [TaintRange(0, 4, Source("test_ospath", b"/foo", OriginType.PARAMETER))]
 
-    res = _aspect_ospathjoin(b"nottainted_ignore", b"alsoignored", tainted_slashfoo)
+    res = ospathjoin_aspect(b"nottainted_ignore", b"alsoignored", tainted_slashfoo)
     assert res == b"/foo"
     assert get_tainted_ranges(res) == [TaintRange(0, 4, Source("test_ospath", b"/foo", OriginType.PARAMETER))]
 
 
 def test_ospathjoin_empty():
-    res = _aspect_ospathjoin("")
+    res = ospathjoin_aspect("")
     assert res == ""
 
 
 def test_ospathjoin_noparams():
     with pytest.raises(TypeError):
-        _ = _aspect_ospathjoin()
+        _ = ospathjoin_aspect()
 
 
 def test_ospathbasename_tainted_normal():
@@ -231,7 +233,7 @@ def test_ospathbasename_tainted_normal():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathbasename(tainted_foobarbaz)
+    res = ospathbasename_aspect(tainted_foobarbaz)
     assert res == "baz"
     assert get_tainted_ranges(res) == [TaintRange(0, 3, Source("test_ospath", "/foo/bar/baz", OriginType.PARAMETER))]
 
@@ -244,20 +246,20 @@ def test_ospathbasename_tainted_empty():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathbasename(tainted_empty)
+    res = ospathbasename_aspect(tainted_empty)
     assert res == ""
     assert not get_tainted_ranges(res)
 
 
 def test_ospathbasename_nottainted():
-    res = _aspect_ospathbasename("/foo/bar/baz")
+    res = ospathbasename_aspect("/foo/bar/baz")
     assert res == "baz"
     assert not get_tainted_ranges(res)
 
 
 def test_ospathbasename_wrong_arg():
     with pytest.raises(TypeError):
-        _ = _aspect_ospathbasename(42)
+        _ = ospathbasename_aspect(42)
 
 
 def test_ospathbasename_bytes_tainted():
@@ -268,13 +270,13 @@ def test_ospathbasename_bytes_tainted():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathbasename(tainted_foobarbaz)
+    res = ospathbasename_aspect(tainted_foobarbaz)
     assert res == b"baz"
     assert get_tainted_ranges(res) == [TaintRange(0, 3, Source("test_ospath", b"/foo/bar/baz", OriginType.PARAMETER))]
 
 
 def test_ospathbasename_bytes_nottainted():
-    res = _aspect_ospathbasename(b"/foo/bar/baz")
+    res = ospathbasename_aspect(b"/foo/bar/baz")
     assert res == b"baz"
     assert not get_tainted_ranges(res)
 
@@ -286,13 +288,13 @@ def test_ospathbasename_single_slash_tainted():
         source_value="/",
         source_origin=OriginType.PARAMETER,
     )
-    res = _aspect_ospathbasename(tainted_slash)
+    res = ospathbasename_aspect(tainted_slash)
     assert res == ""
     assert not get_tainted_ranges(res)
 
 
 def test_ospathbasename_nottainted_empty():
-    res = _aspect_ospathbasename("")
+    res = ospathbasename_aspect("")
     assert res == ""
     assert not get_tainted_ranges(res)
 
@@ -305,7 +307,7 @@ def test_ospathnormcase_tainted_normal():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathnormcase(tainted_foobarbaz)
+    res = ospathnormcase_aspect(tainted_foobarbaz)
     assert res == "/foo/bar/baz"
     assert get_tainted_ranges(res) == [TaintRange(0, 12, Source("test_ospath", "/foo/bar/baz", OriginType.PARAMETER))]
 
@@ -318,20 +320,20 @@ def test_ospathnormcase_tainted_empty():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathnormcase(tainted_empty)
+    res = ospathnormcase_aspect(tainted_empty)
     assert res == ""
     assert not get_tainted_ranges(res)
 
 
 def test_ospathnormcase_nottainted():
-    res = _aspect_ospathnormcase("/foo/bar/baz")
+    res = ospathnormcase_aspect("/foo/bar/baz")
     assert res == "/foo/bar/baz"
     assert not get_tainted_ranges(res)
 
 
 def test_ospathnormcase_wrong_arg():
     with pytest.raises(TypeError):
-        _ = _aspect_ospathnormcase(42)
+        _ = ospathnormcase_aspect(42)
 
 
 def test_ospathnormcase_bytes_tainted():
@@ -342,13 +344,13 @@ def test_ospathnormcase_bytes_tainted():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathnormcase(tainted_foobarbaz)
+    res = ospathnormcase_aspect(tainted_foobarbaz)
     assert res == b"/foo/bar/baz"
     assert get_tainted_ranges(res) == [TaintRange(0, 12, Source("test_ospath", b"/foo/bar/baz", OriginType.PARAMETER))]
 
 
 def test_ospathnormcase_bytes_nottainted():
-    res = _aspect_ospathnormcase(b"/foo/bar/baz")
+    res = ospathnormcase_aspect(b"/foo/bar/baz")
     assert res == b"/foo/bar/baz"
     assert not get_tainted_ranges(res)
 
@@ -360,13 +362,13 @@ def test_ospathnormcase_single_slash_tainted():
         source_value="/",
         source_origin=OriginType.PARAMETER,
     )
-    res = _aspect_ospathnormcase(tainted_slash)
+    res = ospathnormcase_aspect(tainted_slash)
     assert res == "/"
     assert get_tainted_ranges(res) == [TaintRange(0, 1, Source("test_ospath", "/", OriginType.PARAMETER))]
 
 
 def test_ospathnormcase_nottainted_empty():
-    res = _aspect_ospathnormcase("")
+    res = ospathnormcase_aspect("")
     assert res == ""
     assert not get_tainted_ranges(res)
 
@@ -379,7 +381,7 @@ def test_ospathdirname_tainted_normal():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathdirname(tainted_foobarbaz)
+    res = ospathdirname_aspect(tainted_foobarbaz)
     assert res == "/foo/bar"
     assert get_tainted_ranges(res) == [TaintRange(0, 8, Source("test_ospath", "/foo/bar/baz", OriginType.PARAMETER))]
 
@@ -392,20 +394,20 @@ def test_ospathdirname_tainted_empty():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathdirname(tainted_empty)
+    res = ospathdirname_aspect(tainted_empty)
     assert res == ""
     assert not get_tainted_ranges(res)
 
 
 def test_ospathdirname_nottainted():
-    res = _aspect_ospathdirname("/foo/bar/baz")
+    res = ospathdirname_aspect("/foo/bar/baz")
     assert res == "/foo/bar"
     assert not get_tainted_ranges(res)
 
 
 def test_ospathdirname_wrong_arg():
     with pytest.raises(TypeError):
-        _ = _aspect_ospathdirname(42)
+        _ = ospathdirname_aspect(42)
 
 
 def test_ospathdirname_bytes_tainted():
@@ -416,13 +418,13 @@ def test_ospathdirname_bytes_tainted():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathdirname(tainted_foobarbaz)
+    res = ospathdirname_aspect(tainted_foobarbaz)
     assert res == b"/foo/bar"
     assert get_tainted_ranges(res) == [TaintRange(0, 8, Source("test_ospath", b"/foo/bar/baz", OriginType.PARAMETER))]
 
 
 def test_ospathdirname_bytes_nottainted():
-    res = _aspect_ospathdirname(b"/foo/bar/baz")
+    res = ospathdirname_aspect(b"/foo/bar/baz")
     assert res == b"/foo/bar"
     assert not get_tainted_ranges(res)
 
@@ -434,13 +436,13 @@ def test_ospathdirname_single_slash_tainted():
         source_value="/",
         source_origin=OriginType.PARAMETER,
     )
-    res = _aspect_ospathdirname(tainted_slash)
+    res = ospathdirname_aspect(tainted_slash)
     assert res == "/"
     assert get_tainted_ranges(res) == [TaintRange(0, 1, Source("test_ospath", "/", OriginType.PARAMETER))]
 
 
 def test_ospathdirname_nottainted_empty():
-    res = _aspect_ospathdirname("")
+    res = ospathdirname_aspect("")
     assert res == ""
     assert not get_tainted_ranges(res)
 
@@ -453,7 +455,7 @@ def test_ospathsplit_tainted_normal():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathsplit(tainted_foobarbaz)
+    res = ospathsplit_aspect(tainted_foobarbaz)
     assert res == ("/foo/bar", "baz")
     assert get_tainted_ranges(res[0]) == [TaintRange(0, 8, Source("test_ospath", "/foo/bar/baz", OriginType.PARAMETER))]
     assert get_tainted_ranges(res[1]) == [TaintRange(0, 3, Source("test_ospath", "/foo/bar/baz", OriginType.PARAMETER))]
@@ -467,14 +469,14 @@ def test_ospathsplit_tainted_empty():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathsplit(tainted_empty)
+    res = ospathsplit_aspect(tainted_empty)
     assert res == ("", "")
     assert not get_tainted_ranges(res[0])
     assert not get_tainted_ranges(res[1])
 
 
 def test_ospathsplit_nottainted():
-    res = _aspect_ospathsplit("/foo/bar/baz")
+    res = ospathsplit_aspect("/foo/bar/baz")
     assert res == ("/foo/bar", "baz")
     assert not get_tainted_ranges(res[0])
     assert not get_tainted_ranges(res[1])
@@ -482,7 +484,7 @@ def test_ospathsplit_nottainted():
 
 def test_ospathsplit_wrong_arg():
     with pytest.raises(TypeError):
-        _ = _aspect_ospathsplit(42)
+        _ = ospathsplit_aspect(42)
 
 
 def test_ospathsplit_bytes_tainted():
@@ -493,7 +495,7 @@ def test_ospathsplit_bytes_tainted():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathsplit(tainted_foobarbaz)
+    res = ospathsplit_aspect(tainted_foobarbaz)
     assert res == (b"/foo/bar", b"baz")
     assert get_tainted_ranges(res[0]) == [
         TaintRange(0, 8, Source("test_ospath", b"/foo/bar/baz", OriginType.PARAMETER))
@@ -504,7 +506,7 @@ def test_ospathsplit_bytes_tainted():
 
 
 def test_ospathsplit_bytes_nottainted():
-    res = _aspect_ospathsplit(b"/foo/bar/baz")
+    res = ospathsplit_aspect(b"/foo/bar/baz")
     assert res == (b"/foo/bar", b"baz")
     assert not get_tainted_ranges(res[0])
     assert not get_tainted_ranges(res[1])
@@ -517,14 +519,14 @@ def test_ospathsplit_single_slash_tainted():
         source_value="/",
         source_origin=OriginType.PARAMETER,
     )
-    res = _aspect_ospathsplit(tainted_slash)
+    res = ospathsplit_aspect(tainted_slash)
     assert res == ("/", "")
     assert get_tainted_ranges(res[0]) == [TaintRange(0, 1, Source("test_ospath", "/", OriginType.PARAMETER))]
     assert not get_tainted_ranges(res[1])
 
 
 def test_ospathsplit_nottainted_empty():
-    res = _aspect_ospathsplit("")
+    res = ospathsplit_aspect("")
     assert res == ("", "")
     assert not get_tainted_ranges(res[0])
     assert not get_tainted_ranges(res[1])
@@ -538,7 +540,7 @@ def test_ospathsplitext_tainted_normal():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathsplitext(tainted_foobarbaz)
+    res = ospathsplitext_aspect(tainted_foobarbaz)
     assert res == ("/foo/bar/baz", ".jpg")
     assert get_tainted_ranges(res[0]) == [
         TaintRange(0, 12, Source("test_ospath", "/foo/bar/baz.jpg", OriginType.PARAMETER))
@@ -557,7 +559,7 @@ def test_ospathsplitroot_tainted_normal():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathsplitroot(tainted_foobarbaz)
+    res = ospathsplitroot_aspect(tainted_foobarbaz)
     assert res == ("", "/", "foo/bar/baz")
     assert not get_tainted_ranges(res[0])
     assert get_tainted_ranges(res[1]) == [TaintRange(0, 1, Source("test_ospath", "/foo/bar/baz", OriginType.PARAMETER))]
@@ -575,7 +577,7 @@ def test_ospathsplitroot_tainted_doble_initial_slash():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathsplitroot(tainted_foobarbaz)
+    res = ospathsplitroot_aspect(tainted_foobarbaz)
     assert res == ("", "//", "foo/bar/baz")
     assert not get_tainted_ranges(res[0])
     assert get_tainted_ranges(res[1]) == [
@@ -595,7 +597,7 @@ def test_ospathsplitroot_tainted_triple_initial_slash():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathsplitroot(tainted_foobarbaz)
+    res = ospathsplitroot_aspect(tainted_foobarbaz)
     assert res == ("", "/", "//foo/bar/baz")
     assert not get_tainted_ranges(res[0])
     assert get_tainted_ranges(res[1]) == [
@@ -615,7 +617,7 @@ def test_ospathsplitroot_tainted_empty():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathsplitroot(tainted_empty)
+    res = ospathsplitroot_aspect(tainted_empty)
     assert res == ("", "", "")
     for i in res:
         assert not get_tainted_ranges(i)
@@ -623,7 +625,7 @@ def test_ospathsplitroot_tainted_empty():
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Requires Python 3.12")
 def test_ospathsplitroot_nottainted():
-    res = _aspect_ospathsplitroot("/foo/bar/baz")
+    res = ospathsplitroot_aspect("/foo/bar/baz")
     assert res == ("", "/", "foo/bar/baz")
     for i in res:
         assert not get_tainted_ranges(i)
@@ -632,7 +634,7 @@ def test_ospathsplitroot_nottainted():
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Requires Python 3.12")
 def test_ospathsplitroot_wrong_arg():
     with pytest.raises(TypeError):
-        _ = _aspect_ospathsplitroot(42)
+        _ = ospathsplitroot_aspect(42)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Requires Python 3.12")
@@ -644,7 +646,7 @@ def test_ospathsplitroot_bytes_tainted():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathsplitroot(tainted_foobarbaz)
+    res = ospathsplitroot_aspect(tainted_foobarbaz)
     assert res == (b"", b"/", b"foo/bar/baz")
     assert not get_tainted_ranges(res[0])
     assert get_tainted_ranges(res[1]) == [
@@ -657,7 +659,7 @@ def test_ospathsplitroot_bytes_tainted():
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Requires Python 3.12")
 def test_ospathsplitroot_bytes_nottainted():
-    res = _aspect_ospathsplitroot(b"/foo/bar/baz")
+    res = ospathsplitroot_aspect(b"/foo/bar/baz")
     assert res == (b"", b"/", b"foo/bar/baz")
     for i in res:
         assert not get_tainted_ranges(i)
@@ -671,7 +673,7 @@ def tets_ospathsplitroot_single_slash_tainted():
         source_value="/",
         source_origin=OriginType.PARAMETER,
     )
-    res = _aspect_ospathsplitroot(tainted_slash)
+    res = ospathsplitroot_aspect(tainted_slash)
     assert res == ("", "/", "")
     assert not get_tainted_ranges(res[0])
     assert get_tainted_ranges(res[1]) == [TaintRange(0, 1, Source("test_ospath", "/", OriginType.PARAMETER))]
@@ -687,7 +689,7 @@ def test_ospathsplitdrive_tainted_normal():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathsplitdrive(tainted_foobarbaz)
+    res = ospathsplitdrive_aspect(tainted_foobarbaz)
     assert res == ("", "/foo/bar/baz")
     assert not get_tainted_ranges(res[0])
     assert get_tainted_ranges(res[1]) == [
@@ -704,7 +706,7 @@ def test_ospathsplitdrive_tainted_empty():
         source_origin=OriginType.PARAMETER,
     )
 
-    res = _aspect_ospathsplitdrive(tainted_empty)
+    res = ospathsplitdrive_aspect(tainted_empty)
     assert res == ("", "")
     for i in res:
         assert not get_tainted_ranges(i)


### PR DESCRIPTION
## Checklist

- [X] Change(s) are motivated and described in the PR description
- [X] Testing strategy is described if automated tests are not included in the PR
- [X] Risks are described (performance impact, potential for breakage, maintainability)
- [X] Change is maintainable (easy to change, telemetry, documentation)
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [X] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
