### PR TITLE
fix(opentelemetry): enabling dd_trace_sample_ignore_parent for otel sampler

### DIFF
--- a/ddtrace/settings/_otel_remapper.py
+++ b/ddtrace/settings/_otel_remapper.py
@@ -1,15 +1,9 @@
 import os
-import sys
 
 from ..constants import ENV_KEY
 from ..constants import VERSION_KEY
 from ..internal.logger import get_logger
 
-
-if sys.version_info >= (3, 8):
-    import typing
-else:
-    import typing_extensions as typing  # noqa: F401
 
 log = get_logger(__name__)
 
@@ -21,24 +15,26 @@ OTEL_UNIFIED_TAG_MAPPINGS = {
 }
 
 
-def _remap_otel_log_level(otel_value: str) -> str:
+def _remap_otel_log_level(otel_value):
     """Remaps the otel log level to ddtrace log level"""
     if otel_value == "debug":
         return "True"
     else:
         log.warning(
-            "ddtrace does not support otel log level '%s'. ddtrace only supports enabling debug logs.",
+            "ddtrace does not support otel log level '%s'. setting ddtrace to log level info.",
             otel_value,
         )
         return "False"
 
 
-def _remap_otel_propagators(otel_value: str) -> str:
+def _remap_otel_propagators(otel_value):
     """Remaps the otel propagators to ddtrace propagators"""
     accepted_styles = []
     for style in otel_value.split(","):
         style = style.strip().lower()
-        if style in ["b3", "b3multi", "datadog", "tracecontext", "none"]:
+        if style in ["b3", "b3multi", "b3single", "datadog", "tracecontext", "none"]:
+            if style == "b3single":
+                style = "b3"
             if style not in accepted_styles:
                 accepted_styles.append(style)
         else:
@@ -46,27 +42,22 @@ def _remap_otel_propagators(otel_value: str) -> str:
     return ",".join(accepted_styles)
 
 
-def _remap_traces_sampler(otel_value: str) -> str:
+def _remap_traces_sampler(otel_value):
     """Remaps the otel trace sampler to ddtrace trace sampler"""
     if otel_value in ["always_on", "always_off", "traceidratio"]:
-        log.warning(
-            "Trace sampler set from %s to parentbased_%s; only parent based sampling is supported.",
-            otel_value,
-            otel_value,
-        )
-        otel_value = f"parentbased_{otel_value}"
-    if otel_value == "parentbased_always_on":
+        log.warning("Trace sampler set to %s; setting DD_TRACE_SAMPLE_IGNORE_PARENT to True.", otel_value)
+        os.environ["DD_TRACE_SAMPLE_IGNORE_PARENT"] = "True"
+    if otel_value == "always_on" or otel_value == "parentbased_always_on":
         return "1.0"
-    elif otel_value == "parentbased_always_off":
+    elif otel_value == "always_off" or otel_value == "parentbased_always_off":
         return "0.0"
-    elif otel_value == "parentbased_traceidratio":
+    elif otel_value == "traceidratio" or otel_value == "parentbased_traceidratio":
         return os.environ.get("OTEL_TRACES_SAMPLER_ARG", "1")
     else:
-        log.warning("Unknown sampling configuration: %s.", otel_value)
         return otel_value
 
 
-def _remap_traces_exporter(otel_value: str) -> str:
+def _remap_traces_exporter(otel_value):
     """Remaps the otel trace exporter to ddtrace trace enabled"""
     if otel_value == "none":
         return "False"
@@ -76,47 +67,53 @@ def _remap_traces_exporter(otel_value: str) -> str:
     return ""
 
 
-def _remap_metrics_exporter(otel_value: str) -> str:
+def _remap_metrics_exporter(otel_value):
     """Remaps the otel metrics exporter to ddtrace metrics exporter"""
-    if otel_value == "none":
-        return "False"
-    log.warning(
-        "Metrics exporter value is set to unrecognized value: %s.",
-        otel_value,
-    )
-    return ""
+    if otel_value != "none":
+        log.warning(
+            "An unrecognized runtime metrics exporter '%s' is being "
+            "used; setting DD_RUNTIME_METRICS_ENABLED to False.",
+            otel_value,
+        )
+    return "False"
 
 
-def _validate_logs_exporter(otel_value: str) -> typing.Literal[""]:
+def _remap_logs_exporter(otel_value):
     """Logs warning when OTEL Logs exporter is configured. DDTRACE does not support this configuration."""
     if otel_value != "none":
         log.warning(
             "Unsupported OTEL logs exporter value detected: %s. Only the 'none' value is supported.", otel_value
         )
