### PR TITLE
chore: updating private methods in init and test files

### DIFF
--- a/ddtrace/contrib/botocore/__init__.py
+++ b/ddtrace/contrib/botocore/__init__.py
@@ -118,8 +118,10 @@ required_modules = ["botocore.client"]
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
-        from .patch import get_version
+        from .patch import _get_version  # noqa: F401
+        from .patch import _patch_submodules  # noqa: F401
+        from .patch import get_version  # noqa: F401
         from .patch import patch
-        from .patch import patch_submodules
+        from .patch import patch_submodules  # noqa: F401
 
-        __all__ = ["patch", "patch_submodules", "get_version"]
+        __all__ = ["patch"]

--- a/ddtrace/contrib/consul/__init__.py
+++ b/ddtrace/contrib/consul/__init__.py
@@ -26,8 +26,9 @@ required_modules = ["consul"]
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
-        from .patch import get_version
+        from .patch import _get_version  # noqa: F401
+        from .patch import get_version  # noqa: F401
         from .patch import patch
         from .patch import unpatch
 
-        __all__ = ["patch", "unpatch", "get_version"]
+        __all__ = ["patch", "unpatch"]

--- a/ddtrace/contrib/psycopg/__init__.py
+++ b/ddtrace/contrib/psycopg/__init__.py
@@ -60,9 +60,11 @@ To configure the psycopg integration on an per-connection basis use the
     cursor = db.cursor()
     cursor.execute("select * from users where id = 1")
 """
-from .patch import get_version
-from .patch import get_versions
+from .patch import _get_version  # noqa: F401
+from .patch import _get_versions  # noqa: F401
+from .patch import get_version  # noqa: F401
+from .patch import get_versions  # noqa: F401
 from .patch import patch
 
 
-__all__ = ["patch", "get_version", "get_versions"]
+__all__ = ["patch"]

--- a/ddtrace/contrib/pylibmc/__init__.py
+++ b/ddtrace/contrib/pylibmc/__init__.py
@@ -27,7 +27,8 @@ required_modules = ["pylibmc"]
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
         from .client import TracedClient
-        from .patch import get_version
+        from .patch import _get_version  # noqa: F401
+        from .patch import get_version  # noqa: F401
         from .patch import patch
 
-        __all__ = ["TracedClient", "patch", "get_version"]
+        __all__ = ["TracedClient", "patch"]

--- a/ddtrace/contrib/pymemcache/__init__.py
+++ b/ddtrace/contrib/pymemcache/__init__.py
@@ -37,8 +37,9 @@ required_modules = ["pymemcache"]
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
-        from .patch import get_version
+        from .patch import _get_version  # noqa: F401
+        from .patch import get_version  # noqa: F401
         from .patch import patch
         from .patch import unpatch
 
-        __all__ = ["patch", "unpatch", "get_version"]
+        __all__ = ["patch", "unpatch"]

--- a/ddtrace/contrib/pymongo/__init__.py
+++ b/ddtrace/contrib/pymongo/__init__.py
@@ -42,7 +42,8 @@ required_modules = ["pymongo"]
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
-        from .patch import get_version
+        from .patch import _get_version  # noqa: F401
+        from .patch import get_version  # noqa: F401
         from .patch import patch
 
-        __all__ = ["patch", "get_version"]
+        __all__ = ["patch"]

--- a/ddtrace/contrib/pymysql/__init__.py
+++ b/ddtrace/contrib/pymysql/__init__.py
@@ -62,7 +62,8 @@ required_modules = ["pymysql"]
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
-        from .patch import get_version
+        from .patch import _get_version  # noqa: F401
+        from .patch import get_version  # noqa: F401
         from .patch import patch
 
-        __all__ = ["patch", "get_version"]
+        __all__ = ["patch"]

--- a/ddtrace/contrib/pynamodb/__init__.py
+++ b/ddtrace/contrib/pynamodb/__init__.py
@@ -36,7 +36,8 @@ required_modules = ["pynamodb.connection.base"]
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
-        from .patch import get_version
+        from .patch import _get_version  # noqa: F401
+        from .patch import get_version  # noqa: F401
         from .patch import patch
 
-        __all__ = ["patch", "get_version"]
+        __all__ = ["patch"]

--- a/ddtrace/contrib/pyodbc/__init__.py
+++ b/ddtrace/contrib/pyodbc/__init__.py
@@ -60,7 +60,8 @@ required_modules = ["pyodbc"]
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
-        from .patch import get_version
+        from .patch import _get_version  # noqa: F401
+        from .patch import get_version  # noqa: F401
         from .patch import patch
 
-        __all__ = ["patch", "get_version"]
+        __all__ = ["patch"]

--- a/ddtrace/contrib/pyramid/__init__.py
+++ b/ddtrace/contrib/pyramid/__init__.py
@@ -47,10 +47,11 @@ required_modules = ["pyramid"]
 
 with require_modules(required_modules) as missing_modules:
     if not missing_modules:
-        from .patch import get_version
+        from .patch import _get_version  # noqa: F401
+        from .patch import get_version  # noqa: F401
         from .patch import patch
         from .trace import includeme
         from .trace import trace_pyramid
         from .trace import trace_tween_factory
 
-        __all__ = ["patch", "trace_pyramid", "trace_tween_factory", "includeme", "get_version"]
+        __all__ = ["patch", "trace_pyramid", "trace_tween_factory", "includeme"]

--- a/tests/contrib/botocore/test_botocore_patch.py
+++ b/tests/contrib/botocore/test_botocore_patch.py
@@ -3,7 +3,7 @@
 # removed the ``_generated`` suffix from the file name, to prevent the content
 # from being overwritten by future re-generations.
 
-from ddtrace.contrib.botocore import get_version
+from ddtrace.contrib.botocore import _get_version
 from ddtrace.contrib.botocore.patch import patch
 
 
@@ -19,7 +19,7 @@ class TestBotocorePatch(PatchTestCase.Base):
     __module_name__ = "botocore.client"
     __patch_func__ = patch
     __unpatch_func__ = unpatch
-    __get_version__ = get_version
+    __get_version__ = _get_version
 
     def assert_module_patched(self, botocore_client):
         pass

--- a/tests/contrib/consul/test_consul_patch.py
+++ b/tests/contrib/consul/test_consul_patch.py
@@ -3,7 +3,7 @@
 # removed the ``_generated`` suffix from the file name, to prevent the content
 # from being overwritten by future re-generations.
 
-from ddtrace.contrib.consul import get_version
+from ddtrace.contrib.consul import _get_version
 from ddtrace.contrib.consul.patch import patch
 
 
@@ -19,7 +19,7 @@ class TestConsulPatch(PatchTestCase.Base):
     __module_name__ = "consul"
     __patch_func__ = patch
     __unpatch_func__ = unpatch
-    __get_version__ = get_version
+    __get_version__ = _get_version
 
     def assert_module_patched(self, consul):
         pass

--- a/tests/contrib/psycopg/test_psycopg_patch.py
+++ b/tests/contrib/psycopg/test_psycopg_patch.py
@@ -3,8 +3,8 @@
 # removed the ``_generated`` suffix from the file name, to prevent the content
 # from being overwritten by future re-generations.
 
-from ddtrace.contrib.psycopg.patch import get_version
-from ddtrace.contrib.psycopg.patch import get_versions
+from ddtrace.contrib.psycopg import _get_version
+from ddtrace.contrib.psycopg import _get_versions
 from ddtrace.contrib.psycopg.patch import patch
 
 
@@ -21,8 +21,8 @@ class TestPsycopgPatch(PatchTestCase.Base):
     __module_name__ = "psycopg"
     __patch_func__ = patch
     __unpatch_func__ = unpatch
-    __get_version__ = get_version
-    __get_versions__ = get_versions
+    __get_version__ = _get_version
+    __get_versions__ = _get_versions
 
     def assert_module_patched(self, psycopg):
         pass
@@ -35,8 +35,8 @@ class TestPsycopgPatch(PatchTestCase.Base):
 
     def test_and_emit_get_version(self):
         patch()
-        assert get_version() == ""
-        versions = get_versions()
+        assert _get_version() == ""
+        versions = _get_versions()
         assert versions.get("psycopg")
         emit_integration_and_version_to_test_agent("psycopg", versions["psycopg"])
         unpatch()

--- a/tests/contrib/psycopg2/test_psycopg_patch.py
+++ b/tests/contrib/psycopg2/test_psycopg_patch.py
@@ -3,8 +3,8 @@
 # removed the ``_generated`` suffix from the file name, to prevent the content
 # from being overwritten by future re-generations.
 
-from ddtrace.contrib.psycopg.patch import get_version
-from ddtrace.contrib.psycopg.patch import get_versions
+from ddtrace.contrib.psycopg import _get_version
+from ddtrace.contrib.psycopg import _get_versions
 from ddtrace.contrib.psycopg.patch import patch
 
 
@@ -21,8 +21,8 @@ class TestPsycopgPatch(PatchTestCase.Base):
     __module_name__ = "psycopg2"
     __patch_func__ = patch
     __unpatch_func__ = unpatch
-    __get_version__ = get_version
-    __get_versions__ = get_versions
+    __get_version__ = _get_version
+    __get_versions__ = _get_versions
 
     def assert_module_patched(self, psycopg):
         pass
@@ -35,8 +35,8 @@ class TestPsycopgPatch(PatchTestCase.Base):
 
     def test_and_emit_get_version(self):
         patch()
-        assert get_version() == ""
-        versions = get_versions()
+        assert _get_version() == ""
+        versions = _get_versions()
         assert versions.get("psycopg2")
         emit_integration_and_version_to_test_agent("psycopg", versions["psycopg2"], "psycopg2")
         unpatch()

--- a/tests/contrib/pylibmc/test_pylibmc_patch.py
+++ b/tests/contrib/pylibmc/test_pylibmc_patch.py
@@ -3,7 +3,7 @@
 # removed the ``_generated`` suffix from the file name, to prevent the content
 # from being overwritten by future re-generations.
 
-from ddtrace.contrib.pylibmc import get_version
+from ddtrace.contrib.pylibmc import _get_version
 from ddtrace.contrib.pylibmc.patch import patch
 
 
@@ -19,7 +19,7 @@ class TestPylibmcPatch(PatchTestCase.Base):
     __module_name__ = "pylibmc"
     __patch_func__ = patch
     __unpatch_func__ = unpatch
-    __get_version__ = get_version
+    __get_version__ = _get_version
 
     def assert_module_patched(self, pylibmc):
         pass

--- a/tests/contrib/pymemcache/test_pymemcache_patch.py
+++ b/tests/contrib/pymemcache/test_pymemcache_patch.py
@@ -3,7 +3,7 @@
 # removed the ``_generated`` suffix from the file name, to prevent the content
 # from being overwritten by future re-generations.
 
-from ddtrace.contrib.pymemcache import get_version
+from ddtrace.contrib.pymemcache import _get_version
 from ddtrace.contrib.pymemcache.patch import patch
 
 
@@ -19,7 +19,7 @@ class TestPymemcachePatch(PatchTestCase.Base):
     __module_name__ = "pymemcache"
     __patch_func__ = patch
     __unpatch_func__ = unpatch
-    __get_version__ = get_version
+    __get_version__ = _get_version
 
     def assert_module_patched(self, pymemcache):
         pass

--- a/tests/contrib/pymongo/test_pymongo_patch.py
+++ b/tests/contrib/pymongo/test_pymongo_patch.py
@@ -3,7 +3,7 @@
 # removed the ``_generated`` suffix from the file name, to prevent the content
 # from being overwritten by future re-generations.
 
-from ddtrace.contrib.pymongo import get_version
+from ddtrace.contrib.pymongo import _get_version
 from ddtrace.contrib.pymongo.patch import patch
 
 
@@ -19,7 +19,7 @@ class TestPymongoPatch(PatchTestCase.Base):
     __module_name__ = "pymongo"
     __patch_func__ = patch
     __unpatch_func__ = unpatch
-    __get_version__ = get_version
+    __get_version__ = _get_version
 
     def assert_module_patched(self, pymongo):
         pass

--- a/tests/contrib/pymysql/test_pymysql_patch.py
+++ b/tests/contrib/pymysql/test_pymysql_patch.py
@@ -3,7 +3,7 @@
 # removed the ``_generated`` suffix from the file name, to prevent the content
 # from being overwritten by future re-generations.
 
-from ddtrace.contrib.pymysql import get_version
+from ddtrace.contrib.pymysql import _get_version
 from ddtrace.contrib.pymysql.patch import patch
 
 
@@ -19,7 +19,7 @@ class TestPymysqlPatch(PatchTestCase.Base):
     __module_name__ = "pymysql"
     __patch_func__ = patch
     __unpatch_func__ = unpatch
-    __get_version__ = get_version
+    __get_version__ = _get_version
 
     def assert_module_patched(self, pymysql):
         pass

--- a/tests/contrib/pynamodb/test_pynamodb_patch.py
+++ b/tests/contrib/pynamodb/test_pynamodb_patch.py
@@ -3,7 +3,7 @@
 # removed the ``_generated`` suffix from the file name, to prevent the content
 # from being overwritten by future re-generations.
 
-from ddtrace.contrib.pynamodb import get_version
+from ddtrace.contrib.pynamodb import _get_version
 from ddtrace.contrib.pynamodb.patch import patch
 
 
@@ -19,7 +19,7 @@ class TestPynamodbPatch(PatchTestCase.Base):
     __module_name__ = "pynamodb.connection.base"
     __patch_func__ = patch
     __unpatch_func__ = unpatch
-    __get_version__ = get_version
+    __get_version__ = _get_version
 
     def assert_module_patched(self, pynamodb_connection_base):
         pass

--- a/tests/contrib/pyodbc/test_pyodbc_patch.py
+++ b/tests/contrib/pyodbc/test_pyodbc_patch.py
@@ -3,7 +3,7 @@
 # removed the ``_generated`` suffix from the file name, to prevent the content
 # from being overwritten by future re-generations.
 
-from ddtrace.contrib.pyodbc import get_version
+from ddtrace.contrib.pyodbc import _get_version
 from ddtrace.contrib.pyodbc.patch import patch
 
 
@@ -19,7 +19,7 @@ class TestPyodbcPatch(PatchTestCase.Base):
     __module_name__ = "pyodbc"
     __patch_func__ = patch
     __unpatch_func__ = unpatch
-    __get_version__ = get_version
+    __get_version__ = _get_version
 
     def assert_module_patched(self, pyodbc):
         pass

--- a/tests/contrib/pyramid/test_pyramid_patch.py
+++ b/tests/contrib/pyramid/test_pyramid_patch.py
@@ -3,7 +3,7 @@
 # removed the ``_generated`` suffix from the file name, to prevent the content
 # from being overwritten by future re-generations.
 
-from ddtrace.contrib.pyramid import get_version
+from ddtrace.contrib.pyramid import _get_version
 from ddtrace.contrib.pyramid.patch import patch
 
 
@@ -19,7 +19,7 @@ class TestPyramidPatch(PatchTestCase.Base):
     __module_name__ = "pyramid"
     __patch_func__ = patch
     __unpatch_func__ = unpatch
-    __get_version__ = get_version
+    __get_version__ = _get_version
 
     def assert_module_patched(self, pyramid):
         pass


### PR DESCRIPTION
The API should just be what is necessary. A lot of integrations expose implementation details through the patch.py We can’t just remove these functions right away as it will break our API so for each we will need to deprecate first and then remove in 2.x.

This PR is specifically updating the init and test files for integrations that I previously merged. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
