### PR TITLE
chore(llmobs): backport token metric key name changes to 2.10

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -24,3 +24,7 @@ SPAN_START_WHILE_DISABLED_WARNING = (
 )
 
 LANGCHAIN_APM_SPAN_NAME = "langchain.request"
+
+INPUT_TOKENS_METRIC_KEY = "input_tokens"
+OUTPUT_TOKENS_METRIC_KEY = "output_tokens"
+TOTAL_TOKENS_METRIC_KEY = "total_tokens"

--- a/ddtrace/llmobs/_integrations/anthropic.py
+++ b/ddtrace/llmobs/_integrations/anthropic.py
@@ -8,12 +8,15 @@ from typing import Optional
 from ddtrace._trace.span import Span
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._constants import INPUT_MESSAGES
+from ddtrace.llmobs._constants import INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import METADATA
 from ddtrace.llmobs._constants import METRICS
 from ddtrace.llmobs._constants import MODEL_NAME
 from ddtrace.llmobs._constants import MODEL_PROVIDER
 from ddtrace.llmobs._constants import OUTPUT_MESSAGES
+from ddtrace.llmobs._constants import OUTPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import SPAN_KIND
+from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
 
 from .base import BaseLLMIntegration
 
@@ -175,16 +178,16 @@ class AnthropicIntegration(BaseLLMIntegration):
     @staticmethod
     def _get_llmobs_metrics_tags(span):
         usage = {}
-        prompt_tokens = span.get_metric("anthropic.response.usage.input_tokens")
-        completion_tokens = span.get_metric("anthropic.response.usage.output_tokens")
+        input_tokens = span.get_metric("anthropic.response.usage.input_tokens")
+        output_tokens = span.get_metric("anthropic.response.usage.output_tokens")
         total_tokens = span.get_metric("anthropic.response.usage.total_tokens")
 
-        if prompt_tokens is not None:
-            usage["prompt_tokens"] = prompt_tokens
-        if completion_tokens is not None:
-            usage["completion_tokens"] = completion_tokens
+        if input_tokens is not None:
+            usage[INPUT_TOKENS_METRIC_KEY] = input_tokens
+        if output_tokens is not None:
+            usage[OUTPUT_TOKENS_METRIC_KEY] = output_tokens
         if total_tokens is not None:
-            usage["total_tokens"] = total_tokens
+            usage[TOTAL_TOKENS_METRIC_KEY] = total_tokens
         return usage
 
 

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -6,14 +6,17 @@ from typing import Optional
 from ddtrace._trace.span import Span
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._constants import INPUT_MESSAGES
+from ddtrace.llmobs._constants import INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import METADATA
 from ddtrace.llmobs._constants import METRICS
 from ddtrace.llmobs._constants import MODEL_NAME
 from ddtrace.llmobs._constants import MODEL_PROVIDER
 from ddtrace.llmobs._constants import OUTPUT_MESSAGES
+from ddtrace.llmobs._constants import OUTPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import PARENT_ID_KEY
 from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
 from ddtrace.llmobs._constants import SPAN_KIND
+from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
 from ddtrace.llmobs._integrations import BaseLLMIntegration
 from ddtrace.llmobs._utils import _get_llmobs_parent_id
 
@@ -61,9 +64,9 @@ class BedrockIntegration(BaseLLMIntegration):
         if formatted_response and formatted_response.get("text"):
             prompt_tokens = int(span.get_tag("bedrock.usage.prompt_tokens") or 0)
             completion_tokens = int(span.get_tag("bedrock.usage.completion_tokens") or 0)
-            metrics["prompt_tokens"] = prompt_tokens
-            metrics["completion_tokens"] = completion_tokens
-            metrics["total_tokens"] = prompt_tokens + completion_tokens
+            metrics[INPUT_TOKENS_METRIC_KEY] = prompt_tokens
+            metrics[OUTPUT_TOKENS_METRIC_KEY] = completion_tokens
+            metrics[TOTAL_TOKENS_METRIC_KEY] = prompt_tokens + completion_tokens
         return metrics
 
     @staticmethod

