### PR TITLE
chore(tracer): remove attr and cattr from remoteconfig

### DIFF
--- a/ddtrace/internal/remoteconfig/_publishers.py
+++ b/ddtrace/internal/remoteconfig/_publishers.py
@@ -1,5 +1,6 @@
 import abc
 import copy
+import dataclasses
 import os
 from typing import TYPE_CHECKING  # noqa:F401
 
@@ -64,7 +65,7 @@ class RemoteConfigPublisher(RemoteConfigPublisherBase):
         log.debug("[%s][P: %s] Publisher publish data: %s", os.getpid(), os.getppid(), self._config_and_metadata)
 
         self._data_connector.write(
-            [metadata.asdict() if metadata else None for _, metadata in self._config_and_metadata],
+            [dataclasses.asdict(metadata) if metadata else None for _, metadata in self._config_and_metadata],
             [config for config, _ in self._config_and_metadata],
         )
         self._config_and_metadata = []

--- a/ddtrace/internal/remoteconfig/_publishers.py
+++ b/ddtrace/internal/remoteconfig/_publishers.py
@@ -55,7 +55,6 @@ class RemoteConfigPublisher(RemoteConfigPublisherBase):
 
     def dispatch(self, pubsub_instance=None):
         # type: (Optional[Any]) -> None
-        from attr import asdict
 
         # TODO: RemoteConfigPublisher doesn't need _preprocess_results_func callback at this moment. Uncomment those
         #  lines if a new product need it
@@ -65,7 +64,7 @@ class RemoteConfigPublisher(RemoteConfigPublisherBase):
         log.debug("[%s][P: %s] Publisher publish data: %s", os.getpid(), os.getppid(), self._config_and_metadata)
 
         self._data_connector.write(
-            [asdict(metadata) if metadata else None for _, metadata in self._config_and_metadata],
+            [metadata.asdict() if metadata else None for _, metadata in self._config_and_metadata],
             [config for config, _ in self._config_and_metadata],
         )
         self._config_and_metadata = []

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -130,7 +130,8 @@ class Root:
     version: int
 
     def __post_init__(self):
-        assert self._type == "root"
+        if self._type != "root":
+            raise ValueError("Root: invalid root type")
         if isinstance(self.expires, str):
             self.expires = parse_isoformat(self.expires)
         for k, v in self.keys.items():
@@ -171,8 +172,10 @@ class Targets:
     version: int
 
     def __post_init__(self):
-        assert self._type == "targets"
-        assert self.spec_version in ("1.0", "1.0.0")
+        if self._type != "targets":
+            raise ValueError("Targets: invalid targets type")
+        if self.spec_version not in ("1.0", "1.0.0"):
+            raise ValueError("Targets: invalid spec version")
         if isinstance(self.expires, str):
             self.expires = parse_isoformat(self.expires)
         for k, v in self.targets.items():

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -142,7 +142,7 @@ class Root:
 
 
 @dataclasses.dataclass
-class SignedRoot(object):
+class SignedRoot:
     signatures: List[Signature]
     signed: Root
 
@@ -155,14 +155,14 @@ class SignedRoot(object):
 
 
 @dataclasses.dataclass
-class TargetDesc(object):
+class TargetDesc:
     length: int
     hashes: Mapping[str, str]
     custom: Mapping[str, Any]
 
 
 @dataclasses.dataclass
-class Targets(object):
+class Targets:
     _type: str
     custom: Mapping[str, Any]
     expires: datetime
@@ -181,7 +181,7 @@ class Targets(object):
 
 
 @dataclasses.dataclass
-class SignedTargets(object):
+class SignedTargets:
     signatures: List[Signature]
     signed: Targets
 
@@ -194,13 +194,13 @@ class SignedTargets(object):
 
 
 @dataclasses.dataclass
-class TargetFile(object):
+class TargetFile:
     path: str
     raw: str
 
 
 @dataclasses.dataclass
-class AgentPayload(object):
+class AgentPayload:
     roots: List[SignedRoot]
     targets: SignedTargets
     target_files: List[TargetFile] = dataclasses.field(default_factory=list)
@@ -221,7 +221,7 @@ AppliedConfigType = Dict[str, ConfigMetadata]
 TargetsType = Dict[str, ConfigMetadata]
 
 
-class RemoteConfigClient(object):
+class RemoteConfigClient:
     """
     The Remote Configuration client regularly checks for updates on the agent
     and dispatches configurations to registered products.

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -84,10 +84,6 @@ class RemoteConfigError(Exception):
     """
 
 
