### PR TITLE
fix(lib-injection): fix lib-injection docker image size

### DIFF
--- a/lib-injection/Dockerfile
+++ b/lib-injection/Dockerfile
@@ -25,8 +25,9 @@ RUN python3 dl_wheels.py \
         --verbose
 
 FROM alpine:3.20
+ARG UID=10000
 RUN addgroup -g 10000 -S datadog && \
-    adduser -u 10000 -S datadog -G datadog
+    adduser -u ${UID} -S datadog -G datadog
 USER ${UID}
 WORKDIR /datadog-init
 

--- a/lib-injection/Dockerfile
+++ b/lib-injection/Dockerfile
@@ -25,17 +25,14 @@ RUN python3 dl_wheels.py \
         --verbose
 
 FROM alpine:3.20
-COPY --from=0 /build/pkgs /datadog-init/ddtrace_pkgs
-ARG UID=10000
 RUN addgroup -g 10000 -S datadog && \
-    adduser -u ${UID} -S datadog -G datadog
-RUN chown -R datadog:datadog /datadog-init/ddtrace_pkgs
-RUN chmod -R 755 /datadog-init/ddtrace_pkgs
-ADD telemetry-forwarder.sh /datadog-init/telemetry-forwarder.sh
-RUN chown -R datadog:datadog /datadog-init/telemetry-forwarder.sh
-RUN chmod +x /datadog-init/telemetry-forwarder.sh
+    adduser -u 10000 -S datadog -G datadog
 USER ${UID}
 WORKDIR /datadog-init
-ADD min_compatible_versions.csv /datadog-init/min_compatible_versions.csv
-ADD sitecustomize.py /datadog-init/sitecustomize.py
-ADD copy-lib.sh /datadog-init/copy-lib.sh
+
+ADD --chown="datadog:datadog" telemetry-forwarder.sh \
+    min_compatible_versions.csv \
+    sitecustomize.py \
+    copy-lib.sh \
+    /datadog-init/
+COPY --from=0 --chmod=0755 --chown="datadog:datadog" /build/pkgs /datadog-init/ddtrace_pkgs

--- a/releasenotes/notes/fix-lib-injection-docker-image-size-ae171009a786f185.yaml
+++ b/releasenotes/notes/fix-lib-injection-docker-image-size-ae171009a786f185.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    lib-injection: This fix resolves an issue with docker layer caching and the final lib-injection image size.


### PR DESCRIPTION
The main issue was the `RUN chown`/`RUN chmod` commands which were duplicating the package files in their own layers. This caused the final image to be about 3x the actual size it should have been.


Current v2.10.1 image
```
❯ docker history datadog/dd-lib-python-init:v2.10.1
IMAGE          CREATED      CREATED BY                                      SIZE      COMMENT
90c84773b524   2 days ago   ADD copy-lib.sh /datadog-init/copy-lib.sh # …   12.3kB    buildkit.dockerfile.v0
<missing>      2 days ago   ADD sitecustomize.py /datadog-init/sitecusto…   20.5kB    buildkit.dockerfile.v0
<missing>      2 days ago   ADD min_compatible_versions.csv /datadog-ini…   12.3kB    buildkit.dockerfile.v0
<missing>      2 days ago   WORKDIR /datadog-init                           4.1kB     buildkit.dockerfile.v0
<missing>      2 days ago   USER 10000                                      0B        buildkit.dockerfile.v0
<missing>      2 days ago   RUN |1 UID=10000 /bin/sh -c chmod +x /datado…   4.1kB     buildkit.dockerfile.v0
<missing>      2 days ago   RUN |1 UID=10000 /bin/sh -c chown -R datadog…   12.3kB    buildkit.dockerfile.v0
<missing>      2 days ago   ADD telemetry-forwarder.sh /datadog-init/tel…   12.3kB    buildkit.dockerfile.v0
<missing>      2 days ago   RUN |1 UID=10000 /bin/sh -c chmod -R 755 /da…   313MB     buildkit.dockerfile.v0
<missing>      2 days ago   RUN |1 UID=10000 /bin/sh -c chown -R datadog…   319MB     buildkit.dockerfile.v0
<missing>      2 days ago   RUN |1 UID=10000 /bin/sh -c addgroup -g 1000…   41kB      buildkit.dockerfile.v0
<missing>      2 days ago   ARG UID=10000                                   0B        buildkit.dockerfile.v0
<missing>      2 days ago   COPY /build/pkgs /datadog-init/ddtrace_pkgs …   319MB     buildkit.dockerfile.v0
<missing>      9 days ago   /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B
<missing>      9 days ago   /bin/sh -c #(nop) ADD file:a71f7e9bc66668361…   9.49MB
```

After this change:

```
❯ docker history dd-lib-python-init:v2.10.1
IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
697419e0a9dd   5 minutes ago   COPY --chown=datadog:datadog --chmod=0755 /b…   318MB     buildkit.dockerfile.v0
<missing>      5 minutes ago   ADD --chown=datadog:datadog telemetry-forwar…   32.8kB    buildkit.dockerfile.v0
<missing>      8 minutes ago   WORKDIR /datadog-init                           8.19kB    buildkit.dockerfile.v0
<missing>      8 minutes ago   USER                                            0B        buildkit.dockerfile.v0
<missing>      8 minutes ago   RUN /bin/sh -c addgroup -g 10000 -S datadog …   41kB      buildkit.dockerfile.v0
<missing>      9 days ago      /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B
<missing>      9 days ago      /bin/sh -c #(nop) ADD file:a71f7e9bc66668361…   9.49MB
```


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