--- a/ddtrace/llmobs/_integrations/openai.py
+++ b/ddtrace/llmobs/_integrations/openai.py
@@ -10,12 +10,15 @@ from ddtrace._trace.span import Span
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._constants import INPUT_MESSAGES
+from ddtrace.llmobs._constants import INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import METADATA
 from ddtrace.llmobs._constants import METRICS
 from ddtrace.llmobs._constants import MODEL_NAME
 from ddtrace.llmobs._constants import MODEL_PROVIDER
 from ddtrace.llmobs._constants import OUTPUT_MESSAGES
+from ddtrace.llmobs._constants import OUTPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import SPAN_KIND
+from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.pin import Pin
 
@@ -221,17 +224,17 @@ class OpenAIIntegration(BaseLLMIntegration):
             completion_tokens = span.get_metric("openai.response.usage.completion_tokens") or 0
             metrics.update(
                 {
-                    "prompt_tokens": prompt_tokens,
-                    "completion_tokens": completion_tokens,
-                    "total_tokens": prompt_tokens + completion_tokens,
+                    INPUT_TOKENS_METRIC_KEY: prompt_tokens,
+                    OUTPUT_TOKENS_METRIC_KEY: completion_tokens,
+                    TOTAL_TOKENS_METRIC_KEY: prompt_tokens + completion_tokens,
                 }
             )
         elif resp:
             metrics.update(
                 {
-                    "prompt_tokens": resp.usage.prompt_tokens,
-                    "completion_tokens": resp.usage.completion_tokens,
-                    "total_tokens": resp.usage.prompt_tokens + resp.usage.completion_tokens,
+                    INPUT_TOKENS_METRIC_KEY: resp.usage.prompt_tokens,
+                    OUTPUT_TOKENS_METRIC_KEY: resp.usage.completion_tokens,
+                    TOTAL_TOKENS_METRIC_KEY: resp.usage.prompt_tokens + resp.usage.completion_tokens,
                 }
             )
         return metrics

--- a/tests/contrib/anthropic/test_anthropic_llmobs.py
+++ b/tests/contrib/anthropic/test_anthropic_llmobs.py
@@ -59,7 +59,7 @@ class TestLLMObsAnthropic:
                 ],
                 output_messages=[{"content": 'THE BEST-SELLING BOOK OF ALL TIME IS "DON', "role": "assistant"}],
                 metadata={"temperature": 0.8, "max_tokens": 15.0},
-                token_metrics={"prompt_tokens": 32, "completion_tokens": 15, "total_tokens": 47},
+                token_metrics={"input_tokens": 32, "output_tokens": 15, "total_tokens": 47},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -153,7 +153,7 @@ class TestLLMObsAnthropic:
                         {"content": 'The phrase "I think, therefore I am" (originally in Latin as', "role": "assistant"}
                     ],
                     metadata={"temperature": 0.8, "max_tokens": 15.0},
-                    token_metrics={"prompt_tokens": 27, "completion_tokens": 15, "total_tokens": 42},
+                    token_metrics={"input_tokens": 27, "output_tokens": 15, "total_tokens": 42},
                     tags={"ml_app": "<ml-app-name>"},
                 )
             )
@@ -210,7 +210,7 @@ class TestLLMObsAnthropic:
                         }
                     ],
                     metadata={"temperature": 0.8, "max_tokens": 15.0},
-                    token_metrics={"prompt_tokens": 27, "completion_tokens": 15, "total_tokens": 42},
+                    token_metrics={"input_tokens": 27, "output_tokens": 15, "total_tokens": 42},
                     tags={"ml_app": "<ml-app-name>"},
                 )
             )
@@ -265,7 +265,7 @@ class TestLLMObsAnthropic:
                         }
                     ],
                     metadata={"temperature": 0.8, "max_tokens": 15.0},
-                    token_metrics={"prompt_tokens": 246, "completion_tokens": 15, "total_tokens": 261},
+                    token_metrics={"input_tokens": 246, "output_tokens": 15, "total_tokens": 261},
                     tags={"ml_app": "<ml-app-name>"},
                 )
             )
