### PR TITLE
chore: add moto to IAST denylist [backport 2.10]

### DIFF
--- a/ddtrace/appsec/_iast/_ast/ast_patching.py
+++ b/ddtrace/appsec/_iast/_ast/ast_patching.py
@@ -25,19 +25,62 @@ _VISITOR = AstVisitor()
 # Prefixes for modules where IAST patching is allowed
 IAST_ALLOWLIST: Tuple[Text, ...] = ("tests.appsec.iast",)
 IAST_DENYLIST: Tuple[Text, ...] = (
-    "ddtrace",
-    "pkg_resources",
-    "encodings",  # this package is used to load encodings when a module is imported, propagation is not needed
-    "inspect",  # this package is used to get the stack frames, propagation is not needed
-    "pycparser",  # this package is called when a module is imported, propagation is not needed
-    "Crypto",  # This module is patched by the IAST patch methods, propagation is not needed
+    "flask",
+    "werkzeug",
+    "crypto",  # This module is patched by the IAST patch methods, propagation is not needed
+    "deprecated",
     "api_pb2",  # Patching crashes with these auto-generated modules, propagation is not needed
     "api_pb2_grpc",  # ditto
-    "unittest.mock",
-    "pytest",  # Testing framework
+    "asyncpg.pgproto",
+    "blinker",
+    "bytecode",
+    "cattrs",
+    "click",
+    "ddsketch",
+    "ddtrace",
+    "encodings",  # this package is used to load encodings when a module is imported, propagation is not needed
+    "envier",
+    "exceptiongroup",
     "freezegun",  # Testing utilities for time manipulation
+    "hypothesis",
+    "importlib_metadata",
+    "inspect",  # this package is used to get the stack frames, propagation is not needed
+    "itsdangerous",
+    "moto",  # used for mocking AWS, propagation is not needed
+    "moto[all]",
+    "moto[ec2",
+    "moto[s3]",
+    "opentelemetry-api",
+    "packaging",
+    "pip",
+    "pkg_resources",
+    "pluggy",
+    "protobuf",
+    "pycparser",  # this package is called when a module is imported, propagation is not needed
+    "pytest",  # Testing framework
+    "setuptools",
     "sklearn",  # Machine learning library
+    "tomli",
+    "typing_extensions",
+    "unittest.mock",
+    "uvloop",
     "urlpatterns_reverse.tests",  # assertRaises eat exceptions in native code, so we don't call the original function
+    "wrapt",
+    "zipp",
+    ## This is a workaround for Sanic failures:
+    "websocket",
+    "h11",
+    "aioquic",
+    "httptools",
+    "sniffio",
+    "py",
+    "sanic",
+    "rich",
+    "httpx",
+    "websockets",
+    "uvicorn",
+    "anyio",
+    "httpcore",
 )
 
 

--- a/releasenotes/notes/asm-boto-denylist-9ea0dee3a33fff7c.yaml
+++ b/releasenotes/notes/asm-boto-denylist-9ea0dee3a33fff7c.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Code Security: add the boto package to the IAST patching denylist.


### PR DESCRIPTION
## Description

Adds the `moto` package to the IAST patching denylist. It's a AWS-mocking package so propagation is not needed, and it's problematic. Also add other packages from `main`.


## Checklist

- [x] The PR description includes an overview of the change
- [x] The PR description articulates the motivation for the change
- [x] The change includes tests OR the PR description describes a testing strategy
- [x] The PR description notes risks associated with the change, if any
- [x] Newly-added code is easy to change
- [x] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [x] The change includes or references documentation updates if necessary
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Newly-added code is easy to change
- [x] Release note makes sense to a user of the library
- [x] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
