### PR TITLE
chore(ci): update branch for auto-generate package version updates

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -9,6 +9,7 @@ on:
       # special branches used to test this workflow
       # before merging/releasing
       - build_deploy*
+      - 'upgrade-latest-*'
   pull_request:
   release:
     types:

--- a/.github/workflows/generate-package-versions.yml
+++ b/.github/workflows/generate-package-versions.yml
@@ -75,7 +75,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: "upgrade-${{ env.VENV_NAME }}-version"
+          branch: "upgrade-latest-${{ env.VENV_NAME }}-version"
           commit-message: "Test Package Versions update"
           delete-branch: true
           base: main


### PR DESCRIPTION
Currently, the build pipeline isn't triggered automatically upon an open PR unless we merge or push from main ([example](https://github.com/DataDog/dd-trace-py/pull/10392)).

This update adds the branch prefix `upgrade-latest-` to the 'allowlist' of branches that trigger the build and deploy pipeline, in order to have the auto-generated PRs trigger the appropriate jobs. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
