### PR TITLE
ci: ensure suite names match venvs

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -556,6 +556,14 @@ jobs:
           env: 'dd_coverage'
           snapshot: true
 
+  pytest_v2:
+    <<: *machine_executor
+    parallelism: 10
+    steps:
+      - run_hatch_env_test:
+          env: 'pytest_plugin_v2'
+          snapshot: true
+
   sourcecode:
     <<: *contrib_job_small
     steps:

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -8,10 +8,6 @@ variables:
   needs: []
   parallel: 4
   script:
-    - unset DD_SERVICE
-    - unset DD_ENV
-    - unset DD_TAGS
-    - unset DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED
     - |
       envs=( $(hatch env show --json | jq -r --arg suite_name "$SUITE_NAME" 'keys[] | select(. | contains($suite_name))' | sort | ./.gitlab/ci-split-input.sh) )
       if [[ ${#envs[@]} -eq 0 ]]; then

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -10,6 +10,10 @@ variables:
   script:
     - |
       envs=( $(hatch env show --json | jq -r --arg suite_name "$SUITE_NAME" 'keys[] | select(. | contains($suite_name))' | sort | ./.gitlab/ci-split-input.sh) )
+      if [[ ${#envs[@]} -eq 0 ]]; then
+        echo "No hatch envs found for ${SUITE_NAME}"
+        exit 1
+      fi
       for env in "${envs[@]}"
       do
         echo "Running hatch env: ${env}:test"
@@ -31,12 +35,19 @@ variables:
     - unset DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED
     - |
       hashes=( $(riot list --hash-only "${SUITE_NAME}" | sort | ./.gitlab/ci-split-input.sh) )
+      if [[ ${#hashes[@]} -eq 0 ]]; then
+        echo "No riot hashes found for ${SUITE_NAME}"
+        exit 1
+      fi
       for hash in "${hashes[@]}"
       do
         echo "Running riot hash: ${hash}"
         riot list "${hash}"
         ${RIOT_RUN_CMD} "${hash}"
       done
+      ./scripts/check-diff ".riot/requirements/" \
+        "Changes detected after running riot. Consider deleting changed files, running scripts/compile-and-prune-test-requirements and committing the result."
+
 
 .test_base_riot_snapshot:
   extends: .test_base_riot

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -8,6 +8,10 @@ variables:
   needs: []
   parallel: 4
   script:
+    - unset DD_SERVICE
+    - unset DD_ENV
+    - unset DD_TAGS
+    - unset DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED
     - |
       envs=( $(hatch env show --json | jq -r --arg suite_name "$SUITE_NAME" 'keys[] | select(. | contains($suite_name))' | sort | ./.gitlab/ci-split-input.sh) )
       if [[ ${#envs[@]} -eq 0 ]]; then

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -20,6 +20,16 @@ variables:
         hatch run ${env}:test
       done
 
+.test_base_hatch_snapshot:
+  extends: .test_base_hatch
+  services:
+    - !reference [.services, testagent]
+  before_script:
+    - !reference [.testrunner, before_script]
+    # DEV: All job variables get shared with services, setting `DD_TRACE_AGENT_URL` on the testagent will tell it to forward all requests to the
+    # agent at that host. Therefore setting this as a variable will cause recursive requests to the testagent
+    - export DD_TRACE_AGENT_URL="http://testagent:9126"
+
 .test_base_riot:
   extends: .testrunner
   stage: tests

--- a/.gitlab/tests/contrib.yml
+++ b/.gitlab/tests/contrib.yml
@@ -248,6 +248,7 @@ pytest_v2:
   extends: .test_base_hatch_snapshot
   parallel: 10
   variables:
+    DD_SERVICE: pytest
     SUITE_NAME: 'pytest_plugin_v2'
 
 django_hosts:

--- a/.gitlab/tests/contrib.yml
+++ b/.gitlab/tests/contrib.yml
@@ -244,13 +244,6 @@ asynctest:
   variables:
     SUITE_NAME: 'asynctest$'
 
-pytest_v2:
-  extends: .test_base_hatch_snapshot
-  parallel: 10
-  variables:
-    DD_SERVICE: pytest
-    SUITE_NAME: 'pytest_plugin_v2'
-
 django_hosts:
   extends: .test_base_riot_snapshot
   variables:

--- a/.gitlab/tests/contrib.yml
+++ b/.gitlab/tests/contrib.yml
@@ -80,6 +80,7 @@ kafka:
 
 aredis:
   extends: .test_base_riot_snapshot
+  parallel: 3
   services:
     - !reference [.test_base_riot_snapshot, services]
     - !reference [.services, redis]
@@ -239,11 +240,12 @@ logbook:
 
 asynctest:
   extends: .test_base_riot
+  parallel: 3
   variables:
     SUITE_NAME: 'asynctest$'
 
 pytest_v2:
-  extends: .test_base_riot_snapshot
+  extends: .test_base_hatch_snapshot
   parallel: 10
   variables:
     SUITE_NAME: 'pytest_plugin_v2'


### PR DESCRIPTION
This change ensures that every node actually runs at least 1 env/command (riot or hatch).

We also have to fix the broken tests:

- aredis and asynctest were running with `parallel: 4` when they only had 3 envs to run
- `pytest_v2` was running as a riot job when it needed to be hatch
  - the snapshots aren't working on GitLab so we had to convert it back to a CircleCI job

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
