### PR TITLE
flailing: try and workaround setuptools 72.0.0 nightmare

### DIFF
--- a/.riot/requirements/1002685.txt
+++ b/.riot/requirements/1002685.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/100c918.txt
+++ b/.riot/requirements/100c918.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/100cc0e.txt
+++ b/.riot/requirements/100cc0e.txt
@@ -24,3 +24,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==2.0.7
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/10110a8.txt
+++ b/.riot/requirements/10110a8.txt
@@ -90,3 +90,4 @@ urllib3==2.0.7
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1012b6a.txt
+++ b/.riot/requirements/1012b6a.txt
@@ -29,3 +29,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==1.26.18
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/101f000.txt
+++ b/.riot/requirements/101f000.txt
@@ -39,3 +39,4 @@ zc-lockfile==3.0.post1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1026e4e.txt
+++ b/.riot/requirements/1026e4e.txt
@@ -36,3 +36,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 yarl==1.9.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1030725.txt
+++ b/.riot/requirements/1030725.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 vine==5.1.0
+setuptools<72.0.0

--- a/.riot/requirements/104f74e.txt
+++ b/.riot/requirements/104f74e.txt
@@ -43,3 +43,4 @@ urllib3==2.1.0
 uvloop==0.19.0
 websockets==10.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1050efa.txt
+++ b/.riot/requirements/1050efa.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1059060.txt
+++ b/.riot/requirements/1059060.txt
@@ -17,3 +17,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/105d554.txt
+++ b/.riot/requirements/105d554.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1067a9b.txt
+++ b/.riot/requirements/1067a9b.txt
@@ -43,3 +43,4 @@ urllib3==2.1.0
 uvloop==0.19.0
 websockets==10.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/106f2d7.txt
+++ b/.riot/requirements/106f2d7.txt
@@ -22,3 +22,4 @@ pytest-mock==3.14.0
 requests==2.31.0
 sortedcontainers==2.4.0
 urllib3==2.2.1
+setuptools<72.0.0

--- a/.riot/requirements/10733d8.txt
+++ b/.riot/requirements/10733d8.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/107e1ae.txt
+++ b/.riot/requirements/107e1ae.txt
@@ -24,3 +24,4 @@ requests==2.31.0
 six==1.16.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/1092157.txt
+++ b/.riot/requirements/1092157.txt
@@ -28,3 +28,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/109311c.txt
+++ b/.riot/requirements/109311c.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1097f9f.txt
+++ b/.riot/requirements/1097f9f.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1099f43.txt
+++ b/.riot/requirements/1099f43.txt
@@ -18,3 +18,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tornado==5.1.1
+setuptools<72.0.0

--- a/.riot/requirements/10a626b.txt
+++ b/.riot/requirements/10a626b.txt
@@ -30,3 +30,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/10aef09.txt
+++ b/.riot/requirements/10aef09.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/10b89f6.txt
+++ b/.riot/requirements/10b89f6.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 werkzeug==3.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/10b8fc3.txt
+++ b/.riot/requirements/10b8fc3.txt
@@ -29,3 +29,4 @@ pytest-randomly==3.15.0
 sniffio==1.3.1
 sortedcontainers==2.4.0
 toml==0.10.2
+setuptools<72.0.0

--- a/.riot/requirements/10bb064.txt
+++ b/.riot/requirements/10bb064.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/10bb9be.txt
+++ b/.riot/requirements/10bb9be.txt
@@ -40,3 +40,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==1.26.18
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/10bdae9.txt
+++ b/.riot/requirements/10bdae9.txt
@@ -27,3 +27,4 @@ python-memcached==1.62
 redis==5.0.7
 sortedcontainers==2.4.0
 werkzeug==1.0.1
+setuptools<72.0.0

--- a/.riot/requirements/10c6e12.txt
+++ b/.riot/requirements/10c6e12.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/10c926b.txt
+++ b/.riot/requirements/10c926b.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.25.8
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/10d168b.txt
+++ b/.riot/requirements/10d168b.txt
@@ -27,3 +27,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 vertica-python==0.6.14
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/10d32ad.txt
+++ b/.riot/requirements/10d32ad.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 typing-extensions==3.10.0.2
 typing-inspect==0.6.0
+setuptools<72.0.0

--- a/.riot/requirements/10d33c9.txt
+++ b/.riot/requirements/10d33c9.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/10d8f51.txt
+++ b/.riot/requirements/10d8f51.txt
@@ -36,3 +36,4 @@ sortedcontainers==2.4.0
 tomlkit==0.12.3
 typing-extensions==4.9.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/10da678.txt
+++ b/.riot/requirements/10da678.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 structlog==23.2.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/10e34c4.txt
+++ b/.riot/requirements/10e34c4.txt
@@ -20,3 +20,4 @@ sortedcontainers==2.4.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/10e98b3.txt
+++ b/.riot/requirements/10e98b3.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
+setuptools<72.0.0

--- a/.riot/requirements/10ebb4e.txt
+++ b/.riot/requirements/10ebb4e.txt
@@ -41,3 +41,4 @@ urllib3==1.26.18
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/10f565a.txt
+++ b/.riot/requirements/10f565a.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/10fa2b9.txt
+++ b/.riot/requirements/10fa2b9.txt
@@ -23,3 +23,4 @@ reno==4.0.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.15
+setuptools<72.0.0

--- a/.riot/requirements/1101787.txt
+++ b/.riot/requirements/1101787.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/11031a2.txt
+++ b/.riot/requirements/11031a2.txt
@@ -44,3 +44,4 @@ urllib3==2.2.1
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/11047da.txt
+++ b/.riot/requirements/11047da.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/11091fd.txt
+++ b/.riot/requirements/11091fd.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/111ed90.txt
+++ b/.riot/requirements/111ed90.txt
@@ -21,3 +21,4 @@ pytest-cov==5.0.0
 pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/112dc22.txt
+++ b/.riot/requirements/112dc22.txt
@@ -39,3 +39,4 @@ tomli==2.0.1
 typing-extensions==4.10.0
 urllib3==2.2.1
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/113ca1f.txt
+++ b/.riot/requirements/113ca1f.txt
@@ -25,3 +25,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1146bb7.txt
+++ b/.riot/requirements/1146bb7.txt
@@ -25,3 +25,4 @@ requests==2.31.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/1147178.txt
+++ b/.riot/requirements/1147178.txt
@@ -32,3 +32,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.9.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1147cef.txt
+++ b/.riot/requirements/1147cef.txt
@@ -60,3 +60,4 @@ typing-inspect==0.9.0
 urllib3==2.1.0
 werkzeug==3.0.1
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1153ad9.txt
+++ b/.riot/requirements/1153ad9.txt
@@ -30,3 +30,4 @@ requests==2.32.3
 sortedcontainers==2.4.0
 urllib3==2.2.2
 werkzeug==1.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1157d7b.txt
+++ b/.riot/requirements/1157d7b.txt
@@ -17,3 +17,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1159a5a.txt
+++ b/.riot/requirements/1159a5a.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 stevedore==5.1.0
 tomli==2.0.1
 typing-extensions==4.9.0
+setuptools<72.0.0

--- a/.riot/requirements/115aba5.txt
+++ b/.riot/requirements/115aba5.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1163993.txt
+++ b/.riot/requirements/1163993.txt
@@ -29,3 +29,4 @@ pytest-randomly==3.15.0
 sniffio==1.3.1
 sortedcontainers==2.4.0
 toml==0.10.2
+setuptools<72.0.0

--- a/.riot/requirements/116a9e0.txt
+++ b/.riot/requirements/116a9e0.txt
@@ -20,3 +20,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 tornado==4.5.3
+setuptools<72.0.0

--- a/.riot/requirements/116f7b1.txt
+++ b/.riot/requirements/116f7b1.txt
@@ -18,3 +18,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tornado==6.2
+setuptools<72.0.0

--- a/.riot/requirements/11705e0.txt
+++ b/.riot/requirements/11705e0.txt
@@ -30,3 +30,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/11716b7.txt
+++ b/.riot/requirements/11716b7.txt
@@ -27,3 +27,4 @@ sqlalchemy==2.0.29
 tomli==2.0.1
 typing-extensions==4.10.0
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/1181282.txt
+++ b/.riot/requirements/1181282.txt
@@ -25,3 +25,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==1.26.18
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1182d01.txt
+++ b/.riot/requirements/1182d01.txt
@@ -26,3 +26,4 @@ rq==1.15.1
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1185b58.txt
+++ b/.riot/requirements/1185b58.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/11868bf.txt
+++ b/.riot/requirements/11868bf.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/118cb50.txt
+++ b/.riot/requirements/118cb50.txt
@@ -32,3 +32,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.2.2
 werkzeug==1.0.1
+setuptools<72.0.0

--- a/.riot/requirements/118d2ec.txt
+++ b/.riot/requirements/118d2ec.txt
@@ -35,3 +35,4 @@ tomli==2.0.1
 wcwidth==0.2.13
 werkzeug==0.16.1
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/118ee6f.txt
+++ b/.riot/requirements/118ee6f.txt
@@ -35,3 +35,4 @@ tomli==2.0.1
 tzdata==2023.3
 vine==5.1.0
 wcwidth==0.2.12
+setuptools<72.0.0

--- a/.riot/requirements/119431a.txt
+++ b/.riot/requirements/119431a.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/119ebc8.txt
+++ b/.riot/requirements/119ebc8.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/11ac399.txt
+++ b/.riot/requirements/11ac399.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
 sqlparse==0.5.1
+setuptools<72.0.0

--- a/.riot/requirements/11b0623.txt
+++ b/.riot/requirements/11b0623.txt
@@ -54,3 +54,4 @@ zipp==3.17.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/11b941f.txt
+++ b/.riot/requirements/11b941f.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/11bda89.txt
+++ b/.riot/requirements/11bda89.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/11c18f0.txt
+++ b/.riot/requirements/11c18f0.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/11c2588.txt
+++ b/.riot/requirements/11c2588.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/11c3907.txt
+++ b/.riot/requirements/11c3907.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/11d4944.txt
+++ b/.riot/requirements/11d4944.txt
@@ -26,3 +26,4 @@ stevedore==5.1.0
 tomli==2.0.1
 typing-extensions==4.9.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/11d9fc2.txt
+++ b/.riot/requirements/11d9fc2.txt
@@ -43,3 +43,4 @@ urllib3==2.1.0
 uvloop==0.19.0
 websockets==10.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/11dc3f9.txt
+++ b/.riot/requirements/11dc3f9.txt
@@ -24,3 +24,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==2.0.7
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/11dd5c1.txt
+++ b/.riot/requirements/11dd5c1.txt
@@ -40,3 +40,4 @@ zipp==3.15.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/11eae4e.txt
+++ b/.riot/requirements/11eae4e.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/11f9de5.txt
+++ b/.riot/requirements/11f9de5.txt
@@ -92,3 +92,4 @@ urllib3==2.0.7
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/11fbfc7.txt
+++ b/.riot/requirements/11fbfc7.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 typing-extensions==3.10.0.2
 typing-inspect==0.6.0
+setuptools<72.0.0

--- a/.riot/requirements/11ff4d8.txt
+++ b/.riot/requirements/11ff4d8.txt
@@ -17,3 +17,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1212ab8.txt
+++ b/.riot/requirements/1212ab8.txt
@@ -28,3 +28,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1213604.txt
+++ b/.riot/requirements/1213604.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1214426.txt
+++ b/.riot/requirements/1214426.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/121a519.txt
+++ b/.riot/requirements/121a519.txt
@@ -31,3 +31,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/121f3e0.txt
+++ b/.riot/requirements/121f3e0.txt
@@ -37,3 +37,4 @@ tomli==2.0.1
 typing-extensions==4.12.2
 urllib3==2.2.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1221702.txt
+++ b/.riot/requirements/1221702.txt
@@ -30,3 +30,4 @@ sqlparse==0.4.4
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1221a04.txt
+++ b/.riot/requirements/1221a04.txt
@@ -34,3 +34,4 @@ typing-extensions==4.7.1
 urllib3==2.0.7
 werkzeug==2.2.3
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/122d3c5.txt
+++ b/.riot/requirements/122d3c5.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1231d9a.txt
+++ b/.riot/requirements/1231d9a.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1250d61.txt
+++ b/.riot/requirements/1250d61.txt
@@ -39,3 +39,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==2.0.7
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1250eb4.txt
+++ b/.riot/requirements/1250eb4.txt
@@ -27,3 +27,4 @@ sqlalchemy==2.0.28
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1251619.txt
+++ b/.riot/requirements/1251619.txt
@@ -41,3 +41,4 @@ ujson==5.9.0
 urllib3==2.1.0
 uvloop==0.19.0
 websockets==10.4
+setuptools<72.0.0

--- a/.riot/requirements/1252d0f.txt
+++ b/.riot/requirements/1252d0f.txt
@@ -27,3 +27,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sniffio==1.3.1
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1258e80.txt
+++ b/.riot/requirements/1258e80.txt
@@ -28,3 +28,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/12594bd.txt
+++ b/.riot/requirements/12594bd.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/125f4b9.txt
+++ b/.riot/requirements/125f4b9.txt
@@ -70,3 +70,4 @@ zipp==3.19.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1266820.txt
+++ b/.riot/requirements/1266820.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
 sqlparse==0.5.1
+setuptools<72.0.0

--- a/.riot/requirements/127564e.txt
+++ b/.riot/requirements/127564e.txt
@@ -25,3 +25,4 @@ requests==2.31.0
 six==1.16.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/1280196.txt
+++ b/.riot/requirements/1280196.txt
@@ -27,3 +27,4 @@ waitress==2.1.2
 webob==1.8.7
 webtest==3.0.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1295cc0.txt
+++ b/.riot/requirements/1295cc0.txt
@@ -30,3 +30,4 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.9.0
+setuptools<72.0.0

--- a/.riot/requirements/129b75c.txt
+++ b/.riot/requirements/129b75c.txt
@@ -26,3 +26,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==2.0.7
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/12a25de.txt
+++ b/.riot/requirements/12a25de.txt
@@ -32,3 +32,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/12aa44c.txt
+++ b/.riot/requirements/12aa44c.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/12aafe0.txt
+++ b/.riot/requirements/12aafe0.txt
@@ -25,3 +25,4 @@ tomli==2.0.1
 typing-extensions==4.9.0
 vine==5.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/12b4a54.txt
+++ b/.riot/requirements/12b4a54.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/12bb48f.txt
+++ b/.riot/requirements/12bb48f.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/12bb9e4.txt
+++ b/.riot/requirements/12bb9e4.txt
@@ -25,3 +25,4 @@ tomli==2.0.1
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/12bdba7.txt
+++ b/.riot/requirements/12bdba7.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/12bf701.txt
+++ b/.riot/requirements/12bf701.txt
@@ -21,3 +21,4 @@ pytest-cov==5.0.0
 pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/12c10e8.txt
+++ b/.riot/requirements/12c10e8.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/12c877d.txt
+++ b/.riot/requirements/12c877d.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/12cb0e7.txt
+++ b/.riot/requirements/12cb0e7.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/12d5b48.txt
+++ b/.riot/requirements/12d5b48.txt
@@ -25,3 +25,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/12f6833.txt
+++ b/.riot/requirements/12f6833.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 stevedore==5.1.0
+setuptools<72.0.0

--- a/.riot/requirements/13015fd.txt
+++ b/.riot/requirements/13015fd.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/130a7d6.txt
+++ b/.riot/requirements/130a7d6.txt
@@ -19,3 +19,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1315bb9.txt
+++ b/.riot/requirements/1315bb9.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/131666a.txt
+++ b/.riot/requirements/131666a.txt
@@ -34,3 +34,4 @@ tomli==2.0.1
 urllib3==2.1.0
 werkzeug==3.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1336cbd.txt
+++ b/.riot/requirements/1336cbd.txt
@@ -44,3 +44,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1344329.txt
+++ b/.riot/requirements/1344329.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/134bcdd.txt
+++ b/.riot/requirements/134bcdd.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/134e77a.txt
+++ b/.riot/requirements/134e77a.txt
@@ -39,3 +39,4 @@ tzdata==2023.3
 vine==5.1.0
 wcwidth==0.2.12
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1353f0b.txt
+++ b/.riot/requirements/1353f0b.txt
@@ -27,3 +27,4 @@ sqlalchemy==1.3.24
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1353fd0.txt
+++ b/.riot/requirements/1353fd0.txt
@@ -20,3 +20,4 @@ pytest-cov==4.1.0
 pytest-mock==3.11.1
 sortedcontainers==2.4.0
 typing-extensions==4.7.1
+setuptools<72.0.0

--- a/.riot/requirements/1356251.txt
+++ b/.riot/requirements/1356251.txt
@@ -33,3 +33,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/135aac0.txt
+++ b/.riot/requirements/135aac0.txt
@@ -34,3 +34,4 @@ tomli==2.0.1
 urllib3==2.2.2
 werkzeug==1.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/135c565.txt
+++ b/.riot/requirements/135c565.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1367a0e.txt
+++ b/.riot/requirements/1367a0e.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 tornado==5.1.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/136fbd2.txt
+++ b/.riot/requirements/136fbd2.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/137098c.txt
+++ b/.riot/requirements/137098c.txt
@@ -33,3 +33,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1373a22.txt
+++ b/.riot/requirements/1373a22.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/137cba1.txt
+++ b/.riot/requirements/137cba1.txt
@@ -26,3 +26,4 @@ stevedore==5.1.0
 tomli==2.0.1
 typing-extensions==4.9.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/13804af.txt
+++ b/.riot/requirements/13804af.txt
@@ -55,3 +55,4 @@ vcrpy==4.2.1
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/13873ec.txt
+++ b/.riot/requirements/13873ec.txt
@@ -26,3 +26,4 @@ waitress==2.1.2
 webob==1.8.7
 webtest==3.0.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1389734.txt
+++ b/.riot/requirements/1389734.txt
@@ -27,3 +27,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==1.26.18
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/138c1ad.txt
+++ b/.riot/requirements/138c1ad.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/138c2b7.txt
+++ b/.riot/requirements/138c2b7.txt
@@ -33,3 +33,4 @@ sortedcontainers==2.4.0
 tzdata==2023.3
 vine==5.1.0
 wcwidth==0.2.12
+setuptools<72.0.0

--- a/.riot/requirements/13990f5.txt
+++ b/.riot/requirements/13990f5.txt
@@ -30,3 +30,4 @@ sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/13991ca.txt
+++ b/.riot/requirements/13991ca.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/139b6d7.txt
+++ b/.riot/requirements/139b6d7.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/13b57e2.txt
+++ b/.riot/requirements/13b57e2.txt
@@ -22,3 +22,4 @@ tomli==2.0.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/13b8341.txt
+++ b/.riot/requirements/13b8341.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/13c0fff.txt
+++ b/.riot/requirements/13c0fff.txt
@@ -33,3 +33,4 @@ sortedcontainers==2.4.0
 urllib3==2.2.2
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/13cc5fa.txt
+++ b/.riot/requirements/13cc5fa.txt
@@ -26,3 +26,4 @@ stevedore==3.5.2
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/13d8f2b.txt
+++ b/.riot/requirements/13d8f2b.txt
@@ -26,3 +26,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/13e5e9e.txt
+++ b/.riot/requirements/13e5e9e.txt
@@ -46,3 +46,4 @@ urllib3==1.26.18
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/13ecda2.txt
+++ b/.riot/requirements/13ecda2.txt
@@ -30,3 +30,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/13f2bea.txt
+++ b/.riot/requirements/13f2bea.txt
@@ -32,3 +32,4 @@ urllib3==2.2.1
 virtualenv-clone==0.5.7
 werkzeug==3.0.3
 wheel==0.43.0
+setuptools<72.0.0

--- a/.riot/requirements/13fc59d.txt
+++ b/.riot/requirements/13fc59d.txt
@@ -22,3 +22,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/13fe884.txt
+++ b/.riot/requirements/13fe884.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/13fec34.txt
+++ b/.riot/requirements/13fec34.txt
@@ -47,3 +47,4 @@ urllib3==1.26.19
 vcrpy==4.2.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/140ec91.txt
+++ b/.riot/requirements/140ec91.txt
@@ -32,3 +32,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 werkzeug==3.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/14116fa.txt
+++ b/.riot/requirements/14116fa.txt
@@ -19,3 +19,4 @@ pytest-cov==5.0.0
 pytest-mock==3.14.0
 redis==5.0.3
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1415ef8.txt
+++ b/.riot/requirements/1415ef8.txt
@@ -38,3 +38,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==3.0.3
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1418434.txt
+++ b/.riot/requirements/1418434.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1425e39.txt
+++ b/.riot/requirements/1425e39.txt
@@ -29,3 +29,4 @@ sqlparse==0.4.4
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1431337.txt
+++ b/.riot/requirements/1431337.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/1436100.txt
+++ b/.riot/requirements/1436100.txt
@@ -29,3 +29,4 @@ redis==2.10.6
 sortedcontainers==2.4.0
 tomli==2.0.1
 werkzeug==3.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1438a95.txt
