### PR TITLE
test: core fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -536,3 +536,24 @@ def test_agent_session(telemetry_writer, request):
     finally:
         os.environ["DD_CIVISIBILITY_AGENTLESS_ENABLED"] = p_agentless
         telemetry_writer.reset_queues()
+
+
+@pytest.fixture
+def core():
+    from copy import deepcopy
+
+    import ddtrace.internal.core as _core
+    import ddtrace.internal.core.event_hub as _event_hub
+
+    # Save reference to the current state
+    old_state = _event_hub._listeners, _event_hub._all_listeners
+
+    # Make a new event hub state
+    _event_hub._listeners = deepcopy(_event_hub._listeners)
+    _event_hub._all_listeners = deepcopy(_event_hub._all_listeners)
+
+    try:
+        yield _core
+    finally:
+        # Restore the old state
+        _event_hub._listeners, _event_hub._all_listeners = old_state


### PR DESCRIPTION
We introduce a core event hub fixture for auto-cleaning event handlers registered during tests.

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
