### PR TITLE
fix: add nullptr checks for new_pyobject_id [backport 2.9]

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.cpp
@@ -79,31 +79,65 @@ PyObjectToString(PyObject* obj)
 PyObject*
 new_pyobject_id(PyObject* tainted_object)
 {
+    if (!tainted_object)
+        return nullptr;
+
     if (PyUnicode_Check(tainted_object)) {
         PyObject* empty_unicode = PyUnicode_New(0, 127);
+        if (!empty_unicode)
+            return tainted_object;
         PyObject* val = Py_BuildValue("(OO)", tainted_object, empty_unicode);
+        if (!val) {
+            Py_XDECREF(empty_unicode);
+            return tainted_object;
+        }
         PyObject* result = PyUnicode_Join(empty_unicode, val);
-        Py_DecRef(empty_unicode);
-        Py_DecRef(val);
+        if (!result) {
+            result = tainted_object;
+        }
+        Py_XDECREF(empty_unicode);
+        Py_XDECREF(val);
         return result;
     }
     if (PyBytes_Check(tainted_object)) {
         PyObject* empty_bytes = PyBytes_FromString("");
-        auto bytes_join_ptr = py::reinterpret_borrow<py::bytes>(empty_bytes).attr("join");
-        auto val = Py_BuildValue("(OO)", tainted_object, empty_bytes);
-        auto res = PyObject_CallFunctionObjArgs(bytes_join_ptr.ptr(), val, NULL);
-        Py_DecRef(val);
-        Py_DecRef(empty_bytes);
+        if (!empty_bytes)
+            return tainted_object;
+
+        const auto bytes_join_ptr = py::reinterpret_borrow<py::bytes>(empty_bytes).attr("join");
+        const auto val = Py_BuildValue("(OO)", tainted_object, empty_bytes);
+        if (!val or !bytes_join_ptr.ptr()) {
+            Py_XDECREF(empty_bytes);
+            return tainted_object;
+        }
+
+        const auto res = PyObject_CallFunctionObjArgs(bytes_join_ptr.ptr(), val, NULL);
+        Py_XDECREF(val);
+        Py_XDECREF(empty_bytes);
         return res;
     } else if (PyByteArray_Check(tainted_object)) {
         PyObject* empty_bytes = PyBytes_FromString("");
+        if (!empty_bytes)
+            return tainted_object;
+
         PyObject* empty_bytearray = PyByteArray_FromObject(empty_bytes);
-        auto bytearray_join_ptr = py::reinterpret_borrow<py::bytes>(empty_bytearray).attr("join");
-        auto val = Py_BuildValue("(OO)", tainted_object, empty_bytearray);
-        auto res = PyObject_CallFunctionObjArgs(bytearray_join_ptr.ptr(), val, NULL);
-        Py_DecRef(val);
-        Py_DecRef(empty_bytes);
-        Py_DecRef(empty_bytearray);
+        if (!empty_bytearray) {
+            Py_XDECREF(empty_bytes);
+            return tainted_object;
+        }
+
+        const auto bytearray_join_ptr = py::reinterpret_borrow<py::bytes>(empty_bytearray).attr("join");
+        const auto val = Py_BuildValue("(OO)", tainted_object, empty_bytearray);
+        if (!val or !bytearray_join_ptr.ptr()) {
+            Py_XDECREF(empty_bytes);
+            Py_XDECREF(empty_bytearray);
+            return tainted_object;
+        }
+
+        const auto res = PyObject_CallFunctionObjArgs(bytearray_join_ptr.ptr(), val, NULL);
+        Py_XDECREF(val);
+        Py_XDECREF(empty_bytes);
+        Py_XDECREF(empty_bytearray);
         return res;
     }
     return tainted_object;

--- a/releasenotes/notes/iast-new-pyobject-check-6aecf9c4f22e2ae9.yaml
+++ b/releasenotes/notes/iast-new-pyobject-check-6aecf9c4f22e2ae9.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Code Security: add null pointer checks when creating new objects ids.


### PR DESCRIPTION
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

- [x] Reviewer has checked that all the criteria below are met
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

---------

Signed-off-by: Juanjo Alvarez <juanjo.alvarezmartinez@datadoghq.com>
(cherry picked from commit e46c53bc795b72a587dbfd2b64dede57990d2b32)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
