### PR TITLE
chore: privatizing public API of integrations in boto/patch.py

### DIFF
--- a/releasenotes/notes/deprecate-patch-py-functions-boto-d66718ad8bc83678.yaml
+++ b/releasenotes/notes/deprecate-patch-py-functions-boto-d66718ad8bc83678.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    All functions in boto/patch.py except patch() and unpatch() are deprecated and will be removed in version 3.0.0.

--- a/tests/contrib/boto/test_boto_patch.py
+++ b/tests/contrib/boto/test_boto_patch.py
@@ -3,7 +3,7 @@
 # removed the ``_generated`` suffix from the file name, to prevent the content
 # from being overwritten by future re-generations.
 
-from ddtrace.contrib.boto import get_version
+from ddtrace.contrib.boto import _get_version
 from ddtrace.contrib.boto.patch import patch
 
 
@@ -19,7 +19,7 @@ class TestBotoPatch(PatchTestCase.Base):
     __module_name__ = "boto.connection"
     __patch_func__ = patch
     __unpatch_func__ = unpatch
-    __get_version__ = get_version
+    __get_version__ = _get_version
 
     def assert_module_patched(self, boto_connection):
         pass


### PR DESCRIPTION
The API should just be what is necessary. A lot of integrations expose implementation details through the patch.py We can’t just remove these functions right away as it will break our API so for each we will need to deprecate first and then remove in 2.x.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