@@ -303,7 +303,7 @@ class TestLLMObsAnthropic:
                     {"content": WEATHER_OUTPUT_MESSAGE_2, "role": "assistant"},
                 ],
                 metadata={"temperature": 1.0, "max_tokens": 200.0},
-                token_metrics={"prompt_tokens": 599, "completion_tokens": 152, "total_tokens": 751},
+                token_metrics={"input_tokens": 599, "output_tokens": 152, "total_tokens": 751},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -356,7 +356,7 @@ class TestLLMObsAnthropic:
                     }
                 ],
                 metadata={"temperature": 1.0, "max_tokens": 500.0},
-                token_metrics={"prompt_tokens": 768, "completion_tokens": 29, "total_tokens": 797},
+                token_metrics={"input_tokens": 768, "output_tokens": 29, "total_tokens": 797},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -395,7 +395,7 @@ class TestLLMObsAnthropic:
                     {"content": WEATHER_OUTPUT_MESSAGE_2, "role": "assistant"},
                 ],
                 metadata={"temperature": 1.0, "max_tokens": 200.0},
-                token_metrics={"prompt_tokens": 599, "completion_tokens": 152, "total_tokens": 751},
+                token_metrics={"input_tokens": 599, "output_tokens": 152, "total_tokens": 751},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -448,7 +448,7 @@ class TestLLMObsAnthropic:
                     }
                 ],
                 metadata={"temperature": 1.0, "max_tokens": 500.0},
-                token_metrics={"prompt_tokens": 768, "completion_tokens": 29, "total_tokens": 797},
+                token_metrics={"input_tokens": 768, "output_tokens": 29, "total_tokens": 797},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -497,7 +497,7 @@ class TestLLMObsAnthropic:
                     {"content": message[1]["text"], "role": "assistant"},
                 ],
                 metadata={"temperature": 1.0, "max_tokens": 200.0},
-                token_metrics={"prompt_tokens": 599, "completion_tokens": 135, "total_tokens": 734},
+                token_metrics={"input_tokens": 599, "output_tokens": 135, "total_tokens": 734},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -547,7 +547,7 @@ class TestLLMObsAnthropic:
                     }
                 ],
                 metadata={"temperature": 1.0, "max_tokens": 500.0},
-                token_metrics={"prompt_tokens": 762, "completion_tokens": 33, "total_tokens": 795},
+                token_metrics={"input_tokens": 762, "output_tokens": 33, "total_tokens": 795},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -591,7 +591,7 @@ class TestLLMObsAnthropic:
                     {"content": WEATHER_OUTPUT_MESSAGE_2, "role": "assistant"},
                 ],
                 metadata={"temperature": 1.0, "max_tokens": 200.0},
-                token_metrics={"prompt_tokens": 599, "completion_tokens": 146, "total_tokens": 745},
+                token_metrics={"input_tokens": 599, "output_tokens": 146, "total_tokens": 745},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -643,7 +643,7 @@ class TestLLMObsAnthropic:
                     {"content": "\n\nThe current weather in San Francisco, CA is 73°F.", "role": "assistant"}
                 ],
                 metadata={"temperature": 1.0, "max_tokens": 500.0},
-                token_metrics={"prompt_tokens": 762, "completion_tokens": 18, "total_tokens": 780},
+                token_metrics={"input_tokens": 762, "output_tokens": 18, "total_tokens": 780},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )

--- a/tests/contrib/botocore/test_bedrock_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_llmobs.py
@@ -96,8 +96,8 @@ class TestLLMObsBedrock:
             output_messages=[{"content": mock.ANY} for _ in range(n_output)],
             metadata=expected_parameters,
             token_metrics={
-                "prompt_tokens": prompt_tokens,
-                "completion_tokens": completion_tokens,
+                "input_tokens": prompt_tokens,
+                "output_tokens": completion_tokens,
                 "total_tokens": prompt_tokens + completion_tokens,
             },
             tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>"},

