### PR TITLE
fix(profiling): use octet-stream as code provenance content type

### DIFF
--- a/ddtrace/profiling/exporter/http.py
+++ b/ddtrace/profiling/exporter/http.py
@@ -235,7 +235,7 @@ class PprofHTTPExporter(pprof.PprofExporter):
                 {
                     "name": b"code-provenance",
                     "filename": b"code-provenance.json",
-                    "content-type": b"application/json",
+                    "content-type": b"application/octet-stream",
                     "data": code_provenance.getvalue(),
                 }
             )


### PR DESCRIPTION
The PR changes the code provenance content type from `application/json` to `application/octet-stream` as the underlying code provenance data is binary. Also the change makes the content type consistent with DataDog profiler for other languages like Ruby (refer [here](https://github.com/DataDog/dd-trace-rb/issues/3767#issuecomment-2217325350))

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
