### PR TITLE
chore: fix memtest taint count test

### DIFF
--- a/tests/appsec/iast/fixtures/propagation_path.py
+++ b/tests/appsec/iast/fixtures/propagation_path.py
@@ -158,7 +158,8 @@ def propagation_memory_check(origin_string1, tainted_string_2):
     # TAINTSOURCE1TAINTSOURCE2-TAINTSOURCE1TAINTSOURCE2-TAINTSOURCE1TAINTSOURCE_notainted.jpg
     string18 = os.path.splitext(string17)[0]
     # TAINTSOURCE1TAINTSOURCE2-TAINTSOURCE1TAINTSOURCE2-TAINTSOURCE1TAINTSOURCE_notainted
-    string19 = os.path.join(os.sep + string18, "nottainted_notdir")
+    string19_pre = os.sep + string18
+    string19 = os.path.join(string19_pre, "nottainted_notdir")
     # /TAINTSOURCE1TAINTSOURCE2-TAINTSOURCE1TAINTSOURCE2-TAINTSOURCE1TAINTSOURCE_notainted/nottainted_notdir
     string20 = os.path.dirname(string19)
     # /TAINTSOURCE1TAINTSOURCE2-TAINTSOURCE1TAINTSOURCE2-TAINTSOURCE1TAINTSOURCE_notainted

--- a/tests/appsec/iast_memcheck/test_iast_mem_check.py
+++ b/tests/appsec/iast_memcheck/test_iast_mem_check.py
@@ -100,9 +100,7 @@ def test_propagation_memory_check(origin1, origin2, iast_span_defaults):
             _initializer_size = initializer_size()
             assert _initializer_size > 0
 
-        # FIXME: returns 25 instead of 24 on the second loop:
-        # https://datadoghq.atlassian.net/browse/APPSEC-54115
-        # assert _num_objects_tainted == num_objects_tainted()
+        assert _num_objects_tainted == num_objects_tainted()
         assert _active_map_addreses_size == active_map_addreses_size()
         assert _initializer_size == initializer_size()
         reset_context()


### PR DESCRIPTION
## Description

One of the memleak tests compared the count of number of elements in the `tx_map`. The problem was that the test generated one temporal string with an operator add that got added to the map and then deallocated, whose address could or could not be reused later thus making the size if the `tx_map` "flaky" between tests. This changes the test so the string is assigned a name and thus not deallocated.

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
