### PR TITLE
chore(profiling): add native tests to CI

### DIFF
--- a/.github/workflows/profiling-native-tests.yml
+++ b/.github/workflows/profiling-native-tests.yml
@@ -1,0 +1,18 @@
+name: "Profiling Native Tests"
+on:
+  pull_request:
+    paths:
+      - ddtrace/internal/datadog/profiling/**
+
+jobs:
+  check:
+    name: Profiling Native Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        extension: ["ddtrace/internal/datadog/profiling"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: dd_wrapper static analysis (cppcheck)
+        run: ./build_standalone.sh -C -- dd_wrapper
+        working-directory: ${{ matrix.extension }}

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/crashtracker_interface.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/crashtracker_interface.hpp
@@ -10,7 +10,7 @@ extern "C"
 #endif
     void crashtracker_set_url(std::string_view url);
     void crashtracker_set_service(std::string_view service);
-    void crashtracker_set_env(std::string_view env);
+    void crashtracker_set_env(std::string_view environment);
     void crashtracker_set_version(std::string_view version);
     void crashtracker_set_runtime(std::string_view runtime);
     void crashtracker_set_runtime_id(std::string_view runtime_id);

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
@@ -13,7 +13,7 @@ class Sample;
 extern "C"
 {
 #endif
-    void ddup_config_env(std::string_view dd_env);
+    void ddup_config_env(std::string_view environment);
     void ddup_config_service(std::string_view service);
     void ddup_config_version(std::string_view version);
     void ddup_config_runtime_version(std::string_view runtime_version);

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/libdatadog_helpers.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/libdatadog_helpers.hpp
@@ -20,7 +20,7 @@ namespace Datadog {
 // within a C++ symbol name.
 #define EXPORTER_TAGS(X)                                                                                               \
     X(language, "language")                                                                                            \
-    X(dd_env, "env")                                                                                                   \
+    X(environment, "env")                                                                                              \
     X(service, "service")                                                                                              \
     X(version, "version")                                                                                              \
     X(runtime_version, "runtime_version")                                                                              \

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader_builder.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader_builder.hpp
@@ -16,7 +16,7 @@ class UploaderBuilder
     static inline std::mutex tag_mutex{};
 
     // Building parameters
-    static inline std::string dd_env;
+    static inline std::string environment;
     static inline std::string service;
     static inline std::string version;
     static inline std::string runtime{ g_runtime_name };
@@ -30,7 +30,7 @@ class UploaderBuilder
     static constexpr std::string_view family{ g_language_name };
 
   public:
-    static void set_env(std::string_view _dd_env);
+    static void set_env(std::string_view _environment);
     static void set_service(std::string_view _service);
     static void set_version(std::string_view _version);
     static void set_runtime(std::string_view _runtime);

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/crashtracker.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/crashtracker.cpp
@@ -148,7 +148,7 @@ Datadog::Crashtracker::get_tags()
 {
     ddog_Vec_Tag tags = ddog_Vec_Tag_new();
     const std::vector<std::pair<ExportTagKey, std::string_view>> tag_data = {
-        { ExportTagKey::dd_env, env },
+        { ExportTagKey::environment, environment},
         { ExportTagKey::service, service },
         { ExportTagKey::version, version },
         { ExportTagKey::language, family }, // Slight conflation of terms, but should be OK

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/crashtracker_interface.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/crashtracker_interface.cpp
@@ -17,103 +17,103 @@ crashtracker_postfork_child()
 }
 
 void
-crashtracker_set_url(std::string_view url) // cppcheck-suppress unusedFunction
+crashtracker_set_url(std::string_view url)
 {
     crashtracker.set_url(url);
 }
 
 void
-crashtracker_set_service(std::string_view service) // cppcheck-suppress unusedFunction
+crashtracker_set_service(std::string_view service)
 {
     crashtracker.set_service(service);
 }
 
 void
-crashtracker_set_env(std::string_view env) // cppcheck-suppress unusedFunction
+crashtracker_set_env(std::string_view environment)
 {
-    crashtracker.set_env(env);
+    crashtracker.set_env(environment);
 }
 
 void
-crashtracker_set_version(std::string_view version) // cppcheck-suppress unusedFunction
+crashtracker_set_version(std::string_view version)
 {
     crashtracker.set_version(version);
 }
 
 void
-crashtracker_set_runtime(std::string_view runtime) // cppcheck-suppress unusedFunction
+crashtracker_set_runtime(std::string_view runtime)
 {
     crashtracker.set_runtime(runtime);
 }
 
 void
-crashtracker_set_runtime_version(std::string_view runtime_version) // cppcheck-suppress unusedFunction
+crashtracker_set_runtime_version(std::string_view runtime_version)
 {
     crashtracker.set_runtime_version(runtime_version);
 }
 
 void
-crashtracker_set_runtime_id(std::string_view runtime_id) // cppcheck-suppress unusedFunction
+crashtracker_set_runtime_id(std::string_view runtime_id)
 {
     crashtracker.set_runtime_id(runtime_id);
 }
 
 void
-crashtracker_set_library_version(std::string_view profiler_version) // cppcheck-suppress unusedFunction
+crashtracker_set_library_version(std::string_view profiler_version)
 {
     crashtracker.set_library_version(profiler_version);
 }
 
 void
-crashtracker_set_stdout_filename(std::string_view filename) // cppcheck-suppress unusedFunction
+crashtracker_set_stdout_filename(std::string_view filename)
 {
     crashtracker.set_stdout_filename(filename);
 }
 
 void
-crashtracker_set_stderr_filename(std::string_view filename) // cppcheck-suppress unusedFunction
+crashtracker_set_stderr_filename(std::string_view filename)
 {
     crashtracker.set_stderr_filename(filename);
 }
 
 void
-crashtracker_set_alt_stack(bool alt_stack) // cppcheck-suppress unusedFunction
+crashtracker_set_alt_stack(bool alt_stack)
 {
     crashtracker.set_create_alt_stack(alt_stack);
 }
 
 void
-crashtracker_set_resolve_frames_disable() // cppcheck-suppress unusedFunction
+crashtracker_set_resolve_frames_disable()
 {
     crashtracker.set_resolve_frames(DDOG_PROF_STACKTRACE_COLLECTION_DISABLED);
 }
 
 void
-crashtracker_set_resolve_frames_fast() // cppcheck-suppress unusedFunction
+crashtracker_set_resolve_frames_fast()
 {
     crashtracker.set_resolve_frames(DDOG_PROF_STACKTRACE_COLLECTION_WITHOUT_SYMBOLS);
 }
 
 void
-crashtracker_set_resolve_frames_full() // cppcheck-suppress unusedFunction
+crashtracker_set_resolve_frames_full()
 {
     crashtracker.set_resolve_frames(DDOG_PROF_STACKTRACE_COLLECTION_ENABLED_WITH_INPROCESS_SYMBOLS);
 }
 
 void
-crashtracker_set_resolve_frames_safe() // cppcheck-suppress unusedFunction
+crashtracker_set_resolve_frames_safe()
 {
     crashtracker.set_resolve_frames(DDOG_PROF_STACKTRACE_COLLECTION_ENABLED_WITH_SYMBOLS_IN_RECEIVER);
 }
 
 bool
-crashtracker_set_receiver_binary_path(std::string_view path) // cppcheck-suppress unusedFunction
+crashtracker_set_receiver_binary_path(std::string_view path)
 {
     return crashtracker.set_receiver_binary_path(path);
 }
 
 void
-crashtracker_set_tag(std::string_view key, std::string_view value) // cppcheck-suppress unusedFunction
+crashtracker_set_tag(std::string_view key, std::string_view value)
 {
     crashtracker.set_tag(key, value);
 }
@@ -134,7 +134,7 @@ close_stderr_chainer(int signo, siginfo_t* info, void* context)
 }
 
 void
-crashtracker_start() // cppcheck-suppress unusedFunction
+crashtracker_start()
 {
     // This is a one-time start pattern to ensure that the crashtracker is only started once.
     const static bool initialized = []() {
@@ -164,7 +164,7 @@ crashtracker_start() // cppcheck-suppress unusedFunction
 }
 
 void
-crashtracker_profiling_state_sampling_start() // cppcheck-suppress unusedFunction
+crashtracker_profiling_state_sampling_start()
 {
     // These functions may be called by components which have no knowledge of
     // whether the crashtracker was started.  We let them call, but ignore them
@@ -177,7 +177,7 @@ crashtracker_profiling_state_sampling_start() // cppcheck-suppress unusedFunctio
 }
 
 void
-crashtracker_profiling_state_sampling_stop() // cppcheck-suppress unusedFunction
+crashtracker_profiling_state_sampling_stop()
 {
     if (crashtracker_initialized) {
         crashtracker.sampling_stop();
@@ -185,7 +185,7 @@ crashtracker_profiling_state_sampling_stop() // cppcheck-suppress unusedFunction
 }
 
 void
-crashtracker_profiling_state_unwinding_start() // cppcheck-suppress unusedFunction
+crashtracker_profiling_state_unwinding_start()
 {
     if (crashtracker_initialized) {
         crashtracker.unwinding_start();
@@ -193,7 +193,7 @@ crashtracker_profiling_state_unwinding_start() // cppcheck-suppress unusedFuncti
 }
 
 void
-crashtracker_profiling_state_unwinding_stop() // cppcheck-suppress unusedFunction
+crashtracker_profiling_state_unwinding_stop()
 {
     if (crashtracker_initialized) {
         crashtracker.unwinding_stop();
@@ -201,7 +201,7 @@ crashtracker_profiling_state_unwinding_stop() // cppcheck-suppress unusedFunctio
 }
 
 void
-crashtracker_profiling_state_serializing_start() // cppcheck-suppress unusedFunction
+crashtracker_profiling_state_serializing_start()
 {
     if (crashtracker_initialized) {
         crashtracker.serializing_start();
@@ -209,7 +209,7 @@ crashtracker_profiling_state_serializing_start() // cppcheck-suppress unusedFunc
 }
 
 void
-crashtracker_profiling_state_serializing_stop() // cppcheck-suppress unusedFunction
+crashtracker_profiling_state_serializing_stop()
 {
     if (crashtracker_initialized) {
         crashtracker.serializing_stop();
@@ -217,7 +217,7 @@ crashtracker_profiling_state_serializing_stop() // cppcheck-suppress unusedFunct
 }
 
 bool
-crashtracker_is_started() // cppcheck-suppress unusedFunction
+crashtracker_is_started()
 {
     return crashtracker_initialized;
 }

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
@@ -41,85 +41,85 @@ ddup_prefork()
 
 // Configuration
 void
-ddup_config_env(std::string_view dd_env) // cppcheck-suppress unusedFunction
+ddup_config_env(std::string_view environment)
 {
-    Datadog::UploaderBuilder::set_env(dd_env);
+    Datadog::UploaderBuilder::set_env(environment);
 }
 
 void
-ddup_config_service(std::string_view service) // cppcheck-suppress unusedFunction
+ddup_config_service(std::string_view service)
 {
     Datadog::UploaderBuilder::set_service(service);
 }
 
 void
-ddup_config_version(std::string_view version) // cppcheck-suppress unusedFunction
+ddup_config_version(std::string_view version)
 {
     Datadog::UploaderBuilder::set_version(version);
 }
 
 void
-ddup_config_runtime(std::string_view runtime) // cppcheck-suppress unusedFunction
+ddup_config_runtime(std::string_view runtime)
 {
     Datadog::UploaderBuilder::set_runtime(runtime);
 }
 
 void
-ddup_set_runtime_id(std::string_view runtime_id) // cppcheck-suppress unusedFunction
+ddup_set_runtime_id(std::string_view runtime_id)
 {
     Datadog::UploaderBuilder::set_runtime_id(runtime_id);
 }
 
 void
-ddup_config_runtime_version(std::string_view runtime_version) // cppcheck-suppress unusedFunction
+ddup_config_runtime_version(std::string_view runtime_version)
 {
     Datadog::UploaderBuilder::set_runtime_version(runtime_version);
 }
 
 void
-ddup_config_profiler_version(std::string_view profiler_version) // cppcheck-suppress unusedFunction
+ddup_config_profiler_version(std::string_view profiler_version)
 {
     Datadog::UploaderBuilder::set_profiler_version(profiler_version);
 }
 
 void
-ddup_config_url(std::string_view url) // cppcheck-suppress unusedFunction
+ddup_config_url(std::string_view url)
 {
     Datadog::UploaderBuilder::set_url(url);
 }
 
 void
-ddup_config_user_tag(std::string_view key, std::string_view val) // cppcheck-suppress unusedFunction
+ddup_config_user_tag(std::string_view key, std::string_view val)
 {
     Datadog::UploaderBuilder::set_tag(key, val);
 }
 
 void
-ddup_config_sample_type(unsigned int _type) // cppcheck-suppress unusedFunction
+ddup_config_sample_type(unsigned int _type)
 {
     Datadog::SampleManager::add_type(_type);
 }
 
 void
-ddup_config_max_nframes(int max_nframes) // cppcheck-suppress unusedFunction
+ddup_config_max_nframes(int max_nframes)
 {
     Datadog::SampleManager::set_max_nframes(max_nframes);
 }
 
 void
-ddup_config_timeline(bool enabled) // cppcheck-suppress unusedFunction
+ddup_config_timeline(bool enabled)
 {
     Datadog::SampleManager::set_timeline(enabled);
 }
 
 bool
-ddup_is_initialized() // cppcheck-suppress unusedFunction
+ddup_is_initialized()
 {
     return is_ddup_initialized;
 }
 
 void
-ddup_start() // cppcheck-suppress unusedFunction
+ddup_start()
 {
     std::call_once(ddup_init_flag, []() {
         // Perform any one-time startup operations
@@ -136,56 +136,56 @@ ddup_start() // cppcheck-suppress unusedFunction
 }
 
 Datadog::Sample*
-ddup_start_sample() // cppcheck-suppress unusedFunction
+ddup_start_sample()
 {
     return Datadog::SampleManager::start_sample();
 }
 
 void
-ddup_push_walltime(Datadog::Sample* sample, int64_t walltime, int64_t count) // cppcheck-suppress unusedFunction
+ddup_push_walltime(Datadog::Sample* sample, int64_t walltime, int64_t count)
 {
 
     sample->push_walltime(walltime, count);
 }
 
 void
-ddup_push_cputime(Datadog::Sample* sample, int64_t cputime, int64_t count) // cppcheck-suppress unusedFunction
+ddup_push_cputime(Datadog::Sample* sample, int64_t cputime, int64_t count)
 {
     sample->push_cputime(cputime, count);
 }
 
 void
-ddup_push_acquire(Datadog::Sample* sample, int64_t acquire_time, int64_t count) // cppcheck-suppress unusedFunction
+ddup_push_acquire(Datadog::Sample* sample, int64_t acquire_time, int64_t count)
 {
     sample->push_acquire(acquire_time, count);
 }
 
 void
-ddup_push_release(Datadog::Sample* sample, int64_t release_time, int64_t count) // cppcheck-suppress unusedFunction
+ddup_push_release(Datadog::Sample* sample, int64_t release_time, int64_t count)
 {
     sample->push_release(release_time, count);
 }
 
 void
-ddup_push_alloc(Datadog::Sample* sample, int64_t size, int64_t count) // cppcheck-suppress unusedFunction
+ddup_push_alloc(Datadog::Sample* sample, int64_t size, int64_t count)
 {
     sample->push_alloc(size, count);
 }
 
 void
-ddup_push_heap(Datadog::Sample* sample, int64_t size) // cppcheck-suppress unusedFunction
+ddup_push_heap(Datadog::Sample* sample, int64_t size)
 {
     sample->push_heap(size);
 }
 
 void
-ddup_push_lock_name(Datadog::Sample* sample, std::string_view lock_name) // cppcheck-suppress unusedFunction
+ddup_push_lock_name(Datadog::Sample* sample, std::string_view lock_name)
 {
     sample->push_lock_name(lock_name);
 }
 
 void
-ddup_push_threadinfo(Datadog::Sample* sample, // cppcheck-suppress unusedFunction
+ddup_push_threadinfo(Datadog::Sample* sample,
                      int64_t thread_id,
                      int64_t thread_native_id,
                      std::string_view thread_name)
@@ -194,44 +194,44 @@ ddup_push_threadinfo(Datadog::Sample* sample, // cppcheck-suppress unusedFunctio
 }
 
 void
-ddup_push_task_id(Datadog::Sample* sample, int64_t task_id) // cppcheck-suppress unusedFunction
+ddup_push_task_id(Datadog::Sample* sample, int64_t task_id)
 {
     sample->push_task_id(task_id);
 }
 
 void
-ddup_push_task_name(Datadog::Sample* sample, std::string_view task_name) // cppcheck-suppress unusedFunction
+ddup_push_task_name(Datadog::Sample* sample, std::string_view task_name)
 {
     sample->push_task_name(task_name);
 }
 
 void
-ddup_push_span_id(Datadog::Sample* sample, int64_t span_id) // cppcheck-suppress unusedFunction
+ddup_push_span_id(Datadog::Sample* sample, int64_t span_id)
 {
     sample->push_span_id(span_id);
 }
 
 void
-ddup_push_local_root_span_id(Datadog::Sample* sample, int64_t local_root_span_id) // cppcheck-suppress unusedFunction
+ddup_push_local_root_span_id(Datadog::Sample* sample, int64_t local_root_span_id)
 {
     sample->push_local_root_span_id(local_root_span_id);
 }
 
 void
-ddup_push_trace_type(Datadog::Sample* sample, std::string_view trace_type) // cppcheck-suppress unusedFunction
+ddup_push_trace_type(Datadog::Sample* sample, std::string_view trace_type)
 {
     sample->push_trace_type(trace_type);
 }
 
 void
-ddup_push_trace_resource_container(Datadog::Sample* sample, // cppcheck-suppress unusedFunction
+ddup_push_trace_resource_container(Datadog::Sample* sample,
                                    std::string_view trace_resource_container)
 {
     sample->push_trace_resource_container(trace_resource_container);
 }
 
 void
-ddup_push_exceptioninfo(Datadog::Sample* sample, // cppcheck-suppress unusedFunction
+ddup_push_exceptioninfo(Datadog::Sample* sample,
                         std::string_view exception_type,
                         int64_t count)
 {
@@ -239,13 +239,13 @@ ddup_push_exceptioninfo(Datadog::Sample* sample, // cppcheck-suppress unusedFunc
 }
 
 void
-ddup_push_class_name(Datadog::Sample* sample, std::string_view class_name) // cppcheck-suppress unusedFunction
+ddup_push_class_name(Datadog::Sample* sample, std::string_view class_name)
 {
     sample->push_class_name(class_name);
 }
 
 void
-ddup_push_frame(Datadog::Sample* sample, // cppcheck-suppress unusedFunction
+ddup_push_frame(Datadog::Sample* sample,
                 std::string_view _name,
                 std::string_view _filename,
                 uint64_t address,
@@ -255,25 +255,25 @@ ddup_push_frame(Datadog::Sample* sample, // cppcheck-suppress unusedFunction
 }
 
 void
-ddup_push_monotonic_ns(Datadog::Sample* sample, int64_t monotonic_ns) // cppcheck-suppress unusedFunction
+ddup_push_monotonic_ns(Datadog::Sample* sample, int64_t monotonic_ns)
 {
     sample->push_monotonic_ns(monotonic_ns);
 }
 
 void
-ddup_flush_sample(Datadog::Sample* sample) // cppcheck-suppress unusedFunction
+ddup_flush_sample(Datadog::Sample* sample)
 {
     sample->flush_sample();
 }
 
 void
-ddup_drop_sample(Datadog::Sample* sample) // cppcheck-suppress unusedFunction
+ddup_drop_sample(Datadog::Sample* sample)
 {
     Datadog::SampleManager::drop_sample(sample);
 }
 
 bool
-ddup_upload() // cppcheck-suppress unusedFunction
+ddup_upload()
 {
     if (!is_ddup_initialized) {
         std::cerr << "ddup_upload() called before ddup_init()" << std::endl;

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/receiver_interface.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/receiver_interface.cpp
@@ -13,7 +13,7 @@
 // * It's annoying to split the build into an object library for just one file
 
 bool
-crashtracker_receiver_entry() // cppcheck-suppress unusedFunction
+crashtracker_receiver_entry()
 {
     // Assumes that this will be called only in the receiver binary, which is a
     // fresh process

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
@@ -9,10 +9,10 @@
 #include <vector>
 
 void
-Datadog::UploaderBuilder::set_env(std::string_view _dd_env)
+Datadog::UploaderBuilder::set_env(std::string_view _environment)
 {
-    if (!_dd_env.empty()) {
-        dd_env = _dd_env;
+    if (!_environment.empty()) {
+        environment = _environment;
     }
 }
 
@@ -111,7 +111,7 @@ Datadog::UploaderBuilder::build()
     // tags, so we'll just collect all the reasons and report them all at once.
     std::vector<std::string> reasons{};
     const std::vector<std::pair<ExportTagKey, std::string_view>> tag_data = {
-        { ExportTagKey::dd_env, dd_env },
+        { ExportTagKey::environment, environment},
         { ExportTagKey::service, service },
         { ExportTagKey::version, version },
         { ExportTagKey::language, language },


### PR DESCRIPTION
As part of our libdatadog/stack v2 revamp, quite a bit of native code was added to the repo.

This code is currently checked offline for conformance to static analysis results (cppcheck, clang-tidy), the correctness of stress tests (it runs native threads, so we have to check for after-fork issues), and sanitiziers.

This PR adds that stuff  to our CI.  A lot of this code will get rustified in the not-too-distant future, so not making a huge investment here right now.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
