### PR TITLE
feat(llmobs): span writer via agent evp proxy

### DIFF
--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -230,6 +230,8 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
         self._metrics["accepted_traces"] = encoded  # sets accepted traces to number of spans in encoders
 
     def _set_keep_rate(self, trace):
+        # Only triggered if trace is Span type
+        # LLMObsSpanEvent type from LLMObsSpanAgentWriter doesn't have set_metric
         if trace and isinstance(trace[0], Span):
             trace[0].set_metric(KEEP_SPANS_RATE_KEY, 1.0 - self._drop_sma.get())
 

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -47,6 +47,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Callable  # noqa:F401
     from typing import Tuple  # noqa:F401
 
+    from ddtrace.llmobs._writer import LLMObsSpanEvent  # noqa:F401
+
     from .agent import ConnectionType  # noqa:F401
 
 
@@ -231,7 +233,7 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
 
     def _set_keep_rate(self, trace):
         # Only triggered if trace is Span type
-        # LLMObsSpanEvent type from LLMObsSpanAgentWriter doesn't have set_metric
+        # LLMObsSpanEvent type from LLMObsSpanAgentWriter(HTTPWriter) doesn't have set_metric as TypedDict
         if trace and isinstance(trace[0], Span):
             trace[0].set_metric(KEEP_SPANS_RATE_KEY, 1.0 - self._drop_sma.get())
 
@@ -328,7 +330,7 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
             self.flush_queue()
 
     def _write_with_client(self, client, spans=None):
-        # type: (WriterClientBase, Optional[List[Span]]) -> None
+        # type: (WriterClientBase, Optional[List[Union[Span, LLMObsSpanEvent]]]) -> None
         if spans is None:
             return
 

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -13,6 +13,7 @@ from typing import Optional  # noqa:F401
 from typing import TextIO  # noqa:F401
 
 import ddtrace
+from ddtrace import Span
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from ddtrace.settings import _config as config
 from ddtrace.settings.asm import config as asm_config
@@ -45,8 +46,6 @@ from .writer_client import WriterClientBase  # noqa:F401
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Callable  # noqa:F401
     from typing import Tuple  # noqa:F401
-
-    from ddtrace import Span  # noqa:F401
 
     from .agent import ConnectionType  # noqa:F401
 
@@ -231,7 +230,7 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
         self._metrics["accepted_traces"] = encoded  # sets accepted traces to number of spans in encoders
 
     def _set_keep_rate(self, trace):
-        if trace and isinstance(trace, Span):
+        if trace and isinstance(trace[0], Span):
             trace[0].set_metric(KEEP_SPANS_RATE_KEY, 1.0 - self._drop_sma.get())
 
     def _reset_connection(self):

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -231,7 +231,7 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
         self._metrics["accepted_traces"] = encoded  # sets accepted traces to number of spans in encoders
 
     def _set_keep_rate(self, trace):
-        if trace:
+        if trace and isinstance(trace, Span):
             trace[0].set_metric(KEEP_SPANS_RATE_KEY, 1.0 - self._drop_sma.get())
 
     def _reset_connection(self):

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -13,7 +13,6 @@ from typing import Optional  # noqa:F401
 from typing import TextIO  # noqa:F401
 
 import ddtrace
-from ddtrace import Span
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from ddtrace.settings import _config as config
 from ddtrace.settings.asm import config as asm_config
@@ -46,9 +45,8 @@ from .writer_client import WriterClientBase  # noqa:F401
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Callable  # noqa:F401
     from typing import Tuple  # noqa:F401
-    from typing import Union  # noqa:F401
 
-    from ddtrace.llmobs._writer import LLMObsSpanEvent  # noqa:F401
+    from ddtrace import Span  # noqa:F401
 
     from .agent import ConnectionType  # noqa:F401
 
@@ -233,9 +231,7 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
         self._metrics["accepted_traces"] = encoded  # sets accepted traces to number of spans in encoders
 
     def _set_keep_rate(self, trace):
-        # Only triggered if trace is Span type
-        # LLMObsSpanEvent type from LLMObsSpanAgentWriter(HTTPWriter) doesn't have set_metric as TypedDict
-        if trace and isinstance(trace[0], Span):
+        if trace:
             trace[0].set_metric(KEEP_SPANS_RATE_KEY, 1.0 - self._drop_sma.get())
 
     def _reset_connection(self):