--- a/tests/contrib/openai/test_openai_llmobs.py
+++ b/tests/contrib/openai/test_openai_llmobs.py
@@ -36,7 +36,7 @@ class TestLLMObsOpenaiV0:
                 input_messages=[{"content": "Hello world"}],
                 output_messages=[{"content": ", relax!” I said to my laptop"}, {"content": " (1"}],
                 metadata={"temperature": 0.8, "max_tokens": 10},
-                token_metrics={"prompt_tokens": 2, "completion_tokens": 12, "total_tokens": 14},
+                token_metrics={"input_tokens": 2, "output_tokens": 12, "total_tokens": 14},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -58,7 +58,7 @@ class TestLLMObsOpenaiV0:
                 input_messages=[{"content": "Hello world"}],
                 output_messages=[{"content": expected_completion}],
                 metadata={"temperature": 0},
-                token_metrics={"prompt_tokens": 2, "completion_tokens": 16, "total_tokens": 18},
+                token_metrics={"input_tokens": 2, "output_tokens": 16, "total_tokens": 18},
                 tags={"ml_app": "<ml-app-name>"},
             ),
         )
@@ -95,7 +95,7 @@ class TestLLMObsOpenaiV0:
                 input_messages=input_messages,
                 output_messages=[{"role": "assistant", "content": choice.message.content} for choice in resp.choices],
                 metadata={"temperature": 0},
-                token_metrics={"prompt_tokens": 57, "completion_tokens": 34, "total_tokens": 91},
+                token_metrics={"input_tokens": 57, "output_tokens": 34, "total_tokens": 91},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -132,7 +132,7 @@ class TestLLMObsOpenaiV0:
                 input_messages=input_messages,
                 output_messages=[{"content": expected_completion, "role": "assistant"}],
                 metadata={"temperature": 0},
-                token_metrics={"prompt_tokens": 8, "completion_tokens": 12, "total_tokens": 20},
+                token_metrics={"input_tokens": 8, "output_tokens": 12, "total_tokens": 20},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -164,7 +164,7 @@ class TestLLMObsOpenaiV0:
                 input_messages=[{"content": chat_completion_input_description, "role": "user"}],
                 output_messages=[{"content": expected_output, "role": "assistant"}],
                 metadata={"temperature": 0},
-                token_metrics={"prompt_tokens": 157, "completion_tokens": 57, "total_tokens": 214},
+                token_metrics={"input_tokens": 157, "output_tokens": 57, "total_tokens": 214},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -200,7 +200,7 @@ class TestLLMObsOpenaiV0:
                 input_messages=[{"content": chat_completion_input_description, "role": "user"}],
                 output_messages=[{"content": expected_output, "role": "assistant"}],
                 metadata={"temperature": 0},
-                token_metrics={"prompt_tokens": 63, "completion_tokens": 33, "total_tokens": 96},
+                token_metrics={"input_tokens": 63, "output_tokens": 33, "total_tokens": 96},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -227,7 +227,7 @@ class TestLLMObsOpenaiV0:
                 input_messages=[{"content": chat_completion_input_description, "role": "user"}],
                 output_messages=[{"content": expected_output, "role": "assistant"}],
                 metadata={"temperature": 0},
-                token_metrics={"prompt_tokens": 157, "completion_tokens": 57, "total_tokens": 214},
+                token_metrics={"input_tokens": 157, "output_tokens": 57, "total_tokens": 214},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -337,7 +337,7 @@ class TestLLMObsOpenaiV1:
                 input_messages=[{"content": "Hello world"}],
                 output_messages=[{"content": ", relax!” I said to my laptop"}, {"content": " (1"}],
                 metadata={"temperature": 0.8, "max_tokens": 10},
-                token_metrics={"prompt_tokens": 2, "completion_tokens": 12, "total_tokens": 14},
+                token_metrics={"input_tokens": 2, "output_tokens": 12, "total_tokens": 14},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -364,7 +364,7 @@ class TestLLMObsOpenaiV1:
                 input_messages=[{"content": "Hello world"}],
                 output_messages=[{"content": expected_completion}],
                 metadata={"temperature": 0},
