### PR TITLE
chore: set default parallel level for build_ext

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -382,6 +382,9 @@ class CMakeBuild(build_ext):
             # DEV: -j is supported in CMake 3.12+ only.
             if hasattr(self, "parallel") and self.parallel:
                 build_args += ["-j{}".format(self.parallel)]
+            else:
+                njobs = os.cpu_count() or 1
+                build_args += ["-j{}".format(njobs)]
 
         # Arguments to cmake --install command
         install_args = ext.install_args or []

--- a/setup.py
+++ b/setup.py
@@ -381,10 +381,11 @@ class CMakeBuild(build_ext):
             # using -j in the build_ext call, not supported by pip or PyPA-build.
             # DEV: -j is supported in CMake 3.12+ only.
             if hasattr(self, "parallel") and self.parallel:
-                cmake_args += ["-DCMAKE_BUILD_PARALLEL_LEVEL={}".format(self.parallel)]
+                build_args += ["-j{}".format(self.parallel)]
             else:
-                njobs = os.cpu_count() or 1
-                cmake_args += ["-DCMAKE_BUILD_PARALLEL_LEVEL={}".format(njobs)]
+                nprocs = len(os.sched_getaffinity(0))
+                if nprocs:
+                    build_args += ["-j{}".format(nprocs)]
 
         # Arguments to cmake --install command
         install_args = ext.install_args or []

--- a/setup.py
+++ b/setup.py
@@ -381,10 +381,10 @@ class CMakeBuild(build_ext):
             # using -j in the build_ext call, not supported by pip or PyPA-build.
             # DEV: -j is supported in CMake 3.12+ only.
             if hasattr(self, "parallel") and self.parallel:
-                build_args += ["-j{}".format(self.parallel)]
+                cmake_args += ["-DCMAKE_BUILD_PARALLEL_LEVEL={}".format(self.parallel)]
             else:
                 njobs = os.cpu_count() or 1
-                build_args += ["-j{}".format(njobs)]
+                cmake_args += ["-DCMAKE_BUILD_PARALLEL_LEVEL={}".format(njobs)]
 
         # Arguments to cmake --install command
         install_args = ext.install_args or []


### PR DESCRIPTION
Sometimes we forget to set `CMAKE_BUILD_PARALLEL_LEVEL` as in https://github.com/DataDog/system-tests/pull/2876/files#diff-c8613d72fa796e8b51855229a46980f43859107cc8f8251839d13b11de883e15 or underlying tool makes it hard to set it correctly https://github.com/DataDog/dd-trace-py/pull/10129#discussion_r1708158004

This shaves off about ~1min from system-tests-build. Looks like build_wheels on mac are also faster with this. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
