### PR TITLE
chore(asm): replace dependency with updated one

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -184,7 +184,7 @@ CMAKE_BUILD_PARALLEL_LEVEL = "12"
 template = "appsec_threats_django"
 dependencies = [
     "pytest",
-    "pytest-coverage",
+    "pytest-cov",
     "requests",
     "hypothesis",
     "django{matrix:django}"
@@ -227,7 +227,7 @@ django = ["~=5.0"]
 template = "appsec_threats_flask"
 dependencies = [
     "pytest",
-    "pytest-coverage",
+    "pytest-cov",
     "requests",
     "hypothesis",
     "MarkupSafe{matrix:markupsafe:}",
@@ -269,7 +269,7 @@ flask = ["~=3.0"]
 template = "appsec_threats_fastapi"
 dependencies = [
     "pytest",
-    "pytest-coverage",
+    "pytest-cov",
     "requests",
     "hypothesis",
     "httpx",
@@ -305,7 +305,7 @@ fastapi = ["~=0.109"]
 [envs.ddtrace_unit_tests]
 dependencies = [
     "pytest",
-    "pytest-coverage",
+    "pytest-cov",
     "requests",
     "hypothesis",
 ]


### PR DESCRIPTION
pytest-coverage is obsolete and pytest-cov should be used instead

## Checklist

- [x] The PR description includes an overview of the change
- [x] The PR description articulates the motivation for the change
- [x] The change includes tests OR the PR description describes a testing strategy
- [x] The PR description notes risks associated with the change, if any
- [x] Newly-added code is easy to change
- [x] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [x] The change includes or references documentation updates if necessary
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Newly-added code is easy to change
- [x] Release note makes sense to a user of the library
- [x] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
