### PR TITLE
chore(profiling): fixups for profiling cmake artifacts

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/CMakeLists.txt
@@ -43,6 +43,15 @@ target_link_libraries(dd_wrapper PRIVATE
 )
 set_target_properties(dd_wrapper PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
+# For a regular build, the LIB_INSTALL_DIR represents the final location of the library, so nothing special is needed.
+# However, for an inplace build, setup.py will pass a temporary path as the extension output directory, so while it
+# will handle the extension artifacts themselves, supplementary files like this one will be left uncopied.
+# One way around this is to propagate the original source dir of the extension, which can be used to deduce the
+# ideal install directory.
+if (INPLACE_LIB_INSTALL_DIR)
+    set(LIB_INSTALL_DIR "${INPLACE_LIB_INSTALL_DIR}")
+endif()
+
 # If LIB_INSTALL_DIR is set, install the library.
 # Install one directory up--both ddup and stackv2 are set to the same relative level.
 if (LIB_INSTALL_DIR)

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -70,13 +70,13 @@ def test_lock_acquire_events():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 0
     event = r.events[collector_threading.ThreadingLockAcquireEvent][0]
-    assert event.lock_name == "test_threading.py:68"
+    assert event.lock_name == "test_threading.py:69"
     assert event.thread_id == _thread.get_ident()
     assert event.wait_time_ns >= 0
     # It's called through pytest so I'm sure it's gonna be that long, right?
     assert len(event.frames) > 3
     assert event.nframes > 3
-    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 68, "test_lock_acquire_events", "")
+    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 69, "test_lock_acquire_events", "")
     assert event.sampling_pct == 100
 
 
@@ -94,13 +94,13 @@ def test_lock_acquire_events_class():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 0
     event = r.events[collector_threading.ThreadingLockAcquireEvent][0]
-    assert event.lock_name == "test_threading.py:89"
+    assert event.lock_name == "test_threading.py:90"
     assert event.thread_id == _thread.get_ident()
     assert event.wait_time_ns >= 0
     # It's called through pytest so I'm sure it's gonna be that long, right?
     assert len(event.frames) > 3
     assert event.nframes > 3
-    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 89, "lockfunc", "Foobar")
+    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 90, "lockfunc", "Foobar")
     assert event.sampling_pct == 100
 
 
@@ -215,7 +215,7 @@ def test_lock_release_events():
     # It's called through pytest so I'm sure it's gonna be that long, right?
     assert len(event.frames) > 3
     assert event.nframes > 3
-    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 207, "test_lock_release_events", "")
+    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 208, "test_lock_release_events", "")
     assert event.sampling_pct == 100
 
 
@@ -394,7 +394,7 @@ def test_lock_enter_exit_events():
         "__enter__",
         "_ProfiledThreadingLock",
     )
-    assert acquire_event.frames[1] == (__file__.replace(".pyc", ".py"), 372, "test_lock_enter_exit_events", "")
+    assert acquire_event.frames[1] == (__file__.replace(".pyc", ".py"), 376, "test_lock_enter_exit_events", "")
     assert acquire_event.sampling_pct == 100
 
     release_event = r.events[collector_threading.ThreadingLockReleaseEvent][0]

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -22,7 +22,7 @@ def test_repr():
         collector_threading.ThreadingLockCollector,
         "ThreadingLockCollector(status=<ServiceStatus.STOPPED: 'stopped'>, "
         "recorder=Recorder(default_max_events=16384, max_events={}), capture_pct=1.0, nframes=64, "
-        "endpoint_collection_enabled=True, tracer=None)",
+        "endpoint_collection_enabled=True, export_libdd_enabled=False, tracer=None)",
     )
 
 

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -70,7 +70,7 @@ def test_lock_acquire_events():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 0
     event = r.events[collector_threading.ThreadingLockAcquireEvent][0]
-    assert event.lock_name == "test_threading.py:67"
+    assert event.lock_name == "test_threading.py:68"
     assert event.thread_id == _thread.get_ident()
     assert event.wait_time_ns >= 0
     # It's called through pytest so I'm sure it's gonna be that long, right?
@@ -94,7 +94,7 @@ def test_lock_acquire_events_class():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 0
     event = r.events[collector_threading.ThreadingLockAcquireEvent][0]
