### PR TITLE
fix(internal): writer recreate maintain extra headers

### DIFF
--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -539,6 +539,7 @@ class AgentWriter(HTTPWriter):
             dogstatsd=self.dogstatsd,
             sync_mode=self._sync_mode,
             api_version=self._api_version,
+            headers=self._headers,
         )
 
     @property

--- a/releasenotes/notes/fix-internal-writer-recreate-keep-extra-headers-dc8cd1d57c95d692.yaml
+++ b/releasenotes/notes/fix-internal-writer-recreate-keep-extra-headers-dc8cd1d57c95d692.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    internal: This fix resolves an issue where a writer recreate (for example in a subprocess) would not keep extra headers.

--- a/releasenotes/notes/fix-internal-writer-recreate-keep-extra-headers-dc8cd1d57c95d692.yaml
+++ b/releasenotes/notes/fix-internal-writer-recreate-keep-extra-headers-dc8cd1d57c95d692.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    internal: This fix resolves an issue where a writer recreate (for example in a subprocess) would not keep extra headers.

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -17,8 +17,6 @@ from ddtrace import config
 from ddtrace._trace.span import Span
 from ddtrace.constants import KEEP_SPANS_RATE_KEY
 from ddtrace.internal.ci_visibility.writer import CIVisibilityWriter
-from ddtrace.internal.compat import PYTHON_INTERPRETER
-from ddtrace.internal.compat import PYTHON_VERSION
 from ddtrace.internal.compat import get_connection_response
 from ddtrace.internal.compat import httplib
 from ddtrace.internal.encoding import MSGPACK_ENCODERS
@@ -709,20 +707,13 @@ def test_writer_recreate_api_version(init_api_version, api_version, endpoint, en
 
 
 def test_writer_recreate_keeps_headers():
-    expected_headers = {
-        "Content-Type": "application/msgpack",
-        "Datadog-Meta-Lang": "python",
-        "Datadog-Meta-Lang-Version": PYTHON_VERSION,
-        "Datadog-Meta-Lang-Interpreter": PYTHON_INTERPRETER,
-        "Datadog-Meta-Tracer-Version": ddtrace.__version__,
-        "Datadog-Client-Computed-Top-Level": "yes",
-        "Datadog-Client-Computed-Stats": "yes",
-    }
     writer = AgentWriter("http://dne:1234", headers={"Datadog-Client-Computed-Stats": "yes"})
-    assert writer._headers == expected_headers
+    assert "Datadog-Client-Computed-Stats" in writer._headers
+    assert writer._headers["Datadog-Client-Computed-Stats"] == "yes"
 
     writer = writer.recreate()
-    assert writer._headers == expected_headers
+    assert "Datadog-Client-Computed-Stats" in writer._headers
+    assert writer._headers["Datadog-Client-Computed-Stats"] == "yes"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
internal: this fixes an issue where a writer recreate call would make it drop extra headers passed to the ``__init__``.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
