### PR TITLE
fix(profiling): fix endpoint profiling for stack v2

### DIFF
--- a/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
+++ b/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
@@ -284,10 +284,10 @@ cdef class SampleHandle:
             span_type_bytes = ensure_binary_or_empty(span._local_root.span_type)
             ddup_push_trace_type(self.ptr, string_view(<const char*>span_type_bytes, len(span_type_bytes)))
         if endpoint_collection_enabled:
-            root_service_bytes = ensure_binary_or_empty(span._local_root.service)
+            root_resource_bytes = ensure_binary_or_empty(span._local_root.resource)
             ddup_push_trace_resource_container(
                     self.ptr,
-                    string_view(<const char*>root_service_bytes, len(root_service_bytes))
+                    string_view(<const char*>root_resource_bytes, len(root_resource_bytes))
             )
 
     def push_monotonic_ns(self, monotonic_ns: int) -> None:

--- a/releasenotes/notes/profiling-fix-endpoint-v2-a6ca2ebbc9701fe5.yaml
+++ b/releasenotes/notes/profiling-fix-endpoint-v2-a6ca2ebbc9701fe5.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    profiling: Fixes endpoing profiling for stack v2, that is when
+    ``DD_PROFILING_STACK_V2_ENABLED`` set.
+


### PR DESCRIPTION
Stack v1 implementation
https://github.com/DataDog/dd-trace-py/blob/9029186edf9d21e3ff375eb694e60d47f92c0f96/ddtrace/profiling/event.py#L107-L108

Wrong stack v2 implementation
https://github.com/DataDog/dd-trace-py/blob/f42fb50fcef8ef4dd00c168551a5e3b624c25878/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx#L286-L287

Found this while working on #10230. Submitting this as a separate PR to merge and backport this ASAP. 


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
