### PR TITLE
ci: run `tracer` suite in gitlab instead of circleci

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -573,14 +573,6 @@ jobs:
       - run_test:
           pattern: "datastreams"
 
-  tracer:
-    parallelism: 10
-    <<: *contrib_job_large
-    steps:
-      - run_test:
-          pattern: "tracer"
-          trace_agent_url: ""
-
   ci_visibility:
     <<: *machine_executor
     parallelism: 4

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -17,6 +17,8 @@ variables:
   parallel: 4
   script:
     - pip install riot~=0.19.1
+    - unset DD_SERVICE
+    - unset DD_ENV
     - |
       hashes=( $(riot list --hash-only "${SUITE_NAME}" | sort | ./.gitlab/ci-split-input.sh) )
       for hash in "${hashes[@]}"

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -7,5 +7,12 @@
   script:
     - hatch env show --json | jq -r --arg suite_name "$SUITE_NAME" 'keys[] | select(. | contains($suite_name))' | sort | ./.gitlab/ci-split-input.sh | xargs -n 1 -I {} hatch run {}:test
 
+.test_base_riot:
+  extends: .testrunner
+  stage: tests
+  needs: [build_base_venvs]
+  script:
+    - echo "hello world"
+
 include:
   - local: ".gitlab/tests/appsec.yml"

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -20,6 +20,7 @@ variables:
     - unset DD_SERVICE
     - unset DD_ENV
     - unset DD_TAGS
+    - unset DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED
     - |
       hashes=( $(riot list --hash-only "${SUITE_NAME}" | sort | ./.gitlab/ci-split-input.sh) )
       for hash in "${hashes[@]}"

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -19,6 +19,7 @@ variables:
     - pip install riot~=0.19.1
     - unset DD_SERVICE
     - unset DD_ENV
+    - unset DD_TAGS
     - |
       hashes=( $(riot list --hash-only "${SUITE_NAME}" | sort | ./.gitlab/ci-split-input.sh) )
       for hash in "${hashes[@]}"

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -1,3 +1,6 @@
+variables:
+  RIOT_RUN_CMD: riot -P -v run --exitfirst --pass-env -s
+
 .test_base_hatch:
   extends: .testrunner
   stage: tests
@@ -10,9 +13,18 @@
 .test_base_riot:
   extends: .testrunner
   stage: tests
-  needs: [build_base_venvs]
+  needs: [ build_base_venvs ]
+  parallel: 4
   script:
-    - ../scripts/run-test-suite "$SUITE_NAME"
+    - pip install riot~=0.19.1
+    - |
+      hashes=( $(riot list --hash-only "${SUITE_PATTERN}" | sort | ./.gitlab/ci-split-input.sh) )
+      for hash in "${hashes[@]}"
+      do
+        echo "Running riot hash: ${hash}"
+        riot list "${hash}"
+        ${RIOT_RUN_CMD} "${hash}"
+      done
 
 include:
   - local: ".gitlab/tests/appsec.yml"

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -18,7 +18,7 @@ variables:
   script:
     - pip install riot~=0.19.1
     - |
-      hashes=( $(riot list --hash-only "${SUITE_PATTERN}" | sort | ./.gitlab/ci-split-input.sh) )
+      hashes=( $(riot list --hash-only "${SUITE_NAME}" | sort | ./.gitlab/ci-split-input.sh) )
       for hash in "${hashes[@]}"
       do
         echo "Running riot hash: ${hash}"

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -12,7 +12,7 @@
   stage: tests
   needs: [build_base_venvs]
   script:
-    - echo "hello world"
+    - ../scripts/run-test-suite "$SUITE_NAME"
 
 include:
   - local: ".gitlab/tests/appsec.yml"

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -28,3 +28,4 @@ variables:
 
 include:
   - local: ".gitlab/tests/appsec.yml"
+  - local: ".gitlab/tests/tracer.yml"

--- a/.gitlab/tests/tracer.yml
+++ b/.gitlab/tests/tracer.yml
@@ -3,5 +3,3 @@ tracer:
   parallel: 9
   variables:
     SUITE_NAME: "tracer"
-    DD_ENV: ""
-    DD_SERVICE: ""

--- a/.gitlab/tests/tracer.yml
+++ b/.gitlab/tests/tracer.yml
@@ -4,3 +4,4 @@ tracer:
   variables:
     SUITE_NAME: "tracer"
     DD_ENV: ""
+    DD_SERVICE: ""

--- a/.gitlab/tests/tracer.yml
+++ b/.gitlab/tests/tracer.yml
@@ -1,0 +1,5 @@
+tracer:
+  extends: .test_base_riot
+  parallel: 12
+  variables:
+    SUITE_NAME: "tracer"

--- a/.gitlab/tests/tracer.yml
+++ b/.gitlab/tests/tracer.yml
@@ -1,5 +1,6 @@
 tracer:
   extends: .test_base_riot
-  parallel: 12
+  parallel: 9
   variables:
     SUITE_NAME: "tracer"
+    DD_ENV: ""

--- a/ddtrace/internal/runtime/collector.py
+++ b/ddtrace/internal/runtime/collector.py
@@ -55,16 +55,15 @@ class ValueCollector(object):
             return None
         return modules
 
-    def collect(self, keys=None):
-        # type: (Optional[Set[str]]) -> Optional[List[Tuple[str, str]]]
+    def collect(self, enabled: Optional[bool] = None) -> Optional[List[Tuple[str, str]]]:
         """Returns metrics as collected by `collect_fn`.
 
         :param keys: The keys of the metrics to collect.
         """
-        if not self.enabled:
+        if (enabled is not None and not enabled) or (enabled is None and not self.enabled):
             return self.value
 
-        keys = keys or set()
+        keys = set()
 
         if not self.periodic and self.value_loaded:
             return self.value

--- a/ddtrace/internal/runtime/collector.py
+++ b/ddtrace/internal/runtime/collector.py
@@ -63,7 +63,7 @@ class ValueCollector(object):
         if (enabled is not None and not enabled) or (enabled is None and not self.enabled):
             return self.value
 
-        keys = set()
+        keys: Set = set()
 
         if not self.periodic and self.value_loaded:
             return self.value

--- a/ddtrace/internal/runtime/collector.py
+++ b/ddtrace/internal/runtime/collector.py
@@ -55,15 +55,16 @@ class ValueCollector(object):
             return None
         return modules
 
-    def collect(self, enabled: Optional[bool] = None) -> Optional[List[Tuple[str, str]]]:
+    def collect(self, keys=None):
+        # type: (Optional[Set[str]]) -> Optional[List[Tuple[str, str]]]
         """Returns metrics as collected by `collect_fn`.
 
         :param keys: The keys of the metrics to collect.
         """
-        if (enabled is not None and not enabled) or (enabled is None and not self.enabled):
+        if not self.enabled:
             return self.value
 
-        keys: Set = set()
+        keys = keys or set()
 
         if not self.periodic and self.value_loaded:
             return self.value


### PR DESCRIPTION
This change moves the `tracer` test suite to internal gitlab for billing purposes.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
