### PR TITLE
ci: fix by unsetting `test_import` to `google-auth` package

### DIFF
--- a/tests/appsec/iast_packages/test_packages.py
+++ b/tests/appsec/iast_packages/test_packages.py
@@ -254,8 +254,7 @@ PACKAGES = [
         "",
         "",
         "",
-        import_name="google.auth.crypt.rsa",
-        import_module_to_validate="google.auth.crypt.rsa",
+        test_import=False,
     ),
     PackageForTesting(
         "google-api-core",


### PR DESCRIPTION
## Motivation

Fixes CI tests that only run on main: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/65973/workflows/49c8b4e7-651a-4486-9ab9-5a5aabc02e7e/jobs/4060571/tests#failed-test-0

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
