### PR TITLE
fix(internal): handle native module specs

### DIFF
--- a/ddtrace/internal/module.py
+++ b/ddtrace/internal/module.py
@@ -194,14 +194,15 @@ class _ImportHookChainedLoader:
         self.transformers[key] = transformer
 
     def call_back(self, module: ModuleType) -> None:
-        # Restore the original loader
+        # Restore the original loader, if possible. Some specs might be native
+        # and won't support attribute assignment.
         try:
             module.__loader__ = self.loader
-        except AttributeError:
+        except (AttributeError, TypeError):
             pass
         try:
             module.spec.loader = self.loader
-        except AttributeError:
+        except (AttributeError, TypeError):
             pass
 
         if module.__name__ == "pkg_resources":
@@ -235,7 +236,10 @@ class _ImportHookChainedLoader:
         else:
             module = self.loader.load_module(fullname)
 
-        self.call_back(module)
+        try:
+            self.call_back(module)
+        except Exception:
+            log.exception("Failed to call back on module %s", module)
 
         return module
 

--- a/releasenotes/notes/fix-module-callback-type-error-ba5583fa8e2cf0fc.yaml
+++ b/releasenotes/notes/fix-module-callback-type-error-ba5583fa8e2cf0fc.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed an issue with some module imports with native specs that don't support
+    attribute assignments, resulting in a ``TypeError`` exception at runtime.


### PR DESCRIPTION
We add handling of native module specs in the chained loader to prevent `TypeError` exceptions being thrown when the original loader and spec are being set when calling back on module import.

Addresses #10285.

## Testing Strategy

The issue was caught in yum-based Linux OS distributions. We will look into adding a regression test for this scenario later.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
