### PR TITLE
ci: add `importlib_metadata` to `test_get_distributions` [backport 2.8]

### DIFF
--- a/tests/internal/test_packages.py
+++ b/tests/internal/test_packages.py
@@ -51,6 +51,10 @@ def test_get_distributions():
             importlib_pkgs.add("typing-extensions")
         elif pkg.name == "pkgutil_resolve_name" and "pkgutil-resolve-name" in pkg_resources_ws:
             importlib_pkgs.add("pkgutil-resolve-name")
+        elif pkg.name == "importlib_metadata" and "importlib-metadata" in pkg_resources_ws:
+            importlib_pkgs.add("importlib-metadata")
+        elif pkg.name == "importlib-metadata" and "importlib_metadata" in pkg_resources_ws:
+            importlib_pkgs.add("importlib_metadata")
         else:
             importlib_pkgs.add(pkg.name)
 


### PR DESCRIPTION
Follow-up on:
https://github.com/DataDog/dd-trace-py/pull/9467/files#r1642430035

## Checklist
- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist
- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

(cherry picked from commit 68bb423a2ed3ef23a87eb34d32ac96c8d1005016)