@@ -331,7 +327,7 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
             self.flush_queue()
 
     def _write_with_client(self, client, spans=None):
-        # type: (WriterClientBase, Optional[List[Union[Span, LLMObsSpanEvent]]]) -> None
+        # type: (WriterClientBase, Optional[List[Span]]) -> None
         if spans is None:
             return
 

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -46,6 +46,7 @@ from .writer_client import WriterClientBase  # noqa:F401
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Callable  # noqa:F401
     from typing import Tuple  # noqa:F401
+    from typing import Union  # noqa:F401
 
     from ddtrace.llmobs._writer import LLMObsSpanEvent  # noqa:F401
 

--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -29,3 +29,8 @@ OPENAI_APM_SPAN_NAME = "openai.request"
 INPUT_TOKENS_METRIC_KEY = "input_tokens"
 OUTPUT_TOKENS_METRIC_KEY = "output_tokens"
 TOTAL_TOKENS_METRIC_KEY = "total_tokens"
+
+EVP_PROXY_AGENT_BASE_PATH = "evp_proxy/v2"
+EVP_PROXY_AGENT_ENDPOINT = "{}/api/v2/llmobs".format(EVP_PROXY_AGENT_BASE_PATH)
+EVP_SUBDOMAIN_HEADER_NAME = "X-Datadog-EVP-Subdomain"
+EVP_SUBDOMAIN_HEADER_VALUE = "llmobs-intake"

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -80,7 +80,7 @@ class LLMObs(Service):
         )
 
     def _configure_span_writer(self):
-        if asbool(os.getenv("DD_LLMOBS_AGENTLESS_ENABLED")):
+        if config._llmobs_agentless_enabled:
             self._llmobs_span_writer = LLMObsSpanWriter(
                 site=config._dd_site,
                 api_key=config._dd_api_key,

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -87,11 +87,11 @@ class LLMObs(Service):
                 interval=float(os.getenv("_DD_LLMOBS_WRITER_INTERVAL", 1.0)),
                 timeout=float(os.getenv("_DD_LLMOBS_WRITER_TIMEOUT", 5.0)),
             )
-            return
-        self._llmobs_span_writer = LLMObsSpanAgentWriter(
-            interval=float(os.getenv("_DD_LLMOBS_WRITER_INTERVAL", 1.0)),
-            timeout=float(os.getenv("_DD_LLMOBS_WRITER_TIMEOUT", 5.0)),
-        )
+        else:
+            self._llmobs_span_writer = LLMObsSpanAgentWriter(
+                interval=float(os.getenv("_DD_LLMOBS_WRITER_INTERVAL", 1.0)),
+                timeout=float(os.getenv("_DD_LLMOBS_WRITER_TIMEOUT", 5.0)),
+            )
 
     def _start_service(self) -> None:
         tracer_filters = self.tracer._filters

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -158,16 +158,6 @@ class LLMObs(Service):
         config._llmobs_ml_app = ml_app or config._llmobs_ml_app
 
         # validate required values for LLMObs
