### PR TITLE
chore(ci): optimize system-tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -24,7 +24,37 @@ jobs:
           python -c "import os,sys,fnmatch;sys.exit(not bool([_ for pattern in {'ddtrace/*', 'setup*', 'pyproject.toml', '.github/workflows/system-tests.yml'} for _ in fnmatch.filter(os.environ['PATHS'].splitlines(), pattern)]))"
         continue-on-error: true
 
-  system-tests-build:
+  system-tests-build-agent:
+    runs-on: ubuntu-latest
+    needs: needs-run
+    steps:
+
+      - name: Checkout system tests
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        uses: actions/checkout@v4
+        with:
+          repository: 'DataDog/system-tests'
+
+      - name: Build agent
+        id: build
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        run: ./build.sh -i agent
+
+      - name: Save
+        id: save
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        run: |
+          docker image save system_tests/agent:latest | gzip > agent_${{ github.sha }}.tar.gz
+
+      - uses: actions/upload-artifact@v4
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        with:
+          name: agent_${{ github.sha }}
+          path: |
+            agent_${{ github.sha }}.tar.gz
+          retention-days: 2
+
+  system-tests-build-weblog:
     runs-on: ubuntu-latest
     needs: needs-run
     strategy:
@@ -46,11 +76,6 @@ jobs:
       DD_API_KEY: 1234567890abcdef1234567890abcdef
       CMAKE_BUILD_PARALLEL_LEVEL: 12
     steps:
-      - name: Setup python 3.12
-        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
 
       - name: Checkout system tests
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
@@ -71,14 +96,13 @@ jobs:
       - name: Build
         id: build
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        run: ./build.sh
+        run: ./build.sh -i weblog
 
       - name: Save
         id: save
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
         run: |
           docker image save system_tests/weblog:latest | gzip > ${{ matrix.weblog-variant}}_weblog_${{ github.sha }}.tar.gz
-          docker image save system_tests/agent:latest | gzip > ${{ matrix.weblog-variant}}_agent_${{ github.sha }}.tar.gz
 
       - uses: actions/upload-artifact@v4
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
@@ -86,13 +110,11 @@ jobs:
           name: ${{ matrix.weblog-variant }}_${{ github.sha }}
           path: |
             ${{ matrix.weblog-variant}}_weblog_${{ github.sha }}.tar.gz
-            ${{ matrix.weblog-variant}}_agent_${{ github.sha }}.tar.gz
-            venv
           retention-days: 2
 
   system-tests:
     runs-on: ubuntu-latest
-    needs: [needs-run, system-tests-build]
+    needs: [needs-run, system-tests-build-agent, system-tests-build-weblog]
     strategy:
       matrix:
         weblog-variant: [flask-poc, uwsgi-poc , django-poc, fastapi, python3.12]
@@ -108,11 +130,6 @@ jobs:
       DD_API_KEY: 1234567890abcdef1234567890abcdef
       CMAKE_BUILD_PARALLEL_LEVEL: 12
     steps:
-      - name: Setup python 3.12
-        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
 
       - name: Checkout system tests
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
@@ -120,23 +137,26 @@ jobs:
         with:
           repository: 'DataDog/system-tests'
 
+      - name: Build runner
+        uses: ./.github/actions/install_runner
+
       - uses: actions/download-artifact@v4
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
         with:
           name: ${{ matrix.weblog-variant }}_${{ github.sha }}
-          path: ${{ matrix.weblog-variant}}_${{ github.sha }}.tar.gz
+          path: images_artifacts/
+
+      - uses: actions/download-artifact@v4
+        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
+        with:
+          name: agent_${{ github.sha }}
+          path: images_artifacts/
 
       - name: docker load
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
         run: |
