### PR TITLE
chore(asm): appsec propagation tag

### DIFF
--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -71,6 +71,7 @@ class APPSEC(metaclass=Constant_Class):
     USER_MODEL_LOGIN_FIELD = "DD_USER_MODEL_LOGIN_FIELD"
     USER_MODEL_EMAIL_FIELD = "DD_USER_MODEL_EMAIL_FIELD"
     USER_MODEL_NAME_FIELD = "DD_USER_MODEL_NAME_FIELD"
+    PROPAGATION_HEADER = "_dd.p.appsec"
 
 
 class IAST(metaclass=Constant_Class):

--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -28,7 +28,7 @@ def _asm_manual_keep(span: Span) -> None:
     span.set_tag_str(SAMPLING_DECISION_TRACE_TAG_KEY, "-%d" % SamplingMechanism.APPSEC)
 
     # set Security propagation tag
-    span.set_tag_str("_dd.p.appsec", "1")
+    span.set_tag_str(APPSEC.PROPAGATION_HEADER, "1")
 
 
 def _track_user_login_common(

--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -27,6 +27,9 @@ def _asm_manual_keep(span: Span) -> None:
     # set decision maker to ASM = -5
     span.set_tag_str(SAMPLING_DECISION_TRACE_TAG_KEY, "-%d" % SamplingMechanism.APPSEC)
 
+    # set Security propagation tag
+    span.set_tag_str("_dd.p.appsec", "1")
+
 
 def _track_user_login_common(
     tracer: Tracer,

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
@@ -12,6 +12,7 @@
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"nfd-000-006\",\n      \"name\": \"Detect failed attempt to fetch sensitive files\",\n      \"tags\": {\n        \"capec\": \"1000/118/169\",\n        \"category\": \"attack_attempt\",\n        \"confidence\": \"1\",\n        \"cwe\": \"200\",\n        \"type\": \"security_scanner\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"^404$\",\n        \"parameters\": [\n          {\n            \"address\": \"server.response.status\",\n            \"highlight\": [\n              \"404\"\n            ],\n            \"key_path\": [],\n            \"value\": \"404\"\n          }\n        ]\n      },\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"\\\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)\",\n        \"parameters\": [\n          {\n            \"address\": \"server.request.uri.raw\",\n            \"highlight\": [\n              \".git\"\n            ],\n            \"key_path\": [],\n            \"value\": \"/.git\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
       "_dd.appsec.waf.version": "1.18.0",
       "_dd.origin": "appsec",
+      "_dd.p.appsec": "1",
       "_dd.p.dm": "-5",
       "_dd.runtime_family": "python",
       "appsec.event": "true",

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
@@ -12,6 +12,7 @@
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"nfd-000-006\",\n      \"name\": \"Detect failed attempt to fetch sensitive files\",\n      \"tags\": {\n        \"capec\": \"1000/118/169\",\n        \"category\": \"attack_attempt\",\n        \"confidence\": \"1\",\n        \"cwe\": \"200\",\n        \"type\": \"security_scanner\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"^404$\",\n        \"parameters\": [\n          {\n            \"address\": \"server.response.status\",\n            \"highlight\": [\n              \"404\"\n            ],\n            \"key_path\": [],\n            \"value\": \"404\"\n          }\n        ]\n      },\n      {\n        \"operator\": \"match_regex\",\n        \"operator_value\": \"\\\\.(cgi|bat|dll|exe|key|cert|crt|pem|der|pkcs|pkcs|pkcs[0-9]*|nsf|jsa|war|java|class|vb|vba|so|git|svn|hg|cvs)([^a-zA-Z0-9_]|$)\",\n        \"parameters\": [\n          {\n            \"address\": \"server.request.uri.raw\",\n            \"highlight\": [\n              \".git\"\n            ],\n            \"key_path\": [],\n            \"value\": \"/.git\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
       "_dd.appsec.waf.version": "1.18.0",
       "_dd.origin": "appsec",
+      "_dd.p.appsec": "1",
       "_dd.p.dm": "-5",
       "_dd.runtime_family": "python",
       "appsec.event": "true",

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
@@ -13,6 +13,7 @@
       "_dd.appsec.waf.version": "1.18.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
+      "_dd.p.appsec": "1",
       "_dd.p.dm": "-5",
       "_dd.runtime_family": "python",
       "appsec.event": "true",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
@@ -14,6 +14,7 @@
       "_dd.appsec.waf.version": "1.18.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
+      "_dd.p.appsec": "1",
       "_dd.p.dm": "-5",
       "_dd.p.tid": "654a694400000000",
       "_dd.runtime_family": "python",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403.json
@@ -14,6 +14,7 @@
       "_dd.appsec.waf.version": "1.18.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
+      "_dd.p.appsec": "1",
       "_dd.p.dm": "-5",
       "_dd.p.tid": "65c1342000000000",
       "_dd.runtime_family": "python",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403_json.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_request_ipblock_match_403_json.json
@@ -14,6 +14,7 @@
       "_dd.appsec.waf.version": "1.18.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
+      "_dd.p.appsec": "1",
       "_dd.p.dm": "-5",
       "_dd.p.tid": "65c1341d00000000",
       "_dd.runtime_family": "python",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env].json
@@ -14,6 +14,7 @@
       "_dd.appsec.waf.version": "1.18.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
+      "_dd.p.appsec": "1",
       "_dd.p.dm": "-5",
       "_dd.p.tid": "654a694400000000",
       "_dd.runtime_family": "python",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403[flask_appsec_good_rules_env]_220.json
@@ -14,6 +14,7 @@
       "_dd.appsec.waf.version": "1.18.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
+      "_dd.p.appsec": "1",
       "_dd.p.dm": "-5",
       "_dd.p.tid": "654a694400000000",
       "_dd.runtime_family": "python",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env].json
@@ -14,6 +14,7 @@
       "_dd.appsec.waf.version": "1.18.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
+      "_dd.p.appsec": "1",
       "_dd.p.dm": "-5",
       "_dd.p.tid": "654a694400000000",
       "_dd.runtime_family": "python",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_ipblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -14,6 +14,7 @@
       "_dd.appsec.waf.version": "1.18.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
+      "_dd.p.appsec": "1",
       "_dd.p.dm": "-5",
       "_dd.p.tid": "654a694400000000",
       "_dd.runtime_family": "python",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
@@ -14,6 +14,7 @@
       "_dd.appsec.waf.version": "1.18.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
+      "_dd.p.appsec": "1",
       "_dd.p.dm": "-5",
       "_dd.p.tid": "654a694400000000",
       "_dd.runtime_family": "python",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -14,6 +14,7 @@
       "_dd.appsec.waf.version": "1.18.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",
+      "_dd.p.appsec": "1",
       "_dd.p.dm": "-5",
       "_dd.p.tid": "654a694400000000",
       "_dd.runtime_family": "python",


### PR DESCRIPTION
ASM: Adds appsec propagation tag to any (and all) traces with security events

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
