### PR TITLE
ci: update codeowners for gitlab suites

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,6 +84,7 @@ tests/internal/test_injection.py    @DataDog/debugger-python @DataDog/apm-core-p
 tests/internal/test_wrapping.py     @DataDog/debugger-python @DataDog/apm-core-python
 tests/internal/test_module.py       @DataDog/debugger-python @DataDog/apm-core-python
 tests/internal/symbol_db/           @DataDog/debugger-python
+.gitlab/tests/debugging.yml         @DataDog/debugger-python
 
 # ASM
 .gitlab/tests/appsec.yml            @DataDog/asm-python
@@ -133,6 +134,7 @@ tests/contrib/botocore/test_bedrock.py                  @DataDog/ml-observabilit
 tests/contrib/botocore/test_bedrock_llmobs.py           @DataDog/ml-observability
 tests/contrib/botocore/bedrock_cassettes                @DataDog/ml-observability
 tests/contrib/anthropic                                 @DataDog/ml-observability
+.gitlab/tests/llmobs.yml                                @DataDog/ml-observability
 
 # Remote Config
 ddtrace/internal/remoteconfig       @DataDog/remote-config @DataDog/apm-core-python

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -54,5 +54,6 @@ include:
   - local: ".gitlab/tests/contrib.yml"
   - local: ".gitlab/tests/core.yml"
   - local: ".gitlab/tests/debugging.yml"
+  - local: ".gitlab/tests/llmobs.yml"
   - local: ".gitlab/tests/tracer.yml"
   - local: ".gitlab/tests/profiling.yml"

--- a/.gitlab/tests/contrib.yml
+++ b/.gitlab/tests/contrib.yml
@@ -187,25 +187,13 @@ tornado:
 
 unittest:
   extends: .test_base_riot_snapshot
-  variables: 
+  variables:
     SUITE_NAME: "unittest"
 
 wsgi:
   extends: .test_base_riot_snapshot
   variables:
     SUITE_NAME: "wsgi"
-
-langchain:
-  extends: .test_base_riot_snapshot
-  parallel: 6
-  variables:
-    SUITE_NAME: "langchain"
-
-anthropic:
-  extends: .test_base_riot_snapshot
-  parallel: 3
-  variables:
-    SUITE_NAME: "anthropic"
 
 loguru:
   extends: .test_base_riot_snapshot
@@ -243,21 +231,10 @@ stdlib:
   variables:
     SUITE_NAME: 'asyncio$|sqlite3$|futures$|dbapi$|dbapi_async$'
 
-llmobs:
-  extends: .test_base_riot
-  variables:
-    SUITE_NAME: "llmobs"
-
 subprocess:
   extends: .test_base_riot
   variables:
     SUITE_NAME: "subprocess"
-
-openai:
-  extends: .test_base_riot_snapshot
-  parallel: 10
-  variables:
-    SUITE_NAME: "openai"
 
 opentracer:
   extends: .test_base_riot

--- a/.gitlab/tests/llmobs.yml
+++ b/.gitlab/tests/llmobs.yml
@@ -1,0 +1,24 @@
+
+llmobs:
+  extends: .test_base_riot
+  variables:
+    SUITE_NAME: "llmobs"
+
+openai:
+  extends: .test_base_riot_snapshot
+  parallel: 10
+  variables:
+    SUITE_NAME: "openai"
+
+langchain:
+  extends: .test_base_riot_snapshot
+  parallel: 6
+  variables:
+    SUITE_NAME: "langchain"
+
+anthropic:
+  extends: .test_base_riot_snapshot
+  parallel: 3
+  variables:
+    SUITE_NAME: "anthropic"
+


### PR DESCRIPTION
This change updates codeowners for suites defined in gitlab. It also moves llmobs tests to their own file for this purpose.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
