### PR TITLE
chore(asnm): less flakyness in threat tests

### DIFF
--- a/tests/appsec/contrib_appsec/conftest.py
+++ b/tests/appsec/contrib_appsec/conftest.py
@@ -39,9 +39,9 @@ def root_span(test_spans):
 @pytest.fixture
 def check_waf_timeout(request, printer):
     with unittest.mock.patch("ddtrace.appsec._processor._set_waf_error_metric", autospec=True) as mock_metrics:
-        # change timeout to 5 seconds to avoid flaky timeouts
+        # change timeout to 50 seconds to avoid flaky timeouts
         previous_timeout = asm_config._waf_timeout
-        asm_config._waf_timeout = 5000.0
+        asm_config._waf_timeout = 50_000.0
         test_failed = request.session.testsfailed
         yield
         if request.session.testsfailed > test_failed:


### PR DESCRIPTION
To avoid flakyness in threat tests, increase waf timeout even more.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
