### PR TITLE
chore: add no-changelog label and checklist to auto-generated PR updates

### DIFF
--- a/.github/workflows/generate-package-versions.yml
+++ b/.github/workflows/generate-package-versions.yml
@@ -86,24 +86,4 @@ jobs:
           labels: changelog/no-changelog
           body: |
             Updates the ${{ env.VENV_NAME }} integration latest version and regenerates lockfiles.
-            ## Checklist
-            - [x] PR author has checked that all the criteria below are met
-            - The PR description includes an overview of the change
-            - The PR description articulates the motivation for the change
-            - The change includes tests OR the PR description describes a testing strategy
-            - The PR description notes risks associated with the change, if any
-            - Newly-added code is easy to change
-            - The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
-            - The change includes or references documentation updates if necessary
-            - Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
-
-            ## Reviewer Checklist
-            - [ ] Reviewer has checked that all the criteria below are met 
-            - Title is accurate
-            - All changes are related to the pull request's stated goal
-            - Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
-            - Testing strategy adequately addresses listed risks
-            - Newly-added code is easy to change
-            - Release note makes sense to a user of the library
-            - If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
-            - Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
+          body-path: .github/PULL_REQUEST_TEMPLATE.md

--- a/.github/workflows/generate-package-versions.yml
+++ b/.github/workflows/generate-package-versions.yml
@@ -42,6 +42,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/generate-package-versions.yml
+++ b/.github/workflows/generate-package-versions.yml
@@ -83,4 +83,24 @@ jobs:
           labels: changelog/no-changelog
           body: |
             Updates the ${{ env.VENV_NAME }} integration latest version and regenerates lockfiles.
-            - [] requirements checklist
+            ## Checklist
+            - [x] PR author has checked that all the criteria below are met
+            - The PR description includes an overview of the change
+            - The PR description articulates the motivation for the change
+            - The change includes tests OR the PR description describes a testing strategy
+            - The PR description notes risks associated with the change, if any
+            - Newly-added code is easy to change
+            - The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
+            - The change includes or references documentation updates if necessary
+            - Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
+
+            ## Reviewer Checklist
+            - [ ] Reviewer has checked that all the criteria below are met 
+            - Title is accurate
+            - All changes are related to the pull request's stated goal
+            - Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
+            - Testing strategy adequately addresses listed risks
+            - Newly-added code is easy to change
+            - Release note makes sense to a user of the library
+            - If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
+            - Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

--- a/.github/workflows/generate-package-versions.yml
+++ b/.github/workflows/generate-package-versions.yml
@@ -84,6 +84,4 @@ jobs:
           base: main
           title: "chore: update ${{ env.VENV_NAME }} latest version"
           labels: changelog/no-changelog
-          body: |
-            Updates the ${{ env.VENV_NAME }} integration latest version and regenerates lockfiles.
           body-path: .github/PULL_REQUEST_TEMPLATE.md

--- a/.github/workflows/generate-package-versions.yml
+++ b/.github/workflows/generate-package-versions.yml
@@ -80,5 +80,7 @@ jobs:
           delete-branch: true
           base: main
           title: "chore: update ${{ env.VENV_NAME }} latest version"
+          labels: changelog/no-changelog
           body: |
             Updates the ${{ env.VENV_NAME }} integration latest version and regenerates lockfiles.
+            - [] requirements checklist


### PR DESCRIPTION
This PR adds the following that was missing from the automated version update PRs:
- the `changelog/no-changelog` label
- PR template checklist 

Still TODO: figure out appropriate CODEOWNERs. 

Example run here:
https://github.com/DataDog/dd-trace-py/actions/runs/10563875400/job/29265054055

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
