### PR TITLE
chore: add sccache to testrunner docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,7 @@ FROM debian:buster-20221219-slim
 
 ARG TARGETARCH
 ARG HATCH_VERSION=1.8.1
+ENV SCCACHE_VERSION=0.8.1
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
@@ -82,5 +83,13 @@ RUN if [ "$TARGETARCH" = "amd64" ]; \
   && mv hatch-${HATCH_VERSION}-* hatch \
   && install -t /usr/local/bin hatch \
   && hatch -q
+
+RUN if [ "$TARGETARCH" = "amd64" ]; \
+    then curl -L https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz | tar zx; \
+    else curl -L https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-aarch64-unknown-linux-musl.tar.gz | tar zx; \
+    fi \
+    && mv sccache-v${SCCACHE_VERSION}-* sccache \
+    && install -t /usr/local/bin sccache/sccache \
+    && sccache --version
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Tested locally
1. modify docker-compose.yml 

```
     testrunner:
        build:
          context: ./docker
          dockerfile: Dockerfile
```

2. run tests using `riot run` 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