-                token_metrics={"prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4},
+                token_metrics={"input_tokens": 2, "output_tokens": 2, "total_tokens": 4},
                 tags={"ml_app": "<ml-app-name>"},
             ),
         )
@@ -400,7 +400,7 @@ class TestLLMObsOpenaiV1:
                 input_messages=input_messages,
                 output_messages=[{"role": "assistant", "content": choice.message.content} for choice in resp.choices],
                 metadata={"temperature": 0},
-                token_metrics={"prompt_tokens": 57, "completion_tokens": 34, "total_tokens": 91},
+                token_metrics={"input_tokens": 57, "output_tokens": 34, "total_tokens": 91},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -438,7 +438,7 @@ class TestLLMObsOpenaiV1:
                 input_messages=input_messages,
                 output_messages=[{"content": expected_completion, "role": "assistant"}],
                 metadata={"temperature": 0},
-                token_metrics={"prompt_tokens": 8, "completion_tokens": 8, "total_tokens": 16},
+                token_metrics={"input_tokens": 8, "output_tokens": 8, "total_tokens": 16},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -469,7 +469,7 @@ class TestLLMObsOpenaiV1:
                 input_messages=[{"content": chat_completion_input_description, "role": "user"}],
                 output_messages=[{"content": expected_output, "role": "assistant"}],
                 metadata={"temperature": 0},
-                token_metrics={"prompt_tokens": 157, "completion_tokens": 57, "total_tokens": 214},
+                token_metrics={"input_tokens": 157, "output_tokens": 57, "total_tokens": 214},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )
@@ -503,7 +503,7 @@ class TestLLMObsOpenaiV1:
                     }
                 ],
                 metadata={"temperature": 0},
-                token_metrics={"prompt_tokens": 157, "completion_tokens": 57, "total_tokens": 214},
+                token_metrics={"input_tokens": 157, "output_tokens": 57, "total_tokens": 214},
                 tags={"ml_app": "<ml-app-name>"},
             )
         )

--- a/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_span_writer.test_send_chat_completion_event.yaml
+++ b/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_span_writer.test_send_chat_completion_event.yaml
@@ -11,8 +11,8 @@ interactions:
       256}}, "output": {"messages": [{"content": "Ah, a bold and foolish hobbit seeking
       to challenge my dominion in Mordor. Very well, little creature, I shall play
       along. But know that I am always watching, and your quest will not go unnoticed",
-      "role": "assistant"}]}}, "metrics": {"prompt_tokens": 64, "completion_tokens":
-      128, "total_tokens": 192}}]}}'
+      "role": "assistant"}]}}, "metrics": {"input_tokens": 64, "output_tokens":
+      128, "total_tokens": 192}}]}'
     headers:
       Content-Type:
       - application/json

--- a/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_span_writer.test_send_completion_bad_api_key.yaml
+++ b/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_span_writer.test_send_completion_bad_api_key.yaml
@@ -4,11 +4,12 @@ interactions:
       "12345678901", "trace_id": "98765432101", "parent_id": "", "session_id": "98765432101",
       "name": "completion_span", "tags": ["version:", "env:", "service:", "source:integration"],
       "start_ns": 1707763310981223236, "duration": 12345678900, "error": 0, "meta":
-      {"span.kind": "llm", "model_name": "ada", "model_provider": "openai", "input": {"messages":
-      [{"content": "who broke enigma?"}], "parameters": {"temperature": 0, "max_tokens":
-      256}}, "output": {"messages": [{"content": "\n\nThe Enigma code was broken by
-      a team of codebreakers at Bletchley Park, led by mathematician Alan Turing."}]}},
-      "metrics": {"prompt_tokens": 64, "completion_tokens": 128, "total_tokens": 192}}]}}'
+      {"span.kind": "llm", "model_name": "ada", "model_provider": "openai", "input":
+      {"messages": [{"content": "who broke enigma?"}], "parameters": {"temperature":
+      0, "max_tokens": 256}}, "output": {"messages": [{"content": "\n\nThe Enigma
+      code was broken by a team of codebreakers at Bletchley Park, led by mathematician
+      Alan Turing."}]}}, "metrics": {"input_tokens": 64, "output_tokens": 128,
+      "total_tokens": 192}}]}'
     headers:
       Content-Type:
       - application/json

