### PR TITLE
feat(openai): capture token usage for streamed chat/completions

### DIFF
--- a/ddtrace/contrib/internal/openai/utils.py
+++ b/ddtrace/contrib/internal/openai/utils.py
@@ -283,7 +283,9 @@ def _tag_streamed_response(integration, span, completions_or_messages=None):
             span.set_tag_str("openai.response.choices.%d.message.role" % idx, str(message_role))
         message_content = choice.get("content", "")
         if message_content:
-            span.set_tag_str("openai.response.choices.%d.message.content" % idx, integration.trunc(str(message_content)))
+            span.set_tag_str(
+                "openai.response.choices.%d.message.content" % idx, integration.trunc(str(message_content))
+            )
         finish_reason = choice.get("finish_reason", "")
         if finish_reason:
             span.set_tag_str("openai.response.choices.%d.finish_reason" % idx, str(finish_reason))

--- a/ddtrace/contrib/internal/openai/utils.py
+++ b/ddtrace/contrib/internal/openai/utils.py
@@ -304,11 +304,12 @@ def _set_token_metrics(span, integration, response, prompts, messages, kwargs):
         usage = response[0].get("usage", {})
         prompt_tokens = getattr(usage, "prompt_tokens", 0)
         completion_tokens = getattr(usage, "completion_tokens", 0)
+        total_tokens = getattr(usage, "total_tokens", 0)
     else:
         model_name = span.get_tag("openai.response.model") or kwargs.get("model", "")
         estimated, prompt_tokens = _compute_prompt_tokens(model_name, prompts, messages)
         estimated, completion_tokens = _compute_completion_tokens(response, model_name)
-    total_tokens = prompt_tokens + completion_tokens
+        total_tokens = prompt_tokens + completion_tokens
     span.set_metric("openai.response.usage.prompt_tokens", prompt_tokens)
     span.set_metric("openai.request.prompt_tokens_estimated", int(estimated))
     span.set_metric("openai.response.usage.completion_tokens", completion_tokens)

--- a/ddtrace/contrib/internal/openai/utils.py
+++ b/ddtrace/contrib/internal/openai/utils.py
@@ -353,15 +353,14 @@ def _tag_tool_calls(integration, span, tool_calls, choice_idx):
     # type: (...) -> None
     """
     Tagging logic if function_call or tool_calls are provided in the chat response.
-    Note:
-        - since function calls are deprecated and will be replaced with tool calls, apply the same tagging logic/schema.
+    Note: since function calls are deprecated and will be replaced with tool calls, apply the same tagging logic/schema.
     """
     for idy, tool_call in enumerate(tool_calls):
         if hasattr(tool_call, "function"):
             # tool_call is further nested in a "function" object
             tool_call = tool_call.function