+++ b/.riot/requirements/1438a95.txt
@@ -48,3 +48,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/144615f.txt
+++ b/.riot/requirements/144615f.txt
@@ -30,3 +30,4 @@ sniffio==1.3.1
 sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.11.0
+setuptools<72.0.0

--- a/.riot/requirements/145f3f5.txt
+++ b/.riot/requirements/145f3f5.txt
@@ -40,3 +40,4 @@ zipp==3.15.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1463f80.txt
+++ b/.riot/requirements/1463f80.txt
@@ -41,3 +41,4 @@ textual==0.46.0
 typing-extensions==4.9.0
 uc-micro-py==1.0.2
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/1475020.txt
+++ b/.riot/requirements/1475020.txt
@@ -24,3 +24,4 @@ tomli==2.0.1
 waitress==2.1.2
 webob==1.8.7
 webtest==3.0.0
+setuptools<72.0.0

--- a/.riot/requirements/14767b5.txt
+++ b/.riot/requirements/14767b5.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/147bedb.txt
+++ b/.riot/requirements/147bedb.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1483567.txt
+++ b/.riot/requirements/1483567.txt
@@ -37,3 +37,4 @@ tomli==2.0.1
 typing-extensions==4.12.2
 urllib3==2.2.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/14859e9.txt
+++ b/.riot/requirements/14859e9.txt
@@ -28,3 +28,4 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.9.0
+setuptools<72.0.0

--- a/.riot/requirements/148692c.txt
+++ b/.riot/requirements/148692c.txt
@@ -59,3 +59,4 @@ uvicorn[standard]==0.30.1
 uvloop==0.19.0
 watchfiles==0.22.0
 websockets==12.0
+setuptools<72.0.0

--- a/.riot/requirements/148bd89.txt
+++ b/.riot/requirements/148bd89.txt
@@ -28,3 +28,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/149b454.txt
+++ b/.riot/requirements/149b454.txt
@@ -46,3 +46,4 @@ urllib3==1.26.18
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/14a42dd.txt
+++ b/.riot/requirements/14a42dd.txt
@@ -35,3 +35,4 @@ typing-extensions==4.7.1
 wcwidth==0.2.13
 werkzeug==0.16.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/14abcc7.txt
+++ b/.riot/requirements/14abcc7.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 tornado==6.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/14bdc60.txt
+++ b/.riot/requirements/14bdc60.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/14c0bb1.txt
+++ b/.riot/requirements/14c0bb1.txt
@@ -20,3 +20,4 @@ sortedcontainers==2.4.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/14c793e.txt
+++ b/.riot/requirements/14c793e.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/14c9053.txt
+++ b/.riot/requirements/14c9053.txt
@@ -18,3 +18,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 structlog==23.2.0
+setuptools<72.0.0

--- a/.riot/requirements/14ca37f.txt
+++ b/.riot/requirements/14ca37f.txt
@@ -32,3 +32,4 @@ sortedcontainers==2.4.0
 toml==0.10.2
 tomli==2.0.1
 typing-extensions==4.11.0
+setuptools<72.0.0

--- a/.riot/requirements/14ccd31.txt
+++ b/.riot/requirements/14ccd31.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/14d5c18.txt
+++ b/.riot/requirements/14d5c18.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/14d6531.txt
+++ b/.riot/requirements/14d6531.txt
@@ -20,3 +20,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 tornado==6.3.1
+setuptools<72.0.0

--- a/.riot/requirements/14e5fc5.txt
+++ b/.riot/requirements/14e5fc5.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/14eade3.txt
+++ b/.riot/requirements/14eade3.txt
@@ -23,3 +23,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 uwsgi==2.0.23
+setuptools<72.0.0

--- a/.riot/requirements/14ebf3b.txt
+++ b/.riot/requirements/14ebf3b.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/14effbf.txt
+++ b/.riot/requirements/14effbf.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/14f0b34.txt
+++ b/.riot/requirements/14f0b34.txt
@@ -46,3 +46,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/14f9d89.txt
+++ b/.riot/requirements/14f9d89.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/14fb6c4.txt
+++ b/.riot/requirements/14fb6c4.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/151e533.txt
+++ b/.riot/requirements/151e533.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/15222a6.txt
+++ b/.riot/requirements/15222a6.txt
@@ -26,3 +26,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/15235b0.txt
+++ b/.riot/requirements/15235b0.txt
@@ -34,3 +34,4 @@ tomli==2.0.1
 urllib3==2.2.2
 werkzeug==1.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1528aa2.txt
+++ b/.riot/requirements/1528aa2.txt
@@ -43,3 +43,4 @@ urllib3==2.1.0
 uvloop==0.19.0
 websockets==10.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1538581.txt
+++ b/.riot/requirements/1538581.txt
@@ -43,3 +43,4 @@ urllib3==2.0.7
 uvloop==0.18.0
 websockets==10.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1540a76.txt
+++ b/.riot/requirements/1540a76.txt
@@ -20,3 +20,4 @@ pytest-cov==4.1.0
 pytest-mock==3.11.1
 sortedcontainers==2.4.0
 typing-extensions==4.7.1
+setuptools<72.0.0

--- a/.riot/requirements/1544815.txt
+++ b/.riot/requirements/1544815.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/155f357.txt
+++ b/.riot/requirements/155f357.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 tornado==6.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1560cbf.txt
+++ b/.riot/requirements/1560cbf.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1564dd5.txt
+++ b/.riot/requirements/1564dd5.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/156e3cc.txt
+++ b/.riot/requirements/156e3cc.txt
@@ -35,3 +35,4 @@ sqlalchemy==1.4.52
 starlette==0.21.0
 typing-extensions==4.10.0
 urllib3==2.2.1
+setuptools<72.0.0

--- a/.riot/requirements/1577306.txt
+++ b/.riot/requirements/1577306.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/157ee7b.txt
+++ b/.riot/requirements/157ee7b.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1581ea5.txt
+++ b/.riot/requirements/1581ea5.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1586b69.txt
+++ b/.riot/requirements/1586b69.txt
@@ -19,3 +19,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/158be47.txt
+++ b/.riot/requirements/158be47.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/159a2a4.txt
+++ b/.riot/requirements/159a2a4.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 stevedore==5.1.0
+setuptools<72.0.0

--- a/.riot/requirements/15aa558.txt
+++ b/.riot/requirements/15aa558.txt
@@ -37,3 +37,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==2.0.7
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/15ad8d9.txt
+++ b/.riot/requirements/15ad8d9.txt
@@ -22,3 +22,4 @@ pytest-cov==4.1.0
 pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/15b093e.txt
+++ b/.riot/requirements/15b093e.txt
@@ -81,3 +81,4 @@ yarl==1.9.4
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/15b58f8.txt
+++ b/.riot/requirements/15b58f8.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/15ba505.txt
+++ b/.riot/requirements/15ba505.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/15bf3e3.txt
+++ b/.riot/requirements/15bf3e3.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/15c5dd6.txt
+++ b/.riot/requirements/15c5dd6.txt
@@ -26,3 +26,4 @@ waitress==2.1.2
 webob==1.8.7
 webtest==3.0.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/15cab00.txt
+++ b/.riot/requirements/15cab00.txt
@@ -24,3 +24,4 @@ requests-mock==1.11.0
 six==1.16.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/15cc9b9.txt
+++ b/.riot/requirements/15cc9b9.txt
@@ -31,3 +31,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/15dee3b.txt
+++ b/.riot/requirements/15dee3b.txt
@@ -27,3 +27,4 @@ waitress==2.1.2
 webob==1.8.7
 webtest==3.0.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/15e6955.txt
+++ b/.riot/requirements/15e6955.txt
@@ -40,3 +40,4 @@ tomlkit==0.12.3
 typing-extensions==4.9.0
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/15e76f9.txt
+++ b/.riot/requirements/15e76f9.txt
@@ -28,3 +28,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/15eba42.txt
+++ b/.riot/requirements/15eba42.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/15fbf61.txt
+++ b/.riot/requirements/15fbf61.txt
@@ -19,3 +19,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/15fd7ec.txt
+++ b/.riot/requirements/15fd7ec.txt
@@ -39,3 +39,4 @@ urllib3==1.26.18
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1602479.txt
+++ b/.riot/requirements/1602479.txt
@@ -19,3 +19,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1605571.txt
+++ b/.riot/requirements/1605571.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1609bd2.txt
+++ b/.riot/requirements/1609bd2.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/160ef02.txt
+++ b/.riot/requirements/160ef02.txt
@@ -46,3 +46,4 @@ urllib3==1.26.18
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1619693.txt
+++ b/.riot/requirements/1619693.txt
@@ -36,3 +36,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 yarl==1.9.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/162e30e.txt
+++ b/.riot/requirements/162e30e.txt
@@ -25,3 +25,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/162efb6.txt
+++ b/.riot/requirements/162efb6.txt
@@ -32,3 +32,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.9.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/162f3c3.txt
+++ b/.riot/requirements/162f3c3.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 sqlalchemy==1.3.24
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1631653.txt
+++ b/.riot/requirements/1631653.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1632a0e.txt
+++ b/.riot/requirements/1632a0e.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/1632ff5.txt
+++ b/.riot/requirements/1632ff5.txt
@@ -26,3 +26,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 vertica-python==0.7.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1634f79.txt
+++ b/.riot/requirements/1634f79.txt
@@ -36,3 +36,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==1.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/163a963.txt
+++ b/.riot/requirements/163a963.txt
@@ -28,3 +28,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/163c8d2.txt
+++ b/.riot/requirements/163c8d2.txt
@@ -35,3 +35,4 @@ zipp==3.17.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/164210b.txt
+++ b/.riot/requirements/164210b.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 uwsgi==2.0.23
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1645080.txt
+++ b/.riot/requirements/1645080.txt
@@ -26,3 +26,4 @@ tomli==2.0.1
 typing-extensions==3.10.0.2
 typing-inspect==0.6.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/164d658.txt
+++ b/.riot/requirements/164d658.txt
@@ -25,3 +25,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1652e36.txt
+++ b/.riot/requirements/1652e36.txt
@@ -28,3 +28,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/16562eb.txt
+++ b/.riot/requirements/16562eb.txt
@@ -30,3 +30,4 @@ vcrpy==4.4.0
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/165b374.txt
+++ b/.riot/requirements/165b374.txt
@@ -33,3 +33,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 yarl==1.9.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/166af91.txt
+++ b/.riot/requirements/166af91.txt
@@ -22,3 +22,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/166f9ef.txt
+++ b/.riot/requirements/166f9ef.txt
@@ -26,3 +26,4 @@ stevedore==3.5.2
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1674af7.txt
+++ b/.riot/requirements/1674af7.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1679972.txt
+++ b/.riot/requirements/1679972.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1683094.txt
+++ b/.riot/requirements/1683094.txt
@@ -33,3 +33,4 @@ sortedcontainers==2.4.0
 starlette==0.20.4
 typing-extensions==4.12.2
 urllib3==2.2.2
+setuptools<72.0.0

--- a/.riot/requirements/1683324.txt
+++ b/.riot/requirements/1683324.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/16856c4.txt
+++ b/.riot/requirements/16856c4.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/168cc07.txt
+++ b/.riot/requirements/168cc07.txt
@@ -20,3 +20,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 tornado==6.2
+setuptools<72.0.0

--- a/.riot/requirements/1690be2.txt
+++ b/.riot/requirements/1690be2.txt
@@ -23,3 +23,4 @@ tomli==2.0.1
 tornado==6.2
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1691156.txt
+++ b/.riot/requirements/1691156.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
 sqlparse==0.5.1
+setuptools<72.0.0

--- a/.riot/requirements/16969ec.txt
+++ b/.riot/requirements/16969ec.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/16972d1.txt
+++ b/.riot/requirements/16972d1.txt
@@ -26,3 +26,4 @@ tomli==2.0.1
 typing-extensions==3.10.0.2
 typing-inspect==0.6.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/169a543.txt
+++ b/.riot/requirements/169a543.txt
@@ -38,3 +38,4 @@ tomli==2.0.1
 urllib3==1.26.18
 yarl==1.9.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/169a623.txt
+++ b/.riot/requirements/169a623.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/169ae94.txt
+++ b/.riot/requirements/169ae94.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/169c991.txt
+++ b/.riot/requirements/169c991.txt
@@ -69,3 +69,4 @@ zipp==3.19.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/16a9524.txt
+++ b/.riot/requirements/16a9524.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/16ae641.txt
+++ b/.riot/requirements/16ae641.txt
@@ -43,3 +43,4 @@ tomli==2.0.1
 typing-extensions==4.9.0
 uc-micro-py==1.0.2
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/16af089.txt
+++ b/.riot/requirements/16af089.txt
@@ -18,3 +18,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==2.0.0
+setuptools<72.0.0

--- a/.riot/requirements/16af7e0.txt
+++ b/.riot/requirements/16af7e0.txt
@@ -47,3 +47,4 @@ urllib3==1.26.19
 wrapt==1.16.0
 xmltodict==0.13.0
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/16b152c.txt
+++ b/.riot/requirements/16b152c.txt
@@ -24,3 +24,4 @@ requests==2.31.0
 six==1.16.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/16b7aa5.txt
+++ b/.riot/requirements/16b7aa5.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/16bd1a4.txt
+++ b/.riot/requirements/16bd1a4.txt
@@ -30,3 +30,4 @@ sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/16bdd8d.txt
+++ b/.riot/requirements/16bdd8d.txt
@@ -28,3 +28,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/16bfda8.txt
+++ b/.riot/requirements/16bfda8.txt
@@ -26,3 +26,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/16c1c69.txt
+++ b/.riot/requirements/16c1c69.txt
@@ -28,3 +28,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/16c251e.txt
+++ b/.riot/requirements/16c251e.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.12.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/16d0967.txt
+++ b/.riot/requirements/16d0967.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/16eb426.txt
+++ b/.riot/requirements/16eb426.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/16ec0c2.txt
+++ b/.riot/requirements/16ec0c2.txt
@@ -19,3 +19,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/16ed652.txt
+++ b/.riot/requirements/16ed652.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 werkzeug==1.0.1
+setuptools<72.0.0

--- a/.riot/requirements/16ef08d.txt
+++ b/.riot/requirements/16ef08d.txt
@@ -27,3 +27,4 @@ sqlalchemy==2.0.28
 tomli==2.0.1
 typing-extensions==4.10.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/16f0a68.txt
+++ b/.riot/requirements/16f0a68.txt
@@ -29,3 +29,4 @@ zope-interface==6.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/16f33ce.txt
+++ b/.riot/requirements/16f33ce.txt
@@ -22,3 +22,4 @@ pytest-mock==3.14.0
 redis==5.0.3
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/16f97b5.txt
+++ b/.riot/requirements/16f97b5.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/17148ee.txt
+++ b/.riot/requirements/17148ee.txt
@@ -25,3 +25,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/171b20f.txt
+++ b/.riot/requirements/171b20f.txt
@@ -33,3 +33,4 @@ sortedcontainers==2.4.0
 starlette==0.20.4
 typing-extensions==4.12.2
 urllib3==2.2.2
+setuptools<72.0.0

--- a/.riot/requirements/172570f.txt
+++ b/.riot/requirements/172570f.txt
@@ -20,3 +20,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1727339.txt
+++ b/.riot/requirements/1727339.txt
@@ -32,3 +32,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/17298d6.txt
+++ b/.riot/requirements/17298d6.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 tornado==4.5.3
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/17383d5.txt
+++ b/.riot/requirements/17383d5.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 typing-extensions==3.10.0.2
 typing-inspect==0.6.0
+setuptools<72.0.0

--- a/.riot/requirements/173b99c.txt
+++ b/.riot/requirements/173b99c.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/173c90a.txt
+++ b/.riot/requirements/173c90a.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/173e759.txt
+++ b/.riot/requirements/173e759.txt
@@ -62,3 +62,4 @@ urllib3==2.1.0
 werkzeug==3.0.1
 yarl==1.9.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/174c935.txt
+++ b/.riot/requirements/174c935.txt
@@ -66,3 +66,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/174cced.txt
+++ b/.riot/requirements/174cced.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/174d88f.txt
+++ b/.riot/requirements/174d88f.txt
@@ -17,3 +17,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1754ed1.txt
+++ b/.riot/requirements/1754ed1.txt
@@ -74,3 +74,4 @@ vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/175a85c.txt
+++ b/.riot/requirements/175a85c.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/175d0d6.txt
+++ b/.riot/requirements/175d0d6.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1761702.txt
+++ b/.riot/requirements/1761702.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 yaaredis==3.0.0
+setuptools<72.0.0

--- a/.riot/requirements/1762012.txt
+++ b/.riot/requirements/1762012.txt
@@ -22,3 +22,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/176250f.txt
+++ b/.riot/requirements/176250f.txt
@@ -25,3 +25,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==1.26.18
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/176cb93.txt
+++ b/.riot/requirements/176cb93.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/177912e.txt
+++ b/.riot/requirements/177912e.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 redis==5.0.1
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/178099a.txt
+++ b/.riot/requirements/178099a.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/17851e2.txt
+++ b/.riot/requirements/17851e2.txt
@@ -22,3 +22,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/178680b.txt
+++ b/.riot/requirements/178680b.txt
@@ -36,3 +36,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/17879d0.txt
+++ b/.riot/requirements/17879d0.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/178ae92.txt
+++ b/.riot/requirements/178ae92.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/178cd30.txt
+++ b/.riot/requirements/178cd30.txt
@@ -26,3 +26,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 vertica-python==0.6.14
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/179337c.txt
+++ b/.riot/requirements/179337c.txt
@@ -38,3 +38,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==2.3.8
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/17a0f7f.txt
+++ b/.riot/requirements/17a0f7f.txt
@@ -35,3 +35,4 @@ sqlalchemy==1.4.52
 starlette==0.33.0
 typing-extensions==4.10.0
 urllib3==2.2.1
+setuptools<72.0.0

--- a/.riot/requirements/17a138f.txt
+++ b/.riot/requirements/17a138f.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/17a194c.txt
+++ b/.riot/requirements/17a194c.txt
@@ -23,3 +23,4 @@ redis-py-cluster==2.1.3
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/17a7e5e.txt
+++ b/.riot/requirements/17a7e5e.txt
@@ -43,3 +43,4 @@ tomli==2.0.1
 typing-extensions==4.9.0
 uc-micro-py==1.0.2
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/17a868e.txt
+++ b/.riot/requirements/17a868e.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/17a929f.txt
+++ b/.riot/requirements/17a929f.txt
@@ -30,3 +30,4 @@ requests==2.32.3
 sortedcontainers==2.4.0
 urllib3==2.2.2
 werkzeug==1.0.1
+setuptools<72.0.0

--- a/.riot/requirements/17ab061.txt
+++ b/.riot/requirements/17ab061.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/17adcc8.txt
+++ b/.riot/requirements/17adcc8.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/17b5eda.txt
+++ b/.riot/requirements/17b5eda.txt
@@ -30,3 +30,4 @@ requests==2.31.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
 werkzeug==3.0.1
+setuptools<72.0.0

--- a/.riot/requirements/17b8d64.txt
+++ b/.riot/requirements/17b8d64.txt
@@ -25,3 +25,4 @@ pytz==2024.1
 six==1.16.0
 sortedcontainers==2.4.0
 sqlparse==0.5.1
+setuptools<72.0.0

--- a/.riot/requirements/17c09be.txt
+++ b/.riot/requirements/17c09be.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/17cb22b.txt
+++ b/.riot/requirements/17cb22b.txt
@@ -18,3 +18,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 structlog==20.2.0
+setuptools<72.0.0

--- a/.riot/requirements/17cf97e.txt
+++ b/.riot/requirements/17cf97e.txt
@@ -27,3 +27,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sniffio==1.3.1
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/17d2144.txt
+++ b/.riot/requirements/17d2144.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/17d26d1.txt
+++ b/.riot/requirements/17d26d1.txt
@@ -95,3 +95,4 @@ vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/17d317e.txt
+++ b/.riot/requirements/17d317e.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/17d4731.txt
+++ b/.riot/requirements/17d4731.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.12.2
+setuptools<72.0.0

--- a/.riot/requirements/17e1939.txt
+++ b/.riot/requirements/17e1939.txt
@@ -22,3 +22,4 @@ pytest-cov==4.1.0
 pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/17e93e1.txt
+++ b/.riot/requirements/17e93e1.txt
@@ -30,3 +30,4 @@ sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/17ec5eb.txt
+++ b/.riot/requirements/17ec5eb.txt
@@ -33,3 +33,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/17efeae.txt
+++ b/.riot/requirements/17efeae.txt
@@ -22,3 +22,4 @@ soupsieve==2.5
 waitress==2.1.2
 webob==1.8.7
 webtest==3.0.0
+setuptools<72.0.0

