### PR TITLE
chore: adding type Literal to constants.py file

### DIFF
--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -1,43 +1,51 @@
+import sys
+
+
+if sys.version_info >= (3, 8):
+    from typing import Literal  # noqa:F401
+else:
+    from typing_extensions import Literal  # noqa:F401
+
 # TODO: Deprecate and remove the SAMPLE_RATE_METRIC_KEY constant.
 # This key enables legacy trace sampling support in the Datadog agent.
-SAMPLE_RATE_METRIC_KEY = "_sample_rate"
-SAMPLING_PRIORITY_KEY = "_sampling_priority_v1"
-ANALYTICS_SAMPLE_RATE_KEY = "_dd1.sr.eausr"
-SAMPLING_AGENT_DECISION = "_dd.agent_psr"
-SAMPLING_RULE_DECISION = "_dd.rule_psr"
-SAMPLING_LIMIT_DECISION = "_dd.limit_psr"
-_SINGLE_SPAN_SAMPLING_MECHANISM = "_dd.span_sampling.mechanism"
-_SINGLE_SPAN_SAMPLING_RATE = "_dd.span_sampling.rule_rate"
-_SINGLE_SPAN_SAMPLING_MAX_PER_SEC = "_dd.span_sampling.max_per_second"
+SAMPLE_RATE_METRIC_KEY: Literal["_sample_rate"] = "_sample_rate"
+SAMPLING_PRIORITY_KEY: Literal["_sampling_priority_v1"] = "_sampling_priority_v1"
+ANALYTICS_SAMPLE_RATE_KEY: Literal["_dd1.sr.eausr"] = "_dd1.sr.eausr"
+SAMPLING_AGENT_DECISION: Literal["_dd.agent_psr"] = "_dd.agent_psr"
+SAMPLING_RULE_DECISION: Literal["_dd.rule_psr"] = "_dd.rule_psr"
+SAMPLING_LIMIT_DECISION: Literal["_dd.limit_psr"] = "_dd.limit_psr"
+_SINGLE_SPAN_SAMPLING_MECHANISM: Literal["_dd.span_sampling.mechanism"] = "_dd.span_sampling.mechanism"
+_SINGLE_SPAN_SAMPLING_RATE: Literal["_dd.span_sampling.rule_rate"] = "_dd.span_sampling.rule_rate"
+_SINGLE_SPAN_SAMPLING_MAX_PER_SEC: Literal["_dd.span_sampling.max_per_second"] = "_dd.span_sampling.max_per_second"
 _SINGLE_SPAN_SAMPLING_MAX_PER_SEC_NO_LIMIT = -1
-_APM_ENABLED_METRIC_KEY = "_dd.apm.enabled"
+_APM_ENABLED_METRIC_KEY: Literal["_dd.apm.enabled"] = "_dd.apm.enabled"
 
-ORIGIN_KEY = "_dd.origin"
-USER_ID_KEY = "_dd.p.usr.id"
-HOSTNAME_KEY = "_dd.hostname"
-RUNTIME_FAMILY = "_dd.runtime_family"
-ENV_KEY = "env"
-VERSION_KEY = "version"
-SERVICE_KEY = "service.name"
-BASE_SERVICE_KEY = "_dd.base_service"
-SERVICE_VERSION_KEY = "service.version"
-SPAN_KIND = "span.kind"
-SPAN_MEASURED_KEY = "_dd.measured"
-KEEP_SPANS_RATE_KEY = "_dd.tracer_kr"
-MULTIPLE_IP_HEADERS = "_dd.multiple-ip-headers"
+ORIGIN_KEY: Literal["_dd.origin"] = "_dd.origin"
+USER_ID_KEY: Literal["_dd.p.usr.id"] = "_dd.p.usr.id"
+HOSTNAME_KEY: Literal["_dd.hostname"] = "_dd.hostname"
+RUNTIME_FAMILY: Literal["_dd.runtime_family"] = "_dd.runtime_family"
+ENV_KEY: Literal["env"] = "env"
+VERSION_KEY: Literal["version"] = "version"
+SERVICE_KEY: Literal["service.name"] = "service.name"
+BASE_SERVICE_KEY: Literal["_dd.base_service"] = "_dd.base_service"
+SERVICE_VERSION_KEY: Literal["service.version"] = "service.version"
+SPAN_KIND: Literal["span.kind"] = "span.kind"
+SPAN_MEASURED_KEY: Literal["_dd.measured"] = "_dd.measured"
+KEEP_SPANS_RATE_KEY: Literal["_dd.tracer_kr"] = "_dd.tracer_kr"
+MULTIPLE_IP_HEADERS: Literal["_dd.multiple-ip-headers"] = "_dd.multiple-ip-headers"
 
-APPSEC_ENV = "DD_APPSEC_ENABLED"
+APPSEC_ENV: Literal["DD_APPSEC_ENABLED"] = "DD_APPSEC_ENABLED"
 
-IAST_ENV = "DD_IAST_ENABLED"
+IAST_ENV: Literal["DD_IAST_ENABLED"] = "DD_IAST_ENABLED"
 
-MANUAL_DROP_KEY = "manual.drop"
-MANUAL_KEEP_KEY = "manual.keep"
+MANUAL_DROP_KEY: Literal["manual.drop"] = "manual.drop"
+MANUAL_KEEP_KEY: Literal["manual.keep"] = "manual.keep"
 
-ERROR_MSG = "error.message"  # a string representing the error message
-ERROR_TYPE = "error.type"  # a string representing the type of the error
-ERROR_STACK = "error.stack"  # a human readable version of the stack.
+ERROR_MSG: Literal["error.message"] = "error.message"  # a string representing the error message
+ERROR_TYPE: Literal["error.type"] = "error.type"  # a string representing the type of the error
+ERROR_STACK: Literal["error.stack"] = "error.stack"  # a human readable version of the stack.
 
-PID = "process_id"
+PID: Literal["process_id"] = "process_id"
 
 # Use this to explicitly inform the backend that a trace should be rejected and not stored.
 USER_REJECT = -1


### PR DESCRIPTION
Any constant can be typed as being a literal instead of a type. This change will ensure that anywhere we use a constant for typing it means literally the value instead of a type of str. In order for this to work for Python < 3.8 we will need to add typing_extensions as a dependency.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
