### PR TITLE
chore(asm): improve patching mechanism (#10098) [backport 2.11]

### DIFF
--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -290,7 +290,9 @@ def apply_patch(parent, attribute, replacement):
         # Avoid overwriting the original function if we call this twice
         if not isinstance(current_attribute, FunctionWrapper):
             _DD_ORIGINAL_ATTRIBUTES[(parent, attribute)] = current_attribute
-        elif isinstance(replacement, FunctionWrapper):
+        elif isinstance(replacement, FunctionWrapper) and (
+            getattr(replacement, "_self_wrapper", None) is getattr(current_attribute, "_self_wrapper", None)
+        ):
             # Avoid double patching
             return
         setattr(parent, attribute, replacement)

--- a/tests/appsec/appsec/test_exploit_prevention.py
+++ b/tests/appsec/appsec/test_exploit_prevention.py
@@ -35,3 +35,38 @@ def test_lfi_normal_exception():
             assert traceback.format_exc(limit=1).startswith(exception_repr.format(__file__, line_number + 2))
     finally:
         cmp.unpatch_common_modules()
+
+
+def get_result(v: str) -> str:
+    return "A" + v
+
+
+def test_wrapping_twice():
+    """
+    Ensure wrapping mechanism is not wrapping twice the same function in a row, but can still wrap different functions
+    """
+
+    def wrapper1(original, instance, args, kargs):
+        return original("B" + args[0])
+
+    def wrapper2(original, instance, args, kargs):
+        return original("C" + args[0])
+
+    assert get_result("1") == "A1"
+    cmp.try_wrap_function_wrapper(__name__, "get_result", wrapper1)
+    assert get_result("1") == "AB1"
+    # different wrap is applied
+    cmp.try_wrap_function_wrapper(__name__, "get_result", wrapper2)
+    assert get_result("1") == "ABC1"
+    cmp.try_wrap_function_wrapper(__name__, "get_result", wrapper2)
+    # second wrap with same wrapper is ignored
+    assert get_result("1") == "ABC1"
+    cmp.try_unwrap(__name__, "get_result")
+    assert get_result("1") == "A1"
+    cmp.try_wrap_function_wrapper(__name__, "get_result", wrapper1)
+    assert get_result("1") == "AB1"
+    # second wrap with same wrapper is ignored
+    cmp.try_wrap_function_wrapper(__name__, "get_result", wrapper1)
+    assert get_result("1") == "AB1"
+    cmp.try_unwrap(__name__, "get_result")
+    assert get_result("1") == "A1"


### PR DESCRIPTION
This PR allows to appsec common_module_patches mechanism to wrap a different wrapper.

This fix a discrepancy that could prevent exploit prevention for command injection to work.

(not released yet, so no release note).

APPSEC-54439

(cherry picked from commit 14f33c2e8c51b7f985a790ecce86a463ef22077a)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
