### PR TITLE
chore(ci): inject centos 5.11 repo mirror so we can download zip in auditwheel

### DIFF
--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -85,9 +85,6 @@ jobs:
             sed -i 's/#baseurl/baseurl/g' /etc/yum.repos.d/CentOS-fasttrack.repo &&
             sed -i '/mirrorlist/d' /etc/yum.repos.d/CentOS-fasttrack.repo &&
             sed -i 's/mirror.centos.org.centos..releasever/archive.kernel.org\/centos-vault\/5.11/g' /etc/yum.repos.d/CentOS-Base.repo &&
-            sed -i 's/#baseurl/baseurl/g' /etc/yum.repos.d/libselinux.repo &&
-            sed -i '/mirrorlist/d' /etc/yum.repos.d/libselinux.repo &&
-            sed -i 's/mirror.centos.org.centos..releasever/archive.kernel.org\/centos-vault\/5.11/g' /etc/yum.repos.d/libselinux.repo &&
             mkdir ./tempwheelhouse &&
             unzip -l {wheel} | grep '\.so' &&
             auditwheel repair -w ./tempwheelhouse {wheel} &&
@@ -134,9 +131,6 @@ jobs:
             sed -i 's/#baseurl/baseurl/g' /etc/yum.repos.d/CentOS-fasttrack.repo &&
             sed -i '/mirrorlist/d' /etc/yum.repos.d/CentOS-fasttrack.repo &&
             sed -i 's/mirror.centos.org.centos..releasever/archive.kernel.org\/centos-vault\/5.11/g' /etc/yum.repos.d/CentOS-Base.repo &&
-            sed -i 's/#baseurl/baseurl/g' /etc/yum.repos.d/libselinux.repo &&
-            sed -i '/mirrorlist/d' /etc/yum.repos.d/libselinux.repo &&
-            sed -i 's/mirror.centos.org.centos..releasever/archive.kernel.org\/centos-vault\/5.11/g' /etc/yum.repos.d/libselinux.repo &&
             mkdir ./tempwheelhouse &&
             unzip -l {wheel} | grep '\.so' &&
             auditwheel repair -w ./tempwheelhouse {wheel} &&

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -79,6 +79,15 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: rustup target add aarch64-apple-darwin
           CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: |
+            sed -i '/mirrorlist/d' /etc/yum.repos.d/CentOS-Base.repo &&
+            sed -i 's/#baseurl/baseurl/g' /etc/yum.repos.d/CentOS-Base.repo &&
+            sed -i 's/mirror.centos.org.centos..releasever/archive.kernel.org\/centos-vault\/5.11/g' /etc/yum.repos.d/CentOS-fasttrack.repo &&
+            sed -i 's/#baseurl/baseurl/g' /etc/yum.repos.d/CentOS-fasttrack.repo &&
+            sed -i '/mirrorlist/d' /etc/yum.repos.d/CentOS-fasttrack.repo &&
+            sed -i 's/mirror.centos.org.centos..releasever/archive.kernel.org\/centos-vault\/5.11/g' /etc/yum.repos.d/CentOS-Base.repo &&
+            sed -i 's/#baseurl/baseurl/g' /etc/yum.repos.d/libselinux.repo &&
+            sed -i '/mirrorlist/d' /etc/yum.repos.d/libselinux.repo &&
+            sed -i 's/mirror.centos.org.centos..releasever/archive.kernel.org\/centos-vault\/5.11/g' /etc/yum.repos.d/libselinux.repo &&
             mkdir ./tempwheelhouse &&
             unzip -l {wheel} | grep '\.so' &&
             auditwheel repair -w ./tempwheelhouse {wheel} &&
@@ -119,6 +128,15 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: rustup target add aarch64-apple-darwin
           CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: |
