### PR TITLE
ci: remove wrongly backported pygoat in docker compose from 2.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,21 +181,5 @@ services:
       ports:
         - "127.0.0.1:8001:80"
 
-    pygoat:
-        build:
-            context: tests/appsec/integrations/pygoat_tests
-            dockerfile: Dockerfile.pygoat.2.0.1
-        ports:
-            - "127.0.0.1:8321:8321"
-        environment:
-            - DD_APPSEC_ENABLED=true
-            - DD_IAST_ENABLED=true
-            - DD_IAST_REQUEST_SAMPLING=100
-            - DD_IAST_VULNERABILITIES_PER_REQUEST=100
-            - DD_REMOTE_CONFIGURATION_ENABLED=true
-            - DD_AGENT_PORT=8126
-            - DD_TRACE_AGENT_URL=http://testagent:8126
-            - _DD_APPSEC_DEDUPLICATION_ENABLED=false
-
 volumes:
     ddagent:


### PR DESCRIPTION
## Description

#9119 incorrectly added pygoat to the `docker-compose.yml` file, which was not merged in the 2.7 branch. This fixes it.

## Checklist

- [X] Change(s) are motivated and described in the PR description
- [X] Testing strategy is described if automated tests are not included in the PR
- [X] Risks are described (performance impact, potential for breakage, maintainability)
- [X] Change is maintainable (easy to change, telemetry, documentation)
- [X] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [X] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [X] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [X] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
