### PR TITLE
chore(CI): starlette tests

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -621,7 +621,7 @@ jobs:
             profiling: 0
             iast: 0
             appsec: 1
-    name: Starlette 0.37.1 (with ${{ matrix.suffix }})
+    name: Starlette 0.38.4 (with ${{ matrix.suffix }})
     runs-on: "ubuntu-latest"
     needs: needs-run
     env:

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -639,7 +639,7 @@ jobs:
       - uses: actions/setup-python@v5
         if: needs.needs-run.outputs.outcome == 'success'
         with:
-          python-version: '3.12'
+          python-version: '3.11'
       - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -639,7 +639,7 @@ jobs:
       - uses: actions/setup-python@v5
         if: needs.needs-run.outputs.outcome == 'success'
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -639,7 +639,7 @@ jobs:
       - uses: actions/setup-python@v5
         if: needs.needs-run.outputs.outcome == 'success'
         with:
-          python-version: '3.11'
+          python-version: '3.10'
       - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -639,7 +639,7 @@ jobs:
       - uses: actions/setup-python@v5
         if: needs.needs-run.outputs.outcome == 'success'
         with:
-          python-version: '3.10'
+          python-version: '3.9'
       - uses: actions/checkout@v4
         if: needs.needs-run.outputs.outcome == 'success'
         with:

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -601,7 +601,7 @@ jobs:
           pip install ../ddtrace
           tox run -e py312
 
-  starlette-testsuite-0_37_1:
+  starlette-testsuite-0_38_4:
     strategy:
       matrix:
         include:
@@ -648,7 +648,7 @@ jobs:
         if: needs.needs-run.outputs.outcome == 'success'
         with:
           repository: encode/starlette
-          ref: 0.37.1
+          ref: 0.38.4
           path: starlette
       - name: Install ddtrace
         if: needs.needs-run.outputs.outcome == 'success'

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -617,11 +617,10 @@ jobs:
             profiling: 0
             iast: 0
             appsec: 0
-          # Disabled while the bug is investigated: APPSEC-53221
-          # - suffix: APPSEC
-          #   profiling: 0
-          #   iast: 0
-          #   appsec: 1
+          - suffix: APPSEC
+            profiling: 0
+            iast: 0
+            appsec: 1
     name: Starlette 0.37.1 (with ${{ matrix.suffix }})
     runs-on: "ubuntu-latest"
     needs: needs-run

--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -102,7 +102,6 @@ async def _on_asgi_request_parse_body(receive, headers):
     if asm_config._asm_enabled:
         try:
             data_received = await receive()
-            body = data_received.get("body", b"")
         except Exception:
             return receive, None
 
@@ -112,8 +111,9 @@ async def _on_asgi_request_parse_body(receive, headers):
                 return data_received
             return await receive()
 
-        content_type = headers.get("content-type") or headers.get("Content-Type")
         try:
+            body = data_received.get("body", b"")
+            content_type = headers.get("content-type") or headers.get("Content-Type")
             if content_type in ("application/json", "text/json"):
                 if body is None or body == b"":
                     req_body = None

--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -100,8 +100,11 @@ core.on("set_http_meta_for_asm", _on_set_http_meta)
 
 async def _on_asgi_request_parse_body(receive, headers):
     if asm_config._asm_enabled:
-        data_received = await receive()
-        body = data_received.get("body", b"")
+        try:
+            data_received = await receive()
+            body = data_received.get("body", b"")
+        except Exception:
+            return receive, None
 
         async def receive_wrapped(once=[True]):
             if once[0]:


### PR DESCRIPTION
Fix and enable again starlette tests that were disabled.
Reason of the bug:
- starlette was fixed in 0.38.3 for an issue that was causing trouble in our appsec instrumentation. Tests were upgraded accordingly

Fix: 
https://github.com/encode/starlette/pull/2620
Issue:
https://github.com/encode/starlette/issues/2516


Also improve the guards in the asgi middleware appsec instrumentation for request body to ensure that we never break.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
