### PR TITLE
docs: explicitly say in lib-injection docs that it doesnt require ddtrace-run

### DIFF
--- a/lib-injection/README.md
+++ b/lib-injection/README.md
@@ -6,7 +6,7 @@ container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
 which allows users to easily instrument Python applications without requiring
 changes to the application image.
 
-This Library Injection functionality can be used independently of ddtrace-run, ddtrace.auto,
+This Library Injection functionality can be used independently of `ddtrace-run`, `ddtrace.auto`,
 and any other "manual" instrumentation mechanism.
 
 ## Technical Details

--- a/lib-injection/README.md
+++ b/lib-injection/README.md
@@ -6,6 +6,11 @@ container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
 which allows users to easily instrument Python applications without requiring
 changes to the application image.
 
+This Library Injection functionality can be used independently of ddtrace-run, ddtrace.auto,
+and any other "manual" instrumentation mechanism.
+
+## Technical Details
+
 The `Dockerfile` defines the image that is published for `ddtrace` which is used
 as a Kubernetes InitContainer. Kubernetes runs it before deployment pods start.
 It is responsible for providing the files necessary to run `ddtrace` in an


### PR DESCRIPTION
This change fixes https://github.com/DataDog/dd-trace-py/issues/9606 by noting directly in the lib-injection documentation that it works without ddtrace-run and other manual instrumentation methods.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