--- a/.riot/requirements/17f0015.txt
+++ b/.riot/requirements/17f0015.txt
@@ -43,3 +43,4 @@ urllib3==2.0.7
 uvloop==0.18.0
 websockets==10.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/17fcdc3.txt
+++ b/.riot/requirements/17fcdc3.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1800709.txt
+++ b/.riot/requirements/1800709.txt
@@ -30,3 +30,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==2.0.7
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1800771.txt
+++ b/.riot/requirements/1800771.txt
@@ -33,3 +33,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1805689.txt
+++ b/.riot/requirements/1805689.txt
@@ -35,3 +35,4 @@ tomli==2.0.1
 vertica-python==0.6.14
 vine==1.3.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1809449.txt
+++ b/.riot/requirements/1809449.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 sqlalchemy==1.3.24
 tomli==2.0.1
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/180e61d.txt
+++ b/.riot/requirements/180e61d.txt
@@ -26,3 +26,4 @@ tomli==2.0.1
 typing-extensions==3.10.0.2
 typing-inspect==0.6.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/180f6a3.txt
+++ b/.riot/requirements/180f6a3.txt
@@ -26,3 +26,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1810da7.txt
+++ b/.riot/requirements/1810da7.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/181128c.txt
+++ b/.riot/requirements/181128c.txt
@@ -24,3 +24,4 @@ redis==5.0.1
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/181216c.txt
+++ b/.riot/requirements/181216c.txt
@@ -50,3 +50,4 @@ vcrpy==4.2.1
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/18147c2.txt
+++ b/.riot/requirements/18147c2.txt
@@ -27,3 +27,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sniffio==1.3.1
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/181895c.txt
+++ b/.riot/requirements/181895c.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/181c98f.txt
+++ b/.riot/requirements/181c98f.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1825740.txt
+++ b/.riot/requirements/1825740.txt
@@ -47,3 +47,4 @@ vcrpy==4.2.1
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1828aa7.txt
+++ b/.riot/requirements/1828aa7.txt
@@ -24,3 +24,4 @@ requests==2.31.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.2.1
+setuptools<72.0.0

--- a/.riot/requirements/182cbd0.txt
+++ b/.riot/requirements/182cbd0.txt
@@ -20,3 +20,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/182dc13.txt
+++ b/.riot/requirements/182dc13.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 toml==0.10.2
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/18317e8.txt
+++ b/.riot/requirements/18317e8.txt
@@ -43,3 +43,4 @@ urllib3==2.1.0
 uvloop==0.19.0
 websockets==10.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1832584.txt
+++ b/.riot/requirements/1832584.txt
@@ -26,3 +26,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==2.0.7
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/18392ae.txt
+++ b/.riot/requirements/18392ae.txt
@@ -37,3 +37,4 @@ starlette==0.37.2
 tomli==2.0.1
 typing-extensions==4.10.0
 urllib3==2.2.1
+setuptools<72.0.0

--- a/.riot/requirements/183e307.txt
+++ b/.riot/requirements/183e307.txt
@@ -36,3 +36,4 @@ tomli==2.0.1
 urllib3==1.26.18
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1840541.txt
+++ b/.riot/requirements/1840541.txt
@@ -25,3 +25,4 @@ requests==2.31.0
 six==1.16.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/184f390.txt
+++ b/.riot/requirements/184f390.txt
@@ -26,3 +26,4 @@ urllib3==1.26.19
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1853bc5.txt
+++ b/.riot/requirements/1853bc5.txt
@@ -70,3 +70,4 @@ zipp==3.19.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/185c81b.txt
+++ b/.riot/requirements/185c81b.txt
@@ -43,3 +43,4 @@ tomli==2.0.1
 typing-extensions==4.9.0
 uc-micro-py==1.0.2
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/185fc1c.txt
+++ b/.riot/requirements/185fc1c.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/18695ab.txt
+++ b/.riot/requirements/18695ab.txt
@@ -40,3 +40,4 @@ typing-extensions==4.7.1
 urllib3==2.0.7
 wheel==0.42.0
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/186acae.txt
+++ b/.riot/requirements/186acae.txt
@@ -17,3 +17,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/186ece2.txt
+++ b/.riot/requirements/186ece2.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/187cf15.txt
+++ b/.riot/requirements/187cf15.txt
@@ -38,3 +38,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 wheel==0.42.0
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/187df5b.txt
+++ b/.riot/requirements/187df5b.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/188a403.txt
+++ b/.riot/requirements/188a403.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/189128e.txt
+++ b/.riot/requirements/189128e.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1894fac.txt
+++ b/.riot/requirements/1894fac.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1895c02.txt
+++ b/.riot/requirements/1895c02.txt
@@ -27,3 +27,4 @@ rfc3986[idna2008]==1.5.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/189753f.txt
+++ b/.riot/requirements/189753f.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/189a9da.txt
+++ b/.riot/requirements/189a9da.txt
@@ -52,3 +52,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/18a1686.txt
+++ b/.riot/requirements/18a1686.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/18a6687.txt
+++ b/.riot/requirements/18a6687.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/18a9ce6.txt
+++ b/.riot/requirements/18a9ce6.txt
@@ -25,3 +25,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 vine==5.1.0
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/18b1b66.txt
+++ b/.riot/requirements/18b1b66.txt
@@ -28,3 +28,4 @@ waitress==2.1.2
 webob==1.8.7
 webtest==3.0.0
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/18b32f4.txt
+++ b/.riot/requirements/18b32f4.txt
@@ -19,3 +19,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 redis==5.0.1
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/18b992e.txt
+++ b/.riot/requirements/18b992e.txt
@@ -32,3 +32,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 werkzeug==1.0.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/18bfa8f.txt
+++ b/.riot/requirements/18bfa8f.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 sqlalchemy==2.0.29
 tomli==2.0.1
 typing-extensions==4.10.0
+setuptools<72.0.0

--- a/.riot/requirements/18c9043.txt
+++ b/.riot/requirements/18c9043.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 tornado==4.5.3
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/18c939b.txt
+++ b/.riot/requirements/18c939b.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/18ca8de.txt
+++ b/.riot/requirements/18ca8de.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/18e95df.txt
+++ b/.riot/requirements/18e95df.txt
@@ -28,3 +28,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/18f2a74.txt
+++ b/.riot/requirements/18f2a74.txt
@@ -18,3 +18,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tornado==4.5.3
+setuptools<72.0.0

--- a/.riot/requirements/18f859e.txt
+++ b/.riot/requirements/18f859e.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/18fce4a.txt
+++ b/.riot/requirements/18fce4a.txt
@@ -28,3 +28,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/19099fb.txt
+++ b/.riot/requirements/19099fb.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/1916976.txt
+++ b/.riot/requirements/1916976.txt
@@ -24,3 +24,4 @@ redis==4.6.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/191885c.txt
+++ b/.riot/requirements/191885c.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/191bffe.txt
+++ b/.riot/requirements/191bffe.txt
@@ -29,3 +29,4 @@ redis==2.10.6
 sortedcontainers==2.4.0
 tomli==2.0.1
 werkzeug==1.0.1
+setuptools<72.0.0

--- a/.riot/requirements/191cea2.txt
+++ b/.riot/requirements/191cea2.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/19255aa.txt
+++ b/.riot/requirements/19255aa.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/192924c.txt
+++ b/.riot/requirements/192924c.txt
@@ -32,3 +32,4 @@ zipp==3.15.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1929a06.txt
+++ b/.riot/requirements/1929a06.txt
@@ -19,3 +19,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/192e4d0.txt
+++ b/.riot/requirements/192e4d0.txt
@@ -44,3 +44,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/192e690.txt
+++ b/.riot/requirements/192e690.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/1933645.txt
+++ b/.riot/requirements/1933645.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1949639.txt
+++ b/.riot/requirements/1949639.txt
@@ -27,3 +27,4 @@ python-memcached==1.62
 redis==2.10.6
 sortedcontainers==2.4.0
 werkzeug==1.0.1
+setuptools<72.0.0

--- a/.riot/requirements/194a34b.txt
+++ b/.riot/requirements/194a34b.txt
@@ -28,3 +28,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/194d749.txt
+++ b/.riot/requirements/194d749.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/19508cd.txt
+++ b/.riot/requirements/19508cd.txt
@@ -19,3 +19,4 @@ pytest-cov==5.0.0
 pytest-mock==3.14.0
 redis==5.0.3
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1951a77.txt
+++ b/.riot/requirements/1951a77.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1959ed5.txt
+++ b/.riot/requirements/1959ed5.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 vine==5.1.0
+setuptools<72.0.0

--- a/.riot/requirements/195ecad.txt
+++ b/.riot/requirements/195ecad.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 redis==4.6.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/196a072.txt
+++ b/.riot/requirements/196a072.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/196d465.txt
+++ b/.riot/requirements/196d465.txt
@@ -46,3 +46,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/197213a.txt
+++ b/.riot/requirements/197213a.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/197de71.txt
+++ b/.riot/requirements/197de71.txt
@@ -29,3 +29,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/198a57c.txt
+++ b/.riot/requirements/198a57c.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/198fa7f.txt
+++ b/.riot/requirements/198fa7f.txt
@@ -34,3 +34,4 @@ starlette==0.27.0
 structlog==23.2.0
 typing-extensions==4.9.0
 wheel==0.42.0
+setuptools<72.0.0

--- a/.riot/requirements/1994bde.txt
+++ b/.riot/requirements/1994bde.txt
@@ -22,3 +22,4 @@ soupsieve==2.5
 waitress==2.1.2
 webob==1.8.7
 webtest==3.0.0
+setuptools<72.0.0

--- a/.riot/requirements/19ab6ca.txt
+++ b/.riot/requirements/19ab6ca.txt
@@ -20,3 +20,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.6
+setuptools<72.0.0

--- a/.riot/requirements/19aba18.txt
+++ b/.riot/requirements/19aba18.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/19b9cf0.txt
+++ b/.riot/requirements/19b9cf0.txt
@@ -43,3 +43,4 @@ urllib3==2.0.7
 uvloop==0.18.0
 websockets==10.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/19bb0fb.txt
+++ b/.riot/requirements/19bb0fb.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 sqlalchemy==2.0.29
 typing-extensions==4.10.0
+setuptools<72.0.0

--- a/.riot/requirements/19c1421.txt
+++ b/.riot/requirements/19c1421.txt
@@ -67,3 +67,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/19cce5d.txt
+++ b/.riot/requirements/19cce5d.txt
@@ -23,3 +23,4 @@ tomli==2.0.1
 tornado==4.5.3
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/19cd829.txt
+++ b/.riot/requirements/19cd829.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/19dee8b.txt
+++ b/.riot/requirements/19dee8b.txt
@@ -41,3 +41,4 @@ zipp==3.17.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/19e4934.txt
+++ b/.riot/requirements/19e4934.txt
@@ -22,3 +22,4 @@ pytest-mock==3.14.0
 requests==2.31.0
 sortedcontainers==2.4.0
 urllib3==2.2.1
+setuptools<72.0.0

--- a/.riot/requirements/19e9356.txt
+++ b/.riot/requirements/19e9356.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/19ed1c1.txt
+++ b/.riot/requirements/19ed1c1.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/19f3b8d.txt
+++ b/.riot/requirements/19f3b8d.txt
@@ -36,3 +36,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==1.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/19f8b6e.txt
+++ b/.riot/requirements/19f8b6e.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1a00ed1.txt
+++ b/.riot/requirements/1a00ed1.txt
@@ -28,3 +28,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1a06176.txt
+++ b/.riot/requirements/1a06176.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1a06ac7.txt
+++ b/.riot/requirements/1a06ac7.txt
@@ -28,3 +28,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==1.26.18
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1a15059.txt
+++ b/.riot/requirements/1a15059.txt
@@ -90,3 +90,4 @@ urllib3==2.0.7
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1a1ddb4.txt
+++ b/.riot/requirements/1a1ddb4.txt
@@ -34,3 +34,4 @@ typing-extensions==4.7.1
 urllib3==2.0.7
 werkzeug==1.0.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1a1dfc3.txt
+++ b/.riot/requirements/1a1dfc3.txt
@@ -33,3 +33,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1a1e37a.txt
+++ b/.riot/requirements/1a1e37a.txt
@@ -28,3 +28,4 @@ sortedcontainers==2.4.0
 sqlparse==0.5.1
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1a22dee.txt
+++ b/.riot/requirements/1a22dee.txt
@@ -33,3 +33,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1a279aa.txt
+++ b/.riot/requirements/1a279aa.txt
@@ -27,3 +27,4 @@ sqlalchemy==2.0.28
 tomli==2.0.1
 typing-extensions==4.10.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1a2ae3e.txt
+++ b/.riot/requirements/1a2ae3e.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1a2c79e.txt
+++ b/.riot/requirements/1a2c79e.txt
@@ -26,3 +26,4 @@ stevedore==5.1.0
 tomli==2.0.1
 typing-extensions==4.9.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1a38af9.txt
+++ b/.riot/requirements/1a38af9.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1a3a39d.txt
+++ b/.riot/requirements/1a3a39d.txt
@@ -39,3 +39,4 @@ urllib3==1.26.18
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1a3be97.txt
+++ b/.riot/requirements/1a3be97.txt
@@ -25,3 +25,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==1.26.18
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1a45d73.txt
+++ b/.riot/requirements/1a45d73.txt
@@ -35,3 +35,4 @@ zipp==3.15.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1a48ea2.txt
+++ b/.riot/requirements/1a48ea2.txt
@@ -30,3 +30,4 @@ sqlparse==0.4.4
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1a55f7c.txt
+++ b/.riot/requirements/1a55f7c.txt
@@ -20,3 +20,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1a580f7.txt
+++ b/.riot/requirements/1a580f7.txt
@@ -27,3 +27,4 @@ sqlalchemy==2.0.29
 tomli==2.0.1
 typing-extensions==4.10.0
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/1a594ce.txt
+++ b/.riot/requirements/1a594ce.txt
@@ -24,3 +24,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1a692b1.txt
+++ b/.riot/requirements/1a692b1.txt
@@ -27,3 +27,4 @@ sqlalchemy==2.0.28
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1a6cf31.txt
+++ b/.riot/requirements/1a6cf31.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1a6e474.txt
+++ b/.riot/requirements/1a6e474.txt
@@ -70,3 +70,4 @@ zipp==3.19.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1a6e6c0.txt
+++ b/.riot/requirements/1a6e6c0.txt
@@ -30,3 +30,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.9.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1a736ea.txt
+++ b/.riot/requirements/1a736ea.txt
@@ -34,3 +34,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1a7c146.txt
+++ b/.riot/requirements/1a7c146.txt
@@ -26,3 +26,4 @@ pytest-randomly==3.15.0
 rfc3986[idna2008]==1.5.0
 sniffio==1.3.1
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1a83889.txt
+++ b/.riot/requirements/1a83889.txt
@@ -38,3 +38,4 @@ tomli==2.0.1
 typing-extensions==4.9.0
 wheel==0.42.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1a8a6e1.txt
+++ b/.riot/requirements/1a8a6e1.txt
@@ -92,3 +92,4 @@ urllib3==2.0.7
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1a8b5b1.txt
+++ b/.riot/requirements/1a8b5b1.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1a8c53c.txt
+++ b/.riot/requirements/1a8c53c.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1a92267.txt
+++ b/.riot/requirements/1a92267.txt
@@ -39,3 +39,4 @@ zc-lockfile==3.0.post1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1a9b995.txt
+++ b/.riot/requirements/1a9b995.txt
@@ -22,3 +22,4 @@ pytest-mock==3.11.1
 sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
+setuptools<72.0.0

--- a/.riot/requirements/1aa3044.txt
+++ b/.riot/requirements/1aa3044.txt
@@ -43,3 +43,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1aa3fad.txt
+++ b/.riot/requirements/1aa3fad.txt
@@ -23,3 +23,4 @@ tomli==2.0.1
 tornado==6.2
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1aa43eb.txt
+++ b/.riot/requirements/1aa43eb.txt
@@ -28,3 +28,4 @@ sortedcontainers==2.4.0
 sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
+setuptools<72.0.0

--- a/.riot/requirements/1aa652f.txt
+++ b/.riot/requirements/1aa652f.txt
@@ -46,3 +46,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1aaf6f6.txt
+++ b/.riot/requirements/1aaf6f6.txt
@@ -47,3 +47,4 @@ urllib3==1.26.19
 wrapt==1.16.0
 xmltodict==0.13.0
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1ab2cd6.txt
+++ b/.riot/requirements/1ab2cd6.txt
@@ -28,3 +28,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1ab75a5.txt
+++ b/.riot/requirements/1ab75a5.txt
@@ -26,3 +26,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/1abf4f4.txt
+++ b/.riot/requirements/1abf4f4.txt
@@ -22,3 +22,4 @@ pytest-cov==4.1.0
 pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1ac55e4.txt
+++ b/.riot/requirements/1ac55e4.txt
@@ -69,3 +69,4 @@ zipp==3.19.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1ac6ae8.txt
+++ b/.riot/requirements/1ac6ae8.txt
@@ -26,3 +26,4 @@ tomli==2.0.1
 typing-extensions==3.10.0.2
 typing-inspect==0.6.0
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1ac9ec1.txt
+++ b/.riot/requirements/1ac9ec1.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1aca748.txt
+++ b/.riot/requirements/1aca748.txt
@@ -28,3 +28,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1ace55b.txt
+++ b/.riot/requirements/1ace55b.txt
@@ -49,3 +49,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1ad3ffa.txt
+++ b/.riot/requirements/1ad3ffa.txt
@@ -24,3 +24,4 @@ requests==2.31.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.2.1
+setuptools<72.0.0

--- a/.riot/requirements/1ad408c.txt
+++ b/.riot/requirements/1ad408c.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1ae24f1.txt
+++ b/.riot/requirements/1ae24f1.txt
@@ -20,3 +20,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 typing-extensions==4.12.2
+setuptools<72.0.0

--- a/.riot/requirements/1ae2797.txt
+++ b/.riot/requirements/1ae2797.txt
@@ -33,3 +33,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1aedbda.txt
+++ b/.riot/requirements/1aedbda.txt
@@ -38,3 +38,4 @@ tomli==2.0.1
 typing-extensions==4.12.1
 urllib3==2.2.1
 wheel==0.43.0
+setuptools<72.0.0

--- a/.riot/requirements/1aef832.txt
+++ b/.riot/requirements/1aef832.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 werkzeug==1.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1af9cfa.txt
+++ b/.riot/requirements/1af9cfa.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1afa2b3.txt
+++ b/.riot/requirements/1afa2b3.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.9.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1b007f9.txt
+++ b/.riot/requirements/1b007f9.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1b086a5.txt
+++ b/.riot/requirements/1b086a5.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1b09cab.txt
+++ b/.riot/requirements/1b09cab.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.11.0
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/1b09fc5.txt
+++ b/.riot/requirements/1b09fc5.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.9.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1b0d603.txt
+++ b/.riot/requirements/1b0d603.txt
@@ -62,3 +62,4 @@ urllib3==2.1.0
 werkzeug==3.0.1
 yarl==1.9.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1b0d918.txt
+++ b/.riot/requirements/1b0d918.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1b16023.txt
+++ b/.riot/requirements/1b16023.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1b18826.txt
+++ b/.riot/requirements/1b18826.txt
@@ -23,3 +23,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==1.26.18
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1b18942.txt
+++ b/.riot/requirements/1b18942.txt
@@ -17,3 +17,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1b1913f.txt
+++ b/.riot/requirements/1b1913f.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1b19707.txt
+++ b/.riot/requirements/1b19707.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1b1c34d.txt
+++ b/.riot/requirements/1b1c34d.txt
@@ -38,3 +38,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==3.0.3
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1b2734d.txt
+++ b/.riot/requirements/1b2734d.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1b3d47d.txt
+++ b/.riot/requirements/1b3d47d.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1b3efb5.txt
+++ b/.riot/requirements/1b3efb5.txt
@@ -37,3 +37,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==2.0.7
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1b3fcdf.txt
+++ b/.riot/requirements/1b3fcdf.txt
@@ -72,3 +72,4 @@ zipp==3.15.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1b559c7.txt
+++ b/.riot/requirements/1b559c7.txt
@@ -26,3 +26,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1b5d143.txt
+++ b/.riot/requirements/1b5d143.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.9.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1b67e71.txt
+++ b/.riot/requirements/1b67e71.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 sqlalchemy==1.3.24
 tomli==2.0.1
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/1b6f5be.txt
+++ b/.riot/requirements/1b6f5be.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1b73c58.txt
+++ b/.riot/requirements/1b73c58.txt
@@ -35,3 +35,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1b846e9.txt
+++ b/.riot/requirements/1b846e9.txt
@@ -39,3 +39,4 @@ tomli==2.0.1
 typing-extensions==4.10.0
 urllib3==2.2.1
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/1b84c4a.txt
+++ b/.riot/requirements/1b84c4a.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1b90fc9.txt
+++ b/.riot/requirements/1b90fc9.txt
@@ -27,3 +27,4 @@ zope-interface==6.3
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1b91192.txt
+++ b/.riot/requirements/1b91192.txt
@@ -38,3 +38,4 @@ ujson==5.9.0
 urllib3==2.1.0
 uvloop==0.19.0
 websockets==10.4
