### PR TITLE
chore(ci): parallelize build wheels

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -19,35 +19,10 @@ on:
     - cron:  0 2 * * 2-6
 
 jobs:
-  build_wheels_py37:
+  build_wheels:
     uses: ./.github/workflows/build_python_3.yml
     with:
-      cibw_build: 'cp37*'
-
-  build_wheels_py38:
-    uses: ./.github/workflows/build_python_3.yml
-    with:
-      cibw_build: 'cp38*'
-
-  build_wheels_py39:
-    uses: ./.github/workflows/build_python_3.yml
-    with:
-      cibw_build: 'cp39*'
-
-  build_wheels_py310:
-    uses: ./.github/workflows/build_python_3.yml
-    with:
-      cibw_build: 'cp310*'
-
-  build_wheels_py311:
-    uses: ./.github/workflows/build_python_3.yml
-    with:
-      cibw_build: 'cp311*'
-
-  build_wheels_py312:
-    uses: ./.github/workflows/build_python_3.yml
-    with:
-      cibw_build: 'cp312*'
+      cibw_build: 'cp37* cp38* cp39* cp310* cp311* cp312*'
 
   build_sdist:
     name: Build source distribution
@@ -103,12 +78,7 @@ jobs:
 
   upload_pypi:
     needs:
-      - build_wheels_py37
-      - build_wheels_py38
-      - build_wheels_py39
-      - build_wheels_py310
-      - build_wheels_py311
-      - build_wheels_py312
+      - build_wheels
       - test_alpine_sdist
     runs-on: ubuntu-latest
     if: (github.event_name == 'release' && github.event.action == 'published')

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -30,10 +30,10 @@ jobs:
         run: |
           MATRIX_INCLUDE=$(
             {
-              cibuildwheel --print-build-identifiers --platform linux --arch x86_64,i686 | jq -cRr '{only: ., arch: (capture("_(?<arch>x86_64|i686)$") | .arch), os: "ubuntu-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform linux --arch aarch64  | jq -cRr '{only: ., arch: (capture("_(?<arch>aarch64)$") | .arch), os: "arm-4core-linux"}' \
-              && cibuildwheel --print-build-identifiers --platform windows --arch AMD64,x86 | jq -cRr '{only: ., arch: (capture("-(?<arch>win_amd64|win32)$") | .arch), os: "windows-latest"} | if .arch == "win_amd64" then .arch = "AMD64" elif .arch == "win32" then .arch = "x86" else . end' \
-              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,universal2 | jq -cRr '{only: ., arch: (capture("_(?<arch>x86_64|universal2)$") | .arch), os: "macos-12"}'
+              cibuildwheel --print-build-identifiers --platform linux --arch x86_64,i686 | jq -cR '{only: ., os: "ubuntu-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform linux --arch aarch64  | jq -cR '{only: ., os: "arm-4core-linux"}' \
+              && cibuildwheel --print-build-identifiers --platform windows --arch AMD64,x86 | jq -cR '{only: ., os: "windows-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,universal2 | jq -cR '{only: ., os: "macos-12"}'
             } | jq -sc
           )
           echo $MATRIX_INCLUDE
@@ -84,7 +84,6 @@ jobs:
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
-          CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.only }}
           CIBW_SKIP: ${{ inputs.cibw_skip }}
           CIBW_PRERELEASE_PYTHONS: ${{ inputs.cibw_prerelease_pythons }}
@@ -123,7 +122,6 @@ jobs:
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
-          CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.only }}
           CIBW_SKIP: ${{ inputs.cibw_skip }}
           CIBW_PRERELEASE_PYTHONS: ${{ inputs.cibw_prerelease_pythons }}

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -24,9 +24,9 @@ jobs:
         with:
           python-version: '3.8'
       - run: pip install cibuildwheel==2.16.5
+      - id: set-matrix
         env:
           CIBW_BUILD: ${{ inputs.cibw_build }}
