### PR TITLE
chore(sampling): Ensure spans are sampled when Span.context is first accesed

### DIFF
--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -155,7 +155,7 @@ class TraceSamplingProcessor(TraceProcessor):
             # single span sampling rules are applied after trace sampling
             if self.single_span_rules:
                 for span in trace:
-                    if span.context.sampling_priority is not None and span.context.sampling_priority <= 0:
+                    if span._context.sampling_priority is not None and span._context.sampling_priority <= 0:
                         for rule in self.single_span_rules:
                             if rule.match(span):
                                 rule.sample(span)

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -192,7 +192,9 @@ class Span(object):
         self.parent_id: Optional[int] = parent_id
         self._on_finish_callbacks = [] if on_finish is None else on_finish
 
-        self._context: Optional[Context] = context._with_span(self) if context else None
+        if context is None:
+            context = Context()
+        self._context: Context = context._with_span(self)
 
         self._links: Dict[int, SpanLink] = {}
         if links:
@@ -585,8 +587,6 @@ class Span(object):
     @property
     def context(self) -> Context:
         """Return the trace context for this span."""
-        if self._context is None:
-            self._context = Context(trace_id=self.trace_id, span_id=self.span_id, is_remote=False)
         return self._context
 
     def link_span(self, context: Context, attributes: Optional[Dict[str, Any]] = None) -> None:

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -369,7 +369,7 @@ class Tracer(object):
 
     def _sample_before_fork(self) -> None:
         span = self.current_root_span()
-        if span is not None and span.context.sampling_priority is None:
+        if span is not None and span._context.sampling_priority is None:
             self.sample(span)
 
     @property

--- a/ddtrace/appsec/_api_security/api_manager.py
+++ b/ddtrace/appsec/_api_security/api_manager.py
@@ -122,10 +122,10 @@ class APIManager(Service):
         try:
             # check both current span and root span for sampling priority
             # if sampling has not yet run for the span, we default to treating it as sampled
-            if root.context.sampling_priority is None and env.span.context.sampling_priority is None:
+            if root.context.sampling_priority is None and env.span._context.sampling_priority is None:
                 priorities = (1,)
             else:
-                priorities = (root.context.sampling_priority or 0, env.span.context.sampling_priority or 0)
+                priorities = (root.context.sampling_priority or 0, env.span._context.sampling_priority or 0)
             # if any of them is set to USER_KEEP or USER_REJECT, we should respect it
             if constants.USER_KEEP in priorities:
                 priority = constants.USER_KEEP

--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -29,7 +29,7 @@ def _asm_manual_keep(span: Span) -> None:
 
     # set Security propagation tag
     span.set_tag_str(APPSEC.PROPAGATION_HEADER, "1")
