### PR TITLE
chore(profiling): remove unnecessary add_tag for runtime_id

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader.hpp
@@ -24,7 +24,6 @@ class Uploader
     static inline std::mutex upload_lock{};
     std::string errmsg;
     static inline std::unique_ptr<ddog_CancellationToken, DdogCancellationTokenDeleter> cancel;
-    std::string runtime_id;
     std::string url;
     std::unique_ptr<ddog_prof_Exporter, DdogProfExporterDeleter> ddog_exporter;
 

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
@@ -32,10 +32,6 @@ Datadog::Uploader::upload(ddog_prof_Profile& profile)
     }
     ddog_prof_EncodedProfile* encoded = &result.ok; // NOLINT (cppcoreguidelines-pro-type-union-access)
 
-    // If we have any custom tags, set them now
-    ddog_Vec_Tag tags = ddog_Vec_Tag_new();
-    add_tag(tags, ExportTagKey::runtime_id, runtime_id, errmsg);
-
     // Build the request object
     const ddog_prof_Exporter_File file = {
         .name = to_slice("auto.pprof"),
@@ -46,7 +42,7 @@ Datadog::Uploader::upload(ddog_prof_Profile& profile)
                                                       encoded->end,
                                                       ddog_prof_Exporter_Slice_File_empty(),
                                                       { .ptr = &file, .len = 1 },
-                                                      &tags,
+                                                      nullptr,
                                                       nullptr,
                                                       nullptr,
                                                       nullptr);
@@ -58,7 +54,6 @@ Datadog::Uploader::upload(ddog_prof_Profile& profile)
         errmsg = err_to_msg(&err, "Error building request");
         std::cerr << errmsg << std::endl;
         ddog_Error_drop(&err);
-        ddog_Vec_Tag_drop(tags);
         return false;
     }
 
@@ -87,14 +82,11 @@ Datadog::Uploader::upload(ddog_prof_Profile& profile)
             errmsg = err_to_msg(&err, "Error uploading");
             std::cerr << errmsg << std::endl;
             ddog_Error_drop(&err);
-            ddog_Vec_Tag_drop(tags);
             return false;
         }
         ddog_prof_Exporter_Request_drop(&req);
     }
 
-    // Cleanup
-    ddog_Vec_Tag_drop(tags);
     return true;
 }
 


### PR DESCRIPTION
`Uploader::runtime_id` has never been updated and we set it correctly via https://github.com/DataDog/dd-trace-py/pull/9987/files#diff-ce7731c2f99d39b0496ece12ed6e487c0d400ecf0204d17b381f31746d9d9936

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