-        if not config._dd_api_key:
-            raise ValueError(
-                "DD_API_KEY is required for sending LLMObs data. "
-                "Ensure this configuration is set before running your application."
-            )
-        if not config._dd_site:
-            raise ValueError(
-                "DD_SITE is required for sending LLMObs data. "
-                "Ensure this configuration is set before running your application."
-            )
         if not config._llmobs_ml_app:
             raise ValueError(
                 "DD_LLMOBS_ML_APP is required for sending LLMObs data. "
@@ -176,6 +166,17 @@ class LLMObs(Service):
 
         config._llmobs_agentless_enabled = agentless_enabled or config._llmobs_agentless_enabled
         if config._llmobs_agentless_enabled:
+            # validate required values for agentless LLMObs
+            if not config._dd_api_key:
+                raise ValueError(
+                    "DD_API_KEY is required for sending LLMObs data. "
+                    "Ensure this configuration is set before running your application."
+                )
+            if not config._dd_site:
+                raise ValueError(
+                    "DD_SITE is required for sending LLMObs data. "
+                    "Ensure this configuration is set before running your application."
+                )
             if not os.getenv("DD_INSTRUMENTATION_TELEMETRY_ENABLED"):
                 config._telemetry_enabled = False
                 log.debug("Telemetry disabled because DD_LLMOBS_AGENTLESS_ENABLED is set to true.")

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -169,12 +169,12 @@ class LLMObs(Service):
             # validate required values for agentless LLMObs
             if not config._dd_api_key:
                 raise ValueError(
-                    "DD_API_KEY is required for sending LLMObs data. "
+                    "DD_API_KEY is required for sending LLMObs data when agentless mode is enabled. "
                     "Ensure this configuration is set before running your application."
                 )
             if not config._dd_site:
                 raise ValueError(
-                    "DD_SITE is required for sending LLMObs data. "
+                    "DD_SITE is required for sending LLMObs data when agentless mode is enabled. "
                     "Ensure this configuration is set before running your application."
                 )
             if not os.getenv("DD_INSTRUMENTATION_TELEMETRY_ENABLED"):

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -183,14 +183,15 @@ class LLMObsSpanEncoder(BufferedEncoder):
         with self._lock:
             self._buffer = []
 
-    def put(self, event: LLMObsSpanEvent):
+    def put(self, events: List[LLMObsSpanEvent]):
+        # events always has only 1 event - to be compatible with HTTPWriter interfaces
         with self._lock:
             if len(self._buffer) >= self._buffer_limit:
                 logger.warning(
                     "%r event buffer full (limit is %d), dropping event", self.__class__.__name__, self._buffer_limit
                 )
                 return
-            self._buffer.append(event)
+            self._buffer.extend(events)
 
     def encode(self):
         with self._lock:

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -263,6 +263,10 @@ class LLMObsSpanAgentWriter(HTTPWriter):
     def enqueue(self, event: LLMObsSpanEvent) -> None:
         self.write([event])
 
+    # Noop to make it compatible with HTTPWriter interface
+    def _set_keep_rate(self, events: List[LLMObsSpanEvent]):
+        return
+
     def recreate(self):
         # type: () -> HTTPWriter
         return self.__class__(

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -201,6 +201,7 @@ class LLMObsSpanEncoder(BufferedEncoder):
         data = {"_dd.stage": "raw", "event_type": "span", "spans": events}
         try:
             enc_llm_events = json.dumps(data)
+            logger.debug("encode %d LLMObs span events to be sent", len(events))
         except TypeError:
             logger.error("failed to encode %d LLMObs span events", len(events), exc_info=True)
             return

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -166,6 +166,7 @@ class LLMObsEvalMetricWriter(BaseLLMObsWriter):
         return {"data": {"type": "evaluation_metric", "attributes": {"metrics": events}}}
 
 
+# LLMObsSpanEncoder encodes LLMObsSpanEvents to json in buffer, and is used in LLMObsSpanAgentWriter's LLMObsEventClient
 class LLMObsSpanEncoder(BufferedEncoder):
     content_type = "application/json"
 

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -184,7 +184,7 @@ class LLMObsSpanEncoder(BufferedEncoder):
             self._buffer = []
 
     def put(self, events: List[LLMObsSpanEvent]):
-        # events always has only 1 event - to be compatible with HTTPWriter interfaces
+        # events always has only 1 event - with List type to be compatible with HTTPWriter interfaces
         with self._lock:
             if len(self._buffer) >= self._buffer_limit:
                 logger.warning(

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -166,8 +166,9 @@ class LLMObsEvalMetricWriter(BaseLLMObsWriter):
         return {"data": {"type": "evaluation_metric", "attributes": {"metrics": events}}}
 
 
-# LLMObsSpanEncoder encodes LLMObsSpanEvents to json in buffer, and is used in LLMObsSpanAgentWriter's LLMObsEventClient
 class LLMObsSpanEncoder(BufferedEncoder):
+    """Encodes LLMObsSpanEvents to JSON in buffer, and is used in LLMObsSpanAgentWriter's LLMObsEventClient"""
+
     content_type = "application/json"
 
     def __init__(self, *args):

--- a/releasenotes/notes/feat-llmobs-span-writer-via-agent-evp-proxy-d8ea55491a1db2be.yaml
+++ b/releasenotes/notes/feat-llmobs-span-writer-via-agent-evp-proxy-d8ea55491a1db2be.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    LLM Observability: This introduces the agent proxy mode for LLM Observability. By default, if agentless mode is not 
+    enabled, llmobs spans are sent to the agent trace url, and then forwarded to Event Platform's llmobs intake.

--- a/releasenotes/notes/feat-llmobs-span-writer-via-agent-evp-proxy-d8ea55491a1db2be.yaml
+++ b/releasenotes/notes/feat-llmobs-span-writer-via-agent-evp-proxy-d8ea55491a1db2be.yaml
@@ -1,5 +1,7 @@
 ---
 features:
   - |
-    LLM Observability: This introduces the agent proxy mode for LLM Observability. By default, if agentless mode is not 
-    enabled, llmobs spans are sent to the agent trace url, and then forwarded to Event Platform's llmobs intake.
+    LLM Observability: This introduces the agent proxy mode for LLM Observability. By default, LLM Observability spans 
+    will be sent to the Datadog agent and then forwarded to LLM Observability. 
+    To continue submitting data directly to LLM Observability without the Datadog agent, set 
+    ``DD_LLMOBS_AGENTLESS_ENABLED=1`` or set programmatically using ``LLMObs.enable(agentless_enabled=True)``.

--- a/tests/contrib/anthropic/conftest.py
+++ b/tests/contrib/anthropic/conftest.py
@@ -49,7 +49,7 @@ def mock_tracer(ddtrace_global_config, anthropic):
 
 @pytest.fixture
 def mock_llmobs_writer(scope="session"):
-    patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanWriter")
+    patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanAgentWriter")
     try:
         LLMObsSpanWriterMock = patcher.start()
         m = mock.MagicMock()

--- a/tests/contrib/botocore/test_bedrock.py
+++ b/tests/contrib/botocore/test_bedrock.py
@@ -64,7 +64,7 @@ def bedrock_client(boto3, request_vcr):
 
 @pytest.fixture
 def mock_llmobs_span_writer():
-    patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanWriter")
+    patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanAgentWriter")
     try:
         LLMObsSpanWriterMock = patcher.start()
         m = mock.MagicMock()

--- a/tests/contrib/botocore/test_bedrock_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_llmobs.py
@@ -64,7 +64,7 @@ def bedrock_client(boto3, request_vcr):
 
 @pytest.fixture
 def mock_llmobs_span_writer():
-    patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanWriter")
+    patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanAgentWriter")
     try:
         LLMObsSpanWriterMock = patcher.start()
         m = mock.MagicMock()

--- a/tests/contrib/langchain/conftest.py
+++ b/tests/contrib/langchain/conftest.py
@@ -68,7 +68,7 @@ def mock_tracer(langchain, mock_logs, mock_metrics):
 
 @pytest.fixture
 def mock_llmobs_span_writer():
-    patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanWriter")
+    patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanAgentWriter")
     try:
         LLMObsSpanWriterMock = patcher.start()
         m = mock.MagicMock()

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -523,7 +523,7 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
     )
 
     def setUp(self):
-        patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanWriter")
+        patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanAgentWriter")
         LLMObsSpanWriterMock = patcher.start()
         mock_llmobs_span_writer = mock.MagicMock()
         LLMObsSpanWriterMock.return_value = mock_llmobs_span_writer

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -592,7 +592,7 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
         from langchain_core.messages import HumanMessage
 
         patch(langchain=True, botocore=True)
-        LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False, agentless_enabled=True)
+        LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False)
 
         self._call_bedrock_chat_model(ChatBedrock, HumanMessage)
 
