### PR TITLE
chore(asm):  improve rasp call mechanism

### DIFF
--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -47,7 +47,14 @@ def wrapped_open_CFDDB7ABBA9081B6(original_open_callable, instance, args, kwargs
 
         check_and_report_path_traversal(*args, **kwargs)
 
-    if asm_config._asm_enabled and asm_config._ep_enabled:
+    from ddtrace import tracer
+
+    if (
+        asm_config._asm_enabled
+        and asm_config._ep_enabled
+        and tracer._appsec_processor is not None
+        and tracer._appsec_processor.rasp_lfi_enabled
+    ):
         try:
             from ddtrace.appsec._asm_request_context import call_waf_callback
             from ddtrace.appsec._asm_request_context import in_context
@@ -87,7 +94,14 @@ def wrapped_open_ED4CF71136E15EBF(original_open_callable, instance, args, kwargs
         # TODO: IAST SSRF sink to be added
         pass
 
-    if asm_config._asm_enabled and asm_config._ep_enabled:
+    from ddtrace import tracer
+
+    if (
+        asm_config._asm_enabled
+        and asm_config._ep_enabled
+        and tracer._appsec_processor is not None
+        and tracer._appsec_processor.rasp_ssrf_enabled
+    ):
         try:
             from ddtrace.appsec._asm_request_context import call_waf_callback
             from ddtrace.appsec._asm_request_context import in_context
@@ -121,7 +135,15 @@ def wrapped_request_D8CB81E472AF98A2(original_request_callable, instance, args, 
         from ddtrace.appsec._iast.taint_sinks.ssrf import _iast_report_ssrf
 
         _iast_report_ssrf(original_request_callable, *args, **kwargs)
-    if asm_config._asm_enabled and asm_config._ep_enabled:
+
+    from ddtrace import tracer
+
+    if (
+        asm_config._asm_enabled
+        and asm_config._ep_enabled
+        and tracer._appsec_processor is not None
+        and tracer._appsec_processor.rasp_ssrf_enabled
+    ):
         try:
             from ddtrace.appsec._asm_request_context import call_waf_callback
             from ddtrace.appsec._asm_request_context import in_context
@@ -162,7 +184,14 @@ def execute_4C9BAC8E228EB347(instrument_self, query, args, kwargs) -> None:
     listener for dbapi execute and executemany function
     parameters are ignored as they are properly handled by the dbapi without risk of injections
     """
-    if asm_config._asm_enabled and asm_config._ep_enabled:
+    from ddtrace import tracer
+
+    if (
+        asm_config._asm_enabled
+        and asm_config._ep_enabled
+        and tracer._appsec_processor is not None
+        and tracer._appsec_processor.rasp_sqli_enabled
+    ):
         try:
             from ddtrace.appsec._asm_request_context import call_waf_callback
             from ddtrace.appsec._asm_request_context import in_context

--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -8,6 +8,7 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 
+import ddtrace
 from ddtrace.appsec._constants import WAF_ACTIONS
 from ddtrace.appsec._constants import WAF_CONTEXT_NAMES
 from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
@@ -47,13 +48,11 @@ def wrapped_open_CFDDB7ABBA9081B6(original_open_callable, instance, args, kwargs
 
         check_and_report_path_traversal(*args, **kwargs)
 
-    from ddtrace import tracer
-
     if (
         asm_config._asm_enabled
         and asm_config._ep_enabled
-        and tracer._appsec_processor is not None
-        and tracer._appsec_processor.rasp_lfi_enabled
+        and ddtrace.tracer._appsec_processor is not None
+        and ddtrace.tracer._appsec_processor.rasp_lfi_enabled
     ):
         try:
             from ddtrace.appsec._asm_request_context import call_waf_callback
@@ -94,13 +93,11 @@ def wrapped_open_ED4CF71136E15EBF(original_open_callable, instance, args, kwargs
         # TODO: IAST SSRF sink to be added
         pass
 
-    from ddtrace import tracer
-
     if (
         asm_config._asm_enabled
         and asm_config._ep_enabled
-        and tracer._appsec_processor is not None
-        and tracer._appsec_processor.rasp_ssrf_enabled
+        and ddtrace.tracer._appsec_processor is not None
+        and ddtrace.tracer._appsec_processor.rasp_ssrf_enabled
     ):
         try:
             from ddtrace.appsec._asm_request_context import call_waf_callback
@@ -136,13 +133,11 @@ def wrapped_request_D8CB81E472AF98A2(original_request_callable, instance, args, 
 
         _iast_report_ssrf(original_request_callable, *args, **kwargs)
 
-    from ddtrace import tracer
-
     if (
         asm_config._asm_enabled
         and asm_config._ep_enabled
-        and tracer._appsec_processor is not None
-        and tracer._appsec_processor.rasp_ssrf_enabled
+        and ddtrace.tracer._appsec_processor is not None
+        and ddtrace.tracer._appsec_processor.rasp_ssrf_enabled
     ):
         try:
             from ddtrace.appsec._asm_request_context import call_waf_callback
@@ -184,13 +179,12 @@ def execute_4C9BAC8E228EB347(instrument_self, query, args, kwargs) -> None:
     listener for dbapi execute and executemany function
     parameters are ignored as they are properly handled by the dbapi without risk of injections
     """
-    from ddtrace import tracer
 
     if (
         asm_config._asm_enabled
         and asm_config._ep_enabled
-        and tracer._appsec_processor is not None
-        and tracer._appsec_processor.rasp_sqli_enabled
+        and ddtrace.tracer._appsec_processor is not None
+        and ddtrace.tracer._appsec_processor.rasp_sqli_enabled
     ):
         try:
             from ddtrace.appsec._asm_request_context import call_waf_callback

--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -166,6 +166,7 @@ class WAF_DATA_NAMES(metaclass=Constant_Class):
     # EPHEMERAL ADDRESSES
     PROCESSOR_SETTINGS: Literal["waf.context.processor"] = "waf.context.processor"
     LFI_ADDRESS: Literal["server.io.fs.file"] = "server.io.fs.file"
+    SHI_ADDRESS: Literal["server.sys.shell.cmd"] = "server.sys.shell.cmd"
     SSRF_ADDRESS: Literal["server.io.net.url"] = "server.io.net.url"
     SQLI_ADDRESS: Literal["server.db.statement"] = "server.db.statement"
     SQLI_SYSTEM_ADDRESS: Literal["server.db.system"] = "server.db.system"

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -206,6 +206,22 @@ class AppSecSpanProcessor(SpanProcessor):
         self._update_required()
         return result
 
+    @property
+    def rasp_lfi_enabled(self) -> bool:
+        return WAF_DATA_NAMES.LFI_ADDRESS in self._addresses_to_keep
+
+    @property
+    def rasp_shi_enabled(self) -> bool:
+        return WAF_DATA_NAMES.SHI_ADDRESS in self._addresses_to_keep
+
+    @property
+    def rasp_ssrf_enabled(self) -> bool:
+        return WAF_DATA_NAMES.SSRF_ADDRESS in self._addresses_to_keep
+
+    @property
+    def rasp_sqli_enabled(self) -> bool:
+        return WAF_DATA_NAMES.SQLI_ADDRESS in self._addresses_to_keep
+
     def on_span_start(self, span: Span) -> None:
         from ddtrace.contrib import trace_utils
 

--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -78,7 +78,6 @@ def cleanup_loaded_modules():
             "attr",
             "google",
             "google.protobuf",  # the upb backend in >= 4.21 does not like being unloaded
-            "tests",
         ]
     )
     for m in list(_ for _ in sys.modules if _ not in LOADED_MODULES):

--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -78,6 +78,7 @@ def cleanup_loaded_modules():
             "attr",
             "google",
             "google.protobuf",  # the upb backend in >= 4.21 does not like being unloaded
+            "tests",
         ]
     )
     for m in list(_ for _ in sys.modules if _ not in LOADED_MODULES):

