### PR TITLE
chore(asm): add test for immutability of static rules in appsec processor

### DIFF
--- a/tests/appsec/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/appsec/test_remoteconfiguration.py
@@ -1049,3 +1049,27 @@ def test_rules_never_empty(tracer):
             args = call[-1][1][1]
             assert "rules" in args
             assert args["rules"], "empty rules should not be possible, it must switch to default."
+
+
+def test_static_rules_never_modified(tracer):
+    with override_global_config(dict(_asm_enabled=True)):
+        tracer.configure(appsec_enabled=True, api_version="v0.4")
+        processors = str(tracer._appsec_processor._rules["processors"])
+        scanners = str(tracer._appsec_processor._rules["scanners"])
+        proc_add = {"id": "new_processor"}
+        scan_add = {"id": "new_scanner"}
+        with mock.patch("ddtrace.appsec._processor.AppSecSpanProcessor._update_rules", autospec=True) as mock_update:
+            mock_update.reset_mock()
+            _appsec_rules_data({"rules": [], "processors": [proc_add], "scanners": [scan_add]}, tracer)
+            call = mock_update.mock_calls
+            args = call[-1][1][1]
+            # check the new rules have been sent and merged
+            assert "processors" in args
+            assert proc_add in args["processors"]
+            assert len(args["processors"]) > 1
+            assert "scanners" in args
+            assert scan_add in args["scanners"]
+            assert len(args["scanners"]) > 1
+            # check that the original rules are still there unmodified
+            assert processors == str(tracer._appsec_processor._rules["processors"])
+            assert scanners == str(tracer._appsec_processor._rules["scanners"])


### PR DESCRIPTION
Add a little more coverage on https://github.com/DataDog/dd-trace-py/pull/10030 to ensure that the rule structure is not modified by new features.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
