### PR TITLE
chore(ci_visibility): gate coverage-related checks to ITR-supported versions

### DIFF
--- a/ddtrace/contrib/pytest/constants.py
+++ b/ddtrace/contrib/pytest/constants.py
@@ -4,3 +4,5 @@ KIND = "test"
 
 # XFail Reason
 XFAIL_REASON = "pytest.xfail.reason"
+
+ITR_MIN_SUPPORTED_VERSION = (6, 8, 0)

--- a/ddtrace/contrib/pytest/plugin.py
+++ b/ddtrace/contrib/pytest/plugin.py
@@ -16,6 +16,8 @@ from typing import Dict  # noqa:F401
 
 import pytest
 
+from ddtrace.contrib.pytest.utils import _pytest_version_supports_itr
+
 
 DDTRACE_HELP_MSG = "Enable tracing of pytest functions."
 NO_DDTRACE_HELP_MSG = "Disable tracing of pytest functions."
@@ -24,10 +26,16 @@ PATCH_ALL_HELP_MSG = "Call ddtrace.patch_all before running tests."
 
 
 def _is_enabled_early(early_config):
-    """Hackily checks if the ddtrace plugin is enabled before the config is fully populated.
+    """Checks if the ddtrace plugin is enabled before the config is fully populated.
 
-    This is necessary because the module watchdog for coverage collectio needs to be enabled as early as possible.
+    This is necessary because the module watchdog for coverage collection needs to be enabled as early as possible.
+
+    Note: since coverage is used for ITR purposes, we only check if the plugin is enabled if the pytest version supports
+    ITR
     """
+    if not _pytest_version_supports_itr():
+        return False
+
     if (
         "--no-ddtrace" in early_config.invocation_params.args
         or early_config.getini("ddtrace") is False

--- a/ddtrace/contrib/pytest/utils.py
+++ b/ddtrace/contrib/pytest/utils.py
@@ -1,0 +1,17 @@
+import pytest
+
+from ddtrace.contrib.pytest.constants import ITR_MIN_SUPPORTED_VERSION
+
+
+def _get_pytest_version_tuple():
+    if hasattr(pytest, "version_tuple"):
+        return pytest.version_tuple
+    return tuple(map(int, pytest.__version__.split(".")))
+
+
+def _is_pytest_8_or_later():
+    return _get_pytest_version_tuple() >= (8, 0, 0)
+
+
+def _pytest_version_supports_itr():
+    return _get_pytest_version_tuple() >= ITR_MIN_SUPPORTED_VERSION


### PR DESCRIPTION
Internal coverage use for pytest only applies to ITR, so we introduce a function to check whether the pytest version supports ITR, and configure the plugin and hooks accordingly.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