--- a/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_span_writer.test_send_completion_event.yaml
+++ b/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_span_writer.test_send_completion_event.yaml
@@ -4,11 +4,12 @@ interactions:
       "12345678901", "trace_id": "98765432101", "parent_id": "", "session_id": "98765432101",
       "name": "completion_span", "tags": ["version:", "env:", "service:", "source:integration"],
       "start_ns": 1707763310981223236, "duration": 12345678900, "error": 0, "meta":
-      {"span.kind": "llm", "model_name": "ada", "model_provider": "openai", "input": {"messages":
-      [{"content": "who broke enigma?"}], "parameters": {"temperature": 0, "max_tokens":
-      256}}, "output": {"messages": [{"content": "\n\nThe Enigma code was broken by
-      a team of codebreakers at Bletchley Park, led by mathematician Alan Turing."}]}},
-      "metrics": {"prompt_tokens": 64, "completion_tokens": 128, "total_tokens": 192}}]}}'
+      {"span.kind": "llm", "model_name": "ada", "model_provider": "openai", "input":
+      {"messages": [{"content": "who broke enigma?"}], "parameters": {"temperature":
+      0, "max_tokens": 256}}, "output": {"messages": [{"content": "\n\nThe Enigma
+      code was broken by a team of codebreakers at Bletchley Park, led by mathematician
+      Alan Turing."}]}}, "metrics": {"input_tokens": 64, "output_tokens": 128,
+      "total_tokens": 192}}]}'
     headers:
       Content-Type:
       - application/json

--- a/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_span_writer.test_send_multiple_events.yaml
+++ b/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_span_writer.test_send_multiple_events.yaml
@@ -4,23 +4,24 @@ interactions:
       "12345678901", "trace_id": "98765432101", "parent_id": "", "session_id": "98765432101",
       "name": "completion_span", "tags": ["version:", "env:", "service:", "source:integration"],
       "start_ns": 1707763310981223236, "duration": 12345678900, "error": 0, "meta":