+        return ""
     return ""
 
 
-def _remap_otel_tags(otel_value: str) -> str:
+def _remap_otel_tags(otel_value):
     """Remaps the otel tags to ddtrace tags"""
-    dd_tags: typing.List[str] = []
+    dd_tags = []
+    remaining_tags = []
+    otel_tags = otel_value.split(",")
+    otel_user_tag_dict = dict()
 
     try:
-        otel_user_tag_dict: typing.Dict[str, str] = dict()
-        for tag in otel_value.split(","):
-            key, value = tag.split("=")
-            otel_user_tag_dict[key] = value
+        for tag in otel_tags:
+            tag_pair = tag.split("=")
+            otel_user_tag_dict[tag_pair[0]] = tag_pair[1]
+
+        for otel_key, dd_key in OTEL_UNIFIED_TAG_MAPPINGS.items():
+            if otel_key in otel_user_tag_dict.keys():
+                dd_tags.append("{}:{}".format(dd_key, otel_user_tag_dict[otel_key]))
 
         for key, value in otel_user_tag_dict.items():
-            if key.lower() in OTEL_UNIFIED_TAG_MAPPINGS:
-                dd_key = OTEL_UNIFIED_TAG_MAPPINGS[key.lower()]
-                dd_tags.insert(0, f"{dd_key}:{value}")
-            else:
-                dd_tags.append(f"{key}:{value}")
+            if key.lower() not in OTEL_UNIFIED_TAG_MAPPINGS.keys():
+                if len(dd_tags) < 10:
+                    dd_tags.append("{}:{}".format(key, value))
+                else:
+                    remaining_tags.append("{}:{}".format(key, value))
     except Exception:
         log.warning("DDTRACE failed to read OTEL_RESOURCE_ATTRIBUTES. This value is misformatted: %s", otel_value)
 
