### PR TITLE
ci: move some misc non-contrib suites to gitlab

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -1240,22 +1240,6 @@ jobs:
       - store_artifacts:
           path: /tmp/docs
 
-  slotscheck:
-    executor: python310
-    steps:
-      - checkout
-      - setup_rust
-      - setup_hatch
-      - run: hatch run slotscheck:_
-
-  conftests:
-    executor: python310
-    steps:
-      - checkout
-      - setup_rust
-      - setup_hatch
-      - run: hatch run meta-testing:meta-testing
-
 requires_pre_check: &requires_pre_check
   requires:
     - pre_check

--- a/.gitlab/tests/core.yml
+++ b/.gitlab/tests/core.yml
@@ -33,3 +33,14 @@ ddtracerun:
   variables:
     SUITE_NAME: "ddtracerun"
     TEST_REDIS_HOST: "redis"
+
+slotscheck:
+  extends: .testrunner
+  script:
+    - hatch run slotscheck:_
+
+conftests:
+  extends: .testrunner
+  script:
+    - hatch run meta-testing:meta-testing
+

--- a/.gitlab/tests/core.yml
+++ b/.gitlab/tests/core.yml
@@ -36,11 +36,15 @@ ddtracerun:
 
 slotscheck:
   extends: .testrunner
+  stage: tests
+  needs: []
   script:
     - hatch run slotscheck:_
 
 conftests:
   extends: .testrunner
+  stage: tests
+  needs: []
   script:
     - hatch run meta-testing:meta-testing
 


### PR DESCRIPTION
This change moves the `slotscheck` and `conftests` suites from circleci to gitlab for billing purposes.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
