### PR TITLE
ci: downgrade pip to 24.0 for httpx [backport 2.7]

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -365,7 +365,9 @@ jobs:
           python-version: '3.9'
       - name: Install dependencies
         if: needs.needs-run.outputs.outcome == 'success'
-        run: pip install -r requirements.txt
+        run: |
+          pip install pip==24.0
+          pip install -r requirements.txt
       - name: Inject ddtrace
         if: needs.needs-run.outputs.outcome == 'success'
         run: pip install ../ddtrace


### PR DESCRIPTION
HTTPX 0.22.0 requirements.txt uses a notation not compatible with latest `pip` (24.1).

This PR downgrades pip to 24.0 before trying to install HTTPX requirements.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

(cherry picked from commit 03650f8b59624561d33b0d138503a6bd700e8518)