### PR TITLE
ci: revert "ci: migrate elasticsearch suite to GitLab (#10468)"

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -691,6 +691,15 @@ jobs:
       - run_test:
           pattern: 'consul'
 
+  elasticsearch:
+    <<: *machine_executor
+    parallelism: 17
+    steps:
+      - run_test:
+          pattern: 'elasticsearch'
+          snapshot: true
+          docker_services: 'elasticsearch opensearch'
+
   django:
     <<: *machine_executor
     parallelism: 4

--- a/.gitlab/tests/contrib.yml
+++ b/.gitlab/tests/contrib.yml
@@ -23,24 +23,6 @@ dogpile_cache:
   variables:
     SUITE_NAME: "dogpile_cache"
 
-elasticsearch:
-  extends: .test_base_riot_snapshot
-  parallel: 17
-  services:
-    - !reference [.test_base_riot_snapshot, services]
-    - name: registry.ddbuild.io/images/mirror/library/elasticsearch:7.17.23
-      alias: elasticsearch
-      variables:
-        discovery.type: single-node
-        xpack.security.enabled: false
-    - name: registry.ddbuild.io/images/mirror/opensearchproject/opensearch:1.3.13
-      alias: opensearch
-      variables:
-        DISABLE_SECURITY_PLUGIN: true
-        discovery.type: single-node
-  variables:
-    SUITE_NAME: "elasticsearch"
-
 falcon:
   extends: .test_base_riot_snapshot
   variables:


### PR DESCRIPTION
This reverts commit 9fa8f407d5a48f0dc9ae044b3a782da2b55cb414.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
