### PR TITLE
chore(ci): use unified Gitlab pipeline for APM libraries [backport 2.12]

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -2,13 +2,6 @@ name: Build
 
 on:
   push:
-    branches:
-      - main
-      - '[0-9].[0-9]*'
-      - '[0-9].x'
-      # special branches used to test this workflow
-      # before merging/releasing
-      - build_deploy*
   pull_request:
   release:
     types:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,10 +21,10 @@ variables:
 package-oci:
   needs: [ download_dependency_wheels, download_ddtrace_artifacts ]
 
-# no installer tests for python
 onboarding_tests_installer:
-  rules:
-    - when: never
+  parallel:
+    matrix:
+      - ONBOARDING_FILTER_WEBLOG: [test-app-python,test-app-python-container,test-app-python-alpine-libgcc]
 
 onboarding_tests_k8s_injection:
   parallel:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,16 +21,15 @@ variables:
 package-oci:
   needs: [ download_dependency_wheels, download_ddtrace_artifacts ]
 
+# no installer tests for python
 onboarding_tests_installer:
-  parallel:
-    matrix:
-      - ONBOARDING_FILTER_WEBLOG: [test-app-python,test-app-python-container,test-app-python-alpine-libgcc]
-
+  rules:
+    - when: never
 
 onboarding_tests_k8s_injection:
   parallel:
     matrix:
-      - WEBLOG_VARIANT: [dd-lib-python-init-test-django, dd-lib-python-init-test-django-gunicorn, dd-lib-python-init-test-django-uvicorn, dd-lib-python-init-test-protobuf-old]
+      - WEBLOG_VARIANT: [dd-lib-python-init-test-django, dd-lib-python-init-test-django-gunicorn, dd-lib-python-init-test-django-uvicorn]
 
 deploy_to_di_backend:manual:
   stage: shared-pipeline


### PR DESCRIPTION
**What does this PR do?**
Converts the Gitlab workflow to use the unified pipeline.

By using the unified pipeline across all APM libraries, there is less maintenance hassle, fewer mistakes, and a more uniform creation of artifacts.

Additionally, this change creates OCI packages and lib inject images for every `dd-trace-py` build. Previously, only released versions to pypi were built and tested.

The changes can be summarized as follows:
* Removing github actions that are now taken over by the unified pipeline
* Removing Gitlab jobs taken over by the unified pipeline
* Adding a job to download artifacts from the github build
* Merging the download artifacts with dependencies from pypi

`.gitlab-ci.yml` is best reviewed in its final form rather than as a diff.

**How to test the change?**
The changes were tested manually. CI/CD workflows are notoriously hard to test. Final products the final lib-init image was run through automated onboarding tests. `dd-trace-py` doesn't have automated tests for OCI images

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