-    assert event.lock_name == "test_threading.py:88"
+    assert event.lock_name == "test_threading.py:89"
     assert event.thread_id == _thread.get_ident()
     assert event.wait_time_ns >= 0
     # It's called through pytest so I'm sure it's gonna be that long, right?
@@ -121,7 +121,7 @@ def test_lock_events_tracer(tracer):
     events = r.reset()
     # The tracer might use locks, so we need to look into every event to assert we got ours
     for event_type in (collector_threading.ThreadingLockAcquireEvent, collector_threading.ThreadingLockReleaseEvent):
-        assert {"test_threading.py:111", "test_threading.py:114"}.issubset({e.lock_name for e in events[event_type]})
+        assert {"test_threading.py:112", "test_threading.py:115"}.issubset({e.lock_name for e in events[event_type]})
         for event in events[event_type]:
             if event.name == "test_threading.py:86":
                 assert event.trace_id is None
@@ -154,14 +154,14 @@ def test_lock_events_tracer_late_finish(tracer):
     events = r.reset()
     # The tracer might use locks, so we need to look into every event to assert we got ours
     for event_type in (collector_threading.ThreadingLockAcquireEvent, collector_threading.ThreadingLockReleaseEvent):
-        assert {"test_threading.py:142", "test_threading.py:145"}.issubset({e.lock_name for e in events[event_type]})
+        assert {"test_threading.py:143", "test_threading.py:146"}.issubset({e.lock_name for e in events[event_type]})
         for event in events[event_type]:
-            if event.name == "test_threading.py:118":
+            if event.name == "test_threading.py:119":
                 assert event.trace_id is None
                 assert event.span_id is None
                 assert event.trace_resource_container is None
                 assert event.trace_type is None
-            elif event.name == "test_threading.py:121":
+            elif event.name == "test_threading.py:122":
                 assert event.trace_id == trace_id
                 assert event.span_id == span_id
                 assert event.trace_resource_container[0] == span.resource
@@ -186,14 +186,14 @@ def test_resource_not_collected(monkeypatch, tracer):
     events = r.reset()
     # The tracer might use locks, so we need to look into every event to assert we got ours
     for event_type in (collector_threading.ThreadingLockAcquireEvent, collector_threading.ThreadingLockReleaseEvent):
-        assert {"test_threading.py:176", "test_threading.py:179"}.issubset({e.lock_name for e in events[event_type]})
+        assert {"test_threading.py:177", "test_threading.py:180"}.issubset({e.lock_name for e in events[event_type]})
         for event in events[event_type]:
-            if event.name == "test_threading.py:151":
+            if event.name == "test_threading.py:152":
                 assert event.trace_id is None
                 assert event.span_id is None
                 assert event.trace_resource_container is None
                 assert event.trace_type is None
-            elif event.name == "test_threading.py:154":
+            elif event.name == "test_threading.py:155":
                 assert event.trace_id == trace_id
                 assert event.span_id == span_id
                 assert event.trace_resource_container is None
@@ -209,7 +209,7 @@ def test_lock_release_events():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 1
     event = r.events[collector_threading.ThreadingLockReleaseEvent][0]
-    assert event.lock_name == "test_threading.py:205"
+    assert event.lock_name == "test_threading.py:206"
     assert event.thread_id == _thread.get_ident()
     assert event.locked_for_ns >= 0
     # It's called through pytest so I'm sure it's gonna be that long, right?
@@ -378,7 +378,7 @@ def test_lock_enter_exit_events():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 1
     acquire_event = r.events[collector_threading.ThreadingLockAcquireEvent][0]
-    assert acquire_event.lock_name == "test_threading.py:371"
+    assert acquire_event.lock_name == "test_threading.py:375"
     assert acquire_event.thread_id == _thread.get_ident()
     assert acquire_event.wait_time_ns >= 0
     # We know that at least __enter__, this function, and pytest should be
@@ -398,7 +398,7 @@ def test_lock_enter_exit_events():
     assert acquire_event.sampling_pct == 100
 
     release_event = r.events[collector_threading.ThreadingLockReleaseEvent][0]
