### PR TITLE
chore: add types to function definitions to quiesce typing info logs

### DIFF
--- a/ddtrace/internal/datastreams/processor.py
+++ b/ddtrace/internal/datastreams/processor.py
@@ -73,7 +73,7 @@ class SumCount:
 
     __slots__ = ("_sum", "_count")
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._sum: float = 0.0
         self._count: int = 0
 

--- a/ddtrace/internal/periodic.py
+++ b/ddtrace/internal/periodic.py
@@ -31,7 +31,7 @@ def _():
 class PeriodicService(service.Service):
     """A service that runs periodically."""
 
-    def __init__(self, interval=0.0):
+    def __init__(self, interval: float = 0.0) -> None:
         super().__init__()
         self._interval = interval
         self._worker: typing.Optional[PeriodicThread] = None

--- a/ddtrace/internal/runtime/runtime_metrics.py
+++ b/ddtrace/internal/runtime/runtime_metrics.py
@@ -71,7 +71,7 @@ class RuntimeWorker(periodic.PeriodicService):
     _instance = None  # type: ClassVar[Optional[RuntimeWorker]]
     _lock = forksafe.Lock()
 
-    def __init__(self, interval=_get_interval_or_default(), tracer=ddtrace.tracer, dogstatsd_url=None):
+    def __init__(self, interval=_get_interval_or_default(), tracer=ddtrace.tracer, dogstatsd_url=None) -> None:
         super().__init__(interval=interval)
         self.dogstatsd_url: Optional[str] = dogstatsd_url
         self._dogstatsd_client: DogStatsd = get_dogstatsd_client(

--- a/ddtrace/internal/service.py
+++ b/ddtrace/internal/service.py
@@ -28,7 +28,7 @@ class ServiceStatusError(RuntimeError):
 class Service(metaclass=abc.ABCMeta):
     """A service that can be started or stopped."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.status: ServiceStatus = ServiceStatus.STOPPED
         self._service_lock: typing.ContextManager = forksafe.Lock()
 


### PR DESCRIPTION
Adds typing primarily to return method types to take care of a handful of messages like 
```
ddtrace/internal/runtime/runtime_metrics.py:76: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
```

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
