### PR TITLE
chore(iast): `re.match` and `re.Match.groups` aspects

### DIFF
--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -1,4 +1,6 @@
 import os
+from re import Match
+from re import Pattern
 import sys
 
 
@@ -121,6 +123,7 @@ class IAST(metaclass=Constant_Class):
     SEP_MODULES: Literal[","] = ","
     REQUEST_IAST_ENABLED: Literal["_dd.iast.request_enabled"] = "_dd.iast.request_enabled"
     TEXT_TYPES = (str, bytes, bytearray)
+    TAINTEABLE_TYPES = (str, bytes, bytearray, Match, Pattern)
 
 
 class IAST_SPAN_TAGS(metaclass=Constant_Class):

--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -1,6 +1,5 @@
 import os
 from re import Match
-from re import Pattern
 import sys
 
 
@@ -123,7 +122,7 @@ class IAST(metaclass=Constant_Class):
     SEP_MODULES: Literal[","] = ","
     REQUEST_IAST_ENABLED: Literal["_dd.iast.request_enabled"] = "_dd.iast.request_enabled"
     TEXT_TYPES = (str, bytes, bytearray)
-    TAINTEABLE_TYPES = (str, bytes, bytearray, Match, Pattern)
+    TAINTEABLE_TYPES = (str, bytes, bytearray, Match)
 
 
 class IAST_SPAN_TAGS(metaclass=Constant_Class):