-      - id: set-matrix
         run: |
           MATRIX_INCLUDE=$(
             {

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -32,7 +32,7 @@ jobs:
             {
               cibuildwheel --print-build-identifiers --platform linux --arch x86_64,i686 | jq -cRr '{only: ., arch: (capture("_(?<arch>x86_64|i686)$") | .arch), os: "ubuntu-latest"}' \
               && cibuildwheel --print-build-identifiers --platform linux --arch aarch64  | jq -cRr '{only: ., arch: (capture("_(?<arch>aarch64)$") | .arch), os: "arm-4core-linux"}' \
-              && cibuildwheel --print-build-identifiers --platform windows --arch AMD64,x86 | jq -cRr '{only: ., arch: (capture("_(?<arch>AMD64|x86)$") | .arch), os: "windows-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform windows --arch AMD64,x86 | jq -cRr '{only: ., arch: (capture("_(?<arch>amd64|win32)$") | .arch), os: "windows-latest"}' \
               && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,universal2 | jq -cRr '{only: ., arch: (capture("_(?<arch>x86_64|universal2)$") | .arch), os: "macos-12"}'
             } | jq -sc
           )

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -158,7 +158,7 @@ jobs:
 
       - if: runner.os != 'Windows'
         run: |
-          echo "ARTIFACT_NAME=${{ matrix.only }} >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=${{ matrix.only }}" >> $GITHUB_ENV
       - if: runner.os == 'Windows'
         run: |
           chcp 65001 #set code page to utf-8

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -85,7 +85,7 @@ jobs:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BUILD: ${{ inputs.cibw_build }}
+          CIBW_BUILD: ${{ matrix.only }}
           CIBW_SKIP: ${{ inputs.cibw_skip }}
           CIBW_PRERELEASE_PYTHONS: ${{ inputs.cibw_prerelease_pythons }}
           CMAKE_BUILD_PARALLEL_LEVEL: 12
@@ -124,7 +124,7 @@ jobs:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BUILD: ${{ inputs.cibw_build }}
+          CIBW_BUILD: ${{ matrix.only }}
           CIBW_SKIP: ${{ inputs.cibw_skip }}
           CIBW_PRERELEASE_PYTHONS: ${{ inputs.cibw_prerelease_pythons }}
           CMAKE_BUILD_PARALLEL_LEVEL: 12

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -158,11 +158,11 @@ jobs:
 
       - if: runner.os != 'Windows'
         run: |
-          echo "ARTIFACT_NAME=${{ matrix.os }}-${{ matrix.arch }}-$(echo "${{ inputs.cibw_build }}" | tr -cd '[:alnum:]_-')" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=${{ matrix.only }} >> $GITHUB_ENV
       - if: runner.os == 'Windows'
         run: |
           chcp 65001 #set code page to utf-8
-          echo ("ARTIFACT_NAME=${{ matrix.os }}-${{ matrix.arch }}-${{ inputs.cibw_build }}".replace('*', '').replace(' ', '_')) >> $env:GITHUB_ENV
+          echo "ARTIFACT_NAME=${{ matrix.only }}"  >> $env:GITHUB_ENV
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ env.ARTIFACT_NAME }}

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -36,7 +36,8 @@ jobs:
               && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,universal2 | jq -cRr '{only: ., arch: (capture("_(?<arch>x86_64|universal2)$") | .arch), os: "macos-12"}'
             } | jq -sc
           )
-          echo "::set-output name=include::$MATRIX_INCLUDE"
+          echo $MATRIX_INCLUDE
+          echo "include=${MATRIX_INCLUDE}" >> $GITHUB_OUTPUT
 
   build:
     needs: build-wheels-matrix

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -80,11 +80,8 @@ jobs:
 
       - name: Build wheels arm64
         if: matrix.os == 'arm-4core-linux'
-        run: /home/runner/.local/bin/pipx run cibuildwheel==2.16.5 --platform linux
+        run: /home/runner/.local/bin/pipx run cibuildwheel==2.16.5 --only ${{ matrix.only }}
         env:
-          # configure cibuildwheel to build native archs ('auto'), and some
-          # emulated ones
-          CIBW_BUILD: ${{ matrix.only }}
           CIBW_SKIP: ${{ inputs.cibw_skip }}
           CIBW_PRERELEASE_PYTHONS: ${{ inputs.cibw_prerelease_pythons }}
           CMAKE_BUILD_PARALLEL_LEVEL: 12
@@ -119,10 +116,9 @@ jobs:
       - name: Build wheels
         if: matrix.os != 'arm-4core-linux'
         uses: pypa/cibuildwheel@v2.16.5
+        with:
+          only: ${{ matrix.only }}
         env:
-          # configure cibuildwheel to build native archs ('auto'), and some
-          # emulated ones
-          CIBW_BUILD: ${{ matrix.only }}
           CIBW_SKIP: ${{ inputs.cibw_skip }}
           CIBW_PRERELEASE_PYTHONS: ${{ inputs.cibw_prerelease_pythons }}
           CMAKE_BUILD_PARALLEL_LEVEL: 12

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -32,7 +32,7 @@ jobs:
             {
               cibuildwheel --print-build-identifiers --platform linux --arch x86_64,i686 | jq -cRr '{only: ., arch: (capture("_(?<arch>x86_64|i686)$") | .arch), os: "ubuntu-latest"}' \
               && cibuildwheel --print-build-identifiers --platform linux --arch aarch64  | jq -cRr '{only: ., arch: (capture("_(?<arch>aarch64)$") | .arch), os: "arm-4core-linux"}' \
-              && cibuildwheel --print-build-identifiers --platform windows --arch AMD64,x86 | jq -cRr '{only: ., arch: (capture("_(?<arch>amd64|win32)$") | .arch), os: "windows-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform windows --arch AMD64,x86 | jq -cRr '{only: ., arch: (capture("-(?<arch>win_amd64|win32)$") | .arch), os: "windows-latest"} | if .arch == "win_amd64" then .arch = "AMD64" elif .arch == "win32" then .arch = "x86" else . end' \
               && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,universal2 | jq -cRr '{only: ., arch: (capture("_(?<arch>x86_64|universal2)$") | .arch), os: "macos-12"}'
             } | jq -sc
           )

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -34,7 +34,7 @@ jobs:
               && cibuildwheel --print-build-identifiers --platform linux --arch aarch64  | jq -cRr '{only: ., arch: (capture("_(?<arch>aarch64)$") | .arch), os: "arm-4core-linux"}' \
               && cibuildwheel --print-build-identifiers --platform windows --arch AMD64,x86 | jq -cRr '{only: ., arch: (capture("_(?<arch>AMD64|x86)$") | .arch), os: "windows-latest"}' \
               && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,universal2 | jq -cRr '{only: ., arch: (capture("_(?<arch>x86_64|universal2)$") | .arch), os: "macos-12"}'
-            } | jq - sc
+            } | jq -sc
           )
           echo "::set-output name=include::$MATRIX_INCLUDE"
 

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -14,19 +14,38 @@ on:
         type: string
 
 jobs:
+  build-wheels-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{steps.set-matrix.outputs.include}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+      - run: pip install cibuildwheel==2.16.5
+        env:
+          CIBW_BUILD: ${{ inputs.cibw_build }}
+      - id: set-matrix
+        run: |
+          MATRIX_INCLUDE=$(
+            {
+              cibuildwheel --print-build-identifiers --platform linux --arch x86_64,i686 | jq -cRr '{only: ., arch: (capture("_(?<arch>x86_64|i686)$") | .arch), os: "ubuntu-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform linux --arch aarch64  | jq -cRr '{only: ., arch: (capture("_(?<arch>aarch64)$") | .arch), os: "arm-4core-linux"}' \
+              && cibuildwheel --print-build-identifiers --platform windows --arch AMD64,x86 | jq -cRr '{only: ., arch: (capture("_(?<arch>AMD64|x86)$") | .arch), os: "windows-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,universal2 | jq -cRr '{only: ., arch: (capture("_(?<arch>x86_64|universal2)$") | .arch), os: "macos-12"}'
+            } | jq - sc
+          )
+          echo "::set-output name=include::$MATRIX_INCLUDE"
+
   build:
+    needs: build-wheels-matrix
     runs-on: ${{ matrix.os }}
+    name: Build ${{ matrix.only }}
     strategy:
       matrix:
-        include:
-         - os: ubuntu-latest
-           archs: x86_64 i686
-         - os: arm-4core-linux
-           archs: aarch64
-         - os: windows-latest
-           archs: AMD64 x86
-         - os: macos-12
-           archs: x86_64 universal2
+        include: ${{ fromJson(needs.build-wheels-matrix.outputs.include) }}
+
     steps:
       - uses: actions/checkout@v4
         # Include all history and tags
@@ -64,7 +83,7 @@ jobs:
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
-          CIBW_ARCHS: ${{ matrix.archs }}
+          CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ inputs.cibw_build }}
           CIBW_SKIP: ${{ inputs.cibw_skip }}
           CIBW_PRERELEASE_PYTHONS: ${{ inputs.cibw_prerelease_pythons }}
@@ -103,7 +122,7 @@ jobs:
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
-          CIBW_ARCHS: ${{ matrix.archs }}
+          CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ inputs.cibw_build }}
           CIBW_SKIP: ${{ inputs.cibw_skip }}
           CIBW_PRERELEASE_PYTHONS: ${{ inputs.cibw_prerelease_pythons }}
@@ -138,11 +157,11 @@ jobs:
 
       - if: runner.os != 'Windows'
         run: |
-          echo "ARTIFACT_NAME=${{ matrix.os }}-${{ matrix.archs }}-$(echo "${{ inputs.cibw_build }}" | tr -cd '[:alnum:]_-')" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=${{ matrix.os }}-${{ matrix.arch }}-$(echo "${{ inputs.cibw_build }}" | tr -cd '[:alnum:]_-')" >> $GITHUB_ENV
       - if: runner.os == 'Windows'
         run: |
           chcp 65001 #set code page to utf-8
-          echo ("ARTIFACT_NAME=${{ matrix.os }}-${{ matrix.archs }}-${{ inputs.cibw_build }}".replace('*', '').replace(' ', '_')) >> $env:GITHUB_ENV
+          echo ("ARTIFACT_NAME=${{ matrix.os }}-${{ matrix.arch }}-${{ inputs.cibw_build }}".replace('*', '').replace(' ', '_')) >> $env:GITHUB_ENV
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ env.ARTIFACT_NAME }}


### PR DESCRIPTION
Parallelize building wheel using unique identifier used by cibuildwheel, which is a combination of python version, target OS, and target architecture. 

We've been building wheels in parallel across OS's used for builds, as defined [here](https://github.com/DataDog/dd-trace-py/blob/bc14f9f982f1412ed16774d13d210de696e4525b/.github/workflows/build_python_3.yml#L20-L29). For `ubuntu-latest`, it has to build all combinations of `[manylinux, musllinux] * [x86_64, i686]` in serial, which takes about ~[23 mins](https://github.com/DataDog/dd-trace-py/actions/runs/9783802837/job/27013245565). 

However, when split into unique identifier, the slowest one takes about ~9 mins. 

To reviewer: We'd need to change the set of required CI checks from previous set of build_wheels to these new ones. Please let me know how I can do this.


## Checklist

- [x] The PR description includes an overview of the change
- [x] The PR description articulates the motivation for the change
- [x] The change includes tests OR the PR description describes a testing strategy
- [x] The PR description notes risks associated with the change, if any
- [x] Newly-added code is easy to change
- [x] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [x] The change includes or references documentation updates if necessary
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Newly-added code is easy to change
- [x] Release note makes sense to a user of the library
- [x] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