-    assert release_event.lock_name == "test_threading.py:371"
+    assert release_event.lock_name == "test_threading.py:375"
     assert release_event.thread_id == _thread.get_ident()
     assert release_event.locked_for_ns >= 0
     assert release_event.frames[0] == (_lock.__file__.replace(".pyc", ".py"), 234, "__exit__", "_ProfiledThreadingLock")

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -9,7 +9,6 @@ from six.moves import _thread
 from ddtrace.profiling import recorder
 from ddtrace.profiling.collector import _lock
 from ddtrace.profiling.collector import threading as collector_threading
-from ddtrace.profiling.event import DDFrame
 from tests.utils import flaky
 
 from . import test_collector
@@ -70,13 +69,13 @@ def test_lock_acquire_events():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 0
     event = r.events[collector_threading.ThreadingLockAcquireEvent][0]
-    assert event.lock_name == "test_threading.py:68"
+    assert event.lock_name == "test_threading.py:67"
     assert event.thread_id == _thread.get_ident()
     assert event.wait_time_ns >= 0
     # It's called through pytest so I'm sure it's gonna be that long, right?
     assert len(event.frames) > 3
     assert event.nframes > 3
-    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 69, "test_lock_acquire_events", "")
+    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 68, "test_lock_acquire_events", "")
     assert event.sampling_pct == 100
 
 
@@ -94,13 +93,13 @@ def test_lock_acquire_events_class():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 0
     event = r.events[collector_threading.ThreadingLockAcquireEvent][0]
-    assert event.lock_name == "test_threading.py:89"
+    assert event.lock_name == "test_threading.py:88"
     assert event.thread_id == _thread.get_ident()
     assert event.wait_time_ns >= 0
     # It's called through pytest so I'm sure it's gonna be that long, right?
     assert len(event.frames) > 3
     assert event.nframes > 3
-    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 90, "lockfunc", "Foobar")
+    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 89, "lockfunc", "Foobar")
     assert event.sampling_pct == 100
 
 
@@ -121,14 +120,14 @@ def test_lock_events_tracer(tracer):
     events = r.reset()
     # The tracer might use locks, so we need to look into every event to assert we got ours
     for event_type in (collector_threading.ThreadingLockAcquireEvent, collector_threading.ThreadingLockReleaseEvent):
-        assert {"test_threading.py:112", "test_threading.py:115"}.issubset({e.lock_name for e in events[event_type]})
+        assert {"test_threading.py:111", "test_threading.py:114"}.issubset({e.lock_name for e in events[event_type]})
         for event in events[event_type]:
-            if event.name == "test_threading.py:86":
+            if event.name == "test_threading.py:85":
                 assert event.trace_id is None
                 assert event.span_id is None
                 assert event.trace_resource_container is None
                 assert event.trace_type is None
-            elif event.name == "test_threading.py:89":
+            elif event.name == "test_threading.py:88":
                 assert event.trace_id == trace_id
                 assert event.span_id == span_id
                 assert event.trace_resource_container[0] == t.resource
@@ -154,14 +153,14 @@ def test_lock_events_tracer_late_finish(tracer):
     events = r.reset()
     # The tracer might use locks, so we need to look into every event to assert we got ours
     for event_type in (collector_threading.ThreadingLockAcquireEvent, collector_threading.ThreadingLockReleaseEvent):
-        assert {"test_threading.py:143", "test_threading.py:146"}.issubset({e.lock_name for e in events[event_type]})
+        assert {"test_threading.py:142", "test_threading.py:145"}.issubset({e.lock_name for e in events[event_type]})
         for event in events[event_type]:
-            if event.name == "test_threading.py:119":
+            if event.name == "test_threading.py:118":
                 assert event.trace_id is None
                 assert event.span_id is None
                 assert event.trace_resource_container is None
                 assert event.trace_type is None
-            elif event.name == "test_threading.py:122":
+            elif event.name == "test_threading.py:121":
                 assert event.trace_id == trace_id
                 assert event.span_id == span_id
                 assert event.trace_resource_container[0] == span.resource
@@ -186,14 +185,14 @@ def test_resource_not_collected(monkeypatch, tracer):
     events = r.reset()
     # The tracer might use locks, so we need to look into every event to assert we got ours
     for event_type in (collector_threading.ThreadingLockAcquireEvent, collector_threading.ThreadingLockReleaseEvent):
