### PR TITLE
chore(ci_visibility): pytest: only compute dependency coverage once per suite

### DIFF
--- a/ddtrace/contrib/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/pytest/_plugin_v2.py
@@ -90,7 +90,7 @@ def _start_collecting_coverage() -> ModuleCodeCollector.CollectInContext:
 
 def _handle_collected_coverage(test_id, coverage_collector) -> None:
     # TODO: clean up internal coverage API usage
-    test_covered_lines = ModuleCodeCollector._instance._get_covered_lines(include_imported=True)
+    test_covered_lines = coverage_collector.get_covered_lines()
     coverage_collector.__exit__()
 
     record_code_coverage_finished(COVERAGE_LIBRARY.COVERAGEPY, FRAMEWORK)
@@ -106,6 +106,13 @@ def _handle_collected_coverage(test_id, coverage_collector) -> None:
         coverage_data[Path(path_str).absolute()] = covered_lines
 
     CISuite.add_coverage_data(test_id.parent_id, coverage_data)
+
+
+def _handle_coverage_dependencies(suite_id) -> None:
+    coverage_data = CISuite.get_coverage_data(suite_id)
+    coverage_paths = coverage_data.keys()
+    import_coverage = ModuleCodeCollector.get_import_coverage_for_paths(coverage_paths)
+    CISuite.add_coverage_data(suite_id, import_coverage)
 
 
 def _disable_ci_visibility():
@@ -270,6 +277,7 @@ def _pytest_runtest_protocol_post_yield(item, nextitem, coverage_collector):
         if CISuite.is_item_itr_skippable(suite_id) and not CISuite.was_forced_run(suite_id):
             CISuite.mark_itr_skipped(suite_id)
         else:
+            _handle_coverage_dependencies(suite_id)
             CISuite.finish(suite_id)
         if nextitem is None or (next_test_id is not None and next_test_id.parent_id.parent_id != module_id):
             CIModule.finish(module_id)
@@ -309,6 +317,12 @@ def _pytest_runtest_makereport(item, call, outcome):
 
     has_exception = call.excinfo is not None
 
+    # There are scenarios in which we may have already finished this item in setup or call, eg:
+    # - it was skipped by ITR
+    # - it was marked with skipif
+    if CITest.is_finished(test_id):
+        return
+
     # In cases where a test was marked as XFAIL, the reason is only available during when call.when == "call", so we
     # add it as a tag immediately:
     if getattr(result, "wasxfail", None):
@@ -324,12 +338,6 @@ def _pytest_runtest_makereport(item, call, outcome):
     # DEV NOTE: some skip scenarios (eg: skipif) have an exception during setup
 
     if call.when != "teardown" and not (has_exception or result.failed):
-        return
-
-    # There are scenarios in which we may have already finished this item in setup or call, eg:
-    # - it was skipped by ITR
-    # - it was marked with skipif
-    if CITest.is_finished(test_id):
         return
 
     xfail = hasattr(result, "wasxfail") or "xfail" in result.keywords

--- a/ddtrace/ext/ci_visibility/api.py
+++ b/ddtrace/ext/ci_visibility/api.py
@@ -429,6 +429,16 @@ class CIITRMixin(CIBase):
         log.debug("Adding coverage data for item %s: %s", item_id, coverage_data)
         core.dispatch("ci_visibility.item.add_coverage_data", (CIITRMixin.AddCoverageArgs(item_id, coverage_data),))
 
+    @staticmethod
+    @_catch_and_log_exceptions
+    def get_coverage_data(item_id: Union[CISuiteId, CITestId]) -> Optional[Dict[Path, CoverageLines]]:
+        log.debug("Getting coverage data for item %s", item_id)
+        coverage_data = core.dispatch_with_results(
+            "ci_visibility.item.get_coverage_data", (item_id,)
+        ).coverage_data.value
+        log.debug("Coverage data for item %s: %s", item_id, coverage_data)
+        return coverage_data
+
 
 class CISuite(CIITRMixin, CIBase):
     class DiscoverArgs(NamedTuple):

--- a/ddtrace/internal/ci_visibility/api/ci_base.py
+++ b/ddtrace/internal/ci_visibility/api/ci_base.py
@@ -443,6 +443,11 @@ class CIVisibilityItemBase(abc.ABC):
                 COVERAGE_TAG_NAME, self._coverage_data.build_payload(self._session_settings.workspace_path)
             )
 
