### PR TITLE
chore(ci_visibility): add get_path_codeowners event handler

### DIFF
--- a/ddtrace/contrib/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/pytest/_plugin_v2.py
@@ -195,8 +195,6 @@ def _pytest_collection_finish(session) -> None:
     NOTE: Using pytest_collection_finish instead of pytest_collection_modifyitems allows us to capture only the
     tests that pytest has selection for run (eg: with the use of -k as an argument).
     """
-    codeowners = InternalTestSession.get_codeowners()
-
     for item in session.items:
         test_id = _get_test_id_from_item(item)
         suite_id = test_id.parent_id
@@ -208,7 +206,7 @@ def _pytest_collection_finish(session) -> None:
 
         item_path = Path(item.path if hasattr(item, "path") else item.fspath).absolute()
 
-        item_codeowners = codeowners.of(str(item_path)) if codeowners is not None else None
+        item_codeowners = InternalTestSession.get_path_codeowners(item_path)
 
         source_file_info = _get_source_file_info(item, item_path)
 

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -7,6 +7,7 @@ import socket
 from typing import TYPE_CHECKING  # noqa:F401
 from typing import Any  # noqa:F401
 from typing import Dict  # noqa:F401
+from typing import List  # noqa:F401
 from typing import NamedTuple  # noqa:F401
 from typing import Optional
 from typing import Union  # noqa:F401
@@ -83,7 +84,6 @@ from .writer import CIVisibilityWriter
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import DefaultDict  # noqa:F401
-    from typing import List  # noqa:F401
     from typing import Tuple  # noqa:F401
 
     from ddtrace.settings import IntegrationConfig  # noqa:F401
@@ -984,12 +984,22 @@ def _on_session_get_codeowners() -> Optional[Codeowners]:
     return CIVisibility.get_codeowners()
 
 
+@_requires_civisibility_enabled
+def _on_session_get_path_codeowners(path: Path) -> Optional[List[str]]:
+    log.debug("Getting codeowners for path %s", path)
+    codeowners = CIVisibility.get_codeowners()
+    if codeowners is None:
+        return None
+    return codeowners.of(str(path.absolute()))
+
+
 def _register_session_handlers():
     log.debug("Registering session handlers")
     core.on("test_visibility.session.discover", _on_discover_session)
     core.on("test_visibility.session.start", _on_start_session)
     core.on("test_visibility.session.finish", _on_finish_session)
     core.on("test_visibility.session.get_codeowners", _on_session_get_codeowners, "codeowners")
+    core.on("test_visibility.session.get_path_codeowners", _on_session_get_path_codeowners, "path_codeowners")
     core.on("test_visibility.session.get_workspace_path", _on_session_get_workspace_path, "workspace_path")
     core.on(
         "test_visibility.session.should_collect_coverage",

--- a/ddtrace/internal/test_visibility/api.py
+++ b/ddtrace/internal/test_visibility/api.py
@@ -185,6 +185,16 @@ class InternalTestSession(ext_api.TestSession):
 
         return _is_test_skipping_enabled
 
+    @staticmethod
+    @_catch_and_log_exceptions
+    def get_path_codeowners(path: Path) -> t.Optional[t.List[str]]:
+        log.debug("Getting codeowners object for path %s", path)
+
+        path_codeowners: t.Optional[t.List[str]] = core.dispatch_with_results(
+            "test_visibility.session.get_path_codeowners", (path,)
+        ).path_codeowners.value
+        return path_codeowners
+
 
 class InternalTestModule(ext_api.TestModule, InternalTestBase):
     pass


### PR DESCRIPTION
Adds a `test_visibility.session.get_path_codeowners` core event handler to get codeowners without having to fetch a codeowner object from the internal API.

No release note since the API is currently unreleased.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
