### PR TITLE
ci(tracer): fix test_flush_queue_raise

### DIFF
--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -661,7 +661,7 @@ def test_flush_connection_uds(endpoint_uds_server, writer_class):
     writer.flush_queue(raise_exc=True)
 
 
-@pytest.mark.parametrize("writer_class", (AgentWriter,))
+@pytest.mark.parametrize("writer_class", (AgentWriter, CIVisibilityWriter))
 def test_flush_queue_raise(writer_class):
     with override_env(dict(DD_API_KEY="foobar.baz")):
         writer = writer_class("http://dne:1234")
@@ -672,7 +672,8 @@ def test_flush_queue_raise(writer_class):
 
         error = OSError
         with pytest.raises(error):
-            writer.write([])
+            # CIVisibilityWriter requires a non empty list
+            writer.write([Span("name")])
             writer.flush_queue(raise_exc=True)
 
 

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -661,7 +661,7 @@ def test_flush_connection_uds(endpoint_uds_server, writer_class):
     writer.flush_queue(raise_exc=True)
 
 
-@pytest.mark.parametrize("writer_class", (AgentWriter, CIVisibilityWriter))
+@pytest.mark.parametrize("writer_class", (AgentWriter,))
 def test_flush_queue_raise(writer_class):
     with override_env(dict(DD_API_KEY="foobar.baz")):
         writer = writer_class("http://dne:1234")


### PR DESCRIPTION
 With this [change](https://github.com/DataDog/dd-trace-py/commit/a7e765f07481971e148e6c41faa7cba3a910eac4) the CIVisibilityWriter no longer encodes empty payloads and therefore does not raise an OSError in `test_flush_queue_raise`.

This PR ensures `writer.write()` is called with a non-empty list of spans.

Sample Failure: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/68186/workflows/1c3c051b-5a86-4744-9f9e-656fe45861fd/jobs/4168676

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
