### PR TITLE
fix(asm): one click remote config fix (#9874) [backport 2.10]

### DIFF
--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -139,39 +139,33 @@ def _preprocess_results_appsec_1click_activation(
         )
 
         rc_asm_enabled = None
-        if features is not None:
-            if features == {}:
-                rc_asm_enabled = False
-            else:
-                asm_features = features.get("asm", {})
-                if asm_features is not None:
-                    rc_asm_enabled = asm_features.get("enabled")
+        if features and "asm" in features:
+            rc_asm_enabled = features["asm"].get("enabled", False)
             log.debug(
                 "[%s][P: %s] ASM Remote Configuration ASM_FEATURES. Appsec enabled: %s",
                 os.getpid(),
                 os.getppid(),
                 rc_asm_enabled,
             )
-            if rc_asm_enabled is not None:
-                from ddtrace.appsec._constants import PRODUCTS
+            from ddtrace.appsec._constants import PRODUCTS
 
-                if pubsub_instance is None:
-                    pubsub_instance = (
-                        remoteconfig_poller.get_registered(PRODUCTS.ASM_FEATURES)
-                        or remoteconfig_poller.get_registered(PRODUCTS.ASM)
-                        or AppSecRC(_preprocess_results_appsec_1click_activation, _appsec_callback)
-                    )
+            if pubsub_instance is None:
+                pubsub_instance = (
+                    remoteconfig_poller.get_registered(PRODUCTS.ASM_FEATURES)
+                    or remoteconfig_poller.get_registered(PRODUCTS.ASM)
+                    or AppSecRC(_preprocess_results_appsec_1click_activation, _appsec_callback)
+                )
 
-                if rc_asm_enabled and asm_config._asm_static_rule_file is None:
-                    remoteconfig_poller.register(PRODUCTS.ASM_DATA, pubsub_instance)  # IP Blocking
-                    remoteconfig_poller.register(PRODUCTS.ASM, pubsub_instance)  # Exclusion Filters & Custom Rules
-                    remoteconfig_poller.register(PRODUCTS.ASM_DD, pubsub_instance)  # DD Rules
-                else:
-                    remoteconfig_poller.unregister(PRODUCTS.ASM_DATA)
-                    remoteconfig_poller.unregister(PRODUCTS.ASM)
-                    remoteconfig_poller.unregister(PRODUCTS.ASM_DD)
+            if rc_asm_enabled and asm_config._asm_static_rule_file is None:
+                remoteconfig_poller.register(PRODUCTS.ASM_DATA, pubsub_instance)  # IP Blocking
+                remoteconfig_poller.register(PRODUCTS.ASM, pubsub_instance)  # Exclusion Filters & Custom Rules
+                remoteconfig_poller.register(PRODUCTS.ASM_DD, pubsub_instance)  # DD Rules
+            else:
+                remoteconfig_poller.unregister(PRODUCTS.ASM_DATA)
+                remoteconfig_poller.unregister(PRODUCTS.ASM)
+                remoteconfig_poller.unregister(PRODUCTS.ASM_DD)
 
-            features["asm"] = {"enabled": rc_asm_enabled}
+            features["asm"]["enabled"] = rc_asm_enabled
     return features
 
 
@@ -189,7 +183,7 @@ def _appsec_1click_activation(features: Mapping[str, Any], test_tracer: Optional
     | true              | true       | Enabled  |
     ```
     """
-    if asm_config._asm_can_be_enabled:
+    if asm_config._asm_can_be_enabled and "asm" in features:
         # Tracer is a parameter for testing propose
         # Import tracer here to avoid a circular import
         if test_tracer is None:

--- a/releasenotes/notes/rc_asm_features_fix-56fb35d0ca6c5d69.yaml
+++ b/releasenotes/notes/rc_asm_features_fix-56fb35d0ca6c5d69.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ASM: This fix resolves an issue where ASM one click feature could fail to deactivate ASM.

--- a/tests/appsec/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/appsec/test_remoteconfiguration.py
@@ -177,11 +177,29 @@ def test_rc_activation_validate_products(tracer, remote_config_worker):
         ({"_asm_static_rule_file": DEFAULT.RULES}, False),  # Only ASM_FEATURES
     ],
 )
+@pytest.mark.parametrize(
+    "enable_config, disable_config",
+    [
+        ({"asm": {"enabled": True}}, {"asm": {}}),
+        (
+            {"asm": {"enabled": True}, "data": [{"id": 1}]},
+            {"asm": {}, "data": [{"id": 1}]},
+        ),  # additional data in the same product should not change the result
+        (
+            {"asm": {"enabled": True, "data": 0}},
+            {"asm": {"data": 0}},
+        ),  # additional data in the same config should not change the result
+    ],
+)
 def test_rc_activation_check_asm_features_product_disables_rest_of_products(
-    tracer, remote_config_worker, env_rules, expected
+    tracer, remote_config_worker, env_rules, expected, enable_config, disable_config
 ):
     global_config = dict(_remote_config_enabled=True, _asm_enabled=True)
     global_config.update(env_rules)
+    from ddtrace.internal.remoteconfig.client import config as rc_config
+
+    rc_config.skip_shutdown = False
+    empty_config = {}
     with override_global_config(global_config):
         tracer.configure(appsec_enabled=True, api_version="v0.4")
         enable_appsec_rc(tracer)
@@ -190,11 +208,32 @@ def test_rc_activation_check_asm_features_product_disables_rest_of_products(
         assert bool(remoteconfig_poller._client._products.get(PRODUCTS.ASM)) is expected
         assert remoteconfig_poller._client._products.get(PRODUCTS.ASM_FEATURES)
 
-        _preprocess_results_appsec_1click_activation({})
+        # sending nothing should not change anything (configuration is the same)
+        _preprocess_results_appsec_1click_activation(empty_config)
+
+        assert bool(remoteconfig_poller._client._products.get(PRODUCTS.ASM_DATA)) is expected
+        assert bool(remoteconfig_poller._client._products.get(PRODUCTS.ASM)) is expected
+        assert remoteconfig_poller._client._products.get(PRODUCTS.ASM_FEATURES)
+
+        # sending empty config for asm should disable asm (meaning asm was deleted)
+        _preprocess_results_appsec_1click_activation(disable_config)
 
         assert remoteconfig_poller._client._products.get(PRODUCTS.ASM_DATA) is None
         assert remoteconfig_poller._client._products.get(PRODUCTS.ASM) is None
         assert remoteconfig_poller._client._products.get(PRODUCTS.ASM_FEATURES)
+
+        # sending nothing should not change anything (configuration is the same)
+        _preprocess_results_appsec_1click_activation(empty_config)
+        assert remoteconfig_poller._client._products.get(PRODUCTS.ASM_DATA) is None
+        assert remoteconfig_poller._client._products.get(PRODUCTS.ASM) is None
+        assert remoteconfig_poller._client._products.get(PRODUCTS.ASM_FEATURES)
+
+        # sending config should enable asm again
+        _preprocess_results_appsec_1click_activation(enable_config)
+        assert bool(remoteconfig_poller._client._products.get(PRODUCTS.ASM_DATA)) is expected
+        assert bool(remoteconfig_poller._client._products.get(PRODUCTS.ASM)) is expected
+        assert remoteconfig_poller._client._products.get(PRODUCTS.ASM_FEATURES)
+
     disable_appsec_rc()
 
 
@@ -337,7 +376,7 @@ def test_load_new_configurations_remove_config_and_dispatch_applied_configs(
 
     remoteconfig_poller._client._applied_configs = client_configs
     list_callbacks = []
-    remoteconfig_poller._client._remove_previously_applied_configurations(list_callbacks, {}, {}, [])
+    remoteconfig_poller._client._remove_previously_applied_configurations(list_callbacks, {}, {}, {})
     remoteconfig_poller._client._publish_configuration(list_callbacks)
 
     remoteconfig_poller._poll_data()
@@ -394,7 +433,7 @@ def test_load_new_configurations_remove_config_and_dispatch_applied_configs_erro
     }
     list_callbacks = []
     remoteconfig_poller._client._applied_configs = client_configs
-    remoteconfig_poller._client._remove_previously_applied_configurations(list_callbacks, {}, {}, [])
+    remoteconfig_poller._client._remove_previously_applied_configurations(list_callbacks, {}, {}, {})
     remoteconfig_poller._client._publish_configuration(list_callbacks)
 
     remoteconfig_poller._client._load_new_configurations(list_callbacks, {}, client_configs, payload=payload)
@@ -513,17 +552,10 @@ def test_load_new_config_and_remove_targets_file_same_product(
             ),
         }
 
-        target_file = {
-            "mock/ASM_DATA/2": ConfigMetadata(
-                id="",
-                product_name="ASM_DATA",
-                sha256_hash=hashlib.sha256(asm_data_data2).hexdigest(),
-                length=5,
-                tuf_version=5,
-            )
-        }
         list_callbacks = []
-        remoteconfig_poller._client._remove_previously_applied_configurations(list_callbacks, {}, first_config, {})
+        remoteconfig_poller._client._remove_previously_applied_configurations(
+            list_callbacks, {}, first_config, first_config
+        )
         remoteconfig_poller._client._load_new_configurations(
             list_callbacks, applied_configs, first_config, payload=payload
         )
@@ -536,13 +568,13 @@ def test_load_new_config_and_remove_targets_file_same_product(
 
         list_callbacks = []
         remoteconfig_poller._client._remove_previously_applied_configurations(
-            list_callbacks, {}, second_config, target_file
+            list_callbacks, {}, second_config, second_config
         )
         remoteconfig_poller._client._load_new_configurations(list_callbacks, {}, second_config, payload=payload)
         remoteconfig_poller._client._publish_configuration(list_callbacks)
         remoteconfig_poller._poll_data()
 
-        mock_appsec_rules_data.assert_called_with({"asm": {"enabled": None}, "data": [{"d": 2}]}, None)
+        mock_appsec_rules_data.assert_called_with({"asm": {"enabled": True}, "data": [{"c": 1}]}, None)
         disable_appsec_rc()
 
 
@@ -603,17 +635,10 @@ def test_fullpath_appsec_rules_data(mock_update_rules, remote_config_worker, tra
             ),
         }
 
-        target_file = {
-            "mock/ASM_DATA/2": ConfigMetadata(
-                id="",
-                product_name="ASM_DATA",
-                sha256_hash=hashlib.sha256(asm_data_data2).hexdigest(),
-                length=5,
-                tuf_version=5,
-            )
-        }
         list_callbacks = []
-        remoteconfig_poller._client._remove_previously_applied_configurations(list_callbacks, {}, first_config, {})
+        remoteconfig_poller._client._remove_previously_applied_configurations(
+            list_callbacks, {}, first_config, first_config
+        )
         remoteconfig_poller._client._load_new_configurations(
             list_callbacks, applied_configs, first_config, payload=payload
         )
@@ -628,13 +653,13 @@ def test_fullpath_appsec_rules_data(mock_update_rules, remote_config_worker, tra
         enable_appsec_rc(tracer)
         list_callbacks = []
         remoteconfig_poller._client._remove_previously_applied_configurations(
-            list_callbacks, {}, second_config, target_file
+            list_callbacks, {}, second_config, second_config
         )
         remoteconfig_poller._client._load_new_configurations(list_callbacks, {}, second_config, payload=payload)
         remoteconfig_poller._client._publish_configuration(list_callbacks)
         remoteconfig_poller._poll_data()
 
-        mock_update_rules.assert_called_with({"exclusions": [{"f": 2}]})
+        mock_update_rules.assert_called_with({"exclusions": [{"e": 1}]})
     disable_appsec_rc()
 
 
@@ -670,16 +695,6 @@ def test_fullpath_appsec_rules_data_empty_data(mock_update_rules, remote_config_
         }
 
         second_config = {
-            "mock/ASM_DATA/1": ConfigMetadata(
-                id="",
-                product_name="ASM_DATA",
-                sha256_hash=hashlib.sha256(asm_data_data1).hexdigest(),
-                length=5,
-                tuf_version=5,
-            ),
-        }
-
-        target_file = {
             "mock/ASM_DATA/2": ConfigMetadata(
                 id="",
                 product_name="ASM_DATA",
@@ -689,7 +704,9 @@ def test_fullpath_appsec_rules_data_empty_data(mock_update_rules, remote_config_
             )
         }
         list_callbacks = []
-        remoteconfig_poller._client._remove_previously_applied_configurations(list_callbacks, {}, first_config, {})
+        remoteconfig_poller._client._remove_previously_applied_configurations(
+            list_callbacks, {}, first_config, first_config
+        )
         remoteconfig_poller._client._load_new_configurations(
             list_callbacks, applied_configs, first_config, payload=payload
         )
@@ -702,7 +719,7 @@ def test_fullpath_appsec_rules_data_empty_data(mock_update_rules, remote_config_
 
         list_callbacks = []
         remoteconfig_poller._client._remove_previously_applied_configurations(
-            list_callbacks, {}, second_config, target_file
+            list_callbacks, {}, second_config, second_config
         )
         remoteconfig_poller._client._load_new_configurations(list_callbacks, {}, second_config, payload=payload)
         remoteconfig_poller._client._publish_configuration(list_callbacks)


### PR DESCRIPTION
Backport to 2.10 of https://github.com/DataDog/dd-trace-py/pull/9874

This PR fixes a small problem in the Remote Config layer for ASM_FEATURES product.
After that PR:

On the worker side:

1. if we receive a key in the rc configuration and the value is non empty, it means the value was changed
2. if we receive a key in the rc configuration and the value is empty, it means the value was deleted
3. if we don't receive a key in the rc configuration, it means the value was unchanged.

Previously, if the value was a list, it was already the case, but if the value was a dictionary, case 2 and 3 were not correctly separated. Now, an empty dictionary is sent if the key is deleted (case 2).

APPSEC-54105

Also:
- small refactor
- update unit tests appropriately
- increase coverage on ASM_FEATURES unit tests for one click
- this PR will also be validated by new system tests

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
