### PR TITLE
chore(internal): update cache max size to for module/package/file

### DIFF
--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -2,13 +2,15 @@ import logging
 import os
 import sys
 import sysconfig
-import typing as t
 from types import ModuleType
+import typing as t
 
 from ddtrace.internal.compat import Path
 from ddtrace.internal.module import origin
-from ddtrace.internal.utils.cache import cached, callonce
+from ddtrace.internal.utils.cache import cached
+from ddtrace.internal.utils.cache import callonce
 from ddtrace.settings.third_party import config as tp_config
+
 
 LOG = logging.getLogger(__name__)
 

--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -4,7 +4,6 @@ import sys
 import sysconfig
 import typing as t
 from types import ModuleType
-from functools import lru_cache as cached
 
 from ddtrace.internal.compat import Path
 from ddtrace.internal.module import origin

--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -77,7 +77,7 @@ def get_distributions():
     return pkgs
 
 
-@cached(maxsize=65536)
+@cached(maxsize=256)
 def get_version_for_package(name):
     # type: (str) -> str
     """returns the version of a package"""
@@ -194,7 +194,7 @@ def _third_party_packages() -> set:
     ) - tp_config.excludes
 
 
-@cached(maxsize=65536)
+@cached(maxsize=16384)
 def filename_to_package(filename: t.Union[str, Path]) -> t.Optional[Distribution]:
     mapping = _package_for_root_module_mapping()
     if mapping is None:
@@ -209,7 +209,7 @@ def filename_to_package(filename: t.Union[str, Path]) -> t.Optional[Distribution
         return None
 
 
-@cached(maxsize=65536)
+@cached(maxsize=256)
 def module_to_package(module: ModuleType) -> t.Optional[Distribution]:
     """Returns the package distribution for a module"""
     module_origin = origin(module)
@@ -222,7 +222,7 @@ purelib_path = Path(sysconfig.get_path("purelib")).resolve()
 platlib_path = Path(sysconfig.get_path("platlib")).resolve()
 
 
-@cached(maxsize=65536)
+@cached(maxsize=256)
 def is_stdlib(path: Path) -> bool:
     rpath = path.resolve()
 
@@ -231,7 +231,6 @@ def is_stdlib(path: Path) -> bool:
     )
 
 
-@cached(maxsize=65536)
 def is_third_party(path: Path) -> bool:
     package = filename_to_package(str(path))
     if package is None:
@@ -240,12 +239,11 @@ def is_third_party(path: Path) -> bool:
     return package.name in _third_party_packages()
 
 
-@cached(maxsize=65536)
 def is_user_code(path: Path) -> bool:
     return not (is_stdlib(path) or is_third_party(path))
 
 
-@cached(maxsize=65536)
+@cached(maxsize=256)
 def is_distribution_available(name: str) -> bool:
     """Determine if a distribution is available in the current environment."""
     try:

--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -2,15 +2,13 @@ import logging
 import os
 import sys
 import sysconfig
-from types import ModuleType
 import typing as t
+from types import ModuleType
 
 from ddtrace.internal.compat import Path
 from ddtrace.internal.module import origin
-from ddtrace.internal.utils.cache import cached
-from ddtrace.internal.utils.cache import callonce
+from ddtrace.internal.utils.cache import cached, callonce
 from ddtrace.settings.third_party import config as tp_config
-
 
 LOG = logging.getLogger(__name__)
 
@@ -77,7 +75,7 @@ def get_distributions():
     return pkgs
 
 
-@cached()
+@cached(maxsize=65536)
 def get_version_for_package(name):
     # type: (str) -> str
     """returns the version of a package"""
@@ -194,7 +192,7 @@ def _third_party_packages() -> set:
     ) - tp_config.excludes
 
 
-@cached()
+@cached(maxsize=65536)
 def filename_to_package(filename: t.Union[str, Path]) -> t.Optional[Distribution]:
     mapping = _package_for_root_module_mapping()
     if mapping is None:
@@ -209,7 +207,7 @@ def filename_to_package(filename: t.Union[str, Path]) -> t.Optional[Distribution
         return None
 
 
-@cached()
+@cached(maxsize=65536)
 def module_to_package(module: ModuleType) -> t.Optional[Distribution]:
     """Returns the package distribution for a module"""
     module_origin = origin(module)
@@ -222,7 +220,7 @@ purelib_path = Path(sysconfig.get_path("purelib")).resolve()
 platlib_path = Path(sysconfig.get_path("platlib")).resolve()
 
 
-@cached()
+@cached(maxsize=65536)
 def is_stdlib(path: Path) -> bool:
     rpath = path.resolve()
 
@@ -231,7 +229,7 @@ def is_stdlib(path: Path) -> bool:
     )
 
 
-@cached()
+@cached(maxsize=65536)
 def is_third_party(path: Path) -> bool:
     package = filename_to_package(str(path))
     if package is None:
@@ -240,12 +238,12 @@ def is_third_party(path: Path) -> bool:
     return package.name in _third_party_packages()
 
 
-@cached()
+@cached(maxsize=65536)
 def is_user_code(path: Path) -> bool:
     return not (is_stdlib(path) or is_third_party(path))
 
 
-@cached()
+@cached(maxsize=65536)
 def is_distribution_available(name: str) -> bool:
     """Determine if a distribution is available in the current environment."""
     try:

--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -4,6 +4,7 @@ import sys
 import sysconfig
 import typing as t
 from types import ModuleType
+from functools import lru_cache as cached
 
 from ddtrace.internal.compat import Path
 from ddtrace.internal.module import origin


### PR DESCRIPTION
## Summary

Current implementation uses the default size of the `cached` decorator which is 256. This is often (always?) lower than the number of files of a Python program loaded in memory creating cache churn. This is problematic for functions like `filename_to_package` since it performs an expensive operation by calling `_root_module` that walks the filesystem.

Simple benchmark show a 7800% improvement on cache acces for `filename_to_package` function:

Current implementation:

```python
def fill_cache(i=10000):
    for j in range(i):
        filename_to_package(f"/home/benjamin/workspace/dd-trace-py/lib/python3.10/site-packages/ddtrace/internal/test{j}.py")

timeit.timeit("fill_cache(257)", setup="from __main__ import fill_cache", number=10000)
```

```
115.0306228880072
```

With patch:

```python
def fill_cache(i=10000):
    for j in range(i):
        filename_to_package(f"/home/benjamin/workspace/dd-trace-py/lib/python3.10/site-packages/ddtrace/internal/test{j}.py")

timeit.timeit("fill_cache(257)", setup="from __main__ import fill_cache", number=10000)
```

```
1.4706893929978833
```

## Risks

The main risk of this change would be an increase of memory usage from the agent. At most we are adding 7 x 64kB of memory (448kB) as opposed to 1.75kB today. This remains minimal so shouldn't be a problem.

## Checklist

- [x] The PR description includes an overview of the change
- [x] The PR description articulates the motivation for the change
- [x] The change includes tests OR the PR description describes a testing strategy
- [x] The PR description notes risks associated with the change, if any
- [x] Newly-added code is easy to change
- [x] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [x] The change includes or references documentation updates if necessary
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Newly-added code is easy to change
- [x] Release note makes sense to a user of the library
- [x] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
