### PR TITLE
chore(ci_visibility): fix line numbers in Python 3.10 bytecode

### DIFF
--- a/ddtrace/internal/coverage/instrumentation_py3_10.py
+++ b/ddtrace/internal/coverage/instrumentation_py3_10.py
@@ -357,11 +357,12 @@ def instrument_all_lines(code: CodeType, hook: HookType, path: str, package: str
             new_consts[original_offset], nested_lines = instrument_all_lines(nested_code, trap_func, trap_arg, package)
             seen_lines.update(nested_lines)
 
-    code = code.replace(
-        co_code=bytes(new_code),
-        co_consts=tuple(new_consts),
-        co_stacksize=code.co_stacksize + 4,  # TODO: Compute the value!
-        co_linetable=update_location_data(code, traps, [(instr.offset, s) for instr, s in exts]),
+    return (
+        code.replace(
+            co_code=bytes(new_code),
+            co_consts=tuple(new_consts),
+            co_stacksize=code.co_stacksize + 4,  # TODO: Compute the value!
+            co_linetable=update_location_data(code, traps, [(instr.offset, s) for instr, s in exts]),
+        ),
+        seen_lines,
     )
-
-    return code, seen_lines


### PR DESCRIPTION
The line number information in Python 3.10 bytecode is encoded using pairs of (offset_delta, line_number_delta) bytes ([more info here](https://github.com/python/cpython/blob/3.10/Objects/lnotab_notes.txt)). When the line number delta exceeds the limits of a signed byte, this is encoded by using an offset_delta of 0, which was not handled correctly by our instrumentation. This PR fixes that.

This solves an issue where two consecutive opcode instructions with a line gap greater than 127 would be assigned incorrect line numbers, which was triggering an error in dogweb CI.

## Testing strategy

This PR was tested in two ways:

- Verifying that the error in the dogweb CI is solved by the change.
-  Comparing the output of `dis.dis()` on the bytecode of the offending function in dogweb (1) before instrumentation, (2) after instrumentation before this fix, and (3) after instrumentation with this fix. After the fix, the line numbers for (1) and (3) match, whereas those for (2) don't.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
