### PR TITLE
chore(ci): fix up injection image prune job

### DIFF
--- a/.github/workflows/lib-inject-prune.yml
+++ b/.github/workflows/lib-inject-prune.yml
@@ -34,21 +34,20 @@ jobs:
       packages: write
     strategy:
       matrix:
-        image: [
-          'dd-lib-python-init-test-django',
-          'dd-lib-python-init-test-django-gunicorn',
-          'dd-lib-python-init-test-django-uvicorn',
-          'dd-lib-python-init-test-django-uwsgi',
-          'dd-lib-python-init-test-app',
-          'dd-python-agent-init',
-        ]
+        image:
+          - 'dd-lib-python-init-test-django'
+          - 'dd-lib-python-init-test-django-gunicorn'
+          - 'dd-lib-python-init-test-django-uvicorn'
+          - 'dd-lib-python-init-test-django-uwsgi'
+          - 'dd-lib-python-init-test-app'
+          - 'dd-python-agent-init'
     steps:
     - name: Prune registry
       uses: vlaurin/action-ghcr-prune@0a539594d122b915e71c59733a5b115bfaaf5d52 #v0.5.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         organization: Datadog
-        container: dd-trace-py/{{ matrix.image }}
+        container: dd-trace-py/${{ matrix.image }}
         keep-younger-than: 15 # days
         keep-last: 5
         keep-tags: |


### PR DESCRIPTION
These jobs are failing: https://github.com/DataDog/dd-trace-py/actions/runs/9223336076

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
