### PR TITLE
chore(llmobs): extract bedrock LLMObs tests to separate file

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -2,7 +2,6 @@ import json
 import os
 from typing import Any
 from typing import Dict
-from typing import List
 from typing import Optional
 from typing import Union
 
@@ -50,12 +49,7 @@ from ddtrace.llmobs.utils import Messages
 log = get_logger(__name__)
 
 
-SUPPORTED_INTEGRATIONS = {
-    "bedrock": lambda: patch(botocore=True),
-    "langchain": lambda: patch(langchain=True),
-    "openai": lambda: patch(openai=True),
-}
-
+SUPPORTED_LLMOBS_INTEGRATIONS = {"bedrock": "botocore", "openai": "openai", "langchain": "langchain"}
 
 class LLMObs(Service):
     _instance = None  # type: LLMObs
@@ -105,7 +99,7 @@ class LLMObs(Service):
     def enable(
         cls,
         ml_app: Optional[str] = None,
-        integrations: Optional[List[str]] = None,
+        integrations_enabled: bool = True,
         agentless_enabled: bool = False,
         site: Optional[str] = None,
         api_key: Optional[str] = None,
@@ -117,8 +111,7 @@ class LLMObs(Service):
         Enable LLM Observability tracing.
 
         :param str ml_app: The name of your ml application.
-        :param List[str] integrations: A list of integrations to enable auto-tracing for.
-                                        Must be subset of ("openai", "langchain", "bedrock")
+        :param bool integrations_enabled: Set to `true` to enable LLM integrations.
         :param bool agentless_enabled: Set to `true` to disable sending data that requires a Datadog Agent.
         :param str site: Your datadog site.
         :param str api_key: Your datadog api key.
@@ -170,7 +163,8 @@ class LLMObs(Service):
                 log.debug("Remote configuration disabled because DD_LLMOBS_AGENTLESS_ENABLED is set to true.")
                 remoteconfig_poller.disable()
 
-        cls._patch_integrations(integrations)
+        if integrations_enabled:
+            cls._patch_integrations()
         # override the default _instance with a new tracer
         cls._instance = cls(tracer=_tracer)
         cls.enabled = True
@@ -207,30 +201,10 @@ class LLMObs(Service):
             log.warning("Failed to flush LLMObs spans and evaluation metrics.", exc_info=True)
 
     @staticmethod
-    def _patch_integrations(integrations: Optional[List[str]] = None):
-        """
-        Patch LLM integrations based on a list of integrations passed in. Patch all supported integrations by default.
-        """
-        integrations_to_patch = {}
-        if integrations is None:
-            integrations_to_patch.update(SUPPORTED_INTEGRATIONS)
-        else:
-            for integration in integrations:
-                integration = integration.lower()
-                if integration in SUPPORTED_INTEGRATIONS:
-                    integrations_to_patch.update({integration: SUPPORTED_INTEGRATIONS[integration]})
-                else:
-                    log.warning(
-                        "%s is unsupported - LLMObs currently supports %s",
-                        integration,
-                        str(SUPPORTED_INTEGRATIONS.keys()),
-                    )
-        for integration in integrations_to_patch:
-            try:
-                SUPPORTED_INTEGRATIONS[integration]()
-            except Exception:
-                log.warning("couldn't patch %s", integration, exc_info=True)
-        return
+    def _patch_integrations() -> None:
+        """Patch LLM integrations."""
+        patch(**{integration: True for integration in SUPPORTED_LLMOBS_INTEGRATIONS.values()})  # type: ignore[arg-type]
+        log.debug("Patched LLM integrations: %s", list(SUPPORTED_LLMOBS_INTEGRATIONS.values()))
 
     @classmethod
     def export_span(cls, span: Optional[Span] = None) -> Optional[ExportedLLMObsSpan]:

--- a/tests/contrib/botocore/bedrock_utils.py
+++ b/tests/contrib/botocore/bedrock_utils.py
@@ -1,0 +1,88 @@
+import os
+
+
+try:
+    import vcr
+except ImportError:
+    vcr = None
+    get_request_vcr = None
+
+
+_MODELS = {
+    "ai21": "ai21.j2-mid-v1",
+    "amazon": "amazon.titan-tg1-large",
+    "anthropic": "anthropic.claude-instant-v1",
+    "anthropic_message": "anthropic.claude-3-sonnet-20240229-v1:0",
+    "cohere": "cohere.command-light-text-v14",
+    "meta": "meta.llama2-13b-chat-v1",
+}
+
+_REQUEST_BODIES = {
+    "ai21": {
+        "prompt": "Explain like I'm a five-year old: what is a neural network?",
+        "temperature": 0.9,
+        "topP": 1.0,
+        "maxTokens": 10,
+        "stopSequences": [],
+    },
+    "amazon": {
+        "inputText": "Command: can you explain what Datadog is to someone not in the tech industry?",
+        "textGenerationConfig": {"maxTokenCount": 50, "stopSequences": [], "temperature": 0, "topP": 0.9},
+    },
+    "anthropic": {
+        "prompt": "\n\nHuman: %s\n\nAssistant: What makes you better than Chat-GPT or LLAMA?",
+        "temperature": 0.9,
+        "top_p": 1,
+        "top_k": 250,
+        "max_tokens_to_sample": 50,
+        "stop_sequences": ["\n\nHuman:"],
+    },
+    "anthropic_message": {
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "summarize the plot to the lord of the rings in a dozen words"}],
+            }
+        ],
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 50,
+        "temperature": 0,
+    },
+    "cohere": {
+        "prompt": "\n\nHuman: %s\n\nAssistant: Can you explain what a LLM chain is?",
+        "temperature": 0.9,
+        "p": 1.0,
+        "k": 0,
+        "max_tokens": 10,
+        "stop_sequences": [],
+        "stream": False,
+        "num_generations": 1,
+    },
+    "meta": {
+        "prompt": "What does 'lorem ipsum' mean?",
+        "temperature": 0.9,
+        "top_p": 1.0,
+        "max_gen_len": 60,
+    },
+}
+
+
+# VCR is used to capture and store network requests made to OpenAI and other APIs.
+# This is done to avoid making real calls to the API which could introduce
+# flakiness and cost.
+# To (re)-generate the cassettes: pass a real API key with
+# {PROVIDER}_API_KEY, delete the old cassettes and re-run the tests.
+# NOTE: be sure to check that the generated cassettes don't contain your
+#       API key. Keys should be redacted by the filter_headers option below.
+# NOTE: that different cassettes have to be used between sync and async
+#       due to this issue: https://github.com/kevin1024/vcrpy/issues/463
+#       between cassettes generated for requests and aiohttp.
+def get_request_vcr():
+    return vcr.VCR(
+        cassette_library_dir=os.path.join(os.path.dirname(__file__), "bedrock_cassettes/"),
+        record_mode="once",
+        match_on=["path"],
+        filter_headers=["authorization", "X-Amz-Security-Token"],
+        # Ignore requests to the agent
+        ignore_localhost=True,
+    )

