### PR TITLE
fix(profiling): capture lock usages with `with` statement context managers

### DIFF
--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -221,6 +221,13 @@ class _ProfiledLock(wrapt.ObjectProxy):
 
     acquire_lock = acquire
 
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.release()
+
 
 class FunctionWrapper(wrapt.FunctionWrapper):
     # Override the __get__ method: whatever happens, _allocate_lock is always considered by Python like a "static"

--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -98,7 +98,7 @@ class _ProfiledLock(wrapt.ObjectProxy):
     def __aexit__(self, *args, **kwargs):
         return self.__wrapped__.__aexit__(*args, **kwargs)
 
-    def __acquire(self, inner_func, *args, **kwargs):
+    def _acquire(self, inner_func, *args, **kwargs):
         if not self._self_capture_sampler.capture():
             return inner_func(*args, **kwargs)
 
@@ -156,9 +156,9 @@ class _ProfiledLock(wrapt.ObjectProxy):
                 pass  # nosec
 
     def acquire(self, *args, **kwargs):
-        return self.__acquire(self.__wrapped__.acquire, *args, **kwargs)
+        return self._acquire(self.__wrapped__.acquire, *args, **kwargs)
 
-    def __release(self, inner_func, *args, **kwargs):
+    def _release(self, inner_func, *args, **kwargs):
         # type (typing.Any, typing.Any) -> None
         try:
             return inner_func(*args, **kwargs)
@@ -223,15 +223,15 @@ class _ProfiledLock(wrapt.ObjectProxy):
                 pass  # nosec
 
     def release(self, *args, **kwargs):
-        return self.__release(self.__wrapped__.release, *args, **kwargs)
+        return self._release(self.__wrapped__.release, *args, **kwargs)
 
     acquire_lock = acquire
 
     def __enter__(self, *args, **kwargs):
-        return self.__acquire(self.__wrapped__.__enter__, *args, **kwargs)
+        return self._acquire(self.__wrapped__.__enter__, *args, **kwargs)
 
     def __exit__(self, *args, **kwargs):
-        self.__release(self.__wrapped__.__exit__, *args, **kwargs)
+        self._release(self.__wrapped__.__exit__, *args, **kwargs)
 
 
 class FunctionWrapper(wrapt.FunctionWrapper):

--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -98,13 +98,13 @@ class _ProfiledLock(wrapt.ObjectProxy):
     def __aexit__(self, *args, **kwargs):
         return self.__wrapped__.__aexit__(*args, **kwargs)
 
-    def acquire(self, *args, **kwargs):
+    def __acquire(self, inner_func, *args, **kwargs):
         if not self._self_capture_sampler.capture():
-            return self.__wrapped__.acquire(*args, **kwargs)
+            return inner_func(*args, **kwargs)
 
         start = compat.monotonic_ns()
         try:
-            return self.__wrapped__.acquire(*args, **kwargs)
+            return inner_func(*args, **kwargs)
         finally:
             try:
                 end = self._self_acquired_at = compat.monotonic_ns()
@@ -155,10 +155,13 @@ class _ProfiledLock(wrapt.ObjectProxy):
                 LOG.warning("Error recording lock acquire event: %s", e)
                 pass  # nosec
 
-    def release(self, *args, **kwargs):
+    def acquire(self, *args, **kwargs):
+        return self.__acquire(self.__wrapped__.acquire, *args, **kwargs)
+
+    def __release(self, inner_func, *args, **kwargs):
         # type (typing.Any, typing.Any) -> None
         try:
-            return self.__wrapped__.release(*args, **kwargs)
+            return inner_func(*args, **kwargs)
         finally:
             try:
                 if hasattr(self, "_self_acquired_at"):
@@ -219,14 +222,16 @@ class _ProfiledLock(wrapt.ObjectProxy):
                 LOG.warning("Error recording lock release event: %s", e)
                 pass  # nosec
 
+    def release(self, *args, **kwargs):
+        return self.__release(self.__wrapped__.release, *args, **kwargs)
+
     acquire_lock = acquire
 
-    def __enter__(self):
-        self.acquire()
-        return self
+    def __enter__(self, *args, **kwargs):
+        return self.__acquire(self.__wrapped__.__enter__, *args, **kwargs)
 
-    def __exit__(self, exc_type, exc_value, exc_traceback):
-        self.release()
+    def __exit__(self, *args, **kwargs):
+        self.__release(self.__wrapped__.__exit__, *args, **kwargs)
 
 
 class FunctionWrapper(wrapt.FunctionWrapper):

--- a/releasenotes/notes/profiling-add-lock-with-f75908e35a70ab71.yaml
+++ b/releasenotes/notes/profiling-add-lock-with-f75908e35a70ab71.yaml
@@ -1,3 +1,3 @@
 features:
   - |
-    profiling: captures lock usages with `with` context managers, e.g. `with lock:`
+    profiling: captures lock usages with ``with`` context managers, e.g. ``with lock:``

