### PR TITLE
chore: remove py2.7 compatibility code

### DIFF
--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -1,6 +1,6 @@
 from functools import lru_cache as cached
 import logging
-import os
+from os import fspath  # noqa:F401
 import sys
 import sysconfig
 from types import ModuleType
@@ -13,41 +13,6 @@ from ddtrace.settings.third_party import config as tp_config
 
 
 LOG = logging.getLogger(__name__)
-
-
-try:
-    fspath = os.fspath
-except AttributeError:
-    # Stolen from Python 3.10
-    def fspath(path):
-        # For testing purposes, make sure the function is available when the C
-        # implementation exists.
-        """Return the path representation of a path-like object.
-
-        If str or bytes is passed in, it is returned unchanged. Otherwise the
-        os.PathLike interface is used to get the path representation. If the
-        path representation is not str or bytes, TypeError is raised. If the
-        provided path is not str, bytes, or os.PathLike, TypeError is raised.
-        """
-        if isinstance(path, (str, bytes)):
-            return path
-
-        # Work from the object's type to match method resolution of other magic
-        # methods.
-        path_type = type(path)
-        try:
-            path_repr = path_type.__fspath__(path)
-        except AttributeError:
-            if hasattr(path_type, "__fspath__"):
-                raise
-            else:
-                raise TypeError("expected str, bytes or os.PathLike object, not " + path_type.__name__)
-        if isinstance(path_repr, (str, bytes)):
-            return path_repr
-        raise TypeError(
-            "expected {}.__fspath__() to return str or bytes, "
-            "not {}".format(path_type.__name__, type(path_repr).__name__)
-        )
 
 
 Distribution = t.NamedTuple("Distribution", [("name", str), ("version", str), ("path", t.Optional[str])])
@@ -203,9 +168,7 @@ def filename_to_package(filename: t.Union[str, Path]) -> t.Optional[Distribution
     try:
         path = Path(filename) if isinstance(filename, str) else filename
         return mapping.get(_root_module(path.resolve()))
-    except ValueError:
-        return None
-    except OSError:
+    except (ValueError, OSError):
         return None
 
 


### PR DESCRIPTION
This change removes some code that is only active under Python 2, which the library no longer supports.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