--- a/tests/contrib/botocore/test_bedrock.py
+++ b/tests/contrib/botocore/test_bedrock.py
@@ -488,7 +488,7 @@ class TestLLMObsBedrock:
         pin.override(bedrock_client, tracer=mock_tracer)
         # Need to disable and re-enable LLMObs service to use the mock tracer
         LLMObs.disable()
-        LLMObs.enable(_tracer=mock_tracer, integrations=["bedrock"])
+        LLMObs.enable(_tracer=mock_tracer, integrations_enabled=False)  # only want botocore patched
 
         if cassette_name is None:
             cassette_name = "%s_invoke.yaml" % provider
@@ -524,7 +524,7 @@ class TestLLMObsBedrock:
         pin.override(bedrock_client, tracer=mock_tracer)
         # Need to disable and re-enable LLMObs service to use the mock tracer
         LLMObs.disable()
-        LLMObs.enable(_tracer=mock_tracer, integrations=["bedrock"])
+        LLMObs.enable(_tracer=mock_tracer, integrations_enabled=False)  # only want botocore patched
 
         if cassette_name is None:
             cassette_name = "%s_invoke_stream.yaml" % provider
@@ -624,7 +624,7 @@ class TestLLMObsBedrock:
         pin.override(bedrock_client, tracer=mock_tracer)
         # Need to disable and re-enable LLMObs service to use the mock tracer
         LLMObs.disable()
-        LLMObs.enable(_tracer=mock_tracer, integrations=["bedrock"])
+        LLMObs.enable(_tracer=mock_tracer, integrations_enabled=False)  # only want botocore patched
         with pytest.raises(botocore.exceptions.ClientError):
             with request_vcr.use_cassette("meta_invoke_error.yaml"):
                 body, model = json.dumps(_REQUEST_BODIES["meta"]), _MODELS["meta"]

--- a/tests/contrib/botocore/test_bedrock.py
+++ b/tests/contrib/botocore/test_bedrock.py
@@ -7,97 +7,14 @@ import pytest
 from ddtrace import Pin
 from ddtrace.contrib.botocore.patch import patch
 from ddtrace.contrib.botocore.patch import unpatch
-from ddtrace.llmobs import LLMObs
-from tests.llmobs._utils import _expected_llmobs_llm_span_event
+from tests.contrib.botocore.bedrock_utils import _MODELS
+from tests.contrib.botocore.bedrock_utils import _REQUEST_BODIES
+from tests.contrib.botocore.bedrock_utils import get_request_vcr
 from tests.subprocesstest import SubprocessTestCase
 from tests.subprocesstest import run_in_subprocess
 from tests.utils import DummyTracer
 from tests.utils import DummyWriter
-from tests.utils import override_config
 from tests.utils import override_global_config
