### PR TITLE
chore(profiling): improve native module loading [backport-2.10]

### DIFF
--- a/ddtrace/internal/datadog/profiling/ddup/__init__.py
+++ b/ddtrace/internal/datadog/profiling/ddup/__init__.py
@@ -1,4 +1,9 @@
-from .utils import sanitize_string  # noqa: F401
+# This module supports an optional feature.  It may not even load on all platforms or configurations.
+# In ddtrace/settings/profiling.py, this module is imported and the is_available attribute is checked to determine
+# whether the feature is available. If not, then the feature is disabled and all downstream consumption is
+# suppressed.
+is_available = False
+failure_msg = ""
 
 
 try:
@@ -7,89 +12,4 @@ try:
     is_available = True
 
 except Exception as e:
-    from typing import Dict  # noqa:F401
-    from typing import Optional  # noqa:F401
-
-    from ddtrace.internal.logger import get_logger
-
-    LOG = get_logger(__name__)
-    LOG.debug("Failed to import _ddup: %s", e)
-
-    is_available = False
-
-    # Decorator for not-implemented
-    def not_implemented(func):
-        def wrapper(*args, **kwargs):
-            raise NotImplementedError("{} is not implemented on this platform".format(func.__name__))
-
-    @not_implemented
-    def init(
-        env,  # type: Optional[str]
-        service,  # type: Optional[str]
-        version,  # type: Optional[str]
-        tags,  # type: Optional[Dict[str, str]]
-        max_nframes,  # type: Optional[int]
-        url,  # type: Optional[str]
-    ):
-        pass
-
-    @not_implemented
-    def upload():  # type: () -> None
-        pass
-
-    class SampleHandle:
-        @not_implemented
-        def push_cputime(self, value, count):  # type: (int, int) -> None
-            pass
-
-        @not_implemented
-        def push_walltime(self, value, count):  # type: (int, int) -> None
-            pass
-
-        @not_implemented
-        def push_acquire(self, value, count):  # type: (int, int) -> None
-            pass
-
-        @not_implemented
-        def push_release(self, value, count):  # type: (int, int) -> None
-            pass
-
-        @not_implemented
-        def push_alloc(self, value, count):  # type: (int, int) -> None
-            pass
-
-        @not_implemented
-        def push_heap(self, value):  # type: (int) -> None
-            pass
-
-        @not_implemented
-        def push_lock_name(self, lock_name):  # type: (str) -> None
-            pass
-
-        @not_implemented
-        def push_frame(self, name, filename, address, line):  # type: (str, str, int, int) -> None
-            pass
-
-        @not_implemented
-        def push_threadinfo(self, thread_id, thread_native_id, thread_name):  # type: (int, int, Optional[str]) -> None
-            pass
-
-        @not_implemented
-        def push_taskinfo(self, task_id, task_name):  # type: (int, str) -> None
-            pass
-
-        @not_implemented
-        def push_exceptioninfo(self, exc_type, count):  # type: (type, int) -> None
-            pass
-
-        @not_implemented
-        def push_class_name(self, class_name):  # type: (str) -> None
-            pass
-
-        @not_implemented
-        def push_span(self, span, endpoint_collection_enabled):  # type: (Optional[Span], bool) -> None
-            pass
-
-        @not_implemented
-        def flush_sample(self):  # type: () -> None
-            pass
+    failure_msg = str(e)

--- a/ddtrace/internal/datadog/profiling/stack_v2/__init__.py
+++ b/ddtrace/internal/datadog/profiling/stack_v2/__init__.py
@@ -1,34 +1,13 @@
+# See ../ddup/__init__.py for some discussion on the is_available attribute.
+# This component is also loaded in ddtrace/settings/profiling.py
 is_available = False
