### PR TITLE
fix(telemetry): logs payload format [backport 2.7]

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -669,10 +669,10 @@ class TelemetryWriter(PeriodicService):
                     elif payload_type == TELEMETRY_TYPE_GENERATE_METRICS:
                         self.add_event(payload, TELEMETRY_TYPE_GENERATE_METRICS)
 
-    def _generate_logs_event(self, payload):
+    def _generate_logs_event(self, logs):
         # type: (Set[Dict[str, str]]) -> None
         log.debug("%s request payload", TELEMETRY_TYPE_LOGS)
-        self.add_event(list(payload), TELEMETRY_TYPE_LOGS)
+        self.add_event({"logs": list(logs)}, TELEMETRY_TYPE_LOGS)
 
     def periodic(self, force_flush=False):
         namespace_metrics = self._namespace.flush()

--- a/tests/telemetry/test_telemetry_metrics.py
+++ b/tests/telemetry/test_telemetry_metrics.py
@@ -58,12 +58,12 @@ def _assert_logs(
     assert len([event for event in events if event["request_type"] == TELEMETRY_TYPE_LOGS]) == seq_id
 
     # Python 2.7 and Python 3.5 fail with dictionaries and lists order
-    expected_body = _get_request_body(expected_payload, TELEMETRY_TYPE_LOGS, seq_id)
-    expected_body["payload"].sort(key=lambda x: x["message"], reverse=False)
-    expected_body_sorted = expected_body["payload"]
+    expected_body = _get_request_body({"logs": expected_payload}, TELEMETRY_TYPE_LOGS, seq_id)
+    expected_body["payload"]["logs"].sort(key=lambda x: x["message"], reverse=False)
+    expected_body_sorted = expected_body["payload"]["logs"]
 
-    events[0]["payload"].sort(key=lambda x: x["message"], reverse=False)
-    result_event = events[0]["payload"]
+    events[0]["payload"]["logs"].sort(key=lambda x: x["message"], reverse=False)
+    result_event = events[0]["payload"]["logs"]
 
     assert result_event == expected_body_sorted
 


### PR DESCRIPTION
Telemetry: Wrong payload format is being sent to Telemetry logs.

See System Test: https://github.com/DataDog/system-tests/pull/2392

## Checklist
- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist
- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

(cherry picked from commit 104d7522aa124fa77617929084bccbfb0e998441)