-        assert {"test_threading.py:177", "test_threading.py:180"}.issubset({e.lock_name for e in events[event_type]})
+        assert {"test_threading.py:176", "test_threading.py:179"}.issubset({e.lock_name for e in events[event_type]})
         for event in events[event_type]:
-            if event.name == "test_threading.py:152":
+            if event.name == "test_threading.py:151":
                 assert event.trace_id is None
                 assert event.span_id is None
                 assert event.trace_resource_container is None
                 assert event.trace_type is None
-            elif event.name == "test_threading.py:155":
+            elif event.name == "test_threading.py:154":
                 assert event.trace_id == trace_id
                 assert event.span_id == span_id
                 assert event.trace_resource_container is None
@@ -209,13 +208,13 @@ def test_lock_release_events():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 1
     event = r.events[collector_threading.ThreadingLockReleaseEvent][0]
-    assert event.lock_name == "test_threading.py:206"
+    assert event.lock_name == "test_threading.py:205"
     assert event.thread_id == _thread.get_ident()
     assert event.locked_for_ns >= 0
     # It's called through pytest so I'm sure it's gonna be that long, right?
     assert len(event.frames) > 3
     assert event.nframes > 3
-    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 208, "test_lock_release_events", "")
+    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 207, "test_lock_release_events", "")
     assert event.sampling_pct == 100
 
 
@@ -249,12 +248,32 @@ def test_lock_gevent_tasks():
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) >= 1
 
     for event in r.events[collector_threading.ThreadingLockAcquireEvent]:
-        if event.lock_name == "test_threading.py:239":
+        if event.lock_name == "test_threading.py:238":
             assert event.wait_time_ns >= 0
             assert event.task_id == t.ident
             assert event.task_name == "foobar"
             # It's called through pytest so I'm sure it's gonna be that long, right?
             assert len(event.frames) > 3, len(event.frames)
