### PR TITLE
fix(iast): fix leak on slice aspect. Add cleanup code to the trycatch macro.

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.cpp
@@ -52,7 +52,7 @@ api_index_aspect(PyObject* self, PyObject* const* args, const Py_ssize_t nargs)
     if (!is_text(candidate_text) or !is_some_number(idx)) {
         return result_o;
     }
-    TRY_CATCH_ASPECT("index_aspect", {
+    TRY_CATCH_ASPECT("index_aspect", , {
         const auto ctx_map = Initializer::get_tainting_map();
         if (not ctx_map or ctx_map->empty()) {
             return result_o;

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectModulo.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectModulo.cpp
@@ -19,7 +19,7 @@ api_modulo_aspect(StrType candidate_text, py::object candidate_tuple)
     py::tuple parameters =
       py::isinstance<py::tuple>(candidate_tuple) ? candidate_tuple : py::make_tuple(candidate_tuple);
 
-    TRY_CATCH_ASPECT("modulo_aspect", {
+    TRY_CATCH_ASPECT("modulo_aspect", , {
         auto [ranges_orig, candidate_text_ranges] = are_all_text_all_ranges(candidate_text.ptr(), parameters);
 
         if (ranges_orig.empty()) {

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
@@ -85,7 +85,7 @@ api_add_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     // PyNumber_Add actually works for any type!
     result_o = PyNumber_Add(candidate_text, text_to_add);
 
-    TRY_CATCH_ASPECT("add_aspect", {
+    TRY_CATCH_ASPECT("add_aspect", , {
         const auto tx_map = Initializer::get_tainting_map();
         if (not tx_map or tx_map->empty()) {
             return result_o;
@@ -119,7 +119,7 @@ api_add_inplace_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 
     result_o = PyNumber_InPlaceAdd(candidate_text, text_to_add);
 
-    TRY_CATCH_ASPECT("add_inplace_aspect", {
+    TRY_CATCH_ASPECT("add_inplace_aspect", , {
         const auto tx_map = Initializer::get_tainting_map();
         if (not tx_map or tx_map->empty()) {
             return result_o;

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectSlice.cpp
@@ -145,12 +145,13 @@ api_slice_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 
     PyObject* result_o = PyObject_GetItem(candidate_text, slice);
 
-    TRY_CATCH_ASPECT("slice_aspect", {
+    TRY_CATCH_ASPECT("slice_aspect", Py_XDECREF(slice), {
         // If no result or the params are not None|Number or the result is the same as the candidate text, nothing
         // to taint
         if (result_o == nullptr or (!is_text(candidate_text)) or (start != Py_None and !PyLong_Check(start)) or
             (stop != Py_None and !PyLong_Check(stop)) or (step != Py_None and !PyLong_Check(step)) or
             (get_unique_id(result_o) == get_unique_id(candidate_text))) {
+            Py_XDECREF(slice);
             return result_o;
         }
 

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectsOsPath.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectsOsPath.cpp
@@ -23,7 +23,7 @@ api_ospathjoin_aspect(StrType& first_part, const py::args& args)
         return result_o;
     }
 
-    TRY_CATCH_ASPECT("ospathjoin_aspect", {
+    TRY_CATCH_ASPECT("ospathjoin_aspect", , {
         const auto separator = ospath.attr("sep").cast<std::string>();
         const auto sepsize = separator.size();
 
@@ -105,7 +105,7 @@ api_ospathbasename_aspect(const StrType& path)
     auto basename = ospath.attr("basename");
     auto result_o = basename(path);
 
-    TRY_CATCH_ASPECT("ospathbasename_aspect", {
+    TRY_CATCH_ASPECT("ospathbasename_aspect", , {
         const auto tx_map = Initializer::get_tainting_map();
         if (not tx_map or tx_map->empty() or py::len(result_o) == 0) {
             return result_o;
@@ -138,7 +138,7 @@ api_ospathdirname_aspect(const StrType& path)
     auto dirname = ospath.attr("dirname");
     auto result_o = dirname(path);
 
-    TRY_CATCH_ASPECT("ospathdirname_aspect", {
+    TRY_CATCH_ASPECT("ospathdirname_aspect", , {
         const auto tx_map = Initializer::get_tainting_map();
         if (not tx_map or tx_map->empty() or py::len(result_o) == 0) {
             return result_o;
@@ -171,7 +171,7 @@ forward_to_set_ranges_on_splitted(const char* function_name, const StrType& path
     auto function = ospath.attr(function_name);
     auto result_o = function(path);
 
-    TRY_CATCH_ASPECT("forward_to_set_ranges_on_splitted", {
+    TRY_CATCH_ASPECT("forward_to_set_ranges_on_splitted", , {
         const auto tx_map = Initializer::get_tainting_map();
         if (not tx_map or tx_map->empty() or py::len(result_o) == 0) {
             return result_o;
@@ -223,7 +223,7 @@ api_ospathnormcase_aspect(const StrType& path)
     auto normcase = ospath.attr("normcase");
     auto result_o = normcase(path);
 
-    TRY_CATCH_ASPECT("ospathnormcase_aspect", {
+    TRY_CATCH_ASPECT("ospathnormcase_aspect", , {
         const auto tx_map = Initializer::get_tainting_map();
         if (not tx_map or tx_map->empty()) {
             return result_o;

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
@@ -200,15 +200,17 @@ exception_wrapper(Func func, const char* aspect_name, Args... args) -> std::opti
 }
 */
 
-#define TRY_CATCH_ASPECT(NAME, ...)                                                                                    \
+#define TRY_CATCH_ASPECT(NAME, CLEANUP, ...)                                                                           \
     try {                                                                                                              \
         __VA_ARGS__;                                                                                                   \
     } catch (const std::exception& e) {                                                                                \
         const std::string error_message = "IAST propagation error in " NAME ". " + std::string(e.what());              \
         iast_taint_log_error(error_message);                                                                           \
+        CLEANUP;                                                                                                       \
         return result_o;                                                                                               \
     } catch (...) {                                                                                                    \
         const std::string error_message = "Unknown IAST propagation error in " NAME ". ";                              \
         iast_taint_log_error(error_message);                                                                           \
+        CLEANUP;                                                                                                       \
         return result_o;                                                                                               \
     }

--- a/releasenotes/notes/slice-aspect-leak-95e264c4f1aa851c.yaml
+++ b/releasenotes/notes/slice-aspect-leak-95e264c4f1aa851c.yaml
@@ -1,0 +1,4 @@
+---
+issues:
+  - |
+    Fix a memory leak on the native slice aspect.


### PR DESCRIPTION
## Description

- Fix a memory leak on slice_aspect.
- Add a parameter to the TRY_CATCH_ASPECT macro to optionally add cleanup code to the exception handlers.

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
