### PR TITLE
chore(tracer): use simple queue file for extra service names instead of multiprocessing [backport 2.10]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -119,6 +119,7 @@ mypy.ini                            @DataDog/python-guild  @DataDog/apm-core-pyt
 .github/ISSUE_TEMPLATE.md           @DataDog/python-guild  @DataDog/apm-core-python
 .github/CODEOWNERS                  @DataDog/python-guild  @DataDog/apm-core-python
 .github/workflows/system-tests.yml  @DataDog/python-guild  @DataDog/apm-core-python
+ddtrace/internal/_file_queue.py     @DataDog/python-guild
 ddtrace/internal/_unpatched.py      @DataDog/python-guild
 ddtrace/internal/compat.py          @DataDog/python-guild  @DataDog/apm-core-python
 tests/utils.py                      @DataDog/python-guild

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,44 @@
+name: UnitTests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch: {}
+
+jobs:
+  unit-tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+         - os: ubuntu-latest
+           archs: x86_64 i686
+         #- os: arm-4core-linux
+         #  archs: aarch64
+         - os: windows-latest
+           archs: AMD64 x86
+         - os: macos-latest
+           archs: arm64
+    steps:
+      - uses: actions/checkout@v4
+        # Include all history and tags
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: '3.12'
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install latest stable toolchain and rustfmt
+        run: rustup update stable && rustup default stable && rustup component add rustfmt clippy
+
+      - name: Install hatch
+        run: pip install hatch
+
+      - name: Run tests
+        run: hatch run ddtrace_unit_tests:test

--- a/ddtrace/internal/_file_queue.py
+++ b/ddtrace/internal/_file_queue.py
@@ -1,0 +1,88 @@
+import os
+import os.path
+import secrets
+import tempfile
+import typing
+
+from ddtrace.internal._unpatched import unpatched_open
+
+
+MAX_FILE_SIZE = 8192
+
+try:
+    # Unix based file locking
+    # Availability: Unix, not Emscripten, not WASI.
+    import fcntl
+
+    def lock(f):
+        fcntl.lockf(f, fcntl.LOCK_EX)
+
+    def unlock(f):
+        fcntl.lockf(f, fcntl.LOCK_UN)
+
+    def open_file(path, mode):
+        return unpatched_open(path, mode)
+
+except ModuleNotFoundError:
+    # Availability: Windows
+    import msvcrt
+
+    def lock(f):
+        # You need to seek to the beginning of the file before locking it
+        f.seek(0)
+        msvcrt.locking(f.fileno(), msvcrt.LK_RLCK, MAX_FILE_SIZE)
+
+    def unlock(f):
+        # You need to seek to the same position of the file when you locked before unlocking it
+        f.seek(0)
+        msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, MAX_FILE_SIZE)
+
+    def open_file(path, mode):
+        import _winapi
+
+        # force all modes to be read/write binary
+        mode = "r+b"
+        flag = _winapi.GENERIC_READ | _winapi.GENERIC_WRITE
+        fd_flag = os.O_RDWR | os.O_CREAT | os.O_BINARY | os.O_RANDOM
+        SHARED_READ_WRITE = 0x7
+        OPEN_ALWAYS = 4
+        RANDOM_ACCESS = 0x10000000
+        handle = _winapi.CreateFile(path, flag, SHARED_READ_WRITE, 0, OPEN_ALWAYS, RANDOM_ACCESS, 0)
+        fd = msvcrt.open_osfhandle(handle, fd_flag | os.O_NOINHERIT)
+        return unpatched_open(fd, mode)
+
+
+class File_Queue:
+    """A simple file-based queue implementation for multiprocess communication."""
+
+    def __init__(self) -> None:
+        self.directory = tempfile.gettempdir()
+        self.filename = os.path.join(self.directory, secrets.token_hex(8))
+
+    def put(self, data: str) -> None:
+        """Push a string to the queue."""
+        try:
+            with open_file(self.filename, "ab") as f:
+                lock(f)
+                f.seek(0, os.SEEK_END)
+                if f.tell() < MAX_FILE_SIZE:
+                    f.write((data + "\x00").encode())
+                unlock(f)
+        except Exception:  # nosec
+            pass
+
+    def get_all(self) -> typing.Set[str]:
+        """Pop all unique strings from the queue."""
+        try:
+            with open_file(self.filename, "r+b") as f:
+                lock(f)
+                f.seek(0)
+                data = f.read().decode()
+                f.seek(0)
+                f.truncate()
+                unlock(f)
+            if data:
+                return set(data.split("\x00")[:-1])
+        except Exception:  # nosec
+            pass
+        return set()

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -12,7 +12,7 @@ from typing import Tuple  # noqa:F401
 from typing import Union  # noqa:F401
 
 from ddtrace.internal._file_queue import File_Queue
