### PR TITLE
chore: update guild code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -119,7 +119,7 @@ mypy.ini                            @DataDog/python-guild  @DataDog/apm-core-pyt
 .github/PULL_REQUEST_TEMPLATE.md    @DataDog/python-guild  @DataDog/apm-core-python
 .github/ISSUE_TEMPLATE.md           @DataDog/python-guild  @DataDog/apm-core-python
 .github/CODEOWNERS                  @DataDog/python-guild  @DataDog/apm-core-python
-.github/workflows/system-tests.yml  @DataDog/python-guild  @DataDog/apm-core-python
+.github/workflows                   @DataDog/python-guild  @DataDog/apm-core-python
 ddtrace/internal/_file_queue.py     @DataDog/python-guild
 ddtrace/internal/_unpatched.py      @DataDog/python-guild
 ddtrace/internal/compat.py          @DataDog/python-guild  @DataDog/apm-core-python

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -108,13 +108,13 @@ setup.py                            @DataDog/python-guild
 setup.cfg                           @DataDog/python-guild
 pyproject.toml                      @DataDog/python-guild
 hatch.toml                          @DataDog/python-guild
-.readthedocs.yml                    @DataDog/python-guild @DataDog/apm-core-python
-README.md                           @DataDog/python-guild @DataDog/apm-core-python
-mypy.ini                            @DataDog/python-guild @DataDog/apm-core-python
-.circleci/                          @DataDog/python-guild @DataDog/apm-core-python
-.github/                            @DataDog/python-guild @DataDog/apm-core-python
-.gitlab/                            @DataDog/python-guild @DataDog/apm-core-python
+.readthedocs.yml                    @DataDog/python-guild  @DataDog/apm-core-python
+README.md                           @DataDog/python-guild  @DataDog/apm-core-python
+mypy.ini                            @DataDog/python-guild  @DataDog/apm-core-python
+.circleci/                          @DataDog/python-guild  @DataDog/apm-core-python
+.github/                            @DataDog/python-guild  @DataDog/apm-core-python
+.gitlab/                            @DataDog/python-guild  @DataDog/apm-core-python
 ddtrace/internal/_file_queue.py     @DataDog/python-guild
 ddtrace/internal/_unpatched.py      @DataDog/python-guild
-ddtrace/internal/compat.py          @DataDog/python-guild @DataDog/apm-core-python
+ddtrace/internal/compat.py          @DataDog/python-guild  @DataDog/apm-core-python
 tests/utils.py                      @DataDog/python-guild

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -104,23 +104,17 @@ ddtrace/internal/remoteconfig       @DataDog/remote-config @DataDog/apm-core-pyt
 tests/internal/remoteconfig         @DataDog/remote-config @DataDog/apm-core-python
 
 # Guild
-# Note that core is added here since 2 reviewers are required. The guild isn't
-# big enough to support if a guild member makes a change which means 2 other
-# guild members have to review.
-# We should enforce this for important files, but more frequently edited ones
-# can settle for having 1 guild member review + a core team member.
 setup.py                            @DataDog/python-guild
 setup.cfg                           @DataDog/python-guild
 pyproject.toml                      @DataDog/python-guild
 hatch.toml                          @DataDog/python-guild
-.readthedocs.yml                    @DataDog/python-guild  @DataDog/apm-core-python
-README.md                           @DataDog/python-guild  @DataDog/apm-core-python
-mypy.ini                            @DataDog/python-guild  @DataDog/apm-core-python
-.github/PULL_REQUEST_TEMPLATE.md    @DataDog/python-guild  @DataDog/apm-core-python
-.github/ISSUE_TEMPLATE.md           @DataDog/python-guild  @DataDog/apm-core-python
-.github/CODEOWNERS                  @DataDog/python-guild  @DataDog/apm-core-python
-.github/workflows                   @DataDog/python-guild  @DataDog/apm-core-python
+.readthedocs.yml                    @DataDog/python-guild
+README.md                           @DataDog/python-guild
+mypy.ini                            @DataDog/python-guild
+.circleci/                          @DataDog/python-guild
+.github/                            @DataDog/python-guild
+.gitlab/                            @DataDog/python-guild
 ddtrace/internal/_file_queue.py     @DataDog/python-guild
 ddtrace/internal/_unpatched.py      @DataDog/python-guild
-ddtrace/internal/compat.py          @DataDog/python-guild  @DataDog/apm-core-python
+ddtrace/internal/compat.py          @DataDog/python-guild
 tests/utils.py                      @DataDog/python-guild

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -108,13 +108,13 @@ setup.py                            @DataDog/python-guild
 setup.cfg                           @DataDog/python-guild
 pyproject.toml                      @DataDog/python-guild
 hatch.toml                          @DataDog/python-guild
-.readthedocs.yml                    @DataDog/python-guild
-README.md                           @DataDog/python-guild
-mypy.ini                            @DataDog/python-guild
-.circleci/                          @DataDog/python-guild
-.github/                            @DataDog/python-guild
-.gitlab/                            @DataDog/python-guild
+.readthedocs.yml                    @DataDog/python-guild @DataDog/apm-core-python
+README.md                           @DataDog/python-guild @DataDog/apm-core-python
+mypy.ini                            @DataDog/python-guild @DataDog/apm-core-python
+.circleci/                          @DataDog/python-guild @DataDog/apm-core-python
+.github/                            @DataDog/python-guild @DataDog/apm-core-python
+.gitlab/                            @DataDog/python-guild @DataDog/apm-core-python
 ddtrace/internal/_file_queue.py     @DataDog/python-guild
 ddtrace/internal/_unpatched.py      @DataDog/python-guild
-ddtrace/internal/compat.py          @DataDog/python-guild
+ddtrace/internal/compat.py          @DataDog/python-guild @DataDog/apm-core-python
 tests/utils.py                      @DataDog/python-guild


### PR DESCRIPTION
`.github/**`, `.gitlab/**`, and `.circleci/**` should be approvable by the Python guild members, not just core.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