+setuptools<72.0.0

--- a/.riot/requirements/1b92a5a.txt
+++ b/.riot/requirements/1b92a5a.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
 sqlparse==0.5.1
+setuptools<72.0.0

--- a/.riot/requirements/1b99e47.txt
+++ b/.riot/requirements/1b99e47.txt
@@ -25,3 +25,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 vine==1.3.0
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1b9d9b7.txt
+++ b/.riot/requirements/1b9d9b7.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1ba4b57.txt
+++ b/.riot/requirements/1ba4b57.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.2.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1ba8c21.txt
+++ b/.riot/requirements/1ba8c21.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1bb07e0.txt
+++ b/.riot/requirements/1bb07e0.txt
@@ -102,3 +102,4 @@ vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1bb4e1c.txt
+++ b/.riot/requirements/1bb4e1c.txt
@@ -28,3 +28,4 @@ typing-extensions==4.7.1
 urllib3==2.0.7
 websocket-client==1.6.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1bb88c9.txt
+++ b/.riot/requirements/1bb88c9.txt
@@ -23,3 +23,4 @@ tomli==2.0.1
 tornado==5.1.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1bb940b.txt
+++ b/.riot/requirements/1bb940b.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1bbc5e0.txt
+++ b/.riot/requirements/1bbc5e0.txt
@@ -33,3 +33,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 werkzeug==2.2.3
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1bbf463.txt
+++ b/.riot/requirements/1bbf463.txt
@@ -21,3 +21,4 @@ pytest-cov==5.0.0
 pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1bc2c36.txt
+++ b/.riot/requirements/1bc2c36.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 sqlalchemy==1.3.24
+setuptools<72.0.0

--- a/.riot/requirements/1bccebd.txt
+++ b/.riot/requirements/1bccebd.txt
@@ -28,3 +28,4 @@ python-memcached==1.62
 redis==2.10.6
 sortedcontainers==2.4.0
 werkzeug==3.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1bceb88.txt
+++ b/.riot/requirements/1bceb88.txt
@@ -52,3 +52,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1bcefe4.txt
+++ b/.riot/requirements/1bcefe4.txt
@@ -26,3 +26,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1be3cb3.txt
+++ b/.riot/requirements/1be3cb3.txt
@@ -23,3 +23,4 @@ structlog==20.2.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1becf29.txt
+++ b/.riot/requirements/1becf29.txt
@@ -30,3 +30,4 @@ sniffio==1.3.1
 sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.11.0
+setuptools<72.0.0

--- a/.riot/requirements/1bf3da5.txt
+++ b/.riot/requirements/1bf3da5.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1c01d99.txt
+++ b/.riot/requirements/1c01d99.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1c0509d.txt
+++ b/.riot/requirements/1c0509d.txt
@@ -26,3 +26,4 @@ rq==1.8.1
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1c0ccc9.txt
+++ b/.riot/requirements/1c0ccc9.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1c11f3f.txt
+++ b/.riot/requirements/1c11f3f.txt
@@ -34,3 +34,4 @@ starlette==0.27.0
 structlog==23.2.0
 typing-extensions==4.9.0
 wheel==0.42.0
+setuptools<72.0.0

--- a/.riot/requirements/1c17138.txt
+++ b/.riot/requirements/1c17138.txt
@@ -28,3 +28,4 @@ sortedcontainers==2.4.0
 sqlparse==0.5.1
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1c1bb1f.txt
+++ b/.riot/requirements/1c1bb1f.txt
@@ -33,3 +33,4 @@ sortedcontainers==2.4.0
 urllib3==1.26.18
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1c1da8c.txt
+++ b/.riot/requirements/1c1da8c.txt
@@ -23,3 +23,4 @@ redis-py-cluster==2.1.3
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1c1db7a.txt
+++ b/.riot/requirements/1c1db7a.txt
@@ -34,3 +34,4 @@ starlette==0.27.0
 structlog==23.2.0
 typing-extensions==4.9.0
 wheel==0.42.0
+setuptools<72.0.0

--- a/.riot/requirements/1c277a3.txt
+++ b/.riot/requirements/1c277a3.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1c31b2e.txt
+++ b/.riot/requirements/1c31b2e.txt
@@ -23,3 +23,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1c36982.txt
+++ b/.riot/requirements/1c36982.txt
@@ -26,3 +26,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 vine==5.1.0
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1c38c63.txt
+++ b/.riot/requirements/1c38c63.txt
@@ -24,3 +24,4 @@ zipp==3.17.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1c3b84b.txt
+++ b/.riot/requirements/1c3b84b.txt
@@ -66,3 +66,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1c47005.txt
+++ b/.riot/requirements/1c47005.txt
@@ -46,3 +46,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1c489e9.txt
+++ b/.riot/requirements/1c489e9.txt
@@ -39,3 +39,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==2.0.7
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1c48d4b.txt
+++ b/.riot/requirements/1c48d4b.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/1c4a762.txt
+++ b/.riot/requirements/1c4a762.txt
@@ -33,3 +33,4 @@ sortedcontainers==2.4.0
 urllib3==2.0.7
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1c53a7f.txt
+++ b/.riot/requirements/1c53a7f.txt
@@ -36,3 +36,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==3.0.3
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1c5df59.txt
+++ b/.riot/requirements/1c5df59.txt
@@ -40,3 +40,4 @@ typing-extensions==4.7.1
 urllib3==1.26.18
 yarl==1.9.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1c64cfc.txt
+++ b/.riot/requirements/1c64cfc.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1c6c710.txt
+++ b/.riot/requirements/1c6c710.txt
@@ -36,3 +36,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==3.0.3
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1c6f756.txt
+++ b/.riot/requirements/1c6f756.txt
@@ -26,3 +26,4 @@ tomli==2.0.1
 typing-extensions==3.10.0.2
 typing-inspect==0.6.0
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1c756dc.txt
+++ b/.riot/requirements/1c756dc.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1c84c16.txt
+++ b/.riot/requirements/1c84c16.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.11.1
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1c87bc4.txt
+++ b/.riot/requirements/1c87bc4.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1ca5ab3.txt
+++ b/.riot/requirements/1ca5ab3.txt
@@ -39,3 +39,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==2.0.7
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1cb9194.txt
+++ b/.riot/requirements/1cb9194.txt
@@ -33,3 +33,4 @@ typing-extensions==4.7.1
 vine==1.3.0
 wcwidth==0.2.13
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1cc3826.txt
+++ b/.riot/requirements/1cc3826.txt
@@ -30,3 +30,4 @@ sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1cc4eb6.txt
+++ b/.riot/requirements/1cc4eb6.txt
@@ -36,3 +36,4 @@ virtualenv-clone==0.5.7
 werkzeug==3.0.3
 wheel==0.43.0
 zipp==3.19.1
+setuptools<72.0.0

--- a/.riot/requirements/1cc7b0e.txt
+++ b/.riot/requirements/1cc7b0e.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 yaaredis==2.0.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1cc7f49.txt
+++ b/.riot/requirements/1cc7f49.txt
@@ -27,3 +27,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1ccd2df.txt
+++ b/.riot/requirements/1ccd2df.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1cce628.txt
+++ b/.riot/requirements/1cce628.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1ccf91d.txt
+++ b/.riot/requirements/1ccf91d.txt
@@ -25,3 +25,4 @@ requests==2.31.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/1cd1d4a.txt
+++ b/.riot/requirements/1cd1d4a.txt
@@ -69,3 +69,4 @@ zipp==3.19.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1cd2a90.txt
+++ b/.riot/requirements/1cd2a90.txt
@@ -19,3 +19,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/1cd7351.txt
+++ b/.riot/requirements/1cd7351.txt
@@ -28,3 +28,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1cd7c2e.txt
+++ b/.riot/requirements/1cd7c2e.txt
@@ -26,3 +26,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/1cd8f95.txt
+++ b/.riot/requirements/1cd8f95.txt
@@ -27,3 +27,4 @@ sqlalchemy==2.0.29
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1ce3412.txt
+++ b/.riot/requirements/1ce3412.txt
@@ -29,3 +29,4 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1ce43cf.txt
+++ b/.riot/requirements/1ce43cf.txt
@@ -29,3 +29,4 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1ce53fb.txt
+++ b/.riot/requirements/1ce53fb.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1ce9a95.txt
+++ b/.riot/requirements/1ce9a95.txt
@@ -31,3 +31,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1cef696.txt
+++ b/.riot/requirements/1cef696.txt
@@ -25,3 +25,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1cefe54.txt
+++ b/.riot/requirements/1cefe54.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1cf4498.txt
+++ b/.riot/requirements/1cf4498.txt
@@ -29,3 +29,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1cfc8b7.txt
+++ b/.riot/requirements/1cfc8b7.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1d03e99.txt
+++ b/.riot/requirements/1d03e99.txt
@@ -20,3 +20,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 tornado==5.1.1
+setuptools<72.0.0

--- a/.riot/requirements/1d0bd1e.txt
+++ b/.riot/requirements/1d0bd1e.txt
@@ -26,3 +26,4 @@ urllib3==1.26.19
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1d0d96c.txt
+++ b/.riot/requirements/1d0d96c.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1d10c25.txt
+++ b/.riot/requirements/1d10c25.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 werkzeug==3.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1d14180.txt
+++ b/.riot/requirements/1d14180.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/1d21cf3.txt
+++ b/.riot/requirements/1d21cf3.txt
@@ -28,3 +28,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.25.11
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1d32f58.txt
+++ b/.riot/requirements/1d32f58.txt
@@ -24,3 +24,4 @@ redis==4.6.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1d390e8.txt
+++ b/.riot/requirements/1d390e8.txt
@@ -39,3 +39,4 @@ urllib3==1.26.18
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1d44438.txt
+++ b/.riot/requirements/1d44438.txt
@@ -27,3 +27,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1d45d3e.txt
+++ b/.riot/requirements/1d45d3e.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1d50090.txt
+++ b/.riot/requirements/1d50090.txt
@@ -17,3 +17,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1d5012c.txt
+++ b/.riot/requirements/1d5012c.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1d5589b.txt
+++ b/.riot/requirements/1d5589b.txt
@@ -46,3 +46,4 @@ urllib3==2.2.1
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1d5ebaf.txt
+++ b/.riot/requirements/1d5ebaf.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1d6a1a5.txt
+++ b/.riot/requirements/1d6a1a5.txt
@@ -29,3 +29,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1d73048.txt
+++ b/.riot/requirements/1d73048.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1d76fdf.txt
+++ b/.riot/requirements/1d76fdf.txt
@@ -29,3 +29,4 @@ sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1d804d4.txt
+++ b/.riot/requirements/1d804d4.txt
@@ -29,3 +29,4 @@ sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1d863f1.txt
+++ b/.riot/requirements/1d863f1.txt
@@ -41,3 +41,4 @@ ujson==5.9.0
 urllib3==2.1.0
 uvloop==0.19.0
 websockets==10.4
+setuptools<72.0.0

--- a/.riot/requirements/1d8a1bf.txt
+++ b/.riot/requirements/1d8a1bf.txt
@@ -23,3 +23,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1d8be99.txt
+++ b/.riot/requirements/1d8be99.txt
@@ -46,3 +46,4 @@ urllib3==1.26.18
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1da0270.txt
+++ b/.riot/requirements/1da0270.txt
@@ -33,3 +33,4 @@ zc-lockfile==3.0.post1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1dad05b.txt
+++ b/.riot/requirements/1dad05b.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1dadf2b.txt
+++ b/.riot/requirements/1dadf2b.txt
@@ -19,3 +19,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1db4b5f.txt
+++ b/.riot/requirements/1db4b5f.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1db5311.txt
+++ b/.riot/requirements/1db5311.txt
@@ -51,3 +51,4 @@ vcrpy==4.2.1
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1dbb110.txt
+++ b/.riot/requirements/1dbb110.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1dcce79.txt
+++ b/.riot/requirements/1dcce79.txt
@@ -30,3 +30,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1dcd050.txt
+++ b/.riot/requirements/1dcd050.txt
@@ -24,3 +24,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 yaaredis==2.0.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1dd3d04.txt
+++ b/.riot/requirements/1dd3d04.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 sqlalchemy==2.0.29
 typing-extensions==4.10.0
+setuptools<72.0.0

--- a/.riot/requirements/1dd7f62.txt
+++ b/.riot/requirements/1dd7f62.txt
@@ -27,3 +27,4 @@ typing-extensions==4.9.0
 tzdata==2023.3
 vine==5.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1ddcf3c.txt
+++ b/.riot/requirements/1ddcf3c.txt
@@ -34,3 +34,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1de8548.txt
+++ b/.riot/requirements/1de8548.txt
@@ -25,3 +25,4 @@ pytz==2024.1
 six==1.16.0
 sortedcontainers==2.4.0
 sqlparse==0.5.1
+setuptools<72.0.0

--- a/.riot/requirements/1df4767.txt
+++ b/.riot/requirements/1df4767.txt
@@ -30,3 +30,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1df8347.txt
+++ b/.riot/requirements/1df8347.txt
@@ -34,3 +34,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1dfcf17.txt
+++ b/.riot/requirements/1dfcf17.txt
@@ -31,3 +31,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1dfd438.txt
+++ b/.riot/requirements/1dfd438.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1e036e6.txt
+++ b/.riot/requirements/1e036e6.txt
@@ -20,3 +20,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1e05e0c.txt
+++ b/.riot/requirements/1e05e0c.txt
@@ -26,3 +26,4 @@ rq==1.10.1
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1e08b64.txt
+++ b/.riot/requirements/1e08b64.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1e0e29e.txt
+++ b/.riot/requirements/1e0e29e.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1e0e8e5.txt
+++ b/.riot/requirements/1e0e8e5.txt
@@ -46,3 +46,4 @@ urllib3==2.2.1
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1e0ec0b.txt
+++ b/.riot/requirements/1e0ec0b.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1e0ee8d.txt
+++ b/.riot/requirements/1e0ee8d.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1e1ea62.txt
+++ b/.riot/requirements/1e1ea62.txt
@@ -46,3 +46,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1e2d655.txt
+++ b/.riot/requirements/1e2d655.txt
@@ -57,3 +57,4 @@ typing-inspect==0.9.0
 urllib3==2.1.0
 werkzeug==3.0.1
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1e2faa4.txt
+++ b/.riot/requirements/1e2faa4.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 tornado==6.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1e2fbcd.txt
+++ b/.riot/requirements/1e2fbcd.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1e311f5.txt
+++ b/.riot/requirements/1e311f5.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1e3534f.txt
+++ b/.riot/requirements/1e3534f.txt
@@ -35,3 +35,4 @@ zipp==3.17.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1e37fde.txt
+++ b/.riot/requirements/1e37fde.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1e44443.txt
+++ b/.riot/requirements/1e44443.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 requests==2.31.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/1e535fe.txt
+++ b/.riot/requirements/1e535fe.txt
@@ -27,3 +27,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1e53fef.txt
+++ b/.riot/requirements/1e53fef.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1e5b9c4.txt
+++ b/.riot/requirements/1e5b9c4.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1e60db0.txt
+++ b/.riot/requirements/1e60db0.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1e68803.txt
+++ b/.riot/requirements/1e68803.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1e7bd18.txt
+++ b/.riot/requirements/1e7bd18.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==3.10.0.2
 typing-inspect==0.6.0
+setuptools<72.0.0

--- a/.riot/requirements/1e7c940.txt
+++ b/.riot/requirements/1e7c940.txt
@@ -23,3 +23,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==1.25
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1e81527.txt
+++ b/.riot/requirements/1e81527.txt
@@ -34,3 +34,4 @@ tomli==2.0.1
 urllib3==2.1.0
 werkzeug==3.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1e81c99.txt
+++ b/.riot/requirements/1e81c99.txt
@@ -25,3 +25,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1e82f55.txt
+++ b/.riot/requirements/1e82f55.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 vine==5.1.0
+setuptools<72.0.0

--- a/.riot/requirements/1e8652f.txt
+++ b/.riot/requirements/1e8652f.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1e93f9f.txt
+++ b/.riot/requirements/1e93f9f.txt
@@ -38,3 +38,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==2.3.8
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1e9b9b9.txt
+++ b/.riot/requirements/1e9b9b9.txt
@@ -26,3 +26,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==2.0.7
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1ea5080.txt
+++ b/.riot/requirements/1ea5080.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1ea993d.txt
+++ b/.riot/requirements/1ea993d.txt
@@ -19,3 +19,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1eb29d6.txt
+++ b/.riot/requirements/1eb29d6.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.25
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1eb408a.txt
+++ b/.riot/requirements/1eb408a.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1eb9abd.txt
+++ b/.riot/requirements/1eb9abd.txt
@@ -22,3 +22,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1ec15f5.txt
+++ b/.riot/requirements/1ec15f5.txt
@@ -55,3 +55,4 @@ vcrpy==4.2.1
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1ecc45c.txt
+++ b/.riot/requirements/1ecc45c.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1edaced.txt
+++ b/.riot/requirements/1edaced.txt
@@ -38,3 +38,4 @@ tzdata==2023.3
 vine==5.1.0
 wcwidth==0.2.12
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1ee49b9.txt
+++ b/.riot/requirements/1ee49b9.txt
@@ -51,3 +51,4 @@ urllib3==1.26.19
 vcrpy==4.2.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1ef581b.txt
+++ b/.riot/requirements/1ef581b.txt
@@ -36,3 +36,4 @@ virtualenv-clone==0.5.7
 werkzeug==3.0.3
 wheel==0.43.0
 zipp==3.19.1
+setuptools<72.0.0

--- a/.riot/requirements/1ef7371.txt
+++ b/.riot/requirements/1ef7371.txt
@@ -23,3 +23,4 @@ redis-py-cluster==2.0.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1ef773e.txt
+++ b/.riot/requirements/1ef773e.txt
@@ -18,3 +18,4 @@ pytest-cov==5.0.0
 pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1ef847d.txt
+++ b/.riot/requirements/1ef847d.txt
@@ -25,3 +25,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1efd2cc.txt
+++ b/.riot/requirements/1efd2cc.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 sqlalchemy==2.0.28
 typing-extensions==4.10.0
+setuptools<72.0.0

--- a/.riot/requirements/1f08b51.txt
+++ b/.riot/requirements/1f08b51.txt
@@ -28,3 +28,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1f0ede7.txt
+++ b/.riot/requirements/1f0ede7.txt
@@ -19,3 +19,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/1f1570a.txt
+++ b/.riot/requirements/1f1570a.txt
@@ -26,3 +26,4 @@ sqlalchemy==2.0.28
 tomli==2.0.1
 typing-extensions==4.10.0
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/1f18768.txt
+++ b/.riot/requirements/1f18768.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1f18ea8.txt
+++ b/.riot/requirements/1f18ea8.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1f1e9b4.txt
+++ b/.riot/requirements/1f1e9b4.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 yaaredis==3.0.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1f22277.txt
+++ b/.riot/requirements/1f22277.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1f238e9.txt
+++ b/.riot/requirements/1f238e9.txt
@@ -26,3 +26,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1f23a69.txt
+++ b/.riot/requirements/1f23a69.txt
@@ -27,3 +27,4 @@ python-memcached==1.62
 redis==5.0.7
 sortedcontainers==2.4.0
 werkzeug==3.0.3
+setuptools<72.0.0

--- a/.riot/requirements/1f27e33.txt
+++ b/.riot/requirements/1f27e33.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1f2ab25.txt
+++ b/.riot/requirements/1f2ab25.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1f30147.txt
+++ b/.riot/requirements/1f30147.txt
@@ -43,3 +43,4 @@ zipp==3.15.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1f3d2c7.txt
+++ b/.riot/requirements/1f3d2c7.txt
@@ -47,3 +47,4 @@ typing-extensions==4.12.2
 urllib3==2.2.2
 werkzeug==3.0.3
 xmltodict==0.13.0
+setuptools<72.0.0

--- a/.riot/requirements/1f42cb3.txt
+++ b/.riot/requirements/1f42cb3.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.11.0
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/1f512b5.txt
+++ b/.riot/requirements/1f512b5.txt
@@ -19,3 +19,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/1f66fe3.txt
+++ b/.riot/requirements/1f66fe3.txt
@@ -33,3 +33,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 werkzeug==1.0.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1f6865a.txt
+++ b/.riot/requirements/1f6865a.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1f861b6.txt
+++ b/.riot/requirements/1f861b6.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1f8ac1c.txt
+++ b/.riot/requirements/1f8ac1c.txt
@@ -48,3 +48,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1f8f136.txt
+++ b/.riot/requirements/1f8f136.txt
@@ -25,3 +25,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1f99050.txt
+++ b/.riot/requirements/1f99050.txt
@@ -24,3 +24,4 @@ requests==2.31.0
 six==1.16.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/1f9e516.txt
