### PR TITLE
chore(ci): increase cmake parallelization level

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -37,7 +37,6 @@ machine_executor: &machine_executor
     # https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded-
     - PYTHONUNBUFFERED: 1
     - CMAKE_BUILD_PARALLEL_LEVEL: 12
-    - PIP_VERBOSE: 3
   steps:
     - run: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes -y --no-install-recommends openssh-client git
     - &pyenv-set-global
@@ -353,28 +352,24 @@ executors:
       - image: *cimg_base_image
         environment:
           - CMAKE_BUILD_PARALLEL_LEVEL: 6
-          - PIP_VERBOSE: 3
     resource_class: medium
   python310:
     docker:
       - image: *python310_image
         environment:
           - CMAKE_BUILD_PARALLEL_LEVEL: 12
-          - PIP_VERBOSE: 3
     resource_class: large
   ddtrace_dev:
     docker:
       - image: *ddtrace_dev_image
         environment:
           - CMAKE_BUILD_PARALLEL_LEVEL: 6
-          - PIP_VERBOSE: 3
     resource_class: *default_resource_class
   ddtrace_dev_small:
     docker:
       - image: *ddtrace_dev_image
         environment:
           - CMAKE_BUILD_PARALLEL_LEVEL: 4
-          - PIP_VERBOSE: 3
     resource_class: small
 
 # Common configuration blocks as YAML anchors

--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -442,7 +442,7 @@ jobs:
     resource_class: large
     docker:
       - image: *ddtrace_dev_image
-    parallelism: 8
+    parallelism: 6
     steps:
       - checkout
       - setup_riot
@@ -450,6 +450,8 @@ jobs:
           name: "Generate base virtual environments."
           # DEV: riot list -i tracer lists all supported Python versions
           command: "riot list -i tracer | circleci tests split | xargs -I PY riot -P -v generate --python=PY"
+          environment:
+            CMAKE_BUILD_PARALLEL_LEVEL: 8
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -456,12 +456,15 @@ jobs:
       - checkout
       - setup_riot
       - run:
+          name: "Install moreutils"
+          command: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes -y --no-install-recommends moreutils
+      - run:
           name: "Generate base virtual environments."
           # DEV: riot list -i tracer lists all supported Python versions
-          command: "riot list -i tracer | circleci tests split | xargs -I PY riot -P -v generate --python=PY 2>&1 | awk '{ print strftime(\"[%Y-%m-%d %H:%M:%S]\"), $0 }'"
+          command: "riot list -i tracer | circleci tests split | xargs -I PY riot -P -v generate --python=PY 2>&1 | ts"
           environment:
             CMAKE_BUILD_PARALLEL_LEVEL: 12
-            PIP_VERBOSE: 3
+            PIP_VERBOSE: 1
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -458,7 +458,7 @@ jobs:
       - run:
           name: "Generate base virtual environments."
           # DEV: riot list -i tracer lists all supported Python versions
-          command: "riot list -i tracer | circleci tests split | xargs -I PY riot -P -v generate --python=PY"
+          command: "riot list -i tracer | circleci tests split | xargs -I PY riot -P -v generate --python=PY" 2>&1 | awk '{ print strftime("[%Y-%m-%d %H:%M:%S]"), $0 }'
           environment:
             CMAKE_BUILD_PARALLEL_LEVEL: 12
             PIP_VERBOSE: 3

--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -458,7 +458,7 @@ jobs:
       - run:
           name: "Generate base virtual environments."
           # DEV: riot list -i tracer lists all supported Python versions
-          command: "riot list -i tracer | circleci tests split | xargs -I PY riot -P -v generate --python=PY" 2>&1 | awk '{ print strftime("[%Y-%m-%d %H:%M:%S]"), $0 }'
+          command: "riot list -i tracer | circleci tests split | xargs -I PY riot -P -v generate --python=PY 2>&1 | awk '{ print strftime(\"[%Y-%m-%d %H:%M:%S]\"), $0 }'"
           environment:
             CMAKE_BUILD_PARALLEL_LEVEL: 12
             PIP_VERBOSE: 3

--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -451,7 +451,8 @@ jobs:
           # DEV: riot list -i tracer lists all supported Python versions
           command: "riot list -i tracer | circleci tests split | xargs -I PY riot -P -v generate --python=PY"
           environment:
-            CMAKE_BUILD_PARALLEL_LEVEL: 8
+            CMAKE_BUILD_PARALLEL_LEVEL: 12
+            PIP_VERBOSE: 3
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -36,6 +36,8 @@ machine_executor: &machine_executor
     - BOTO_CONFIG: /dev/null
     # https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded-
     - PYTHONUNBUFFERED: 1
+    - CMAKE_BUILD_PARALLEL_LEVEL: 12
+    - PIP_VERBOSE: 3
   steps:
     - run: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes -y --no-install-recommends openssh-client git
     - &pyenv-set-global
@@ -349,18 +351,30 @@ executors:
   cimg_base:
     docker:
       - image: *cimg_base_image
+        environment:
+          - CMAKE_BUILD_PARALLEL_LEVEL: 6
+          - PIP_VERBOSE: 3
     resource_class: medium
   python310:
     docker:
       - image: *python310_image
+        environment:
+          - CMAKE_BUILD_PARALLEL_LEVEL: 12
+          - PIP_VERBOSE: 3
     resource_class: large
   ddtrace_dev:
     docker:
       - image: *ddtrace_dev_image
+        environment:
+          - CMAKE_BUILD_PARALLEL_LEVEL: 6
+          - PIP_VERBOSE: 3
     resource_class: *default_resource_class
   ddtrace_dev_small:
     docker:
       - image: *ddtrace_dev_image
+        environment:
+          - CMAKE_BUILD_PARALLEL_LEVEL: 4
+          - PIP_VERBOSE: 3
     resource_class: small
 
 # Common configuration blocks as YAML anchors

--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -456,12 +456,9 @@ jobs:
       - checkout
       - setup_riot
       - run:
-          name: "Install moreutils"
-          command: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes -y --no-install-recommends moreutils
-      - run:
           name: "Generate base virtual environments."
           # DEV: riot list -i tracer lists all supported Python versions
-          command: "riot list -i tracer | circleci tests split | xargs -I PY riot -P -v generate --python=PY 2>&1 | ts"
+          command: "riot list -i tracer | circleci tests split | xargs -I PY riot -P -v generate --python=PY"
           environment:
             CMAKE_BUILD_PARALLEL_LEVEL: 12
             PIP_VERBOSE: 1


### PR DESCRIPTION
Improve library build times across all jobs by setting `CMAKE_BUILD_PARALLEL_LEVEL` in most task environments.

Current p95 `build_base_venv` duration:
![image](https://github.com/DataDog/dd-trace-py/assets/1320353/f0f46ea0-baf5-4d22-a2d4-c7c2eb47af38)


This change reduces `build_base_venvs` to <4 minutes. It also has an impact on hatch jobs (e.g. `slotscheck`, `conftests`, `build_docs`, etc).


## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
