### PR TITLE
chore(debugger): guard inline wrapping operations

### DIFF
--- a/ddtrace/debugging/_debugger.py
+++ b/ddtrace/debugging/_debugger.py
@@ -172,22 +172,7 @@ class DebuggerWrappingContext(WrappingContext):
     def has_probes(self) -> bool:
         return bool(self.probes)
 
-    def _close_contexts(self, retval=None, exc_info=(None, None, None)) -> None:
-        end_time = compat.monotonic_ns()
-        contexts = self.get("contexts")
-        while contexts:
-            # Open probe signal contexts are ordered, with those that have
-            # created new tracing context first. We need to finalise them in
-            # reverse order, so we pop them from the end of the queue (LIFO).
-            context = contexts.pop()
-            context.exit(retval, exc_info, end_time - self.get("start_time"))
-            signal = context.signal
-            if signal.state is SignalState.DONE:
-                self._probe_registry.set_emitting(signal.probe)
-
-    def __enter__(self) -> "DebuggerWrappingContext":
-        super().__enter__()
-
+    def _open_contexts(self) -> None:
         frame = self.__frame__
         assert frame is not None  # nosec
 
@@ -253,16 +238,43 @@ class DebuggerWrappingContext(WrappingContext):
         self.set("start_time", compat.monotonic_ns())
         self.set("contexts", contexts)
 
+    def _close_contexts(self, retval=None, exc_info=(None, None, None)) -> None:
+        end_time = compat.monotonic_ns()
+        contexts = self.get("contexts")
+        while contexts:
+            # Open probe signal contexts are ordered, with those that have
+            # created new tracing context first. We need to finalise them in
+            # reverse order, so we pop them from the end of the queue (LIFO).
+            context = contexts.pop()
+            context.exit(retval, exc_info, end_time - self.get("start_time"))
+            signal = context.signal
+            if signal.state is SignalState.DONE:
+                self._probe_registry.set_emitting(signal.probe)
+
+    def __enter__(self) -> "DebuggerWrappingContext":
+        super().__enter__()
+
+        try:
+            self._open_contexts()
+        except Exception:
+            log.exception("Failed to open debugging contexts")
+
         return self
 
     def __return__(self, value: T) -> T:
-        self._close_contexts(retval=value)
+        try:
+            self._close_contexts(retval=value)
+        except Exception:
+            log.exception("Failed to close debugging contexts from return")
         return super().__return__(value)
 
     def __exit__(
         self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
     ) -> None:
-        self._close_contexts(exc_info=(exc_type, exc_val, exc_tb))
+        try:
+            self._close_contexts(exc_info=(exc_type, exc_val, exc_tb))
+        except Exception:
+            log.exception("Failed to close debugging contexts from exception block")
         super().__exit__(exc_type, exc_val, exc_tb)
 
 


### PR DESCRIPTION
We guard the debugger inline wrapping operations with exception blocks to prevent causing an exception in the wrapped function which would result in altered behaviour.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
