### PR TITLE
ci: download all GitHub Actions artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ include:
   - local: ".gitlab/dogfood.yml"
 
 package-oci:
-  needs: [ download_dependency_wheels, download_ddtrace_wheels ]
+  needs: [ download_dependency_wheels, download_ddtrace_artifacts ]
 
 onboarding_tests_installer:
   parallel:

--- a/.gitlab/download-wheels-from-gh-actions.sh
+++ b/.gitlab/download-wheels-from-gh-actions.sh
@@ -47,6 +47,6 @@ echo "Finished downloading wheels. Fixing directory structure"
 # Flatten directory structure so all wheels are top level
 find pywheels -type f -exec mv {} pywheels \;
 # Remove the now empty artifact directories
-find pywheels -type f -exec rm -rf {} \;
+find pywheels/* -type d -exec rm -rf {} \;
 
 echo "Done"

--- a/.gitlab/download-wheels-from-gh-actions.sh
+++ b/.gitlab/download-wheels-from-gh-actions.sh
@@ -46,5 +46,7 @@ echo "Finished downloading wheels. Fixing directory structure"
 
 # Flatten directory structure so all wheels are top level
 find pywheels -type f -exec mv {} pywheels \;
+# Remove the now empty artifact directories
+find pywheels -type f -exec rm -rf {} \;
 
 echo "Done"

--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -17,7 +17,7 @@ build_base_venvs:
       - ddtrace/**/*.so*
       - ddtrace/internal/datadog/profiling/crashtracker/crashtracker_exe
 
-download_ddtrace_wheels:
+download_ddtrace_artifacts:
   image: registry.ddbuild.io/github-cli:v27480869-eafb11d-2.43.0
   tags: [ "arch:amd64" ]
   stage: package
@@ -28,13 +28,13 @@ download_ddtrace_wheels:
     - .gitlab/download-wheels-from-gh-actions.sh
   artifacts:
     paths:
-      - "pywheels/*.whl"
+      - "pywheels/"
 
 download_dependency_wheels:
   image: registry.ddbuild.io/images/mirror/python:$PYTHON_IMAGE_TAG
   tags: [ "arch:amd64" ]
   stage: package
-  needs: [ download_ddtrace_wheels ]
+  needs: [ download_ddtrace_artifacts ]
   parallel:
     matrix: # The image tags that are mirrored are in: https://github.com/DataDog/images/blob/master/mirror.yaml
       - PYTHON_IMAGE_TAG: "3.7"


### PR DESCRIPTION
Right now we download all artifacts from the GitHub Actions build job, but we don't save them to as GitLab artifact. This change ensures we include all artifacts.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
