### PR TITLE
chore: restore module loader after import

### DIFF
--- a/ddtrace/internal/module.py
+++ b/ddtrace/internal/module.py
@@ -173,6 +173,16 @@ class _ImportHookChainedLoader:
         self.transformers[key] = transformer
 
     def call_back(self, module: ModuleType) -> None:
+        # Restore the original loader
+        try:
+            module.__loader__ = self.loader
+        except AttributeError:
+            pass
+        try:
+            module.spec.loader = self.loader
+        except AttributeError:
+            pass
+
         if module.__name__ == "pkg_resources":
             # DEV: pkg_resources support to prevent errors such as
             # NotImplementedError: Can't perform this operation for unregistered


### PR DESCRIPTION
We restore the original loader after a module has been imported. We only need our custom chained loader while the module is being imported to allow the import hooks to be triggered at the right time. There is no need for the custom loader once the module is fully imported.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
