### PR TITLE
fix: fix ddtrace file attributes being stripped when repairing linux wheels

### DIFF
--- a/releasenotes/notes/fix-wheel-file-permissions-59b497ed8163e885.yaml
+++ b/releasenotes/notes/fix-wheel-file-permissions-59b497ed8163e885.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    This fix resolves an issue where ``ddtrace`` package files were published with incorrect file attributes.

--- a/scripts/zip_filter.py
+++ b/scripts/zip_filter.py
@@ -9,11 +9,11 @@ def remove_from_zip(zip_filename, patterns):
     with zipfile.ZipFile(zip_filename, "r") as source_zip, zipfile.ZipFile(
         temp_zip_filename, "w", zipfile.ZIP_DEFLATED
     ) as temp_zip:
-        files_to_keep = (
-            file for file in source_zip.namelist() if not any(fnmatch.fnmatch(file, pattern) for pattern in patterns)
-        )
-        for file in files_to_keep:
-            temp_zip.writestr(file, source_zip.read(file))
+        # DEV: Use ZipInfo objects to ensure original file attributes are preserved
+        for file in source_zip.infolist():
+            if any(fnmatch.fnmatch(file.filename, pattern) for pattern in patterns):
+                continue
+            temp_zip.writestr(file, source_zip.read(file.filename))
     os.replace(temp_zip_filename, zip_filename)
 
 


### PR DESCRIPTION
The problem is the script we used to strip unwanted files from the resulting wheels on linux were not maintaining the original file attributes.

This hasn't been a problem before before files just needed read permissions only. However with the introduction of the crashtracker which brings with it an executable, the executable attribute was being stripped from the file.

We never caught this because we do not have any smoke or integration tests on the wheels we generate which validate crashtracking behavior (or the stderr logs).

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
