### PR TITLE
chore(profiling): use ddtrace config instead of reading os.environ

### DIFF
--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -9,6 +9,7 @@ from typing import Type  # noqa:F401
 from typing import Union  # noqa:F401
 
 import ddtrace
+from ddtrace import config
 from ddtrace.internal import agent
 from ddtrace.internal import atexit
 from ddtrace.internal import forksafe
@@ -26,7 +27,7 @@ from ddtrace.profiling.collector import memalloc
 from ddtrace.profiling.collector import stack
 from ddtrace.profiling.collector import stack_event
 from ddtrace.profiling.collector import threading
-from ddtrace.settings.profiling import config
+from ddtrace.settings.profiling import config as profiling_config
 
 
 LOG = logging.getLogger(__name__)
@@ -114,23 +115,23 @@ class _ProfilerInstance(service.Service):
         version: Optional[str] = None,
         tracer: Any = ddtrace.tracer,
         api_key: Optional[str] = None,
-        agentless: bool = config.agentless,
-        _memory_collector_enabled: bool = config.memory.enabled,
-        _stack_collector_enabled: bool = config.stack.enabled,
-        _stack_v2_enabled: bool = config.stack.v2_enabled,
-        _lock_collector_enabled: bool = config.lock.enabled,
-        enable_code_provenance: bool = config.code_provenance,
-        endpoint_collection_enabled: bool = config.endpoint_collection,
+        agentless: bool = profiling_config.agentless,
+        _memory_collector_enabled: bool = profiling_config.memory.enabled,
+        _stack_collector_enabled: bool = profiling_config.stack.enabled,
+        _stack_v2_enabled: bool = profiling_config.stack.v2_enabled,
+        _lock_collector_enabled: bool = profiling_config.lock.enabled,
+        enable_code_provenance: bool = profiling_config.code_provenance,
+        endpoint_collection_enabled: bool = profiling_config.endpoint_collection,
     ):
         super().__init__()
         # User-supplied values
         self.url: Optional[str] = url
-        self.service: Optional[str] = service if service is not None else os.environ.get("DD_SERVICE")
-        self.tags: Dict[str, str] = tags if tags is not None else config.tags
-        self.env: Optional[str] = env if env is not None else os.environ.get("DD_ENV")
-        self.version: Optional[str] = version if version is not None else os.environ.get("DD_VERSION")
+        self.service: Optional[str] = service if service is not None else config.service
+        self.tags: Dict[str, str] = tags if tags is not None else profiling_config.tags
+        self.env: Optional[str] = env if env is not None else config.env
+        self.version: Optional[str] = version if version is not None else config.version
         self.tracer: Any = tracer
-        self.api_key: Optional[str] = api_key if api_key is not None else os.environ.get("DD_API_KEY")
+        self.api_key: Optional[str] = api_key if api_key is not None else config._dd_api_key
         self.agentless: bool = agentless
         self._memory_collector_enabled: bool = _memory_collector_enabled
         self._stack_collector_enabled: bool = _stack_collector_enabled
@@ -145,7 +146,7 @@ class _ProfilerInstance(service.Service):
         self._collectors_on_import: Any = None
         self._scheduler: Optional[Union[scheduler.Scheduler, scheduler.ServerlessScheduler]] = None
         self._lambda_function_name: Optional[str] = os.environ.get("AWS_LAMBDA_FUNCTION_NAME")
-        self._export_libdd_enabled: bool = config.export.libdd_enabled
+        self._export_libdd_enabled: bool = profiling_config.export.libdd_enabled
 
         self.__post_init__()
 
@@ -161,7 +162,7 @@ class _ProfilerInstance(service.Service):
         # type: (...) -> List[exporter.Exporter]
         if not self._export_libdd_enabled:
             # If libdatadog support is enabled, we can skip this part
-            _OUTPUT_PPROF = config.output_pprof
+            _OUTPUT_PPROF = profiling_config.output_pprof
             if _OUTPUT_PPROF:
                 # DEV: Import this only if needed to avoid importing protobuf
                 # unnecessarily
@@ -207,15 +208,15 @@ class _ProfilerInstance(service.Service):
             configured_features.append("lock")
         if self._memory_collector_enabled:
             configured_features.append("mem")
-        if config.heap.sample_size > 0:
+        if profiling_config.heap.sample_size > 0:
             configured_features.append("heap")
 
         if self._export_libdd_enabled:
             configured_features.append("exp_dd")
         else:
             configured_features.append("exp_py")
