### PR TITLE
chore(profiling): set libdd_required when timeline_enabled (#10182) [backport-2.11]

### DIFF
--- a/ddtrace/settings/profiling.py
+++ b/ddtrace/settings/profiling.py
@@ -83,7 +83,8 @@ def _is_libdd_required(config):
     # v2 requires libdd because it communicates over a pure-native channel
     # libdd... requires libdd
     # injected environments _cannot_ deploy protobuf, so they must use libdd
-    return config.stack.v2_enabled or config.export._libdd_enabled or config._injected
+    # timeline requires libdd
+    return config.stack.v2_enabled or config.export._libdd_enabled or config._injected or config.timeline_enabled
 
 
 # This value indicates whether or not profiling is _loaded_ in an injected environment. It does not by itself


### PR DESCRIPTION
Manual backport of #10182 to 2.11

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

(cherry picked from commit 56f907a208a2d23c014482d8664ad37bc3a1d1aa)