### PR TITLE
ci: disable pyarrow iast package test

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -486,7 +486,7 @@ jobs:
 
   appsec_iast_packages:
     <<: *machine_executor
-    parallelism: 10
+    parallelism: 5
     steps:
       - run_test:
           pattern: 'appsec_iast_packages'

--- a/tests/appsec/iast_packages/test_packages.py
+++ b/tests/appsec/iast_packages/test_packages.py
@@ -592,15 +592,22 @@ PACKAGES = [
     PackageForTesting(
         "docutils", "0.21.2", "Hello, **world**!", "Conversion successful!", "", skip_python_version=[(3, 8)]
     ),
-    PackageForTesting(
-        "pyarrow",
-        "16.1.0",
-        "some-value",
-        "Table data: {'column1': {0: 'some-value'}, 'column2': {0: 1}}",
-        "",
-        extras=[("pandas", "1.1.5")],
-        skip_python_version=[(3, 12)],  # pandas 1.1.5 does not work with Python 3.12
-    ),
+    ## TODO: https://datadoghq.atlassian.net/browse/APPSEC-53659
+    ## Disabled due to a bug in CI:
+    ## >           assert content["result1"].startswith(package.expected_result1)
+    ## E           assert False
+    ## E            +  where False = <built-in method startswith of str object at 0x7f223bc9d240>("Table data: {'column1': {0: 'some-value'}, 'column2': {0: 1}}")  # noqa: E501
+    ## E            +    where <built-in method startswith of str object at 0x7f223bc9d240> = 'Error: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject'.startswith  # noqa: E501
+    ## E            +    and   "Table data: {'column1': {0: 'some-value'}, 'column2': {0: 1}}" = pyarrow==16.1.0: .expected_result1  # noqa: E501
+    # PackageForTesting(
+    #     "pyarrow",
+    #     "16.1.0",
+    #     "some-value",
+    #     "Table data: {'column1': {0: 'some-value'}, 'column2': {0: 1}}",
+    #     "",
+    #     extras=[("pandas", "1.1.5")],
+    #     skip_python_version=[(3, 12)],  # pandas 1.1.5 does not work with Python 3.12
+    # ),
     PackageForTesting("requests-oauthlib", "2.0.0", "", "", "", test_e2e=False, import_name="requests_oauthlib"),
     PackageForTesting("pyparsing", "3.1.2", "123-456-7890", "Parsed phone number: ['123', '456', '7890']", ""),
     # TODO: e2e implemented but fails unpatched: "RateLimiter object has no attribute _is_allowed"


### PR DESCRIPTION
CI: Disables Pyarrow IAST package test as it's failing consistently on CI

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