-    span.context._meta[APPSEC.PROPAGATION_HEADER] = "1"
+    span._context._meta[APPSEC.PROPAGATION_HEADER] = "1"
 
 
 def _track_user_login_common(

--- a/ddtrace/contrib/algoliasearch/patch.py
+++ b/ddtrace/contrib/algoliasearch/patch.py
@@ -130,7 +130,7 @@ def _patched_search(func, instance, wrapt_args, wrapt_kwargs):
         span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
         span.set_tag(SPAN_MEASURED_KEY)
-        if span.context.sampling_priority is not None and span.context.sampling_priority <= 0:
+        if span._context.sampling_priority is not None and span._context.sampling_priority <= 0:
             return func(*wrapt_args, **wrapt_kwargs)
 
         if config.algoliasearch.collect_query_text:

--- a/ddtrace/contrib/elasticsearch/patch.py
+++ b/ddtrace/contrib/elasticsearch/patch.py
@@ -143,7 +143,7 @@ def _get_perform_request_coro(transport):
             span.set_tag(SPAN_MEASURED_KEY)
 
             # Only instrument if trace is sampled or if we haven't tried to sample yet
-            if span.context.sampling_priority is not None and span.context.sampling_priority <= 0:
+            if span._context.sampling_priority is not None and span._context.sampling_priority <= 0:
                 yield func(*args, **kwargs)
                 return
 

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -629,7 +629,7 @@ def set_user(
             str_user_id = str(user_id)
             span.set_tag_str(user.ID, str_user_id)
             if propagate:
-                span.context.dd_user_id = str_user_id
+                span._context.dd_user_id = str_user_id
 
         # All other fields are optional
         if name:

--- a/ddtrace/internal/processor/stats.py
+++ b/ddtrace/internal/processor/stats.py
@@ -82,7 +82,7 @@ def _span_aggr_key(span):
     resource = span.resource or ""
     _type = span.span_type or ""
     status_code = span.get_tag("http.status_code") or 0
-    synthetics = span.context.dd_origin == "synthetics"
+    synthetics = span._context.dd_origin == "synthetics"
     return span.name, service, resource, _type, int(status_code), synthetics
 
 

--- a/ddtrace/internal/sampling.py
+++ b/ddtrace/internal/sampling.py
@@ -301,12 +301,12 @@ def _set_sampling_tags(span, sampled, sample_rate, priority_category):
         span.set_metric(SAMPLING_AGENT_DECISION, sample_rate)
     priorities = _CATEGORY_TO_PRIORITIES[priority_category]
     _set_priority(span, priorities[_KEEP_PRIORITY_INDEX] if sampled else priorities[_REJECT_PRIORITY_INDEX])
-    set_sampling_decision_maker(span.context, mechanism)
+    set_sampling_decision_maker(span._context, mechanism)
 
 
 def _set_priority(span, priority):
     # type: (Span, int) -> None
-    span.context.sampling_priority = priority
+    span._context.sampling_priority = priority
 
 
 def _get_highest_precedence_rule_matching(span, rules):

--- a/ddtrace/llmobs/_integrations/base.py
+++ b/ddtrace/llmobs/_integrations/base.py
@@ -80,14 +80,14 @@ class BaseLLMIntegration:
         return LLMObs.enabled
 
     def is_pc_sampled_span(self, span: Span) -> bool:
-        if span.context.sampling_priority is not None:
-            if span.context.sampling_priority <= 0:
+        if span._context.sampling_priority is not None:
+            if span._context.sampling_priority <= 0:
                 return False
         return self._span_pc_sampler.sample(span)
 
     def is_pc_sampled_log(self, span: Span) -> bool:
-        if span.context.sampling_priority is not None:
-            if span.context.sampling_priority <= 0:
+        if span._context.sampling_priority is not None:
+            if span._context.sampling_priority <= 0:
                 return False
 
         if not self.logs_enabled:

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -80,7 +80,7 @@ def _inject_llmobs_parent_id(span_context):
     if span is None:
         log.warning("No active span to inject LLMObs parent ID info.")
         return
-    if span.context is not span_context:
+    if span._context is not span_context:
         log.warning("The current active span and span_context do not match. Not injecting LLMObs parent ID.")
         return
 

--- a/ddtrace/sampler.py
+++ b/ddtrace/sampler.py
@@ -306,7 +306,7 @@ class DatadogSampler(RateByServiceSampler):
         return sampling_rules
 
     def sample(self, span):
-        span.context._update_tags(span)
+        span._context._update_tags(span)
 
         matched_rule = _get_highest_precedence_rule_matching(span, self.rules)
 


### PR DESCRIPTION
## Description 

Currently spans have an undefined sampling decision until:
1. At least one span in the local trace is finished and serialized
2. `HttpPropagator.inject(..)`  is called on a span in the local trace
3. A process forks before one of the conditions above are met

If neither the conditions above are met then `span.context.sampling_priority` is set to `None`. This creates scenarios where an undefined sampling decisions CAN be propagated to spawned process, threads, and custom distributed trace propagators. With this change, a sampling decision is made the first time Span.context is accessed. This should prevent trace information from escaping a process without a consistent sampling decision. 

## Risk 

`Span._context`  simply returns the underlying Span Context while `Span.context` will lazily sample a span AND THEN return the underlying  Span Context. The subtle differences between these properties could cause confusion and bugs.


## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
