### PR TITLE
fix(internal): fix telemetry URL for EU [backport 2.10]

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -121,7 +121,7 @@ def _get_agentless_telemetry_url(site: str):
     if site == "datad0g.com":
         return "https://all-http-intake.logs.datad0g.com"
     if site == "datadoghq.eu":
-        return "https://instrumentation-telemetry-intake.eu1.datadoghq.com"
+        return "https://instrumentation-telemetry-intake.datadoghq.eu"
     return f"https://instrumentation-telemetry-intake.{site}/"
 
 

--- a/releasenotes/notes/ci_visibility-fix-update_eu_telemetry_url-0642a6f665c75a0f.yaml
+++ b/releasenotes/notes/ci_visibility-fix-update_eu_telemetry_url-0642a6f665c75a0f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    CI Visibility: fixes incorrect URL for telemetry intake in EU that was causing missing telemetry data and SSL error log messages.

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -648,9 +648,7 @@ def test_telemetry_writer_agentless_setup_eu():
         assert new_telemetry_writer._client._is_agentless is True
         assert new_telemetry_writer._client._is_disabled is False
         assert new_telemetry_writer._client._endpoint == "api/v2/apmtelemetry"
-        assert (
-            new_telemetry_writer._client._telemetry_url == "https://instrumentation-telemetry-intake.eu1.datadoghq.com"
-        )
+        assert new_telemetry_writer._client._telemetry_url == "https://instrumentation-telemetry-intake.datadoghq.eu"
         assert new_telemetry_writer._client._headers["dd-api-key"] == "foobarkey"
 
 


### PR DESCRIPTION
Backport 513f7e56b783f0b700b8baba9d5d76c6f57874b9 from #10021 to 2.10.

This PR fixes incorrect URL for telemetry intake in EU that was causing missing telemetry data and SSL error log messages.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
