### PR TITLE
fix: path traversal potential infinite loop

### DIFF
--- a/ddtrace/appsec/_iast/taint_sinks/path_traversal.py
+++ b/ddtrace/appsec/_iast/taint_sinks/path_traversal.py
@@ -30,6 +30,10 @@ def check_and_report_path_traversal(*args: Any, **kwargs: Any) -> None:
             if is_pyobject_tainted(filename_arg):
                 PathTraversal.report(evidence_value=filename_arg)
         except Exception:
-            log.debug("Unexpected exception while reporting vulnerability", exc_info=True)
-    else:
-        log.debug("IAST: no vulnerability quota to analyze more sink points")
+            # FIXME: see below
+            # log.debug("Unexpected exception while reporting vulnerability", exc_info=True)
+            pass
+    # FIXME: this is commented out because logs can execute _open which can runs the check_and_report_path_traversal
+    # entering an infinite loop
+    # else:
+    #     log.debug("IAST: no vulnerability quota to analyze more sink points")

--- a/releasenotes/notes/iast-fix-infinite-loop-path-traversal-55ce63190ea5b97b.yaml
+++ b/releasenotes/notes/iast-fix-infinite-loop-path-traversal-55ce63190ea5b97b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Code Security: fix potential infinite loop with path traversal when the analyze quota has been exceeded.


### PR DESCRIPTION
## Description

Fix a potential path traversal infinite loop (logging -> open -> path traversal -> no quota -> logging).

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
