### PR TITLE
fix(langchain): tag non-dict inputs appropriately [backport 2.9]

### DIFF
--- a/ddtrace/contrib/langchain/patch.py
+++ b/ddtrace/contrib/langchain/patch.py
@@ -738,7 +738,7 @@ def traced_lcel_runnable_sequence(langchain, pin, func, instance, args, kwargs):
             if not isinstance(inputs, list):
                 inputs = [inputs]
             for idx, inp in enumerate(inputs):
-                if isinstance(inp, str):
+                if not isinstance(inp, dict):
                     span.set_tag_str("langchain.request.inputs.%d" % idx, integration.trunc(str(inp)))
                 else:
                     for k, v in inp.items():
@@ -785,7 +785,7 @@ async def traced_lcel_runnable_sequence_async(langchain, pin, func, instance, ar
             if not isinstance(inputs, list):
                 inputs = [inputs]
             for idx, inp in enumerate(inputs):
-                if isinstance(inp, str):
+                if not isinstance(inp, dict):
                     span.set_tag_str("langchain.request.inputs.%d" % idx, integration.trunc(str(inp)))
                 else:
                     for k, v in inp.items():

--- a/releasenotes/notes/langchain-non-dict-inputs-310427c510acf1e5.yaml
+++ b/releasenotes/notes/langchain-non-dict-inputs-310427c510acf1e5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    langchain: tag non-dict inputs to LCEL chains appropriately. Non-dict inputs are stringified, and dict inputs are tagged by key-value pairs.

--- a/tests/contrib/langchain/test_langchain_community.py
+++ b/tests/contrib/langchain/test_langchain_community.py
@@ -1251,6 +1251,18 @@ async def test_lcel_chain_batch_async(langchain_core, langchain_openai, request_
         await chain.abatch(inputs=["chickens", "pigs"])
 
 
+@pytest.mark.snapshot
+def test_lcecl_chain_non_dict_input(langchain_core):
+    """
+    Tests that non-dict inputs (specifically also non-string) are stringified properly
+    """
+    add_one = langchain_core.runnables.RunnableLambda(lambda x: x + 1)
+    multiply_two = langchain_core.runnables.RunnableLambda(lambda x: x * 2)
+    sequence = add_one | multiply_two
+
+    sequence.invoke(1)
+
+
 @pytest.mark.parametrize(
     "ddtrace_global_config",
     [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="langchain_community_test")],

--- a/tests/snapshots/tests.contrib.langchain.test_langchain_community.test_lcecl_chain_non_dict_input.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain_community.test_lcecl_chain_non_dict_input.json
@@ -1,0 +1,29 @@
+[[
+  {
+    "name": "langchain.request",
+    "service": "",
+    "resource": "langchain_core.runnables.base.RunnableSequence",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "",
+    "error": 0,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "668bfb9100000000",
+      "langchain.request.inputs.0": "1",
+      "langchain.request.type": "chain",
+      "langchain.response.outputs.0": "4",
+      "language": "python",
+      "runtime-id": "f7e2ec0951f9471e8fd2857fbeb4ee5f"
+    },
+    "metrics": {
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 59445
+    },
+    "duration": 6687000,
+    "start": 1720449937260976000
+  }]]

--- a/tests/snapshots/tests.contrib.langchain.test_langchain_community.test_lcecl_chain_non_dict_input.json
+++ b/tests/snapshots/tests.contrib.langchain.test_langchain_community.test_lcecl_chain_non_dict_input.json
@@ -6,7 +6,7 @@
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,
-    "type": "",
+    "type": "llm",
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",


### PR DESCRIPTION
Backport d012b1da5e6662dfd91cca1bbfc9f576e61e7681 from #9747 to 2.9.

## What does this PR do?
Tags langchain LCEL chain non-dict inputs appropriately. Previously, this logic considered strings and, as a default, dicts. This PR changes this logic to consider non-dicts (and stringify), and then fall back on it being a dict.

## Motivation
Fixes #9707 
This PR cherry-picks #9706 to add a test and run CI

## Checklist

- [x] The PR description includes an overview of the change
- [x] The PR description articulates the motivation for the change
- [x] The change includes tests OR the PR description describes a testing strategy
- [x] The PR description notes risks associated with the change, if any
- [x] Newly-added code is easy to change
- [x] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [x] The change includes or references documentation updates if necessary
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Newly-added code is easy to change
- [x] Release note makes sense to a user of the library
- [x] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
