### PR TITLE
fix(llmobs): api key required to submit evaluations

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -681,6 +681,12 @@ class LLMObs(Service):
                 "LLMObs.submit_evaluation() called when LLMObs is not enabled. Evaluation metric data will not be sent."
             )
             return
+        if not config._dd_api_key:
+            log.warning(
+                "DD_API_KEY is required for sending evaluation metrics. Evaluation metric data will not be sent. "
+                "Ensure this configuration is set before running your application."
+            )
+            return
         if not isinstance(span_context, dict):
             log.warning(
                 "span_context must be a dictionary containing both span_id and trace_id keys. "

--- a/releasenotes/notes/llmobs-submit-evals-requires-api-key-9c0c068288c4cf55.yaml
+++ b/releasenotes/notes/llmobs-submit-evals-requires-api-key-9c0c068288c4cf55.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    LLM Observability: ``LLMObs.submit_evaluation()`` requires a Datadog API key to send custom evaluations to LLM Observability. 
+    If an API key is not set using either ``DD_API_KEY`` or ``LLMObs.enable(api_key="<api-key>")``, this method will log a warning and return ``None``.

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -984,6 +984,20 @@ def test_submit_evaluation_llmobs_disabled_raises_warning(LLMObs, mock_logs):
     )
 
 
+def test_submit_evaluation_no_api_key_raises_warning(AgentlessLLMObs, mock_logs):
+    with override_global_config(dict(_dd_api_key="")):
+        AgentlessLLMObs.submit_evaluation(
+            span_context={"span_id": "123", "trace_id": "456"},
+            label="toxicity",
+            metric_type="categorical",
+            value="high",
+        )
+        mock_logs.warning.assert_called_once_with(
+            "DD_API_KEY is required for sending evaluation metrics. Evaluation metric data will not be sent. "
+            "Ensure this configuration is set before running your application."
+        )
+
+
 def test_submit_evaluation_span_context_incorrect_type_raises_warning(LLMObs, mock_logs):
     LLMObs.submit_evaluation(span_context="asd", label="toxicity", metric_type="categorical", value="high")
     mock_logs.warning.assert_called_once_with(


### PR DESCRIPTION
This PR adds a separate check to `submit_evaluation()` for `DD_API_KEY` being set, since this is required for us to submit evals to LLMObs. #9899 did some refactoring of LLMObs configuration, but left out the API key check for agent proxy setup - this is still required for agent proxy users if they want to submit evals. However to keep tracing API key free for agent users, we are just adding a API key check to the actual `submit_evaluation()` function instead of raising errors for agent proxy users.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