+            assert event.nframes > 3
+            assert event.frames[1] == (
+                "tests/profiling/collector/test_threading.py",
+                239,
+                "play_with_lock",
+                "",
+            ), event.frames
+            assert event.sampling_pct == 100
+            break
+    else:
+        assert False, r.events[collector_threading.ThreadingLockAcquireEvent]  # TODO remove
+        pytest.fail("Lock event not found")
+
+    for event in r.events[collector_threading.ThreadingLockReleaseEvent]:
+        if event.lock_name == "test_threading.py:238":
+            assert event.locked_for_ns >= 0
+            assert event.task_id == t.ident
+            assert event.task_name == "foobar"
+            # It's called through pytest so I'm sure it's gonna be that long, right?
+            assert len(event.frames) > 3
             assert event.nframes > 3
             assert event.frames[1] == (
                 "tests/profiling/collector/test_threading.py",
@@ -265,27 +284,7 @@ def test_lock_gevent_tasks():
             assert event.sampling_pct == 100
             break
     else:
-        assert False, r.events[collector_threading.ThreadingLockAcquireEvent] # TODO remove
-        pytest.fail("Lock event not found")
-
-    for event in r.events[collector_threading.ThreadingLockReleaseEvent]:
-        if event.lock_name == "test_threading.py:239":
-            assert event.locked_for_ns >= 0
-            assert event.task_id == t.ident
-            assert event.task_name == "foobar"
-            # It's called through pytest so I'm sure it's gonna be that long, right?
-            assert len(event.frames) > 3
-            assert event.nframes > 3
-            assert event.frames[1] == (
-                "tests/profiling/collector/test_threading.py",
-                241,
-                "play_with_lock",
-                "",
-            ), event.frames
-            assert event.sampling_pct == 100
-            break
-    else:
-        assert False, r.events[collector_threading.ThreadingLockAcquireEvent] # TODO remove
+        assert False, r.events[collector_threading.ThreadingLockAcquireEvent]  # TODO remove
         pytest.fail("Lock event not found")
 
 
@@ -389,19 +388,19 @@ def test_lock_enter_exit_events():
 
     assert acquire_event.frames[0] == (
         _lock.__file__.replace(".pyc", ".py"),
-        231,
+        230,
         "__enter__",
         "_ProfiledThreadingLock",
     )
-    assert acquire_event.frames[1] == (__file__.replace(".pyc", ".py"), 375, "test_lock_enter_exit_events", "")
+    assert acquire_event.frames[1] == (__file__.replace(".pyc", ".py"), 374, "test_lock_enter_exit_events", "")
     assert acquire_event.sampling_pct == 100
 
     release_event = r.events[collector_threading.ThreadingLockReleaseEvent][0]
-    assert release_event.lock_name == "test_threading.py:374"
+    assert release_event.lock_name == "test_threading.py:373"
     assert release_event.thread_id == _thread.get_ident()
     assert release_event.locked_for_ns >= 0
-    assert release_event.frames[0] == (_lock.__file__.replace(".pyc", ".py"), 234, "__exit__", "_ProfiledThreadingLock")
-    release_lineno = 375 if sys.version_info >= (3, 10) else 376
+    assert release_event.frames[0] == (_lock.__file__.replace(".pyc", ".py"), 233, "__exit__", "_ProfiledThreadingLock")
+    release_lineno = 374 if sys.version_info >= (3, 10) else 375
     assert release_event.frames[1] == (
         __file__.replace(".pyc", ".py"),
         release_lineno,

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -376,7 +376,7 @@ def test_lock_enter_exit_events():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 1
     acquire_event = r.events[collector_threading.ThreadingLockAcquireEvent][0]
-    assert acquire_event.lock_name == "test_threading.py:374"
+    assert acquire_event.lock_name == "test_threading.py:373"
     assert acquire_event.thread_id == _thread.get_ident()
     assert acquire_event.wait_time_ns >= 0
     # We know that at least __enter__, this function, and pytest should be
@@ -388,7 +388,7 @@ def test_lock_enter_exit_events():
 
     assert acquire_event.frames[0] == (
         _lock.__file__.replace(".pyc", ".py"),
-        230,
+        231,
         "__enter__",
         "_ProfiledThreadingLock",
     )
@@ -399,7 +399,7 @@ def test_lock_enter_exit_events():
     assert release_event.lock_name == "test_threading.py:373"
     assert release_event.thread_id == _thread.get_ident()
     assert release_event.locked_for_ns >= 0
-    assert release_event.frames[0] == (_lock.__file__.replace(".pyc", ".py"), 233, "__exit__", "_ProfiledThreadingLock")
+    assert release_event.frames[0] == (_lock.__file__.replace(".pyc", ".py"), 234, "__exit__", "_ProfiledThreadingLock")
     release_lineno = 374 if sys.version_info >= (3, 10) else 375
     assert release_event.frames[1] == (
         __file__.replace(".pyc", ".py"),

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -248,7 +248,7 @@ def test_lock_gevent_tasks():
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) >= 1
 
     for event in r.events[collector_threading.ThreadingLockAcquireEvent]:
-        if event.lock_name == "test_threading.py:237":
+        if event.lock_name == "test_threading.py:238":
             assert event.wait_time_ns >= 0
             assert event.task_id == t.ident
             assert event.task_name == "foobar"
@@ -267,7 +267,7 @@ def test_lock_gevent_tasks():
         pytest.fail("Lock event not found")
 
     for event in r.events[collector_threading.ThreadingLockReleaseEvent]:
-        if event.lock_name == "test_threading.py:237":
+        if event.lock_name == "test_threading.py:238":
             assert event.locked_for_ns >= 0
             assert event.task_id == t.ident
             assert event.task_name == "foobar"

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -22,7 +22,7 @@ def test_repr():
         collector_threading.ThreadingLockCollector,
         "ThreadingLockCollector(status=<ServiceStatus.STOPPED: 'stopped'>, "
         "recorder=Recorder(default_max_events=16384, max_events={}), capture_pct=1.0, nframes=64, "
-        "endpoint_collection_enabled=True, export_libdd_enabled=False, tracer=None)",
+        "endpoint_collection_enabled=True, tracer=None)",
     )
 
 

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -253,7 +253,7 @@ def test_lock_gevent_tasks():
             assert event.task_id == t.ident
             assert event.task_name == "foobar"
             # It's called through pytest so I'm sure it's gonna be that long, right?
-            assert len(event.frames) > 3, len(event.frames)
+            assert len(event.frames) > 3
             assert event.nframes > 3
             assert event.frames[1] == (
                 "tests/profiling/collector/test_threading.py",
@@ -264,7 +264,6 @@ def test_lock_gevent_tasks():
             assert event.sampling_pct == 100
             break
     else:
-        assert False, r.events[collector_threading.ThreadingLockAcquireEvent]  # TODO remove
         pytest.fail("Lock event not found")
 
     for event in r.events[collector_threading.ThreadingLockReleaseEvent]:
@@ -284,7 +283,6 @@ def test_lock_gevent_tasks():
             assert event.sampling_pct == 100
             break
     else:
-        assert False, r.events[collector_threading.ThreadingLockAcquireEvent]  # TODO remove
         pytest.fail("Lock event not found")
 
 
@@ -376,7 +374,7 @@ def test_lock_enter_exit_events():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 1
     acquire_event = r.events[collector_threading.ThreadingLockAcquireEvent][0]
-    assert acquire_event.lock_name == "test_threading.py:373"
+    assert acquire_event.lock_name == "test_threading.py:371"
     assert acquire_event.thread_id == _thread.get_ident()
     assert acquire_event.wait_time_ns >= 0
     # We know that at least __enter__, this function, and pytest should be
@@ -392,15 +390,15 @@ def test_lock_enter_exit_events():
         "__enter__",
         "_ProfiledThreadingLock",
     )
-    assert acquire_event.frames[1] == (__file__.replace(".pyc", ".py"), 374, "test_lock_enter_exit_events", "")
+    assert acquire_event.frames[1] == (__file__.replace(".pyc", ".py"), 372, "test_lock_enter_exit_events", "")
     assert acquire_event.sampling_pct == 100
 
     release_event = r.events[collector_threading.ThreadingLockReleaseEvent][0]
-    assert release_event.lock_name == "test_threading.py:373"
+    assert release_event.lock_name == "test_threading.py:371"
     assert release_event.thread_id == _thread.get_ident()
     assert release_event.locked_for_ns >= 0
     assert release_event.frames[0] == (_lock.__file__.replace(".pyc", ".py"), 234, "__exit__", "_ProfiledThreadingLock")
-    release_lineno = 374 if sys.version_info >= (3, 10) else 375
+    release_lineno = 372 if sys.version_info >= (3, 10) else 373
     assert release_event.frames[1] == (
         __file__.replace(".pyc", ".py"),
         release_lineno,

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -9,6 +9,7 @@ from six.moves import _thread
 from ddtrace.profiling import recorder
 from ddtrace.profiling.collector import _lock
 from ddtrace.profiling.collector import threading as collector_threading
+from ddtrace.profiling.event import DDFrame
 from tests.utils import flaky
 
 from . import test_collector
@@ -255,12 +256,15 @@ def test_lock_gevent_tasks():
             # It's called through pytest so I'm sure it's gonna be that long, right?
             assert len(event.frames) > 3
             assert event.nframes > 3
-            assert event.frames[0] == (
+            expected_frame = DDFrame(
                 "tests/profiling/collector/test_threading.py",
-                238,
+                239,
                 "play_with_lock",
                 "",
-            ), event.frames
+            )
+
+            # Better lock contexts means we have to check the leaf and one level up for the target
+            assert event.frames[0] == expected_frame or event.frames[1] == expected_frame, event.frames
             assert event.sampling_pct == 100
             break
     else:

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -76,7 +76,7 @@ def test_lock_acquire_events():
     # It's called through pytest so I'm sure it's gonna be that long, right?
     assert len(event.frames) > 3
     assert event.nframes > 3
-    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 68, "test_lock_acquire_events", "")
+    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 69, "test_lock_acquire_events", "")
     assert event.sampling_pct == 100
 
 