-
-
-vcr = pytest.importorskip("vcr")
-
-
-_MODELS = {
-    "ai21": "ai21.j2-mid-v1",
-    "amazon": "amazon.titan-tg1-large",
-    "anthropic": "anthropic.claude-instant-v1",
-    "anthropic_message": "anthropic.claude-3-sonnet-20240229-v1:0",
-    "cohere": "cohere.command-light-text-v14",
-    "meta": "meta.llama2-13b-chat-v1",
-}
-
-_REQUEST_BODIES = {
-    "ai21": {
-        "prompt": "Explain like I'm a five-year old: what is a neural network?",
-        "temperature": 0.9,
-        "topP": 1.0,
-        "maxTokens": 10,
-        "stopSequences": [],
-    },
-    "amazon": {
-        "inputText": "Command: can you explain what Datadog is to someone not in the tech industry?",
-        "textGenerationConfig": {"maxTokenCount": 50, "stopSequences": [], "temperature": 0, "topP": 0.9},
-    },
-    "anthropic": {
-        "prompt": "\n\nHuman: %s\n\nAssistant: What makes you better than Chat-GPT or LLAMA?",
-        "temperature": 0.9,
-        "top_p": 1,
-        "top_k": 250,
-        "max_tokens_to_sample": 50,
-        "stop_sequences": ["\n\nHuman:"],
-    },
-    "anthropic_message": {
-        "messages": [
-            {
-                "role": "user",
-                "content": [{"type": "text", "text": "summarize the plot to the lord of the rings in a dozen words"}],
-            }
-        ],
-        "anthropic_version": "bedrock-2023-05-31",
-        "max_tokens": 50,
-        "temperature": 0,
-    },
-    "cohere": {
-        "prompt": "\n\nHuman: %s\n\nAssistant: Can you explain what a LLM chain is?",
-        "temperature": 0.9,
-        "p": 1.0,
-        "k": 0,
-        "max_tokens": 10,
-        "stop_sequences": [],
-        "stream": False,
-        "num_generations": 1,
-    },
-    "meta": {
-        "prompt": "What does 'lorem ipsum' mean?",
-        "temperature": 0.9,
-        "top_p": 1.0,
-        "max_gen_len": 60,
-    },
-}
-
-
-# VCR is used to capture and store network requests made to OpenAI and other APIs.
-# This is done to avoid making real calls to the API which could introduce
-# flakiness and cost.
-# To (re)-generate the cassettes: pass a real API key with
-# {PROVIDER}_API_KEY, delete the old cassettes and re-run the tests.
-# NOTE: be sure to check that the generated cassettes don't contain your
-#       API key. Keys should be redacted by the filter_headers option below.
-# NOTE: that different cassettes have to be used between sync and async
-#       due to this issue: https://github.com/kevin1024/vcrpy/issues/463
-#       between cassettes generated for requests and aiohttp.
-def get_request_vcr():
-    return vcr.VCR(
-        cassette_library_dir=os.path.join(os.path.dirname(__file__), "bedrock_cassettes/"),
-        record_mode="once",
-        match_on=["path"],
-        filter_headers=["authorization", "X-Amz-Security-Token"],
-        # Ignore requests to the agent
-        ignore_localhost=True,
-    )
 
 
 @pytest.fixture(scope="session")
@@ -111,15 +28,6 @@ def ddtrace_global_config():
     return config
 
 
-def default_global_config():
-    return {"_dd_api_key": "<not-a-real-api_key>"}
-
-
-@pytest.fixture
-def ddtrace_config_botocore():
-    return {}
-
-
 @pytest.fixture
 def aws_credentials():
     """Mocked AWS Credentials. To regenerate test cassettes, comment this out and use real credentials."""
@@ -131,16 +39,15 @@ def aws_credentials():
 
 
 @pytest.fixture
-def boto3(aws_credentials, mock_llmobs_span_writer, ddtrace_global_config, ddtrace_config_botocore):
-    global_config = default_global_config()
+def boto3(aws_credentials, mock_llmobs_span_writer, ddtrace_global_config):
+    global_config = {"_dd_api_key": "<not-a-real-api_key>"}
     global_config.update(ddtrace_global_config)
     with override_global_config(global_config):
-        with override_config("botocore", ddtrace_config_botocore):
-            patch()
-            import boto3
+        patch()
+        import boto3
 
-            yield boto3
-            unpatch()
+        yield boto3
+        unpatch()
 
 
 @pytest.fixture
@@ -153,7 +60,6 @@ def bedrock_client(boto3, request_vcr):
     )
     bedrock_client = session.client("bedrock-runtime")
     yield bedrock_client
-    LLMObs.disable()
 
 
 @pytest.fixture
@@ -450,208 +356,3 @@ def test_cohere_embedding(bedrock_client, request_vcr):
     with request_vcr.use_cassette("cohere_embedding.yaml"):
         response = bedrock_client.invoke_model(body=body, modelId=model)
         json.loads(response.get("body").read())