-from ddtrace.internal.serverless import in_azure_function 
+from ddtrace.internal.serverless import in_azure_function
 from ddtrace.internal.serverless import in_gcp_function
 from ddtrace.internal.utils.cache import cachedmethod
 from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -12,7 +12,7 @@ from typing import Tuple  # noqa:F401
 from typing import Union  # noqa:F401
 
 from ddtrace.internal._file_queue import File_Queue
-from ddtrace.internal.serverless import in_azure_function_consumption_plan
+from ddtrace.internal.serverless import in_azure_function 
 from ddtrace.internal.serverless import in_gcp_function
 from ddtrace.internal.utils.cache import cachedmethod
 from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -11,8 +11,8 @@ from typing import Optional  # noqa:F401
 from typing import Tuple  # noqa:F401
 from typing import Union  # noqa:F401
 
-from ddtrace.internal.compat import get_mp_context
-from ddtrace.internal.serverless import in_azure_function
+from ddtrace.internal._file_queue import File_Queue
+from ddtrace.internal.serverless import in_azure_function_consumption_plan
 from ddtrace.internal.serverless import in_gcp_function
 from ddtrace.internal.utils.cache import cachedmethod
 from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
@@ -334,8 +334,6 @@ class Config(object):
     available and can be updated by users.
     """
 
-    _extra_services_queue = None if in_aws_lambda() else get_mp_context().Queue(512)
-
     class _HTTPServerConfig(object):
         _error_statuses = "500-599"  # type: str
         _error_ranges = get_error_ranges(_error_statuses)  # type: List[Tuple[int, int]]
@@ -447,6 +445,7 @@ class Config(object):
             self.service = os.environ.get("WEBSITE_SITE_NAME")
 
         self._extra_services = set()
+        self._extra_services_queue = None if in_aws_lambda() or not self._remote_config_enabled else File_Queue()
         self.version = os.getenv("DD_VERSION", default=self.tags.get("version"))
         self.http_server = self._HTTPServerConfig()
 
@@ -577,23 +576,16 @@ class Config(object):
     def _add_extra_service(self, service_name: str) -> None:
         if self._extra_services_queue is None:
             return
-        if self._remote_config_enabled and service_name != self.service:
-            try:
-                self._extra_services_queue.put_nowait(service_name)
-            except Exception:  # nosec
-                pass
+        if service_name != self.service:
+            self._extra_services_queue.put(service_name)
 
     def _get_extra_services(self):
         # type: () -> set[str]
         if self._extra_services_queue is None:
             return set()
-        try:
-            while True:
-                self._extra_services.add(self._extra_services_queue.get(timeout=0.002))
-                if len(self._extra_services) > 64:
-                    self._extra_services.pop()
-        except Exception:  # nosec
-            pass
+        self._extra_services.update(self._extra_services_queue.get_all())
+        while len(self._extra_services) > 64:
+            self._extra_services.pop()
         return self._extra_services
 
     def get_from(self, obj):

--- a/hatch.toml
+++ b/hatch.toml
@@ -192,6 +192,7 @@ dependencies = [
 
 [envs.appsec_threats_django.scripts]
 test = [
+    "uname -a",
     "pip freeze",
     "DD_IAST_ENABLED=false python -m pytest tests/appsec/contrib_appsec/test_django.py",
     "DD_IAST_ENABLED=true DD_IAST_REQUEST_SAMPLING=100 python -m pytest tests/appsec/contrib_appsec/test_django.py"
@@ -237,6 +238,7 @@ dependencies = [
 
 [envs.appsec_threats_flask.scripts]
 test = [
+    "uname -a",
     "pip freeze",
     "DD_IAST_ENABLED=false python -m pytest tests/appsec/contrib_appsec/test_flask.py",
     "DD_IAST_ENABLED=true DD_IAST_REQUEST_SAMPLING=100 python -m pytest tests/appsec/contrib_appsec/test_flask.py"
@@ -279,6 +281,7 @@ dependencies = [
 
 [envs.appsec_threats_fastapi.scripts]
 test = [
+    "uname -a",
     "pip freeze",
     "DD_IAST_ENABLED=false python -m pytest tests/appsec/contrib_appsec/test_fastapi.py",
     "DD_IAST_ENABLED=true DD_IAST_REQUEST_SAMPLING=100 python -m pytest tests/appsec/contrib_appsec/test_fastapi.py"
@@ -299,3 +302,27 @@ fastapi = ["==0.94.1"]
 [[envs.appsec_threats_fastapi.matrix]]
 python = ["3.8", "3.10", "3.11"]
 fastapi = ["~=0.109"]
+
+## Unit Tests
+
+[envs.ddtrace_unit_tests]
+dependencies = [
+    "pytest",
+    "pytest-coverage",
+    "requests",
+    "hypothesis",
+]
+
+[envs.ddtrace_unit_tests.env-vars]
+DD_IAST_ENABLED = "false"
+DD_REMOTE_CONFIGURATION_ENABLED = "false"
+
+[envs.ddtrace_unit_tests.scripts]
+test = [
+    "uname -a",
+    "pip freeze",
+    "python -m pytest tests/internal/service_name/test_extra_services_names.py -vvv -s",
+]
+
+[[envs.ddtrace_unit_tests.matrix]]
+python = ["3.12", "3.10", "3.7"]

--- a/tests/.suitespec.json
+++ b/tests/.suitespec.json
@@ -37,6 +37,7 @@
         "core": [
             "ddtrace/internal/__init__.py",
             "ddtrace/internal/_exceptions.py",
+            "ddtrace/internal/_file_queue.py",
             "ddtrace/internal/_rand.pyi",
             "ddtrace/internal/_rand.pyx",
             "ddtrace/internal/_stdint.h",

--- a/tests/internal/service_name/test_extra_services_names.py
+++ b/tests/internal/service_name/test_extra_services_names.py
@@ -1,17 +1,16 @@
 import random
+import re
 import threading
 import time
 
 import pytest
 
 import ddtrace
-from tests.utils import flaky
 
 
 MAX_NAMES = 64
 
 
-@flaky(1735812000)
 @pytest.mark.parametrize("nb_service", [2, 16, 64, 256])
 def test_service_name(nb_service):
     ddtrace.config._extra_services = set()
@@ -22,12 +21,22 @@ def test_service_name(nb_service):
 
     default_remote_config_enabled = ddtrace.config._remote_config_enabled
     ddtrace.config._remote_config_enabled = True
+    if ddtrace.config._extra_services_queue is None:
+        import ddtrace.internal._file_queue as file_queue
+
+        ddtrace.config._extra_services_queue = file_queue.File_Queue()
 
     threads = [threading.Thread(target=write_in_subprocess, args=(i,)) for i in range(nb_service)]
     for thread in threads:
         thread.start()
     for thread in threads:
         thread.join()
+
+    extra_services = ddtrace.config._get_extra_services()
+    assert len(extra_services) == min(nb_service, MAX_NAMES)
+    assert all(re.match(r"extra_service_\d+", service) for service in extra_services)
+
     ddtrace.config._remote_config_enabled = default_remote_config_enabled
-    assert len(ddtrace.config._get_extra_services()) == min(nb_service, MAX_NAMES)
+    if not default_remote_config_enabled:
+        ddtrace.config._extra_services_queue = None
     ddtrace.config._extra_services = set()


### PR DESCRIPTION
…of multiprocessing (#9701)

To prevent further problems with multiprocessing in config:
- remove multiprocessing queue from main config file
- add a new File_Queue using low level locking to write into temporary file
- Use the new queue to exchange messages between multiple processes for extra service names
- update tests
- added a new unit-tests workflow on github to launch any tests on linux(x86), macos(arm64) and windows(x86). (For now, only the test relevant to that PR is used).

This is an alternative solution to
https://github.com/DataDog/dd-trace-py/pull/9626 ensuring that we still report extra service names.

[APPSEC-53927]

- [x] The PR description includes an overview of the change
- [x] The PR description articulates the motivation for the change
- [x] The change includes tests OR the PR description describes a testing strategy
- [x] The PR description notes risks associated with the change, if any
- [x] Newly-added code is easy to change
- [x] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [x] The change includes or references documentation updates if necessary
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Newly-added code is easy to change
- [x] Release note makes sense to a user of the library
- [x] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

[APPSEC-53927]:
https://datadoghq.atlassian.net/browse/APPSEC-53927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

(cherry picked from commit f85625adceb18107014c3229b834a1df7e912395)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)


[APPSEC-53927]: https://datadoghq.atlassian.net/browse/APPSEC-53927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPSEC-53927]: https://datadoghq.atlassian.net/browse/APPSEC-53927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