### PR TITLE
feat(asm): standalone asm propagation

### DIFF
--- a/ddtrace/_trace/context.py
+++ b/ddtrace/_trace/context.py
@@ -56,7 +56,6 @@ class Context(object):
         "_span_links",
         "_baggage",
         "_is_remote",
-        "_propagation_header_type",
         "_previous_sampling_priority",
     ]
 
@@ -72,7 +71,6 @@ class Context(object):
         span_links=None,  # type: Optional[list[SpanLink]]
         baggage=None,  # type: Optional[dict[str, Any]]
         is_remote=True,  # type: bool
-        propagation_header_type=None,  # type: Optional[str]
         previous_sampling_priority=None,  # type: Optional[float]
     ):
         self._meta = meta if meta is not None else {}  # type: _MetaDictType
@@ -85,7 +83,6 @@ class Context(object):
 
         if dd_origin is not None and _DD_ORIGIN_INVALID_CHARS_REGEX.search(dd_origin) is None:
             self._meta[ORIGIN_KEY] = dd_origin
-
         if sampling_priority is not None:
             self._metrics[SAMPLING_PRIORITY_KEY] = sampling_priority
         if span_links is not None:
@@ -93,7 +90,6 @@ class Context(object):
         else:
             self._span_links = []
 
-        self._propagation_header_type = propagation_header_type
         self._previous_sampling_priority = previous_sampling_priority
 
         if lock is not None:

