### PR TITLE
chore(llmobs): add internal contrib files to MLObs codeownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -113,18 +113,22 @@ ddtrace/internal/datadog/profiling  @DataDog/profiling-python
 tests/profiling                     @DataDog/profiling-python
 
 # MLObs
-ddtrace/llmobs/                                     @DataDog/ml-observability
-ddtrace/contrib/openai                              @DataDog/ml-observability
-ddtrace/contrib/langchain                           @DataDog/ml-observability
-ddtrace/contrib/botocore/services/bedrock.py        @DataDog/ml-observability
-ddtrace/contrib/anthropic                           @DataDog/ml-observability
-tests/llmobs                                        @DataDog/ml-observability
-tests/contrib/openai                                @DataDog/ml-observability
-tests/contrib/langchain                             @DataDog/ml-observability
-tests/contrib/botocore/test_bedrock.py              @DataDog/ml-observability
-tests/contrib/botocore/test_bedrock_llmobs.py       @DataDog/ml-observability
-tests/contrib/botocore/bedrock_cassettes            @DataDog/ml-observability
-tests/contrib/anthropic                             @DataDog/ml-observability
+ddtrace/llmobs/                                         @DataDog/ml-observability
+ddtrace/contrib/internal/openai                         @DataDog/ml-observability
+ddtrace/contrib/openai                                  @DataDog/ml-observability
+ddtrace/contrib/internal/langchain                      @DataDog/ml-observability
+ddtrace/contrib/langchain                               @DataDog/ml-observability
+ddtrace/contrib/internal/botocore/services/bedrock.py   @DataDog/ml-observability
+ddtrace/contrib/botocore/services/bedrock.py            @DataDog/ml-observability
+ddtrace/contrib/internal/anthropic                      @DataDog/ml-observability
+ddtrace/contrib/anthropic                               @DataDog/ml-observability
+tests/llmobs                                            @DataDog/ml-observability
+tests/contrib/openai                                    @DataDog/ml-observability
+tests/contrib/langchain                                 @DataDog/ml-observability
+tests/contrib/botocore/test_bedrock.py                  @DataDog/ml-observability
+tests/contrib/botocore/test_bedrock_llmobs.py           @DataDog/ml-observability
+tests/contrib/botocore/bedrock_cassettes                @DataDog/ml-observability
+tests/contrib/anthropic                                 @DataDog/ml-observability
 
 # Remote Config
 ddtrace/internal/remoteconfig       @DataDog/remote-config @DataDog/apm-core-python


### PR DESCRIPTION
This PR updates the codeowners file following the `contrib` code move to `contrib/internal` so that team MLObs can continue to be the codeowners for the MLObs integration patch code.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
