### PR TITLE
fix(internal): catch pathlib OSError in packages.py

### DIFF
--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -205,6 +205,8 @@ def filename_to_package(filename: t.Union[str, Path]) -> t.Optional[Distribution
         return mapping.get(_root_module(path.resolve()))
     except ValueError:
         return None
+    except OSError:
+        return None
 
 
 @cached()

--- a/releasenotes/notes/fix_packages_oserror-b8da190cea6997de.yaml
+++ b/releasenotes/notes/fix_packages_oserror-b8da190cea6997de.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    internal: fixes an issue where some pathlib functions return OSError on Windows.

--- a/tests/internal/test_packages.py
+++ b/tests/internal/test_packages.py
@@ -80,6 +80,11 @@ def test_filename_to_package(packages):
     package = packages.filename_to_package(gp.__file__)
     assert package.name == "protobuf"
 
+    try:
+        package = packages.filename_to_package("You may be wondering how I got here even though I am not a file.")
+    except Exception:
+        pytest.fail("filename_to_package should not raise an exception when given a non-file path")
+
 
 def test_third_party_packages():
     assert 4000 < len(_third_party_packages()) < 5000


### PR DESCRIPTION
This should fix the issue reported in #9718 , whereby pathlib propagates an OSError from the underlying WindowsPath implementation.  This is an allowed error as per the [docs](https://docs.python.org/3/library/pathlib.html#pathlib.WindowsPath).

I'm proposing a test for this, but I'm actually unable to validate the fix since I don't have the means to test this without significant investment.  Hopefully a reviewer can suggest something...

## Checklist

- [x] The PR description includes an overview of the change
- [x] The PR description articulates the motivation for the change
- [x] The change includes tests OR the PR description describes a testing strategy
- [x] The PR description notes risks associated with the change, if any
- [x] Newly-added code is easy to change
- [x] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [x] The change includes or references documentation updates if necessary
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Newly-added code is easy to change
- [x] Release note makes sense to a user of the library
- [x] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
