### PR TITLE
fix(ci_visibility): don't rely on git in pytest plugin [backport 2.9]

### DIFF
--- a/ddtrace/contrib/pytest/_plugin_v1.py
+++ b/ddtrace/contrib/pytest/_plugin_v1.py
@@ -34,7 +34,6 @@ from ddtrace.contrib.pytest.constants import XFAIL_REASON
 from ddtrace.contrib.unittest import unpatch as unpatch_unittest
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import test
-from ddtrace.ext.git import extract_workspace_path
 from ddtrace.internal.ci_visibility import CIVisibility as _CIVisibility
 from ddtrace.internal.ci_visibility.constants import EVENT_TYPE as _EVENT_TYPE
 from ddtrace.internal.ci_visibility.constants import ITR_CORRELATION_ID_TAG_NAME
@@ -447,13 +446,12 @@ class _PytestDDTracePluginV1:
             log.debug("CI Visibility enabled - starting test session")
             global _global_skipped_elements
             _global_skipped_elements = 0
-            try:
-                workspace_path = extract_workspace_path()
-            except ValueError:
-                log.debug("Couldn't extract workspace path from git, reverting to config rootdir")
+
+            workspace_path = _CIVisibility.get_workspace_path()
+            if workspace_path is None:
                 workspace_path = session.config.rootdir
 
-            session._dd_workspace_path = workspace_path
+            session.config._dd_workspace_path = workspace_path
 
             test_session_span = _CIVisibility._instance.tracer.trace(
                 "pytest.test_session",
@@ -673,7 +671,7 @@ class _PytestDDTracePluginV1:
                     span,
                     test_method_object,
                     test_name,
-                    getattr(item.session, "_dd_workspace_path", item.config.rootdir),
+                    getattr(item.session.config, "_dd_workspace_path", item.config.rootdir),
                 )
 
             # We preemptively set FAIL as a status, because if pytest_runtest_makereport is not called

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -797,6 +797,17 @@ class CIVisibility(Service):
         return instance._service
 
     @classmethod
+    def get_workspace_path(cls) -> Optional[str]:
+        if not cls.enabled:
+            error_msg = "CI Visibility is not enabled"
+            log.warning(error_msg)
+            raise CIVisibilityError(error_msg)
+        instance = cls.get_instance()
+        if instance is None:
+            return None
+        return instance._tags.get(ci.WORKSPACE_PATH)
+
+    @classmethod
     def is_item_itr_skippable(cls, item_id: CIItemId) -> bool:
         if not cls.enabled:
             error_msg = "CI Visibility is not enabled"

--- a/releasenotes/notes/ci_visibility-fix-dont_make_pytest_contrib_depend_on_git-d922e9326c981f38.yaml
+++ b/releasenotes/notes/ci_visibility-fix-dont_make_pytest_contrib_depend_on_git-d922e9326c981f38.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    CI Visibility: Fixes an issue where the pytest plugin would crash if the git binary was absent

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -3774,3 +3774,59 @@ class PytestTestCase(TracerTestCase):
         }
 
         assert expected_source_info == test_names_to_source_info
+
+    def test_pytest_without_git_does_not_crash(self):
+        with open("tools.py", "w+") as fd:
+            fd.write(
+                textwrap.dedent(
+                    (
+                        """
+                    def add_two_number_list(list_1, list_2):
+                        output_list = []
+                        for number_a, number_b in zip(list_1, list_2):
+                            output_list.append(number_a + number_b)
+                        return output_list
+
+                    def multiply_two_number_list(list_1, list_2):
+                        output_list = []
+                        for number_a, number_b in zip(list_1, list_2):
+                            output_list.append(number_a * number_b)
+                        return output_list
+                    """
+                    )
+                )
+            )
+
+        with open("test_tools.py", "w+") as fd:
+            fd.write(
+                textwrap.dedent(
+                    (
+                        """
+                    from tools import add_two_number_list
+
+                    def test_add_two_number_list():
+                        a_list = [1,2,3,4,5,6,7,8]
+                        b_list = [2,3,4,5,6,7,8,9]
+                        actual_output = add_two_number_list(a_list, b_list)
+
+                        assert actual_output == [3,5,7,9,11,13,15,17]
+                    """
+                    )
+                )
+            )
+
+        self.testdir.chdir()
+        with mock.patch("ddtrace.ext.git._get_executable_path", return_value=None):
+            self.inline_run("--ddtrace")
+
+            spans = self.pop_spans()
+            assert len(spans) == 4
+            test_span = spans[0]
+            test_session_span = spans[1]
+            test_module_span = spans[2]
+            test_suite_span = spans[3]
+
+            assert test_session_span.get_metric("test.code_coverage.lines_pct") is None
+            assert test_module_span.get_metric("test.code_coverage.lines_pct") is None
+            assert test_suite_span.get_metric("test.code_coverage.lines_pct") is None
+            assert test_span.get_metric("test.code_coverage.lines_pct") is None


### PR DESCRIPTION
Backport c460441c0c43d40b5d12e647ce60086b2f8f493f from #9989 to 2.9.

Fixes an issue introduced by #9586 and reported in #9981 where the pytest plugin would crash if the `git` binary was absent.

The workspace is instead grabbed from the `CIVisibility` service's tags (via a new getter classmethod).

In order for the variable to persist through to the `pytest_terminal_summary` hook, it is moved from being stashed on the pytest `session` object to the nested `config` object (which itself is passed to `pytest_terminal_summary`).

For improved testability, a function to get the location of the `git` binary's passed, using `@cached()` to avoid re-fetching the path each time we call `git`.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