--- a/releasenotes/notes/profiling-add-lock-with-f75908e35a70ab71.yaml
+++ b/releasenotes/notes/profiling-add-lock-with-f75908e35a70ab71.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    profiling: captures lock usages with `with` context managers, e.g. `with lock:`

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -398,5 +398,6 @@ def test_lock_enter_exit_events():
     assert release_event.thread_id == _thread.get_ident()
     assert release_event.locked_for_ns >= 0
     assert release_event.frames[0] == (_lock.__file__.replace(".pyc", ".py"), 234, "__exit__", "_ProfiledThreadingLock")
-    assert release_event.frames[1:] == acquire_event.frames[1:]
+    release_lineno = 372 if sys.version_info >= (3, 10) else 373
+    assert release_event.frames[1] == (__file__.replace(".pyc", ".py"), release_lineno, "test_lock_enter_exit_events", "")
     assert release_event.sampling_pct == 100

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -399,5 +399,10 @@ def test_lock_enter_exit_events():
     assert release_event.locked_for_ns >= 0
     assert release_event.frames[0] == (_lock.__file__.replace(".pyc", ".py"), 234, "__exit__", "_ProfiledThreadingLock")
     release_lineno = 372 if sys.version_info >= (3, 10) else 373
-    assert release_event.frames[1] == (__file__.replace(".pyc", ".py"), release_lineno, "test_lock_enter_exit_events", "")
+    assert release_event.frames[1] == (
+        __file__.replace(".pyc", ".py"),
+        release_lineno,
+        "test_lock_enter_exit_events",
+        "",
+    )
     assert release_event.sampling_pct == 100

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -22,7 +22,7 @@ def test_repr():
         collector_threading.ThreadingLockCollector,
         "ThreadingLockCollector(status=<ServiceStatus.STOPPED: 'stopped'>, "
         "recorder=Recorder(default_max_events=16384, max_events={}), capture_pct=1.0, nframes=64, "
-        "endpoint_collection_enabled=True, export_libdd_enabled=False, tracer=None)",
+        "endpoint_collection_enabled=True, tracer=None)",
     )
 
 

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -22,7 +22,7 @@ def test_repr():
         collector_threading.ThreadingLockCollector,
         "ThreadingLockCollector(status=<ServiceStatus.STOPPED: 'stopped'>, "
         "recorder=Recorder(default_max_events=16384, max_events={}), capture_pct=1.0, nframes=64, "
-        "endpoint_collection_enabled=True, tracer=None)",
+        "endpoint_collection_enabled=True, export_libdd_enabled=False, tracer=None)",
     )
 
 
@@ -69,13 +69,13 @@ def test_lock_acquire_events():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 0
     event = r.events[collector_threading.ThreadingLockAcquireEvent][0]
-    assert event.lock_name == "test_threading.py:66"
+    assert event.lock_name == "test_threading.py:67"
     assert event.thread_id == _thread.get_ident()
     assert event.wait_time_ns >= 0
     # It's called through pytest so I'm sure it's gonna be that long, right?
     assert len(event.frames) > 3
     assert event.nframes > 3
-    assert event.frames[0] == (__file__.replace(".pyc", ".py"), 67, "test_lock_acquire_events", "")
+    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 68, "test_lock_acquire_events", "")
     assert event.sampling_pct == 100
 
 
@@ -93,13 +93,13 @@ def test_lock_acquire_events_class():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 0
     event = r.events[collector_threading.ThreadingLockAcquireEvent][0]
-    assert event.lock_name == "test_threading.py:87"
+    assert event.lock_name == "test_threading.py:88"
     assert event.thread_id == _thread.get_ident()
     assert event.wait_time_ns >= 0
     # It's called through pytest so I'm sure it's gonna be that long, right?
     assert len(event.frames) > 3
     assert event.nframes > 3
-    assert event.frames[0] == (__file__.replace(".pyc", ".py"), 88, "lockfunc", "Foobar")
+    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 89, "lockfunc", "Foobar")
     assert event.sampling_pct == 100
 
 
@@ -120,7 +120,7 @@ def test_lock_events_tracer(tracer):
     events = r.reset()
     # The tracer might use locks, so we need to look into every event to assert we got ours
     for event_type in (collector_threading.ThreadingLockAcquireEvent, collector_threading.ThreadingLockReleaseEvent):
-        assert {"test_threading.py:110", "test_threading.py:113"}.issubset({e.lock_name for e in events[event_type]})
+        assert {"test_threading.py:111", "test_threading.py:114"}.issubset({e.lock_name for e in events[event_type]})
         for event in events[event_type]:
             if event.name == "test_threading.py:86":
                 assert event.trace_id is None
@@ -153,14 +153,14 @@ def test_lock_events_tracer_late_finish(tracer):
     events = r.reset()
     # The tracer might use locks, so we need to look into every event to assert we got ours
     for event_type in (collector_threading.ThreadingLockAcquireEvent, collector_threading.ThreadingLockReleaseEvent):
