### PR TITLE
fix(profiling): fix encoding-related issues in stack v2 [backport 2.9] (#9501)

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/interface.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/interface.hpp
@@ -56,6 +56,7 @@ extern "C"
                          std::string_view _filename,
                          uint64_t address,
                          int64_t line);
+    void ddup_push_monotonic_ns(Datadog::Sample* sample, int64_t monotonic_ns);
     void ddup_flush_sample(Datadog::Sample* sample);
     void ddup_drop_sample(Datadog::Sample* sample);
 

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profile.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profile.hpp
@@ -76,6 +76,6 @@ class Profile
     const ValueIndex& val();
 
     // collect
-    bool collect(const ddog_prof_Sample& sample);
+    bool collect(const ddog_prof_Sample& sample, int64_t endtime_ns);
 };
 } // namespace Datadog

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
@@ -25,6 +25,12 @@ class Sample
     SampleType type_mask;
     std::string errmsg;
 
+    // Timeline support works by endowing each sample with a timestamp. Collection of this data this data is cheap, but
+    // due to the underlying pprof format, timeline support increases the sample cardinality. Rather than switching
+    // around the frontend code too much, we push enablement down to whether or not timestamps get added to samples (a
+    // 0 value suppresses the tag). However, Sample objects are short-lived, so we make the flag static.
+    static inline bool timeline_enabled = false;
+
     // Keeps temporary buffer of frames in the stack
     std::vector<ddog_prof_Location> locations;
     size_t dropped_frames = 0;
@@ -35,6 +41,9 @@ class Sample
 
     // Storage for values
     std::vector<int64_t> values = {};
+
+    // Additional metadata
+    int64_t endtime_ns = 0; // end of the event
 
   public:
     // Helpers
@@ -62,6 +71,11 @@ class Sample
     bool push_trace_resource_container(std::string_view trace_resource_container);
     bool push_exceptioninfo(std::string_view exception_type, int64_t count);
     bool push_class_name(std::string_view class_name);
