### PR TITLE
chore(asm): import gc in unpatched

### DIFF
--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -2,7 +2,6 @@
 # require iast, ddwaf or any native optional module.
 
 import ctypes
-import gc
 import os
 from typing import Any
 from typing import Callable
@@ -15,6 +14,7 @@ from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
 from ddtrace.appsec._iast.constants import VULN_PATH_TRAVERSAL
 from ddtrace.internal import core
 from ddtrace.internal._exceptions import BlockingException
+from ddtrace.internal._unpatched import _gc as gc
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.settings.asm import config as asm_config

--- a/ddtrace/internal/_unpatched.py
+++ b/ddtrace/internal/_unpatched.py
@@ -8,3 +8,4 @@ from builtins import open as unpatched_open  # noqa
 # to the threading module used by ddtrace here, we make it easy for those parts
 # to get a reference to the right threading module.
 import threading as _threading  # noqa
+import gc as _gc  # noqa


### PR DESCRIPTION
To avoid any potential issues we should avoid importing critical modules in post-preload hooks.

This PR moves import of gc from asm hooks to intial _unpatched module.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
