### PR TITLE
chore(iast): fix memleak on process_flag_added_args

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/Helpers.h
@@ -179,17 +179,19 @@ inline PyObject*
 process_flag_added_args(PyObject* orig_function, const int flag_added_args, PyObject* args, PyObject* kwargs)
 {
     // If orig_function is not None and not the built-in str, bytes, or bytearray, slice args
-    auto orig_function_type = Py_TYPE(orig_function);
 
-    if (orig_function != Py_None && orig_function_type != &PyUnicode_Type && orig_function_type != &PyByteArray_Type &&
+    if (const auto orig_function_type = Py_TYPE(orig_function);
+        orig_function != Py_None && orig_function_type != &PyUnicode_Type && orig_function_type != &PyByteArray_Type &&
         orig_function_type != &PyBytes_Type) {
 
         if (flag_added_args > 0) {
-            Py_ssize_t num_args = PyTuple_Size(args);
+            const Py_ssize_t num_args = PyTuple_Size(args);
             PyObject* sliced_args = PyTuple_New(num_args - flag_added_args);
             for (Py_ssize_t i = 0; i < num_args - flag_added_args; ++i) {
-                PyTuple_SET_ITEM(sliced_args, i, PyTuple_GetItem(args, i + flag_added_args));
-                Py_INCREF(PyTuple_GetItem(args, i + flag_added_args));
+                // PyTuple_SET_ITEM(sliced_args, i, PyTuple_GET_ITEM(args, i + flag_added_args));
+                PyObject* item = PyTuple_GetItem(args, i + flag_added_args);
+                Py_INCREF(item);                        // Increase the reference count here
+                PyTuple_SET_ITEM(sliced_args, i, item); // Steal the reference
             }
             // Call the original function with the sliced args and return its result
             PyObject* result = PyObject_Call(orig_function, sliced_args, kwargs);
@@ -201,7 +203,10 @@ process_flag_added_args(PyObject* orig_function, const int flag_added_args, PyOb
     }
 
     // If orig_function is None or one of the built-in types, just return args for further processing
-    Py_INCREF(args); // Increment reference count before returning
+    // Note: it the caller assigns the PyObject* to a py::object or derivate like with:
+    // auto foo py::reinterpret_borrow<py::list>(result_or_args);
+    // Then you don't need to Py_INCREF the resulted value. But if it's used as a PyObject*, then you need
+    // to do it.
     return args;
 }
 


### PR DESCRIPTION
## Description

Fix a memleak on the recently introduced `process_flag_added_args` native utlity function.

Leak explanation: 

The new `process_flag_added_args` did a `Py_INCREF` of the returned args. This was correct on isolation, however all the uses of this function called `py::reinterpret_borrow<Typename>` on the returned value, which already internally increases the reference, thus causing a leak. 

Fix: remove the `Py_INCREF` and document the need to potentially do it on the caller if not used with pybind11 stuff.

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
