### PR TITLE
chore(asm): add initial frame on top of traceback for lfi exploit prevention for regular exception

### DIFF
--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -70,8 +70,13 @@ def wrapped_open_CFDDB7ABBA9081B6(original_open_callable, instance, args, kwargs
             )
             if res and WAF_ACTIONS.BLOCK_ACTION in res.actions:
                 raise BlockingException(core.get_item(WAF_CONTEXT_NAMES.BLOCKED), "exploit_prevention", "lfi", filename)
-
-    return original_open_callable(*args, **kwargs)
+    try:
+        return original_open_callable(*args, **kwargs)
+    except Exception as e:
+        previous_frame = e.__traceback__.tb_frame.f_back
+        raise e.with_traceback(
+            e.__traceback__.__class__(None, previous_frame, previous_frame.f_lasti, previous_frame.f_lineno)
+        )
 
 
 def wrapped_open_ED4CF71136E15EBF(original_open_callable, instance, args, kwargs):

--- a/tests/appsec/appsec/test_exploit_prevention.py
+++ b/tests/appsec/appsec/test_exploit_prevention.py
@@ -1,0 +1,40 @@
+from inspect import currentframe
+from inspect import getframeinfo
+import traceback
+
+import pytest
+
+import ddtrace.appsec._common_module_patches as cmp
+
+
+def test_lfi_normal_exception():
+    """
+    Ensure the top frame is the one where the exception is raised in the customer code
+    """
+    exception_repr = """Traceback (most recent call last):
+  File "/Users/christophe.papazian/GitHub/version_1.x/dd-trace-py/tests/appsec/appsec/\
+test_exploit_prevention.py", line {}, in test_lfi_normal_exception
+    with open("/unknown/do_not_exist_test.txt", "w"):
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+FileNotFoundError: [Errno 2] No such file or directory: '/unknown/do_not_exist_test.txt'
+"""
+    try:
+        cmp.patch_common_modules()
+        with pytest.raises(Exception) as e:
+            with open("/unknown/do_not_exist_test.txt", "w"):
+                pass
+        assert e.type is FileNotFoundError
+        # ensure the last frame is from the file where open was called
+        assert e.traceback[-1].path.as_posix() == __file__
+        # Does not work as we can't remove futur frames at raising point
+        # assert len(e.traceback) == 1
+        line_number = getframeinfo(currentframe()).lineno
+        try:
+            with open("/unknown/do_not_exist_test.txt", "w"):
+                pass
+        except Exception as e:
+            assert e.__class__.__name__ == "FileNotFoundError"
+            assert e.__traceback__.tb_frame.f_code.co_filename == __file__
+            assert traceback.format_exc(limit=1) == exception_repr.format(line_number + 2)
+    finally:
+        cmp.unpatch_common_modules()

--- a/tests/appsec/appsec/test_exploit_prevention.py
+++ b/tests/appsec/appsec/test_exploit_prevention.py
@@ -14,8 +14,6 @@ def test_lfi_normal_exception():
     exception_repr = """Traceback (most recent call last):
   File "{}", line {}, in test_lfi_normal_exception
     with open("/unknown/do_not_exist_test.txt", "w"):
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-FileNotFoundError: [Errno 2] No such file or directory: '/unknown/do_not_exist_test.txt'
 """
     try:
         cmp.patch_common_modules()
@@ -34,6 +32,6 @@ FileNotFoundError: [Errno 2] No such file or directory: '/unknown/do_not_exist_t
         except Exception as e:
             assert e.__class__.__name__ == "FileNotFoundError"
             assert e.__traceback__.tb_frame.f_code.co_filename == __file__
-            assert traceback.format_exc(limit=1) == exception_repr.format(__file__, line_number + 2)
+            assert traceback.format_exc(limit=1).startswith(exception_repr.format(__file__, line_number + 2))
     finally:
         cmp.unpatch_common_modules()

--- a/tests/appsec/appsec/test_exploit_prevention.py
+++ b/tests/appsec/appsec/test_exploit_prevention.py
@@ -12,8 +12,7 @@ def test_lfi_normal_exception():
     Ensure the top frame is the one where the exception is raised in the customer code
     """
     exception_repr = """Traceback (most recent call last):
-  File "/Users/christophe.papazian/GitHub/version_1.x/dd-trace-py/tests/appsec/appsec/\
-test_exploit_prevention.py", line {}, in test_lfi_normal_exception
+  File "{}", line {}, in test_lfi_normal_exception
     with open("/unknown/do_not_exist_test.txt", "w"):
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 FileNotFoundError: [Errno 2] No such file or directory: '/unknown/do_not_exist_test.txt'
@@ -35,6 +34,6 @@ FileNotFoundError: [Errno 2] No such file or directory: '/unknown/do_not_exist_t
         except Exception as e:
             assert e.__class__.__name__ == "FileNotFoundError"
             assert e.__traceback__.tb_frame.f_code.co_filename == __file__
-            assert traceback.format_exc(limit=1) == exception_repr.format(line_number + 2)
+            assert traceback.format_exc(limit=1) == exception_repr.format(__file__, line_number + 2)
     finally:
         cmp.unpatch_common_modules()


### PR DESCRIPTION
LFI exploit prevention is encapsulating all regular calls to builtins.open in a wrapper.
If, for any regular reason, the call is raising an Exception (like FileNotFound), the top of the trace is pointing inside the wrapper, obfuscating the initial line of code in the customer code that is responsible for the exception.

This PR adds back that frame on top of the exception traceback. This is not perfect as the instrumentation is still present in the strack trace and the initial frame will be duplicated, but it definitely makes easier to find the root cause of the exception.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
