### PR TITLE
chore(ci): add CI image for running native profiling checks

### DIFF
--- a/.github/workflows/build_profiling_native_checks_image.yml
+++ b/.github/workflows/build_profiling_native_checks_image.yml
@@ -1,0 +1,21 @@
+name: Build profiling native checks image
+
+on:
+  workflow_dispatch:
+  push:
+    #    branches:
+    #      - main
+    #    paths:
+    #      - 'docker/Dockerfile.profiling_native_checks'
+
+jobs:
+  build-and-publish-image:
+    uses: ./.github/workflows/build-and-publish-image.yml
+    with:
+      tags: 'ghcr.io/datadog/dd-trace-py/profiling_native_checks:${{ github.sha }},ghcr.io/datadog/dd-trace-py/profiling_native_checks:latest'
+      platforms: linux/amd64
+      build-args: ''
+      context: ./docker
+      file: Dockerfile.profiling_native_checks
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/docker/Dockerfile.profiling_native_checks
+++ b/docker/Dockerfile.profiling_native_checks
@@ -1,0 +1,32 @@
+FROM debian:buster-20221219-slim
+
+# Update and install dependencies
+RUN apt-get update && \
+    apt-get install -y \
+    build-essential \
+    cmake \
+    git \
+    wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install sccache
+ENV SCCACHE_VERSION=0.8.1
+RUN wget https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz && \
+    tar -xzf sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz && \
+    mv sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache /usr/local/bin/ && \
+    rm -rf sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz
+
+# Install cppcheck
+ENV CPPCHECK_VERSION=2.14.2
+RUN wget https://github.com/danmar/cppcheck/archive/refs/tags/${CPPCHECK_VERSION}.tar.gz && \
+    tar -xzf ${CPPCHECK_VERSION}.tar.gz && \
+    rm -rf ${CPPCHECK_VERSION}.tar.gz && \
+    cd cppcheck-${CPPCHECK_VERSION} && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    cmake --build . --parallel $(nproc) && \
+    cp bin/cppcheck /usr/local/bin/ && \
+    cd ../.. && \
+    rm -rf cppcheck-${CPPCHECK_VERSION}


### PR DESCRIPTION
Since profiling contains quite a bit of native code, it has a number of native checks (running with sanitizers, static analysis, etc) that's done outside of our normal build operation.  This PR adds an image which can be used to perform those tests in CI

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
