### PR TITLE
chore(tornado): fix failing tornado test cases

### DIFF
--- a/tests/contrib/tornado/test_executor_decorator.py
+++ b/tests/contrib/tornado/test_executor_decorator.py
@@ -3,6 +3,7 @@ import unittest
 
 from tornado import version_info
 
+import ddtrace
 from ddtrace.constants import ERROR_MSG
 from ddtrace.ext import http
 from tests.utils import assert_span_http_status_code
@@ -44,7 +45,7 @@ class TestTornadoExecutor(TornadoTestCase):
 
         # this trace is executed in a different thread
         executor_span = traces[0][1]
-        assert executor_span.service is None
+        assert ddtrace.config.service == executor_span.service
         assert "tornado.executor.with" == executor_span.name
         assert executor_span.parent_id == request_span.span_id
         assert 0 == executor_span.error
@@ -76,7 +77,7 @@ class TestTornadoExecutor(TornadoTestCase):
 
         # this trace is executed in a different thread
         executor_span = traces[0][1]
-        assert executor_span.service is None
+        assert ddtrace.config.service == executor_span.service
         assert "tornado.executor.query" == executor_span.name
         assert executor_span.parent_id == request_span.span_id
         assert 0 == executor_span.error
@@ -108,7 +109,7 @@ class TestTornadoExecutor(TornadoTestCase):
 
         # this trace is executed in a different thread
         executor_span = traces[0][1]
-        assert executor_span.service is None
+        assert ddtrace.config.service == executor_span.service
         assert "tornado.executor.with" == executor_span.name
         assert executor_span.parent_id == request_span.span_id
         assert 1 == executor_span.error
@@ -145,7 +146,7 @@ class TestTornadoExecutor(TornadoTestCase):
 
         # this trace is executed in a different thread
         executor_span = traces[0][1]
-        assert executor_span.service is None
+        assert ddtrace.config.service == executor_span.service
         assert "tornado.executor.with" == executor_span.name
         assert executor_span.parent_id == request_span.span_id
         assert 0 == executor_span.error

--- a/tests/contrib/tornado/test_executor_decorator.py
+++ b/tests/contrib/tornado/test_executor_decorator.py
@@ -44,7 +44,7 @@ class TestTornadoExecutor(TornadoTestCase):
 
         # this trace is executed in a different thread
         executor_span = traces[0][1]
-        assert "tornado-web" == executor_span.service
+        assert executor_span.service is None
         assert "tornado.executor.with" == executor_span.name
         assert executor_span.parent_id == request_span.span_id
         assert 0 == executor_span.error
@@ -76,7 +76,7 @@ class TestTornadoExecutor(TornadoTestCase):
 
         # this trace is executed in a different thread
         executor_span = traces[0][1]
-        assert "tornado-web" == executor_span.service
+        assert executor_span.service is None
         assert "tornado.executor.query" == executor_span.name
         assert executor_span.parent_id == request_span.span_id
         assert 0 == executor_span.error
@@ -108,7 +108,7 @@ class TestTornadoExecutor(TornadoTestCase):
 
         # this trace is executed in a different thread
         executor_span = traces[0][1]
-        assert "tornado-web" == executor_span.service
+        assert executor_span.service is None
         assert "tornado.executor.with" == executor_span.name
         assert executor_span.parent_id == request_span.span_id
         assert 1 == executor_span.error
@@ -145,7 +145,7 @@ class TestTornadoExecutor(TornadoTestCase):
 
         # this trace is executed in a different thread
         executor_span = traces[0][1]
-        assert "tornado-web" == executor_span.service
+        assert executor_span.service is None
         assert "tornado.executor.with" == executor_span.name
         assert executor_span.parent_id == request_span.span_id
         assert 0 == executor_span.error


### PR DESCRIPTION
Fix failing tornado jobs.

When we updated the `ThreadPoolExecutor` implementation to pass `Context` instead of `Span` one piece of information we are not passing along is the current Span's "service".

We do not need this since spans created within the `ThreadPoolExecutor` will use the `DD_SERVICE` that is set.

These tests do not set a `DD_SERVICE` so it is expected that their service names are `None` (will inherit from their parent).

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
