### PR TITLE
chore(ci): add logging when pytest raised OSError on shutdown

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,17 +61,19 @@ if os.environ.get("CI") == "true":
             except Exception as e:
                 import traceback
 
-                print("Failed to close FDCapture", e)
+                # Write to stderr since pytest captures and hides stdout by default
+                sys.stderr.write("Failed to close FDCapture: %s\n" % e)
                 traceback.print_exc()
 
-                print(f"FDCapture: {self!r}")
+                sys.stderr.write(f"FDCapture: {self!r}\n")
                 for name in ("_state", "tmpfile", "syscapture", "target_save", "targetfd_save", "targetfd_invalid"):
                     value = "<unknown>"
                     try:
                         value = getattr(self, name, "<unknown>")
                     except Exception:
                         pass
-                    print(f"FDCapture.{name}: {value!r}")
+                    sys.stderr.write(f"FDCapture.{name}: {value!r}\n")
+                sys.stderr.flush()
 
                 # Try to mark the state as done anyways....
                 try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,7 @@ if os.environ.get("CI") == "true":
                 traceback.print_exc()
 
                 sys.stderr.write(f"FDCapture: {self!r}\n")
-                for name in ("_state", "tmpfile", "syscapture", "target_save", "targetfd_save", "targetfd_invalid"):
+                for name in ("_state", "tmpfile", "syscapture", "targetfd", "targetfd_save", "targetfd_invalid"):
                     value = "<unknown>"
                     try:
                         value = getattr(self, name, "<unknown>")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,16 +59,25 @@ if os.environ.get("CI") == "true":
             try:
                 original_done(self)
             except Exception as e:
-                # Try to mark the state as done anyways.... :shrug: ?
-                try:
-                    self._state = "done"
-                except Exception:
-                    pass
-
                 import traceback
 
                 print("Failed to close FDCapture", e)
                 traceback.print_exc()
+
+                print(f"FDCapture: {self!r}")
+                for name in ("_state", "tmpfile", "syscapture", "target_save", "targetfd_save", "targetfd_invalid"):
+                    value = "<unknown>"
+                    try:
+                        value = getattr(self, name, "<unknown>")
+                    except Exception:
+                        pass
+                    print(f"FDCapture.{name}: {value!r}")
+
+                # Try to mark the state as done anyways....
+                try:
+                    self._state = "done"
+                except Exception:
+                    pass
 
         FDCapture.done = wrapped_done
     except Exception as e:


### PR DESCRIPTION
This PR attempts to:

1. Grab more information about the consistent exception we are getting on pytest shutdown
2. Make this error no longer prevent a job from finishing

We monkeypatch the `_pytest.capture.FDCapture.done` method to wrap it in a `try/except` block and add logging when we get the exception, while also not re-raising the exception.

Since the job won't be failing anymore, we have to manually look for the error and debug on successful jobs.

Risks: if something with this change fails it may cause exceptions on non-internal jobs, but given the failure rate on internal jobs it can't be too much worse than what we have now.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
