### PR TITLE
chore(ci): deal with missing zip dependency [backport 2.10]

### DIFF
--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -82,9 +82,8 @@ jobs:
             mkdir ./tempwheelhouse &&
             unzip -l {wheel} | grep '\.so' &&
             auditwheel repair -w ./tempwheelhouse {wheel} &&
-            (yum install -y zip || apk add zip) &&
             for w in ./tempwheelhouse/*.whl; do
-              zip -d $w \*.c \*.cpp \*.cc \*.h \*.hpp \*.pyx
+              python scripts/zip_filter.py $w \*.c \*.cpp \*.cc \*.h \*.hpp \*.pyx
               mv $w {dest_dir}
             done &&
             rm -rf ./tempwheelhouse
@@ -122,9 +121,8 @@ jobs:
             mkdir ./tempwheelhouse &&
             unzip -l {wheel} | grep '\.so' &&
             auditwheel repair -w ./tempwheelhouse {wheel} &&
-            (yum install -y zip || apk add zip) &&
             for w in ./tempwheelhouse/*.whl; do
-              zip -d $w \*.c \*.cpp \*.cc \*.h \*.hpp \*.pyx
+              python scripts/zip_filter.py $w \*.c \*.cpp \*.cc \*.h \*.hpp \*.pyx
               mv $w {dest_dir}
             done &&
             rm -rf ./tempwheelhouse

--- a/scripts/zip_filter.py
+++ b/scripts/zip_filter.py
@@ -1,0 +1,29 @@
+import argparse
+import fnmatch
+import os
+import zipfile
+
+
+def remove_from_zip(zip_filename, patterns):
+    temp_zip_filename = f"{zip_filename}.tmp"
+    with zipfile.ZipFile(zip_filename, "r") as source_zip, zipfile.ZipFile(
+        temp_zip_filename, "w", zipfile.ZIP_DEFLATED
+    ) as temp_zip:
+        files_to_keep = (
+            file for file in source_zip.namelist() if not any(fnmatch.fnmatch(file, pattern) for pattern in patterns)
+        )
+        for file in files_to_keep:
+            temp_zip.writestr(file, source_zip.read(file))
+    os.replace(temp_zip_filename, zip_filename)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Remove specified file types from a ZIP archive.")
+    parser.add_argument("zipfile", help="Name of the ZIP file.")
+    parser.add_argument("patterns", nargs="+", help="File patterns to remove from the ZIP file.")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    remove_from_zip(args.zipfile, args.patterns)


### PR DESCRIPTION
Backport for https://github.com/DataDog/dd-trace-py/pull/9697

It looks like the centos project has decomissioned the package repositories for centos 5 and 7. Since our cibuildwheel configuration has us stripping source files out of the wheel during the repairwheel phase, this breaks our CI as we rely on centos.

The centos thing will probably emerge as a significant issue, but I noticed that the manylinux docker image has the `zipfile` library, so I wrote a drop-in replacement for our use of `zip -d`. Looks like it works.

## Checklist

- [x] Change(s) are motivated and described in the PR description
- [x] Testing strategy is described if automated tests are not included in the PR
- [x] Risks are described (performance impact, potential for breakage, maintainability)
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] [Library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html) are followed or label `changelog/no-changelog` is set
- [x] Documentation is included (in-code, generated user docs, [public corp docs](https://github.com/DataDog/documentation/))
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
- [x] If this PR changes the public interface, I've notified `@DataDog/apm-tees`.

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Description motivates each change
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Change is maintainable (easy to change, telemetry, documentation)
- [x] Release note makes sense to a user of the library
- [x] Author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)