### PR TITLE
chore(lib-injection): update base image to alpine 3.20

### DIFF
--- a/lib-injection/Dockerfile
+++ b/lib-injection/Dockerfile
@@ -24,7 +24,7 @@ RUN python3 dl_wheels.py \
         --output-dir /build/pkgs \
         --verbose
 
-FROM alpine:3.18.6
+FROM alpine:3.20
 COPY --from=0 /build/pkgs /datadog-init/ddtrace_pkgs
 ARG UID=10000
 RUN addgroup -g 10000 -S datadog && \

--- a/lib-injection/Dockerfile
+++ b/lib-injection/Dockerfile
@@ -24,7 +24,7 @@ RUN python3 dl_wheels.py \
         --output-dir /build/pkgs \
         --verbose
 
-FROM alpine:3.18.3
+FROM alpine:3.18.6
 COPY --from=0 /build/pkgs /datadog-init/ddtrace_pkgs
 ARG UID=10000
 RUN addgroup -g 10000 -S datadog && \

--- a/releasenotes/notes/lib-inject-base-image-dffa9a9579a9350d.yaml
+++ b/releasenotes/notes/lib-inject-base-image-dffa9a9579a9350d.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    lib-injection: update base Alpine image to 3.20.


### PR DESCRIPTION
3.18.3 has a known vulnerability, CVE-2023-5363 that can trigger warnings even though this image is not used to run any applications.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