--- a/ddtrace/appsec/_iast/_ast/visitor.py
+++ b/ddtrace/appsec/_iast/_ast/visitor.py
@@ -67,6 +67,8 @@ _ASPECTS_SPEC: Dict[Text, Any] = {
         "splitlines": "ddtrace_aspects.splitlines_aspect",
         "sub": "ddtrace_aspects.re_sub_aspect",
         "subn": "ddtrace_aspects.re_subn_aspect",
+        "match": "ddtrace_aspects.re_match_aspect",
+        "groups": "ddtrace_aspects.re_groups_aspect",
     },
     # Replacement function for indexes and ranges
     "slices": {

--- a/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/TaintTracking/TaintRange.cpp
@@ -150,7 +150,7 @@ std::pair<TaintRangeRefs, bool>
 get_ranges(PyObject* string_input, const TaintRangeMapTypePtr& tx_map)
 {
     TaintRangeRefs result;
-    if (not is_text(string_input))
+    if (not is_tainteable(string_input))
         return std::make_pair(result, true);
 
     if (tx_map->empty()) {
@@ -197,7 +197,7 @@ set_ranges(PyObject* str, const TaintRangeRefs& ranges, const TaintRangeMapTypeP
 std::tuple<TaintRangeRefs, TaintRangeRefs>
 are_all_text_all_ranges(PyObject* candidate_text, const py::tuple& parameter_list)
 {
-    if (not is_text(candidate_text))
+    if (not is_tainteable(candidate_text))
         return {};
 
     TaintRangeRefs all_ranges;
@@ -209,7 +209,7 @@ are_all_text_all_ranges(PyObject* candidate_text, const py::tuple& parameter_lis
     auto [candidate_text_ranges, ranges_error] = get_ranges(candidate_text, tx_map);
     if (not ranges_error) {
         for (const auto& param_handler : parameter_list) {
-            if (const auto param = param_handler.cast<py::object>().ptr(); is_text(param)) {
+            if (const auto param = param_handler.cast<py::object>().ptr(); is_tainteable(param)) {
                 if (auto [ranges, ranges_error] = get_ranges(param, tx_map); not ranges_error) {
                     all_ranges.insert(all_ranges.end(), ranges.begin(), ranges.end());
                 }
@@ -339,7 +339,7 @@ get_internal_hash(PyObject* obj)
 void
 set_tainted_object(PyObject* str, TaintedObjectPtr tainted_object, const TaintRangeMapTypePtr& tx_map)
 {
-    if (not str or not is_text(str)) {
+    if (not str or not is_tainteable(str)) {
         return;
     }
     auto obj_id = get_unique_id(str);

--- a/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
@@ -14,6 +14,18 @@ get_unique_id(const PyObject* str)
     return reinterpret_cast<uintptr_t>(str);
 }
 
+inline static bool PyReMatch_Check(const PyObject* obj)
+{
+    PyObject* re_module = PyImport_ImportModule("re");
+    PyTypeObject* match_type = (PyTypeObject*)PyObject_GetAttrString(re_module, "Match");
+    bool res = PyObject_IsInstance(obj, match_type);
+    // Alternatively:
+    // bool res = PyType_IsSubtype(Py_TYPE(obj), match_type);
+    Py_DECREF(re_module);
+    Py_DECREF(match_type);
+    return res;
+}
+
 bool
 is_notinterned_notfasttainted_unicode(const PyObject* objptr);
 
@@ -26,7 +38,7 @@ is_text(const PyObject* pyptr)
     if (!pyptr)
         return false;
 
-    return PyUnicode_Check(pyptr) || PyBytes_Check(pyptr) || PyByteArray_Check(pyptr);
+    return PyUnicode_Check(pyptr) || PyBytes_Check(pyptr) || PyByteArray_Check(pyptr) || PyReMatch_Check(pyptr);
 }
 
 string

--- a/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
@@ -14,7 +14,8 @@ get_unique_id(const PyObject* str)
     return reinterpret_cast<uintptr_t>(str);
 }
 
-inline static bool PyReMatch_Check(const PyObject* obj)
+inline static bool
+PyReMatch_Check(const PyObject* obj)
 {
     PyObject* re_module = PyImport_ImportModule("re");
     PyTypeObject* match_type = (PyTypeObject*)PyObject_GetAttrString(re_module, "Match");

--- a/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
@@ -34,7 +34,13 @@ is_text(const PyObject* pyptr)
     if (!pyptr)
         return false;
 
-    return PyUnicode_Check(pyptr) || PyBytes_Check(pyptr) || PyByteArray_Check(pyptr) || PyReMatch_Check(pyptr);
+    return PyUnicode_Check(pyptr) || PyBytes_Check(pyptr) || PyByteArray_Check(pyptr);
+}
+
+inline bool
+is_tainteable(const PyObject* pyptr)
+{
+    return is_text(pyptr) || PyReMatch_Check(pyptr);
 }
 
 // Base function for the variadic template

--- a/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
@@ -19,9 +19,7 @@ PyReMatch_Check(const PyObject* obj)
 {
     PyObject* re_module = PyImport_ImportModule("re");
     PyTypeObject* match_type = (PyTypeObject*)PyObject_GetAttrString(re_module, "Match");
-    bool res = PyObject_IsInstance(obj, match_type);
-    // Alternatively:
-    // bool res = PyType_IsSubtype(Py_TYPE(obj), match_type);
+    bool res = PyType_IsSubtype(Py_TYPE(obj), match_type);
     Py_DECREF(re_module);
     Py_DECREF(match_type);
     return res;

--- a/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
@@ -19,12 +19,7 @@ get_unique_id(const PyObject* str)
 inline static bool
 PyReMatch_Check(const PyObject* obj)
 {
-    PyObject* re_module = PyImport_ImportModule("re");
-    PyTypeObject* match_type = (PyTypeObject*)PyObject_GetAttrString(re_module, "Match");
-    bool res = PyType_IsSubtype(Py_TYPE(obj), match_type);
-    Py_DECREF(re_module);
-    Py_DECREF(match_type);
-    return res;
+    return py::isinstance((PyObject*)obj, py::module_::import("re").attr("Match"));
 }
 
 bool

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -123,7 +123,7 @@ def iast_taint_log_error(msg):
 
 
 def is_pyobject_tainted(pyobject: Any) -> bool:
-    if not isinstance(pyobject, IAST.TEXT_TYPES):
+    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):  # type: ignore[misc]
         return False
 
     try:
@@ -135,12 +135,15 @@ def is_pyobject_tainted(pyobject: Any) -> bool:
 
 def taint_pyobject(pyobject: Any, source_name: Any, source_value: Any, source_origin=None) -> Any:
     # Pyobject must be Text with len > 1
-    if not isinstance(pyobject, IAST.TEXT_TYPES):
+    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):  # type: ignore[misc]
         return pyobject
     # We need this validation in different contition if pyobject is not a text type and creates a side-effect such as
     # __len__ magic method call.
-    if len(pyobject) == 0:
-        return pyobject
+    pyobject_len = 0
+    if isinstance(pyobject, IAST.TEXT_TYPES):
+        pyobject_len = len(pyobject)
+        if pyobject_len == 0:
+            return pyobject
 
     if isinstance(source_name, (bytes, bytearray)):
         source_name = str(source_name, encoding="utf8", errors="ignore")
@@ -153,7 +156,7 @@ def taint_pyobject(pyobject: Any, source_name: Any, source_value: Any, source_or
         source_origin = OriginType.PARAMETER
 
     try:
-        pyobject_newid = set_ranges_from_values(pyobject, len(pyobject), source_name, source_value, source_origin)
+        pyobject_newid = set_ranges_from_values(pyobject, pyobject_len, source_name, source_value, source_origin)
         _set_metric_iast_executed_source(source_origin)
         return pyobject_newid
     except ValueError as e:
@@ -162,7 +165,7 @@ def taint_pyobject(pyobject: Any, source_name: Any, source_value: Any, source_or
 
 
 def taint_pyobject_with_ranges(pyobject: Any, ranges: Tuple) -> bool:
-    if not isinstance(pyobject, IAST.TEXT_TYPES):
+    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):  # type: ignore[misc]
         return False
     try:
         set_ranges(pyobject, ranges)
@@ -173,7 +176,7 @@ def taint_pyobject_with_ranges(pyobject: Any, ranges: Tuple) -> bool:
 
 
 def get_tainted_ranges(pyobject: Any) -> Tuple:
-    if not isinstance(pyobject, IAST.TEXT_TYPES):
+    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):  # type: ignore[misc]
         return tuple()
     try:
         return get_ranges(pyobject)

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -2,6 +2,7 @@ from builtins import bytearray as builtin_bytearray
 from builtins import bytes as builtin_bytes
 from builtins import str as builtin_str
 import codecs
+from re import Match
 from re import Pattern
 from types import BuiltinFunctionType
 from types import ModuleType
@@ -1096,6 +1097,53 @@ def translate_aspect(
 
 def empty_func(*args, **kwargs):
     pass
+
+
+def re_match_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> Any:
+    if orig_function is not None and (not flag_added_args or not args):
+        # This patch is unexpected, so we fallback
+        # to executing the original function
+        return orig_function(*args, **kwargs)
+    elif orig_function is None:
+        orig_function = args[0].match
+
+    self = args[0]
+    args = args[(flag_added_args or 1) :]
+    result = orig_function(*args, **kwargs)
+
+    offset = 0
+    if isinstance(self, ModuleType):
+        if self.__name__ != "re" or self.__package__ not in ("", "re") or not isinstance(result, Match):
+            return result
+    elif isinstance(self, Pattern):
+        offset = -1
+
+    if len(args) >= 2 + offset and is_pyobject_tainted(args[1 + offset]):
+        taint_pyobject_with_ranges(result, get_ranges(args[1 + offset]))
+
+    return result
+
+
+def re_groups_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> Any:
+    if orig_function is not None and (not flag_added_args or not args):
+        # This patch is unexpected, so we fallback
+        # to executing the original function
+        return orig_function(*args, **kwargs)
+    elif orig_function is None:
+        orig_function = args[0].groups
+
+    self = args[0]
+    args = args[(flag_added_args or 1) :]
+    result = orig_function(*args, **kwargs)
+
+    if not result or not isinstance(self, Match) or not is_pyobject_tainted(self):
+        return result
+
+    for group in result:
+        if group is not None:
+            copy_and_shift_ranges_from_strings(self, group, 0, len(group))
+
+    return result
 
 
 def re_sub_aspect(

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -1099,53 +1099,6 @@ def empty_func(*args, **kwargs):
     pass
 
 
-def re_match_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> Any:
-    if orig_function is not None and (not flag_added_args or not args):
-        # This patch is unexpected, so we fallback
-        # to executing the original function
-        return orig_function(*args, **kwargs)
-    elif orig_function is None:
-        orig_function = args[0].match
-
-    self = args[0]
-    args = args[(flag_added_args or 1) :]
-    result = orig_function(*args, **kwargs)
-
-    offset = 0
-    if isinstance(self, ModuleType):
-        if self.__name__ != "re" or self.__package__ not in ("", "re") or not isinstance(result, Match):
-            return result
-    elif isinstance(self, Pattern):
-        offset = -1
-
-    if len(args) >= 2 + offset and is_pyobject_tainted(args[1 + offset]):
-        taint_pyobject_with_ranges(result, get_ranges(args[1 + offset]))
-
-    return result
-
-
-def re_groups_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> Any:
-    if orig_function is not None and (not flag_added_args or not args):
-        # This patch is unexpected, so we fallback
-        # to executing the original function
-        return orig_function(*args, **kwargs)
-    elif orig_function is None:
-        orig_function = args[0].groups
-
-    self = args[0]
-    args = args[(flag_added_args or 1) :]
-    result = orig_function(*args, **kwargs)
-
-    if not result or not isinstance(self, Match) or not is_pyobject_tainted(self):
-        return result
-
-    for group in result:
-        if group is not None:
-            copy_and_shift_ranges_from_strings(self, group, 0, len(group))
-
-    return result
-
-
 def re_sub_aspect(
     orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
 ) -> Union[TEXT_TYPES]:
@@ -1222,3 +1175,50 @@ def re_subn_aspect(
             copy_and_shift_ranges_from_strings(repl, new_string, 0, len(new_string))
 
     return (new_string, number)
+
+
+def re_match_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> Any:
+    if orig_function is not None and (not flag_added_args or not args):
+        # This patch is unexpected, so we fallback
+        # to executing the original function
+        return orig_function(*args, **kwargs)
+    elif orig_function is None:
+        orig_function = args[0].match
+
+    self = args[0]
+    args = args[(flag_added_args or 1) :]
+    result = orig_function(*args, **kwargs)
+
+    offset = 0
+    if isinstance(self, ModuleType):
+        if self.__name__ != "re" or self.__package__ not in ("", "re") or not isinstance(result, Match):
+            return result
+    elif isinstance(self, Pattern):
+        offset = -1
+
+    if len(args) >= 2 + offset and is_pyobject_tainted(args[1 + offset]):
+        taint_pyobject_with_ranges(result, get_ranges(args[1 + offset]))
+
+    return result
+
+
+def re_groups_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> Any:
+    if orig_function is not None and (not flag_added_args or not args):
+        # This patch is unexpected, so we fallback
+        # to executing the original function
+        return orig_function(*args, **kwargs)
+    elif orig_function is None:
+        orig_function = args[0].groups
+
+    self = args[0]
+    args = args[(flag_added_args or 1) :]
+    result = orig_function(*args, **kwargs)
+
+    if not result or not isinstance(self, Match) or not is_pyobject_tainted(self):
+        return result
+
+    for group in result:
+        if group is not None:
+            copy_and_shift_ranges_from_strings(self, group, 0, len(group))
+
+    return result

--- a/tests/appsec/app.py
+++ b/tests/appsec/app.py
@@ -368,6 +368,50 @@ def iast_ast_patching_non_re_findall():
     return resp
 
 
+@app.route("/iast-ast-patching-re-groups", methods=["GET"])
+def iast_ast_patching_re_groups():
+    filename = request.args.get("filename")
+    style = request.args.get("style")
+    if style == "re_module":
+        result = re.match(r"_[a-z]*", filename).groups()
+    elif style == "re_object":
+        pattern = re.compile(r"_[a-z]*")
+        matches = pattern.match(filename)
+        result = matches.groups()
+    resp = Response("Fail")
+    try:
+        from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
+
+        if all(map(is_pyobject_tainted, result)):
+            resp = Response("OK")
+    except Exception as e:
+        print(e)
+    return resp
+
+
+@app.route("/iast-ast-patching-non-re-groups", methods=["GET"])
+def iast_ast_patching_non_re_groups():
+    import iast.fixtures.non_re_module as re
+
+    filename = request.args.get("filename")
+    style = request.args.get("style")
+    if style == "re_module":
+        result = re.match(r"_[a-z]*", filename).groups()
+    elif style == "re_object":
+        pattern = re.compile(r"_[a-z]*")
+        matches = pattern.match(filename)
+        result = matches.groups()
+    resp = Response("Fail")
+    try:
+        from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
+
+        if all(map(is_pyobject_tainted, result)):
+            resp = Response("OK")
+    except Exception as e:
+        print(e)
+    return resp
+
+
 if __name__ == "__main__":
     env_port = os.getenv("FLASK_RUN_PORT", 8000)
     ddtrace_iast_flask_patch()

--- a/tests/appsec/app.py
+++ b/tests/appsec/app.py
@@ -373,11 +373,18 @@ def iast_ast_patching_re_groups():
     filename = request.args.get("filename")
     style = request.args.get("style")
     if style == "re_module":
-        result = re.match(r"_[a-z]*", filename).groups()
+        re_match = re.match(r"(\w+) (\w+)", filename)
+        if re_match is not None:
+            result = re_match.groups()
+        else:
+            result = []
     elif style == "re_object":
-        pattern = re.compile(r"_[a-z]*")
-        matches = pattern.match(filename)
-        result = matches.groups()
+        pattern = re.compile(r"(\w+) (\w+)")
+        re_match = pattern.match(filename)
+        if re_match is not None:
+            result = re_match.groups()
+        else:
+            result = []
     resp = Response("Fail")
     try:
         from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
@@ -396,17 +403,24 @@ def iast_ast_patching_non_re_groups():
     filename = request.args.get("filename")
     style = request.args.get("style")
     if style == "re_module":
-        result = re.match(r"_[a-z]*", filename).groups()
+        re_match = re.match(r"(\w+) (\w+)", filename)
+        if re_match is not None:
+            result = re_match.groups()
+        else:
+            result = []
     elif style == "re_object":
-        pattern = re.compile(r"_[a-z]*")
-        matches = pattern.match(filename)
-        result = matches.groups()
-    resp = Response("Fail")
+        pattern = re.compile(r"(\w+) (\w+)")
+        re_match = pattern.match(filename)
+        if re_match is not None:
+            result = re_match.groups()
+        else:
+            result = []
+    resp = Response("OK")
     try:
         from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
 
-        if all(map(is_pyobject_tainted, result)):
-            resp = Response("OK")
+        if any(map(is_pyobject_tainted, result)):
+            resp = Response("Fail")
     except Exception as e:
         print(e)
     return resp

--- a/tests/appsec/app.py
+++ b/tests/appsec/app.py
@@ -389,7 +389,7 @@ def iast_ast_patching_re_groups():
     try:
         from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
 
-        if all(map(is_pyobject_tainted, result)):
+        if result and all(map(is_pyobject_tainted, result)):
             resp = Response("OK")
     except Exception as e:
         print(e)
@@ -419,7 +419,7 @@ def iast_ast_patching_non_re_groups():
     try:
         from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
 
-        if any(map(is_pyobject_tainted, result)):
+        if not result or any(map(is_pyobject_tainted, result)):
             resp = Response("Fail")
     except Exception as e:
         print(e)

--- a/tests/appsec/iast/aspects/test_re_aspects.py
+++ b/tests/appsec/iast/aspects/test_re_aspects.py
@@ -6,9 +6,9 @@ from ddtrace.appsec._iast._taint_tracking import TaintRange
 from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking.aspects import re_findall_aspect
 from ddtrace.appsec._iast._taint_tracking.aspects import re_groups_aspect
 from ddtrace.appsec._iast._taint_tracking.aspects import re_match_aspect
-from ddtrace.appsec._iast._taint_tracking.aspects import re_findall_aspect
 from ddtrace.appsec._iast._taint_tracking.aspects import re_sub_aspect
 from ddtrace.appsec._iast._taint_tracking.aspects import re_subn_aspect
 from ddtrace.appsec._iast._taint_tracking.aspects import split_aspect

--- a/tests/appsec/iast/fixtures/non_re_module.py
+++ b/tests/appsec/iast/fixtures/non_re_module.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python3
 
 
+class ReMatch:
+    def __init__(self, pattern, string):
+        self.pattern = pattern
+        self.string = string
+
+    def group(self, index):
+        return "fake_group_{}".format(index)
+
+    def groups(self):
+        return ("fake_group_0", "fake_group_1", "fake_group_2")
+
+
 class ReObject:
     def __init__(self, pattern):
         self.pattern = pattern
@@ -17,6 +29,9 @@ class ReObject:
     def split(self, string, *args, **kwargs):
         return ["fake_result_2", "fake_result_1", "fake_result_0"]
 
+    def match(self, string):
+        return ReMatch(self.pattern, string)
+
 
 def findall(pattern, string):
     return ["fake_result_2", "fake_result_1", "fake_result_0"]
@@ -32,6 +47,10 @@ def subn(pattern, replacement, string):
 
 def split(pattern, string, *args, **kwargs):
     return ["fake_result_0", "fake_result_1", "fake_result_2"]
+
+
+def match(pattern, string):
+    return ReMatch(pattern, string)
 
 
 def compile(pattern):  # noqa: A001

--- a/tests/appsec/integrations/test_flask_iast_patching.py
+++ b/tests/appsec/integrations/test_flask_iast_patching.py
@@ -24,7 +24,7 @@ def test_flask_iast_ast_patching_import_error():
 
 @pytest.mark.parametrize("style", ["re_module", "re_object"])
 @pytest.mark.parametrize("endpoint", ["re", "non-re"])
-@pytest.mark.parametrize("function", ["sub", "subn", "split"])
+@pytest.mark.parametrize("function", ["sub", "subn", "split", "groups"])
 def test_flask_iast_ast_patching_re(style, endpoint, function):
     """
     Tests re module patching end to end by checking that re.sub is propagating properly

--- a/tests/appsec/integrations/test_flask_iast_patching.py
+++ b/tests/appsec/integrations/test_flask_iast_patching.py
@@ -29,14 +29,17 @@ def test_flask_iast_ast_patching_re(style, endpoint, function):
     """
     Tests re module patching end to end by checking that re.sub is propagating properly
     """
+    filename = "path_traversal_test_file.txt"
+    if function == "groups":
+        from urllib.parse import quote_plus
+
+        filename = quote_plus("Isaac Newton, physicist")
     with flask_server(
         appsec_enabled="false", iast_enabled="true", token=None, port=8020, assert_debug=False
     ) as context:
         _, flask_client, pid = context
 
-        response = flask_client.get(
-            f"/iast-ast-patching-{endpoint}-{function}?style={style}&filename=path_traversal_test_file.txt"
-        )
+        response = flask_client.get(f"/iast-ast-patching-{endpoint}-{function}?style={style}&filename={filename}")
 
         assert response.status_code == 200
         assert response.content == b"OK"


### PR DESCRIPTION
IAST: Aspects for `re.match()` and `re.Match.groups()`

Note: this change involves allowing to taint `re.Match` objects and not only `text objects` as before.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
