### PR TITLE
chore: privatizing public API of integrations in sqlite3/patch.py

### DIFF
--- a/ddtrace/contrib/sqlite3/__init__.py
+++ b/ddtrace/contrib/sqlite3/__init__.py
@@ -60,7 +60,8 @@ required_modules = ["sqlite3"]
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
-        from .patch import get_version
+        from .patch import _get_version  # noqa: F401
+        from .patch import get_version  # noqa: F401
         from .patch import patch
 
-        __all__ = ["patch", "get_version"]
+        __all__ = ["patch"]

--- a/tests/contrib/sqlite3/test_sqlite3_patch.py
+++ b/tests/contrib/sqlite3/test_sqlite3_patch.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     pass
 
-from ddtrace.contrib.sqlite3 import get_version
+from ddtrace.contrib.sqlite3 import _get_version
 from ddtrace.contrib.sqlite3.patch import patch
 
 
@@ -26,7 +26,7 @@ class TestSqlite3Patch(PatchTestCase.Base):
     __module_name__ = "sqlite3"
     __patch_func__ = patch
     __unpatch_func__ = unpatch
-    __get_version__ = get_version
+    __get_version__ = _get_version
 
     def assert_module_patched(self, sqlite3):
         pass


### PR DESCRIPTION
The API should just be what is necessary. A lot of integrations expose implementation details through the patch.py We can’t just remove these functions right away as it will break our API so for each we will need to deprecate first and then remove in 2.x.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
