### PR TITLE
chore(rc): register restart on fork

### DIFF
--- a/ddtrace/internal/remoteconfig/worker.py
+++ b/ddtrace/internal/remoteconfig/worker.py
@@ -34,6 +34,7 @@ class RemoteConfigPoller(periodic.PeriodicService):
         self._client = RemoteConfigClient()
         self._state = self._agent_check
         self._parent_id = os.getpid()
+        self._products_to_restart_on_fork = set()
         log.debug("RemoteConfigWorker created with polling interval %d", get_poll_interval_seconds())
 
     def _agent_check(self):
@@ -92,8 +93,10 @@ class RemoteConfigPoller(periodic.PeriodicService):
         # type: () -> None
         """Client Id needs to be refreshed when application forks"""
         self._enable = False
-        log.debug("[%s][P: %s] Remote Config Poller fork. Refreshing state", os.getpid(), os.getppid())
+        log.debug("[%d][P: %d] Remote Config Poller fork. Refreshing state", os.getpid(), os.getppid())
         self._client.renew_id()
+        self.start_subscribers_by_product(self._products_to_restart_on_fork)
+        log.debug("[%d][P: %d] Remote Config Poller restarted services: %s", str(self._products_to_restart_on_fork))
 
     def start_subscribers_by_product(self, products_list):
         # type: (List[str]) -> None
@@ -147,8 +150,8 @@ class RemoteConfigPoller(periodic.PeriodicService):
         """
         return self._client.update_product_callback(product, callback)
 
-    def register(self, product, pubsub_instance, skip_enabled=False):
-        # type: (str, PubSub, bool) -> None
+    def register(self, product, pubsub_instance, skip_enabled=False, restart_on_fork=False):
+        # type: (str, PubSub, bool, bool) -> None
         try:
             # By enabling on registration we ensure we start the RCM client only
             # if there is at least one registered product.
@@ -158,6 +161,9 @@ class RemoteConfigPoller(periodic.PeriodicService):
             self._client.register_product(product, pubsub_instance)
             if not self._client.is_subscriber_running(pubsub_instance):
                 pubsub_instance.start_subscriber()
+
+            if restart_on_fork:
+                self._products_to_restart_on_fork.add(product)
         except Exception:
             log.debug("error starting the RCM client", exc_info=True)
 


### PR DESCRIPTION
We allow products being registered with remote config to specify whether they need to be automatically restarted on fork.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