-def _base64_to_struct(val, cls):
-    return json.loads(base64.b64decode(val))
-
-
 @dataclasses.dataclass
 class ConfigMetadata:
     """

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -1,4 +1,5 @@
 import base64
+import dataclasses
 from datetime import datetime
 import enum
 import hashlib
@@ -14,8 +15,6 @@ from typing import Optional  # noqa:F401
 from typing import Set  # noqa:F401
 import uuid
 
-import attr
-import cattr
 from envier import En
 
 import ddtrace
@@ -85,93 +84,141 @@ class RemoteConfigError(Exception):
     """
 
 
-@attr.s
-class ConfigMetadata(object):
+def _base64_to_struct(val, cls):
+    return json.loads(base64.b64decode(val))
+
+
+@dataclasses.dataclass
+class ConfigMetadata:
     """
     Configuration TUF target metadata
     """
 
-    id = attr.ib(type=str)
-    product_name = attr.ib(type=str)
-    sha256_hash = attr.ib(type=Optional[str])
-    length = attr.ib(type=Optional[int])
-    tuf_version = attr.ib(type=Optional[int])
-    apply_state = attr.ib(type=Optional[int], default=1, eq=False)
-    apply_error = attr.ib(type=Optional[str], default=None, eq=False)
+    id: str
+    product_name: str
+    sha256_hash: Optional[str]
+    length: Optional[int]
+    tuf_version: Optional[int]
+    apply_state: Optional[int] = dataclasses.field(default=1, compare=False)
+    apply_error: Optional[str] = dataclasses.field(default=None, compare=False)
 
 
-@attr.s
-class Signature(object):
-    keyid = attr.ib(type=str)
-    sig = attr.ib(type=str)
+@dataclasses.dataclass
+class Signature:
+    keyid: str
+    sig: str
 
 
-@attr.s
-class Key(object):
-    keytype = attr.ib(type=str)
-    keyid_hash_algorithms = attr.ib(type=List[str])
-    keyval = attr.ib(type=Mapping)
-    scheme = attr.ib(type=str)
+@dataclasses.dataclass
+class Key:
+    keytype: str
+    keyid_hash_algorithms: List[str]
+    keyval: Mapping
+    scheme: str
 
 
-@attr.s
-class Role(object):
-    keyids = attr.ib(type=List[str])
-    threshold = attr.ib(type=int)
+@dataclasses.dataclass
+class Role:
+    keyids: List[str]
+    threshold: int
 
 
-@attr.s
-class Root(object):
-    _type = attr.ib(type=str, validator=attr.validators.in_(("root",)))
-    spec_version = attr.ib(type=str)
-    consistent_snapshot = attr.ib(type=bool)
-    expires = attr.ib(type=datetime, converter=parse_isoformat)
-    keys = attr.ib(type=Mapping[str, Key])
-    roles = attr.ib(type=Mapping[str, Role])
-    version = attr.ib(type=int)
+@dataclasses.dataclass
+class Root:
+    _type: str
+    spec_version: str
+    consistent_snapshot: bool
+    expires: datetime
+    keys: Mapping[str, Key]
+    roles: Mapping[str, Role]
+    version: int
+
+    def __post_init__(self):
+        assert self._type == "root"
+        if isinstance(self.expires, str):
+            self.expires = parse_isoformat(self.expires)
+        for k, v in self.keys.items():
+            if isinstance(v, dict):
+                self.keys[k] = Key(**v)
+        for k, v in self.roles.items():
+            if isinstance(v, dict):
+                self.roles[k] = Role(**v)
 
 
-@attr.s
+@dataclasses.dataclass
 class SignedRoot(object):
-    signatures = attr.ib(type=List[Signature])
-    signed = attr.ib(type=Root)
+    signatures: List[Signature]
+    signed: Root
+
+    def __post_init__(self):
+        for i in range(len(self.signatures)):
+            if isinstance(self.signatures[i], dict):
+                self.signatures[i] = Signature(**self.signatures[i])
+        if isinstance(self.signed, dict):
+            self.signed = Root(**self.signed)
 
 
-@attr.s
+@dataclasses.dataclass
 class TargetDesc(object):
-    length = attr.ib(type=int)
-    hashes = attr.ib(type=Mapping[str, str])
-    custom = attr.ib(type=Mapping[str, Any])
+    length: int
+    hashes: Mapping[str, str]
+    custom: Mapping[str, Any]
 
 
-@attr.s
+@dataclasses.dataclass
 class Targets(object):
-    _type = attr.ib(type=str, validator=attr.validators.in_(("targets",)))
-    custom = attr.ib(type=Mapping[str, Any])
-    expires = attr.ib(type=datetime, converter=parse_isoformat)
-    spec_version = attr.ib(type=str, validator=attr.validators.in_(("1.0", "1.0.0")))
-    targets = attr.ib(type=Mapping[str, TargetDesc])
-    version = attr.ib(type=int)
+    _type: str
+    custom: Mapping[str, Any]
+    expires: datetime
+    spec_version: str
+    targets: Mapping[str, TargetDesc]
+    version: int
+
+    def __post_init__(self):
+        assert self._type == "targets"
+        assert self.spec_version in ("1.0", "1.0.0")
+        if isinstance(self.expires, str):
+            self.expires = parse_isoformat(self.expires)
+        for k, v in self.targets.items():
+            if isinstance(v, dict):
+                self.targets[k] = TargetDesc(**v)
 
 
-@attr.s
+@dataclasses.dataclass
 class SignedTargets(object):
