### PR TITLE
chore(ci_visibility): only store longrepr as XFAIL_REASON if the test is an xfail

### DIFF
--- a/ddtrace/contrib/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/pytest/_plugin_v2.py
@@ -324,7 +324,7 @@ def _pytest_runtest_makereport(item, call, outcome):
     # add it as a tag immediately:
     if getattr(result, "wasxfail", None):
         CITest.set_tag(test_id, XFAIL_REASON, result.wasxfail)
-    elif getattr(result, "longrepr", None):
+    elif "xfail" in getattr(result, "keywords", []) and getattr(result, "longrepr", None):
         CITest.set_tag(test_id, XFAIL_REASON, result.longrepr)
 
     # Only capture result if:


### PR DESCRIPTION
This primarily addresses warning messages that would be shown if a test was marked as skipped by ITR, but also xfailed.

This would've resulted in a log warning that the test item was already finished, which would result in the tag setting being a noop.

No changelog is added because this plugin is not yet released.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
