### PR TITLE
chore(ci): ensure 'fix' PRs include a release note

### DIFF
--- a/scripts/check-releasenotes
+++ b/scripts/check-releasenotes
@@ -8,6 +8,15 @@ echo "JQ: $(which jq)"
 # Skip the label check if we do not have a GitHub event path
 if [[ -f "${GITHUB_EVENT_PATH}" ]] && jq -e '.pull_request?.labels[]?.name | select(. == "changelog/no-changelog")' "${GITHUB_EVENT_PATH}";
 then
+    PR_TITLE=$(jq -er '.pull_request?.title' "${GITHUB_EVENT_PATH}")
+
+    if [[ "${PR_TITLE}" == "fix"* ]];
+    then
+        echo "Fix PRs must have a changelog entry, remove the 'changelog/no-changelog' label"
+        echo "Use 'reno new <slug>' to add a new note to 'releasenotes/notes'"
+        exit 1
+    fi
+
     echo "PR has label 'changelog/no-changelog', skipping validation"
     exit 0
 fi


### PR DESCRIPTION
PR https://github.com/DataDog/dd-trace-py/pull/10112 was merged, backported, and released without a release note. This causes confusion when the changelog/release notes do not reflect what is include in the release.

This PR updates the release note CI check to explicitly fail if the PR title starts with `fix` and includes the `changelog/no-changelog` label.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