@@ -249,44 +249,43 @@ def test_lock_gevent_tasks():
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) >= 1
 
     for event in r.events[collector_threading.ThreadingLockAcquireEvent]:
-        if event.lock_name == "test_threading.py:238":
+        if event.lock_name == "test_threading.py:239":
             assert event.wait_time_ns >= 0
             assert event.task_id == t.ident
             assert event.task_name == "foobar"
             # It's called through pytest so I'm sure it's gonna be that long, right?
-            assert len(event.frames) > 3
+            assert len(event.frames) > 3, len(event.frames)
             assert event.nframes > 3
-            expected_frame = DDFrame(
+            assert event.frames[1] == (
                 "tests/profiling/collector/test_threading.py",
-                239,
-                "play_with_lock",
-                "",
-            )
-
-            # Better lock contexts means we have to check the leaf and one level up for the target
-            assert event.frames[0] == expected_frame or event.frames[1] == expected_frame, event.frames
-            assert event.sampling_pct == 100
-            break
-    else:
-        pytest.fail("Lock event not found")
-
-    for event in r.events[collector_threading.ThreadingLockReleaseEvent]:
-        if event.lock_name == "test_threading.py:238":
-            assert event.locked_for_ns >= 0
-            assert event.task_id == t.ident
-            assert event.task_name == "foobar"
-            # It's called through pytest so I'm sure it's gonna be that long, right?
-            assert len(event.frames) > 3
-            assert event.nframes > 3
-            assert event.frames[0] == (
-                "tests/profiling/collector/test_threading.py",
-                239,
+                240,
                 "play_with_lock",
                 "",
             ), event.frames
             assert event.sampling_pct == 100
             break
     else:
+        assert False, r.events[collector_threading.ThreadingLockAcquireEvent] # TODO remove
+        pytest.fail("Lock event not found")
+
+    for event in r.events[collector_threading.ThreadingLockReleaseEvent]:
+        if event.lock_name == "test_threading.py:239":
+            assert event.locked_for_ns >= 0
+            assert event.task_id == t.ident
+            assert event.task_name == "foobar"
+            # It's called through pytest so I'm sure it's gonna be that long, right?
+            assert len(event.frames) > 3
+            assert event.nframes > 3
+            assert event.frames[1] == (
+                "tests/profiling/collector/test_threading.py",
+                241,
+                "play_with_lock",
+                "",
+            ), event.frames
+            assert event.sampling_pct == 100
+            break
+    else:
+        assert False, r.events[collector_threading.ThreadingLockAcquireEvent] # TODO remove
         pytest.fail("Lock event not found")
 
 
@@ -378,7 +377,7 @@ def test_lock_enter_exit_events():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 1
     acquire_event = r.events[collector_threading.ThreadingLockAcquireEvent][0]
-    assert acquire_event.lock_name == "test_threading.py:375"
+    assert acquire_event.lock_name == "test_threading.py:374"
     assert acquire_event.thread_id == _thread.get_ident()
     assert acquire_event.wait_time_ns >= 0
     # We know that at least __enter__, this function, and pytest should be
@@ -394,15 +393,15 @@ def test_lock_enter_exit_events():
         "__enter__",
         "_ProfiledThreadingLock",
     )
