### PR TITLE
fix(internal): set net.git-fetch-with-cli=true for core rust extension

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -33,6 +33,7 @@ variables:
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA # The commit revision the project is built for.
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-py
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+    CARGO_NET_GIT_FETCH_WITH_CLI: "true" # use system git binary to pull git dependencies
 
 benchmarks-pr-comment:
   stage: benchmarks-pr-comment

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -21,3 +21,9 @@ pyo3-build-config = "0.21.2"
 name = "_core"
 path = "lib.rs"
 crate-type = ["cdylib"]
+
+
+[net]
+# Use git binary from the system instead of the built-in git client
+# "Setting this to true can be helpful if you have special authentication requirements that Cargo does not support."
+git-fetch-with-cli = true


### PR DESCRIPTION
https://doc.rust-lang.org/nightly/cargo/reference/config.html#netgit-fetch-with-cli


The built-in git client used by Cargo does not support all of the same Git authentication configuration as the git binary. This setting ensures the system git binary is used instead of the built-in client, ensuring that any/all custom git configuration is used.

This means we require `git` to be installed to build from source, but this should already be the case.


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
