### PR TITLE
fix(internal): prevent multiple calls to telemetry writer periodic during shutdown

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -258,7 +258,7 @@ class TelemetryWriter(PeriodicService):
         self._forked = False  # type: bool
         self._events_queue = []  # type: List[Dict]
         self._configuration_queue = {}  # type: Dict[str, Dict]
-        self._lock = forksafe.Lock()  # type: forksafe.ResetObject
+        self._lock = forksafe.RLock()  # type: forksafe.ResetObject
         self._imported_dependencies: Dict[str, Distribution] = dict()
 
         self._is_agentless = config._ci_visibility_agentless_enabled if agentless is None else agentless

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -768,9 +768,10 @@ class TelemetryWriter(PeriodicService):
             self._client.send_event(telemetry_event)
 
     def app_shutdown(self):
+        # DEV: Disable first to prevent periodic being called from the PeriodicService loop
+        self.disable()
         self._app_closing_event()
         self.periodic(force_flush=True)
-        self.disable()
 
     def reset_queues(self):
         # type: () -> None

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -331,7 +331,8 @@ class TelemetryWriter(PeriodicService):
                 "payload": payload,
                 "request_type": payload_type,
             }
-            self._events_queue.append(event)
+            with self._lock:
+                self._events_queue.append(event)
 
     def add_integration(self, integration_name, patched, auto_patched=None, error_msg=None, version=""):
         # type: (str, bool, Optional[bool], Optional[str], Optional[str]) -> None
@@ -556,22 +557,22 @@ class TelemetryWriter(PeriodicService):
     def _flush_integrations_queue(self):
         # type: () -> List[Dict]
         """Flushes and returns a list of all queued integrations"""
-        with self._lock:
-            integrations = list(self._integrations_queue.values())
-            self._integrations_queue = dict()
+        # DEV: We must be holding self._lock to call this method
+        integrations = list(self._integrations_queue.values())
+        self._integrations_queue = dict()
         return integrations
 
     def _flush_new_imported_dependencies(self) -> List[str]:
-        with self._lock:
-            new_deps = TelemetryWriterModuleWatchdog.get_new_imports()
+        # DEV: We must be holding self._lock to call this method
+        new_deps = TelemetryWriterModuleWatchdog.get_new_imports()
         return new_deps
 
     def _flush_configuration_queue(self):
         # type: () -> List[Dict]
         """Flushes and returns a list of all queued configurations"""
-        with self._lock:
-            configurations = list(self._configuration_queue.values())
-            self._configuration_queue = {}
+        # DEV: We must be holding self._lock to call this method
+        configurations = list(self._configuration_queue.values())
+        self._configuration_queue = {}
         return configurations
 
     def _app_client_configuration_changed_event(self, configurations):
@@ -584,12 +585,12 @@ class TelemetryWriter(PeriodicService):
 
     def _update_dependencies_event(self, newly_imported_deps: List[str]):
         """Adds events to report imports done since the last periodic run"""
+        # DEV: We must be holding self._lock to call this method
 
         if not config._telemetry_dependency_collection or not self._enabled:
             return
 
-        with self._lock:
-            packages = update_imported_dependencies(self._imported_dependencies, newly_imported_deps)
+        packages = update_imported_dependencies(self._imported_dependencies, newly_imported_deps)
 
         if packages:
             payload = {"dependencies": packages}
@@ -641,7 +642,8 @@ class TelemetryWriter(PeriodicService):
                 data["tags"] = ",".join(["%s:%s" % (k, str(v).lower()) for k, v in tags.items()])
             if stack_trace:
                 data["stack_trace"] = stack_trace
-            self._logs.add(data)
+            with self._lock:
+                self._logs.add(data)
 
     def add_gauge_metric(self, namespace, name, value, tags=None):
         # type: (str,str, float, MetricTagType) -> None
@@ -703,9 +705,9 @@ class TelemetryWriter(PeriodicService):
 
     def _flush_log_metrics(self):
         # type () -> Set[Metric]
-        with self._lock:
-            log_metrics = self._logs
-            self._logs = set()
+        # DEV: We must be holding self._lock to call this
+        log_metrics = self._logs
+        self._logs = set()
         return log_metrics
 
     def _generate_metrics_event(self, namespace_metrics):
