### PR TITLE
chore(debugger): include locals/globals in evals

### DIFF
--- a/ddtrace/debugging/_signal/metric_sample.py
+++ b/ddtrace/debugging/_signal/metric_sample.py
@@ -40,14 +40,14 @@ class MetricSample(LogSignal):
             return
 
         probe = self.probe
-        _args = self._enrich_args(retval, exc_info, duration)
+        _locals = self._enrich_locals(retval, exc_info, duration)
 
         if probe.evaluate_at != ProbeEvaluateTimingForMethod.EXIT:
             return
-        if not self._eval_condition(_args):
+        if not self._eval_condition(_locals):
             return
 
-        self.sample(_args)
+        self.sample(_locals)
         self.state = SignalState.DONE
 
     def line(self) -> None:

--- a/ddtrace/debugging/_signal/snapshot.py
+++ b/ddtrace/debugging/_signal/snapshot.py
@@ -147,10 +147,10 @@ class Snapshot(LogSignal):
             return
 
         probe = self.probe
-        _args = self._enrich_args(retval, exc_info, duration)
+        _locals = self._enrich_locals(retval, exc_info, duration)
 
         if probe.evaluate_at == ProbeEvaluateTimingForMethod.EXIT:
-            if not self._eval_condition(_args):
+            if not self._eval_condition(_locals):
                 return
             if probe.limiter.limit() is RateLimitExceeded:
                 self.state = SignalState.SKIP_RATE
@@ -172,7 +172,7 @@ class Snapshot(LogSignal):
         self.duration = duration
         self.state = SignalState.DONE
         if probe.evaluate_at != ProbeEvaluateTimingForMethod.ENTER:
-            self._eval_message(dict(_args))
+            self._eval_message(dict(_locals))
 
         stack = utils.capture_stack(self.frame)
 

--- a/ddtrace/debugging/_signal/tracing.py
+++ b/ddtrace/debugging/_signal/tracing.py
@@ -129,7 +129,7 @@ class SpanDecoration(LogSignal):
             return
 
         if probe.evaluate_at == ProbeEvaluateTimingForMethod.EXIT:
-            self._decorate_span(self._enrich_args(retval, exc_info, duration))
+            self._decorate_span(self._enrich_locals(retval, exc_info, duration))
             self.state = SignalState.DONE
 
     def line(self):

--- a/tests/debugging/signal/test_model.py
+++ b/tests/debugging/signal/test_model.py
@@ -5,9 +5,32 @@ from ddtrace.debugging._signal.snapshot import Snapshot
 from tests.debugging.utils import create_log_function_probe
 
 
+def test_enriched_args_locals_globals():
+    duration = 123456
+    _locals = dict(
+        Snapshot(
+            probe=create_log_function_probe(
+                probe_id="test_duration_millis",
+                module="foo",
+                func_qname="bar",
+                template="",
+                segments=[],
+            ),
+            frame=sys._getframe(),
+            thread=current_thread(),
+        )._enrich_locals(None, (None, None, None), duration)
+    )
+
+    # Check for globals
+    assert "__file__" in _locals
+
+    # Check for locals
+    assert "duration" in _locals
+
+
 def test_duration_millis():
     duration = 123456
-    args = Snapshot(
+    _locals = Snapshot(
         probe=create_log_function_probe(
             probe_id="test_duration_millis",
             module="foo",
@@ -17,6 +40,6 @@ def test_duration_millis():
         ),
         frame=sys._getframe(),
         thread=current_thread(),
-    )._enrich_args(None, (None, None, None), duration)
+    )._enrich_locals(None, (None, None, None), duration)
 
-    assert args["@duration"] == duration / 1e6
+    assert _locals["@duration"] == duration / 1e6


### PR DESCRIPTION
We make sure that local and global variables are available to expression evaluations on function probe exit.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
