### PR TITLE
ci(tracer): limit time spent waiting for subprocesses to join in tracer tests

### DIFF
--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -1052,7 +1052,7 @@ def test_tracer_runtime_tags_fork():
     q = multiprocessing.Queue()
     p = multiprocessing.Process(target=_test_tracer_runtime_tags_fork_task, args=(tracer, q))
     p.start()
-    p.join()
+    p.join(60)
 
     children_tag = q.get()
     assert children_tag != span.get_tag("runtime-id")
@@ -1121,7 +1121,7 @@ def test_threaded_import():
 
     t = threading.Thread(target=thread_target)
     t.start()
-    t.join()
+    t.join(60)
 
 
 def test_runtime_id_parent_only():
@@ -1766,7 +1766,7 @@ def test_closing_other_context_spans_single_span(tracer, test_spans):
     assert tracer.current_span() is span
     t1 = threading.Thread(target=_target, args=(span,))
     t1.start()
-    t1.join()
+    t1.join(60)
     assert tracer.current_span() is None
 
     spans = test_spans.pop()
@@ -1789,7 +1789,7 @@ def test_closing_other_context_spans_multi_spans(tracer, test_spans):
     assert tracer.current_span() is span
     t1 = threading.Thread(target=_target, args=(span,))
     t1.start()
-    t1.join()
+    t1.join(60)
     assert tracer.current_span() is root
     root.finish()
 


### PR DESCRIPTION
This change updates `join()` calls in `test_tracer.py` to limit the amount of time they can spend waiting on a hung subprocess, fixing CI failures like [this one](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/63032/workflows/a935d176-194e-41e7-8c34-f824a8bcff77/jobs/3921815). After this change, this example would still be a test failure, but it would also run all subsequent tests in the suite rather than timing out midway through.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.