--- a/releasenotes/notes/rasp_conditional_call-f700a122b82b4c4f.yaml
+++ b/releasenotes/notes/rasp_conditional_call-f700a122b82b4c4f.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    ASM: This upgrade prevents the WAF from being invoked for exploit prevention if the corresponding rules are not enabled via remote configuration.

--- a/tests/appsec/appsec/rules-rasp-disabled.json
+++ b/tests/appsec/appsec/rules-rasp-disabled.json
@@ -1,0 +1,157 @@
+{
+  "version": "2.1",
+  "metadata": {
+    "rules_version": "rules_rasp"
+  },
+  "rules": [
+    {
+      "id": "rasp-930-100",
+      "name": "Local file inclusion exploit",
+      "enabled": false,
+      "tags": {
+        "type": "lfi",
+        "category": "vulnerability_trigger",
+        "cwe": "22",
+        "capec": "1000/255/153/126",
+        "confidence": "0",
+        "module": "rasp"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "resource": [
+              {
+                "address": "server.io.fs.file"
+              }
+            ],
+            "params": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
+              }
+            ]
+          },
+          "operator": "lfi_detector"
+        }
+      ],
+      "transformers": [],
+      "on_match": [
+        "stack_trace"
+      ]
+    },
+    {
+      "id": "rasp-934-100",
+      "name": "Server-side request forgery exploit",
+      "enabled": false,
+      "tags": {
+        "type": "ssrf",
+        "category": "vulnerability_trigger",
+        "cwe": "918",
+        "capec": "1000/225/115/664",
+        "confidence": "0",
+        "module": "rasp"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "resource": [
+              {
+                "address": "server.io.net.url"
+              }
+            ],
+            "params": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
+              }
+            ]
+          },
+          "operator": "ssrf_detector"
+        }
+      ],
+      "transformers": [],
+      "on_match": [
+        "stack_trace"
+      ]
+    },
+    {
+      "id": "rasp-942-100",
+      "name": "SQL injection exploit",
+      "enabled": false,
+      "tags": {
+        "type": "sql_injection",
+        "category": "vulnerability_trigger",
+        "cwe": "89",
+        "capec": "1000/152/248/66",
+        "confidence": "0",
+        "module": "rasp"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "resource": [
+              {
+                "address": "server.db.statement"
+              }
+            ],
+            "params": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
+              }
+            ],
+            "db_type": [
+              {
+                "address": "server.db.system"
+              }
+            ]
+          },
+          "operator": "sqli_detector"
+        }
+      ],
+      "transformers": [],
+      "on_match": [
+        "stack_trace"
+      ]
+    }
+  ]
+}