@@ -604,7 +604,7 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
         from langchain_core.messages import HumanMessage
 
         patch(langchain=True)
-        LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False, agentless_enabled=True)
+        LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False)
 
         self._call_bedrock_chat_model(ChatBedrock, HumanMessage)
 
@@ -615,7 +615,7 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
         from langchain_aws import BedrockLLM
 
         patch(langchain=True, botocore=True)
-        LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False, agentless_enabled=True)
+        LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False)
         self._call_bedrock_llm(BedrockLLM)
         self._assert_trace_structure_from_writer_call_args(["workflow", "llm"])
 
@@ -624,7 +624,7 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
         from langchain_aws import BedrockLLM
 
         patch(langchain=True)
-        LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False, agentless_enabled=True)
+        LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False)
         self._call_bedrock_llm(BedrockLLM)
         self._assert_trace_structure_from_writer_call_args(["llm"])
 
@@ -633,7 +633,7 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
         from langchain_openai import OpenAI
 
         patch(langchain=True, openai=True)
-        LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False, agentless_enabled=True)
+        LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False)
         self._call_openai_llm(OpenAI)
         self._assert_trace_structure_from_writer_call_args(["workflow", "llm"])
 
@@ -643,7 +643,7 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
 
         patch(langchain=True)
 
-        LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False, agentless_enabled=True)
+        LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False)
         self._call_openai_llm(OpenAI)
         self._assert_trace_structure_from_writer_call_args(["llm"])
 
