### PR TITLE
chore(ci_visibility): respect DD_CIVISIBILITY_AGENTLESS_URL when set

### DIFF
--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -341,6 +341,8 @@ class CIVisibility(Service):
                 log.debug("Cannot make request to setting endpoint if API key is not set")
                 return _error_return_value
             url = "https://api." + self._dd_site + SETTING_ENDPOINT
+            if ddconfig._ci_visibility_agentless_url:
+                url = ddconfig._ci_visibility_agentless_url + SETTING_ENDPOINT
             _headers = {
                 AGENTLESS_API_KEY_HEADER_NAME: self._api_key,
                 "Content-Type": "application/json",
@@ -479,6 +481,8 @@ class CIVisibility(Service):
             }
         elif self._requests_mode == REQUESTS_MODE.AGENTLESS_EVENTS:
             url = "https://api." + self._dd_site + SKIPPABLE_ENDPOINT
+            if ddconfig._ci_visibility_agentless_url:
+                url = ddconfig._ci_visibility_agentless_url + SKIPPABLE_ENDPOINT
         else:
             log.warning("Cannot make requests to skippable endpoint if mode is not agentless or evp proxy")
             return

--- a/tests/ci_visibility/test_ci_visibility.py
+++ b/tests/ci_visibility/test_ci_visibility.py
@@ -869,6 +869,33 @@ class TestCheckEnabledFeatures:
             assert mock_do_request.call_count == expected_call_count
             assert enabled_features == _CIVisibilitySettings(False, False, False, False)
 
+    @pytest.mark.parametrize(
+        "dd_civisibility_agentless_url, expected_url",
+        [
+            ("", "https://api.datad0g.com/api/v2/libraries/tests/services/setting"),
+            ("https://bar.foo:1234", "https://bar.foo:1234/api/v2/libraries/tests/services/setting"),
+        ],
+    )
+    def test_civisibility_check_enabled_feature_respects_civisibility_agentless_url(
+        self, dd_civisibility_agentless_url, expected_url
+    ):
+        """Tests that DD_CIVISIBILITY_AGENTLESS_URL is respected when set"""
+        with override_env(
+            dict(
+                DD_API_KEY="foobar.baz",
+                DD_CIVISIBILITY_AGENTLESS_URL=dd_civisibility_agentless_url,
+                DD_CIVISIBILITY_AGENTLESS_ENABLED="1",
+            )
+        ):
+            with mock.patch(
+                "ddtrace.internal.ci_visibility.recorder._do_request",
+                side_effect=[self._get_settings_api_response(200, False, False, False, False)],
+            ) as mock_do_request:
+                mock_civisibility = self._get_mock_civisibility(REQUESTS_MODE.AGENTLESS_EVENTS, False)
+                _ = mock_civisibility._check_enabled_features()
+
+                assert mock_do_request.call_args_list[0][0][1] == expected_url
+
 
 def test_run_protocol_unshallow_git_ge_227():
     with mock.patch("ddtrace.internal.ci_visibility.git_client.extract_git_version", return_value=(2, 27, 0)):
@@ -1437,11 +1464,17 @@ class TestFetchTestsToSkip:
             assert mock_civisibility._tests_to_skip == {}
 
 
-def test_fetch_tests_to_skip_custom_configurations():
+@pytest.mark.parametrize(
+    "dd_ci_visibility_agentless_url,expected_url_prefix",
+    [("", "https://api.datadoghq.com"), ("https://mycustomurl.com:1234", "https://mycustomurl.com:1234")],
+)
+def test_fetch_tests_to_skip_custom_configurations(dd_ci_visibility_agentless_url, expected_url_prefix):
+    expected_url = expected_url_prefix + "/api/v2/ci/tests/skippable"
     with override_env(
         dict(
             DD_API_KEY="foobar.baz",
             DD_CIVISIBILITY_AGENTLESS_ENABLED="1",
+            DD_CIVISIBILITY_AGENTLESS_URL=dd_ci_visibility_agentless_url,
             DD_TAGS="test.configuration.disk:slow,test.configuration.memory:low",
             DD_SERVICE="test-service",
             DD_ENV="test-env",
@@ -1511,7 +1544,7 @@ def test_fetch_tests_to_skip_custom_configurations():
 
             mock_do_request.assert_called_once_with(
                 "POST",
-                "https://api.datadoghq.com/api/v2/ci/tests/skippable",
+                expected_url,
                 expected_data_arg,
                 {"dd-api-key": "foobar.baz", "Content-Type": "application/json"},
                 20,


### PR DESCRIPTION
`DD_CIVISIBILITY_AGENTLESS_URL` is an env var meant for internal use (mainly testing) to override endpoints the tracer should send data to (or make requests to).

This fixes the fact that the env var was not being used to control where CI visiblity setting, and skippable test requests were being sent.

No changelog as the env var is not meant for public use.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