-
-
-@pytest.mark.parametrize(
-    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
-)
-class TestLLMObsBedrock:
-    @staticmethod
-    def expected_llmobs_span_event(span, n_output, message=False):
-        prompt_tokens = int(span.get_tag("bedrock.usage.prompt_tokens"))
-        completion_tokens = int(span.get_tag("bedrock.usage.completion_tokens"))
-        expected_parameters = {"temperature": float(span.get_tag("bedrock.request.temperature"))}
-        if span.get_tag("bedrock.request.max_tokens"):
-            expected_parameters["max_tokens"] = int(span.get_tag("bedrock.request.max_tokens"))
-        expected_input = [{"content": mock.ANY}]
-        if message:
-            expected_input = [{"content": mock.ANY, "role": "user"}]
-        return _expected_llmobs_llm_span_event(
-            span,
-            model_name=span.get_tag("bedrock.request.model"),
-            model_provider=span.get_tag("bedrock.request.model_provider"),
-            input_messages=expected_input,
-            output_messages=[{"content": mock.ANY} for _ in range(n_output)],
-            metadata=expected_parameters,
-            token_metrics={
-                "prompt_tokens": prompt_tokens,
-                "completion_tokens": completion_tokens,
-                "total_tokens": prompt_tokens + completion_tokens,
-            },
-            tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>"},
-        )
-
-    @classmethod
-    def _test_llmobs_invoke(cls, provider, bedrock_client, mock_llmobs_span_writer, cassette_name=None, n_output=1):
-        mock_tracer = DummyTracer(writer=DummyWriter(trace_flush_enabled=False))
-        pin = Pin.get_from(bedrock_client)
-        pin.override(bedrock_client, tracer=mock_tracer)
-        # Need to disable and re-enable LLMObs service to use the mock tracer
-        LLMObs.disable()
-        LLMObs.enable(_tracer=mock_tracer, integrations_enabled=False)  # only want botocore patched
-
-        if cassette_name is None:
-            cassette_name = "%s_invoke.yaml" % provider
-        body = _REQUEST_BODIES[provider]
-        if provider == "cohere":
-            body = {
-                "prompt": "\n\nHuman: %s\n\nAssistant: Can you explain what a LLM chain is?",
-                "temperature": 0.9,
-                "p": 1.0,
-                "k": 0,
-                "max_tokens": 10,
-                "stop_sequences": [],
-                "stream": False,
-                "num_generations": n_output,
-            }
-        with get_request_vcr().use_cassette(cassette_name):
-            body, model = json.dumps(body), _MODELS[provider]
-            response = bedrock_client.invoke_model(body=body, modelId=model)
-            json.loads(response.get("body").read())
-        span = mock_tracer.pop_traces()[0][0]
-
-        assert mock_llmobs_span_writer.enqueue.call_count == 1
-        mock_llmobs_span_writer.enqueue.assert_called_with(
-            cls.expected_llmobs_span_event(span, n_output, message="message" in provider)
-        )
-
-    @classmethod
-    def _test_llmobs_invoke_stream(
-        cls, provider, bedrock_client, mock_llmobs_span_writer, cassette_name=None, n_output=1
-    ):
-        mock_tracer = DummyTracer(writer=DummyWriter(trace_flush_enabled=False))
-        pin = Pin.get_from(bedrock_client)
-        pin.override(bedrock_client, tracer=mock_tracer)
-        # Need to disable and re-enable LLMObs service to use the mock tracer
-        LLMObs.disable()
-        LLMObs.enable(_tracer=mock_tracer, integrations_enabled=False)  # only want botocore patched
-
-        if cassette_name is None:
-            cassette_name = "%s_invoke_stream.yaml" % provider
-        body = _REQUEST_BODIES[provider]
-        if provider == "cohere":
-            body = {
-                "prompt": "\n\nHuman: %s\n\nAssistant: Can you explain what a LLM chain is?",
-                "temperature": 0.9,
-                "p": 1.0,
-                "k": 0,
-                "max_tokens": 10,
-                "stop_sequences": [],
-                "stream": True,
-                "num_generations": n_output,
-            }
-        with get_request_vcr().use_cassette(cassette_name):
-            body, model = json.dumps(body), _MODELS[provider]
-            response = bedrock_client.invoke_model_with_response_stream(body=body, modelId=model)
-            for _ in response.get("body"):
-                pass
-        span = mock_tracer.pop_traces()[0][0]
-
-        assert mock_llmobs_span_writer.enqueue.call_count == 1
-        mock_llmobs_span_writer.enqueue.assert_called_with(
-            cls.expected_llmobs_span_event(span, n_output, message="message" in provider)
-        )
-
-    def test_llmobs_ai21_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke("ai21", bedrock_client, mock_llmobs_span_writer)
-
-    def test_llmobs_amazon_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke("amazon", bedrock_client, mock_llmobs_span_writer)
-
-    def test_llmobs_anthropic_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke("anthropic", bedrock_client, mock_llmobs_span_writer)
-
-    def test_llmobs_anthropic_message(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke("anthropic_message", bedrock_client, mock_llmobs_span_writer)
-
-    def test_llmobs_cohere_single_output_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke(
-            "cohere", bedrock_client, mock_llmobs_span_writer, cassette_name="cohere_invoke_single_output.yaml"
-        )
-
-    def test_llmobs_cohere_multi_output_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke(
-            "cohere",
-            bedrock_client,
-            mock_llmobs_span_writer,
-            cassette_name="cohere_invoke_multi_output.yaml",
-            n_output=2,
-        )
-
-    def test_llmobs_meta_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke("meta", bedrock_client, mock_llmobs_span_writer)
-
-    def test_llmobs_amazon_invoke_stream(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke_stream("amazon", bedrock_client, mock_llmobs_span_writer)
-
-    def test_llmobs_anthropic_invoke_stream(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke_stream("anthropic", bedrock_client, mock_llmobs_span_writer)
-
-    def test_llmobs_anthropic_message_invoke_stream(
-        self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer
-    ):
-        self._test_llmobs_invoke_stream("anthropic_message", bedrock_client, mock_llmobs_span_writer)
-
-    def test_llmobs_cohere_single_output_invoke_stream(
-        self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer
-    ):
-        self._test_llmobs_invoke_stream(
-            "cohere",
-            bedrock_client,
-            mock_llmobs_span_writer,
-            cassette_name="cohere_invoke_stream_single_output.yaml",
-        )
-
-    def test_llmobs_cohere_multi_output_invoke_stream(
-        self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer
-    ):
-        self._test_llmobs_invoke_stream(
-            "cohere",
-            bedrock_client,
-            mock_llmobs_span_writer,
-            cassette_name="cohere_invoke_stream_multi_output.yaml",
-            n_output=2,
-        )
-
-    def test_llmobs_meta_invoke_stream(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke_stream("meta", bedrock_client, mock_llmobs_span_writer)
-
-    def test_llmobs_error(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer, request_vcr):
-        import botocore
-
-        mock_tracer = DummyTracer(writer=DummyWriter(trace_flush_enabled=False))
-        pin = Pin.get_from(bedrock_client)
-        pin.override(bedrock_client, tracer=mock_tracer)
-        # Need to disable and re-enable LLMObs service to use the mock tracer
-        LLMObs.disable()
-        LLMObs.enable(_tracer=mock_tracer, integrations_enabled=False)  # only want botocore patched
-        with pytest.raises(botocore.exceptions.ClientError):
-            with request_vcr.use_cassette("meta_invoke_error.yaml"):
-                body, model = json.dumps(_REQUEST_BODIES["meta"]), _MODELS["meta"]
-                response = bedrock_client.invoke_model(body=body, modelId=model)
-                json.loads(response.get("body").read())
-        span = mock_tracer.pop_traces()[0][0]
-
-        expected_llmobs_writer_calls = [
-            mock.call.start(),
-            mock.call.enqueue(
-                _expected_llmobs_llm_span_event(
-                    span,
-                    model_name=span.get_tag("bedrock.request.model"),
-                    model_provider=span.get_tag("bedrock.request.model_provider"),
-                    input_messages=[{"content": mock.ANY}],
-                    metadata={
-                        "temperature": float(span.get_tag("bedrock.request.temperature")),
-                        "max_tokens": int(span.get_tag("bedrock.request.max_tokens")),
-                    },
-                    output_messages=[{"content": ""}],
-                    error=span.get_tag("error.type"),
-                    error_message=span.get_tag("error.message"),
-                    error_stack=span.get_tag("error.stack"),
-                    tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>"},
-                )
-            ),
-        ]
-
-        assert mock_llmobs_span_writer.enqueue.call_count == 1
-        mock_llmobs_span_writer.assert_has_calls(expected_llmobs_writer_calls)

--- a/tests/contrib/botocore/test_bedrock_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_llmobs.py
@@ -1,0 +1,279 @@
+import json
+import os
+
+import mock
+import pytest
+
+from ddtrace import Pin
+from ddtrace.contrib.botocore.patch import patch
+from ddtrace.contrib.botocore.patch import unpatch
+from ddtrace.llmobs import LLMObs
+from tests.contrib.botocore.bedrock_utils import _MODELS
+from tests.contrib.botocore.bedrock_utils import _REQUEST_BODIES
+from tests.contrib.botocore.bedrock_utils import get_request_vcr
+from tests.llmobs._utils import _expected_llmobs_llm_span_event
+from tests.utils import DummyTracer
+from tests.utils import DummyWriter
+from tests.utils import override_global_config
+
+
+@pytest.fixture(scope="session")
+def request_vcr():
+    yield get_request_vcr()
+
+
+@pytest.fixture
+def ddtrace_global_config():
+    config = {}
+    return config
+
+
+@pytest.fixture
+def aws_credentials():
+    """Mocked AWS Credentials. To regenerate test cassettes, comment this out and use real credentials."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+
+@pytest.fixture
+def boto3(aws_credentials, mock_llmobs_span_writer, ddtrace_global_config):
+    global_config = {"_dd_api_key": "<not-a-real-api_key>"}
+    global_config.update(ddtrace_global_config)
+    with override_global_config(global_config):
+        patch()
+        import boto3
+
+        yield boto3
+        unpatch()
+
+
+@pytest.fixture
+def bedrock_client(boto3, request_vcr):
+    session = boto3.Session(
+        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID", ""),
+        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY", ""),
+        aws_session_token=os.getenv("AWS_SESSION_TOKEN", ""),
+        region_name=os.getenv("AWS_DEFAULT_REGION", "us-east-1"),
+    )
+    bedrock_client = session.client("bedrock-runtime")
+    yield bedrock_client
+
+
+@pytest.fixture
+def mock_llmobs_span_writer():
+    patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanWriter")
+    try:
+        LLMObsSpanWriterMock = patcher.start()
+        m = mock.MagicMock()
+        LLMObsSpanWriterMock.return_value = m
+        yield m
+    finally:
+        patcher.stop()
+
+
+@pytest.mark.parametrize(
+    "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
+)
+class TestLLMObsBedrock:
+    @staticmethod
+    def expected_llmobs_span_event(span, n_output, message=False):
+        prompt_tokens = int(span.get_tag("bedrock.usage.prompt_tokens"))
+        completion_tokens = int(span.get_tag("bedrock.usage.completion_tokens"))
+        expected_parameters = {"temperature": float(span.get_tag("bedrock.request.temperature"))}
+        if span.get_tag("bedrock.request.max_tokens"):
+            expected_parameters["max_tokens"] = int(span.get_tag("bedrock.request.max_tokens"))
+        expected_input = [{"content": mock.ANY}]
+        if message:
+            expected_input = [{"content": mock.ANY, "role": "user"}]
+        return _expected_llmobs_llm_span_event(
+            span,
+            model_name=span.get_tag("bedrock.request.model"),
+            model_provider=span.get_tag("bedrock.request.model_provider"),
+            input_messages=expected_input,
+            output_messages=[{"content": mock.ANY} for _ in range(n_output)],
+            metadata=expected_parameters,
+            token_metrics={
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": prompt_tokens + completion_tokens,
+            },
+            tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>"},
+        )
+
+    @classmethod
+    def _test_llmobs_invoke(cls, provider, bedrock_client, mock_llmobs_span_writer, cassette_name=None, n_output=1):
+        mock_tracer = DummyTracer(writer=DummyWriter(trace_flush_enabled=False))
+        pin = Pin.get_from(bedrock_client)
+        pin.override(bedrock_client, tracer=mock_tracer)
+        # Need to disable and re-enable LLMObs service to use the mock tracer
+        LLMObs.disable()
+        LLMObs.enable(_tracer=mock_tracer, integrations_enabled=False)  # only want botocore patched
+
+        if cassette_name is None:
+            cassette_name = "%s_invoke.yaml" % provider
+        body = _REQUEST_BODIES[provider]
+        if provider == "cohere":
+            body = {
+                "prompt": "\n\nHuman: %s\n\nAssistant: Can you explain what a LLM chain is?",
+                "temperature": 0.9,
+                "p": 1.0,
+                "k": 0,
+                "max_tokens": 10,
+                "stop_sequences": [],
+                "stream": False,
+                "num_generations": n_output,
+            }
+        with get_request_vcr().use_cassette(cassette_name):
+            body, model = json.dumps(body), _MODELS[provider]
+            response = bedrock_client.invoke_model(body=body, modelId=model)
+            json.loads(response.get("body").read())
+        span = mock_tracer.pop_traces()[0][0]
+
+        assert mock_llmobs_span_writer.enqueue.call_count == 1
+        mock_llmobs_span_writer.enqueue.assert_called_with(
+            cls.expected_llmobs_span_event(span, n_output, message="message" in provider)
+        )
+
+    @classmethod
+    def _test_llmobs_invoke_stream(
+        cls, provider, bedrock_client, mock_llmobs_span_writer, cassette_name=None, n_output=1
+    ):
+        mock_tracer = DummyTracer(writer=DummyWriter(trace_flush_enabled=False))
+        pin = Pin.get_from(bedrock_client)
+        pin.override(bedrock_client, tracer=mock_tracer)
+        # Need to disable and re-enable LLMObs service to use the mock tracer
+        LLMObs.disable()
+        LLMObs.enable(_tracer=mock_tracer, integrations_enabled=False)  # only want botocore patched
+
+        if cassette_name is None:
+            cassette_name = "%s_invoke_stream.yaml" % provider
+        body = _REQUEST_BODIES[provider]
+        if provider == "cohere":
+            body = {
+                "prompt": "\n\nHuman: %s\n\nAssistant: Can you explain what a LLM chain is?",
+                "temperature": 0.9,
+                "p": 1.0,
+                "k": 0,
+                "max_tokens": 10,
+                "stop_sequences": [],
+                "stream": True,
+                "num_generations": n_output,
+            }
+        with get_request_vcr().use_cassette(cassette_name):
+            body, model = json.dumps(body), _MODELS[provider]
+            response = bedrock_client.invoke_model_with_response_stream(body=body, modelId=model)
+            for _ in response.get("body"):
+                pass
+        span = mock_tracer.pop_traces()[0][0]
+
+        assert mock_llmobs_span_writer.enqueue.call_count == 1
+        mock_llmobs_span_writer.enqueue.assert_called_with(
+            cls.expected_llmobs_span_event(span, n_output, message="message" in provider)
+        )
+
+    def test_llmobs_ai21_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
+        self._test_llmobs_invoke("ai21", bedrock_client, mock_llmobs_span_writer)
+
+    def test_llmobs_amazon_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
+        self._test_llmobs_invoke("amazon", bedrock_client, mock_llmobs_span_writer)
+
+    def test_llmobs_anthropic_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
+        self._test_llmobs_invoke("anthropic", bedrock_client, mock_llmobs_span_writer)
+
+    def test_llmobs_anthropic_message(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
+        self._test_llmobs_invoke("anthropic_message", bedrock_client, mock_llmobs_span_writer)
+
+    def test_llmobs_cohere_single_output_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
+        self._test_llmobs_invoke(
+            "cohere", bedrock_client, mock_llmobs_span_writer, cassette_name="cohere_invoke_single_output.yaml"
+        )
+
+    def test_llmobs_cohere_multi_output_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
+        self._test_llmobs_invoke(
+            "cohere",
+            bedrock_client,
+            mock_llmobs_span_writer,
+            cassette_name="cohere_invoke_multi_output.yaml",
+            n_output=2,
+        )
+
+    def test_llmobs_meta_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
+        self._test_llmobs_invoke("meta", bedrock_client, mock_llmobs_span_writer)
+
+    def test_llmobs_amazon_invoke_stream(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
+        self._test_llmobs_invoke_stream("amazon", bedrock_client, mock_llmobs_span_writer)
+
+    def test_llmobs_anthropic_invoke_stream(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
+        self._test_llmobs_invoke_stream("anthropic", bedrock_client, mock_llmobs_span_writer)
+
+    def test_llmobs_anthropic_message_invoke_stream(
+        self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer
+    ):
+        self._test_llmobs_invoke_stream("anthropic_message", bedrock_client, mock_llmobs_span_writer)
+
+    def test_llmobs_cohere_single_output_invoke_stream(
+        self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer
+    ):
+        self._test_llmobs_invoke_stream(
+            "cohere",
+            bedrock_client,
+            mock_llmobs_span_writer,
+            cassette_name="cohere_invoke_stream_single_output.yaml",
+        )
+
+    def test_llmobs_cohere_multi_output_invoke_stream(
+        self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer
+    ):
+        self._test_llmobs_invoke_stream(
+            "cohere",
+            bedrock_client,
+            mock_llmobs_span_writer,
+            cassette_name="cohere_invoke_stream_multi_output.yaml",
+            n_output=2,
+        )
+
+    def test_llmobs_meta_invoke_stream(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
+        self._test_llmobs_invoke_stream("meta", bedrock_client, mock_llmobs_span_writer)
+
+    def test_llmobs_error(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer, request_vcr):
+        import botocore
+
+        mock_tracer = DummyTracer(writer=DummyWriter(trace_flush_enabled=False))
+        pin = Pin.get_from(bedrock_client)
+        pin.override(bedrock_client, tracer=mock_tracer)
+        # Need to disable and re-enable LLMObs service to use the mock tracer
+        LLMObs.disable()
+        LLMObs.enable(_tracer=mock_tracer, integrations_enabled=False)  # only want botocore patched
+        with pytest.raises(botocore.exceptions.ClientError):
+            with request_vcr.use_cassette("meta_invoke_error.yaml"):
+                body, model = json.dumps(_REQUEST_BODIES["meta"]), _MODELS["meta"]
+                response = bedrock_client.invoke_model(body=body, modelId=model)
+                json.loads(response.get("body").read())
+        span = mock_tracer.pop_traces()[0][0]
+
+        expected_llmobs_writer_calls = [
+            mock.call.start(),
+            mock.call.enqueue(
+                _expected_llmobs_llm_span_event(
+                    span,
+                    model_name=span.get_tag("bedrock.request.model"),
+                    model_provider=span.get_tag("bedrock.request.model_provider"),
+                    input_messages=[{"content": mock.ANY}],
+                    metadata={
+                        "temperature": float(span.get_tag("bedrock.request.temperature")),
+                        "max_tokens": int(span.get_tag("bedrock.request.max_tokens")),
+                    },
+                    output_messages=[{"content": ""}],
+                    error=span.get_tag("error.type"),
+                    error_message=span.get_tag("error.message"),
+                    error_stack=span.get_tag("error.stack"),
+                    tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>"},
+                )
+            ),
+        ]
+
+        assert mock_llmobs_span_writer.enqueue.call_count == 1
+        mock_llmobs_span_writer.assert_has_calls(expected_llmobs_writer_calls)

--- a/tests/contrib/langchain/test_langchain.py
+++ b/tests/contrib/langchain/test_langchain.py
@@ -1352,7 +1352,7 @@ class TestLLMObsLangchain:
         different_py39_cassette=False,
     ):
         LLMObs.disable()
-        LLMObs.enable(_tracer=mock_tracer, integrations=["langchain"])
+        LLMObs.enable(_tracer=mock_tracer, integrations_enabled=False)  # only want langchain patched
 
         if sys.version_info < (3, 10, 0) and different_py39_cassette:
             cassette_name = cassette_name.replace(".yaml", "_39.yaml")
@@ -1388,7 +1388,7 @@ class TestLLMObsLangchain:
     ):
         # disable the service before re-enabling it, as it was enabled in another test
         LLMObs.disable()
-        LLMObs.enable(_tracer=mock_tracer, integrations=["langchain"])
+        LLMObs.enable(_tracer=mock_tracer, integrations_enabled=False)  # only want langchain patched
 
         if sys.version_info < (3, 10, 0) and different_py39_cassette:
             cassette_name = cassette_name.replace(".yaml", "_39.yaml")

--- a/tests/contrib/langchain/test_langchain_community.py
+++ b/tests/contrib/langchain/test_langchain_community.py
@@ -1339,7 +1339,7 @@ class TestLLMObsLangchain:
         output_role=None,
     ):
         LLMObs.disable()
-        LLMObs.enable(_tracer=mock_tracer, integrations=["langchain"])
+        LLMObs.enable(_tracer=mock_tracer, integrations_enabled=False)  # only want langchain patched
 
         with request_vcr.use_cassette(cassette_name):
             generate_trace("Can you explain what an LLM chain is?")
@@ -1372,7 +1372,7 @@ class TestLLMObsLangchain:
     ):
         # disable the service before re-enabling it, as it was enabled in another test
         LLMObs.disable()
-        LLMObs.enable(_tracer=mock_tracer, integrations=["langchain"])
+        LLMObs.enable(_tracer=mock_tracer, integrations_enabled=False)  # only want langchain patched
 
         with request_vcr.use_cassette(cassette_name):
             generate_trace("Can you explain what an LLM chain is?")

--- a/tests/contrib/openai/conftest.py
+++ b/tests/contrib/openai/conftest.py
@@ -191,7 +191,7 @@ def mock_tracer(ddtrace_global_config, openai, patch_openai, mock_logs, mock_met
     if ddtrace_global_config.get("_llmobs_enabled", False):
         # Have to disable and re-enable LLMObs to use to mock tracer.
         LLMObs.disable()
-        LLMObs.enable(_tracer=mock_tracer, integrations=["openai"])
+        LLMObs.enable(_tracer=mock_tracer, integrations_enabled=False)
 
     yield mock_tracer
 

--- a/tests/contrib/openai/test_openai_v0.py
+++ b/tests/contrib/openai/test_openai_v0.py
@@ -1935,7 +1935,6 @@ with get_openai_vcr(subdirectory_name="v0").use_cassette("completion.yaml"):
 )
 def test_llmobs_completion(openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer):
     """Ensure llmobs records are emitted for completion endpoints when configured.
-
     Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
     """
     with openai_vcr.use_cassette("completion.yaml"):
@@ -1990,7 +1989,6 @@ def test_llmobs_completion_stream(openai_vcr, openai, ddtrace_global_config, moc
 )
 def test_llmobs_chat_completion(openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer):
     """Ensure llmobs records are emitted for chat completion endpoints when configured.
-
     Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
     """
     if not hasattr(openai, "ChatCompletion"):
@@ -2033,7 +2031,6 @@ async def test_llmobs_chat_completion_stream(
     openai_vcr, openai, ddtrace_global_config, mock_llmobs_writer, mock_tracer
 ):
     """Ensure llmobs records are emitted for chat completion endpoints when configured.
-
     Also ensure the llmobs records have the correct tagging including trace/span ID for trace correlation.
     """
     if not hasattr(openai, "ChatCompletion"):


### PR DESCRIPTION
This PR moves LLMObs tests from the test_bedrock.py file into test_bedrock_llmobs.py to ease maintainability for LLMObs tests in the future. No functionality is added/removed.

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
