### PR TITLE
chore(tracer): simplify llmobs injection assertion on tracer propagation tests

### DIFF
--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -4,6 +4,7 @@ import logging
 import os
 import pickle
 
+import mock
 import pytest
 
 from ddtrace import tracer as ddtracer
@@ -2690,69 +2691,24 @@ print(json.dumps(headers))
     assert result == expected_headers
 
 
-def test_llmobs_enabled_injects_parent_id(run_python_code_in_subprocess):
-    code = """
-from ddtrace import tracer
-from ddtrace.ext import SpanTypes
-from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
-from ddtrace.propagation.http import HTTPPropagator
-
-with tracer.trace("LLMObs span", span_type=SpanTypes.LLM) as root_span:
-    with tracer.trace("Non-LLMObs span") as child_span:
-        headers = {}
-        HTTPPropagator.inject(child_span.context, headers)
-
-assert "{}={}".format(PROPAGATED_PARENT_ID_KEY, root_span.span_id) in headers["x-datadog-tags"]
-        """
-
-    env = os.environ.copy()
-    env["DD_LLMOBS_ENABLED"] = "1"
-    env["DD_TRACE_ENABLED"] = "0"
-    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=env)
-    assert status == 0, (stdout, stderr)
-    assert stderr == b"", (stdout, stderr)
+def test_llmobs_enabled_injects_llmobs_parent_id():
+    with override_global_config(dict(_llmobs_enabled=True)):
+        with mock.patch("ddtrace.llmobs._utils._inject_llmobs_parent_id") as mock_llmobs_inject:
+            context = Context(trace_id=1, span_id=2)
+            HTTPPropagator.inject(context, {})
+            mock_llmobs_inject.assert_called_once_with(context)
 
 
-def test_llmobs_disabled_does_not_inject_parent_id(run_python_code_in_subprocess):
-    code = """
-from ddtrace import tracer
-from ddtrace.ext import SpanTypes
-from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
-from ddtrace.propagation.http import HTTPPropagator
-
-with tracer.trace("LLMObs span", span_type=SpanTypes.LLM) as root_span:
-    with tracer.trace("Non-LLMObs span") as child_span:
-        headers = {}
-        HTTPPropagator.inject(child_span.context, headers)
-
-assert "{}".format(PROPAGATED_PARENT_ID_KEY) not in headers["x-datadog-tags"]
-        """
-
-    env = os.environ.copy()
-    env["DD_LLMOBS_ENABLED"] = "0"
-    env["DD_TRACE_ENABLED"] = "0"
-    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=env)
-    assert status == 0, (stdout, stderr)
-    assert stderr == b"", (stdout, stderr)
+def test_llmobs_disabled_does_not_inject_parent_id():
+    with override_global_config(dict(_llmobs_enabled=False)):
+        with mock.patch("ddtrace.llmobs._utils._inject_llmobs_parent_id") as mock_llmobs_inject:
+            context = Context(trace_id=1, span_id=2)
+            HTTPPropagator.inject(context, {})
+            mock_llmobs_inject.assert_not_called()
 
 
-def test_llmobs_enabled_does_not_inject_parent_id_if_no_llm_span(run_python_code_in_subprocess):
-    code = """
-from ddtrace import tracer
-from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
-from ddtrace.propagation.http import HTTPPropagator
-
-with tracer.trace("Non-LLMObs span") as root_span:
-    with tracer.trace("Non-LLMObs span") as child_span:
-        headers = {}
-        HTTPPropagator.inject(child_span.context, headers)
-
-assert f"{PROPAGATED_PARENT_ID_KEY}=undefined" in headers["x-datadog-tags"]
-        """
-
-    env = os.environ.copy()
-    env["DD_LLMOBS_ENABLED"] = "1"
-    env["DD_TRACE_ENABLED"] = "0"
-    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=env)
-    assert status == 0, (stdout, stderr)
-    assert stderr == b"", (stdout, stderr)
+def test_llmobs_parent_id_not_injected_by_default():
+    with mock.patch("ddtrace.llmobs._utils._inject_llmobs_parent_id") as mock_llmobs_inject:
+        context = Context(trace_id=1, span_id=2)
+        HTTPPropagator.inject(context, {})
+        mock_llmobs_inject.assert_not_called()


### PR DESCRIPTION
#9455 fixed a failing test in the tracer test suite due to not being tested when llmobs made some changes to `_inject_llmobs_parent_id()`, and also ensured that tracer tests run on llmobs changes moving forward.

This PR also changes the corresponding tracer tests to be less focused on exact implementation of `_inject_llmobs_parent_id()`, as `tests/llmobs/test_propagation.py` is responsible for testing the actual injection logic. We only care on the tracer propagation test level that `_inject_llmobs_parent_id()` is called if llmobs is enabled.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