+++ b/.riot/requirements/1f9e516.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
+setuptools<72.0.0

--- a/.riot/requirements/1fa5bd6.txt
+++ b/.riot/requirements/1fa5bd6.txt
@@ -21,3 +21,4 @@ pytest-cov==5.0.0
 pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1fa807e.txt
+++ b/.riot/requirements/1fa807e.txt
@@ -47,3 +47,4 @@ urllib3==1.26.19
 wrapt==1.16.0
 xmltodict==0.13.0
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1fab05e.txt
+++ b/.riot/requirements/1fab05e.txt
@@ -23,3 +23,4 @@ requests==2.32.3
 requests-mock==1.12.1
 sortedcontainers==2.4.0
 urllib3==1.26.19
+setuptools<72.0.0

--- a/.riot/requirements/1faec17.txt
+++ b/.riot/requirements/1faec17.txt
@@ -24,3 +24,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 yaaredis==3.0.0
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1fb1389.txt
+++ b/.riot/requirements/1fb1389.txt
@@ -23,3 +23,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1fb1413.txt
+++ b/.riot/requirements/1fb1413.txt
@@ -26,3 +26,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 vertica-python==0.7.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1fb1eb3.txt
+++ b/.riot/requirements/1fb1eb3.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/1fb546b.txt
+++ b/.riot/requirements/1fb546b.txt
@@ -45,3 +45,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1fb6c68.txt
+++ b/.riot/requirements/1fb6c68.txt
@@ -28,3 +28,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==1.26.18
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1fb9968.txt
+++ b/.riot/requirements/1fb9968.txt
@@ -57,3 +57,4 @@ typing-inspect==0.9.0
 urllib3==2.1.0
 werkzeug==3.0.1
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1fbf1f2.txt
+++ b/.riot/requirements/1fbf1f2.txt
@@ -43,3 +43,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1fc50b1.txt
+++ b/.riot/requirements/1fc50b1.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/1fcb05f.txt
+++ b/.riot/requirements/1fcb05f.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 vine==1.3.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1fcbf26.txt
+++ b/.riot/requirements/1fcbf26.txt
@@ -29,3 +29,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==2.0.7
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1fda250.txt
+++ b/.riot/requirements/1fda250.txt
@@ -74,3 +74,4 @@ vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/1fe5c31.txt
+++ b/.riot/requirements/1fe5c31.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 structlog==23.2.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1fe6270.txt
+++ b/.riot/requirements/1fe6270.txt
@@ -41,3 +41,4 @@ urllib3==1.26.18
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1fe881e.txt
+++ b/.riot/requirements/1fe881e.txt
@@ -24,3 +24,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1feb806.txt
+++ b/.riot/requirements/1feb806.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/1fefc1d.txt
+++ b/.riot/requirements/1fefc1d.txt
@@ -31,3 +31,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1ff1638.txt
+++ b/.riot/requirements/1ff1638.txt
@@ -26,3 +26,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/1ff1ba2.txt
+++ b/.riot/requirements/1ff1ba2.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/1ff2f1b.txt
+++ b/.riot/requirements/1ff2f1b.txt
@@ -31,3 +31,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/1ffb22d.txt
+++ b/.riot/requirements/1ffb22d.txt
@@ -28,3 +28,4 @@ zope-interface==6.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/1fff452.txt
+++ b/.riot/requirements/1fff452.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/20387f9.txt
+++ b/.riot/requirements/20387f9.txt
@@ -29,3 +29,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==1.24.3
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/20a6a1c.txt
+++ b/.riot/requirements/20a6a1c.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/210a985.txt
+++ b/.riot/requirements/210a985.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/2164da7.txt
+++ b/.riot/requirements/2164da7.txt
@@ -28,3 +28,4 @@ python-memcached==1.62
 redis==5.0.7
 sortedcontainers==2.4.0
 werkzeug==3.0.3
+setuptools<72.0.0

--- a/.riot/requirements/21acb0e.txt
+++ b/.riot/requirements/21acb0e.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 uwsgi==2.0.23
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/220bd92.txt
+++ b/.riot/requirements/220bd92.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/2249718.txt
+++ b/.riot/requirements/2249718.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 tornado==5.1.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/22824e9.txt
+++ b/.riot/requirements/22824e9.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
 sqlparse==0.5.1
+setuptools<72.0.0

--- a/.riot/requirements/2302519.txt
+++ b/.riot/requirements/2302519.txt
@@ -67,3 +67,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/23e7ade.txt
+++ b/.riot/requirements/23e7ade.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/25528b4.txt
+++ b/.riot/requirements/25528b4.txt
@@ -26,3 +26,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 vertica-python==0.6.14
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/257c9c5.txt
+++ b/.riot/requirements/257c9c5.txt
@@ -18,3 +18,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 structlog==23.2.0
+setuptools<72.0.0

--- a/.riot/requirements/26054ba.txt
+++ b/.riot/requirements/26054ba.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/260ead7.txt
+++ b/.riot/requirements/260ead7.txt
@@ -46,3 +46,4 @@ uvloop==0.19.0
 websockets==9.1
 yarl==1.9.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/26b7f73.txt
+++ b/.riot/requirements/26b7f73.txt
@@ -44,3 +44,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/26ee64c.txt
+++ b/.riot/requirements/26ee64c.txt
@@ -53,3 +53,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/27a0418.txt
+++ b/.riot/requirements/27a0418.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 stevedore==5.1.0
 tomli==2.0.1
 typing-extensions==4.9.0
+setuptools<72.0.0

--- a/.riot/requirements/27d0ff3.txt
+++ b/.riot/requirements/27d0ff3.txt
@@ -29,3 +29,4 @@ zope-interface==6.3
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/27d8bd1.txt
+++ b/.riot/requirements/27d8bd1.txt
@@ -21,3 +21,4 @@ redis==3.0.1
 redis-py-cluster==2.0.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/285f337.txt
+++ b/.riot/requirements/285f337.txt
@@ -30,3 +30,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/28643f8.txt
+++ b/.riot/requirements/28643f8.txt
@@ -68,3 +68,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/28f1677.txt
+++ b/.riot/requirements/28f1677.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/2933921.txt
+++ b/.riot/requirements/2933921.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/2953aa1.txt
+++ b/.riot/requirements/2953aa1.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/29fa506.txt
+++ b/.riot/requirements/29fa506.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.12.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/2ab4a50.txt
+++ b/.riot/requirements/2ab4a50.txt
@@ -36,3 +36,4 @@ tomli==2.0.1
 urllib3==1.26.18
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/2b30eed.txt
+++ b/.riot/requirements/2b30eed.txt
@@ -26,3 +26,4 @@ sqlalchemy==2.0.28
 tomli==2.0.1
 typing-extensions==4.10.0
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/2b3511f.txt
+++ b/.riot/requirements/2b3511f.txt
@@ -28,3 +28,4 @@ sortedcontainers==2.4.0
 sqlparse==0.5.1
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/2b4e2d5.txt
+++ b/.riot/requirements/2b4e2d5.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/2b7ab63.txt
+++ b/.riot/requirements/2b7ab63.txt
@@ -36,3 +36,4 @@ tomli==2.0.1
 urllib3==2.0.7
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/2b94418.txt
+++ b/.riot/requirements/2b94418.txt
@@ -32,3 +32,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 werkzeug==3.0.1
+setuptools<72.0.0

--- a/.riot/requirements/2b9f1e7.txt
+++ b/.riot/requirements/2b9f1e7.txt
@@ -31,3 +31,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/2be0986.txt
+++ b/.riot/requirements/2be0986.txt
@@ -20,3 +20,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 typing-extensions==4.12.2
+setuptools<72.0.0

--- a/.riot/requirements/2be0e27.txt
+++ b/.riot/requirements/2be0e27.txt
@@ -43,3 +43,4 @@ urllib3==2.1.0
 uvloop==0.19.0
 websockets==10.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/2be57d3.txt
+++ b/.riot/requirements/2be57d3.txt
@@ -36,3 +36,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==2.3.8
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/2c855a9.txt
+++ b/.riot/requirements/2c855a9.txt
@@ -39,3 +39,4 @@ tomli==2.0.1
 typing-extensions==4.10.0
 urllib3==2.2.1
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/2cc3d48.txt
+++ b/.riot/requirements/2cc3d48.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/2d19e52.txt
+++ b/.riot/requirements/2d19e52.txt
@@ -30,3 +30,4 @@ zope-interface==6.3
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/2d3b0ef.txt
+++ b/.riot/requirements/2d3b0ef.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/2da4f4c.txt
+++ b/.riot/requirements/2da4f4c.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/2eee4bd.txt
+++ b/.riot/requirements/2eee4bd.txt
@@ -27,3 +27,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/2ef1234.txt
+++ b/.riot/requirements/2ef1234.txt
@@ -25,3 +25,4 @@ pytest-randomly==3.15.0
 rfc3986[idna2008]==1.5.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/2f0fd21.txt
+++ b/.riot/requirements/2f0fd21.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/2f6439d.txt
+++ b/.riot/requirements/2f6439d.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/2f68e1b.txt
+++ b/.riot/requirements/2f68e1b.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/2f7da3e.txt
+++ b/.riot/requirements/2f7da3e.txt
@@ -85,3 +85,4 @@ zipp==3.19.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/30829b6.txt
+++ b/.riot/requirements/30829b6.txt
@@ -26,3 +26,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/30a63da.txt
+++ b/.riot/requirements/30a63da.txt
@@ -41,3 +41,4 @@ ujson==5.9.0
 urllib3==2.1.0
 uvloop==0.19.0
 websockets==10.4
+setuptools<72.0.0

--- a/.riot/requirements/30b2227.txt
+++ b/.riot/requirements/30b2227.txt
@@ -33,3 +33,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/30b65e2.txt
+++ b/.riot/requirements/30b65e2.txt
@@ -30,3 +30,4 @@ redis==2.10.6
 sortedcontainers==2.4.0
 tomli==2.0.1
 werkzeug==1.0.1
+setuptools<72.0.0

--- a/.riot/requirements/315c2cb.txt
+++ b/.riot/requirements/315c2cb.txt
@@ -24,3 +24,4 @@ redis==4.6.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/317842c.txt
+++ b/.riot/requirements/317842c.txt
@@ -29,3 +29,4 @@ sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/31c0470.txt
+++ b/.riot/requirements/31c0470.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/3348fe3.txt
+++ b/.riot/requirements/3348fe3.txt
@@ -44,3 +44,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/334a70d.txt
+++ b/.riot/requirements/334a70d.txt
@@ -63,3 +63,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/3390a6b.txt
+++ b/.riot/requirements/3390a6b.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/3482d15.txt
+++ b/.riot/requirements/3482d15.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/34f3f75.txt
+++ b/.riot/requirements/34f3f75.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/3506e01.txt
+++ b/.riot/requirements/3506e01.txt
@@ -41,3 +41,4 @@ urllib3==1.26.18
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/35bdce1.txt
+++ b/.riot/requirements/35bdce1.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/35ce786.txt
+++ b/.riot/requirements/35ce786.txt
@@ -53,3 +53,4 @@ urllib3==1.26.19
 vcrpy==4.2.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/35e4d8d.txt
+++ b/.riot/requirements/35e4d8d.txt
@@ -61,3 +61,4 @@ uvloop==0.19.0
 watchfiles==0.22.0
 websockets==12.0
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/35e5cdb.txt
+++ b/.riot/requirements/35e5cdb.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/36a011d.txt
+++ b/.riot/requirements/36a011d.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/36a2b9a.txt
+++ b/.riot/requirements/36a2b9a.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/372b57b.txt
+++ b/.riot/requirements/372b57b.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/37847ab.txt
+++ b/.riot/requirements/37847ab.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/39626b6.txt
+++ b/.riot/requirements/39626b6.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
 sqlparse==0.5.1
+setuptools<72.0.0

--- a/.riot/requirements/39bb283.txt
+++ b/.riot/requirements/39bb283.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/3a31be0.txt
+++ b/.riot/requirements/3a31be0.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 structlog==20.2.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/3af9e27.txt
+++ b/.riot/requirements/3af9e27.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.11.0
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/3b65323.txt
+++ b/.riot/requirements/3b65323.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/3c4b933.txt
+++ b/.riot/requirements/3c4b933.txt
@@ -44,3 +44,4 @@ urllib3==2.2.1
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/3c8534a.txt
+++ b/.riot/requirements/3c8534a.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/3c8d9c0.txt
+++ b/.riot/requirements/3c8d9c0.txt
@@ -23,3 +23,4 @@ structlog==23.1.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/3cbb6c7.txt
+++ b/.riot/requirements/3cbb6c7.txt
@@ -24,3 +24,4 @@ redis==5.0.1
 rq==1.15.1
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/3cbe634.txt
+++ b/.riot/requirements/3cbe634.txt
@@ -38,3 +38,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==3.0.3
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/3d84480.txt
+++ b/.riot/requirements/3d84480.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/3df1421.txt
+++ b/.riot/requirements/3df1421.txt
@@ -26,3 +26,4 @@ pytest-randomly==3.15.0
 rfc3986[idna2008]==1.5.0
 sniffio==1.3.1
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/3dfb58a.txt
+++ b/.riot/requirements/3dfb58a.txt
@@ -18,3 +18,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tornado==6.3.1
+setuptools<72.0.0

--- a/.riot/requirements/3e6dcb6.txt
+++ b/.riot/requirements/3e6dcb6.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/3e8a9d6.txt
+++ b/.riot/requirements/3e8a9d6.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/3ed1250.txt
+++ b/.riot/requirements/3ed1250.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/3f38536.txt
+++ b/.riot/requirements/3f38536.txt
@@ -67,3 +67,4 @@ zipp==3.19.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/3f40530.txt
+++ b/.riot/requirements/3f40530.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/401d7e2.txt
+++ b/.riot/requirements/401d7e2.txt
@@ -30,3 +30,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/404933a.txt
+++ b/.riot/requirements/404933a.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 requests==2.31.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/40b1a4f.txt
+++ b/.riot/requirements/40b1a4f.txt
@@ -27,3 +27,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 vertica-python==0.7.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/4132bce.txt
+++ b/.riot/requirements/4132bce.txt
@@ -24,3 +24,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/41529f2.txt
+++ b/.riot/requirements/41529f2.txt
@@ -35,3 +35,4 @@ sqlalchemy==1.4.52
 starlette==0.37.2
 typing-extensions==4.12.2
 urllib3==2.2.2
+setuptools<72.0.0

--- a/.riot/requirements/4211915.txt
+++ b/.riot/requirements/4211915.txt
@@ -49,3 +49,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/427c22a.txt
+++ b/.riot/requirements/427c22a.txt
@@ -35,3 +35,4 @@ typing-extensions==4.7.1
 urllib3==2.0.7
 werkzeug==1.0.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/429d258.txt
+++ b/.riot/requirements/429d258.txt
@@ -32,3 +32,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/42d803c.txt
+++ b/.riot/requirements/42d803c.txt
@@ -25,3 +25,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 uwsgi==2.0.23
+setuptools<72.0.0

--- a/.riot/requirements/432f978.txt
+++ b/.riot/requirements/432f978.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/4334c5c.txt
+++ b/.riot/requirements/4334c5c.txt
@@ -70,3 +70,4 @@ zipp==3.19.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/437caff.txt
+++ b/.riot/requirements/437caff.txt
@@ -19,3 +19,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/4393b7f.txt
+++ b/.riot/requirements/4393b7f.txt
@@ -95,3 +95,4 @@ vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/44339c7.txt
+++ b/.riot/requirements/44339c7.txt
@@ -54,3 +54,4 @@ zipp==3.17.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/44ddc3d.txt
+++ b/.riot/requirements/44ddc3d.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 sqlalchemy==2.0.29
 typing-extensions==4.10.0
+setuptools<72.0.0

--- a/.riot/requirements/452c0ec.txt
+++ b/.riot/requirements/452c0ec.txt
@@ -18,3 +18,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tornado==6.3.1
+setuptools<72.0.0

--- a/.riot/requirements/45b92b9.txt
+++ b/.riot/requirements/45b92b9.txt
@@ -37,3 +37,4 @@ tomli==2.0.1
 typing-extensions==4.12.2
 urllib3==2.2.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/45f9c27.txt
+++ b/.riot/requirements/45f9c27.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/461797f.txt
+++ b/.riot/requirements/461797f.txt
@@ -20,3 +20,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 structlog==20.2.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/4628049.txt
+++ b/.riot/requirements/4628049.txt
@@ -36,3 +36,4 @@ sqlalchemy==2.0.22
 typing-extensions==4.12.1
 urllib3==2.2.1
 wheel==0.43.0
+setuptools<72.0.0

--- a/.riot/requirements/481655f.txt
+++ b/.riot/requirements/481655f.txt
@@ -36,3 +36,4 @@ sortedcontainers==2.4.0
 tomlkit==0.12.5
 typing-extensions==4.12.2
 urllib3==2.2.2
+setuptools<72.0.0

--- a/.riot/requirements/48247d7.txt
+++ b/.riot/requirements/48247d7.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/48462b1.txt
+++ b/.riot/requirements/48462b1.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/489ffd5.txt
+++ b/.riot/requirements/489ffd5.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/48eb599.txt
+++ b/.riot/requirements/48eb599.txt
@@ -27,3 +27,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sniffio==1.3.1
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/4920d3f.txt
+++ b/.riot/requirements/4920d3f.txt
@@ -28,3 +28,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/49543f5.txt
+++ b/.riot/requirements/49543f5.txt
@@ -25,3 +25,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 uwsgi==2.0.23
+setuptools<72.0.0

--- a/.riot/requirements/4a3b7fa.txt
+++ b/.riot/requirements/4a3b7fa.txt
@@ -28,3 +28,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==1.26.18
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/4ad4ecd.txt
+++ b/.riot/requirements/4ad4ecd.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 requests==2.31.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/4b1629e.txt
+++ b/.riot/requirements/4b1629e.txt
@@ -37,3 +37,4 @@ starlette==0.20.4
 tomli==2.0.1
 typing-extensions==4.10.0
 urllib3==2.2.1
+setuptools<72.0.0

--- a/.riot/requirements/4bb9a03.txt
+++ b/.riot/requirements/4bb9a03.txt
@@ -29,3 +29,4 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.9.0
+setuptools<72.0.0

--- a/.riot/requirements/4be94bf.txt
+++ b/.riot/requirements/4be94bf.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/4c49dba.txt
+++ b/.riot/requirements/4c49dba.txt
@@ -30,3 +30,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/4c6b7c3.txt
+++ b/.riot/requirements/4c6b7c3.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/4c87f15.txt
+++ b/.riot/requirements/4c87f15.txt
@@ -20,3 +20,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/4ccd5e8.txt
+++ b/.riot/requirements/4ccd5e8.txt
@@ -24,3 +24,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/4e87dd9.txt
+++ b/.riot/requirements/4e87dd9.txt
@@ -30,3 +30,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/4ed631d.txt
+++ b/.riot/requirements/4ed631d.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/4f8a3a1.txt
+++ b/.riot/requirements/4f8a3a1.txt
@@ -36,3 +36,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 yarl==1.9.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/4f9be04.txt
+++ b/.riot/requirements/4f9be04.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/5000f7f.txt
+++ b/.riot/requirements/5000f7f.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/512bff3.txt
+++ b/.riot/requirements/512bff3.txt
@@ -52,3 +52,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/51442dd.txt
+++ b/.riot/requirements/51442dd.txt
@@ -37,3 +37,4 @@ tomli==2.0.1
 typing-extensions==4.12.2
 urllib3==2.2.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/51867c5.txt
+++ b/.riot/requirements/51867c5.txt
@@ -38,3 +38,4 @@ tomli==2.0.1
 typing-extensions==4.9.0
 wheel==0.42.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/51aba1e.txt
+++ b/.riot/requirements/51aba1e.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/51b9c26.txt
+++ b/.riot/requirements/51b9c26.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 stevedore==5.1.0
+setuptools<72.0.0

--- a/.riot/requirements/51c004c.txt
+++ b/.riot/requirements/51c004c.txt
@@ -25,3 +25,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/51e2096.txt
+++ b/.riot/requirements/51e2096.txt
@@ -19,3 +19,4 @@ pytest-randomly==3.15.0
 redis==3.0.1
 redis-py-cluster==2.0.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/51f5382.txt