-    assert acquire_event.frames[1] == (__file__.replace(".pyc", ".py"), 376, "test_lock_enter_exit_events", "")
+    assert acquire_event.frames[1] == (__file__.replace(".pyc", ".py"), 375, "test_lock_enter_exit_events", "")
     assert acquire_event.sampling_pct == 100
 
     release_event = r.events[collector_threading.ThreadingLockReleaseEvent][0]
-    assert release_event.lock_name == "test_threading.py:375"
+    assert release_event.lock_name == "test_threading.py:374"
     assert release_event.thread_id == _thread.get_ident()
     assert release_event.locked_for_ns >= 0
     assert release_event.frames[0] == (_lock.__file__.replace(".pyc", ".py"), 234, "__exit__", "_ProfiledThreadingLock")
-    release_lineno = 376 if sys.version_info >= (3, 10) else 377
+    release_lineno = 375 if sys.version_info >= (3, 10) else 376
     assert release_event.frames[1] == (
         __file__.replace(".pyc", ".py"),
         release_lineno,

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -70,13 +70,13 @@ def test_lock_acquire_events():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 0
     event = r.events[collector_threading.ThreadingLockAcquireEvent][0]
-    assert event.lock_name == "test_threading.py:69"
+    assert event.lock_name == "test_threading.py:68"
     assert event.thread_id == _thread.get_ident()
     assert event.wait_time_ns >= 0
     # It's called through pytest so I'm sure it's gonna be that long, right?
     assert len(event.frames) > 3
     assert event.nframes > 3
-    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 69, "test_lock_acquire_events", "")
+    assert event.frames[1] == (__file__.replace(".pyc", ".py"), 68, "test_lock_acquire_events", "")
     assert event.sampling_pct == 100
 
 
