### PR TITLE
chore: use separate directory for testrunner container riot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ ENV/
 # Riot
 .riot/venv*
 .riot/requirements/*.in
+.ddtest_riot/*
 
 # Auto-generated version file
 ddtrace/_version.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,7 +158,7 @@ services:
           - ddagent:/tmp/ddagent
           - ./:/root/project
           - ./.ddtox:/root/project/.tox
-          - ./.riot:/root/project/.riot
+          - ./.ddtest_riot:/root/project/.riot
 
     localstack:
         image: localstack/localstack:1.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ exclude = '''
 (
   .venv*
   | \.riot
+  | \.ddtest_riot
   | ddtrace/profiling/
 )
 '''
@@ -89,6 +90,7 @@ exclude = '''
 (
   .venv*
   | \.riot/
+  | \.ddtest_riot/
   | ddtrace/appsec/_ddwaf.pyx$
   | ddtrace/internal/_encoding.pyx$
   | ddtrace/internal/_rand.pyx$
@@ -124,6 +126,7 @@ exclude = [
   ".ddriot",
   ".ddtox",
   ".riot",
+  ".ddtest_riot",
   ".tox",
   ".venv",
 ]
@@ -196,6 +199,7 @@ SYSTEM_VERSION_COMPAT = "0"
 [tool.ruff]
 exclude = [
     ".riot",
+    ".ddtest_riot",
     ".ddriot",
     ".venv*",
     ".git",

--- a/scripts/cformat.sh
+++ b/scripts/cformat.sh
@@ -23,6 +23,7 @@ then
     | grep -v '_taint_tracking/CMakeFiles' \
     | grep -v '_taint_tracking/_deps/' \
     | grep -v '.riot/' \
+    | grep -v '.ddtest_riot/' \
     | grep -v 'ddtrace/vendor/' \
     | grep -v '_taint_tracking/_vendor/' \
     | grep -v 'ddtrace/appsec/_iast/_taint_tracking/cmake-build-debug/' \

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal=1
 
 [codespell]
-skip = *.json,*.h,*.cpp,*.c,.riot,.tox,.mypy_cache,.git,*ddtrace/vendor,tests/contrib/openai/cassettes/*,tests/contrib/langchain/cassettes/*,ddtrace/appsec/_iast/_taint_tracking/_vendor/*
+skip = *.json,*.h,*.cpp,*.c,.riot,.ddtest_riot,.tox,.mypy_cache,.git,*ddtrace/vendor,tests/contrib/openai/cassettes/*,tests/contrib/langchain/cassettes/*,ddtrace/appsec/_iast/_taint_tracking/_vendor/*
 exclude-file = .codespellignorelines
 ignore-words-list = asend,dne,fo,medias,ment,nin,ot,setttings,statics,ba,spawnve,doas
 


### PR DESCRIPTION
Small quality-of-life improvement to separate the `.riot` directory used when inside a `testrunner` container from the `.riot` directory outside the container. This is achieved simply by changing the bind-mounted directory when the container is started with `docker-compose`.

This is primarily because the `testrunner`'s `riot` envs will have symlinks to Python binaries in `/root/` which are incorrect outside of the container.

This makes it less likely that there would be issues when developers mix running tests inside the container with using workflow-related `riot` commands outside of the container.

Two notable locations where `.riot` remains untouched:
* `scripts/compile-and-prune-test-requirements`: this needs to run outside of the container in order to modify the proper files
* `scripts/run-test-suite`: this would either run outside or inside the container (although I don't think anyone uses it manually anyway since it requires a bit of setup)

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