-      {"span.kind": "llm", "model_name": "ada", "model_provider": "openai", "input": {"messages":
-      [{"content": "who broke enigma?"}], "parameters": {"temperature": 0, "max_tokens":
-      256}}, "output": {"messages": [{"content": "\n\nThe Enigma code was broken by
-      a team of codebreakers at Bletchley Park, led by mathematician Alan Turing."}]}},
-      "metrics": {"prompt_tokens": 64, "completion_tokens": 128, "total_tokens": 192}},
-      {"span_id": "12345678902", "trace_id": "98765432102", "parent_id": "",
-      "session_id": "98765432102", "name": "chat_completion_span", "tags": ["version:", "env:",
-      "service:", "source:integration"], "start_ns": 1707763310981223936, "duration":
-      12345678900, "error": 0, "meta": {"span.kind": "llm", "model_name": "gpt-3.5-turbo",
-      "model_provider": "openai", "input": {"messages": [{"role": "system", "content":
-      "You are an evil dark lord looking for his one ring to rule them all"}, {"role":
-      "user", "content": "I am a hobbit looking to go to Mordor"}], "parameters":
-      {"temperature": 0.9, "max_tokens": 256}}, "output": {"messages": [{"content":
-      "Ah, a bold and foolish hobbit seeking to challenge my dominion in Mordor. Very
-      well, little creature, I shall play along. But know that I am always watching,
-      and your quest will not go unnoticed", "role": "assistant"}]}}, "metrics": {"prompt_tokens":
-      64, "completion_tokens": 128, "total_tokens": 192}}]}}'
+      {"span.kind": "llm", "model_name": "ada", "model_provider": "openai", "input":
+      {"messages": [{"content": "who broke enigma?"}], "parameters": {"temperature":
+      0, "max_tokens": 256}}, "output": {"messages": [{"content": "\n\nThe Enigma
+      code was broken by a team of codebreakers at Bletchley Park, led by mathematician
+      Alan Turing."}]}}, "metrics": {"input_tokens": 64, "output_tokens": 128,
+      "total_tokens": 192}}, {"span_id": "12345678902", "trace_id": "98765432102",
+      "parent_id": "", "session_id": "98765432102", "name": "chat_completion_span",
+      "tags": ["version:", "env:", "service:", "source:integration"], "start_ns":
+      1707763310981223936, "duration": 12345678900, "error": 0, "meta": {"span.kind":
+      "llm", "model_name": "gpt-3.5-turbo", "model_provider": "openai", "input": {"messages":
+      [{"role": "system", "content": "You are an evil dark lord looking for his one
+      ring to rule them all"}, {"role": "user", "content": "I am a hobbit looking
+      to go to Mordor"}], "parameters": {"temperature": 0.9, "max_tokens": 256}},
+      "output": {"messages": [{"content": "Ah, a bold and foolish hobbit seeking to
+      challenge my dominion in Mordor. Very well, little creature, I shall play along.
+      But know that I am always watching, and your quest will not go unnoticed", "role":
+      "assistant"}]}}, "metrics": {"input_tokens": 64, "output_tokens": 128,
+      "total_tokens": 192}}]}'
     headers:
       Content-Type:
       - application/json

--- a/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_span_writer.test_send_timed_events.yaml
+++ b/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_span_writer.test_send_timed_events.yaml
@@ -4,11 +4,12 @@ interactions:
       "12345678901", "trace_id": "98765432101", "parent_id": "", "session_id": "98765432101",
       "name": "completion_span", "tags": ["version:", "env:", "service:", "source:integration"],
       "start_ns": 1707763310981223236, "duration": 12345678900, "error": 0, "meta":
-      {"span.kind": "llm", "model_name": "ada", "model_provider": "openai", "input": {"messages":
-      [{"content": "who broke enigma?"}], "parameters": {"temperature": 0, "max_tokens":
-      256}}, "output": {"messages": [{"content": "\n\nThe Enigma code was broken by
-      a team of codebreakers at Bletchley Park, led by mathematician Alan Turing."}]}},
-      "metrics": {"prompt_tokens": 64, "completion_tokens": 128, "total_tokens": 192}}]}}'
+      {"span.kind": "llm", "model_name": "ada", "model_provider": "openai", "input":
+      {"messages": [{"content": "who broke enigma?"}], "parameters": {"temperature":
+      0, "max_tokens": 256}}, "output": {"messages": [{"content": "\n\nThe Enigma
+      code was broken by a team of codebreakers at Bletchley Park, led by mathematician
+      Alan Turing."}]}}, "metrics": {"input_tokens": 64, "output_tokens": 128,
+      "total_tokens": 192}}]}'
     headers:
       Content-Type:
       - application/json
@@ -51,8 +52,13 @@ interactions:
       256}}, "output": {"messages": [{"content": "Ah, a bold and foolish hobbit seeking
       to challenge my dominion in Mordor. Very well, little creature, I shall play
       along. But know that I am always watching, and your quest will not go unnoticed",
+<<<<<<< HEAD
       "role": "assistant"}]}}, "metrics": {"prompt_tokens": 64, "completion_tokens":
       128, "total_tokens": 192}}]}}'
+=======
+      "role": "assistant"}]}}, "metrics": {"input_tokens": 64, "output_tokens":
+      128, "total_tokens": 192}}]}'
+>>>>>>> 65aca749f (chore(llmobs): token metrics name changes (#9657))
     headers:
       Content-Type:
       - application/json

--- a/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_span_writer.test_send_timed_events.yaml
+++ b/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_span_writer.test_send_timed_events.yaml
@@ -52,13 +52,8 @@ interactions:
       256}}, "output": {"messages": [{"content": "Ah, a bold and foolish hobbit seeking
       to challenge my dominion in Mordor. Very well, little creature, I shall play
       along. But know that I am always watching, and your quest will not go unnoticed",
-<<<<<<< HEAD
-      "role": "assistant"}]}}, "metrics": {"prompt_tokens": 64, "completion_tokens":
-      128, "total_tokens": 192}}]}}'
-=======
       "role": "assistant"}]}}, "metrics": {"input_tokens": 64, "output_tokens":
       128, "total_tokens": 192}}]}'
