### PR TITLE
ci: revert mypy lint against the oldest supported py version (#9684)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -12,7 +12,6 @@ no_implicit_optional = true
 ignore_missing_imports = true
 namespace_packages = true
 plugins = envier.mypy
-python_version = 3.7
 
 [mypy-ddtrace.contrib.*]
 ignore_errors = true


### PR DESCRIPTION
This reverts commit 15355d7df49a0d97244b3700ee6d7ea12d798370.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
