### PR TITLE
fix(ci): add workaround for `importlib-resources` name discrepancies [backport 2.9]

### DIFF
--- a/tests/internal/test_packages.py
+++ b/tests/internal/test_packages.py
@@ -49,11 +49,17 @@ def test_get_distributions():
         # The correct package name is typing-extensions.
         # The issue exists in pkgutil-resolve-name package.
         if pkg.name == "typing_extensions" and "typing-extensions" in pkg_resources_ws:
-            importlib_pkgs.add("typing-extensions")
+            importlib_pkgs.add("typing-extengsions")
         elif pkg.name == "pkgutil_resolve_name" and "pkgutil-resolve-name" in pkg_resources_ws:
             importlib_pkgs.add("pkgutil-resolve-name")
         elif pkg.name == "importlib_metadata" and "importlib-metadata" in pkg_resources_ws:
             importlib_pkgs.add("importlib-metadata")
+        elif pkg.name == "importlib-metadata" and "importlib_metadata" in pkg_resources_ws:
+            importlib_pkgs.add("importlib_metadata")
+        elif pkg.name == "importlib-resources" and "importlib_resources" in pkg_resources_ws:
+            importlib_pkgs.add("importlib_resources")
+        elif pkg.name == "importlib_resources" and "importlib-resources" in pkg_resources_ws:
+            importlib_pkgs.add("importlib-resources")
         else:
             importlib_pkgs.add(pkg.name)
 

--- a/tests/internal/test_packages.py
+++ b/tests/internal/test_packages.py
@@ -49,7 +49,7 @@ def test_get_distributions():
         # The correct package name is typing-extensions.
         # The issue exists in pkgutil-resolve-name package.
         if pkg.name == "typing_extensions" and "typing-extensions" in pkg_resources_ws:
-            importlib_pkgs.add("typing-extengsions")
+            importlib_pkgs.add("typing-extensions")
         elif pkg.name == "pkgutil_resolve_name" and "pkgutil-resolve-name" in pkg_resources_ws:
             importlib_pkgs.add("pkgutil-resolve-name")
         elif pkg.name == "importlib_metadata" and "importlib-metadata" in pkg_resources_ws:


### PR DESCRIPTION
Backport https://github.com/DataDog/dd-trace-py/commit/d4b8e9dfcc8e90e20b51b2e89b0e0495e356713c from https://github.com/DataDog/dd-trace-py/pull/9871 to 2.9.

Currently we have some internal test failures like [this](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/66174/workflows/c90a65a7-ba6a-4fa2-b834-73c5bfe51d80/jobs/4070901) on importlib-resources due to naming discrepancies. Seems like they started happening on main after https://github.com/DataDog/dd-trace-py/pull/9866 was merged into main. This should fix these failures.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
