### PR TITLE
chore: forksafe awakeable periodic service

### DIFF
--- a/ddtrace/internal/periodic.py
+++ b/ddtrace/internal/periodic.py
@@ -94,3 +94,15 @@ class AwakeablePeriodicService(PeriodicService):
         # type: (...) -> None
         if self._worker:
             self._worker.awake()
+
+
+class ForksafeAwakeablePeriodicService(AwakeablePeriodicService):
+    """An awakeable periodic service that auto-restarts on fork."""
+
+    def _start_service(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        super()._start_service(*args, **kwargs)
+        forksafe.register(super()._start_service)
+
+    def _stop_service(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        forksafe.unregister(super()._start_service)
+        super()._stop_service(*args, **kwargs)

--- a/tests/internal/test_periodic.py
+++ b/tests/internal/test_periodic.py
@@ -1,3 +1,4 @@
+import os
 from threading import Event
 from time import sleep
 
@@ -119,3 +120,29 @@ def test_awakeable_periodic_service():
     awake_me.stop()
 
     assert queue == list(range(n + 1))
+
+
+def test_forksafe_awakeable_periodic_service():
+    queue = []
+
+    class AwakeMe(periodic.ForksafeAwakeablePeriodicService):
+        def periodic(self):
+            queue.append(len(queue))
+
+    awake_me = AwakeMe(0.1)
+    awake_me.start()
+
+    pid = os.fork()
+    if pid == 0:
+        # child: check that the thread has been restarted
+        queue.clear()
+        assert not queue
+        awake_me.awake()
+        assert queue
+        os._exit(42)
+
+    awake_me.stop()
+
+    _, status = os.waitpid(pid, 0)
+    exit_code = os.WEXITSTATUS(status)
+    assert exit_code == 42


### PR DESCRIPTION
We implement a variant of the awakeable periodic service that is also forksafe. That is, it will auto-restart on fork in the child process.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
