### PR TITLE
ci: add a final dd-gitlab/status job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ stages:
   - benchmarks
   - macrobenchmarks
   - dogfood
+  - status
 
 variables:
   REPO_LANG: python # "python" is used everywhere rather than "py"
@@ -55,3 +56,16 @@ deploy_to_di_backend:manual:
     UPSTREAM_COMMIT_AUTHOR: $CI_COMMIT_AUTHOR
     UPSTREAM_TAG: $CI_COMMIT_TAG
     UPSTREAM_PACKAGE_JOB: build
+
+
+status:
+  stage: status
+  rules:
+    - when: on_success
+      variables:
+        STATUS: 0
+    - when: on_failure
+      variables:
+        STATUS: 1
+  script:
+    - exit ${STATUS}


### PR DESCRIPTION
GitHub allows us to make certain jobs required for PRs to be merged, but for our GitLab jobs they need to be individually listed. We also would have issues if some jobs are optionally run based on changes.

Instead this single job is meant to be a final success/failure that we can depend on on PRs.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
