### PR TITLE
chore: privatizing public API of integrations in tornado patch.py

### DIFF
--- a/ddtrace/contrib/tornado/patch.py
+++ b/ddtrace/contrib/tornado/patch.py
@@ -5,6 +5,8 @@ import tornado
 import ddtrace
 from ddtrace import config
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+from ddtrace.vendor.debtcollector import deprecate
 
 from ...internal.utils.formats import asbool
 from ...internal.utils.wrappers import unwrap as _u
@@ -23,10 +25,18 @@ config._add(
 )
 
 
-def get_version():
+def _get_version():
     # type: () -> str
     return getattr(tornado, "version", "")
 
+def get_version():
+    deprecate(
+        "get_version is deprecated",
+        message="get_version is deprecated",
+        removal_version="3.0.0",
+        category=DDTraceDeprecationWarning,
+    )
+    return _get_version()
 
 def patch():
     """

--- a/ddtrace/contrib/urllib/patch.py
+++ b/ddtrace/contrib/urllib/patch.py
@@ -5,14 +5,24 @@ from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
 from ddtrace.appsec._iast.constants import VULN_SSRF
 from ddtrace.settings.asm import config as asm_config
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+from ddtrace.vendor.debtcollector import deprecate
 
 from ..trace_utils import unwrap as _u
 
 
-def get_version():
+def _get_version():
     # type: () -> str
     return ""
 
+def get_version():
+    deprecate(
+        "get_version is deprecated",
+        message="get_version is deprecated",
+        removal_version="3.0.0",
+        category=DDTraceDeprecationWarning,
+    )
+    return _get_version()
 
 def patch():
     """patch the built-in urllib.request methods for tracing"""

--- a/ddtrace/contrib/urllib3/patch.py
+++ b/ddtrace/contrib/urllib3/patch.py
@@ -11,6 +11,8 @@ from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.pin import Pin
 from ddtrace.settings.asm import config as asm_config
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+from ddtrace.vendor.debtcollector import deprecate
 
 from ...constants import ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import SPAN_KIND
@@ -42,9 +44,18 @@ config._add(
 )
 
 
-def get_version():
+def _get_version():
     # type: () -> str
     return getattr(urllib3, "__version__", "")
+
+def get_version():
+    deprecate(
+        "get_version is deprecated",
+        message="get_version is deprecated",
+        removal_version="3.0.0",
+        category=DDTraceDeprecationWarning,
+    )
+    return _get_version()
 
 
 def patch():

--- a/releasenotes/notes/deprecate-patch-py-methods-tornado-unittest-urllib-vertica-7e5e7bd8f5613323.yaml
+++ b/releasenotes/notes/deprecate-patch-py-methods-tornado-unittest-urllib-vertica-7e5e7bd8f5613323.yaml
@@ -1,0 +1,12 @@
+---
+deprecations:
+  - |
+    All methods in tornado/patch.py except patch() and unpatch() are deprecated and will be removed in version 3.0.0.
+  - |
+    All methods in unittest/patch.py except patch() and unpatch() are deprecated and will be removed in version 3.0.0.
+  - |
+    All methods in urllib/patch.py except patch() and unpatch() are deprecated and will be removed in version 3.0.0.
+  - |
+    All methods in urllib3/patch.py except patch() and unpatch() are deprecated and will be removed in version 3.0.0.
+  - |
+    All methods in vertica/patch.py except patch() and unpatch() are deprecated and will be removed in version 3.0.0.


### PR DESCRIPTION
The API should just be what is necessary. A lot of integrations expose implementation details through the patch.py We can’t just remove these functions right away as it will break our API so for each we will need to deprecate first and then remove in 2.x.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
