### PR TITLE
fix(azure_functions): run the mini agent regardless of azure hosting plan [backport 2.10]

### DIFF
--- a/ddtrace/internal/serverless/__init__.py
+++ b/ddtrace/internal/serverless/__init__.py
@@ -31,17 +31,9 @@ def in_gcp_function():
     return is_deprecated_gcp_function or is_newer_gcp_function
 
 
-def in_azure_function_consumption_plan():
+def in_azure_function():
     # type: () -> bool
-    """Returns whether the environment is an Azure Consumption Plan Function.
-    This is accomplished by checking the presence of two Azure Function env vars,
-    as well as a third SKU variable indicating consumption plans.
-    """
-    is_azure_function = (
+    """Returns whether the environment is an Azure Function."""
+    return (
         os.environ.get("FUNCTIONS_WORKER_RUNTIME", "") != "" and os.environ.get("FUNCTIONS_EXTENSION_VERSION", "") != ""
     )
-
-    website_sku = os.environ.get("WEBSITE_SKU", "")
-    is_consumption_plan = website_sku == "" or website_sku == "Dynamic"
-
-    return is_azure_function and is_consumption_plan

--- a/ddtrace/internal/serverless/mini_agent.py
+++ b/ddtrace/internal/serverless/mini_agent.py
@@ -4,7 +4,7 @@ import sys
 
 from ..compat import PYTHON_VERSION_INFO
 from ..logger import get_logger
-from ..serverless import in_azure_function_consumption_plan
+from ..serverless import in_azure_function
 from ..serverless import in_gcp_function
 
 
@@ -12,7 +12,7 @@ log = get_logger(__name__)
 
 
 def maybe_start_serverless_mini_agent():
-    if not (in_gcp_function() or in_azure_function_consumption_plan()):
+    if not (in_gcp_function() or in_azure_function()):
         return
 
     if sys.platform != "win32" and sys.platform != "linux":

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -32,7 +32,7 @@ from ..constants import _HTTPLIB_NO_TRACE_REQUEST
 from ..encoding import JSONEncoderV2
 from ..logger import get_logger
 from ..runtime import container
-from ..serverless import in_azure_function_consumption_plan
+from ..serverless import in_azure_function
 from ..serverless import in_gcp_function
 from ..sma import SimpleMovingAverage
 from .writer_client import WRITER_CLIENTS
@@ -482,7 +482,7 @@ class AgentWriter(HTTPWriter):
         is_windows = sys.platform.startswith("win") or sys.platform.startswith("cygwin")
 
         default_api_version = "v0.5"
-        if is_windows or in_gcp_function() or in_azure_function_consumption_plan() or asm_config._asm_enabled:
+        if is_windows or in_gcp_function() or in_azure_function() or asm_config._asm_enabled:
             default_api_version = "v0.4"
 
         self._api_version = api_version or config._trace_api or default_api_version

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -12,7 +12,7 @@ from typing import Tuple  # noqa:F401
 from typing import Union  # noqa:F401
 
 from ddtrace.internal.compat import get_mp_context
-from ddtrace.internal.serverless import in_azure_function_consumption_plan
+from ddtrace.internal.serverless import in_azure_function
 from ddtrace.internal.serverless import in_gcp_function
 from ddtrace.internal.utils.cache import cachedmethod
 from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
@@ -443,7 +443,7 @@ class Config(object):
 
         if self.service is None and in_gcp_function():
             self.service = os.environ.get("K_SERVICE", os.environ.get("FUNCTION_NAME"))
-        if self.service is None and in_azure_function_consumption_plan():
+        if self.service is None and in_azure_function():
             self.service = os.environ.get("WEBSITE_SITE_NAME")
 
         self._extra_services = set()
@@ -510,7 +510,7 @@ class Config(object):
         # Raise certain errors only if in testing raise mode to prevent crashing in production with non-critical errors
         self._raise = asbool(os.getenv("DD_TESTING_RAISE", False))
 
-        trace_compute_stats_default = in_gcp_function() or in_azure_function_consumption_plan()
+        trace_compute_stats_default = in_gcp_function() or in_azure_function()
         self._trace_compute_stats = asbool(
             os.getenv(
                 "DD_TRACE_COMPUTE_STATS", os.getenv("DD_TRACE_STATS_COMPUTATION_ENABLED", trace_compute_stats_default)

--- a/releasenotes/notes/allow-mini-agent-to-run-on-all-hosting-plans-5e8df7330c108d71.yaml
+++ b/releasenotes/notes/allow-mini-agent-to-run-on-all-hosting-plans-5e8df7330c108d71.yaml
@@ -1,0 +1,4 @@
+
+features:
+  - |
+   azure: Removes the restrictions on the tracer to only run the mini-agent on the consumption plan. The mini-agent now runs regardless of the hosting plan


### PR DESCRIPTION
Runs the Serverless Mini Agent for Azure Functions on all consumption plans not just if the hosting plan is consumption.

The changes were tested by running the test suite for the internal folder using the following instructions for the repo: https://ddtrace.readthedocs.io/en/stable/contributing-testing.html#testing-guidelines

Co-authored-by: Brett Langdon <brett.langdon@datadoghq.com>
(cherry picked from commit 4f31f7e0e7c0d8f2cb2e4c225c8d187fee84a83a)

## Checklist

- [x] The PR description includes an overview of the change
- [x] The PR description articulates the motivation for the change
- [x] The change includes tests OR the PR description describes a testing strategy
- [x] The PR description notes risks associated with the change, if any
- [x] Newly-added code is easy to change
- [x] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [x] The change includes or references documentation updates if necessary
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Newly-added code is easy to change
- [x] Release note makes sense to a user of the library
- [x] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
