### PR TITLE
chore(doc): correct documented default for DD_TRACE_PARTIAL_FLUSH_MIN_SPANS

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -414,7 +414,7 @@ The following environment variables for the tracer are supported:
 
    DD_TRACE_PARTIAL_FLUSH_MIN_SPANS:
      type: Integer
-     default: 500
+     default: 300
      description: Maximum number of spans sent per trace per payload when ``DD_TRACE_PARTIAL_FLUSH_ENABLED=True``.
 
    DD_APPSEC_ENABLED:


### PR DESCRIPTION
The current documentation for `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS` is inaccurate since the code sets [DD_TRACE_PARTIAL_FLUSH_MIN_SPANS to 300](https://github.com/DataDog/dd-trace-py/blob/036f8233d8f0102ac48aaac1e78ebcc2d07edd04/ddtrace/settings/config.py#L381), not `500`

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
