### PR TITLE
chore(ci): ensure we run tracer tests on llmobs changes

### DIFF
--- a/tests/.suitespec.json
+++ b/tests/.suitespec.json
@@ -474,6 +474,7 @@
             "@bootstrap",
             "@core",
             "@contrib",
+            "@llmobs",
             "@serverless",
             "@remoteconfig",
             "tests/tracer/*",

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -2747,7 +2747,7 @@ with tracer.trace("Non-LLMObs span") as root_span:
         headers = {}
         HTTPPropagator.inject(child_span.context, headers)
 
-assert "{}".format(PROPAGATED_PARENT_ID_KEY) not in headers["x-datadog-tags"]
+assert f"{PROPAGATED_PARENT_ID_KEY}=undefined" in headers["x-datadog-tags"]
         """
 
     env = os.environ.copy()


### PR DESCRIPTION
Ensure we run tracer tests whenever we make changes to llmobs.

This would have caught this failing test, which did not run on #9449

https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/62935/workflows/f6fd3f80-bbf7-46cc-b4ee-189f49578fc8/jobs/3917045


## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