-    if len(dd_tags) > 10:
-        dd_tags, remaining_tags = dd_tags[:10], dd_tags[10:]
+    if len(otel_user_tag_dict.items()) > 10:
         log.warning(
             "To preserve metrics cardinality, only the following first 10 tags have been processed %s. "
             "The following tags were not ingested: %s",
@@ -126,7 +123,7 @@ def _remap_otel_tags(otel_value: str) -> str:
     return ",".join(dd_tags)
 
 
-def _remap_otel_sdk_config(otel_value: str) -> str:
+def _remap_otel_sdk_config(otel_value):
     """Remaps the otel sdk config to ddtrace sdk config"""
     if otel_value == "false":
         return "True"
@@ -137,7 +134,7 @@ def _remap_otel_sdk_config(otel_value: str) -> str:
         return otel_value
 
 
-def _remap_default(otel_value: str) -> str:
+def _remap_default(otel_value):
     """Remaps the otel default value to ddtrace default value"""
     return otel_value
 
@@ -149,7 +146,7 @@ ENV_VAR_MAPPINGS = {
     "OTEL_TRACES_SAMPLER": ("DD_TRACE_SAMPLE_RATE", _remap_traces_sampler),
     "OTEL_TRACES_EXPORTER": ("DD_TRACE_ENABLED", _remap_traces_exporter),
     "OTEL_METRICS_EXPORTER": ("DD_RUNTIME_METRICS_ENABLED", _remap_metrics_exporter),
-    "OTEL_LOGS_EXPORTER": ("", _validate_logs_exporter),  # Does not set a DDTRACE environment variable.
+    "OTEL_LOGS_EXPORTER": ("", _remap_logs_exporter),  # Does not set a DDTRACE environment variable.
     "OTEL_RESOURCE_ATTRIBUTES": ("DD_TAGS", _remap_otel_tags),
     "OTEL_SDK_DISABLED": ("DD_TRACE_OTEL_ENABLED", _remap_otel_sdk_config),
 }
@@ -163,10 +160,10 @@ def otel_remapping():
     user_envs = {key.upper(): value for key, value in os.environ.items()}
 
     for otel_env, otel_value in user_envs.items():
-        if otel_env not in ENV_VAR_MAPPINGS:
+        if otel_env not in ENV_VAR_MAPPINGS.keys():
             continue
 
-        dd_env, otel_config_validator = ENV_VAR_MAPPINGS[otel_env]
+        dd_env, otel_config_remapper = ENV_VAR_MAPPINGS[otel_env]
         if dd_env in user_envs:
             log.debug(
                 "Datadog configuration %s is already set. OpenTelemetry configuration will be ignored: %s=%s",
@@ -176,12 +173,12 @@ def otel_remapping():
             )
             continue
 
-        if otel_env not in ("OTEL_RESOURCE_ATTRIBUTES", "OTEL_SERVICE_NAME"):
+        if otel_env not in ["OTEL_RESOURCE_ATTRIBUTES", "OTEL_SERVICE_NAME"]:
             # Resource attributes and service name are case-insensitive
             otel_value = otel_value.lower()
 
-        mapped_value = otel_config_validator(otel_value)
-        if mapped_value:
+        mapped_value = otel_config_remapper(otel_value)
+        if mapped_value != "":
             os.environ[dd_env] = mapped_value
             log.debug(
                 "OpenTelemetry configuration %s has been remapped to ddtrace configuration %s=%s",

--- a/tests/opentelemetry/test_config.py
+++ b/tests/opentelemetry/test_config.py
@@ -111,7 +111,7 @@ def test_otel_log_level_configuration_unsupported():
     assert config._debug_mode is False, config._debug_mode
 
 
-@pytest.mark.subprocess(env={"OTEL_PROPAGATORS": "b3, tracecontext"})
+@pytest.mark.subprocess(env={"OTEL_PROPAGATORS": "b3single, tracecontext, b3"})
 def test_otel_propagation_style_configuration():
     from ddtrace import config
 
@@ -129,7 +129,7 @@ def test_otel_propagation_style_configuration_unsupportedwarning():
 
 @pytest.mark.subprocess(
     env={"OTEL_TRACES_SAMPLER": "always_on"},
-    err=b"Trace sampler set from always_on to parentbased_always_on; only parent based sampling is supported.\n",
+    err=b"Trace sampler set to always_on; setting DD_TRACE_SAMPLE_IGNORE_PARENT to True.\n",
 )
 def test_otel_traces_sampler_configuration_alwayson():
     from ddtrace import config
@@ -138,18 +138,8 @@ def test_otel_traces_sampler_configuration_alwayson():
 
 
 @pytest.mark.subprocess(
-    env={"OTEL_TRACES_SAMPLER": "always_on"},
-    err=b"Trace sampler set from always_on to parentbased_always_on; only parent based sampling is supported.\n",
-)
-def test_otel_traces_sampler_configuration_ignore_parent():
-    from ddtrace import config
-
-    assert config._trace_sample_rate == 1.0, config._trace_sample_rate
-
-
-@pytest.mark.subprocess(
     env={"OTEL_TRACES_SAMPLER": "always_off"},
-    err=b"Trace sampler set from always_off to parentbased_always_off; only parent based sampling is supported.\n",
+    err=b"Trace sampler set to always_off; setting DD_TRACE_SAMPLE_IGNORE_PARENT to True.\n",
 )
 def test_otel_traces_sampler_configuration_alwaysoff():
     from ddtrace import config
@@ -162,7 +152,7 @@ def test_otel_traces_sampler_configuration_alwaysoff():
         "OTEL_TRACES_SAMPLER": "traceidratio",
         "OTEL_TRACES_SAMPLER_ARG": "0.5",
     },
-    err=b"Trace sampler set from traceidratio to parentbased_traceidratio; only parent based sampling is supported.\n",
+    err=b"Trace sampler set to traceidratio; setting DD_TRACE_SAMPLE_IGNORE_PARENT to True.\n",
 )
 def test_otel_traces_sampler_configuration_traceidratio():
     from ddtrace import config


### PR DESCRIPTION
## Description

Adding support for otel trace sampler to ignore parent trace sample rate from dd-trace-py.

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
