### PR TITLE
chore(asm): add exploit prevention capabilities

### DIFF
--- a/ddtrace/appsec/_capabilities.py
+++ b/ddtrace/appsec/_capabilities.py
@@ -29,6 +29,14 @@ class Flags(enum.IntFlag):
     ASM_CUSTOM_BLOCKING_RESPONSE = 1 << 9
     ASM_TRUSTED_IPS = 1 << 10
     ASM_API_SECURITY_SAMPLE_RATE = 1 << 11
+    ASM_RASP_SQLI = 1 << 21
+    ASM_RASP_LFI = 1 << 22
+    ASM_RASP_SSRF = 1 << 23
+    ASM_RASP_SHI = 1 << 24
+    ASM_RASP_XXE = 1 << 25
+    ASM_RASP_RCE = 1 << 26
+    ASM_RASP_NOSQLI = 1 << 27
+    ASM_RASP_XSS = 1 << 28
 
 
 _ALL_ASM_BLOCKING = (
@@ -43,6 +51,8 @@ _ALL_ASM_BLOCKING = (
     | Flags.ASM_CUSTOM_BLOCKING_RESPONSE
 )
 
+_ALL_RASP = Flags.ASM_RASP_LFI | Flags.ASM_RASP_SSRF
+
 
 def _rc_capabilities(test_tracer: Optional[ddtrace.Tracer] = None) -> Flags:
     tracer = ddtrace.tracer if test_tracer is None else test_tracer
@@ -52,6 +62,8 @@ def _rc_capabilities(test_tracer: Optional[ddtrace.Tracer] = None) -> Flags:
             value |= Flags.ASM_ACTIVATION
         if tracer._appsec_processor and _appsec_rc_file_is_not_static():
             value |= _ALL_ASM_BLOCKING
+            if asm_config._ep_enabled:
+                value |= _ALL_RASP
         if asm_config._api_security_enabled:
             value |= Flags.ASM_API_SECURITY_SAMPLE_RATE
     return value

--- a/tests/appsec/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/appsec/test_remoteconfiguration.py
@@ -120,7 +120,7 @@ def test_rc_activation_states_off(tracer, appsec_enabled, rc_value, remote_confi
 @pytest.mark.parametrize(
     "rc_enabled, appsec_enabled, capability",
     [
-        (True, "true", "C/w="),  # All capabilities except ASM_ACTIVATION
+        (True, "true", "wAv8"),  # All capabilities except ASM_ACTIVATION
         (False, "true", ""),
         (True, "false", "CAA="),
         (False, "false", ""),
@@ -145,7 +145,7 @@ def test_rc_capabilities(rc_enabled, appsec_enabled, capability, tracer):
 @pytest.mark.parametrize(
     "env_rules, expected",
     [
-        ({}, "C/4="),  # All capabilities
+        ({}, "wAv+"),  # All capabilities
         ({"DD_APPSEC_RULES": DEFAULT.RULES}, "CAI="),  # Only ASM_FEATURES
     ],
 )


### PR DESCRIPTION
This PR adds all exploit prevention capabilities and enable 2 of them RASP_LFI and RASP_SSRF, if remote config and exploit prevention are enabled in the tracer.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
