### PR TITLE
chore(ci): add OCI packaging [backport 2.9]

### DIFF
--- a/.gitlab/build-oci.sh
+++ b/.gitlab/build-oci.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+source common_build_functions.sh
+
+if [ -n "$CI_COMMIT_TAG" ] && [ -z "$PYTHON_PACKAGE_VERSION" ]; then
+  PYTHON_PACKAGE_VERSION=${CI_COMMIT_TAG##v}
+fi
+
+if [ -z "$ARCH" ]; then
+  ARCH=amd64
+fi
+
+
+TMP_DIR=$(mktemp --dir)
+BUILD_DIR=$TMP_DIR/datadog-python-apm.build
+mkdir $TMP_DIR/datadog-python-apm.build
+
+# Install known compatible pip as default version shipped in Ubuntu (20.0.2)
+# does not work.
+python3 -m pip install -U "pip>=22.0"
+python3 -m pip install packaging
+
+WHEEL_ARCH="x86_64"
+if [ "$ARCH" = "arm64" ]; then
+  WHEEL_ARCH="aarch64"
+fi
+
+../lib-injection/dl_wheels.py \
+    --python-version=3.12 \
+    --python-version=3.11 \
+    --python-version=3.10 \
+    --python-version=3.9 \
+    --python-version=3.8 \
+    --python-version=3.7 \
+    --ddtrace-version=$PYTHON_PACKAGE_VERSION \
+    --arch=$WHEEL_ARCH \
+    --platform=musllinux_1_1 \
+    --platform=manylinux2014 \
+    --output-dir=$BUILD_DIR/ddtrace_pkgs \
+    --verbose
+echo -n $PYTHON_PACKAGE_VERSION > auto_inject-python.version
+cp ../lib-injection/sitecustomize.py $BUILD_DIR/
+cp auto_inject-python.version $BUILD_DIR/version
+chmod -R o-w $BUILD_DIR
+chmod -R g-w $BUILD_DIR
+
+# Build packages
+datadog-package create \
+    --version="$PYTHON_PACKAGE_VERSION" \
+    --package="datadog-apm-library-python" \
+    --archive=true \
+    --archive-path="datadog-apm-library-python-$PYTHON_PACKAGE_VERSION-$ARCH.tar" \
+    --arch "$ARCH" \
+    --os "linux" \
+    $BUILD_DIR


### PR DESCRIPTION
Manual backport for https://github.com/DataDog/dd-trace-py/pull/8932

Need this to be backported to 2.9 in order to fully enable https://github.com/DataDog/dd-trace-py/pull/9790 (which has already been backported). This is currently erroring out (see example [here](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/569985194))

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