->>>>>>> 65aca749f (chore(llmobs): token metrics name changes (#9657))
     headers:
       Content-Type:
       - application/json

--- a/tests/llmobs/test_llmobs_decorators.py
+++ b/tests/llmobs/test_llmobs_decorators.py
@@ -285,7 +285,7 @@ def test_llm_annotate(LLMObs, mock_llmobs_span_writer):
             input_data=[{"content": "test_prompt"}],
             output_data=[{"content": "test_response"}],
             tags={"custom_tag": "tag_value"},
-            metrics={"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+            metrics={"input_tokens": 10, "output_tokens": 20, "total_tokens": 30},
         )
 
     f()
@@ -299,7 +299,7 @@ def test_llm_annotate(LLMObs, mock_llmobs_span_writer):
             input_messages=[{"content": "test_prompt"}],
             output_messages=[{"content": "test_response"}],
             parameters={"temperature": 0.9, "max_tokens": 50},
-            token_metrics={"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+            token_metrics={"input_tokens": 10, "output_tokens": 20, "total_tokens": 30},
             tags={"custom_tag": "tag_value"},
             session_id="test_session_id",
         )
@@ -314,7 +314,7 @@ def test_llm_annotate_raw_string_io(LLMObs, mock_llmobs_span_writer):
             input_data="test_prompt",
             output_data="test_response",
             tags={"custom_tag": "tag_value"},
-            metrics={"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+            metrics={"input_tokens": 10, "output_tokens": 20, "total_tokens": 30},
         )
 
     f()
@@ -328,7 +328,7 @@ def test_llm_annotate_raw_string_io(LLMObs, mock_llmobs_span_writer):
             input_messages=[{"content": "test_prompt"}],
             output_messages=[{"content": "test_response"}],
             parameters={"temperature": 0.9, "max_tokens": 50},
-            token_metrics={"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+            token_metrics={"input_tokens": 10, "output_tokens": 20, "total_tokens": 30},
             tags={"custom_tag": "tag_value"},
             session_id="test_session_id",
         )

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -615,8 +615,8 @@ def test_annotate_output_llm_message_wrong_type(LLMObs, mock_logs):
 
 def test_annotate_metrics(LLMObs):
     with LLMObs.llm(model_name="test_model") as span:
-        LLMObs.annotate(span=span, metrics={"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30})
-        assert json.loads(span.get_tag(METRICS)) == {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
+        LLMObs.annotate(span=span, metrics={"input_tokens": 10, "output_tokens": 20, "total_tokens": 30})
+        assert json.loads(span.get_tag(METRICS)) == {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30}
 
 
 def test_annotate_metrics_wrong_type(LLMObs, mock_logs):

--- a/tests/llmobs/test_llmobs_span_writer.py
+++ b/tests/llmobs/test_llmobs_span_writer.py
@@ -40,7 +40,7 @@ def _completion_event():
                 ]
             },
         },
-        "metrics": {"prompt_tokens": 64, "completion_tokens": 128, "total_tokens": 192},
+        "metrics": {"input_tokens": 64, "output_tokens": 128, "total_tokens": 192},
     }
 
 
@@ -78,7 +78,7 @@ def _chat_completion_event():
                 ]
             },
         },
-        "metrics": {"prompt_tokens": 64, "completion_tokens": 128, "total_tokens": 192},
+        "metrics": {"input_tokens": 64, "output_tokens": 128, "total_tokens": 192},
     }
 
 


### PR DESCRIPTION
Manual backport for https://github.com/DataDog/dd-trace-py/pull/9657 to 2.10

Backport allows us to remove logic in the backend which parses both (prompt/completion_tokens) and (input/output_tokens) keys

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

