### PR TITLE
chore(ci): restore microbenchmarks runs

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -9,6 +9,7 @@ variables:
   image: $MICROBENCHMARKS_CI_IMAGE
   interruptible: true
   timeout: 1h
+  needs: []
   script:
     - export REPORTS_DIR="$(pwd)/reports/" && (mkdir "${REPORTS_DIR}" || :)
     - export CMAKE_BUILD_PARALLEL_LEVEL=12

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -16,7 +16,7 @@ variables:
     - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
     - git clone --branch dd-trace-py https://github.com/DataDog/benchmarking-platform /platform && cd /platform
     - ./steps/capture-hardware-software-info.sh
-    - '([[ $SCENARIO =~ ^flask_* ]] && BP_SCENARIO=$SCENARIO /benchmarking-platform-tools/bp-runner/bp-runner "$REPORTS_DIR/../.gitlab/benchmarks/bp-runner.yml" --debug -t) || (! [[ $SCENARIO =~ ^flask_* ]] && ./steps/run-benchmarks.sh)'
+    - '([[ $SCENARIO =~ ^flask_* ]] && BP_SCENARIO=$SCENARIO bp-runner "$REPORTS_DIR/../.gitlab/benchmarks/bp-runner.yml" --debug -t) || (! [[ $SCENARIO =~ ^flask_* ]] && ./steps/run-benchmarks.sh)'
     - ./steps/analyze-results.sh
     - "./steps/upload-results-to-s3.sh || :"
   artifacts:

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -36,7 +36,7 @@ variables:
 
 benchmarks-pr-comment:
   stage: benchmarks-pr-comment
-  when: on_success
+  when: always
   tags: ["arch:amd64"]
   image: $MICROBENCHMARKS_CI_IMAGE
   script:

--- a/benchmarks/Dockerfile
+++ b/benchmarks/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:buster-slim as base
 
-ARG PYTHON_VERSION=3.9.6
-ARG PYENV_VERSION=2.0.4
+ARG PYTHON_VERSION=3.9.15
+ARG PYENV_VERSION=2.4.1
 RUN apt-get update && apt-get install --no-install-recommends -y \
     make build-essential libssl-dev zlib1g-dev \
     libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
@@ -14,7 +14,7 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git --branch "v$PYENV_VER
 RUN pyenv install "$PYTHON_VERSION"
 
 FROM debian:buster-slim
-ARG PYTHON_VERSION=3.9.6
+ARG PYTHON_VERSION=3.9.15
 
 COPY --from=base /pyenv /pyenv
 ENV PYENV_ROOT "/pyenv"


### PR DESCRIPTION
1. Update python and pyenv versions in microbenchmarks.
2. Dogfooding stage won't block benchmarks anymore.
3. Simplify a call to bp-runner.
4. Ensure that benchmarks' PR comment is created, even when dogfooding fails.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
