### PR TITLE
chore(ci): refactor gitlab benchmarks stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,6 @@ stages:
   - shared-pipeline
   - dogfood
   - benchmarks
-  - benchmarks-pr-comment
   - macrobenchmarks
   - dogfood
 

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -35,11 +35,34 @@ variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
     CARGO_NET_GIT_FETCH_WITH_CLI: "true" # use system git binary to pull git dependencies
 
+microbenchmarks:
+  extends: .benchmarks
+  parallel:
+    matrix:
+      - SCENARIO:
+        - "span"
+        - "tracer"
+        - "sampling_rule_matches"
+        - "set_http_meta"
+        - "django_simple"
+        - "flask_simple"
+        - "flask_sqli"
+        - "core_api"
+        - "otel_span"
+        - "appsec_iast_propagation"
+        - "appsec_iast_aspects"
+        # Flaky. Timeout errors
+        # - "encoder"
+        - "http_propagation_extract"
+        - "http_propagation_inject"
+        - "rate_limiter"
+
 benchmarks-pr-comment:
-  stage: benchmarks-pr-comment
-  when: always
-  tags: ["arch:amd64"]
   image: $MICROBENCHMARKS_CI_IMAGE
+  tags: ["arch:amd64"]
+  stage: benchmarks
+  needs: [ "microbenchmarks" ]
+  when: always
   script:
     - export REPORTS_DIR="$(pwd)/reports/" && (mkdir "${REPORTS_DIR}" || :)
     - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
@@ -54,84 +77,6 @@ benchmarks-pr-comment:
     UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME # The branch or tag name for which project is built.
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA # The commit revision the project is built for.
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-py
-
-benchmark-span:
-  extends: .benchmarks
-  variables:
-    SCENARIO: "span"
-
-benchmark-tracer:
-  extends: .benchmarks
-  variables:
-    SCENARIO: "tracer"
-
-benchmark-sampling-rule-matches:
-  extends: .benchmarks
-  variables:
-    SCENARIO: "sampling_rule_matches"
-
-benchmark-set-http-meta:
-  extends: .benchmarks
-  variables:
-    SCENARIO: "set_http_meta"
-
-benchmark-django-simple:
-  extends: .benchmarks
-  timeout: 1h 30m
-  variables:
-    SCENARIO: "django_simple"
-
-benchmark-flask-simple:
-  extends: .benchmarks
-  timeout: 1h 30m
-  variables:
-    SCENARIO: "flask_simple"
-
-benchmark-flask-sqli:
-  extends: .benchmarks
-  variables:
-    SCENARIO: "flask_sqli"
-
-benchmark-core-api:
-  extends: .benchmarks
-  variables:
-    SCENARIO: "core_api"
-
-benchmark-otel-span:
-  extends: .benchmarks
-  variables:
-    SCENARIO: "otel_span"
-
-appsec-iast-propagation:
-  extends: .benchmarks
-  variables:
-    SCENARIO: "appsec_iast_propagation"
-
-appsec-iast-aspects:
-    extends: .benchmarks
-    variables:
-        SCENARIO: "appsec_iast_aspects"
-
-# Flaky benchmark test. Timeout errors
-#benchmark-encoder:
-#  extends: .benchmarks
-#  variables:
-#    SCENARIO: "encoder"
-
-benchmark-http-propagation-extract:
-  extends: .benchmarks
-  variables:
-    SCENARIO: "http_propagation_extract"
-
-benchmark-http-propagation-inject:
-  extends: .benchmarks
-  variables:
-    SCENARIO: "http_propagation_inject"
-
-benchmark-rate-limiter:
-  extends: .benchmarks
-  variables:
-    SCENARIO: "rate_limiter"
 
 benchmark-serverless:
   stage: benchmarks

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -83,8 +83,7 @@ benchmark-serverless:
   image: $SLS_CI_IMAGE
   tags: ["arch:amd64"]
   when: on_success
-  needs:
-    - benchmark-serverless-trigger
+  needs: [ "benchmark-serverless-trigger" ]
   script:
     - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/serverless-tools.git ./serverless-tools && cd ./serverless-tools
     - ./ci/check_trigger_status.sh
@@ -96,6 +95,7 @@ benchmark-serverless-trigger:
   trigger:
     project: DataDog/serverless-tools
     strategy: depend
+  needs: []
   allow_failure: true
   variables:
     UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID


### PR DESCRIPTION
The microbenchmarking setup was really repetitive and could easily be refactored to use a matrix instead of individual jobs.

This refactor also gives us the benefit of collapsing all benchmark runs under a single "microbenchmark" item in the UI so it takes up less real estate. It also allows us to get rid of the benchmark pr comment specific stage and instead make it just depend on the single "microbenchmarks" job.

We also trigger the serverless benchmarks immediately instead of waiting on prior stages completion first.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
