### PR TITLE
chore(ci_visibility): bump minimum ITR-supported pytest

### DIFF
--- a/ddtrace/contrib/pytest/constants.py
+++ b/ddtrace/contrib/pytest/constants.py
@@ -5,4 +5,4 @@ KIND = "test"
 # XFail Reason
 XFAIL_REASON = "pytest.xfail.reason"
 
-ITR_MIN_SUPPORTED_VERSION = (6, 8, 0)
+ITR_MIN_SUPPORTED_VERSION = (7, 2, 0)


### PR DESCRIPTION
This bumps the minimum `pytest` version for ITR-supported behavior, but that version check is only happening when enabling the new internal coverage collector.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
