### PR TITLE
chore(ci): added quotes to fix the `--omit` flag for coverage report

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -439,10 +439,10 @@ jobs:
           path: coverage.json
       # Print ddtrace/ report to stdout
       # DEV: "--ignore-errors" to skip over files that are missing
-      - run: coverage report --ignore-errors --omit=tests/ || true
+      - run: coverage report --ignore-errors --omit='tests/*' || true
       # Print tests/ report to stdout
       # DEV: "--ignore-errors" to skip over files that are missing
-      - run: coverage report --ignore-errors --omit=ddtrace/ || true
+      - run: coverage report --ignore-errors --omit='ddtrace/*' || true
       # Print diff-cover report to stdout (compares against origin/1.x)
       - run: diff-cover --compare-branch $(git rev-parse --abbrev-ref origin/HEAD) coverage.xml || true
 


### PR DESCRIPTION
The coverage job was not omitting the directories specified as intended, which was skewing the coverage report to be significantly lower (see [here](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/65442/workflows/574d568f-90d3-41f8-9c8f-8fb70f24d397/jobs/4033899) for example).

Making this syntax fix so that the omission works as intended. Reproduced original behavior locally, and tested the solution locally.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