@@ -729,49 +731,49 @@ class TelemetryWriter(PeriodicService):
         self.add_event({"logs": list(logs)}, TELEMETRY_TYPE_LOGS)
 
     def periodic(self, force_flush=False):
-        namespace_metrics = self._namespace.flush()
-        if namespace_metrics:
-            self._generate_metrics_event(namespace_metrics)
+        with self._lock:
+            namespace_metrics = self._namespace.flush()
+            if namespace_metrics:
+                self._generate_metrics_event(namespace_metrics)
 
-        logs_metrics = self._flush_log_metrics()
-        if logs_metrics:
-            self._generate_logs_event(logs_metrics)
+            logs_metrics = self._flush_log_metrics()
+            if logs_metrics:
+                self._generate_logs_event(logs_metrics)
 
-        # Telemetry metrics and logs should be aggregated into payloads every time periodic is called.
-        # This ensures metrics and logs are submitted in 0 to 10 second time buckets.
-        # Optimization: All other events should be aggregated using `config._telemetry_heartbeat_interval`.
-        # Telemetry payloads will be submitted according to `config._telemetry_heartbeat_interval`.
-        if self._is_periodic and force_flush is False:
-            if self._periodic_count < self._periodic_threshold:
-                self._periodic_count += 1
-                return
-            self._periodic_count = 0
+            # Telemetry metrics and logs should be aggregated into payloads every time periodic is called.
+            # This ensures metrics and logs are submitted in 0 to 10 second time buckets.
+            # Optimization: All other events should be aggregated using `config._telemetry_heartbeat_interval`.
+            # Telemetry payloads will be submitted according to `config._telemetry_heartbeat_interval`.
+            if self._is_periodic and force_flush is False:
+                if self._periodic_count < self._periodic_threshold:
+                    self._periodic_count += 1
+                    return
+                self._periodic_count = 0
 
-        integrations = self._flush_integrations_queue()
-        if integrations:
-            self._app_integrations_changed_event(integrations)
+            integrations = self._flush_integrations_queue()
+            if integrations:
+                self._app_integrations_changed_event(integrations)
 
-        configurations = self._flush_configuration_queue()
-        if configurations:
-            self._app_client_configuration_changed_event(configurations)
+            configurations = self._flush_configuration_queue()
+            if configurations:
+                self._app_client_configuration_changed_event(configurations)
 
-        if config._telemetry_dependency_collection:
-            newly_imported_deps = self._flush_new_imported_dependencies()
-            if newly_imported_deps:
-                self._update_dependencies_event(newly_imported_deps)
+            if config._telemetry_dependency_collection:
+                newly_imported_deps = self._flush_new_imported_dependencies()
+                if newly_imported_deps:
+                    self._update_dependencies_event(newly_imported_deps)
 
-        # Send a heartbeat event to the agent, this is required to keep RC connections alive
-        self._app_heartbeat_event()
+            # Send a heartbeat event to the agent, this is required to keep RC connections alive
+            self._app_heartbeat_event()
 
-        telemetry_events = self._flush_events_queue()
-        for telemetry_event in telemetry_events:
-            self._client.send_event(telemetry_event)
+            telemetry_events = self._flush_events_queue()
+            for telemetry_event in telemetry_events:
+                self._client.send_event(telemetry_event)
 
     def app_shutdown(self):
-        # DEV: Disable first to prevent periodic being called from the PeriodicService loop
-        self.disable()
         self._app_closing_event()
         self.periodic(force_flush=True)
+        self.disable()
 
     def reset_queues(self):
         # type: () -> None
@@ -783,9 +785,9 @@ class TelemetryWriter(PeriodicService):
     def _flush_events_queue(self):
         # type: () -> List[Dict]
         """Flushes and returns a list of all telemtery event"""
-        with self._lock:
-            events = self._events_queue
-            self._events_queue = []
+        # DEV: We must be holding self._lock to call this method
+        events = self._events_queue
+        self._events_queue = []
         return events
 
     def _fork_writer(self):


### PR DESCRIPTION
Sometimes periodic will get called while app_shutdown is still running, especially if it is taking longer than expected.

Move locking to adding data to the TelemetryWriter and when calling `periodic` to prevent multiple calls to periodic at the same time.


## Checklist

- [x] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
