### PR TITLE
chore(docs): install rust for .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,5 +6,7 @@ build:
   commands:
     - git fetch --unshallow || true
     - pip install hatch~=1.8.0 hatch-containers==0.7.0
+    - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
+    - echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$BASH_ENV"
     - hatch -v run docs:sphinx-build -W -b html docs docs/_build/html
     - mv docs/_build $READTHEDOCS_OUTPUT


### PR DESCRIPTION
[Our readthedocs build is failing currently due to not having Rust installed](https://app.readthedocs.org/projects/ddtrace/builds/24988009/). This change should fix this, so our docs can be updated.

Currently, the readthedocs builds haven't happened in 2 months (2.8.1). We need at least 2.9.2 to be published.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