+++ b/.riot/requirements/51f5382.txt
@@ -46,3 +46,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/52d1484.txt
+++ b/.riot/requirements/52d1484.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/52e82c5.txt
+++ b/.riot/requirements/52e82c5.txt
@@ -27,3 +27,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/52fe8c7.txt
+++ b/.riot/requirements/52fe8c7.txt
@@ -26,3 +26,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/53e5eed.txt
+++ b/.riot/requirements/53e5eed.txt
@@ -28,3 +28,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 uwsgi==2.0.23
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/541b4d9.txt
+++ b/.riot/requirements/541b4d9.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/5425133.txt
+++ b/.riot/requirements/5425133.txt
@@ -97,3 +97,4 @@ urllib3==2.2.2
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/546aa25.txt
+++ b/.riot/requirements/546aa25.txt
@@ -41,3 +41,4 @@ urllib3==1.26.18
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/547b36f.txt
+++ b/.riot/requirements/547b36f.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/54a9b03.txt
+++ b/.riot/requirements/54a9b03.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/54b91ab.txt
+++ b/.riot/requirements/54b91ab.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/55a0f54.txt
+++ b/.riot/requirements/55a0f54.txt
@@ -54,3 +54,4 @@ zipp==3.15.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/56b3d29.txt
+++ b/.riot/requirements/56b3d29.txt
@@ -30,3 +30,4 @@ sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/56ee07b.txt
+++ b/.riot/requirements/56ee07b.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 requests==2.31.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/573ce40.txt
+++ b/.riot/requirements/573ce40.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 sqlalchemy==2.0.28
 tomli==2.0.1
 typing-extensions==4.10.0
+setuptools<72.0.0

--- a/.riot/requirements/573fdbf.txt
+++ b/.riot/requirements/573fdbf.txt
@@ -27,3 +27,4 @@ waitress==2.1.2
 webob==1.8.7
 webtest==3.0.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/5773634.txt
+++ b/.riot/requirements/5773634.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
+setuptools<72.0.0

--- a/.riot/requirements/57b9548.txt
+++ b/.riot/requirements/57b9548.txt
@@ -63,3 +63,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/58032ff.txt
+++ b/.riot/requirements/58032ff.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.2.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/58881b9.txt
+++ b/.riot/requirements/58881b9.txt
@@ -38,3 +38,4 @@ tomli==2.0.1
 typing-extensions==4.12.1
 urllib3==2.2.1
 wheel==0.43.0
+setuptools<72.0.0

--- a/.riot/requirements/58ce485.txt
+++ b/.riot/requirements/58ce485.txt
@@ -29,3 +29,4 @@ sniffio==1.3.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.9.0
+setuptools<72.0.0

--- a/.riot/requirements/596b753.txt
+++ b/.riot/requirements/596b753.txt
@@ -22,3 +22,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/59df9d0.txt
+++ b/.riot/requirements/59df9d0.txt
@@ -24,3 +24,4 @@ pytest-mock==3.12.0
 rich==13.6.0
 sortedcontainers==2.4.0
 toml==0.10.2
+setuptools<72.0.0

--- a/.riot/requirements/5a0532b.txt
+++ b/.riot/requirements/5a0532b.txt
@@ -26,3 +26,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/5a48bdf.txt
+++ b/.riot/requirements/5a48bdf.txt
@@ -22,3 +22,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/5aff90d.txt
+++ b/.riot/requirements/5aff90d.txt
@@ -41,3 +41,4 @@ textual==0.46.0
 typing-extensions==4.9.0
 uc-micro-py==1.0.2
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/5b339ac.txt
+++ b/.riot/requirements/5b339ac.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/5b55f2d.txt
+++ b/.riot/requirements/5b55f2d.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/5b82761.txt
+++ b/.riot/requirements/5b82761.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/5baaec1.txt
+++ b/.riot/requirements/5baaec1.txt
@@ -32,3 +32,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/5bde71c.txt
+++ b/.riot/requirements/5bde71c.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/5be696d.txt
+++ b/.riot/requirements/5be696d.txt
@@ -48,3 +48,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/5c95c1a.txt
+++ b/.riot/requirements/5c95c1a.txt
@@ -22,3 +22,4 @@ pytest-mock==3.11.1
 sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
+setuptools<72.0.0

--- a/.riot/requirements/5da4fd8.txt
+++ b/.riot/requirements/5da4fd8.txt
@@ -47,3 +47,4 @@ urllib3==1.26.19
 vcrpy==4.2.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/5ddbef6.txt
+++ b/.riot/requirements/5ddbef6.txt
@@ -30,3 +30,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/5e2238a.txt
+++ b/.riot/requirements/5e2238a.txt
@@ -24,3 +24,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==1.26.18
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/5e63315.txt
+++ b/.riot/requirements/5e63315.txt
@@ -46,3 +46,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/5ed7bed.txt
+++ b/.riot/requirements/5ed7bed.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/5eed329.txt
+++ b/.riot/requirements/5eed329.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/5f78892.txt
+++ b/.riot/requirements/5f78892.txt
@@ -25,3 +25,4 @@ pytest-randomly==3.15.0
 rfc3986[idna2008]==1.5.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/5ff3018.txt
+++ b/.riot/requirements/5ff3018.txt
@@ -79,3 +79,4 @@ yarl==1.9.4
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/6028c6e.txt
+++ b/.riot/requirements/6028c6e.txt
@@ -26,3 +26,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/605a6de.txt
+++ b/.riot/requirements/605a6de.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/60ad98e.txt
+++ b/.riot/requirements/60ad98e.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/60b507f.txt
+++ b/.riot/requirements/60b507f.txt
@@ -83,3 +83,4 @@ zipp==3.19.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/610b7cb.txt
+++ b/.riot/requirements/610b7cb.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/61891b4.txt
+++ b/.riot/requirements/61891b4.txt
@@ -29,3 +29,4 @@ zope-interface==6.3
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/61ae1ec.txt
+++ b/.riot/requirements/61ae1ec.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 stevedore==5.1.0
+setuptools<72.0.0

--- a/.riot/requirements/620a309.txt
+++ b/.riot/requirements/620a309.txt
@@ -34,3 +34,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/63292b1.txt
+++ b/.riot/requirements/63292b1.txt
@@ -28,3 +28,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/638973a.txt
+++ b/.riot/requirements/638973a.txt
@@ -22,3 +22,4 @@ pytest-mock==3.14.0
 redis==5.0.3
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/63b44e2.txt
+++ b/.riot/requirements/63b44e2.txt
@@ -38,3 +38,4 @@ tomli==2.0.1
 typing-extensions==4.12.1
 urllib3==2.2.1
 wheel==0.43.0
+setuptools<72.0.0

--- a/.riot/requirements/63c9090.txt
+++ b/.riot/requirements/63c9090.txt
@@ -20,3 +20,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/640588f.txt
+++ b/.riot/requirements/640588f.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/640d59b.txt
+++ b/.riot/requirements/640d59b.txt
@@ -37,3 +37,4 @@ zc-lockfile==3.0.post1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/64dcf93.txt
+++ b/.riot/requirements/64dcf93.txt
@@ -29,3 +29,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==2.0.7
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/6682e06.txt
+++ b/.riot/requirements/6682e06.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/66c248d.txt
+++ b/.riot/requirements/66c248d.txt
@@ -34,3 +34,4 @@ urllib3==2.2.1
 virtualenv-clone==0.5.7
 werkzeug==3.0.3
 wheel==0.43.0
+setuptools<72.0.0

--- a/.riot/requirements/67c0ba5.txt
+++ b/.riot/requirements/67c0ba5.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 vine==5.1.0
+setuptools<72.0.0

--- a/.riot/requirements/681161c.txt
+++ b/.riot/requirements/681161c.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/685a359.txt
+++ b/.riot/requirements/685a359.txt
@@ -43,3 +43,4 @@ urllib3==2.1.0
 uvloop==0.19.0
 websockets==10.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/6861164.txt
+++ b/.riot/requirements/6861164.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
 sqlparse==0.5.1
+setuptools<72.0.0

--- a/.riot/requirements/6875074.txt
+++ b/.riot/requirements/6875074.txt
@@ -38,3 +38,4 @@ tomli==2.0.1
 tomlkit==0.12.3
 typing-extensions==4.9.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/688e35d.txt
+++ b/.riot/requirements/688e35d.txt
@@ -22,3 +22,4 @@ pytest-cov==4.1.0
 pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/689a3fb.txt
+++ b/.riot/requirements/689a3fb.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/68d8bc6.txt
+++ b/.riot/requirements/68d8bc6.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/68e9201.txt
+++ b/.riot/requirements/68e9201.txt
@@ -41,3 +41,4 @@ ujson==5.9.0
 urllib3==2.1.0
 uvloop==0.19.0
 websockets==10.4
+setuptools<72.0.0

--- a/.riot/requirements/694a5dc.txt
+++ b/.riot/requirements/694a5dc.txt
@@ -19,3 +19,4 @@ pytest-randomly==3.15.0
 redis==3.5.3
 redis-py-cluster==2.1.3
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/69997b1.txt
+++ b/.riot/requirements/69997b1.txt
@@ -48,3 +48,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/69fbaa6.txt
+++ b/.riot/requirements/69fbaa6.txt
@@ -29,3 +29,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/6bff0b2.txt
+++ b/.riot/requirements/6bff0b2.txt
@@ -44,3 +44,4 @@ urllib3==2.2.1
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/6c2acd8.txt
+++ b/.riot/requirements/6c2acd8.txt
@@ -90,3 +90,4 @@ urllib3==2.0.7
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/6c872ab.txt
+++ b/.riot/requirements/6c872ab.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/6cb445e.txt
+++ b/.riot/requirements/6cb445e.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/6cbe0ef.txt
+++ b/.riot/requirements/6cbe0ef.txt
@@ -25,3 +25,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/6d67b0b.txt
+++ b/.riot/requirements/6d67b0b.txt
@@ -40,3 +40,4 @@ tomlkit==0.12.3
 typing-extensions==4.9.0
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/6dd3b2a.txt
+++ b/.riot/requirements/6dd3b2a.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/6e16fa2.txt
+++ b/.riot/requirements/6e16fa2.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==3.10.0.2
 typing-inspect==0.6.0
+setuptools<72.0.0

--- a/.riot/requirements/6e1aef3.txt
+++ b/.riot/requirements/6e1aef3.txt
@@ -18,3 +18,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==1.26.8
+setuptools<72.0.0

--- a/.riot/requirements/6e78b72.txt
+++ b/.riot/requirements/6e78b72.txt
@@ -32,3 +32,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/6e85bcc.txt
+++ b/.riot/requirements/6e85bcc.txt
@@ -19,3 +19,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/6ebd15f.txt
+++ b/.riot/requirements/6ebd15f.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/6fd655c.txt
+++ b/.riot/requirements/6fd655c.txt
@@ -28,3 +28,4 @@ sortedcontainers==2.4.0
 sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
+setuptools<72.0.0

--- a/.riot/requirements/7046fe8.txt
+++ b/.riot/requirements/7046fe8.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/705d3ca.txt
+++ b/.riot/requirements/705d3ca.txt
@@ -25,3 +25,4 @@ zipp==3.15.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/724adbd.txt
+++ b/.riot/requirements/724adbd.txt
@@ -32,3 +32,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 werkzeug==1.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/72aa2be.txt
+++ b/.riot/requirements/72aa2be.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/7341bd9.txt
+++ b/.riot/requirements/7341bd9.txt
@@ -23,3 +23,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/745db14.txt
+++ b/.riot/requirements/745db14.txt
@@ -48,3 +48,4 @@ uvloop==0.18.0
 websockets==9.1
 yarl==1.9.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/74901f6.txt
+++ b/.riot/requirements/74901f6.txt
@@ -46,3 +46,4 @@ uvloop==0.19.0
 websockets==9.1
 yarl==1.9.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/74e07bf.txt
+++ b/.riot/requirements/74e07bf.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 redis==4.6.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/75d9e47.txt
+++ b/.riot/requirements/75d9e47.txt
@@ -19,3 +19,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/75dda93.txt
+++ b/.riot/requirements/75dda93.txt
@@ -32,3 +32,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 werkzeug==1.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/760d56e.txt
+++ b/.riot/requirements/760d56e.txt
@@ -28,3 +28,4 @@ waitress==2.1.2
 webob==1.8.7
 webtest==3.0.0
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/769aa27.txt
+++ b/.riot/requirements/769aa27.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/77b1594.txt
+++ b/.riot/requirements/77b1594.txt
@@ -30,3 +30,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.9.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/7800b91.txt
+++ b/.riot/requirements/7800b91.txt
@@ -32,3 +32,4 @@ sortedcontainers==2.4.0
 toml==0.10.2
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/793e383.txt
+++ b/.riot/requirements/793e383.txt
@@ -37,3 +37,4 @@ zc-lockfile==3.0.post1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/79deb5b.txt
+++ b/.riot/requirements/79deb5b.txt
@@ -39,3 +39,4 @@ urllib3==1.26.18
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/79f2ab7.txt
+++ b/.riot/requirements/79f2ab7.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/7a6a528.txt
+++ b/.riot/requirements/7a6a528.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/7abacd9.txt
+++ b/.riot/requirements/7abacd9.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/7b8e50e.txt
+++ b/.riot/requirements/7b8e50e.txt
@@ -39,3 +39,4 @@ tomli==2.0.1
 typing-extensions==4.10.0
 urllib3==2.2.1
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/7c104f7.txt
+++ b/.riot/requirements/7c104f7.txt
@@ -48,3 +48,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/7c88ce5.txt
+++ b/.riot/requirements/7c88ce5.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 vine==5.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/7e7551c.txt
+++ b/.riot/requirements/7e7551c.txt
@@ -31,3 +31,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/7ed64b0.txt
+++ b/.riot/requirements/7ed64b0.txt
@@ -17,3 +17,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/7f40666.txt
+++ b/.riot/requirements/7f40666.txt
@@ -25,3 +25,4 @@ pytz==2024.1
 six==1.16.0
 sortedcontainers==2.4.0
 sqlparse==0.5.1
+setuptools<72.0.0

--- a/.riot/requirements/7f56123.txt
+++ b/.riot/requirements/7f56123.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/7f7863d.txt
+++ b/.riot/requirements/7f7863d.txt
@@ -39,3 +39,4 @@ tomli==2.0.1
 typing-extensions==4.10.0
 urllib3==2.2.1
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/7f84968.txt
+++ b/.riot/requirements/7f84968.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/7fa00cf.txt
+++ b/.riot/requirements/7fa00cf.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/7faa8e0.txt
+++ b/.riot/requirements/7faa8e0.txt
@@ -57,3 +57,4 @@ uvicorn[standard]==0.30.1
 uvloop==0.19.0
 watchfiles==0.22.0
 websockets==12.0
+setuptools<72.0.0

--- a/.riot/requirements/7ff8c97.txt
+++ b/.riot/requirements/7ff8c97.txt
@@ -37,3 +37,4 @@ starlette==0.33.0
 tomli==2.0.1
 typing-extensions==4.10.0
 urllib3==2.2.1
+setuptools<72.0.0

--- a/.riot/requirements/8049cd3.txt
+++ b/.riot/requirements/8049cd3.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/816352e.txt
+++ b/.riot/requirements/816352e.txt
@@ -26,3 +26,4 @@ rq==1.8.1
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/81db984.txt
+++ b/.riot/requirements/81db984.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/81e3c73.txt
+++ b/.riot/requirements/81e3c73.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/84ec59a.txt
+++ b/.riot/requirements/84ec59a.txt
@@ -51,3 +51,4 @@ vcrpy==4.2.1
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/857094b.txt
+++ b/.riot/requirements/857094b.txt
@@ -22,3 +22,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/85acf6e.txt
+++ b/.riot/requirements/85acf6e.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/85c8e30.txt
+++ b/.riot/requirements/85c8e30.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/85c90b4.txt
+++ b/.riot/requirements/85c90b4.txt
@@ -48,3 +48,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/85e923f.txt
+++ b/.riot/requirements/85e923f.txt
@@ -34,3 +34,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/86be119.txt
+++ b/.riot/requirements/86be119.txt
@@ -43,3 +43,4 @@ urllib3==2.1.0
 uvloop==0.19.0
 websockets==10.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/87a1fff.txt
+++ b/.riot/requirements/87a1fff.txt
@@ -51,3 +51,4 @@ vcrpy==4.2.1
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/87ce77a.txt
+++ b/.riot/requirements/87ce77a.txt
@@ -44,3 +44,4 @@ urllib3==2.2.1
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/87dc480.txt
+++ b/.riot/requirements/87dc480.txt
@@ -23,3 +23,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 uwsgi==2.0.23
+setuptools<72.0.0

--- a/.riot/requirements/880a8ad.txt
+++ b/.riot/requirements/880a8ad.txt
@@ -26,3 +26,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==2.0.7
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/8830759.txt
+++ b/.riot/requirements/8830759.txt
@@ -27,3 +27,4 @@ python-memcached==1.62
 redis==2.10.6
 sortedcontainers==2.4.0
 werkzeug==3.0.1
+setuptools<72.0.0

--- a/.riot/requirements/89b8013.txt
+++ b/.riot/requirements/89b8013.txt
@@ -29,3 +29,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/89d7a5f.txt
+++ b/.riot/requirements/89d7a5f.txt
@@ -38,3 +38,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==2.3.8
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/8a17cb2.txt
+++ b/.riot/requirements/8a17cb2.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/8a19bdc.txt
+++ b/.riot/requirements/8a19bdc.txt
@@ -27,3 +27,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/8a3bd2b.txt
+++ b/.riot/requirements/8a3bd2b.txt
@@ -27,3 +27,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/8c110bf.txt
+++ b/.riot/requirements/8c110bf.txt
@@ -27,3 +27,4 @@ waitress==2.1.2
 webob==1.8.7
 webtest==3.0.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/8c5c91a.txt
+++ b/.riot/requirements/8c5c91a.txt
@@ -72,3 +72,4 @@ vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/8d6eaf8.txt
+++ b/.riot/requirements/8d6eaf8.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
 sqlparse==0.5.1
+setuptools<72.0.0

--- a/.riot/requirements/8dd750a.txt
+++ b/.riot/requirements/8dd750a.txt
@@ -99,3 +99,4 @@ urllib3==2.2.2
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/8dea090.txt
+++ b/.riot/requirements/8dea090.txt
@@ -48,3 +48,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/8e06425.txt
+++ b/.riot/requirements/8e06425.txt
@@ -25,3 +25,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/8e06e19.txt
+++ b/.riot/requirements/8e06e19.txt
@@ -20,3 +20,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/8e47e0a.txt
+++ b/.riot/requirements/8e47e0a.txt
@@ -18,3 +18,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tornado==6.2
+setuptools<72.0.0

--- a/.riot/requirements/8ef4a62.txt
+++ b/.riot/requirements/8ef4a62.txt
@@ -31,3 +31,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/8f46789.txt
+++ b/.riot/requirements/8f46789.txt
@@ -20,3 +20,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/8fc3285.txt
+++ b/.riot/requirements/8fc3285.txt
@@ -67,3 +67,4 @@ zipp==3.19.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/8fd4efc.txt
+++ b/.riot/requirements/8fd4efc.txt
@@ -32,3 +32,4 @@ sortedcontainers==2.4.0
 toml==0.10.2
 typing-extensions==4.11.0
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/9029977.txt
+++ b/.riot/requirements/9029977.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/9050f7e.txt
+++ b/.riot/requirements/9050f7e.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/908f9c9.txt
+++ b/.riot/requirements/908f9c9.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/9093195.txt
+++ b/.riot/requirements/9093195.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/9105e5c.txt
+++ b/.riot/requirements/9105e5c.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/912dbf5.txt
+++ b/.riot/requirements/912dbf5.txt
@@ -26,3 +26,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/91629cd.txt
+++ b/.riot/requirements/91629cd.txt
@@ -28,3 +28,4 @@ python-memcached==1.62
 redis==2.10.6
 sortedcontainers==2.4.0
 werkzeug==1.0.1
+setuptools<72.0.0

--- a/.riot/requirements/91a1ee4.txt
+++ b/.riot/requirements/91a1ee4.txt
@@ -33,3 +33,4 @@ sortedcontainers==2.4.0
 tzdata==2023.3
 vine==5.1.0
 wcwidth==0.2.12
+setuptools<72.0.0

--- a/.riot/requirements/91a3315.txt
+++ b/.riot/requirements/91a3315.txt
@@ -39,3 +39,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==2.0.7
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/91bec06.txt
+++ b/.riot/requirements/91bec06.txt
@@ -32,3 +32,4 @@ sortedcontainers==2.4.0
 toml==0.10.2
 typing-extensions==4.11.0
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/91cc60d.txt
+++ b/.riot/requirements/91cc60d.txt
@@ -34,3 +34,4 @@ starlette==0.27.0
 structlog==23.2.0
 typing-extensions==4.9.0
 wheel==0.42.0
+setuptools<72.0.0