--- a/ddtrace/_trace/context.py
+++ b/ddtrace/_trace/context.py
@@ -47,7 +47,18 @@ class Context(object):
     boundaries.
     """
 
-    __slots__ = ["trace_id", "span_id", "_lock", "_meta", "_metrics", "_span_links", "_baggage", "_is_remote"]
+    __slots__ = [
+        "trace_id",
+        "span_id",
+        "_lock",
+        "_meta",
+        "_metrics",
+        "_span_links",
+        "_baggage",
+        "_is_remote",
+        "_propagation_header_type",
+        "_previous_sampling_priority",
+    ]
 
     def __init__(
         self,
@@ -61,6 +72,8 @@ class Context(object):
         span_links=None,  # type: Optional[list[SpanLink]]
         baggage=None,  # type: Optional[dict[str, Any]]
         is_remote=True,  # type: bool
+        propagation_header_type=None,  # type: Optional[str]
+        previous_sampling_priority=None,  # type: Optional[float]
     ):
         self._meta = meta if meta is not None else {}  # type: _MetaDictType
         self._metrics = metrics if metrics is not None else {}  # type: _MetricDictType
@@ -72,12 +85,16 @@ class Context(object):
 
         if dd_origin is not None and _DD_ORIGIN_INVALID_CHARS_REGEX.search(dd_origin) is None:
             self._meta[ORIGIN_KEY] = dd_origin
+
         if sampling_priority is not None:
             self._metrics[SAMPLING_PRIORITY_KEY] = sampling_priority
         if span_links is not None:
             self._span_links = span_links
         else:
             self._span_links = []
+
+        self._propagation_header_type = propagation_header_type
+        self._previous_sampling_priority = previous_sampling_priority
 
         if lock is not None:
             self._lock = lock

--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -14,7 +14,9 @@ from ddtrace import config
 from ddtrace._trace.span import Span  # noqa:F401
 from ddtrace._trace.span import _get_64_highest_order_bits_as_hex
 from ddtrace._trace.span import _is_top_level
+from ddtrace.appsec._constants import APPSEC
 from ddtrace.constants import _APM_ENABLED_METRIC_KEY as MK_APM_ENABLED
+from ddtrace.constants import MANUAL_DROP_KEY
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
 from ddtrace.constants import USER_KEEP
 from ddtrace.internal import gitmetadata
@@ -160,6 +162,10 @@ class TraceSamplingProcessor(TraceProcessor):
 
             if self.apm_opt_out:
                 chunk_root.set_metric(MK_APM_ENABLED, 0)
+                if APPSEC.PROPAGATION_HEADER not in chunk_root.get_tags():
+                    if root_ctx and root_ctx._propagation_header_type != APPSEC.PROPAGATION_HEADER:
+                        root_ctx._previous_sampling_priority = root_ctx.sampling_priority
+                        chunk_root.set_tag(MANUAL_DROP_KEY)
 
             # only trace sample if we haven't already sampled
             if root_ctx and root_ctx.sampling_priority is None:

--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -163,7 +163,7 @@ class TraceSamplingProcessor(TraceProcessor):
             if self.apm_opt_out:
                 chunk_root.set_metric(MK_APM_ENABLED, 0)
                 if APPSEC.PROPAGATION_HEADER not in chunk_root.get_tags():
-                    if root_ctx and root_ctx._propagation_header_type != APPSEC.PROPAGATION_HEADER:
+                    if root_ctx and APPSEC.PROPAGATION_HEADER not in root_ctx._meta:
                         root_ctx._previous_sampling_priority = root_ctx.sampling_priority
                         chunk_root.set_tag(MANUAL_DROP_KEY)
 

--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -29,6 +29,7 @@ def _asm_manual_keep(span: Span) -> None:
 
     # set Security propagation tag
     span.set_tag_str(APPSEC.PROPAGATION_HEADER, "1")
+    span.context._meta[APPSEC.PROPAGATION_HEADER] = "1"
 
 
 def _track_user_login_common(

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -248,7 +248,7 @@ class _DatadogMultiHeader:
 
         if (
             asm_config._appsec_standalone_enabled
-            and span_context._propagation_header_type != APPSEC.PROPAGATION_HEADER
+            and APPSEC.PROPAGATION_HEADER not in span_context._meta
             and span_context._previous_sampling_priority
             and sampling_priority is not None
             and sampling_priority < span_context._previous_sampling_priority
@@ -316,7 +316,6 @@ class _DatadogMultiHeader:
             default="0",
         )
         sampling_priority = _extract_header_value(POSSIBLE_HTTP_HEADER_SAMPLING_PRIORITIES, headers, default=USER_KEEP)  # type: ignore[arg-type]
-        propagation_header_type = None
         origin = _extract_header_value(
             POSSIBLE_HTTP_HEADER_ORIGIN,
             headers,
@@ -327,9 +326,6 @@ class _DatadogMultiHeader:
         tags_value = _DatadogMultiHeader._get_tags_value(headers)
         if tags_value:
             meta = _DatadogMultiHeader._extract_meta(tags_value)
-
-            if asm_config._appsec_standalone_enabled and APPSEC.PROPAGATION_HEADER in meta.keys():
-                propagation_header_type = APPSEC.PROPAGATION_HEADER
 
         # When 128 bit trace ids are propagated the 64 lowest order bits are set in the `x-datadog-trace-id`
         # header. The 64 highest order bits are encoded in base 16 and store in the `_dd.p.tid` tag.
@@ -370,7 +366,6 @@ class _DatadogMultiHeader:
                 # span tags and trace tags which are currently implemented using
                 # the same type internally (_MetaDictType).
                 meta=cast(_MetaDictType, meta),
-                propagation_header_type=propagation_header_type,
             )
         except (TypeError, ValueError):
             log.debug(

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -304,6 +304,139 @@ def test_extract(tracer):  # noqa: F811
             }
 
 
+def test_extract_asm_standalone_missing_appsec_tag_sampling_span_dropped_sampling_propagates(tracer):  # noqa: F811
+    tracer.configure(appsec_enabled=True, appsec_standalone_enabled=True)
+    headers = {
+        "x-datadog-trace-id": "1234",
+        "x-datadog-parent-id": "5678",
+        "x-datadog-sampling-priority": "2",
+        "x-datadog-origin": "synthetics",
+        "x-datadog-tags": "_dd.p.test=value,any=tag",
+        "ot-baggage-key1": "value1",
+    }
+
+    context = HTTPPropagator.extract(headers)
+
+    tracer.context_provider.activate(context)
+
+    with tracer.trace("local_root_span") as span:
+        assert span.trace_id == 1234
+        assert span.parent_id == 5678
+        assert span.context.sampling_priority == 2
+        assert span.context.dd_origin == "synthetics"
+        assert span.context._meta == {
+            "_dd.origin": "synthetics",
+            "_dd.p.dm": "-3",
+            "_dd.p.test": "value",
+        }
+
+    next_headers = {}
+    HTTPPropagator.inject(span.context, next_headers)
+
+    # Ensure propagation of headers takes place as expected
+    assert next_headers["x-datadog-origin"] == "synthetics"
+    assert next_headers["x-datadog-sampling-priority"] == "2"
+    assert next_headers["x-datadog-trace-id"] == "1234"
+    assert next_headers["x-datadog-tags"].startswith("_dd.p.test=value,")
+
+    # Ensure span is dropped
+    assert span._metrics["_sampling_priority_v1"] == -1
+
+    tracer.configure(appsec_enabled=False, appsec_standalone_enabled=False)
+
+
+def test_extract_asm_standalone_missing_appsec_tag_appsec_event(tracer):  # noqa: F811
+    from ddtrace.appsec._trace_utils import _asm_manual_keep
+
+    tracer.configure(appsec_enabled=True, appsec_standalone_enabled=True)
+    headers = {
+        "x-datadog-trace-id": "1234",
+        "x-datadog-parent-id": "5678",
+        "x-datadog-sampling-priority": "0",
+        "x-datadog-origin": "synthetics",
+        "x-datadog-tags": "_dd.p.test=value,any=tag",
+        "ot-baggage-key1": "value1",
+    }
+
+    context = HTTPPropagator.extract(headers)
+
+    tracer.context_provider.activate(context)
+
+    with tracer.trace("local_root_span") as span:
+        _asm_manual_keep(span)
+        assert span.trace_id == 1234
+        assert span.parent_id == 5678
+        assert span.context.sampling_priority == 2
+        assert span.context.dd_origin == "synthetics"
+        assert span.context._meta == {
+            "_dd.origin": "synthetics",
+            "_dd.p.dm": "-4",
+            "_dd.p.test": "value",
+            "_dd.p.appsec": "1",
+        }
+
+    next_headers = {}
+    HTTPPropagator.inject(span.context, next_headers)
+
+    # Ensure propagation of headers takes place as expected
+    assert next_headers["x-datadog-origin"] == "synthetics"
+    assert next_headers["x-datadog-sampling-priority"] == "2"
+    assert next_headers["x-datadog-trace-id"] == "1234"
+    assert next_headers["x-datadog-tags"].startswith("_dd.p.test=value,")
+    assert "_dd.p.appsec=1" in next_headers["x-datadog-tags"]
+
+    # Ensure span is dropped
+    assert span._metrics["_sampling_priority_v1"] == 2
+
+    tracer.configure(appsec_enabled=False, appsec_standalone_enabled=False)
+
+
+def test_extract_asm_standalone_present_appsec_tag_sampling_priority_honored(tracer):  # noqa: F811
+    tracer.configure(appsec_enabled=True, appsec_standalone_enabled=True)
+    headers = {
+        "x-datadog-trace-id": "1234",
+        "x-datadog-parent-id": "5678",
+        "x-datadog-sampling-priority": "1",
+        "x-datadog-origin": "synthetics",
+        "x-datadog-tags": "_dd.p.appsec=1,any=tag",
+        "ot-baggage-key1": "value1",
+    }
+
+    context = HTTPPropagator.extract(headers)
+
+    tracer.context_provider.activate(context)
+
+    with tracer.trace("local_root_span") as span:
+        assert span.trace_id == 1234
+        assert span.parent_id == 5678
+        assert span.context.sampling_priority == 1
+        assert span.context.dd_origin == "synthetics"
+        assert span.context._meta == {
+            "_dd.origin": "synthetics",
+            "_dd.p.dm": "-3",
+            "_dd.p.appsec": "1",
+        }
+        with tracer.trace("child_span") as child_span:
+            assert child_span.trace_id == 1234
+            assert child_span.parent_id != 5678
+            assert child_span.context.sampling_priority == 1
+            assert child_span.context.dd_origin == "synthetics"
+            assert child_span.context._meta == {
+                "_dd.origin": "synthetics",
+                "_dd.p.dm": "-3",
+                "_dd.p.appsec": "1",
+            }
+
+        next_headers = {}
+        HTTPPropagator.inject(span.context, next_headers)
+        assert next_headers["x-datadog-origin"] == "synthetics"
+        assert next_headers["x-datadog-sampling-priority"] == "1"
+        assert next_headers["x-datadog-trace-id"] == "1234"
+        assert next_headers["x-datadog-tags"].startswith("_dd.p.appsec=1,")
+
+    tracer.configure(appsec_enabled=False, appsec_standalone_enabled=False)
+
+
 def test_extract_with_baggage_http_propagation(tracer):  # noqa: F811
     with override_global_config(dict(propagation_http_baggage_enabled=True)):
         headers = {


### PR DESCRIPTION
ASM: adds standalone asm propagation as described in "RFC: Standalone ASM billing V2"

## Checklist
- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
