### PR TITLE
chore: reset logic for forksafe periodic service

### DIFF
--- a/ddtrace/internal/periodic.py
+++ b/ddtrace/internal/periodic.py
@@ -99,10 +99,22 @@ class AwakeablePeriodicService(PeriodicService):
 class ForksafeAwakeablePeriodicService(AwakeablePeriodicService):
     """An awakeable periodic service that auto-restarts on fork."""
 
+    def reset(self) -> None:
+        """Reset the service on fork.
+
+        Implement this to clear the service state before restarting the thread
+        in the child process.
+        """
+        pass
+
+    def _restart(self) -> None:
+        self.reset()
+        super()._start_service()
+
     def _start_service(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         super()._start_service(*args, **kwargs)
-        forksafe.register(super()._start_service)
+        forksafe.register(self._restart)
 
     def _stop_service(self, *args: typing.Any, **kwargs: typing.Any) -> None:
-        forksafe.unregister(super()._start_service)
+        forksafe.unregister(self._restart)
         super()._stop_service(*args, **kwargs)

--- a/tests/internal/test_periodic.py
+++ b/tests/internal/test_periodic.py
@@ -123,19 +123,24 @@ def test_awakeable_periodic_service():
 
 
 def test_forksafe_awakeable_periodic_service():
-    queue = []
+    queue = [None]
 
     class AwakeMe(periodic.ForksafeAwakeablePeriodicService):
+        def reset(self):
+            queue.clear()
+
         def periodic(self):
             queue.append(len(queue))
 
-    awake_me = AwakeMe(0.1)
+    awake_me = AwakeMe(1)
     awake_me.start()
+
+    assert queue
 
     pid = os.fork()
     if pid == 0:
-        # child: check that the thread has been restarted
-        queue.clear()
+        # child: check that the thread has been restarted and the state has been
+        # reset
         assert not queue
         awake_me.awake()
         assert queue


### PR DESCRIPTION
It is likely that a periodic service wanting to restart after fork needs some clean-up logic to be triggered before the periodic worker process is spawned. We extend the API with a reset method that needs to be implemented in order to define such logic when needed.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
