### PR TITLE
chore(asm): fix lint for taint tracking CPP files

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Initializer/Initializer.cpp
@@ -228,7 +228,6 @@ pyexport_initializer(py::module& m)
     m.def("initializer_size", [] { return initializer->initializer_size(); });
     m.def("active_map_addreses_size", [] { return initializer->active_map_addreses_size(); });
 
-    m.def(
-      "create_context", []() { return initializer->create_context(); }, py::return_value_policy::reference);
+    m.def("create_context", []() { return initializer->create_context(); }, py::return_value_policy::reference);
     m.def("reset_context", [] { initializer->reset_context(); });
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/Source.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/Source.cpp
@@ -10,13 +10,15 @@ Source::Source(string name, string value, OriginType origin)
   : name(std::move(name))
   , value(std::move(value))
   , origin(origin)
-{}
+{
+}
 
 Source::Source(int name, string value, const OriginType origin)
   : name(origin_to_str(OriginType{ name }))
   , value(std::move(value))
   , origin(origin)
-{}
+{
+}
 
 string
 Source::toString() const


### PR DESCRIPTION
This fixes an annoying lint issue in a pair of CPP files that show up during git merges.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