+    def get_coverage_data(self) -> Optional[Dict[Path, CoverageLines]]:
+        if self._coverage_data is None:
+            return None
+        return self._coverage_data.get_data()
+
 
 class CIVisibilityChildItem(CIVisibilityItemBase, Generic[CIDT]):
     pass

--- a/ddtrace/internal/ci_visibility/api/ci_coverage_data.py
+++ b/ddtrace/internal/ci_visibility/api/ci_coverage_data.py
@@ -27,6 +27,9 @@ class CICoverageData:
     def __bool__(self):
         return bool(self._coverage_data)
 
+    def get_data(self):
+        return self._coverage_data
+
     def add_covered_files(self, covered_files: Dict[Path, CoverageLines]):
         """Add coverage segments to the coverage data"""
         for file_path, covered_lines in covered_files.items():

--- a/ddtrace/internal/ci_visibility/api/ci_coverage_data.py
+++ b/ddtrace/internal/ci_visibility/api/ci_coverage_data.py
@@ -27,7 +27,7 @@ class CICoverageData:
     def __bool__(self):
         return bool(self._coverage_data)
 
-    def get_data(self):
+    def get_data(self) -> Dict[Path, CoverageLines]:
         return self._coverage_data
 
     def add_covered_files(self, covered_files: Dict[Path, CoverageLines]):

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import socket
 from typing import TYPE_CHECKING  # noqa:F401
 from typing import Any  # noqa:F401
+from typing import Dict  # noqa:F401
 from typing import NamedTuple  # noqa:F401
 from typing import Optional
 from typing import Union  # noqa:F401
@@ -45,6 +46,7 @@ from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.writer.writer import Response
 
 from .. import agent
+from ..coverage.lines import CoverageLines
 from ..utils.http import verify_url
 from ..utils.time import StopWatch
 from .api.ci_module import CIVisibilityModule
@@ -80,7 +82,6 @@ from .writer import CIVisibilityWriter
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import DefaultDict  # noqa:F401
-    from typing import Dict  # noqa:F401
     from typing import List  # noqa:F401
     from typing import Tuple  # noqa:F401
 
@@ -1126,6 +1127,12 @@ def _register_item_handlers():
 
 
 @_requires_civisibility_enabled
+def _on_get_coverage_data(item_id: Union[CISuiteId, CITestId]) -> Optional[Dict[Path, CoverageLines]]:
+    log.debug("Handling get coverage data for item %s", item_id)
+    return CIVisibility.get_item_by_id(item_id).get_coverage_data()
+
+
+@_requires_civisibility_enabled
 def _on_add_coverage_data(add_coverage_args: CIITRMixin.AddCoverageArgs):
     """Adds coverage data to an item, merging with existing coverage data if necessary"""
     item_id = add_coverage_args.item_id
@@ -1142,6 +1149,7 @@ def _on_add_coverage_data(add_coverage_args: CIITRMixin.AddCoverageArgs):
 
 def _register_coverage_handlers():
     log.debug("Registering coverage handlers")
+    core.on("ci_visibility.item.get_coverage_data", _on_get_coverage_data, "coverage_data")
     core.on("ci_visibility.item.add_coverage_data", _on_add_coverage_data)
 
 

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -256,6 +256,19 @@ class ModuleCodeCollector(ModuleWatchdog):
         return cls._instance._coverage_enabled
 
     @classmethod
+    def get_import_coverage_for_paths(cls, paths: t.Iterable[Path]) -> t.Optional[t.Dict[Path, CoverageLines]]:
+        """Returns import-time coverage data for the given paths"""
+        coverages: t.Dict[Path, CoverageLines] = {}
+        if cls._instance is None:
+            return {}
+        for path in paths:
+            path_str = str(path)
+            if path_str in cls._instance._import_time_covered:
+                coverages[path] = cls._instance._import_time_covered[path_str]
+
+        return coverages
+
+    @classmethod
     def coverage_enabled_in_context(cls):
         return cls._instance is not None and ctx_coverage_enabled.get()
 


### PR DESCRIPTION
This updates the coverage collection mechanism for the new pytest plugin version to only collect dependency coverage once per suite.

`get_coverage_data()` is introduced as an API for `CISuite` and `CITest` items to fetch coverage data from the internal API.
`ModuleCodeCollector` gets a new `get_import_coverage_for_paths()` classmethod that returns coverage for the given paths.

No release note is added since this is still internal/unreleased code.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