-          docker load < ${{ matrix.weblog-variant}}_${{ github.sha }}.tar.gz/${{ matrix.weblog-variant}}_weblog_${{ github.sha }}.tar.gz
-          docker load < ${{ matrix.weblog-variant}}_${{ github.sha }}.tar.gz/${{ matrix.weblog-variant}}_agent_${{ github.sha }}.tar.gz
-
-      - name: move venv
-        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        run: |
-          mv ${{ matrix.weblog-variant}}_${{ github.sha }}.tar.gz/venv venv
-          chmod -R +x venv/bin/*
+          docker load < images_artifacts/${{ matrix.weblog-variant}}_weblog_${{ github.sha }}.tar.gz
+          docker load < images_artifacts/agent_${{ github.sha }}.tar.gz
 
       - name: Run DEFAULT
         if: (needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule') && matrix.scenario == 'other'
@@ -237,7 +257,8 @@ jobs:
 
 
   parametric:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: "APM Larger Runners"
     needs: needs-run
     env:
       TEST_LIBRARY: python
@@ -254,14 +275,9 @@ jobs:
           path: 'binaries/dd-trace-py'
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - uses: actions/setup-python@v5
-        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        with:
-          python-version: '3.12'
 
-      - name: Build
-        if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'
-        run: ./build.sh -i runner
+      - name: Build runner
+        uses: ./.github/actions/install_runner
 
       - name: Run
         if: needs.needs-run.outputs.outcome == 'success' || github.event_name == 'schedule'


### PR DESCRIPTION
## TL:DR;

CI time goes from 25mn to 19mn
Billable time goes from 3h45 to 3h15

## Changes 

1. Build only once the agent image
   * expected time gain : 30s
   * expected cost gain : as it was build 5 times, we gain 30s * 4 seconds of CI cost ( actually way more, as the cost part is not building the image, but compress it)
2. use the system-tests action for building runner (optimized to be reused across jobs)
   * expected time gain : 50s (10s vs 60s)
   * expected cost gain : as it was build 5 times, and as it's now cached across job, the gain is 5 * 60 - 10 * split_scenario = 560 s 
2. (bis) use the system-tests action for building runner for parametric test (optimized to be reused across jobs)
   * expected time gain : 50s (10s vs 60s), but as it was in parallel with other scenario
   * expected cost gain : 50 s also.
3. use large runner for parametric tests
   * expected time gain: 12mn vs 17mn (but in // with other job, so mainly it's a gain on the cost)

Figures are approx, and I may have missed some details.

|  | [before](https://github.com/DataDog/dd-trace-py/actions/runs/10522834739) | [after](https://github.com/DataDog/dd-trace-py/actions/runs/10524019400?pr=10350) | 
|-|-|-|
| Build runner + weblog + agent | [630s](https://github.com/DataDog/dd-trace-py/actions/runs/10522834739/job/29156321962#step:5:1) |  |  
| build runner |   |  [10s](https://github.com/DataDog/dd-trace-py/actions/runs/10524211093/job/29160845788?pr=10350) approx |
| build weblog |   |  [420s](https://github.com/DataDog/dd-trace-py/actions/runs/10524019400/job/29159940402?pr=10350) |
| build agent |   |   [120s](https://github.com/DataDog/dd-trace-py/actions/runs/10524019400/job/29159940060?pr=10350) but in // with weblog, so it's free|
| parametric | [17mn](https://github.com/DataDog/dd-trace-py/actions/runs/10522834739/job/29156320002) | 12mn
| Total time | [25mn3s](https://github.com/DataDog/dd-trace-py/actions/runs/10522834739) | [19mn](https://github.com/DataDog/dd-trace-py/actions/runs/10524211093?pr=10350)
| Total billable time | [3h44s](https://github.com/DataDog/dd-trace-py/actions/runs/10522834739/usage) | [3h15](https://github.com/DataDog/dd-trace-py/actions/runs/10524211093/usage?pr=10350)


### 1. Build only once the agent image

Previously, the system tests CI spawn one runner per weblog. In this runner, it builds sequentially : 

* the corresponding weblog image
* an agent image 
* the runner

But the agent image and the runner are the same for all weblogs. This first change spawn a runner dedicated to build the agent image only once per job.

### 2.Use the system-test actions to build runner

It get the runner for github action cache if exists, or build it if not. For a given arch/system-tests requirements, it'll be built only once on your repo. This is deployed with success on system-tests CI.

3. use large runner for parametric tests

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
