### PR TITLE
fix(redis): unboundlocalerror in redis utils

### DIFF
--- a/ddtrace/contrib/redis_utils.py
+++ b/ddtrace/contrib/redis_utils.py
@@ -68,6 +68,7 @@ async def _run_redis_command_async(ctx: core.ExecutionContext, func, args, kwarg
     parsed_command = stringify_cache_args(args)
     redis_command = parsed_command.split(" ")[0]
     rowcount = None
+    result = None
     try:
         result = await func(*args, **kwargs)
         return result

--- a/releasenotes/notes/redis-unbound-fb8f0703949c9348.yaml
+++ b/releasenotes/notes/redis-unbound-fb8f0703949c9348.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    redis: This fix resolves a programming error that could result in uncaught exceptions from Redis-related integrations.


### PR DESCRIPTION
This change resolves a programming error in `redis_utils.py`.

Fixes #9548

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
