### PR TITLE
ci: check that core dumps are generated

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -405,6 +405,21 @@ jobs:
           name: "Spelling"
           command: hatch run lint:spelling
 
+  coredump_check:
+    executor: python310
+    steps:
+      - checkout
+      - run:
+          name: "Cause a core dump"
+          command: |
+            ulimit -c unlimited
+            python -c "import ctypes;ctypes.string_at(0)" || true
+      - run:
+          name: "Check for core dumps"
+          command: |
+            echo "Core pattern: $( cat /proc/sys/kernel/core_pattern )"
+            ls -l core.*
+
   ccheck:
     executor: cimg_base
     steps:
@@ -1357,5 +1372,7 @@ workflows:
   version: 2
   test: &workflow_test
     jobs:
+      # Ensure that we are able to collect core dumps
+      - coredump_check
       # Pre-checking before running all jobs
       - pre_check


### PR DESCRIPTION
We add a step in the CircleCI workflow to ensure that we can generate core dumps when encountering fatal issues such as segmentation faults

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
