### PR TITLE
chore: privatizing methods celery,coverage,django,dogpile,dramatiq

### DIFF
--- a/ddtrace/contrib/celery/patch.py
+++ b/ddtrace/contrib/celery/patch.py
@@ -3,7 +3,9 @@ import os
 import celery
 
 from ddtrace import config
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.internal.utils.formats import asbool
+from ddtrace.vendor.debtcollector import deprecate
 
 from .app import patch_app
 from .app import unpatch_app
@@ -22,9 +24,19 @@ config._add(
 )
 
 
-def get_version():
+def _get_version():
     # type: () -> str
     return str(celery.__version__)
+
+
+def get_version():
+    deprecate(
+        "get_version is deprecated",
+        message="get_version is deprecated",
+        removal_version="3.0.0",
+        category=DDTraceDeprecationWarning,
+    )
+    return _get_version()
 
 
 def patch():

--- a/ddtrace/contrib/coverage/patch.py
+++ b/ddtrace/contrib/coverage/patch.py
@@ -2,8 +2,10 @@ from ddtrace.contrib.coverage.constants import PCT_COVERED_KEY
 from ddtrace.contrib.coverage.data import _coverage_data
 from ddtrace.contrib.coverage.utils import is_coverage_loaded
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.vendor import wrapt
+from ddtrace.vendor.debtcollector import deprecate
 
 
 try:
@@ -15,9 +17,19 @@ except ImportError:
 log = get_logger(__name__)
 
 
-def get_version():
+def _get_version():
     # type: () -> str
     return ""
+
+
+def get_version():
+    deprecate(
+        "get_version is deprecated",
+        message="get_version is deprecated",
+        removal_version="3.0.0",
+        category=DDTraceDeprecationWarning,
+    )
+    return _get_version()
 
 
 def patch():
@@ -31,7 +43,7 @@ def patch():
 
     _w = wrapt.wrap_function_wrapper
 
-    _w(coverage, "Coverage.report", report_total_pct_covered_wrapper)
+    _w(coverage, "Coverage.report", _report_total_pct_covered_wrapper)
 
 
 def unpatch():
@@ -46,13 +58,23 @@ def unpatch():
     coverage._datadog_patch = False
 
 
-def report_total_pct_covered_wrapper(func, instance, args: tuple, kwargs: dict):
+def _report_total_pct_covered_wrapper(func, instance, args: tuple, kwargs: dict):
     pct_covered = func(*args, **kwargs)
     _coverage_data[PCT_COVERED_KEY] = pct_covered
     return pct_covered
 
 
-def run_coverage_report():
+def report_total_pct_covered_wrapper(func, instance, args: tuple, kwargs: dict):
+    deprecate(
+        "report_total_pct_covered_wrapper is deprecated",
+        message="report_total_pct_covered_wrapper is deprecated",
+        removal_version="3.0.0",
+        category=DDTraceDeprecationWarning,
+    )
+    return _report_total_pct_covered_wrapper(func, instance, args, kwargs)
+
+
+def _run_coverage_report():
     if not is_coverage_loaded():
         return
     try:
@@ -60,3 +82,13 @@ def run_coverage_report():
         _coverage_data[PCT_COVERED_KEY] = current_coverage_object.report()
     except Exception:
         log.warning("An exception occurred when running a coverage report")
+
+
+def run_coverage_report():
+    deprecate(
+        "run_coverage_report is deprecated",
+        message="run_coverage_report is deprecated",
+        removal_version="3.0.0",
+        category=DDTraceDeprecationWarning,
+    )
+    return _run_coverage_report()

--- a/ddtrace/contrib/dogpile_cache/patch.py
+++ b/ddtrace/contrib/dogpile_cache/patch.py
@@ -6,9 +6,11 @@ except AttributeError:
     from dogpile import lock as dogpile_lock
 
 from ddtrace.internal.schema import schematize_service_name
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.pin import _DD_PIN_NAME
 from ddtrace.pin import _DD_PIN_PROXY_NAME
 from ddtrace.pin import Pin
+from ddtrace.vendor.debtcollector import deprecate
 from ddtrace.vendor.wrapt import wrap_function_wrapper as _w
 
 from .lock import _wrap_lock_ctor
@@ -21,9 +23,19 @@ _get_or_create_multi = dogpile_cache.region.CacheRegion.get_or_create_multi
 _lock_ctor = dogpile_lock.Lock.__init__
 
 
-def get_version():
+def _get_version():
     # type: () -> str
     return getattr(dogpile_cache, "__version__", "")
