### PR TITLE
fix(ci): fix failing telemetry test_app_started_error_handled_exception

### DIFF
--- a/tests/.suitespec.json
+++ b/tests/.suitespec.json
@@ -660,6 +660,7 @@
             "@bootstrap",
             "@core",
             "@telemetry",
+            "@tracing",
             "@settings",
             "@profiling",
             "tests/telemetry/*",

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -208,9 +208,13 @@ tracer.trace("hello").finish()
     app_started_events = [event for event in events if event["request_type"] == "app-started"]
     assert len(app_started_events) == 1
     assert app_started_events[0]["payload"]["error"]["code"] == 1
-    assert "error applying processor FailingFilture()" in app_started_events[0]["payload"]["error"]["message"]
+    assert (
+        "error applying processor <__main__.FailingFilture object at"
+        in app_started_events[0]["payload"]["error"]["message"]
+    )
     pattern = re.compile(
-        ".*ddtrace/_trace/processor/__init__.py/__init__.py:[0-9]+: error applying processor FailingFilture()"
+        ".*ddtrace/_trace/processor/__init__.py/__init__.py:[0-9]+: "
+        "error applying processor <__main__.FailingFilture object at 0x[0-9a-f]+>"
     )
     assert pattern.match(app_started_events[0]["payload"]["error"]["message"]), app_started_events[0]["payload"][
         "error"


### PR DESCRIPTION
https://github.com/DataDog/dd-trace-py/pull/9857 removed the usage of `attr` which removed the `__str__` and `__repr__` from trace processor. This means the assertions in the telemetry tests started to fail.

The telemetry tests were not run on tracing changes, which is why it wasn't found in the original PR.


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