+            sed -i '/mirrorlist/d' /etc/yum.repos.d/CentOS-Base.repo &&
+            sed -i 's/#baseurl/baseurl/g' /etc/yum.repos.d/CentOS-Base.repo &&
+            sed -i 's/mirror.centos.org.centos..releasever/archive.kernel.org\/centos-vault\/5.11/g' /etc/yum.repos.d/CentOS-fasttrack.repo &&
+            sed -i 's/#baseurl/baseurl/g' /etc/yum.repos.d/CentOS-fasttrack.repo &&
+            sed -i '/mirrorlist/d' /etc/yum.repos.d/CentOS-fasttrack.repo &&
+            sed -i 's/mirror.centos.org.centos..releasever/archive.kernel.org\/centos-vault\/5.11/g' /etc/yum.repos.d/CentOS-Base.repo &&
+            sed -i 's/#baseurl/baseurl/g' /etc/yum.repos.d/libselinux.repo &&
+            sed -i '/mirrorlist/d' /etc/yum.repos.d/libselinux.repo &&
+            sed -i 's/mirror.centos.org.centos..releasever/archive.kernel.org\/centos-vault\/5.11/g' /etc/yum.repos.d/libselinux.repo &&
             mkdir ./tempwheelhouse &&
             unzip -l {wheel} | grep '\.so' &&
             auditwheel repair -w ./tempwheelhouse {wheel} &&

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -79,18 +79,9 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: rustup target add aarch64-apple-darwin
           CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: |
-            sed -i '/mirrorlist/d' /etc/yum.repos.d/CentOS-Base.repo &&
-            sed -i 's/#baseurl/baseurl/g' /etc/yum.repos.d/CentOS-Base.repo &&
-            sed -i 's/mirror.centos.org.centos..releasever/archive.kernel.org\/centos-vault\/5.11/g' /etc/yum.repos.d/CentOS-fasttrack.repo &&
-            sed -i 's/#baseurl/baseurl/g' /etc/yum.repos.d/CentOS-fasttrack.repo &&
-            sed -i '/mirrorlist/d' /etc/yum.repos.d/CentOS-fasttrack.repo &&
-            sed -i 's/mirror.centos.org.centos..releasever/archive.kernel.org\/centos-vault\/5.11/g' /etc/yum.repos.d/CentOS-Base.repo &&
             mkdir ./tempwheelhouse &&
-            unzip -l {wheel} | grep '\.so' &&
             auditwheel repair -w ./tempwheelhouse {wheel} &&
-            (yum install -y zip || apk add zip) &&
             for w in ./tempwheelhouse/*.whl; do
-              zip -d $w \*.c \*.cpp \*.cc \*.h \*.hpp \*.pyx
               mv $w {dest_dir}
             done &&
             rm -rf ./tempwheelhouse
@@ -125,18 +116,9 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: rustup target add aarch64-apple-darwin
           CIBW_ENVIRONMENT_LINUX: "PATH=$HOME/.cargo/bin:$PATH"
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: |
-            sed -i '/mirrorlist/d' /etc/yum.repos.d/CentOS-Base.repo &&
-            sed -i 's/#baseurl/baseurl/g' /etc/yum.repos.d/CentOS-Base.repo &&
-            sed -i 's/mirror.centos.org.centos..releasever/archive.kernel.org\/centos-vault\/5.11/g' /etc/yum.repos.d/CentOS-fasttrack.repo &&
-            sed -i 's/#baseurl/baseurl/g' /etc/yum.repos.d/CentOS-fasttrack.repo &&
-            sed -i '/mirrorlist/d' /etc/yum.repos.d/CentOS-fasttrack.repo &&
-            sed -i 's/mirror.centos.org.centos..releasever/archive.kernel.org\/centos-vault\/5.11/g' /etc/yum.repos.d/CentOS-Base.repo &&
             mkdir ./tempwheelhouse &&
-            unzip -l {wheel} | grep '\.so' &&
             auditwheel repair -w ./tempwheelhouse {wheel} &&
-            (yum install -y zip || apk add zip) &&
             for w in ./tempwheelhouse/*.whl; do
-              zip -d $w \*.c \*.cpp \*.cc \*.h \*.hpp \*.pyx
               mv $w {dest_dir}
             done &&
             rm -rf ./tempwheelhouse


### PR DESCRIPTION
1. centos 7 is EOL, so I guess this was a good time to eliminate the archived mirrors and huge swathes of infrastructure?
2. this actually isn't a huge problem somehow, but we still need to download zip

## Checklist

- [ ] Change(s) are motivated and described in the PR description
- [ ] Testing strategy is described if automated tests are not included in the PR
- [ ] Risks are described (performance impact, potential for breakage, maintainability)
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [ ] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [ ] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Description motivates each change
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Change is maintainable (easy to change, telemetry, documentation)
- [ ] Release note makes sense to a user of the library
- [ ] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