@@ -653,7 +653,7 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
 
         patch(langchain=True, anthropic=True)
 
-        LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False, agentless_enabled=True)
+        LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False)
         self._call_anthropic_chat(ChatAnthropic)
         self._assert_trace_structure_from_writer_call_args(["workflow", "llm"])
 
@@ -663,7 +663,7 @@ class TestTraceStructureWithLLMIntegrations(SubprocessTestCase):
 
         patch(langchain=True)
 
-        LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False, agentless_enabled=True)
+        LLMObs.enable(ml_app="<ml-app-name>", integrations_enabled=False)
 
         self._call_anthropic_chat(ChatAnthropic)
         self._assert_trace_structure_from_writer_call_args(["llm"])

--- a/tests/contrib/openai/conftest.py
+++ b/tests/contrib/openai/conftest.py
@@ -130,7 +130,7 @@ def mock_logs(scope="session"):
 
 @pytest.fixture
 def mock_llmobs_writer(scope="session"):
-    patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanWriter")
+    patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanAgentWriter")
     try:
         LLMObsSpanWriterMock = patcher.start()
         m = mock.MagicMock()

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -224,3 +224,73 @@ def _expected_llmobs_eval_metric_event(
         eval_metric_event["tags"] = tags
 
     return eval_metric_event
+
+
+def _completion_event():
+    return {
+        "kind": "llm",
+        "span_id": "12345678901",
+        "trace_id": "98765432101",
+        "parent_id": "",
+        "session_id": "98765432101",
+        "name": "completion_span",
+        "tags": ["version:", "env:", "service:", "source:integration"],
+        "start_ns": 1707763310981223236,
+        "duration": 12345678900,
+        "error": 0,
+        "meta": {
+            "span.kind": "llm",
+            "model_name": "ada",
+            "model_provider": "openai",
+            "input": {
+                "messages": [{"content": "who broke enigma?"}],
+                "parameters": {"temperature": 0, "max_tokens": 256},
+            },
+            "output": {
+                "messages": [
+                    {
+                        "content": "\n\nThe Enigma code was broken by a team of codebreakers at Bletchley Park, led by mathematician Alan Turing."  # noqa: E501
+                    }
+                ]
+            },
+        },
+        "metrics": {"input_tokens": 64, "output_tokens": 128, "total_tokens": 192},
+    }
+
+
+def _chat_completion_event():
+    return {
+        "span_id": "12345678902",
+        "trace_id": "98765432102",
+        "parent_id": "",
+        "session_id": "98765432102",
+        "name": "chat_completion_span",
+        "tags": ["version:", "env:", "service:", "source:integration"],
+        "start_ns": 1707763310981223936,
+        "duration": 12345678900,
+        "error": 0,
+        "meta": {
+            "span.kind": "llm",
+            "model_name": "gpt-3.5-turbo",
+            "model_provider": "openai",
+            "input": {
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "You are an evil dark lord looking for his one ring to rule them all",
+                    },
+                    {"role": "user", "content": "I am a hobbit looking to go to Mordor"},
+                ],
+                "parameters": {"temperature": 0.9, "max_tokens": 256},
+            },
+            "output": {
+                "messages": [
+                    {
+                        "content": "Ah, a bold and foolish hobbit seeking to challenge my dominion in Mordor. Very well, little creature, I shall play along. But know that I am always watching, and your quest will not go unnoticed",  # noqa: E501
+                        "role": "assistant",
+                    },
+                ]
+            },
+        },
+        "metrics": {"input_tokens": 64, "output_tokens": 128, "total_tokens": 192},
+    }

