### PR TITLE
chore(ci): fix incorrect importlib_metadata name

### DIFF
--- a/tests/internal/test_packages.py
+++ b/tests/internal/test_packages.py
@@ -52,6 +52,8 @@ def test_get_distributions():
             importlib_pkgs.add("typing-extensions")
         elif pkg.name == "pkgutil_resolve_name" and "pkgutil-resolve-name" in pkg_resources_ws:
             importlib_pkgs.add("pkgutil-resolve-name")
+        elif pkg.name == "importlib_metadata" and "importlib-metadata" in pkg_resources_ws:
+            importlib_pkgs.add("importlib-metadata")
         else:
             importlib_pkgs.add(pkg.name)
 


### PR DESCRIPTION
This is a manual backport to fix the CI. The fix is cherry-picked from https://github.com/DataDog/dd-trace-py/pull/9339. We don't want to backport this entire PR because the tracer flare is not in scope for 2.9

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
