### PR TITLE
chore(docs): update the contributing testing instructions for specific tests

### DIFF
--- a/docs/contributing-testing.rst
+++ b/docs/contributing-testing.rst
@@ -69,7 +69,7 @@ How do I run only the tests I care about?
 2. Find the ``Venv`` in the `riotfile <https://github.com/DataDog/dd-trace-py/blob/32b88eadc00e05cd0bc2aec587f565cc89f71229/riotfile.py#L426>`_
    whose ``command`` contains the tests you're interested in. Note the ``Venv``'s ``name`` - this is the
    "suite name".
-3. Find the directive in the `CI config <https://github.com/DataDog/dd-trace-py/blob/32b88eadc00e05cd0bc2aec587f565cc89f71229/.circleci/config.yml#L664>`_
+3. Find the directive in the file `./circleci/config.templ.yml <https://github.com/DataDog/dd-trace-py/blob/733a80eeb08c631967d3b17502cf0d6a9239c5cb/.circleci/config.templ.yml#L799>`_
    whose ``pattern`` is equal to the suite name. Note the ``docker_services`` section of the directive, if present -
    these are the "suite services".
 4. Start the suite services, if applicable, with ``$ docker-compose up -d service1 service2``.


### PR DESCRIPTION
Replaces https://github.com/DataDog/dd-trace-py/pull/10500 .

Thank you @taegyunkim for reviewing!

In the current docs for running specific tests, it says: 
> Find the directive in the [CI config](https://github.com/DataDog/dd-trace-py/blob/32b88eadc00e05cd0bc2aec587f565cc89f71229/.circleci/config.yml#L664) whose pattern is equal to the suite name. Note the docker_services section of the directive, if present - these are the "suite services".

This is referring to an older version of the repo, and assumes these lines are there:
```
  gevent:
    <<: *contrib_job
    docker:
      - image: *ddtrace_dev_image
      - *testagent
    steps:
      - run_test:
          pattern: 'gevent'
```

However, if I change the branch to `main`, it no longer looks like this.

Instead, it looks like this logic has been shifted to `config.templ.yml`: https://github.com/DataDog/dd-trace-py/blob/733a80eeb08c631967d3b17502cf0d6a9239c5cb/.circleci/config.templ.yml#L799 .

The goal of this PR is to update the link.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
