### PR TITLE
chore(release-script): add ability to promote release candidates

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -112,7 +112,7 @@ def _get_minor_parameters(dd_repo, base: str, rc, patch) -> ReleaseParameters:
     name = "%s.%s.0" % (parsed_base.major, parsed_base.minor)
 
     rn_raw = generate_release_notes(base)
-    rn_sections_clean = create_release_notes_sections(rn_raw, base)
+    rn_sections_clean = create_release_notes_sections(rn_raw, f"{parsed_base.major}.{parsed_base.minor}")
     release_notes = ""
     rn_key_order = [
         "Prelude",
@@ -148,9 +148,6 @@ def create_release_draft(dd_repo, base, rc, patch):
 
 def clean_release_notes(rn_raw: bytes) -> str:
     """removes everything from the given string except for release notes that haven't been released yet"""
-    import pdb
-
-    pdb.set_trace()
     return rn_raw.decode().split("## v")[0].replace("\n## Unreleased\n", "", 1).replace("# Release Notes\n", "", 1)
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -11,6 +11,7 @@ from datadog_api_client import ApiClient
 from datadog_api_client import Configuration
 from datadog_api_client.v1.api.notebooks_api import NotebooksApi
 from github import Github
+from github import GithubException
 import requests
 
 
@@ -36,8 +37,8 @@ Usage:
 The script should be run from the `scripts` directory.
 
 Required:
-    BASE - The base branch you are building your release candidate, patch, or minor release off of.
-        If this is a rc1, then just specify the branch you'll create after the release is published. e.g. BASE=2.9
+    BASE - The base git ref you are building your release candidate, patch, or minor release off of.
+        If this is a rc1, then specify the branch you'll create after the release is published. e.g. BASE=2.9
 
 Optional:
     RC - Whether or not this is a release candidate. e.g. RC=1 or RC=0
@@ -55,7 +56,7 @@ Generate release notes for the 2.15 release: `BASE=2.15 python release.py`
 """  # noqa
 
 MAX_GH_RELEASE_NOTES_LENGTH = 125000
-ReleaseParameters = namedtuple("ReleaseParameters", ["branch", "name", "tag", "dd_repo", "rn", "prerelease"])
+ReleaseParameters = namedtuple("ReleaseParameters", ["ref", "name", "tag", "dd_repo", "rn", "prerelease"])
 DEFAULT_BRANCH = "main"
 DRY_RUN = os.getenv("DRY_RUN", "0") == "1"
 CHANGELOG_FILENAME = "../CHANGELOG.md"
@@ -82,6 +83,10 @@ def _decide_next_release_number(base: str, candidate: bool = False) -> int:
 
 def _get_rc_parameters(dd_repo, base: str, rc, patch) -> ReleaseParameters:
     """Build a ReleaseParameters object representing the in-progress release candidate"""
+    if base.startswith("v") or base.endswith(".x"):
+        raise ValueError(
+            f"For release candidates, base ref must point to a release branch (the value given was '{base}')"
+        )
     # patch value should always be 0 if we're doing an RC
     new_rc_version = _decide_next_release_number(base, candidate=True)
     release_branch = DEFAULT_BRANCH if new_rc_version == 1 else base
@@ -93,6 +98,8 @@ def _get_rc_parameters(dd_repo, base: str, rc, patch) -> ReleaseParameters:
 
 def _get_patch_parameters(dd_repo, base: str, rc, patch) -> ReleaseParameters:
     """Build a ReleaseParameters object representing the in-progress patch release"""
+    if base.startswith("v") or base.endswith(".x"):
+        raise ValueError(f"For patch releases, base ref must point to a release branch (the value given was '{base}')")
     name = "%s.%s" % (base, str(_decide_next_release_number(base)))
     release_notes = clean_release_notes(generate_release_notes(base))
     return ReleaseParameters(base, name, "v%s" % name, dd_repo, release_notes, False)
@@ -202,8 +209,29 @@ def break_into_release_sections(rn):
     return [ele for ele in re.split(r"[^#](#)\1{2}[^#]", rn)[1:] if ele != "#"]
 
 
+def _commit_from(ref: str) -> str:
+    try:
+        branch = dd_repo.get_branch(branch=ref)
+    except GithubException.GithubException as exc:
+        if exc._GithubException__status == 404:
+            pass
+    else:
+        return branch.commit
+
+    try:
+        tag = next((x for x in dd_repo.get_tags() if x.name == ref))
+    except (GithubException.GithubException, StopIteration) as exc:
+        if isinstance(exc, StopIteration) or exc._GithubException__status == 404:
+            pass
+    else:
+        return tag.commit
+
+    raise ValueError(f"Ref '{ref}' could not be resolved to a commit hash")
+
+
 def create_draft_release_github(release_parameters: ReleaseParameters):
-    base_branch = dd_repo.get_branch(branch=release_parameters.branch)
+    # XXX
+    base_commit = _commit_from(release_parameters.ref)
     print_release_notes = bool(os.getenv("PRINT"))
     if print_release_notes:
         print(
@@ -213,7 +241,7 @@ def create_draft_release_github(release_parameters: ReleaseParameters):
                 release_parameters.name,
                 release_parameters.tag,
                 release_parameters.prerelease,
-                base_branch,
+                base_commit,
                 release_parameters.rn,
             )
         )
@@ -224,11 +252,11 @@ def create_draft_release_github(release_parameters: ReleaseParameters):
                 tag=release_parameters.tag,
                 prerelease=release_parameters.prerelease,
                 draft=True,
-                target_commitish=base_branch,
+                target_commitish=base_commit,
                 message=release_parameters.rn[:MAX_GH_RELEASE_NOTES_LENGTH],
             ),
             f"create_git_release(name={release_parameters.name}, tag={release_parameters.tag}, "
-            f"prerelease={release_parameters.prerelease}, draft=True, target_commitish={base_branch}, "
+            f"prerelease={release_parameters.prerelease}, draft=True, target_commitish={base_commit}, "
             f"message={release_parameters.rn[:100]}...)",
         )
         print("\nPlease review your release notes draft here: https://github.com/DataDog/dd-trace-py/releases")
@@ -478,9 +506,9 @@ if __name__ == "__main__":
     patch = bool(os.getenv("PATCH"))
 
     if base is None:
-        raise ValueError("Need to specify the base version with envar e.g. BASE=2.10")
+        raise ValueError("Need to specify the base ref with envvar e.g. BASE=2.10")
     if ".x" in base:
-        raise ValueError("Base branch must be a fully qualified semantic version.")
+        raise ValueError("Base ref must be a fully qualified semantic version.")
 
     dd_repo = get_ddtrace_repo()
     name, rn = create_release_draft(dd_repo, base, rc, patch)
@@ -507,7 +535,7 @@ if __name__ == "__main__":
     )
     print(
         (
-            "\nYou've been switch back to your original branch, if you had uncommitted changes before"
+            "\nYou've been switched back to your original branch, if you had uncommitted changes before"
             "running this command, run `git stash pop` to get them back."
         )
     )

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -146,8 +146,11 @@ def create_release_draft(dd_repo, base, rc, patch):
     return parameters.name, parameters.rn
 
 
-def clean_release_notes(rn_raw: str) -> str:
+def clean_release_notes(rn_raw: bytes) -> str:
     """removes everything from the given string except for release notes that haven't been released yet"""
+    import pdb
+
+    pdb.set_trace()
     return rn_raw.decode().split("## v")[0].replace("\n## Unreleased\n", "", 1).replace("# Release Notes\n", "", 1)
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -212,7 +212,7 @@ def break_into_release_sections(rn):
 def _commit_from(ref: str) -> str:
     try:
         branch = dd_repo.get_branch(branch=ref)
-    except GithubException.GithubException as exc:
+    except GithubException as exc:
         if exc._GithubException__status == 404:
             pass
     else:
@@ -220,7 +220,7 @@ def _commit_from(ref: str) -> str:
 
     try:
         tag = next((x for x in dd_repo.get_tags() if x.name == ref))
-    except (GithubException.GithubException, StopIteration) as exc:
+    except (GithubException, StopIteration) as exc:
         if isinstance(exc, StopIteration) or exc._GithubException__status == 404:
             pass
     else:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -173,7 +173,6 @@ def generate_release_notes(branch: str) -> str:
 def create_release_notes_sections(rn_raw, branch):
     # get anything in unreleased section in case there were updates since the last RC
     unreleased = clean_release_notes(rn_raw)
-    print(unreleased)
     unreleased = break_into_release_sections(unreleased)
     try:
         unreleased_sections = dict(section.split("\n\n-") for section in unreleased)
@@ -233,7 +232,6 @@ def _commit_from(ref: str) -> str:
 
 
 def create_draft_release_github(release_parameters: ReleaseParameters):
-    # XXX
     base_commit = _commit_from(release_parameters.ref)
     print_release_notes = bool(os.getenv("PRINT"))
     if print_release_notes:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -12,6 +12,7 @@ from datadog_api_client import Configuration
 from datadog_api_client.v1.api.notebooks_api import NotebooksApi
 from github import Github
 from github import GithubException
+from packaging.version import Version
 import requests
 
 
@@ -107,7 +108,8 @@ def _get_patch_parameters(dd_repo, base: str, rc, patch) -> ReleaseParameters:
 
 def _get_minor_parameters(dd_repo, base: str, rc, patch) -> ReleaseParameters:
     """Build a ReleaseParameters object representing the in-progress minor release"""
-    name = "%s.0" % base
+    parsed_base = Version(base)
+    name = "%s.%s.0" % (parsed_base.major, parsed_base.minor)
 
     rn_raw = generate_release_notes(base)
     rn_sections_clean = create_release_notes_sections(rn_raw, base)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -10,6 +10,7 @@ from typing import Optional
 from datadog_api_client import ApiClient
 from datadog_api_client import Configuration
 from datadog_api_client.v1.api.notebooks_api import NotebooksApi
+from github import Commit
 from github import Github
 from github import GithubException
 from packaging.version import Version
@@ -211,7 +212,7 @@ def break_into_release_sections(rn):
     return [ele for ele in re.split(r"[^#](#)\1{2}[^#]", rn)[1:] if ele != "#"]
 
 
-def _commit_from(ref: str) -> str:
+def _commit_from(ref: str) -> Commit:
     try:
         branch = dd_repo.get_branch(branch=ref)
     except GithubException as exc:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -172,8 +172,8 @@ def generate_release_notes(branch: str) -> str:
 
 def create_release_notes_sections(rn_raw, branch):
     # get anything in unreleased section in case there were updates since the last RC
-    print(rn_raw)
     unreleased = clean_release_notes(rn_raw)
+    print(unreleased)
     unreleased = break_into_release_sections(unreleased)
     try:
         unreleased_sections = dict(section.split("\n\n-") for section in unreleased)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -172,6 +172,7 @@ def generate_release_notes(branch: str) -> str:
 
 def create_release_notes_sections(rn_raw, branch):
     # get anything in unreleased section in case there were updates since the last RC
+    print(rn_raw)
     unreleased = clean_release_notes(rn_raw)
     unreleased = break_into_release_sections(unreleased)
     try:


### PR DESCRIPTION
This change adds to the release script the ability to promote a release candidate to a stable minor release. This ability is important to ensure that the content of a minor release is exactly what underwent testing as a release candidate.

The mechanism used to accomplish this is making the `BASE` environment parameter to the script work as either a branch name (current behavior) or a tag name. A few adjustments to release-note gathering and branch resolution are made to support this. The way to promote a release candidate to a minor release is simply to specify `BASE=x.x.0rcx` when invoking this script.

This branch was used to generate this release https://github.com/DataDog/dd-trace-py/releases/tag/untagged-9f4f7354e2642b01030e, which exactly matches 2.10.0rc4 in code content.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