--- a/tests/llmobs/conftest.py
+++ b/tests/llmobs/conftest.py
@@ -101,10 +101,9 @@ def LLMObs(mock_llmobs_span_writer, mock_llmobs_eval_metric_writer, ddtrace_glob
 def AgentlessLLMObs(mock_llmobs_span_agentless_writer, mock_llmobs_eval_metric_writer, ddtrace_global_config):
     global_config = default_global_config()
     global_config.update(ddtrace_global_config)
+    global_config.update(dict(_llmobs_agentless_enabled=True))
     with override_global_config(global_config):
-        os.environ["DD_LLMOBS_AGENTLESS_ENABLED"] = "1"
         dummy_tracer = DummyTracer()
         llmobs_service.enable(_tracer=dummy_tracer)
         yield llmobs_service
         llmobs_service.disable()
-        os.environ.pop("DD_LLMOBS_AGENTLESS_ENABLED", None)

--- a/tests/llmobs/conftest.py
+++ b/tests/llmobs/conftest.py
@@ -29,7 +29,7 @@ def pytest_configure(config):
 
 @pytest.fixture
 def mock_llmobs_span_writer():
-    patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanWriter")
+    patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanAgentWriter")
     LLMObsSpanWriterMock = patcher.start()
     m = mock.MagicMock()
     LLMObsSpanWriterMock.return_value = m

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -101,10 +101,11 @@ def test_service_enable_no_api_key():
     with override_global_config(dict(_dd_api_key="", _llmobs_ml_app="<ml-app-name>")):
         dummy_tracer = DummyTracer()
         with pytest.raises(ValueError):
-            llmobs_service.enable(_tracer=dummy_tracer)
+            llmobs_service.enable(_tracer=dummy_tracer, agentless_enabled=True)
         assert llmobs_service.enabled is False
         assert llmobs_service._instance._llmobs_eval_metric_writer.status.value == "stopped"
         assert llmobs_service._instance._llmobs_span_writer.status.value == "stopped"
+        os.environ.pop("DD_LLMOBS_AGENTLESS_ENABLED", None)
 
 
 def test_service_enable_no_ml_app_specified():

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import mock
 import pytest
@@ -83,6 +84,7 @@ def test_service_enable_with_apm_disabled(monkeypatch):
         assert run_llmobs_trace_filter(dummy_tracer) is None
 
         llmobs_service.disable()
+        os.environ.pop("DD_LLMOBS_AGENTLESS_ENABLED", None)
 
 
 def test_service_disable():

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -1,5 +1,4 @@
 import json
-import os
 
 import mock
 import pytest
@@ -84,7 +83,6 @@ def test_service_enable_with_apm_disabled(monkeypatch):
         assert run_llmobs_trace_filter(dummy_tracer) is None
 
         llmobs_service.disable()
-        os.environ.pop("DD_LLMOBS_AGENTLESS_ENABLED", None)
 
 
 def test_service_disable():
@@ -105,7 +103,6 @@ def test_service_enable_no_api_key():
         assert llmobs_service.enabled is False
         assert llmobs_service._instance._llmobs_eval_metric_writer.status.value == "stopped"
         assert llmobs_service._instance._llmobs_span_writer.status.value == "stopped"
-        os.environ.pop("DD_LLMOBS_AGENTLESS_ENABLED", None)
 
 
 def test_service_enable_no_ml_app_specified():

--- a/tests/llmobs/test_llmobs_span_agent_writer.py
+++ b/tests/llmobs/test_llmobs_span_agent_writer.py
@@ -1,7 +1,6 @@
 import time
 
 import mock
-import pytest
 
 from ddtrace.internal import agent
 from ddtrace.llmobs._writer import LLMObsSpanAgentWriter
@@ -18,8 +17,7 @@ def test_writer_start(mock_writer_logs):
     mock_writer_logs.debug.assert_has_calls([mock.call("started %r to %r", "LLMObsSpanAgentWriter", INTAKE_ENDPOINT)])
 
 
-@pytest.mark.mock_http_writer_send_payload_response
-def test_buffer_limit(mock_writer_logs):
+def test_buffer_limit(mock_writer_logs, mock_http_writer_send_payload_response):
     llmobs_span_writer = LLMObsSpanAgentWriter(interval=1000, timeout=1)
     for _ in range(1001):
         llmobs_span_writer.enqueue({})
@@ -28,8 +26,7 @@ def test_buffer_limit(mock_writer_logs):
     )
 
 
