### PR TITLE
feat(tracer): add Span Pointer support

### DIFF
--- a/ddtrace/_trace/_span_pointer.py
+++ b/ddtrace/_trace/_span_pointer.py
@@ -1,0 +1,85 @@
+"""
+Span Pointers
+=============
+
+Description
+-----------
+
+``ddtrace.trace.SpanPointer`` is used in situations where a
+:class:`ddtrace.trace.SpanLink` cannot be used. This comes up when we want to
+link spans but cannot pass the span context between them. The Span Pointer
+relies on consistent hashing rules to identify the linking entity between the
+spans. When both the upstream and downstream spans point to the same entity
+(and are both sampled), the Spans are linked in the Datadog UI.
+
+Usage
+-----
+
+Span Links can be created using :meth:`ddtrace.Span.add_span_pointer(...)` Ex::
+
+    from ddtrace import tracer
+
+    s1 = tracer.trace("s1")
+    s1.add_span_pointer(
+        kind="some.thing",
+        direction=SpanPointerDirection.DOWNSTREAM,
+        hash="same-hash",
+    )
+
+    // somewhere else where we cannot call `s1.link_span(s2.context)`
+
+    s2 = tracer.trace("s2")
+    s2.add_span_pointer(
+        kind="some.thing",
+        direction=SpanPointerDirection.UPSTREAM,
+        hash="same-hash",
+    )
+"""
+
+import dataclasses
+from enum import Enum
+from typing import NewType
+from ddtrace._trace._span_link import _span_link_shaped_dict
+
+
+SpanPointerHash = NewType("SpanPointerHash", str)
+
+
+class SpanPointerDirection(Enum):
+    """
+    SpanPointerDirection represents the direction of the Pointer from the
+    perspective of the Span. The Span that creates an Entity would have a
+    pointer with direction DOWNSTREAM. The Span that is triggered by the Entity
+    would have a pointer with direction UPSTREAM.
+    """
+
+    UPSTREAM = "u"
+    DOWNSTREAM = "d"
+
+
+SPAN_POINTER_SPAN_LINK_TRACE_ID = 0
+SPAN_POINTER_SPAN_LINK_SPAN_ID = 0
+
+
+@dataclasses.dataclass
+class SpanPointer:
+    kind: str
+    direction: SpanPointerDirection
+    hash: SpanPointerHash
+    extra_attributes: dict = dataclasses.field(default_factory=dict)
+
+    def to_dict(self):
+        return _span_link_shaped_dict(
+            trace_id=SPAN_POINTER_SPAN_LINK_TRACE_ID,
+            span_id=SPAN_POINTER_SPAN_LINK_SPAN_ID,
+            attributes={
+                "link.kind": "span-pointer",
+                "ptr.kind": self.kind,
+                "ptr.dir": self.direction.value,
+                "ptr.hash": self.hash,
+                **self.extra_attributes,
+            },
+            dropped_attributes_count=0,
+            tracestate=None,
+            flags=None,
+        )

--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -904,8 +904,13 @@ cdef class MsgpackEncoderV05(MsgpackEncoderBase):
             return ret
 
         span_links = ""
+        all_links = []
         if span._links:
-            span_links = json_dumps([link.to_dict() for _, link in span._links.items()])
+            all_links = [link.to_dict() for _, link in span._links.items()]
+        if span._pointers:
+            all_links.extend([pointer.to_dict() for _, pointer in span._pointers.items()])
+        if all_links:
+            span_links = json_dumps(all_links)
 
         span_events = ""
         if span._events:


### PR DESCRIPTION
Span Pointers can be used in situations where Span Context cannot be propagated to try to create Span Links after the span is ingested. Though they have some significant limitations, they are sometimes the only way to try to link spans.

This PR adds the basic `Span.set_pointer` functionality. We will be following up with an initial S3 object implementation to support Serverless workflows.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