-        assert {"test_threading.py:141", "test_threading.py:144"}.issubset({e.lock_name for e in events[event_type]})
+        assert {"test_threading.py:142", "test_threading.py:145"}.issubset({e.lock_name for e in events[event_type]})
         for event in events[event_type]:
-            if event.name == "test_threading.py:117":
+            if event.name == "test_threading.py:118":
                 assert event.trace_id is None
                 assert event.span_id is None
                 assert event.trace_resource_container is None
                 assert event.trace_type is None
-            elif event.name == "test_threading.py:120":
+            elif event.name == "test_threading.py:121":
                 assert event.trace_id == trace_id
                 assert event.span_id == span_id
                 assert event.trace_resource_container[0] == span.resource
@@ -185,7 +185,7 @@ def test_resource_not_collected(monkeypatch, tracer):
     events = r.reset()
     # The tracer might use locks, so we need to look into every event to assert we got ours
     for event_type in (collector_threading.ThreadingLockAcquireEvent, collector_threading.ThreadingLockReleaseEvent):
-        assert {"test_threading.py:175", "test_threading.py:178"}.issubset({e.lock_name for e in events[event_type]})
+        assert {"test_threading.py:176", "test_threading.py:179"}.issubset({e.lock_name for e in events[event_type]})
         for event in events[event_type]:
             if event.name == "test_threading.py:151":
                 assert event.trace_id is None
@@ -208,13 +208,13 @@ def test_lock_release_events():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 1
     event = r.events[collector_threading.ThreadingLockReleaseEvent][0]
-    assert event.lock_name == "test_threading.py:204"
+    assert event.lock_name == "test_threading.py:205"
     assert event.thread_id == _thread.get_ident()
     assert event.locked_for_ns >= 0
     # It's called through pytest so I'm sure it's gonna be that long, right?
     assert len(event.frames) > 3
     assert event.nframes > 3
-    assert event.frames[0] == (__file__.replace(".pyc", ".py"), 206, "test_lock_release_events", "")
+    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 207, "test_lock_release_events", "")
     assert event.sampling_pct == 100
 
 
@@ -374,7 +374,7 @@ def test_lock_enter_exit_events():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 1
     acquire_event = r.events[collector_threading.ThreadingLockAcquireEvent][0]
-    assert acquire_event.lock_name == "test_threading.py:370"
+    assert acquire_event.lock_name == "test_threading.py:371"
     assert acquire_event.thread_id == _thread.get_ident()
     assert acquire_event.wait_time_ns >= 0
     # We know that at least __enter__, this function, and pytest should be
@@ -386,17 +386,17 @@ def test_lock_enter_exit_events():
 
     assert acquire_event.frames[0] == (
         _lock.__file__.replace(".pyc", ".py"),
-        225,
+        231,
         "__enter__",
         "_ProfiledThreadingLock",
     )
-    assert acquire_event.frames[1] == (__file__.replace(".pyc", ".py"), 371, "test_lock_enter_exit_events", "")
+    assert acquire_event.frames[1] == (__file__.replace(".pyc", ".py"), 372, "test_lock_enter_exit_events", "")
     assert acquire_event.sampling_pct == 100
 
     release_event = r.events[collector_threading.ThreadingLockReleaseEvent][0]
-    assert release_event.lock_name == "test_threading.py:370"
+    assert release_event.lock_name == "test_threading.py:371"
     assert release_event.thread_id == _thread.get_ident()
     assert release_event.locked_for_ns >= 0
-    assert release_event.frames[0] == (_lock.__file__.replace(".pyc", ".py"), 229, "__exit__", "_ProfiledThreadingLock")
+    assert release_event.frames[0] == (_lock.__file__.replace(".pyc", ".py"), 234, "__exit__", "_ProfiledThreadingLock")
     assert release_event.frames[1:] == acquire_event.frames[1:]
     assert release_event.sampling_pct == 100

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -7,8 +7,8 @@ import pytest
 from six.moves import _thread
 
 from ddtrace.profiling import recorder
-from ddtrace.profiling.collector import threading as collector_threading
 from ddtrace.profiling.collector import _lock
+from ddtrace.profiling.collector import threading as collector_threading
 from tests.utils import flaky
 
 from . import test_collector


### PR DESCRIPTION
Python profiler doesn't capture lock usages with `with lock:` statement even though this seems to be more common usage pattern. 

GitHub search with `/with.*lock:/ language:Python -path:test` shows [228k code results](https://github.com/search?q=%2Fwith.*lock%3A%2F+language%3APython+-path%3Atest&type=code)
GitHub search with `/.*lock.acquire\(\)/ language:Python -path:test` shows [89.1k code results 
](https://github.com/search?q=%2F.*lock.acquire%5C%28%5C%29%2F+language%3APython+-path%3Atest&type=code)

We'll get more lock related samples in profiles with this change. 

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
