### PR TITLE
fix(llmobs): fix document typing

### DIFF
--- a/ddtrace/llmobs/utils.py
+++ b/ddtrace/llmobs/utils.py
@@ -14,6 +14,7 @@ from ddtrace.internal.logger import get_logger
 
 log = get_logger(__name__)
 
+DocumentType = Dict[str, Union[str, int, float]]
 
 ExportedLLMObsSpan = TypedDict("ExportedLLMObsSpan", {"span_id": str, "trace_id": str})
 Document = TypedDict("Document", {"name": str, "id": str, "text": str, "score": float}, total=False)
@@ -44,7 +45,7 @@ class Messages:
 
 
 class Documents:
-    def __init__(self, documents: Union[List[Dict[str, str]], Dict[str, str], str]):
+    def __init__(self, documents: Union[List[DocumentType], DocumentType, str]):
         self.documents = []
         if not isinstance(documents, list):
             documents = [documents]  # type: ignore[list-item]

--- a/releasenotes/notes/fix-llmobs-document-typing-5ff08feef2659220.yaml
+++ b/releasenotes/notes/fix-llmobs-document-typing-5ff08feef2659220.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    LLM Observability: This resolves a typing hint error in the ``ddtrace.llmobs.utils.Documents`` helper class 
+    constructor where type hints did not accept input dictionaries with integer or float values.


### PR DESCRIPTION
Resolves #9600.

This PR addresses the incorrect typing hint in the `ddtrace.llmobs.utils.py` Documents constructor. The documents constructor currently accepts integer/float values for the document score field, but the typing specifies only string field values. The typing fix resolves this inconsistency.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