--- a/.riot/requirements/9204343.txt
+++ b/.riot/requirements/9204343.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/9232661.txt
+++ b/.riot/requirements/9232661.txt
@@ -19,3 +19,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 redis==5.0.7
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/92fcc12.txt
+++ b/.riot/requirements/92fcc12.txt
@@ -17,3 +17,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/93bc4fa.txt
+++ b/.riot/requirements/93bc4fa.txt
@@ -29,3 +29,4 @@ sqlparse==0.4.4
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/94509b6.txt
+++ b/.riot/requirements/94509b6.txt
@@ -20,3 +20,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 structlog==23.2.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/94de9f8.txt
+++ b/.riot/requirements/94de9f8.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/94edf33.txt
+++ b/.riot/requirements/94edf33.txt
@@ -39,3 +39,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 wheel==0.42.0
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/9571147.txt
+++ b/.riot/requirements/9571147.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/957161b.txt
+++ b/.riot/requirements/957161b.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/958996c.txt
+++ b/.riot/requirements/958996c.txt
@@ -35,3 +35,4 @@ starlette==0.13.6
 tomli==2.0.1
 typing-extensions==4.12.2
 urllib3==2.2.2
+setuptools<72.0.0

--- a/.riot/requirements/95aa957.txt
+++ b/.riot/requirements/95aa957.txt
@@ -42,3 +42,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/95f5020.txt
+++ b/.riot/requirements/95f5020.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/9627328.txt
+++ b/.riot/requirements/9627328.txt
@@ -20,3 +20,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/976376a.txt
+++ b/.riot/requirements/976376a.txt
@@ -36,3 +36,4 @@ typing-extensions==4.7.1
 urllib3==1.26.19
 werkzeug==2.2.3
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/9777f3d.txt
+++ b/.riot/requirements/9777f3d.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/97d2271.txt
+++ b/.riot/requirements/97d2271.txt
@@ -44,3 +44,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/98b02a4.txt
+++ b/.riot/requirements/98b02a4.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/9a13b9a.txt
+++ b/.riot/requirements/9a13b9a.txt
@@ -20,3 +20,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/9a81f68.txt
+++ b/.riot/requirements/9a81f68.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/9a8d5f9.txt
+++ b/.riot/requirements/9a8d5f9.txt
@@ -24,3 +24,4 @@ requests==2.31.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.2.1
+setuptools<72.0.0

--- a/.riot/requirements/9aea1c4.txt
+++ b/.riot/requirements/9aea1c4.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/9af62ac.txt
+++ b/.riot/requirements/9af62ac.txt
@@ -25,3 +25,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/9b18162.txt
+++ b/.riot/requirements/9b18162.txt
@@ -72,3 +72,4 @@ zipp==3.15.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/9b3b6c2.txt
+++ b/.riot/requirements/9b3b6c2.txt
@@ -46,3 +46,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/9b8251b.txt
+++ b/.riot/requirements/9b8251b.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 yaaredis==3.0.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/9b8c47e.txt
+++ b/.riot/requirements/9b8c47e.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/9ba9bfd.txt
+++ b/.riot/requirements/9ba9bfd.txt
@@ -45,3 +45,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/9bc08b4.txt
+++ b/.riot/requirements/9bc08b4.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/9d631d9.txt
+++ b/.riot/requirements/9d631d9.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/9d72125.txt
+++ b/.riot/requirements/9d72125.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/9d9517f.txt
+++ b/.riot/requirements/9d9517f.txt
@@ -17,3 +17,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/9e2c461.txt
+++ b/.riot/requirements/9e2c461.txt
@@ -26,3 +26,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/9e36105.txt
+++ b/.riot/requirements/9e36105.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/9eedbc0.txt
+++ b/.riot/requirements/9eedbc0.txt
@@ -42,3 +42,4 @@ zipp==3.17.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/9f052d0.txt
+++ b/.riot/requirements/9f052d0.txt
@@ -37,3 +37,4 @@ zc-lockfile==3.0.post1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/9f4d6f1.txt
+++ b/.riot/requirements/9f4d6f1.txt
@@ -24,3 +24,4 @@ requests==2.31.0
 six==1.16.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/9fbe7fd.txt
+++ b/.riot/requirements/9fbe7fd.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/a009c45.txt
+++ b/.riot/requirements/a009c45.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/a0454b7.txt
+++ b/.riot/requirements/a0454b7.txt
@@ -20,3 +20,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/a061610.txt
+++ b/.riot/requirements/a061610.txt
@@ -18,3 +18,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==2.2.0
+setuptools<72.0.0

--- a/.riot/requirements/a0aa271.txt
+++ b/.riot/requirements/a0aa271.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/a0b5e82.txt
+++ b/.riot/requirements/a0b5e82.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/a0f2001.txt
+++ b/.riot/requirements/a0f2001.txt
@@ -46,3 +46,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/a1ca9a5.txt
+++ b/.riot/requirements/a1ca9a5.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/a1eb4c8.txt
+++ b/.riot/requirements/a1eb4c8.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/a273f3b.txt
+++ b/.riot/requirements/a273f3b.txt
@@ -18,3 +18,4 @@ pytest-cov==5.0.0
 pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/a36a30e.txt
+++ b/.riot/requirements/a36a30e.txt
@@ -24,3 +24,4 @@ requests-mock==1.11.0
 six==1.16.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/a3adb9c.txt
+++ b/.riot/requirements/a3adb9c.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/a3c3dfa.txt
+++ b/.riot/requirements/a3c3dfa.txt
@@ -36,3 +36,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==3.0.3
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/a41adfe.txt
+++ b/.riot/requirements/a41adfe.txt
@@ -33,3 +33,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/a42e1fb.txt
+++ b/.riot/requirements/a42e1fb.txt
@@ -22,3 +22,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/a4ee05c.txt
+++ b/.riot/requirements/a4ee05c.txt
@@ -35,3 +35,4 @@ tomli==2.0.1
 wcwidth==0.2.13
 werkzeug==0.16.1
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/a4fc6be.txt
+++ b/.riot/requirements/a4fc6be.txt
@@ -25,3 +25,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/a53d339.txt
+++ b/.riot/requirements/a53d339.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/a54b2db.txt
+++ b/.riot/requirements/a54b2db.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/a55b017.txt
+++ b/.riot/requirements/a55b017.txt
@@ -26,3 +26,4 @@ stevedore==5.1.0
 tomli==2.0.1
 typing-extensions==4.9.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/a5642ea.txt
+++ b/.riot/requirements/a5642ea.txt
@@ -38,3 +38,4 @@ tomli==2.0.1
 urllib3==1.26.18
 yarl==1.9.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/a5eb94b.txt
+++ b/.riot/requirements/a5eb94b.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/a5efead.txt
+++ b/.riot/requirements/a5efead.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/a5f7aa3.txt
+++ b/.riot/requirements/a5f7aa3.txt
@@ -24,3 +24,4 @@ zipp==3.17.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/a5fb44d.txt
+++ b/.riot/requirements/a5fb44d.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 uwsgi==2.0.23
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/a6329d3.txt
+++ b/.riot/requirements/a6329d3.txt
@@ -22,3 +22,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/a750d73.txt
+++ b/.riot/requirements/a750d73.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/a7d2dc1.txt
+++ b/.riot/requirements/a7d2dc1.txt
@@ -61,3 +61,4 @@ uvloop==0.19.0
 watchfiles==0.22.0
 websockets==12.0
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/a8351f1.txt
+++ b/.riot/requirements/a8351f1.txt
@@ -48,3 +48,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/a98b986.txt
+++ b/.riot/requirements/a98b986.txt
@@ -20,3 +20,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/a9dcb3f.txt
+++ b/.riot/requirements/a9dcb3f.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/aa4ae37.txt
+++ b/.riot/requirements/aa4ae37.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 stevedore==5.1.0
+setuptools<72.0.0

--- a/.riot/requirements/aaf6987.txt
+++ b/.riot/requirements/aaf6987.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/aba89a0.txt
+++ b/.riot/requirements/aba89a0.txt
@@ -36,3 +36,4 @@ sqlalchemy==2.0.22
 typing-extensions==4.12.1
 urllib3==2.2.1
 wheel==0.43.0
+setuptools<72.0.0

--- a/.riot/requirements/abc0b46.txt
+++ b/.riot/requirements/abc0b46.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/abfbfa5.txt
+++ b/.riot/requirements/abfbfa5.txt
@@ -67,3 +67,4 @@ zipp==3.19.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/ac45b1e.txt
+++ b/.riot/requirements/ac45b1e.txt
@@ -30,3 +30,4 @@ sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/aca97c1.txt
+++ b/.riot/requirements/aca97c1.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/ad1bcb5.txt
+++ b/.riot/requirements/ad1bcb5.txt
@@ -26,3 +26,4 @@ rq==1.15.1
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/ad22fca.txt
+++ b/.riot/requirements/ad22fca.txt
@@ -28,3 +28,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/adb0290.txt
+++ b/.riot/requirements/adb0290.txt
@@ -52,3 +52,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/adec509.txt
+++ b/.riot/requirements/adec509.txt
@@ -23,3 +23,4 @@ redis-py-cluster==2.0.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/ae13b87.txt
+++ b/.riot/requirements/ae13b87.txt
@@ -33,3 +33,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/ae55137.txt
+++ b/.riot/requirements/ae55137.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 requests==2.31.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/af3567d.txt
+++ b/.riot/requirements/af3567d.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/b06b6cb.txt
+++ b/.riot/requirements/b06b6cb.txt
@@ -37,3 +37,4 @@ starlette==0.15.0
 tomli==2.0.1
 typing-extensions==4.10.0
 urllib3==2.2.1
+setuptools<72.0.0

--- a/.riot/requirements/b084483.txt
+++ b/.riot/requirements/b084483.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/b0a5cc3.txt
+++ b/.riot/requirements/b0a5cc3.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/b1df5a4.txt
+++ b/.riot/requirements/b1df5a4.txt
@@ -35,3 +35,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/b1eb794.txt
+++ b/.riot/requirements/b1eb794.txt
@@ -30,3 +30,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/b1f6b59.txt
+++ b/.riot/requirements/b1f6b59.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/b1fd8ec.txt
+++ b/.riot/requirements/b1fd8ec.txt
@@ -48,3 +48,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/b2251c4.txt
+++ b/.riot/requirements/b2251c4.txt
@@ -44,3 +44,4 @@ websockets==10.4
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/b26db48.txt
+++ b/.riot/requirements/b26db48.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/b29b7a2.txt
+++ b/.riot/requirements/b29b7a2.txt
@@ -18,3 +18,4 @@ pytest-cov==5.0.0
 pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/b2ac981.txt
+++ b/.riot/requirements/b2ac981.txt
@@ -20,3 +20,4 @@ ruamel-yaml==0.17.32
 ruamel-yaml-clib==0.2.7
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/b39e5f7.txt
+++ b/.riot/requirements/b39e5f7.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 werkzeug==1.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/b436a4c.txt
+++ b/.riot/requirements/b436a4c.txt
@@ -44,3 +44,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/b48f841.txt
+++ b/.riot/requirements/b48f841.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/b4cb901.txt
+++ b/.riot/requirements/b4cb901.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 tornado==6.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/b56d9af.txt
+++ b/.riot/requirements/b56d9af.txt
@@ -40,3 +40,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/b5df1ff.txt
+++ b/.riot/requirements/b5df1ff.txt
@@ -97,3 +97,4 @@ urllib3==2.2.2
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/b5fb73e.txt
+++ b/.riot/requirements/b5fb73e.txt
@@ -33,3 +33,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/b67aa96.txt
+++ b/.riot/requirements/b67aa96.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 sqlalchemy==2.0.28
 typing-extensions==4.10.0
+setuptools<72.0.0

--- a/.riot/requirements/b767984.txt
+++ b/.riot/requirements/b767984.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 redis==5.0.1
 rq==1.15.1
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/b786604.txt
+++ b/.riot/requirements/b786604.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/b7a530f.txt
+++ b/.riot/requirements/b7a530f.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/b80e42b.txt
+++ b/.riot/requirements/b80e42b.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/b90472a.txt
+++ b/.riot/requirements/b90472a.txt
@@ -23,3 +23,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/b910bfb.txt
+++ b/.riot/requirements/b910bfb.txt
@@ -41,3 +41,4 @@ zipp==3.17.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/b92b3b0.txt
+++ b/.riot/requirements/b92b3b0.txt
@@ -26,3 +26,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/b970d9a.txt
+++ b/.riot/requirements/b970d9a.txt
@@ -20,3 +20,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/b9941cb.txt
+++ b/.riot/requirements/b9941cb.txt
@@ -70,3 +70,4 @@ zipp==3.19.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/baf46ab.txt
+++ b/.riot/requirements/baf46ab.txt
@@ -24,3 +24,4 @@ redis==4.6.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/bb514db.txt
+++ b/.riot/requirements/bb514db.txt
@@ -39,3 +39,4 @@ urllib3==1.26.18
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/bb588fd.txt
+++ b/.riot/requirements/bb588fd.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/bb8bd85.txt
+++ b/.riot/requirements/bb8bd85.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 vcrpy==6.0.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/bbb3af0.txt
+++ b/.riot/requirements/bbb3af0.txt
@@ -48,3 +48,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/bc1efaa.txt
+++ b/.riot/requirements/bc1efaa.txt
@@ -32,3 +32,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 werkzeug==2.2.3
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/bc5cfa5.txt
+++ b/.riot/requirements/bc5cfa5.txt
@@ -22,3 +22,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/bceb0bd.txt
+++ b/.riot/requirements/bceb0bd.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/bd14427.txt
+++ b/.riot/requirements/bd14427.txt
@@ -21,3 +21,4 @@ redis==3.5.3
 redis-py-cluster==2.1.3
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/bdefe70.txt
+++ b/.riot/requirements/bdefe70.txt
@@ -27,3 +27,4 @@ waitress==2.1.2
 webob==1.8.7
 webtest==3.0.0
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/be3147f.txt
+++ b/.riot/requirements/be3147f.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/becad20.txt
+++ b/.riot/requirements/becad20.txt
@@ -28,3 +28,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/bed28f9.txt
+++ b/.riot/requirements/bed28f9.txt
@@ -30,3 +30,4 @@ sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/beea277.txt
+++ b/.riot/requirements/beea277.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/bf3c888.txt
+++ b/.riot/requirements/bf3c888.txt
@@ -26,3 +26,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/c08cf9c.txt
+++ b/.riot/requirements/c08cf9c.txt
@@ -24,3 +24,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/c0bc2fa.txt
+++ b/.riot/requirements/c0bc2fa.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/c18a3b5.txt
+++ b/.riot/requirements/c18a3b5.txt
@@ -33,3 +33,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/c1cb3f7.txt
+++ b/.riot/requirements/c1cb3f7.txt
@@ -20,3 +20,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.2.0
+setuptools<72.0.0

--- a/.riot/requirements/c23f533.txt
+++ b/.riot/requirements/c23f533.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 typing-extensions==3.10.0.2
 typing-inspect==0.6.0
+setuptools<72.0.0

--- a/.riot/requirements/c285110.txt
+++ b/.riot/requirements/c285110.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 vine==5.1.0
+setuptools<72.0.0

--- a/.riot/requirements/c2a85a5.txt
+++ b/.riot/requirements/c2a85a5.txt
@@ -43,3 +43,4 @@ urllib3==2.0.7
 uvloop==0.18.0
 websockets==10.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/c2ee914.txt
+++ b/.riot/requirements/c2ee914.txt
@@ -22,3 +22,4 @@ pytest-mock==3.11.1
 sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
+setuptools<72.0.0

--- a/.riot/requirements/c384590.txt
+++ b/.riot/requirements/c384590.txt
@@ -36,3 +36,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==2.3.8
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/c38ef26.txt
+++ b/.riot/requirements/c38ef26.txt
@@ -26,3 +26,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/c3912b5.txt
+++ b/.riot/requirements/c3912b5.txt
@@ -36,3 +36,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==1.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/c3e8b1a.txt
+++ b/.riot/requirements/c3e8b1a.txt
@@ -48,3 +48,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/c43afd8.txt
+++ b/.riot/requirements/c43afd8.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/c4dace8.txt
+++ b/.riot/requirements/c4dace8.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/c52f9f6.txt
+++ b/.riot/requirements/c52f9f6.txt
@@ -39,3 +39,4 @@ tomli==2.0.1
 typing-extensions==4.10.0
 urllib3==2.2.1
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/c54cef3.txt
+++ b/.riot/requirements/c54cef3.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.12.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/c60dd9e.txt
+++ b/.riot/requirements/c60dd9e.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/c61da82.txt
+++ b/.riot/requirements/c61da82.txt
@@ -38,3 +38,4 @@ tzdata==2023.3
 vine==5.1.0
 wcwidth==0.2.12
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/c74560f.txt
+++ b/.riot/requirements/c74560f.txt
@@ -30,3 +30,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/c74f6e0.txt
+++ b/.riot/requirements/c74f6e0.txt
@@ -49,3 +49,4 @@ urllib3==1.26.19
 vcrpy==4.2.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/c7b5ba5.txt
+++ b/.riot/requirements/c7b5ba5.txt
@@ -52,3 +52,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/c7c679a.txt
+++ b/.riot/requirements/c7c679a.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/c961281.txt
+++ b/.riot/requirements/c961281.txt
@@ -19,3 +19,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 redis==4.6.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/c998f1e.txt
+++ b/.riot/requirements/c998f1e.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/c9aa578.txt
+++ b/.riot/requirements/c9aa578.txt
@@ -28,3 +28,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/ca86aae.txt
+++ b/.riot/requirements/ca86aae.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/cc03823.txt
+++ b/.riot/requirements/cc03823.txt
@@ -24,3 +24,4 @@ toml==0.10.2
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/cc2f3f8.txt
+++ b/.riot/requirements/cc2f3f8.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/ccf18c9.txt
+++ b/.riot/requirements/ccf18c9.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/ccffa6b.txt
+++ b/.riot/requirements/ccffa6b.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/cd2e4ea.txt
+++ b/.riot/requirements/cd2e4ea.txt
@@ -51,3 +51,4 @@ vcrpy==4.2.1
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/ce26b2c.txt
+++ b/.riot/requirements/ce26b2c.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/ce6cd33.txt
+++ b/.riot/requirements/ce6cd33.txt
@@ -50,3 +50,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/cea6065.txt
+++ b/.riot/requirements/cea6065.txt
@@ -70,3 +70,4 @@ zipp==3.19.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/cf88166.txt
+++ b/.riot/requirements/cf88166.txt
@@ -45,3 +45,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/cfa93dd.txt
+++ b/.riot/requirements/cfa93dd.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/d0116c6.txt
+++ b/.riot/requirements/d0116c6.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/d03449e.txt
+++ b/.riot/requirements/d03449e.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.11.0
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/d0355c2.txt
+++ b/.riot/requirements/d0355c2.txt
@@ -31,3 +31,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/d0fc014.txt
+++ b/.riot/requirements/d0fc014.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/d153fb7.txt
+++ b/.riot/requirements/d153fb7.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
+setuptools<72.0.0

--- a/.riot/requirements/d168e78.txt
+++ b/.riot/requirements/d168e78.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/d171c08.txt
+++ b/.riot/requirements/d171c08.txt
@@ -25,3 +25,4 @@ zope-interface==6.3
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/d1dd9c4.txt
+++ b/.riot/requirements/d1dd9c4.txt
@@ -36,3 +36,4 @@ typing-extensions==4.7.1
 urllib3==1.26.19
 werkzeug==1.0.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/d2b8f24.txt
+++ b/.riot/requirements/d2b8f24.txt
@@ -79,3 +79,4 @@ yarl==1.9.4
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/d2cb323.txt
+++ b/.riot/requirements/d2cb323.txt
@@ -22,3 +22,4 @@ sortedcontainers==2.4.0
 structlog==20.2.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/d308d1f.txt
+++ b/.riot/requirements/d308d1f.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/d3c9d7c.txt
+++ b/.riot/requirements/d3c9d7c.txt
@@ -25,3 +25,4 @@ pytz==2024.1
 six==1.16.0
 sortedcontainers==2.4.0
 sqlparse==0.5.1
+setuptools<72.0.0

--- a/.riot/requirements/d3c9ec8.txt
+++ b/.riot/requirements/d3c9ec8.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/d44f455.txt
+++ b/.riot/requirements/d44f455.txt
@@ -24,3 +24,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/d4987bc.txt
+++ b/.riot/requirements/d4987bc.txt
@@ -26,3 +26,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/d59b088.txt
+++ b/.riot/requirements/d59b088.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/d59e395.txt
+++ b/.riot/requirements/d59e395.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/d5d6e2c.txt
+++ b/.riot/requirements/d5d6e2c.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/d68f919.txt
+++ b/.riot/requirements/d68f919.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/d6b8465.txt
+++ b/.riot/requirements/d6b8465.txt
@@ -21,3 +21,4 @@ pytest-cov==5.0.0
 pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/d6ceb22.txt
+++ b/.riot/requirements/d6ceb22.txt
@@ -35,3 +35,4 @@ sqlalchemy==1.4.52
 starlette==0.37.2
 typing-extensions==4.10.0
 urllib3==2.2.1
+setuptools<72.0.0

