### PR TITLE
chore(asm): use byte pointer instead of c_char_p (#10428)

### DIFF
--- a/ddtrace/appsec/_ddwaf/ddwaf_types.py
+++ b/ddtrace/appsec/_ddwaf/ddwaf_types.py
@@ -181,7 +181,7 @@ class ddwaf_object(ctypes.Structure):
     def struct(self) -> DDWafRulesType:
         """Generate a python structure from ddwaf_object"""
         if self.type == DDWAF_OBJ_TYPE.DDWAF_OBJ_STRING:
-            return self.value.stringValue.decode("UTF-8", errors="ignore")
+            return self.value.stringValue[: self.nbEntries].decode("UTF-8", errors="ignore")
         if self.type == DDWAF_OBJ_TYPE.DDWAF_OBJ_MAP:
             return {
                 self.value.array[i].parameterName.decode("UTF-8", errors="ignore"): self.value.array[i].struct
@@ -211,7 +211,7 @@ ddwaf_object_p = ctypes.POINTER(ddwaf_object)
 
 class ddwaf_value(ctypes.Union):
     _fields_ = [
-        ("stringValue", ctypes.c_char_p),
+        ("stringValue", ctypes.POINTER(ctypes.c_char)),
         ("uintValue", ctypes.c_ulonglong),
         ("intValue", ctypes.c_longlong),
         ("array", ddwaf_object_p),


### PR DESCRIPTION
Backport of https://github.com/DataDog/dd-trace-py/pull/10428

(cherry picked from commit 46bb2a83d85cfeb2b2d0301a4d2de1ef9ae3fc20)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