--- a/tests/appsec/rules.py
+++ b/tests/appsec/rules.py
@@ -12,6 +12,7 @@ RULES_SRB_METHOD = os.path.join(ROOT_DIR, "rules-suspicious-requests-get.json")
 RULES_BAD_VERSION = os.path.join(ROOT_DIR, "rules-bad_version.json")
 RULES_EXPLOIT_PREVENTION = os.path.join(ROOT_DIR, "rules-rasp.json")
 RULES_EXPLOIT_PREVENTION_BLOCKING = os.path.join(ROOT_DIR, "rules-rasp-blocking.json")
+RULES_EXPLOIT_PREVENTION_DISABLED = os.path.join(ROOT_DIR, "rules-rasp-disabled.json")
 
 RESPONSE_CUSTOM_JSON = os.path.join(ROOT_DIR, "response-custom.json")
 RESPONSE_CUSTOM_HTML = os.path.join(ROOT_DIR, "response-custom.html")


### PR DESCRIPTION
Unless explicitly disabled by an environment variable, the WAF is used for each supported exploit prevention endpoint. This PR enhances this behaviour by leveraging the WAF's "known addresses" feature, which, as of version 1.19.0, skips disabled rules, to prevent calling the WAF if unnecessary. 
Now, calls to the WAF will only occur if at least one specific rule for that endpoint has been enabled via remote configuration.

Also:
- add new Shell Injection address in the address list in appsec constants and corresponding property in appsec span processor
- add regression tests in the hatch threat test for exploit prevention to check that no call and no telemetry is generated for disabled rules

APPSEC-54272

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
