### PR TITLE
ci: make pypi test upload actually upload [backport 2.12] (#10449)

### DIFF
--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -22,7 +22,7 @@ variables:
     - python -m pip install twine
     - python -m twine check --strict pywheels/*
   script:
-    - echo "python -m twine upload --repository ${PYPI_REPOSITORY} pywheels/*"
+    - python -m twine upload --repository ${PYPI_REPOSITORY} pywheels/*
   artifacts:
     paths:
       - pywheels/*.whl


### PR DESCRIPTION
Backport https://github.com/DataDog/dd-trace-py/commit/d80d22d7650ddd1e858128bf3989084af4f7fb50 from #10449 to 2.12.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing
strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note
guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if
[applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking
[API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces)
changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance
implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the
[release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

(cherry picked from commit https://github.com/DataDog/dd-trace-py/commit/d80d22d7650ddd1e858128bf3989084af4f7fb50)