-
-
-# Decorator for not-implemented
-def not_implemented(func):
-    def wrapper(*args, **kwargs):
-        raise NotImplementedError("{} is not implemented on this platform".format(func.__name__))
-
-
-@not_implemented
-def start(*args, **kwargs):
-    pass
-
-
-@not_implemented
-def stop(*args, **kwargs):
-    pass
-
-
-@not_implemented
-def set_interval(*args, **kwargs):
-    pass
+failure_msg = ""
 
 
 try:
-    from ._stack_v2 import *  # noqa: F401, F403
+    from ._stack_v2 import *  # noqa: F403, F401
 
     is_available = True
+
 except Exception as e:
-    from ddtrace.internal.logger import get_logger
-
-    LOG = get_logger(__name__)
-
-    LOG.debug("Failed to import _stack_v2: %s", e)
+    failure_msg = str(e)

--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -478,7 +478,7 @@ class StackCollector(collector.PeriodicCollector):
     _thread_time = attr.ib(init=False, repr=False, eq=False)
     _last_wall_time = attr.ib(init=False, repr=False, eq=False, type=int)
     _thread_span_links = attr.ib(default=None, init=False, repr=False, eq=False)
-    _stack_collector_v2_enabled = attr.ib(type=bool, default=config.stack.v2.enabled)
+    _stack_collector_v2_enabled = attr.ib(type=bool, default=config.stack.v2_enabled)
 
     @max_time_usage_pct.validator
     def _check_max_time_usage(self, attribute, value):
@@ -497,7 +497,7 @@ class StackCollector(collector.PeriodicCollector):
         if config.export.libdd_enabled:
             set_use_libdd(True)
 
-        # If at the end of things, stack v2 is still enabled, then start the native thread running the v2 sampler
+        # If stack v2 is enabled, then use the v2 sampler
         if self._stack_collector_v2_enabled:
             LOG.debug("Starting the stack v2 sampler")
             stack_v2.start()

--- a/ddtrace/settings/profiling.py
+++ b/ddtrace/settings/profiling.py
@@ -10,8 +10,15 @@ from ddtrace.internal.utils.formats import parse_tags_str
 logger = get_logger(__name__)
 
 
+# Stash the reason why a transitive dependency failed to load; since we try to load things safely in order to guide
+# configuration, these errors won't bubble up naturally.  All of these components should use the same pattern
+# in order to guarantee uniformity.
+ddup_failure_msg = ""
+stack_v2_failure_msg = ""
+
+
 def _derive_default_heap_sample_size(heap_config, default_heap_sample_size=1024 * 1024):
-    # type: (ProfilingConfig.Heap, int) -> int
+    # type: (ProfilingConfigHeap, int) -> int
     heap_sample_size = heap_config._sample_size
     if heap_sample_size is not None:
         return heap_sample_size
