### PR TITLE
chore(flake): marking `test_service_name` as flaky

### DIFF
--- a/tests/internal/service_name/test_extra_services_names.py
+++ b/tests/internal/service_name/test_extra_services_names.py
@@ -5,11 +5,13 @@ import time
 import pytest
 
 import ddtrace
+from tests.utils import flaky
 
 
 MAX_NAMES = 64
 
 
+@flaky(1735812000)
 @pytest.mark.parametrize("nb_service", [2, 16, 64, 256])
 def test_service_name(nb_service):
     ddtrace.config._extra_services = set()


### PR DESCRIPTION
Marking flaky tests exposed from running CI on another PR: https://github.com/DataDog/dd-trace-py/pull/9339

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