-    signatures = attr.ib(type=List[Signature])
-    signed = attr.ib(type=Targets)
+    signatures: List[Signature]
+    signed: Targets
+
+    def __post_init__(self):
+        for i in range(len(self.signatures)):
+            if isinstance(self.signatures[i], dict):
+                self.signatures[i] = Signature(**self.signatures[i])
+        if isinstance(self.signed, dict):
+            self.signed = Targets(**self.signed)
 
 
-@attr.s
+@dataclasses.dataclass
 class TargetFile(object):
-    path = attr.ib(type=str)
-    raw = attr.ib(type=str)
+    path: str
+    raw: str
 
 
-@attr.s
+@dataclasses.dataclass
 class AgentPayload(object):
-    roots = attr.ib(type=List[SignedRoot], default=None)
-    targets = attr.ib(type=SignedTargets, default=None)
-    target_files = attr.ib(type=List[TargetFile], default=[])
-    client_configs = attr.ib(type=Set[str], default=set())
+    roots: List[SignedRoot]
+    targets: SignedTargets
+    target_files: List[TargetFile] = dataclasses.field(default_factory=list)
+    client_configs: Set[str] = dataclasses.field(default_factory=set)
+
+    def __post_init__(self):
+        for i in range(len(self.roots)):
+            if isinstance(self.roots[i], str):
+                self.roots[i] = SignedRoot(**json.loads(base64.b64decode(self.roots[i])))
+        if isinstance(self.targets, str):
+            self.targets = SignedTargets(**json.loads(base64.b64decode(self.targets)))
+        for i in range(len(self.target_files)):
+            if isinstance(self.target_files[i], dict):
+                self.target_files[i] = TargetFile(**self.target_files[i])
 
 
 AppliedConfigType = Dict[str, ConfigMetadata]
@@ -221,21 +268,6 @@ class RemoteConfigClient(object):
             tags=[":".join(_) for _ in tags.items()],
         )
         self.cached_target_files = []  # type: List[AppliedConfigType]
-        self.converter = cattr.Converter()
-
-        # cattrs doesn't implement datetime converter in Py27, we should register
-        def date_to_fromisoformat(val, cls):
-            return val
-
-        self.converter.register_structure_hook(datetime, date_to_fromisoformat)
-
-        def base64_to_struct(val, cls):
-            raw = base64.b64decode(val)
-            obj = json.loads(raw)
-            return self.converter.structure_attrs_fromdict(obj, cls)
-
-        self.converter.register_structure_hook(SignedRoot, base64_to_struct)
-        self.converter.register_structure_hook(SignedTargets, base64_to_struct)
 
         self._products = dict()  # type: MutableMapping[str, PubSub]
         self._applied_configs = dict()  # type: AppliedConfigType
@@ -545,7 +577,9 @@ class RemoteConfigClient(object):
     def _process_response(self, data):
         # type: (Mapping[str, Any]) -> None
         try:
-            payload = self.converter.structure_attrs_fromdict(data, AgentPayload)
+            print(">>>> parsing")
+            payload = AgentPayload(**data)
+            print(f">>>> parsed {payload}")
         except Exception as e:
             log.debug("invalid agent payload received: %r", data, exc_info=True)
             msg = f"invalid agent payload received: {e}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "bytecode>=0.15.0; python_version>='3.12'",
     "bytecode>=0.14.0; python_version~='3.11.0'",
     "bytecode>=0.13.0; python_version<'3.11'",
-    "cattrs",
     "ddsketch>=3.0.0",
     "envier~=0.5",
     "importlib_metadata<=6.5.0; python_version<'3.8'",


### PR DESCRIPTION
Remove dependencies to `attrs` and `cattrs` in remoteconfig.

- Use dataclasses
- use post_init to simulate validators and parsers

After that PR, `cattrs` is **no longer used** in ddtrace and removed from install dependencies

## Checklist

- [x] The PR description includes an overview of the change
- [x] The PR description articulates the motivation for the change
- [x] The change includes tests OR the PR description describes a testing strategy
- [x] The PR description notes risks associated with the change, if any
- [x] Newly-added code is easy to change
- [x] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [x] The change includes or references documentation updates if necessary
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Newly-added code is easy to change
- [x] Release note makes sense to a user of the library
- [x] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
