### PR TITLE
docs: add remote config envar to docs and clarify when enabled

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -68,6 +68,16 @@ The following environment variables for the tracer are supported:
        v0.41.0: |
            Formerly named ``DATADOG_TRACE_ENABLED``
 
+   DD_REMOTE_CONFIGURATION_ENABLED:
+     type: Boolean
+     default: True
+     description: |
+         Enable or disable the remote configuration feature. When disabled, the agent will not fetch configuration from the Datadog agent.
+         This feature is only enabled by default if ``ddtrace-run`` is used, ``import ddtrace.auto`` is done,
+         or if ``ddtrace.config.enable_remote_configuration()`` is called.
+     version_added:
+       v1.19.0
+
    DD_TRACE_OTEL_ENABLED:
      type: Boolean
      default: False


### PR DESCRIPTION
The circumstances under which remote config is enabled were unclear and the envar was not documented before.

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
