### PR TITLE
Unable to export events due to invalid path value from events. #9717

### DIFF
--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -202,7 +202,7 @@ def filename_to_package(filename: t.Union[str, Path]) -> t.Optional[Distribution
 
     try:
         path = Path(filename) if isinstance(filename, str) else filename
-        return mapping.get(_root_module(path.resolve()))
+        return mapping.get(_root_module(path.resolve())) if path.is_file() else None
     except ValueError:
         return None
 

--- a/tests/internal/test_packages.py
+++ b/tests/internal/test_packages.py
@@ -67,6 +67,7 @@ def test_filename_to_package_invalid_path(packages):
     package = packages.filename_to_package("<string>")
     assert package is None
 
+
 def test_filename_to_package(packages):
     # type: (...) -> None
     package = packages.filename_to_package(packages.__file__)

--- a/tests/internal/test_packages.py
+++ b/tests/internal/test_packages.py
@@ -63,6 +63,10 @@ def test_get_distributions():
     assert pkg_resources_ws == importlib_pkgs
 
 
+def test_filename_to_package_invalid_path(packages):
+    package = packages.filename_to_package("<string>")
+    assert package is None
+
 def test_filename_to_package(packages):
     # type: (...) -> None
     package = packages.filename_to_package(packages.__file__)


### PR DESCRIPTION
## Overview
While integrating DataDog library in FastAPI Application, the events are not exported to the dd-agent. The exception occurs for different values of module path, where the value is not a valid path rather string representation of type/object. 

## Changes
- If condition to test valid file path is added before resolving the path.

## Checklist

- [x] The PR description includes an overview of the change
- [x] The PR description articulates the motivation for the change
- [x] The change includes tests OR the PR description describes a testing strategy
- [x] The PR description notes risks associated with the change, if any
- [x] Newly-added code is easy to change
- [x] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [x] The change includes or references documentation updates if necessary
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Newly-added code is easy to change
- [ ] Release note makes sense to a user of the library
- [ ] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
