### PR TITLE
chore(asm): remove flaky decorator and add more waf timeout

### DIFF
--- a/tests/appsec/appsec/test_processor.py
+++ b/tests/appsec/appsec/test_processor.py
@@ -19,7 +19,6 @@ from ddtrace.contrib.trace_utils import set_http_meta
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
 import tests.appsec.rules as rules
-from tests.utils import flaky
 from tests.utils import override_env
 from tests.utils import override_global_config
 from tests.utils import snapshot
@@ -322,7 +321,6 @@ def test_appsec_span_tags_snapshot(tracer):
         assert get_triggers(span)
 
 
-@flaky(1735812000)
 @snapshot(
     include_tracer=True,
     ignores=[
@@ -335,7 +333,11 @@ def test_appsec_span_tags_snapshot(tracer):
 )
 def test_appsec_span_tags_snapshot_with_errors(tracer):
     with override_global_config(
-        dict(_asm_enabled=True, _asm_static_rule_file=os.path.join(rules.ROOT_DIR, "rules-with-2-errors.json"))
+        dict(
+            _asm_enabled=True,
+            _asm_static_rule_file=os.path.join(rules.ROOT_DIR, "rules-with-2-errors.json"),
+            _waf_timeout=50_000,
+        )
     ):
         _enable_appsec(tracer)
         with _asm_request_context.asm_request_context_manager(), tracer.trace(


### PR DESCRIPTION
remove flaky decorator in tests/appsec/appsec/test_processor.py and prevent flakyness by using a large waf timeout

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