@@ -94,7 +94,7 @@ def test_lock_acquire_events_class():
     assert len(r.events[collector_threading.ThreadingLockAcquireEvent]) == 1
     assert len(r.events[collector_threading.ThreadingLockReleaseEvent]) == 0
     event = r.events[collector_threading.ThreadingLockAcquireEvent][0]
-    assert event.lock_name == "test_threading.py:90"
+    assert event.lock_name == "test_threading.py:89"
     assert event.thread_id == _thread.get_ident()
     assert event.wait_time_ns >= 0
     # It's called through pytest so I'm sure it's gonna be that long, right?
@@ -402,7 +402,7 @@ def test_lock_enter_exit_events():
     assert release_event.thread_id == _thread.get_ident()
     assert release_event.locked_for_ns >= 0
     assert release_event.frames[0] == (_lock.__file__.replace(".pyc", ".py"), 234, "__exit__", "_ProfiledThreadingLock")
-    release_lineno = 372 if sys.version_info >= (3, 10) else 373
+    release_lineno = 376 if sys.version_info >= (3, 10) else 377
     assert release_event.frames[1] == (
         __file__.replace(".pyc", ".py"),
         release_lineno,

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 import time
 
 import mock
@@ -434,3 +435,37 @@ def test_profiler_ddtrace_deprecation():
         from ddtrace.profiling.collector import memalloc  # noqa:F401
         from ddtrace.profiling.collector import stack  # noqa:F401
         from ddtrace.profiling.collector import stack_event  # noqa:F401
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")
+@pytest.mark.subprocess(env={"DD_PROFILING_EXPORT_LIBDD_ENABLED": "true"})
+def test_profiler_libdd_available():
+    """
+    Tests that the libdd module can be loaded
+    """
+    from ddtrace.internal.datadog.profiling import ddup
+
+    assert ddup.is_available
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")
+@pytest.mark.subprocess(env={"DD_PROFILING_EXPORT_LIBDD_ENABLED": "true"})
+def test_profiler_ddup_start():
+    """
+    Tests that the the libdatadog exporter can be enabled
+    """
+    import pytest
+
+    from ddtrace.internal.datadog.profiling import ddup
+
+    try:
+        ddup.config(
+            env="my_env",
+            service="my_service",
+            version="my_version",
+            tags={},
+            url="http://localhost:8126",
+        )
+        ddup.start()
+    except Exception as e:
+        pytest.fail(str(e))

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -450,7 +450,7 @@ def test_profiler_libdd_available():
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")
 @pytest.mark.subprocess(env={"DD_PROFILING_EXPORT_LIBDD_ENABLED": "true"})
-def test_profiler_ddup_start():
+def test_profiler_ddup_init():
     """
     Tests that the the libdatadog exporter can be enabled
     """
@@ -466,6 +466,5 @@ def test_profiler_ddup_start():
             tags={},
             url="http://localhost:8126",
         )
-        ddup.start()
     except Exception as e:
         pytest.fail(str(e))

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -459,7 +459,7 @@ def test_profiler_ddup_start():
     from ddtrace.internal.datadog.profiling import ddup
 
     try:
-        ddup.config(
+        ddup.init(
             env="my_env",
             service="my_service",
             version="my_version",


### PR DESCRIPTION
stack v2 and the libdatadog uploader have been built as part of the normal ddtrace wheel distribution process for a while.

A recent PR also made this non-optional, so builds of these products must succeed.

However, for inplace builds (which is what is used to run tests), while the build process itself was "succeeding," it failed to copy non-module products from the temporary build directory into the source directory.

This fixes that, adds tests for it, and cleans up some other debris around the change of interface.


## Checklist

- [X] Change(s) are motivated and described in the PR description
- [X] Testing strategy is described if automated tests are not included in the PR
- [X] Risks are described (performance impact, potential for breakage, maintainability)
- [X] Change is maintainable (easy to change, telemetry, documentation)
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [X] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