+
+
+def get_version():
+    deprecate(
+        "get_version is deprecated",
+        message="get_version is deprecated",
+        removal_version="3.0.0",
+        category=DDTraceDeprecationWarning,
+    )
+    return _get_version()
 
 
 def patch():

--- a/ddtrace/contrib/dramatiq/patch.py
+++ b/ddtrace/contrib/dramatiq/patch.py
@@ -11,11 +11,23 @@ from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.settings.config import Config
+from ddtrace.vendor.debtcollector import deprecate
 
 
-def get_version() -> str:
+def _get_version() -> str:
     return str(dramatiq.__version__)
+
+
+def get_version():
+    deprecate(
+        "get_version is deprecated",
+        message="get_version is deprecated",
+        removal_version="3.0.0",
+        category=DDTraceDeprecationWarning,
+    )
+    return _get_version()
 
 
 def patch() -> None:

--- a/ddtrace/contrib/pytest/_plugin_v1.py
+++ b/ddtrace/contrib/pytest/_plugin_v1.py
@@ -24,8 +24,8 @@ import pytest
 import ddtrace
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib.coverage.data import _coverage_data
+from ddtrace.contrib.coverage.patch import _run_coverage_report
 from ddtrace.contrib.coverage.patch import patch as patch_coverage
-from ddtrace.contrib.coverage.patch import run_coverage_report
 from ddtrace.contrib.coverage.patch import unpatch as unpatch_coverage
 from ddtrace.contrib.coverage.utils import _is_coverage_invoked_by_coverage_run
 from ddtrace.contrib.coverage.utils import _is_coverage_patched
@@ -508,7 +508,7 @@ class _PytestDDTracePluginV1:
                 invoked_by_coverage_run_status = _is_coverage_invoked_by_coverage_run()
                 if _is_coverage_patched() and (pytest_cov_status or invoked_by_coverage_run_status):
                     if invoked_by_coverage_run_status and not pytest_cov_status:
-                        run_coverage_report()
+                        _run_coverage_report()
                     _add_pct_covered_to_span(_coverage_data, test_session_span)
                     unpatch_coverage()
                 test_session_span.finish()

--- a/ddtrace/contrib/unittest/patch.py
+++ b/ddtrace/contrib/unittest/patch.py
@@ -7,8 +7,8 @@ import ddtrace
 from ddtrace import config
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib.coverage.data import _coverage_data
+from ddtrace.contrib.coverage.patch import _run_coverage_report
 from ddtrace.contrib.coverage.patch import patch as patch_coverage
-from ddtrace.contrib.coverage.patch import run_coverage_report
 from ddtrace.contrib.coverage.patch import unpatch as unpatch_coverage
 from ddtrace.contrib.coverage.utils import _is_coverage_invoked_by_coverage_run
 from ddtrace.contrib.coverage.utils import _is_coverage_patched
@@ -804,7 +804,7 @@ def _finish_test_session_span():
     if _CIVisibility._instance._collect_coverage_enabled and _module_has_dd_coverage_enabled(unittest):
         _stop_coverage(unittest)
     if _is_coverage_patched() and _is_coverage_invoked_by_coverage_run():
-        run_coverage_report()
+        _run_coverage_report()
         _add_pct_covered_to_span(_coverage_data, _CIVisibility._datadog_session_span)
         unpatch_coverage()
     _finish_span(_CIVisibility._datadog_session_span)

--- a/releasenotes/notes/deprecate-patch-py-methods-celery-coverage-django-dogpile-dramatiq-68c334f5479615c8.yaml
+++ b/releasenotes/notes/deprecate-patch-py-methods-celery-coverage-django-dogpile-dramatiq-68c334f5479615c8.yaml
@@ -1,0 +1,12 @@
+---
+deprecations:
+  - |
+    celery: All methods in celery/patch.py except ``patch()`` and ``unpatch()`` are deprecated and will be removed in version 3.0.0.
+  - |
+    coverage: All methods in coverage/patch.py except ``patch()`` and ``unpatch()`` are deprecated and will be removed in version 3.0.0.
+  - |
+    django: All methods in django/patch.py except ``patch()`` and ``unpatch()`` are deprecated and will be removed in version 3.0.0.
+  - |
+    dogpile_cache: All methods in dogpile_cache/patch.py except ``patch()`` and ``unpatch()`` are deprecated and will be removed in version 3.0.0.
+  - |
+    dramatiq: All methods in dramatiq/patch.py except ``patch()`` and ``unpatch()`` are deprecated and will be removed in version 3.0.0.


### PR DESCRIPTION
The API should just be what is necessary. A lot of integrations expose implementation details through the patch.py We can’t just remove these functions right away as it will break our API so for each we will need to deprecate first and then remove in 2.x.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