-@pytest.mark.mock_http_writer_send_payload_response
-def test_send_completion_event(mock_writer_logs):
+def test_send_completion_event(mock_writer_logs, mock_http_writer_send_payload_response):
     llmobs_span_writer = LLMObsSpanAgentWriter(interval=1000, timeout=1)
     llmobs_span_writer.start()
     llmobs_span_writer.enqueue(_completion_event())
@@ -37,8 +34,7 @@ def test_send_completion_event(mock_writer_logs):
     mock_writer_logs.debug.assert_has_calls([mock.call("encode %d LLMObs span events to be sent", 1)])
 
 
-@pytest.mark.mock_http_writer_send_payload_response
-def test_send_chat_completion_event(mock_writer_logs):
+def test_send_chat_completion_event(mock_writer_logs, mock_http_writer_send_payload_response):
     llmobs_span_writer = LLMObsSpanAgentWriter(interval=1000, timeout=1)
     llmobs_span_writer.start()
     llmobs_span_writer.enqueue(_chat_completion_event())
@@ -46,8 +42,7 @@ def test_send_chat_completion_event(mock_writer_logs):
     mock_writer_logs.debug.assert_has_calls([mock.call("encode %d LLMObs span events to be sent", 1)])
 
 
-@pytest.mark.mock_http_writer_send_payload_response
-def test_send_timed_events(mock_writer_logs):
+def test_send_timed_events(mock_writer_logs, mock_http_writer_send_payload_response):
     llmobs_span_writer = LLMObsSpanAgentWriter(interval=0.05, timeout=1)
     llmobs_span_writer.start()
     mock_writer_logs.reset_mock()

--- a/tests/llmobs/test_llmobs_span_agent_writer.py
+++ b/tests/llmobs/test_llmobs_span_agent_writer.py
@@ -1,0 +1,61 @@
+import time
+
+import mock
+import pytest
+
+from ddtrace.internal import agent
+from ddtrace.llmobs._writer import LLMObsSpanAgentWriter
+from tests.llmobs._utils import _chat_completion_event
+from tests.llmobs._utils import _completion_event
+
+
+INTAKE_ENDPOINT = agent.get_trace_url()
+
+
+def test_writer_start(mock_writer_logs):
+    llmobs_span_writer = LLMObsSpanAgentWriter(interval=1000, timeout=1)
+    llmobs_span_writer.start()
+    mock_writer_logs.debug.assert_has_calls([mock.call("started %r to %r", "LLMObsSpanAgentWriter", INTAKE_ENDPOINT)])
+
+
+@pytest.mark.mock_http_writer_send_payload_response
+def test_buffer_limit(mock_writer_logs):
+    llmobs_span_writer = LLMObsSpanAgentWriter(interval=1000, timeout=1)
+    for _ in range(1001):
+        llmobs_span_writer.enqueue({})
+    mock_writer_logs.warning.assert_called_with(
+        "%r event buffer full (limit is %d), dropping event", "LLMObsSpanEncoder", 1000
+    )
+
+
+@pytest.mark.mock_http_writer_send_payload_response
+def test_send_completion_event(mock_writer_logs):
+    llmobs_span_writer = LLMObsSpanAgentWriter(interval=1000, timeout=1)
+    llmobs_span_writer.start()
+    llmobs_span_writer.enqueue(_completion_event())
+    llmobs_span_writer.periodic()
+    mock_writer_logs.debug.assert_has_calls([mock.call("encode %d LLMObs span events to be sent", 1)])
+
+
+@pytest.mark.mock_http_writer_send_payload_response
+def test_send_chat_completion_event(mock_writer_logs):
+    llmobs_span_writer = LLMObsSpanAgentWriter(interval=1000, timeout=1)
+    llmobs_span_writer.start()
+    llmobs_span_writer.enqueue(_chat_completion_event())
+    llmobs_span_writer.periodic()
+    mock_writer_logs.debug.assert_has_calls([mock.call("encode %d LLMObs span events to be sent", 1)])
+
+
+@pytest.mark.mock_http_writer_send_payload_response
+def test_send_timed_events(mock_writer_logs):
+    llmobs_span_writer = LLMObsSpanAgentWriter(interval=0.05, timeout=1)
+    llmobs_span_writer.start()
+    mock_writer_logs.reset_mock()
+
+    llmobs_span_writer.enqueue(_completion_event())
+    time.sleep(0.1)
+    mock_writer_logs.debug.assert_has_calls([mock.call("encode %d LLMObs span events to be sent", 1)])
+    mock_writer_logs.reset_mock()
+    llmobs_span_writer.enqueue(_chat_completion_event())
+    time.sleep(0.1)
+    mock_writer_logs.debug.assert_has_calls([mock.call("encode %d LLMObs span events to be sent", 1)])

