### PR TITLE
chore(ci): use python 3.12 for parametric tests (#9775) [backport 2.7]

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -248,7 +248,7 @@ jobs:
       - uses: actions/setup-python@v4
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
         with:
-          python-version: '3.9'
+          python-version: '3.12'
 
       - name: Build
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'


### PR DESCRIPTION
Manual backport of #9775 for 2.7

As it was done in https://github.com/DataDog/dd-trace-py/pull/9741

## Checklist

- [x] The PR description includes an overview of the change
- [x] The PR description articulates the motivation for the change
- [x] The change includes tests OR the PR description describes a testing strategy
- [x] The PR description notes risks associated with the change, if any
- [x] Newly-added code is easy to change
- [x] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [x] The change includes or references documentation updates if necessary
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Newly-added code is easy to change
- [x] Release note makes sense to a user of the library
- [x] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
