### PR TITLE
chore(llmobs): remove contrib import in llmobs directory

### DIFF
--- a/ddtrace/llmobs/_integrations/anthropic.py
+++ b/ddtrace/llmobs/_integrations/anthropic.py
@@ -3,7 +3,6 @@ from typing import Dict
 from typing import Optional
 
 from ddtrace._trace.span import Span
-from ddtrace.contrib.anthropic.utils import _get_attr
 from ddtrace.internal.logger import get_logger
 
 from .base import BaseLLMIntegration
@@ -38,8 +37,8 @@ class AnthropicIntegration(BaseLLMIntegration):
     def record_usage(self, span: Span, usage: Dict[str, Any]) -> None:
         if not usage:
             return
-        input_tokens = _get_attr(usage, "input_tokens", None)
-        output_tokens = _get_attr(usage, "output_tokens", None)
+        input_tokens = getattr(usage, "input_tokens", None)
+        output_tokens = getattr(usage, "output_tokens", None)
 
         span.set_metric("anthropic.response.usage.input_tokens", input_tokens)
         span.set_metric("anthropic.response.usage.output_tokens", output_tokens)


### PR DESCRIPTION
This PR removes an import from the `ddtrace.contrib.anthropic.*` directory made by the `ddtrace.llmobs.integrations` module, as this can lead to circular imports (ex: langchain conftest imports langchain unpatch, langchain unpatch imports LangchainIntegration, LangchainIntegration imports from base, base imports from Anthropic integration, Anthropic integration imports from anthropic contrib, anthropic contrib imports Anthropic integration --> circular error)

There is no change in functionality - existing tests verify this.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
