### PR TITLE
docs(advanced_usage): clarify ddtrace-run info command

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -635,7 +635,7 @@ and database modules without the need for changing your code::
 
   Usage: ddtrace-run <my_program>
 
-`--info`: This argument prints an easily readable tracer health check and configurations. It does not reflect configuration changes made at the code level,
+``--info``: This argument prints an easily readable tracer health check and configurations. It does not reflect configuration changes made at the code level,
 only environment variable configurations.
 
 The environment variables for ``ddtrace-run`` used to configure the tracer are


### PR DESCRIPTION
## Motivation

Fix docstrings [here](https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtrace-run:~:text=ddtrace%2Drun%20%3Cmy_program%3E-,%E2%80%93info%3A,-This%20argument%20prints), the `--info` arg hyphens were being combined into one large hyphen, which is the wrong symbol. Use double backticks to prevent this. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
