### PR TITLE
fix: telemetry exception hooks (#9830) [backport 2.10]

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -240,6 +240,7 @@ class TelemetryWriter(PeriodicService):
     # of `itertools.count()` which is a CPython implementation detail. The sequence field in telemetry
     # payloads is only used in tests and is not required to process Telemetry events.
     _sequence = itertools.count(1)
+    _ORIGINAL_EXCEPTHOOK = staticmethod(sys.excepthook)
 
     def __init__(self, is_periodic=True, agentless=None):
         # type: (bool, Optional[bool]) -> None
@@ -461,9 +462,11 @@ class TelemetryWriter(PeriodicService):
                 (TELEMETRY_TRACE_COMPUTE_STATS, config._trace_compute_stats, "unknown"),
                 (
                     TELEMETRY_OBFUSCATION_QUERY_STRING_PATTERN,
-                    config._obfuscation_query_string_pattern.pattern.decode("ascii")
-                    if config._obfuscation_query_string_pattern
-                    else "",
+                    (
+                        config._obfuscation_query_string_pattern.pattern.decode("ascii")
+                        if config._obfuscation_query_string_pattern
+                        else ""
+                    ),
                     "unknown",
                 ),
                 (TELEMETRY_OTEL_ENABLED, config._otel_enabled, "unknown"),
@@ -817,3 +820,47 @@ class TelemetryWriter(PeriodicService):
         super(TelemetryWriter, self)._stop_service(*args, **kwargs)
         if join:
             self.join(timeout=2)
+
+    def _telemetry_excepthook(self, tp, value, root_traceback):
+        if root_traceback is not None:
+            # Get the frame which raised the exception
+            traceback = root_traceback
+            while traceback.tb_next:
+                traceback = traceback.tb_next
+
+            lineno = traceback.tb_frame.f_code.co_firstlineno
+            filename = traceback.tb_frame.f_code.co_filename
+            self.add_error(1, str(value), filename, lineno)
+
+            dir_parts = filename.split(os.path.sep)
+            # Check if exception was raised in the  `ddtrace.contrib` package
+            if "ddtrace" in dir_parts and "contrib" in dir_parts:
+                ddtrace_index = dir_parts.index("ddtrace")
+                contrib_index = dir_parts.index("contrib")
+                # Check if the filename has the following format:
+                # `../ddtrace/contrib/integration_name/..(subpath and/or file)...`
+                if ddtrace_index + 1 == contrib_index and len(dir_parts) - 2 > contrib_index:
+                    integration_name = dir_parts[contrib_index + 1]
+                    self.add_count_metric(
+                        "tracers",
+                        "integration_errors",
+                        1,
+                        (("integration_name", integration_name), ("error_type", tp.__name__)),
+                    )
+                    error_msg = "{}:{} {}".format(filename, lineno, str(value))
+                    self.add_integration(integration_name, True, error_msg=error_msg)
+
+            if self._enabled and not self.started:
+                self._app_started_event(False)
+
+            self.app_shutdown()
+
+        return TelemetryWriter._ORIGINAL_EXCEPTHOOK(tp, value, root_traceback)
+
+    def install_excepthook(self):
+        """Install a hook that intercepts unhandled exception and send metrics about them."""
+        sys.excepthook = self._telemetry_excepthook
+
+    def uninstall_excepthook(self):
+        """Uninstall the global tracer except hook."""
+        sys.excepthook = TelemetryWriter._ORIGINAL_EXCEPTHOOK

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 import pytest


### PR DESCRIPTION
When wrapping pre-configured exception hooks the telemetry writer converts exception hooks from type `function` to type `method `. This adds the `self` argument to pre-configured exception which raised the following error: `TypeError: xxxsome_funcxxxx() takes 3 positional arguments but 4 were given`.

To resolve this issue this PR casts
`TelemetryWriter._ORIGINAL_EXCEPTHOOK` is cast to a static method. This ensures the telemetry writer does not modify the argument of preconfigured hooks.

When an application raises an unhandled exception and ddtrace instrumentation telemetry is enabled:
 - the ddtrace telemetry exception will be executed
- the ddtrace library will fail to run exception hooks that were configured before ddtrace was imported
- applications will log `TypeError: xxxsome_funcxxxx() takes 3 positional arguments but 4 were given` on application shutdown.

Resolves the following errors:
https://github.com/DataDog/dd-trace-py/actions/runs/9891512830/job/27322136218#step:5:141

This bug was introduced in:
https://github.com/DataDog/dd-trace-py/commit/0cdc0831a62ee2575833298c49ff468cb14d51fb

- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

- [x] Reviewer has checked that all the criteria below are met
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

(cherry picked from commit d323bbab450bded455a35969d3a4994210612f07)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
