### PR TITLE
chore(di): improve enriched locals

### DIFF
--- a/ddtrace/debugging/_signal/model.py
+++ b/ddtrace/debugging/_signal/model.py
@@ -17,7 +17,6 @@ from uuid import uuid4
 
 from ddtrace._trace.context import Context
 from ddtrace._trace.span import Span
-from ddtrace.debugging import _safety
 from ddtrace.debugging._expressions import DDExpressionEvaluationError
 from ddtrace.debugging._probe.model import FunctionLocationMixin
 from ddtrace.debugging._probe.model import LineLocationMixin
@@ -83,14 +82,17 @@ class Signal(abc.ABC):
 
     def _enrich_locals(self, retval, exc_info, duration):
         frame = self.frame
-        _locals = list(self.args or _safety.get_args(frame))
-        _locals.append(("@duration", duration / 1e6))  # milliseconds
+        _locals = dict(frame.f_locals)
+        _locals["@duration"] = duration / 1e6  # milliseconds
 
         exc = exc_info[1]
-        _locals.append(("@return", retval) if exc is None else ("@exception", exc))
+        if exc is not None:
+            _locals["@exception"] = exc
+        else:
+            _locals["@return"] = retval
 
-        # Include the frame locals and globals.
-        return ChainMap(dict(_locals), frame.f_locals, frame.f_globals)
+        # Include the frame globals.
+        return ChainMap(_locals, frame.f_globals)
 
     @abc.abstractmethod
     def enter(self):

--- a/ddtrace/debugging/_signal/snapshot.py
+++ b/ddtrace/debugging/_signal/snapshot.py
@@ -158,16 +158,20 @@ class Snapshot(LogSignal):
         elif self.state not in {SignalState.NONE, SignalState.DONE}:
             return
 
-        _locals = list(_safety.get_locals(self.frame))
+        _pure_locals = list(_safety.get_locals(self.frame))
         _, exc, tb = exc_info
         if exc is None:
-            _locals.append(("@return", retval))
+            _pure_locals.append(("@return", retval))
         else:
-            _locals.append(("@exception", exc))
+            _pure_locals.append(("@exception", exc))
 
         if probe.take_snapshot:
             self.return_capture = _capture_context(
-                self.args or _safety.get_args(self.frame), _locals, [], exc_info, limits=probe.limits
+                self.args or _safety.get_args(self.frame),
+                _pure_locals,
+                _safety.get_globals(self.frame),
+                exc_info,
+                limits=probe.limits,
             )
         self.duration = duration
         self.state = SignalState.DONE

--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -1203,7 +1203,9 @@ def test_debugger_redacted_identifiers():
                     },
                     "@return": {"type": "str", "value": "'top secret'"},  # TODO: Ouch!
                 },
-                "staticFields": {},
+                "staticFields": {
+                    "SensitiveData": {"type": "type", "value": "<class 'tests.submod.stuff.SensitiveData'>"}
+                },
                 "throwable": None,
             },
         }


### PR DESCRIPTION
We improve the logic to retrieve the enriched locals with extra values and globals. There is no need to split between arguments and actual locals, as their union is just the full set of the frame locals.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
