### PR TITLE
fix(profiling): stack_v2 properly tracks Threading [backport-2.10]

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack_v2/include/sampler.hpp
+++ b/ddtrace/internal/datadog/profiling/stack_v2/include/sampler.hpp
@@ -39,6 +39,8 @@ class Sampler
     static Sampler& get();
     void start();
     void stop();
+    void register_thread(uint64_t id, uint64_t native_id, const char* name);
+    void unregister_thread(uint64_t id);
 
     // The Python side dynamically adjusts the sampling rate based on overhead, so we need to be able to update our own
     // intervals accordingly.  Rather than a preemptive measure, we assume the rate is ~fairly stable and just update

--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -22,6 +22,7 @@ from ddtrace.profiling import collector
 from ddtrace.profiling.collector import _task
 from ddtrace.profiling.collector import _traceback
 from ddtrace.profiling.collector import stack_event
+from ddtrace.profiling.collector import threading
 from ddtrace.settings.profiling import config
 
 
@@ -499,7 +500,10 @@ class StackCollector(collector.PeriodicCollector):
 
         # If stack v2 is enabled, then use the v2 sampler
         if self._stack_collector_v2_enabled:
-            LOG.debug("Starting the stack v2 sampler")
+            # stack v2 requires us to patch the Threading module.  It's possible to do this from the stack v2 code
+            # itself, but it's a little bit fiddly and it's easier to make it correct here.
+            # TODO take the `threading` import out of here and just handle it in v2 startup
+            threading.init_stack_v2()
             stack_v2.start()
 
 

--- a/ddtrace/profiling/collector/threading.py
+++ b/ddtrace/profiling/collector/threading.py
@@ -1,9 +1,13 @@
 from __future__ import absolute_import
 
 import threading
+from threading import Thread
 import typing  # noqa:F401
 
 import attr
+
+from ddtrace.internal.datadog.profiling import stack_v2
+from ddtrace.settings.profiling import config
 
 from .. import event
 from . import _lock
@@ -39,3 +43,25 @@ class ThreadingLockCollector(_lock.LockCollector):
     ):
         # type: (...) -> None
         threading.Lock = value  # type: ignore[misc]
+
+
+# Also patch threading.Thread so echion can track thread lifetimes
+def init_stack_v2():
+    if config.stack.v2_enabled and stack_v2.is_available:
+        _thread_set_native_id = Thread._set_native_id
+        _thread_bootstrap_inner = Thread._bootstrap_inner
+
+        def thread_set_native_id(self, *args, **kswargs):
+            _thread_set_native_id(self, *args, **kswargs)
+            stack_v2.register_thread(self.ident, self.native_id, self.name)
+
+        def thread_bootstrap_inner(self, *args, **kwargs):
+            _thread_bootstrap_inner(self, *args, **kwargs)
+            stack_v2.unregister_thread(self.ident)
+
+        Thread._set_native_id = thread_set_native_id
+        Thread._bootstrap_inner = thread_bootstrap_inner
+
+        # Instrument any living threads
+        for thread_id, thread in threading._active.items():
+            stack_v2.register_thread(thread.ident, thread.native_id, thread.name)


### PR DESCRIPTION
Backport https://github.com/DataDog/dd-trace-py/commit/9848190b10af9e07f32cd79b333d1c23a0a0c60a from https://github.com/DataDog/dd-trace-py/pull/10066 to 2.10.

Looks like we dropped this part in the first cut for stack v2. Adding it back in.

Basically, stack v2 needs to know when threads are created in order to be able to track them off-GIL. In the future, we should probably harmonize on a common backplane for thread tracking, but for now... let's not.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [X] Reviewer has checked that all the criteria below are met
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

(cherry picked from commit 9848190b10af9e07f32cd79b333d1c23a0a0c60a)
