### PR TITLE
chore(ci_visibility): don't log exception when codeowners can't be loaded

### DIFF
--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -239,8 +239,6 @@ class CIVisibility(Service):
 
         try:
             self._codeowners = Codeowners()
-        except ValueError:
-            log.warning("CODEOWNERS file is not available")
         except Exception:
             log.warning("Failed to load CODEOWNERS", exc_info=True)
 
@@ -683,8 +681,10 @@ class CIVisibility(Service):
             handles = cls._instance._codeowners.of(location)
             if handles:
                 span.set_tag(test.CODEOWNERS, json.dumps(handles))
-        except KeyError:
-            log.debug("no matching codeowners for %s", location)
+            else:
+                log.debug("no matching codeowners for %s", location)
+        except Exception:
+            log.debug("Failed to set codeowners for %s", location, exc_info=True)
 
     @classmethod
     def add_session(cls, session: CIVisibilitySession):

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -685,7 +685,7 @@ class CIVisibility(Service):
                 span.set_tag(test.CODEOWNERS, json.dumps(handles))
             else:
                 log.debug("no matching codeowners for %s", location)
-        except KeyError:
+        except:  # noqa: E722
             log.debug("Error setting codeowners for %s", location, exc_info=True)
 
     @classmethod

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -239,6 +239,8 @@ class CIVisibility(Service):
 
         try:
             self._codeowners = Codeowners()
+        except ValueError:
+            log.warning("CODEOWNERS file is not available")
         except Exception:
             log.warning("Failed to load CODEOWNERS", exc_info=True)
 
@@ -681,10 +683,8 @@ class CIVisibility(Service):
             handles = cls._instance._codeowners.of(location)
             if handles:
                 span.set_tag(test.CODEOWNERS, json.dumps(handles))
-            else:
-                log.debug("no matching codeowners for %s", location)
-        except Exception:
-            log.debug("Failed to set codeowners for %s", location, exc_info=True)
+        except KeyError:
+            log.debug("no matching codeowners for %s", location)
 
     @classmethod
     def add_session(cls, session: CIVisibilitySession):

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -683,8 +683,10 @@ class CIVisibility(Service):
             handles = cls._instance._codeowners.of(location)
             if handles:
                 span.set_tag(test.CODEOWNERS, json.dumps(handles))
+            else:
+                log.debug("no matching codeowners for %s", location)
         except KeyError:
-            log.debug("no matching codeowners for %s", location)
+            log.debug("Error setting codeowners for %s", location, exc_info=True)
 
     @classmethod
     def add_session(cls, session: CIVisibilitySession):

--- a/ddtrace/internal/codeowners.py
+++ b/ddtrace/internal/codeowners.py
@@ -124,8 +124,10 @@ class Codeowners(object):
         :param path: path to CODEOWNERS file otherwise try to use any from known locations
         """
         path = path or self.location(cwd)
-        if path is not None:
-            self.path: str = path
+        if path is None:
+            raise ValueError("CODEOWNERS file not found")
+
+        self.path: str = path
         self.patterns: List[Tuple[re.Pattern, List[str]]] = []
         self.parse()
 
@@ -136,7 +138,7 @@ class Codeowners(object):
             path = os.path.join(cwd, location)
             if os.path.isfile(path):
                 return path
-        raise ValueError("CODEOWNERS file not found")
+        return None
 
     def parse(self) -> None:
         """Parse CODEOWNERS file and store the lines and regexes."""

--- a/ddtrace/internal/codeowners.py
+++ b/ddtrace/internal/codeowners.py
@@ -123,12 +123,15 @@ class Codeowners(object):
 
         :param path: path to CODEOWNERS file otherwise try to use any from known locations
         """
+        self.patterns: List[Tuple[re.Pattern, List[str]]] = []
+        self.path: Optional[str] = None
+
         path = path or self.location(cwd)
+
         if path is None:
             raise ValueError("CODEOWNERS file not found")
 
-        self.path: str = path
-        self.patterns: List[Tuple[re.Pattern, List[str]]] = []
+        self.path = path
         self.parse()
 
     def location(self, cwd: Optional[str] = None) -> Optional[str]:
@@ -142,6 +145,9 @@ class Codeowners(object):
 
     def parse(self) -> None:
         """Parse CODEOWNERS file and store the lines and regexes."""
+        if self.path is None:
+            return
+
         with open(self.path) as f:
             patterns = []
             for line in f.readlines():

--- a/ddtrace/internal/codeowners.py
+++ b/ddtrace/internal/codeowners.py
@@ -4,11 +4,6 @@ from typing import List  # noqa:F401
 from typing import Optional  # noqa:F401
 from typing import Tuple  # noqa:F401
 
-from ddtrace.internal.logger import get_logger
-
-
-log = get_logger(__name__)
-
 
 def path_to_regex(pattern):
     # type: (str) -> re.Pattern
