### PR TITLE
fix(llmobs): fix propagation memory usage

### DIFF
--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -1,5 +1,4 @@
 from typing import Optional
-from typing import Union
 
 import ddtrace
 from ddtrace import Span
@@ -26,7 +25,7 @@ def _get_nearest_llmobs_ancestor(span: Span) -> Optional[Span]:
     return None
 
 
-def _get_llmobs_parent_id(span: Span) -> Optional[Union[str, int]]:
+def _get_llmobs_parent_id(span: Span) -> Optional[str]:
     """Return the span ID of the nearest LLMObs-type span in the span's ancestor tree.
     In priority order: manually set parent ID tag, nearest LLMObs ancestor, local root's propagated parent ID tag.
     """
@@ -34,7 +33,7 @@ def _get_llmobs_parent_id(span: Span) -> Optional[Union[str, int]]:
         return span.get_tag(PARENT_ID_KEY)
     nearest_llmobs_ancestor = _get_nearest_llmobs_ancestor(span)
     if nearest_llmobs_ancestor:
-        return nearest_llmobs_ancestor.span_id
+        return str(nearest_llmobs_ancestor.span_id)
     return span.get_tag(PROPAGATED_PARENT_ID_KEY)
 
 
@@ -83,8 +82,8 @@ def _inject_llmobs_parent_id(span_context):
         return
 
     if span.span_type == SpanTypes.LLM:
-        llmobs_parent_id = span.span_id
+        llmobs_parent_id = str(span.span_id)
     else:
         llmobs_parent_id = _get_llmobs_parent_id(span)
     if llmobs_parent_id:
-        span_context._meta[PROPAGATED_PARENT_ID_KEY] = str(llmobs_parent_id)
+        span_context._meta[PROPAGATED_PARENT_ID_KEY] = llmobs_parent_id

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from typing import Union
 
 import ddtrace
 from ddtrace import Span
@@ -25,7 +26,7 @@ def _get_nearest_llmobs_ancestor(span: Span) -> Optional[Span]:
     return None
 
 
-def _get_llmobs_parent_id(span: Span) -> Optional[str]:
+def _get_llmobs_parent_id(span: Span) -> Optional[Union[str, int]]:
     """Return the span ID of the nearest LLMObs-type span in the span's ancestor tree.
     In priority order: manually set parent ID tag, nearest LLMObs ancestor, local root's propagated parent ID tag.
     """
@@ -33,7 +34,7 @@ def _get_llmobs_parent_id(span: Span) -> Optional[str]:
         return span.get_tag(PARENT_ID_KEY)
     nearest_llmobs_ancestor = _get_nearest_llmobs_ancestor(span)
     if nearest_llmobs_ancestor:
-        return str(nearest_llmobs_ancestor.span_id)
+        return nearest_llmobs_ancestor.span_id
     return span.get_tag(PROPAGATED_PARENT_ID_KEY)
 
 
@@ -82,8 +83,8 @@ def _inject_llmobs_parent_id(span_context):
         return
 
     if span.span_type == SpanTypes.LLM:
-        llmobs_parent_id = str(span.span_id)
+        llmobs_parent_id = span.span_id
     else:
         llmobs_parent_id = _get_llmobs_parent_id(span)
     if llmobs_parent_id:
-        span_context._meta[PROPAGATED_PARENT_ID_KEY] = llmobs_parent_id
+        span_context._meta[PROPAGATED_PARENT_ID_KEY] = str(llmobs_parent_id)

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -52,7 +52,6 @@ from ..internal.sampling import SAMPLING_DECISION_TRACE_TAG_KEY
 from ..internal.sampling import SamplingMechanism
 from ..internal.sampling import validate_sampling_decision
 from ..internal.utils.http import w3c_tracestate_add_p
-from ..llmobs._utils import _inject_llmobs_parent_id
 from ._utils import get_wsgi_header
 
 
@@ -991,6 +990,8 @@ class HTTPPropagator(object):
                 headers[_HTTP_BAGGAGE_PREFIX + key] = span_context._baggage[key]
 
         if config._llmobs_enabled:
+            from ddtrace.llmobs._utils import _inject_llmobs_parent_id
+
             _inject_llmobs_parent_id(span_context)
 
         if PROPAGATION_STYLE_DATADOG in config._propagation_style_inject:


### PR DESCRIPTION
This PR is a follow up of #9152, and attempts to minimize any added memory overhead by moving the `llmobs` utility import to inside the conditional check that `LLMObs` is enabled.

By importing inside the `ddtrace.llmobs.` directory we are implicitly running the `ddtrace.llmobs.__init__.py` code, which involves instantiating a `LLMObs` instance. This is likely the largest culprit of the memory overhead.

Moving the import to only happening if LLMObs is enabled should avoid that added overhead, given that LLMObs is only running in a select few customer applications at the moment.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
