### PR TITLE
fix: prevent module import callback side-effects

### DIFF
--- a/ddtrace/internal/module.py
+++ b/ddtrace/internal/module.py
@@ -201,7 +201,7 @@ class _ImportHookChainedLoader:
         except (AttributeError, TypeError):
             pass
         try:
-            module.spec.loader = self.loader
+            object.__getattribute__(module, "spec").loader = self.loader
         except (AttributeError, TypeError):
             pass
 
@@ -313,7 +313,10 @@ class _ImportHookChainedLoader:
                     exception_hook(self, module)
                 raise
 
-        self.call_back(module)
+        try:
+            self.call_back(module)
+        except Exception:
+            log.exception("Failed to call back on module %s", module)
 
 
 class BaseModuleWatchdog(abc.ABC):

--- a/releasenotes/notes/fix-module-callback-no-side-effects-df422ae52b87772d.yaml
+++ b/releasenotes/notes/fix-module-callback-no-side-effects-df422ae52b87772d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix for a side-effect issue with module import callbacks that could cause
+    a runtime exception.

--- a/tests/internal/side_effect_module.py
+++ b/tests/internal/side_effect_module.py
@@ -1,0 +1,11 @@
+import sys
+from types import ModuleType
+
+
+class SideEffectModule(ModuleType):
+    def __getattribute__(self, name):
+        if name in {"spec"}:
+            raise RuntimeError("Attribute lookup side effect")
+
+
+sys.modules[__name__].__class__ = SideEffectModule

--- a/tests/internal/test_module.py
+++ b/tests/internal/test_module.py
@@ -526,3 +526,10 @@ def test_module_watchdog_reloads_dont_cause_errors():
     sys.setrecursionlimit(1000)
     for _ in range(sys.getrecursionlimit() * 2):
         reload(ns_module)
+
+
+@pytest.mark.subprocess(ddtrace_run=True)
+def test_module_import_side_effect():
+    # Test that we can import a module that raises an exception during specific
+    # attribute lookups.
+    import tests.internal.side_effect_module  # noqa:F401


### PR DESCRIPTION
We make sure that we avoid side-effects when looking up methods from module objects, as these could be of arbitrary type and have custom attribute lookups implemented.

Addresses #10314.

## Testing Strategy

We try to replicate the side-effect caused by attribute lookup of the custom module object in `yt-dlp`, and use that as a base for a regression test.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