--- a/tests/llmobs/test_llmobs_span_writer.py
+++ b/tests/llmobs/test_llmobs_span_writer.py
@@ -5,81 +5,13 @@ import mock
 import pytest
 
 from ddtrace.llmobs._writer import LLMObsSpanWriter
+from tests.llmobs._utils import _chat_completion_event
+from tests.llmobs._utils import _completion_event
 
 
 INTAKE_ENDPOINT = "https://llmobs-intake.datad0g.com/api/v2/llmobs"
 DD_SITE = "datad0g.com"
 dd_api_key = os.getenv("DD_API_KEY", default="<not-a-real-api-key>")
-
-
-def _completion_event():
-    return {
-        "kind": "llm",
-        "span_id": "12345678901",
-        "trace_id": "98765432101",
-        "parent_id": "",
-        "session_id": "98765432101",
-        "name": "completion_span",
-        "tags": ["version:", "env:", "service:", "source:integration"],
-        "start_ns": 1707763310981223236,
-        "duration": 12345678900,
-        "error": 0,
-        "meta": {
-            "span.kind": "llm",
-            "model_name": "ada",
-            "model_provider": "openai",
-            "input": {
-                "messages": [{"content": "who broke enigma?"}],
-                "parameters": {"temperature": 0, "max_tokens": 256},
-            },
-            "output": {
-                "messages": [
-                    {
-                        "content": "\n\nThe Enigma code was broken by a team of codebreakers at Bletchley Park, led by mathematician Alan Turing."  # noqa: E501
-                    }
-                ]
-            },
-        },
-        "metrics": {"input_tokens": 64, "output_tokens": 128, "total_tokens": 192},
-    }
-
-
-def _chat_completion_event():
-    return {
-        "span_id": "12345678902",
-        "trace_id": "98765432102",
-        "parent_id": "",
-        "session_id": "98765432102",
-        "name": "chat_completion_span",
-        "tags": ["version:", "env:", "service:", "source:integration"],
-        "start_ns": 1707763310981223936,
-        "duration": 12345678900,
-        "error": 0,
-        "meta": {
-            "span.kind": "llm",
-            "model_name": "gpt-3.5-turbo",
-            "model_provider": "openai",
-            "input": {
-                "messages": [
-                    {
-                        "role": "system",
-                        "content": "You are an evil dark lord looking for his one ring to rule them all",
-                    },
-                    {"role": "user", "content": "I am a hobbit looking to go to Mordor"},
-                ],
-                "parameters": {"temperature": 0.9, "max_tokens": 256},
-            },
-            "output": {
-                "messages": [
-                    {
-                        "content": "Ah, a bold and foolish hobbit seeking to challenge my dominion in Mordor. Very well, little creature, I shall play along. But know that I am always watching, and your quest will not go unnoticed",  # noqa: E501
-                        "role": "assistant",
-                    },
-                ]
-            },
-        },
-        "metrics": {"input_tokens": 64, "output_tokens": 128, "total_tokens": 192},
-    }
 
 
 def test_writer_start(mock_writer_logs):


### PR DESCRIPTION
Implementation of the `llm_span_agent_writer` that sends llm span via agent endpoint's EvP proxy. 
Context: we want to use existing Agent EvP proxy available in `HTTPWriter` class, so that LLMOBS customers don't need to configure api key & site explicitly.
https://datadoghq.atlassian.net/browse/MLOB-1207

Test:
Unit tests updated.
E2e test, with updated [test script ](https://github.com/DataDog/llm-obs/blob/main/test-scripts/openai/patch_simple_chat_completions_call.py), we can see the payload gets successfully forwarded via agent EvP proxy and shows in Datadog LLMOBS UI.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