+    bool push_monotonic_ns(int64_t monotonic_ns);
+
+    // Interacts with static Sample state
+    bool is_timeline_enabled() const;
+    static void set_timeline(bool enabled);
 
     // Assumes frames are pushed in leaf-order
     void push_frame(std::string_view name,     // for ddog_prof_Function

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/interface.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/interface.cpp
@@ -248,6 +248,12 @@ ddup_push_frame(Datadog::Sample* sample, // cppcheck-suppress unusedFunction
 }
 
 void
+ddup_push_monotonic_ns(Datadog::Sample* sample, int64_t monotonic_ns)
+{
+    sample->push_monotonic_ns(monotonic_ns);
+}
+
+void
 ddup_flush_sample(Datadog::Sample* sample) // cppcheck-suppress unusedFunction
 {
     sample->flush_sample();

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profile.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profile.cpp
@@ -184,11 +184,11 @@ Datadog::Profile::val()
 }
 
 bool
-Datadog::Profile::collect(const ddog_prof_Sample& sample)
+Datadog::Profile::collect(const ddog_prof_Sample& sample, int64_t endtime_ns)
 {
     // TODO this should propagate some kind of timestamp for timeline support
     const std::lock_guard<std::mutex> lock(profile_mtx);
-    auto res = ddog_prof_Profile_add(&cur_profile, sample, 0);
+    auto res = ddog_prof_Profile_add(&cur_profile, sample, endtime_ns);
     if (!res.ok) {          // NOLINT (cppcoreguidelines-pro-type-union-access)
         auto err = res.err; // NOLINT (cppcoreguidelines-pro-type-union-access)
         const std::string errmsg = err_to_msg(&err, "Error adding sample to profile");

--- a/ddtrace/internal/datadog/profiling/stack_v2/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/stack_v2/CMakeLists.txt
@@ -26,7 +26,7 @@ if (NOT Python3_INCLUDE_DIRS)
 endif()
 
 # Add echion
-set(ECHION_COMMIT "d69048b63e7d49091659964915eb52ff0ced9fc8" CACHE STRING "Commit hash of echion to use")
+set(ECHION_COMMIT "b2f2d49f2f5d5c4dd78d1d9b83280db8ac2949c0" CACHE STRING "Commit hash of echion to use")
 FetchContent_Declare(
     echion
     GIT_REPOSITORY "https://github.com/sanchda/echion.git"

--- a/ddtrace/internal/datadog/profiling/stack_v2/include/stack_renderer.hpp
+++ b/ddtrace/internal/datadog/profiling/stack_v2/include/stack_renderer.hpp
@@ -16,9 +16,24 @@
 
 namespace Datadog {
 
+struct ThreadState
+{
+    // Current thread info.  Keeping one instance of this per StackRenderer is sufficient because the renderer visits
+    // threads one at a time.
+    // The only time this information is revealed is when the sampler observes a thread. When the sampler goes on to
+    // process tasks, it needs to place thread-level information in the Sample.
+    uintptr_t id = 0;
+    unsigned long native_id = 0;
+    std::string name;
+    microsecond_t wall_time_ns = 0;
+    microsecond_t cpu_time_ns = 0;
+    int64_t now_time_ns = 0;
+};
+
 class StackRenderer : public RendererInterface
 {
     Sample* sample = nullptr;
+    ThreadState thread_state = {};
 
     virtual void render_message(std::string_view msg) override;
     virtual void render_thread_begin(PyThreadState* tstate,
@@ -26,7 +41,7 @@ class StackRenderer : public RendererInterface
                                      microsecond_t wall_time_us,
                                      uintptr_t thread_id,
                                      unsigned long native_id) override;
-
+    virtual void render_task_begin(std::string_view name);
     virtual void render_stack_begin() override;
     virtual void render_python_frame(std::string_view name, std::string_view file, uint64_t line) override;
     virtual void render_native_frame(std::string_view name, std::string_view file, uint64_t line) override;

--- a/releasenotes/notes/fix-stack-v2-task-encoding-447f39478749027c.yaml
+++ b/releasenotes/notes/fix-stack-v2-task-encoding-447f39478749027c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: Fixes an issue where task information coming from echion was
+    encoded improperly, which could segfault the application.

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,6 @@ HERE = Path(__file__).resolve().parent
 
 DEBUG_COMPILE = "DD_COMPILE_DEBUG" in os.environ
 
-# stack_v2 profiling extensions are optional, unless they are made explicitly required by this environment variable
-STACK_V2_REQUIRED = "DD_STACK_V2_REQUIRED" in os.environ
-
 IS_PYSTON = hasattr(sys, "pyston_version_info")
 
 LIBDDWAF_DOWNLOAD_DIR = HERE / "ddtrace" / "appsec" / "_ddwaf" / "libddwaf"
@@ -448,7 +445,7 @@ if not IS_PYSTON:
                     "-DPY_MINOR_VERSION={}".format(sys.version_info.minor),
                     "-DPY_MICRO_VERSION={}".format(sys.version_info.micro),
                 ],
-                optional=not STACK_V2_REQUIRED,
+                optional=False,
             )
         )
 
@@ -458,7 +455,7 @@ if not IS_PYSTON:
                 CMakeExtension(
                     "ddtrace.internal.datadog.profiling.stack_v2._stack_v2",
                     source_dir=STACK_V2_DIR,
-                    optional=not STACK_V2_REQUIRED,
+                    optional=False,
                 ),
             )
 


### PR DESCRIPTION
Backport da759a93a772d88120f4983d7fdf8c34699152f2 from #9501 to 2.8.

This adjusts the stack V2 API in order to conform to the new proposed echion renderer.  This also fixes an encoding error in stack V2 which was caused by the old task renderer.

## Checklist

- [x] The PR description includes an overview of the change
- [x] The PR description articulates the motivation for the change
- [x] The change includes tests OR the PR description describes a testing strategy
- [x] The PR description notes risks associated with the change, if any
- [x] Newly-added code is easy to change
- [x] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [x] The change includes or references documentation updates if necessary
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Newly-added code is easy to change
- [x] Release note makes sense to a user of the library
- [x] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
