### PR TITLE
chore(asm): increase RC shared memory

### DIFF
--- a/ddtrace/internal/remoteconfig/_connectors.py
+++ b/ddtrace/internal/remoteconfig/_connectors.py
@@ -17,7 +17,7 @@ log = get_logger(__name__)
 # Size of the shared variable. It's calculated based on Remote Config Payloads. At 2023-04-26 we measure on stagging
 # RC payloads and the max size of a multiprocess.array was 139.002 (sys.getsizeof(data.value)) and
 # max len 138.969 (len(data.value))
-SHARED_MEMORY_SIZE = 603432
+SHARED_MEMORY_SIZE = 0x100000
 
 SharedDataType = Mapping[str, Any]
 


### PR DESCRIPTION
To enable the tracer to block at least 2500 IPs and 2500 users, Remote Config Shared Memory needs to be increased for the tracer to be able to receive large enough payloads.

## Checklist

- [ ] The PR description includes an overview of the change
- [ ] The PR description articulates the motivation for the change
- [ ] The change includes tests OR the PR description describes a testing strategy
- [ ] The PR description notes risks associated with the change, if any
- [ ] Newly-added code is easy to change
- [ ] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [ ] The change includes or references documentation updates if necessary
- [ ] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Newly-added code is easy to change
- [ ] Release note makes sense to a user of the library
- [ ] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
