### PR TITLE
chore(telemetry): hardcode telemetry heartbeat interval

### DIFF
--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -467,7 +467,6 @@ class Config(object):
         self.health_metrics_enabled = asbool(os.getenv("DD_TRACE_HEALTH_METRICS_ENABLED", default=False))
 
         self._telemetry_enabled = asbool(os.getenv("DD_INSTRUMENTATION_TELEMETRY_ENABLED", True))
-        self._telemetry_heartbeat_interval = float(os.getenv("DD_TELEMETRY_HEARTBEAT_INTERVAL", "60"))
         self._telemetry_dependency_collection = asbool(os.getenv("DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED", True))
 
         self._runtime_metrics_enabled = asbool(os.getenv("DD_RUNTIME_METRICS_ENABLED", False))


### PR DESCRIPTION
Telemetry logs and metrics must be queued every 10 seconds. Telemetry heartbeat events must be queued and sent every 60 seconds. Currently these intervals can be modified by setting  `DD_TELEMETRY_HEARTBEAT_INTERVAL`. We should NOT provide user's with the ability to modify these intervals. This will break aggregations and monitors in internal services. 

## Checklist

- [ ] The PR description includes an overview of the change
- [ ] The PR description articulates the motivation for the change
- [ ] The change includes tests OR the PR description describes a testing strategy
- [ ] The PR description notes risks associated with the change, if any
- [ ] Newly-added code is easy to change
- [ ] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [ ] The change includes or references documentation updates if necessary
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Newly-added code is easy to change
- [ ] Release note makes sense to a user of the library
- [ ] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
