### PR TITLE
ci: install mock for encoders profile

### DIFF
--- a/scripts/profiles/encoders/setup.sh
+++ b/scripts/profiles/encoders/setup.sh
@@ -2,10 +2,9 @@
 
 set -eu
 
-if [[ "$OSTYPE" != "linux-gnu"* ]]
-then
-    echo "Platform $OSTYPE not supported."
-    exit 1
+if [[ "$OSTYPE" != "linux-gnu"* ]]; then
+	echo "Platform $OSTYPE not supported."
+	exit 1
 fi
 
 PREFIX=${1}
@@ -19,7 +18,7 @@ source ${PREFIX}/bin/activate
 pip install pip --upgrade
 
 # Install dependencies
-pip install hypothesis msgpack pytest austin-python~=1.7 austin-dist~=3.6
+pip install hypothesis msgpack pytest mock austin-python~=1.7 austin-dist~=3.6
 
 # Install ddtrace
 pip install -e .


### PR DESCRIPTION
This change attempts to resolve main-branch CI failures like [this one](https://github.com/DataDog/dd-trace-py/actions/runs/9387454355/job/25850411962) by installing `mock` in the profile's environment.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