-        function_arguments = tool_call.get("arguments", "")
-        function_name = tool_call.get("name", "")
+        function_arguments = getattr(tool_call, "arguments", "")
+        function_name = getattr(tool_call, "name", "")
         span.set_tag_str(
             "openai.response.choices.%d.message.tool_calls.%d.arguments" % (choice_idx, idy),
             integration.trunc(str(function_arguments)),

--- a/ddtrace/llmobs/_integrations/openai.py
+++ b/ddtrace/llmobs/_integrations/openai.py
@@ -199,16 +199,11 @@ class OpenAIIntegration(BaseLLMIntegration):
             return
         if streamed_messages:
             messages = []
-            for streamed_message in streamed_messages:
-                message = {"content": streamed_message["content"], "role": streamed_message["role"]}
-                tool_calls = streamed_message.get("tool_calls", [])
-                if tool_calls:
-                    message["tool_calls"] = [
-                        {
-                            "name": tool_call.get("name", ""), "arguments": json.loads(tool_call.get("arguments", "")),
-                        } for tool_call in tool_calls
-                    ]
-                messages.append(message)
+            for message in streamed_messages:
+                if "formatted_content" in message:
+                    messages.append({"content": message["formatted_content"], "role": message["role"]})
+                    continue
+                messages.append({"content": message["content"], "role": message["role"]})
             span.set_tag_str(OUTPUT_MESSAGES, json.dumps(messages))
             return
         output_messages = []

--- a/ddtrace/llmobs/_integrations/openai.py
+++ b/ddtrace/llmobs/_integrations/openai.py
@@ -199,11 +199,16 @@ class OpenAIIntegration(BaseLLMIntegration):
             return
         if streamed_messages:
             messages = []
-            for message in streamed_messages:
-                if "formatted_content" in message:
-                    messages.append({"content": message["formatted_content"], "role": message["role"]})
-                    continue
-                messages.append({"content": message["content"], "role": message["role"]})
+            for streamed_message in streamed_messages:
+                message = {"content": streamed_message["content"], "role": streamed_message["role"]}
+                tool_calls = streamed_message.get("tool_calls", [])
+                if tool_calls:
+                    message["tool_calls"] = [
+                        {
+                            "name": tool_call.get("name", ""), "arguments": json.loads(tool_call.get("arguments", "")),
+                        } for tool_call in tool_calls
+                    ]
+                messages.append(message)
             span.set_tag_str(OUTPUT_MESSAGES, json.dumps(messages))
             return
         output_messages = []

--- a/releasenotes/notes/feat-openai-streamed-tokens-ed7f5c6a779006a9.yaml
+++ b/releasenotes/notes/feat-openai-streamed-tokens-ed7f5c6a779006a9.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    openai: The OpenAI integration now captures token data from streamed completions and chat completions, if provided 
+    in the streamed response. To ensure accurate token data in the traced streamed operation, ensure
+    that the ``stream_options={"include_usage": True}`` option is set on the completion or chat completion call.

--- a/releasenotes/notes/feat-openai-streamed-tokens-ed7f5c6a779006a9.yaml
+++ b/releasenotes/notes/feat-openai-streamed-tokens-ed7f5c6a779006a9.yaml
@@ -4,3 +4,7 @@ features:
     openai: The OpenAI integration now captures token data from streamed completions and chat completions, if provided 
     in the streamed response. To ensure accurate token data in the traced streamed operation, ensure
     that the ``stream_options={"include_usage": True}`` option is set on the completion or chat completion call.
+  - |
+    LLM Observability: The OpenAI integration now ensures accurate token data from streamed OpenAI completions and 
+    chat completions, if provided in the streamed response. To ensure accurate token data in the traced streamed operation, 
+    ensure that the ``stream_options={"include_usage": True}`` option is set on the completion or chat completion call.

--- a/tests/contrib/openai/cassettes/v1/chat_completion_streamed_tokens.yaml
+++ b/tests/contrib/openai/cassettes/v1/chat_completion_streamed_tokens.yaml
@@ -1,0 +1,151 @@
+interactions:
+- request:
+    body: '{"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "Who
+      won the world series in 2020?"}], "stream": true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '122'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.0.0-beta.3
+      x-stainless-arch:
+      - arm64
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.0.0-beta.3
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.5
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    content: 'data: {"id":"chatcmpl-77HaPClCxqCQhWCNKcdWAJlHsnAiD","object":"chat.completion.chunk","created":1681970253,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"role":"assistant"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-77HaPClCxqCQhWCNKcdWAJlHsnAiD","object":"chat.completion.chunk","created":1681970253,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"The"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-77HaPClCxqCQhWCNKcdWAJlHsnAiD","object":"chat.completion.chunk","created":1681970253,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        Los"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-77HaPClCxqCQhWCNKcdWAJlHsnAiD","object":"chat.completion.chunk","created":1681970253,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        Angeles"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-77HaPClCxqCQhWCNKcdWAJlHsnAiD","object":"chat.completion.chunk","created":1681970253,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        Dodgers"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-77HaPClCxqCQhWCNKcdWAJlHsnAiD","object":"chat.completion.chunk","created":1681970253,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        won"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-77HaPClCxqCQhWCNKcdWAJlHsnAiD","object":"chat.completion.chunk","created":1681970253,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        the"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-77HaPClCxqCQhWCNKcdWAJlHsnAiD","object":"chat.completion.chunk","created":1681970253,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        World"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-77HaPClCxqCQhWCNKcdWAJlHsnAiD","object":"chat.completion.chunk","created":1681970253,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        Series"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-77HaPClCxqCQhWCNKcdWAJlHsnAiD","object":"chat.completion.chunk","created":1681970253,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        in"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-77HaPClCxqCQhWCNKcdWAJlHsnAiD","object":"chat.completion.chunk","created":1681970253,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"
+        "},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-77HaPClCxqCQhWCNKcdWAJlHsnAiD","object":"chat.completion.chunk","created":1681970253,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"202"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-77HaPClCxqCQhWCNKcdWAJlHsnAiD","object":"chat.completion.chunk","created":1681970253,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"0"},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-77HaPClCxqCQhWCNKcdWAJlHsnAiD","object":"chat.completion.chunk","created":1681970253,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"."},"index":0,"finish_reason":null}]}
+
+
+        data: {"id":"chatcmpl-77HaPClCxqCQhWCNKcdWAJlHsnAiD","object":"chat.completion.chunk","created":1681970253,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{},"index":0,"finish_reason":"stop"}]}
+
+
+        data: {"id":"chatcmpl-77HaPClCxqCQhWCNKcdWAJlHsnAiD","object":"chat.completion.chunk","created":1681970253,"model":"gpt-3.5-turbo-0301","choices":[], "usage": {"completion_tokens": 19, "prompt_tokens": 17, "total_tokens": 36}}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 81aca99e1a3b8cc3-EWR
+      Cache-Control:
+      - no-cache, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Oct 2023 20:17:16 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-model:
+      - ada
+      openai-organization:
+      - datadog-4
+      openai-processing-ms:
+      - '73'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=15724800; includeSubDomains
+      x-ratelimit-limit-requests:
+      - '3000'
+      x-ratelimit-limit-tokens:
+      - '250000'
+      x-ratelimit-limit-tokens_usage_based:
+      - '250000'
+      x-ratelimit-remaining-requests:
+      - '2999'
+      x-ratelimit-remaining-tokens:
+      - '249979'
+      x-ratelimit-remaining-tokens_usage_based:
+      - '249979'
+      x-ratelimit-reset-requests:
+      - 20ms
+      x-ratelimit-reset-tokens:
+      - 4ms
+      x-ratelimit-reset-tokens_usage_based:
+      - 4ms
+      x-request-id:
+      - 13b4d901f024ad5d987ee5ee8217c0cc
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1


### PR DESCRIPTION
This PR adds support to capture token metrics if provided in the OpenAI streamed response. If `stream_options={"include_usage": True}` is specified as an argument in a streamed Completion/ChatCompletion call, OpenAI provides a chunk containing the request/response pair's token usage metrics. 

We do this by prepending the token usage chunk (if provided in the response) at the beginning of the streamed chunks list we keep track of. Instead of computing/estimating token usage from streamed responses (which are not guaranteed to be accurate), we can ensure correct token metrics IF the user adds this option.

This PR also makes a small refactor to clean up the stream handler code involved in getting/setting the token metrics, and submitting token metrics as Datadog integration metrics.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
