### PR TITLE
ci(iast): change logic for fixme_propagation_fails

### DIFF
--- a/tests/appsec/iast_packages/test_packages.py
+++ b/tests/appsec/iast_packages/test_packages.py
@@ -882,6 +882,7 @@ def _assert_propagation_results(response, package):
             else:
                 pytest.xfail("FIXME: Test passed unexpectedly for package %s" % package.name)
         else:
+            # result not OK, so propagation is not yet working for the package
             pytest.xfail("FIXME: Test failed expectedly for package %s" % package.name)
 
     if not result_ok:


### PR DESCRIPTION
IAST: Set as `xfail` instead of `fail` a known package that is successfully propagating sometimes (not always) when it was usually not propagating at all.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