@@ -131,13 +126,9 @@ class Codeowners(object):
         :param path: path to CODEOWNERS file otherwise try to use any from known locations
         """
         path = path or self.location(cwd)
-        self.patterns: List[Tuple[re.Pattern, List[str]]] = []
-
-        if path is None:
-            log.warning("CODEOWNERS file is not available")
-            return
-
-        self.path: str = path
+        if path is not None:
+            self.path = path  # type: str
+        self.patterns = []  # type: List[Tuple[re.Pattern, List[str]]]
         self.parse()
 
     def location(self, cwd: Optional[str] = None) -> Optional[str]:

--- a/ddtrace/internal/codeowners.py
+++ b/ddtrace/internal/codeowners.py
@@ -131,7 +131,7 @@ class Codeowners(object):
         self.patterns: List[Tuple[re.Pattern, List[str]]] = []
         self.parse()
 
-    def location(self, cwd=None) -> Optional[str]:
+    def location(self, cwd: Optional[str] = None) -> Optional[str]:
         """Return the location of the CODEOWNERS file."""
         cwd = cwd or os.getcwd()
         for location in self.KNOWN_LOCATIONS:

--- a/ddtrace/internal/codeowners.py
+++ b/ddtrace/internal/codeowners.py
@@ -190,4 +190,4 @@ class Codeowners(object):
         for pattern, owners in self.patterns:
             if pattern.search(path):
                 return owners
-        raise KeyError("no code owners found for {path}".format(path=path))
+        return []

--- a/ddtrace/internal/codeowners.py
+++ b/ddtrace/internal/codeowners.py
@@ -4,6 +4,11 @@ from typing import List  # noqa:F401
 from typing import Optional  # noqa:F401
 from typing import Tuple  # noqa:F401
 
+from ddtrace.internal.logger import get_logger
+
+
+log = get_logger(__name__)
+
 
 def path_to_regex(pattern):
     # type: (str) -> re.Pattern
@@ -126,9 +131,13 @@ class Codeowners(object):
         :param path: path to CODEOWNERS file otherwise try to use any from known locations
         """
         path = path or self.location(cwd)
-        if path is not None:
-            self.path = path  # type: str
-        self.patterns = []  # type: List[Tuple[re.Pattern, List[str]]]
+        self.patterns: List[Tuple[re.Pattern, List[str]]] = []
+
+        if path is None:
+            log.warning("CODEOWNERS file is not available")
+            return
+
+        self.path: str = path
         self.parse()
 
     def location(self, cwd: Optional[str] = None) -> Optional[str]:

--- a/ddtrace/internal/codeowners.py
+++ b/ddtrace/internal/codeowners.py
@@ -127,18 +127,18 @@ class Codeowners(object):
         """
         path = path or self.location(cwd)
         if path is not None:
-            self.path = path  # type: str
-        self.patterns = []  # type: List[Tuple[re.Pattern, List[str]]]
+            self.path: str = path
+        self.patterns: List[Tuple[re.Pattern, List[str]]] = []
         self.parse()
 
-    def location(self, cwd: Optional[str] = None) -> Optional[str]:
+    def location(self, cwd=None) -> Optional[str]:
         """Return the location of the CODEOWNERS file."""
         cwd = cwd or os.getcwd()
         for location in self.KNOWN_LOCATIONS:
             path = os.path.join(cwd, location)
             if os.path.isfile(path):
                 return path
-        return None
+        raise ValueError("CODEOWNERS file not found")
 
     def parse(self):
         # type: () -> None
@@ -190,4 +190,4 @@ class Codeowners(object):
         for pattern, owners in self.patterns:
             if pattern.search(path):
                 return owners
-        return []
+        raise KeyError("no code owners found for {path}".format(path=path))

--- a/ddtrace/internal/codeowners.py
+++ b/ddtrace/internal/codeowners.py
@@ -1,12 +1,11 @@
 import os
 import re
-from typing import List  # noqa:F401
-from typing import Optional  # noqa:F401
-from typing import Tuple  # noqa:F401
+from typing import List
+from typing import Optional
+from typing import Tuple
 
 
-def path_to_regex(pattern):
-    # type: (str) -> re.Pattern
+def path_to_regex(pattern: str) -> re.Pattern:
     """
     source https://github.com/sbdchd/codeowners/blob/c95e13d384ac09cfa1c23be1a8601987f41968ea/codeowners/__init__.py
 
@@ -119,8 +118,7 @@ class Codeowners(object):
         ".gitlab/CODEOWNERS",
     )
 
-    def __init__(self, path=None, cwd=None):
-        # type: (Optional[str], Optional[str]) -> None
+    def __init__(self, path: Optional[str] = None, cwd: Optional[str] = None):
         """Initialize Codeowners object.
 
         :param path: path to CODEOWNERS file otherwise try to use any from known locations
@@ -140,8 +138,7 @@ class Codeowners(object):
                 return path
         raise ValueError("CODEOWNERS file not found")
 
-    def parse(self):
-        # type: () -> None
+    def parse(self) -> None:
         """Parse CODEOWNERS file and store the lines and regexes."""
         with open(self.path) as f:
             patterns = []


### PR DESCRIPTION
Reverts the `Codeowners.__init__()` behavior introduced in #10094 which changed the exception being caught by the `CIVisibility` service when instantiating `Codeowners()`, resulting in undesirable log messages.

`Codeowners.__init__()` raising a `ValueError` exception, caught by the sole caller (`CIVisibility.__init__()`).

The `of()` behavior is maintained and the caller is updated to check for `[]` as an indication that no codeowner was found.

There is no release note as #10094 was only backported into `2.12`.

As a bonus, type hints are converted from comments to annotations.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