@@ -38,18 +45,24 @@ def _derive_default_heap_sample_size(heap_config, default_heap_sample_size=1024 
 
 
 def _check_for_ddup_available():
+    global ddup_failure_msg
     ddup_is_available = False
     try:
         from ddtrace.internal.datadog.profiling import ddup
 
         ddup_is_available = ddup.is_available
+        ddup_failure_msg = ddup.failure_msg
     except Exception:
         pass  # nosec
     return ddup_is_available
 
 
 def _check_for_stack_v2_available():
+    global stack_v2_failure_msg
     stack_v2_is_available = False
+
+    # stack_v2 will use libdd; in order to prevent two separate collectors from running, it then needs to force
+    # libdd to be enabled as well; that means it depends on the libdd interface (ddup)
     if not _check_for_ddup_available():
         return False
 
@@ -57,15 +70,14 @@ def _check_for_stack_v2_available():
         from ddtrace.internal.datadog.profiling import stack_v2
 
         stack_v2_is_available = stack_v2.is_available
+        stack_v2_failure_msg = stack_v2.failure_msg
     except Exception:
         pass  # nosec
     return stack_v2_is_available
 
 
-# We don't check for the availability of the ddup module when determining whether libdd is _required_,
-# since it's up to the application code to determine what happens in that failure case.
 def _is_libdd_required(config):
-    return config.stack.v2.enabled or config._libdd_required
+    return config.stack.v2_enabled or config.export._libdd_enabled
 
 
 class ProfilingConfig(En):
@@ -220,98 +232,125 @@ class ProfilingConfig(En):
 
             enabled = En.d(bool, lambda c: _check_for_stack_v2_available() and c._enabled)
 
-    class Lock(En):
-        __item__ = __prefix__ = "lock"
 
-        enabled = En.v(
-            bool,
-            "enabled",
-            default=True,
-            help_type="Boolean",
-            help="Whether to enable the lock profiler",
-        )
+class ProfilingConfigStack(En):
+    __item__ = __prefix__ = "stack"
 
-        name_inspect_dir = En.v(
-            bool,
-            "name_inspect_dir",
-            default=True,
-            help_type="Boolean",
-            help="Whether to inspect the ``dir()`` of local and global variables to find the name of the lock. "
-            "With this enabled, the profiler finds the name of locks that are attributes of an object.",
-        )
+    enabled = En.v(
+        bool,
+        "enabled",
+        default=True,
+        help_type="Boolean",
+        help="Whether to enable the stack profiler",
+    )
 
-    class Memory(En):
-        __item__ = __prefix__ = "memory"
+    _v2_enabled = En.v(
+        bool,
+        "v2_enabled",
+        default=False,
+        help_type="Boolean",
+        help="Whether to enable the v2 stack profiler. Also enables the libdatadog collector.",
+    )
 
-        enabled = En.v(
-            bool,
-            "enabled",
-            default=True,
-            help_type="Boolean",
-            help="Whether to enable the memory profiler",
-        )
+    # V2 can't be enabled if stack collection is disabled or if pre-requisites are not met
+    v2_enabled = En.d(bool, lambda c: _check_for_stack_v2_available() and c._v2_enabled and c.enabled)
 
-        events_buffer = En.v(
-            int,
-            "events_buffer",
-            default=16,
-            help_type="Integer",
-            help="",
-        )
 
-    class Heap(En):
-        __item__ = __prefix__ = "heap"
+class ProfilingConfigLock(En):
+    __item__ = __prefix__ = "lock"
 
-        enabled = En.v(
-            bool,
-            "enabled",
-            default=True,
-            help_type="Boolean",
-            help="Whether to enable the heap memory profiler",
-        )
+    enabled = En.v(
+        bool,
+        "enabled",
+        default=True,
+        help_type="Boolean",
+        help="Whether to enable the lock profiler",
+    )
 
-        _sample_size = En.v(
-            t.Optional[int],
-            "sample_size",
-            default=None,
-            help_type="Integer",
-            help="",
-        )
-        sample_size = En.d(int, _derive_default_heap_sample_size)
+    name_inspect_dir = En.v(
+        bool,
+        "name_inspect_dir",
+        default=True,
+        help_type="Boolean",
+        help="Whether to inspect the ``dir()`` of local and global variables to find the name of the lock. "
+        "With this enabled, the profiler finds the name of locks that are attributes of an object.",
+    )
 
-    class Export(En):
-        __item__ = __prefix__ = "export"
 
-        _libdd_required = En.v(
-            bool,
-            "libdd_required",
-            default=False,
-            help_type="Boolean",
-            help="Requires the native exporter to be enabled",
-        )
+class ProfilingConfigMemory(En):
+    __item__ = __prefix__ = "memory"
 
-        libdd_required = En.d(
-            bool,
-            _is_libdd_required,
-        )
+    enabled = En.v(
+        bool,
+        "enabled",
+        default=True,
+        help_type="Boolean",
+        help="Whether to enable the memory profiler",
+    )
 
-        _libdd_enabled = En.v(
-            bool,
-            "libdd_enabled",
-            default=False,
-            help_type="Boolean",
-            help="Enables collection and export using a native exporter.  Can fallback to the pure-Python exporter.",
-        )
+    events_buffer = En.v(
+        int,
+        "events_buffer",
+        default=16,
+        help_type="Integer",
+        help="",
+    )
 
-        libdd_enabled = En.d(
-            bool, lambda c: (_is_libdd_required(c) or c._libdd_enabled) and _check_for_ddup_available()
-        )
 
-    Export.include(Stack, namespace="stack")
+class ProfilingConfigHeap(En):
+    __item__ = __prefix__ = "heap"
 
+    enabled = En.v(
+        bool,
+        "enabled",
+        default=True,
+        help_type="Boolean",
+        help="Whether to enable the heap memory profiler",
+    )
+
+    _sample_size = En.v(
+        t.Optional[int],
+        "sample_size",
+        default=None,
+        help_type="Integer",
+        help="",
+    )
+    sample_size = En.d(int, _derive_default_heap_sample_size)
+
+
+class ProfilingConfigExport(En):
+    __item__ = __prefix__ = "export"
+
+    _libdd_enabled = En.v(
+        bool,
+        "libdd_enabled",
+        default=False,
+        help_type="Boolean",
+        help="Enables collection and export using a native exporter.  Can fallback to the pure-Python exporter.",
+    )
+
+
+# Include all the sub-configs
+ProfilingConfig.include(ProfilingConfigStack, namespace="stack")
+ProfilingConfig.include(ProfilingConfigLock, namespace="lock")
+ProfilingConfig.include(ProfilingConfigMemory, namespace="memory")
+ProfilingConfig.include(ProfilingConfigHeap, namespace="heap")
+ProfilingConfig.include(ProfilingConfigExport, namespace="export")
 
 config = ProfilingConfig()
 
-if config.export.libdd_required and not config.export.libdd_enabled:
-    logger.warning("The native exporter is required, but not enabled. Disabling profiling.")
-    config.enabled = False
+# Force the enablement of libdd if the user requested a feature which requires it; otherwise the user has to manage
+# configuration too intentionally and we'll need to change the API too much over time.
+config.export.libdd_enabled = _is_libdd_required(config)
+
+# Certain features depend on libdd being available.  If it isn't for some reason, those features cannot be enabled.
+if config.stack.v2_enabled and not config.export.libdd_enabled:
+    msg = ddup_failure_msg or "libdd not available"
+    logger.warning("The v2 stack profiler cannot be used (%s)", msg)
+    config.stack.v2_enabled = False
+
+# Loading stack_v2 can fail for similar reasons
+if config.stack.v2_enabled and not _check_for_stack_v2_available():
+    msg = stack_v2_failure_msg or "stack_v2 not available"
+    logger.warning("The v2 stack profiler cannot be used (%s)", msg)
+    config.stack.v2_enabled = False


### PR DESCRIPTION
Manual backport of #9719 to 2.10

Crashtracker was not backported to 2.10 and this PR is #9719 without crashtracker edits. 

The profiler bundles some native components which are not available on all platforms. The pattern we were using for detecting and handling this case was needlessly fiddly and incomplete.

This patch refactors some aspects of this.

## Checklist
- [x] The PR description includes an overview of the change
- [x] The PR description articulates the motivation for the change
- [x] The change includes tests OR the PR description describes a testing strategy
- [x] The PR description notes risks associated with the change, if any
- [x] Newly-added code is easy to change
- [x] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [x] The change includes or references documentation updates if necessary
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Title is accurate
- [x] All changes are related to the pull request's stated goal
- [x] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [x] Testing strategy adequately addresses listed risks
- [x] Newly-added code is easy to change
- [x] Release note makes sense to a user of the library
- [x] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [x] Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

(cherry picked from commit 20579134bf261f40c2632af05208ea95eab43690)