--- a/.riot/requirements/d751a10.txt
+++ b/.riot/requirements/d751a10.txt
@@ -41,3 +41,4 @@ urllib3==1.26.18
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/d7cd7fb.txt
+++ b/.riot/requirements/d7cd7fb.txt
@@ -33,3 +33,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/d7f052d.txt
+++ b/.riot/requirements/d7f052d.txt
@@ -40,3 +40,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/d80bce2.txt
+++ b/.riot/requirements/d80bce2.txt
@@ -30,3 +30,4 @@ sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/d825572.txt
+++ b/.riot/requirements/d825572.txt
@@ -47,3 +47,4 @@ typing-extensions==4.12.2
 urllib3==2.2.2
 werkzeug==3.0.3
 xmltodict==0.13.0
+setuptools<72.0.0

--- a/.riot/requirements/d82f331.txt
+++ b/.riot/requirements/d82f331.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/d88b3ac.txt
+++ b/.riot/requirements/d88b3ac.txt
@@ -39,3 +39,4 @@ tomli==2.0.1
 typing-extensions==4.10.0
 urllib3==2.2.1
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/da15808.txt
+++ b/.riot/requirements/da15808.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/da79693.txt
+++ b/.riot/requirements/da79693.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/daa4242.txt
+++ b/.riot/requirements/daa4242.txt
@@ -39,3 +39,4 @@ urllib3==1.26.18
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/daada28.txt
+++ b/.riot/requirements/daada28.txt
@@ -18,3 +18,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 structlog==20.2.0
+setuptools<72.0.0

--- a/.riot/requirements/dab7cce.txt
+++ b/.riot/requirements/dab7cce.txt
@@ -19,3 +19,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/db02b05.txt
+++ b/.riot/requirements/db02b05.txt
@@ -24,3 +24,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/db0f71f.txt
+++ b/.riot/requirements/db0f71f.txt
@@ -33,3 +33,4 @@ sortedcontainers==2.4.0
 urllib3==1.26.18
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/dbdd8c0.txt
+++ b/.riot/requirements/dbdd8c0.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/dbf191e.txt
+++ b/.riot/requirements/dbf191e.txt
@@ -43,3 +43,4 @@ zipp==3.17.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/dc9f475.txt
+++ b/.riot/requirements/dc9f475.txt
@@ -42,3 +42,4 @@ zipp==3.17.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/dcf90ee.txt
+++ b/.riot/requirements/dcf90ee.txt
@@ -57,3 +57,4 @@ uvicorn[standard]==0.30.1
 uvloop==0.19.0
 watchfiles==0.22.0
 websockets==12.0
+setuptools<72.0.0

--- a/.riot/requirements/dcfed5e.txt
+++ b/.riot/requirements/dcfed5e.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/dd2bb3b.txt
+++ b/.riot/requirements/dd2bb3b.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/dd346e6.txt
+++ b/.riot/requirements/dd346e6.txt
@@ -23,3 +23,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/dd525d9.txt
+++ b/.riot/requirements/dd525d9.txt
@@ -47,3 +47,4 @@ urllib3==1.26.19
 wrapt==1.16.0
 xmltodict==0.13.0
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/ddba314.txt
+++ b/.riot/requirements/ddba314.txt
@@ -46,3 +46,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/ddbda57.txt
+++ b/.riot/requirements/ddbda57.txt
@@ -25,3 +25,4 @@ requests==2.31.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/de13093.txt
+++ b/.riot/requirements/de13093.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/de578a7.txt
+++ b/.riot/requirements/de578a7.txt
@@ -25,3 +25,4 @@ zope-interface==6.3
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/de7d3ce.txt
+++ b/.riot/requirements/de7d3ce.txt
@@ -20,3 +20,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/def2a48.txt
+++ b/.riot/requirements/def2a48.txt
@@ -20,3 +20,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/df5c335.txt
+++ b/.riot/requirements/df5c335.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/df69ea1.txt
+++ b/.riot/requirements/df69ea1.txt
@@ -36,3 +36,4 @@ typing-extensions==4.7.1
 urllib3==1.26.19
 werkzeug==1.0.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/e02e81a.txt
+++ b/.riot/requirements/e02e81a.txt
@@ -21,3 +21,4 @@ pytest-randomly==3.15.0
 redis==5.0.1
 rq==1.15.1
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/e092ac7.txt
+++ b/.riot/requirements/e092ac7.txt
@@ -28,3 +28,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/e0b9dc9.txt
+++ b/.riot/requirements/e0b9dc9.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/e1220d6.txt
+++ b/.riot/requirements/e1220d6.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 requests==2.31.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/e126ba4.txt
+++ b/.riot/requirements/e126ba4.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/e1e09c9.txt
+++ b/.riot/requirements/e1e09c9.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/e20bbeb.txt
+++ b/.riot/requirements/e20bbeb.txt
@@ -48,3 +48,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/e2ae847.txt
+++ b/.riot/requirements/e2ae847.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/e2c6900.txt
+++ b/.riot/requirements/e2c6900.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.12.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/e2e33be.txt
+++ b/.riot/requirements/e2e33be.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/e33edda.txt
+++ b/.riot/requirements/e33edda.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/e39f833.txt
+++ b/.riot/requirements/e39f833.txt
@@ -46,3 +46,4 @@ urllib3==1.26.19
 wrapt==1.16.0
 xmltodict==0.13.0
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/e3a9589.txt
+++ b/.riot/requirements/e3a9589.txt
@@ -25,3 +25,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==1.26.18
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/e45d6bf.txt
+++ b/.riot/requirements/e45d6bf.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/e53ccba.txt
+++ b/.riot/requirements/e53ccba.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==2.1.0
 werkzeug==1.0.1
+setuptools<72.0.0

--- a/.riot/requirements/e59b1f6.txt
+++ b/.riot/requirements/e59b1f6.txt
@@ -29,3 +29,4 @@ sniffio==1.3.1
 sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.12.2
+setuptools<72.0.0

--- a/.riot/requirements/e610a94.txt
+++ b/.riot/requirements/e610a94.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/e6619c9.txt
+++ b/.riot/requirements/e6619c9.txt
@@ -36,3 +36,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 yarl==1.9.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/e68fea2.txt
+++ b/.riot/requirements/e68fea2.txt
@@ -32,3 +32,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/e75aea6.txt
+++ b/.riot/requirements/e75aea6.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/e771330.txt
+++ b/.riot/requirements/e771330.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/e79a8f5.txt
+++ b/.riot/requirements/e79a8f5.txt
@@ -40,3 +40,4 @@ zipp==3.15.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/e82070b.txt
+++ b/.riot/requirements/e82070b.txt
@@ -37,3 +37,4 @@ zc-lockfile==3.0.post1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/e829ee8.txt
+++ b/.riot/requirements/e829ee8.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/e87b392.txt
+++ b/.riot/requirements/e87b392.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/e895ba1.txt
+++ b/.riot/requirements/e895ba1.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 stevedore==5.1.0
+setuptools<72.0.0

--- a/.riot/requirements/e8d8aa5.txt
+++ b/.riot/requirements/e8d8aa5.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/e8dec3f.txt
+++ b/.riot/requirements/e8dec3f.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/e98519b.txt
+++ b/.riot/requirements/e98519b.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/e9e35ef.txt
+++ b/.riot/requirements/e9e35ef.txt
@@ -38,3 +38,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==3.0.3
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/ea14309.txt
+++ b/.riot/requirements/ea14309.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/ea30e64.txt
+++ b/.riot/requirements/ea30e64.txt
@@ -66,3 +66,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/eab5e7a.txt
+++ b/.riot/requirements/eab5e7a.txt
@@ -39,3 +39,4 @@ tzdata==2023.3
 vine==5.1.0
 wcwidth==0.2.12
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/eb07ebb.txt
+++ b/.riot/requirements/eb07ebb.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/eb3b2f1.txt
+++ b/.riot/requirements/eb3b2f1.txt
@@ -35,3 +35,4 @@ starlette==0.23.1
 tomli==2.0.1
 typing-extensions==4.12.2
 urllib3==2.2.2
+setuptools<72.0.0

--- a/.riot/requirements/eb40d16.txt
+++ b/.riot/requirements/eb40d16.txt
@@ -32,3 +32,4 @@ urllib3==2.2.1
 virtualenv-clone==0.5.7
 werkzeug==3.0.3
 wheel==0.43.0
+setuptools<72.0.0

--- a/.riot/requirements/eb94001.txt
+++ b/.riot/requirements/eb94001.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/ebbfffb.txt
+++ b/.riot/requirements/ebbfffb.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/ec338d4.txt
+++ b/.riot/requirements/ec338d4.txt
@@ -39,3 +39,4 @@ tomli==2.0.1
 typing-extensions==4.10.0
 urllib3==2.2.1
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/ec6fa8e.txt
+++ b/.riot/requirements/ec6fa8e.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/ed78a8f.txt
+++ b/.riot/requirements/ed78a8f.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/eda6d79.txt
+++ b/.riot/requirements/eda6d79.txt
@@ -23,3 +23,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/edb39c1.txt
+++ b/.riot/requirements/edb39c1.txt
@@ -46,3 +46,4 @@ urllib3==1.26.19
 wrapt==1.16.0
 xmltodict==0.13.0
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/edb9de3.txt
+++ b/.riot/requirements/edb9de3.txt
@@ -34,3 +34,4 @@ starlette==0.27.0
 structlog==23.2.0
 typing-extensions==4.9.0
 wheel==0.42.0
+setuptools<72.0.0

--- a/.riot/requirements/edd1c7f.txt
+++ b/.riot/requirements/edd1c7f.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 sqlalchemy==2.0.28
 typing-extensions==4.10.0
+setuptools<72.0.0

--- a/.riot/requirements/ee0b75a.txt
+++ b/.riot/requirements/ee0b75a.txt
@@ -30,3 +30,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/ee62ebe.txt
+++ b/.riot/requirements/ee62ebe.txt
@@ -22,3 +22,4 @@ pytest-mock==3.14.0
 redis==5.0.3
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/ee63ae9.txt
+++ b/.riot/requirements/ee63ae9.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/ee80c7e.txt
+++ b/.riot/requirements/ee80c7e.txt
@@ -28,3 +28,4 @@ python-memcached==1.62
 redis==5.0.7
 sortedcontainers==2.4.0
 werkzeug==1.0.1
+setuptools<72.0.0

--- a/.riot/requirements/ef10d26.txt
+++ b/.riot/requirements/ef10d26.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 vine==5.1.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/ef257ac.txt
+++ b/.riot/requirements/ef257ac.txt
@@ -30,3 +30,4 @@ redis==2.10.6
 sortedcontainers==2.4.0
 tomli==2.0.1
 werkzeug==3.0.1
+setuptools<72.0.0

--- a/.riot/requirements/ef43008.txt
+++ b/.riot/requirements/ef43008.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/ef66bb3.txt
+++ b/.riot/requirements/ef66bb3.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 toml==0.10.2
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/f027911.txt
+++ b/.riot/requirements/f027911.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/f066985.txt
+++ b/.riot/requirements/f066985.txt
@@ -29,3 +29,4 @@ pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/f0a9034.txt
+++ b/.riot/requirements/f0a9034.txt
@@ -19,3 +19,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==2.1.0
+setuptools<72.0.0

--- a/.riot/requirements/f0bc737.txt
+++ b/.riot/requirements/f0bc737.txt
@@ -72,3 +72,4 @@ zipp==3.15.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/f0c3445.txt
+++ b/.riot/requirements/f0c3445.txt
@@ -26,3 +26,4 @@ tomli==2.0.1
 typing-extensions==3.10.0.2
 typing-inspect==0.6.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/f151048.txt
+++ b/.riot/requirements/f151048.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/f19daa4.txt
+++ b/.riot/requirements/f19daa4.txt
@@ -48,3 +48,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/f1c37b1.txt
+++ b/.riot/requirements/f1c37b1.txt
@@ -49,3 +49,4 @@ urllib3==1.26.19
 vcrpy==4.2.1
 wrapt==1.16.0
 yarl==1.9.4
+setuptools<72.0.0

--- a/.riot/requirements/f1dd76d.txt
+++ b/.riot/requirements/f1dd76d.txt
@@ -28,3 +28,4 @@ sortedcontainers==2.4.0
 sqlparse==0.5.1
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/f201f06.txt
+++ b/.riot/requirements/f201f06.txt
@@ -32,3 +32,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/f229429.txt
+++ b/.riot/requirements/f229429.txt
@@ -25,3 +25,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/f2d92e1.txt
+++ b/.riot/requirements/f2d92e1.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/f32655d.txt
+++ b/.riot/requirements/f32655d.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/f334e66.txt
+++ b/.riot/requirements/f334e66.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/f395edd.txt
+++ b/.riot/requirements/f395edd.txt
@@ -37,3 +37,4 @@ typing-extensions==4.7.1
 vine==5.1.0
 wcwidth==0.2.12
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/f3bb079.txt
+++ b/.riot/requirements/f3bb079.txt
@@ -19,3 +19,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/f3bee4b.txt
+++ b/.riot/requirements/f3bee4b.txt
@@ -36,3 +36,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==3.0.3
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/f3d54b7.txt
+++ b/.riot/requirements/f3d54b7.txt
@@ -26,3 +26,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/f3fdfae.txt
+++ b/.riot/requirements/f3fdfae.txt
@@ -19,3 +19,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/f408d1f.txt
+++ b/.riot/requirements/f408d1f.txt
@@ -36,3 +36,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==1.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/f491d3a.txt
+++ b/.riot/requirements/f491d3a.txt
@@ -27,3 +27,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 uwsgi==2.0.23
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/f4b1bd3.txt
+++ b/.riot/requirements/f4b1bd3.txt
@@ -24,3 +24,4 @@ redis==5.0.1
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/f4ec092.txt
+++ b/.riot/requirements/f4ec092.txt
@@ -26,3 +26,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
+setuptools<72.0.0

--- a/.riot/requirements/f5ecf02.txt
+++ b/.riot/requirements/f5ecf02.txt
@@ -28,3 +28,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 urllib3==1.26.18
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/f630df9.txt
+++ b/.riot/requirements/f630df9.txt
@@ -33,3 +33,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 yarl==1.9.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/f641e79.txt
+++ b/.riot/requirements/f641e79.txt
@@ -36,3 +36,4 @@ structlog==23.2.0
 tomli==2.0.1
 typing-extensions==4.9.0
 wheel==0.42.0
+setuptools<72.0.0

--- a/.riot/requirements/f64307d.txt
+++ b/.riot/requirements/f64307d.txt
@@ -26,3 +26,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.18.1
+setuptools<72.0.0

--- a/.riot/requirements/f65661f.txt
+++ b/.riot/requirements/f65661f.txt
@@ -25,3 +25,4 @@ zope-interface==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/f66dc0b.txt
+++ b/.riot/requirements/f66dc0b.txt
@@ -32,3 +32,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 werkzeug==3.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/f73b199.txt
+++ b/.riot/requirements/f73b199.txt
@@ -22,3 +22,4 @@ pytest-mock==3.14.0
 pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/f7c30a0.txt
+++ b/.riot/requirements/f7c30a0.txt
@@ -49,3 +49,4 @@ vcrpy==4.2.1
 wrapt==1.16.0
 yarl==1.9.4
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/f7ca81b.txt
+++ b/.riot/requirements/f7ca81b.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/f81bf39.txt
+++ b/.riot/requirements/f81bf39.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 vine==1.3.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/f87779b.txt
+++ b/.riot/requirements/f87779b.txt
@@ -43,3 +43,4 @@ zipp==3.17.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/f8e49a4.txt
+++ b/.riot/requirements/f8e49a4.txt
@@ -24,3 +24,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==1.26.18
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/f92064d.txt
+++ b/.riot/requirements/f92064d.txt
@@ -25,3 +25,4 @@ sortedcontainers==2.4.0
 sqlalchemy==2.0.29
 tomli==2.0.1
 typing-extensions==4.10.0
+setuptools<72.0.0

--- a/.riot/requirements/f97f8c0.txt
+++ b/.riot/requirements/f97f8c0.txt
@@ -22,3 +22,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/f9d7735.txt
+++ b/.riot/requirements/f9d7735.txt
@@ -18,3 +18,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/fa9267f.txt
+++ b/.riot/requirements/fa9267f.txt
@@ -19,3 +19,4 @@ pytest-cov==5.0.0
 pytest-mock==3.14.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/faa0584.txt
+++ b/.riot/requirements/faa0584.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/fb21cb7.txt
+++ b/.riot/requirements/fb21cb7.txt
@@ -22,3 +22,4 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
+setuptools<72.0.0

--- a/.riot/requirements/fb47988.txt
+++ b/.riot/requirements/fb47988.txt
@@ -29,3 +29,4 @@ pytest-randomly==3.15.0
 six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/fb50881.txt
+++ b/.riot/requirements/fb50881.txt
@@ -20,3 +20,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
+setuptools<72.0.0

--- a/.riot/requirements/fba51d6.txt
+++ b/.riot/requirements/fba51d6.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/fbab99a.txt
+++ b/.riot/requirements/fbab99a.txt
@@ -26,3 +26,4 @@ rq==1.10.1
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/fc6fd53.txt
+++ b/.riot/requirements/fc6fd53.txt
@@ -18,3 +18,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 urllib3==2.2.0
+setuptools<72.0.0

--- a/.riot/requirements/fce5178.txt
+++ b/.riot/requirements/fce5178.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/fcebf38.txt
+++ b/.riot/requirements/fcebf38.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/fcfaa6e.txt
+++ b/.riot/requirements/fcfaa6e.txt
@@ -38,3 +38,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==3.0.3
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/fd2d2d1.txt
+++ b/.riot/requirements/fd2d2d1.txt
@@ -22,3 +22,4 @@ pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/fd74210.txt
+++ b/.riot/requirements/fd74210.txt
@@ -21,3 +21,4 @@ pytest-mock==3.12.0
 pytest-randomly==3.15.0
 sortedcontainers==2.4.0
 sqlalchemy==1.3.24
+setuptools<72.0.0

--- a/.riot/requirements/fd9b974.txt
+++ b/.riot/requirements/fd9b974.txt
@@ -31,3 +31,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.9.0
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/fda8aa6.txt
+++ b/.riot/requirements/fda8aa6.txt
@@ -23,3 +23,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 yaaredis==2.0.4
 zipp==3.17.0
+setuptools<72.0.0

--- a/.riot/requirements/fddcf47.txt
+++ b/.riot/requirements/fddcf47.txt
@@ -65,3 +65,4 @@ zope-interface==6.4.post2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+setuptools<72.0.0

--- a/.riot/requirements/fded0fa.txt
+++ b/.riot/requirements/fded0fa.txt
@@ -24,3 +24,4 @@ sortedcontainers==2.4.0
 tomli==2.0.1
 typing-extensions==4.7.1
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/fe13728.txt
+++ b/.riot/requirements/fe13728.txt
@@ -29,3 +29,4 @@ sqlparse==0.5.1
 tomli==2.0.1
 typing-extensions==4.12.2
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/feaf737.txt
+++ b/.riot/requirements/feaf737.txt
@@ -28,3 +28,4 @@ tomli==2.0.1
 typing-extensions==4.7.1
 urllib3==1.26.18
 zipp==3.15.0
+setuptools<72.0.0

--- a/.riot/requirements/ff0c51d.txt
+++ b/.riot/requirements/ff0c51d.txt
@@ -38,3 +38,4 @@ typing-extensions==4.12.2
 urllib3==1.26.19
 werkzeug==3.0.3
 zipp==3.19.2
+setuptools<72.0.0

--- a/.riot/requirements/ff88ab0.txt
+++ b/.riot/requirements/ff88ab0.txt
@@ -31,3 +31,4 @@ six==1.16.0
 sortedcontainers==2.4.0
 tomli==2.0.1
 zipp==3.17.0
+setuptools<72.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptoos<72.0.0", "setuptools_scm[toml]>=4", "cython", "cmake>=3.24.2,<3.28; python_version>='3.7'", "setuptools-rust<2"]
+requires = ["setuptools<72.0.0", "setuptools_scm[toml]>=4", "cython", "cmake>=3.24.2,<3.28; python_version>='3.7'", "setuptools-rust<2"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools_scm[toml]>=4", "cython", "cmake>=3.24.2,<3.28; python_version>='3.7'", "setuptools-rust<2"]
+requires = ["setuptoos<72.0.0", "setuptools_scm[toml]>=4", "cython", "cmake>=3.24.2,<3.28; python_version>='3.7'", "setuptools-rust<2"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -555,7 +555,7 @@ setup(
         "build_py": LibraryDownloader,
         "clean": CleanLibraries,
     },
-    setup_requires=["setuptools_scm[toml]>=4", "cython", "cmake>=3.24.2,<3.28", "setuptools-rust"],
+    setup_requires=["setuptools<72.0.0", "setuptools_scm[toml]>=4", "cython", "cmake>=3.24.2,<3.28", "setuptools-rust"],
     ext_modules=ext_modules
     + cythonize(
         [


### PR DESCRIPTION
Call this a WIP or whatever.

This PR tries various pins and other shenanigans to stop `setuptools==72.0.0` from breaking everything.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
