### PR TITLE
docs: update contributing-integrations.rst

### DIFF
--- a/docs/contributing-integrations.rst
+++ b/docs/contributing-integrations.rst
@@ -109,13 +109,13 @@ What are "snapshot tests"?
 --------------------------
 
 Many of the tests are based on "snapshots": saved copies of actual traces sent to the
-`APM test agent <../README.md#use-the-apm-test-agent>`_. When an integration is added or modified, the snapshots
+`APM test agent <https://github.com/datadog/dd-apm-test-agent?tab=readme-ov-file#datadog-apm-test-agent>`_. When an integration is added or modified, the snapshots
 (if they exist) should be updated to match the new expected output.
 
 1. Update the library and test code to generate new traces.
 2. Delete the snapshot file corresponding to your test at ``tests/snapshots/<snapshot_file>`` (if applicable).
 3. Use `docker-compose up -d testagent` to start the APM test agent, and then re-run the test. Use `--pass-env` as described
-   `here <../README.md#use-the-apm-test-agent>`_ to ensure that your test run can talk to the test agent.
+   `here <https://github.com/datadog/dd-apm-test-agent?tab=readme-ov-file#running-the-tests>`_ to ensure that your test run can talk to the test agent.
 
 Once the run finishes, the snapshot file will have been regenerated.
 


### PR DESCRIPTION
updated the links in the snapshot-tests section of the doc to direct you to the [datadog-apm-test-agent](https://github.com/DataDog/dd-apm-test-agent?tab=readme-ov-file#datadog-apm-test-agent)


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
