### PR TITLE
chore: added entire `ddtrace/internal/*` to internal test suite

### DIFF
--- a/tests/.suitespec.json
+++ b/tests/.suitespec.json
@@ -447,6 +447,7 @@
             "@remoteconfig",
             "@symbol_db",
             "@tracing",
+            "ddtrace/internal/*",
             "tests/internal/*",
             "tests/submod/*",
             "tests/cache/*"


### PR DESCRIPTION
We've run into multiple instances where changes that should have triggered the `internal` test suite have not. In order to prevent future false negatives, we're adding the entire `ddtrace/internal/**` directory to the internal test suitespec.

The goal is to remove false positives as we encounter them, rather than doing one-offs of adding back false negatives as we encounter them.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