-        configured_features.append("CAP" + str(config.capture_pct))
-        configured_features.append("MAXF" + str(config.max_frames))
+        configured_features.append("CAP" + str(profiling_config.capture_pct))
+        configured_features.append("MAXF" + str(profiling_config.max_frames))
         self.tags.update({"profiler_config": "_".join(configured_features)})
 
         endpoint_call_counter_span_processor = self.tracer._endpoint_call_counter_span_processor
@@ -231,11 +232,11 @@ class _ProfilerInstance(service.Service):
                     service=self.service,
                     version=self.version,
                     tags=self.tags,  # type: ignore
-                    max_nframes=config.max_frames,
+                    max_nframes=profiling_config.max_frames,
                     url=endpoint,
-                    timeline_enabled=config.timeline_enabled,
-                    output_filename=config.output_pprof,
-                    sample_pool_capacity=config.sample_pool_capacity,
+                    timeline_enabled=profiling_config.timeline_enabled,
+                    output_filename=profiling_config.output_pprof,
+                    sample_pool_capacity=profiling_config.sample_pool_capacity,
                 )
                 ddup.start()
 
@@ -243,13 +244,13 @@ class _ProfilerInstance(service.Service):
             except Exception as e:
                 LOG.error("Failed to initialize libdd collector (%s), falling back to the legacy collector", e)
                 self._export_libdd_enabled = False
-                config.export.libdd_enabled = False
+                profiling_config.export.libdd_enabled = False
 
                 # also disable other features that might be enabled
                 if self._stack_v2_enabled:
                     LOG.error("Disabling stack_v2 as libdd collector failed to initialize")
                     self._stack_v2_enabled = False
-                    config.stack.v2_enabled = False
+                    profiling_config.stack.v2_enabled = False
 
         # DEV: Import this only if needed to avoid importing protobuf
         # unnecessarily
@@ -284,7 +285,7 @@ class _ProfilerInstance(service.Service):
                 # Do not limit the heap sample size as the number of events is relative to allocated memory anyway
                 memalloc.MemoryHeapSampleEvent: None,
             },
-            default_max_events=config.max_events,
+            default_max_events=profiling_config.max_events,
         )
 
         if self._stack_collector_enabled:

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -43,13 +43,15 @@ def test_multiple_stop():
     p.stop(flush=False)
 
 
-@pytest.mark.parametrize(
-    "service_name_var",
-    ("DD_SERVICE",),
+@pytest.mark.subprocess(
+    env=dict(DD_API_KEY="foobar", DD_SERVICE="foobar"),
 )
-def test_default_from_env(service_name_var, monkeypatch):
-    monkeypatch.setenv("DD_API_KEY", "foobar")
-    monkeypatch.setenv(service_name_var, "foobar")
+def test_default_from_env():
+    import pytest
+
+    from ddtrace.profiling import profiler
+    from ddtrace.profiling.exporter import http
+
     prof = profiler.Profiler()
     for exp in prof._profiler._scheduler.exporters:
         if isinstance(exp, http.PprofHTTPExporter):
@@ -110,10 +112,15 @@ prof._recorder.push_event(stack_event.StackExceptionSampleEvent())
     assert err == b""
 
 
-def test_env_default(monkeypatch):
-    monkeypatch.setenv("DD_API_KEY", "foobar")
-    monkeypatch.setenv("DD_ENV", "staging")
-    monkeypatch.setenv("DD_VERSION", "123")
+@pytest.mark.subprocess(
+    env=dict(DD_API_KEY="foobar", DD_ENV="staging", DD_VERSION="123"),
+)
+def test_env_default():
+    import pytest
+
+    from ddtrace.profiling import profiler
+    from ddtrace.profiling.exporter import http
+
     prof = profiler.Profiler()
     assert prof.env == "staging"
     assert prof.version == "123"
@@ -295,9 +302,11 @@ def test_env_endpoint_url():
     _check_url(prof, "http://foobar:123", os.environ.get("DD_API_KEY"))
 
 
-def test_env_endpoint_url_no_agent(monkeypatch):
-    monkeypatch.setenv("DD_SITE", "datadoghq.eu")
-    monkeypatch.setenv("DD_API_KEY", "123")
+@pytest.mark.subprocess(env=dict(DD_SITE="datadoghq.eu", DD_API_KEY="123"))
+def test_env_endpoint_url_no_agent():
+    from ddtrace.profiling import profiler
+    from tests.profiling.test_profiler import _check_url
+
     prof = profiler.Profiler()
     _check_url(prof, "http://localhost:8126", "123")
 


### PR DESCRIPTION
## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
