### PR TITLE
fix(iast): avoid potencial attribute error raise errors

### DIFF
--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -7,6 +7,7 @@ from wrapt import when_imported
 from wrapt import wrap_function_wrapper as _w
 import xmltodict
 
+from ddtrace.appsec._common_module_patches import try_wrap_function_wrapper
 from ddtrace.appsec._constants import SPAN_DATA_NAMES
 from ddtrace.appsec._iast._patch import if_iast_taint_returned_object_for
 from ddtrace.appsec._iast._patch import if_iast_taint_yield_tuple_for
@@ -221,7 +222,6 @@ def _on_flask_patch(flask_version):
     if _is_iast_enabled():
         from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_source
         from ddtrace.appsec._iast._patch import _patched_dictionary
-        from ddtrace.appsec._iast._patch import try_wrap_function_wrapper
         from ddtrace.appsec._iast._taint_tracking import OriginType
 
         try_wrap_function_wrapper(

--- a/ddtrace/appsec/_iast/_patch.py
+++ b/ddtrace/appsec/_iast/_patch.py
@@ -1,11 +1,8 @@
 import functools
 import sys
-from typing import Callable
 from typing import Text
 
-from wrapt import FunctionWrapper
-
-from ddtrace.appsec._common_module_patches import wrap_object
+from ddtrace.appsec._common_module_patches import try_wrap_function_wrapper
 from ddtrace.internal.logger import get_logger
 
 from ._metrics import _set_metric_iast_instrumented_source
@@ -35,13 +32,6 @@ def set_module_unpatched(module_str: Text, default_attr: Text = "_datadog_patch"
         setattr(module, default_attr, False)
     except ImportError:
         pass
-
-
-def try_wrap_function_wrapper(module: Text, name: Text, wrapper: Callable):
-    try:
-        wrap_object(module, name, FunctionWrapper, (wrapper,))
-    except (ImportError, AttributeError):
-        log.debug("IAST patching. Module %s.%s not exists", module, name)
 
 
 def if_iast_taint_returned_object_for(origin, wrapped, instance, args, kwargs):

--- a/ddtrace/appsec/_iast/_patches/json_tainting.py
+++ b/ddtrace/appsec/_iast/_patches/json_tainting.py
@@ -1,12 +1,12 @@
 from typing import Text
 
 from ddtrace.appsec._common_module_patches import try_unwrap
+from ddtrace.appsec._common_module_patches import try_wrap_function_wrapper
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
 
 from .._patch import set_and_check_module_is_patched
 from .._patch import set_module_unpatched
-from .._patch import try_wrap_function_wrapper
 
 
 log = get_logger(__name__)

--- a/ddtrace/appsec/_iast/taint_sinks/command_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/command_injection.py
@@ -3,10 +3,11 @@ import subprocess  # nosec
 from typing import List
 from typing import Union
 
-from ddtrace.contrib import trace_utils
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
 
+from ..._common_module_patches import try_unwrap
+from ..._common_module_patches import try_wrap_function_wrapper
 from ..._constants import IAST_SPAN_TAGS
 from .. import oce
 from .._metrics import _set_metric_iast_instrumented_sink
@@ -29,10 +30,10 @@ def patch():
 
     if not getattr(os, "_datadog_cmdi_patch", False):
         # all os.spawn* variants eventually use this one:
-        trace_utils.wrap(os, "_spawnvef", _iast_cmdi_osspawn)
+        try_wrap_function_wrapper("os", "_spawnvef", _iast_cmdi_osspawn)
 
     if not getattr(subprocess, "_datadog_cmdi_patch", False):
-        trace_utils.wrap(subprocess, "Popen.__init__", _iast_cmdi_subprocess_init)
+        try_wrap_function_wrapper("subprocess", "Popen.__init__", _iast_cmdi_subprocess_init)
 
         os._datadog_cmdi_patch = True
         subprocess._datadog_cmdi_patch = True
@@ -41,9 +42,9 @@ def patch():
 
 
 def unpatch() -> None:
-    trace_utils.unwrap(os, "system")
-    trace_utils.unwrap(os, "_spawnvef")
-    trace_utils.unwrap(subprocess.Popen, "__init__")
+    try_unwrap("os", "system")
+    try_unwrap("os", "_spawnvef")
+    try_unwrap("subprocess", "Popen.__init__")
 
     os._datadog_cmdi_patch = False  # type: ignore[attr-defined]
     subprocess._datadog_cmdi_patch = False  # type: ignore[attr-defined]

--- a/ddtrace/appsec/_iast/taint_sinks/header_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/header_injection.py
@@ -7,6 +7,7 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
 
 from ..._common_module_patches import try_unwrap
+from ..._common_module_patches import try_wrap_function_wrapper
 from ..._constants import IAST_SPAN_TAGS
 from .. import oce
 from .._metrics import _set_metric_iast_instrumented_sink
@@ -37,18 +38,18 @@ def patch():
 
     @when_imported("wsgiref.headers")
     def _(m):
-        trace_utils.wrap(m, "Headers.add_header", _iast_h)
-        trace_utils.wrap(m, "Headers.__setitem__", _iast_h)
+        try_wrap_function_wrapper(m, "Headers.add_header", _iast_h)
+        try_wrap_function_wrapper(m, "Headers.__setitem__", _iast_h)
 
     @when_imported("werkzeug.datastructures")
     def _(m):
-        trace_utils.wrap(m, "Headers.add", _iast_h)
+        try_wrap_function_wrapper(m, "Headers.add", _iast_h)
         trace_utils.wrap(m, "Headers.set", _iast_h)
 
     @when_imported("django.http.response")
     def _(m):
-        trace_utils.wrap(m, "HttpResponse.__setitem__", _iast_h)
-        trace_utils.wrap(m, "HttpResponseBase.__setitem__", _iast_h)
+        try_wrap_function_wrapper(m, "HttpResponse.__setitem__", _iast_h)
+        try_wrap_function_wrapper(m, "HttpResponseBase.__setitem__", _iast_h)
         try:
             trace_utils.wrap(m, "ResponseHeaders.__setitem__", _iast_h)
         except AttributeError:

--- a/ddtrace/appsec/_iast/taint_sinks/weak_cipher.py
+++ b/ddtrace/appsec/_iast/taint_sinks/weak_cipher.py
@@ -5,6 +5,7 @@ from typing import Set
 from typing import Text
 
 from ddtrace.appsec._common_module_patches import try_unwrap
+from ddtrace.appsec._common_module_patches import try_wrap_function_wrapper
 from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.appsec._iast.constants import BLOWFISH_DEF
 from ddtrace.appsec._iast.constants import DEFAULT_WEAK_CIPHER_ALGORITHMS
@@ -20,7 +21,6 @@ from .._metrics import _set_metric_iast_instrumented_sink
 from .._metrics import increment_iast_span_metric
 from .._patch import set_and_check_module_is_patched
 from .._patch import set_module_unpatched
-from .._patch import try_wrap_function_wrapper
 from ._base import VulnerabilityBase
 
 

--- a/ddtrace/appsec/_iast/taint_sinks/weak_hash.py
+++ b/ddtrace/appsec/_iast/taint_sinks/weak_hash.py
@@ -7,6 +7,7 @@ from typing import Set
 from typing import Text  # noqa:F401
 
 from ddtrace.appsec._common_module_patches import try_unwrap
+from ddtrace.appsec._common_module_patches import try_wrap_function_wrapper
 from ddtrace.internal.logger import get_logger
 
 from ..._constants import IAST_SPAN_TAGS
@@ -16,7 +17,6 @@ from .._metrics import _set_metric_iast_instrumented_sink
 from .._metrics import increment_iast_span_metric
 from .._patch import set_and_check_module_is_patched
 from .._patch import set_module_unpatched
-from .._patch import try_wrap_function_wrapper
 from ..constants import DEFAULT_WEAK_HASH_ALGORITHMS
 from ..constants import MD5_DEF
 from ..constants import SHA1_DEF

--- a/releasenotes/notes/iast-fix-iast-import-error-f26e1451571ecbae.yaml
+++ b/releasenotes/notes/iast-fix-iast-import-error-f26e1451571ecbae.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Code Security: This fixes a bug in the AST patching process where ``ImportError`` exceptions were being caught, interfering with the proper application cycle if an ``ImportError`` was expected.

--- a/releasenotes/notes/iast-fix-iast-import-error-f26e1451571ecbae.yaml
+++ b/releasenotes/notes/iast-fix-iast-import-error-f26e1451571ecbae.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Code Security: This fixes a bug in the AST patching process where ``ImportError`` exceptions were being caught, interfering with the proper application cycle if an ``ImportError`` was expected.
+    Code Security: This fixes a bug in the IAST patching process where ``AttributeError`` exceptions were being caught, interfering with the proper application cycle.

--- a/tests/appsec/iast/test_taint_utils.py
+++ b/tests/appsec/iast/test_taint_utils.py
@@ -1,6 +1,7 @@
 import mock
 import pytest
 
+from ddtrace.appsec._common_module_patches import try_wrap_function_wrapper
 from ddtrace.appsec._iast import oce
 from ddtrace.appsec._iast._patch_modules import patch_iast
 from ddtrace.appsec._iast._taint_tracking import OriginType
@@ -239,7 +240,6 @@ def test_checked_tainted_args():
 def lazy_taint_json_patch():
     from ddtrace.appsec._iast._patches.json_tainting import patched_json_encoder_default
     from ddtrace.appsec._iast._patches.json_tainting import try_unwrap
-    from ddtrace.appsec._iast._patches.json_tainting import try_wrap_function_wrapper
 
     try_wrap_function_wrapper("json.encoder", "JSONEncoder.default", patched_json_encoder_default)
     try_wrap_function_wrapper("simplejson.encoder", "JSONEncoder.default", patched_json_encoder_default)

--- a/tests/contrib/django/test_django_appsec_snapshots.py
+++ b/tests/contrib/django/test_django_appsec_snapshots.py
@@ -51,7 +51,7 @@ def daphne_client(django_asgi, additional_env=None):
     client = Client("http://localhost:%d" % SERVER_PORT)
 
     # Wait for the server to start up
-    client.wait(max_tries=120, delay=0.2, initial_wait=1.0)
+    client.wait(max_tries=120, delay=0.2, initial_wait=1.0, timeout=4)
 
     try:
         yield client

--- a/tests/contrib/django/test_django_appsec_snapshots.py
+++ b/tests/contrib/django/test_django_appsec_snapshots.py
@@ -67,6 +67,7 @@ def daphne_client(django_asgi, additional_env=None):
         "error",
         "type",
         "meta.error.stack",
+        "meta.http.request.headers.accept-encoding",
         "meta.http.request.headers.user-agent",
         "meta.http.useragent",
         "meta_struct",
@@ -91,6 +92,7 @@ def test_appsec_enabled():
         "error",
         "type",
         "meta.error.stack",
+        "meta.http.request.headers.accept-encoding",
         "meta.http.request.headers.user-agent",
         "meta.http.response.headers.content-type",  # depends of the Django version
         "meta.http.useragent",

--- a/tests/contrib/django/test_django_appsec_snapshots.py
+++ b/tests/contrib/django/test_django_appsec_snapshots.py
@@ -51,7 +51,7 @@ def daphne_client(django_asgi, additional_env=None):
     client = Client("http://localhost:%d" % SERVER_PORT)
 
     # Wait for the server to start up
-    client.wait()
+    client.wait(max_tries=120, delay=0.2, initial_wait=1.0)
 
     try:
         yield client

--- a/tests/webclient.py
+++ b/tests/webclient.py
@@ -43,13 +43,13 @@ class Client(object):
     def request(self, method, path, *args, **kwargs):
         return self._session.request(method, self._url(path), *args, **kwargs)
 
-    def wait(self, path="/", max_tries=100, delay=0.1, initial_wait=0):
+    def wait(self, path="/", max_tries=100, delay=0.1, initial_wait=0, timeout=1):
         # type: (str, int, float) -> None
         """Wait for the server to start by repeatedly http `get`ting `path` until a 200 is received."""
 
         @retry(after=[delay] * (max_tries - 1), initial_wait=initial_wait)
         def ping():
-            r = self.get_ignored(path, timeout=1)
+            r = self.get_ignored(path, timeout=timeout)
             assert r.status_code == 200
 
         ping()


### PR DESCRIPTION
Fix potencial AttributeError exception in IAST functions that wrap with trace_utils.wrap instead of try_wrap_function_wrapper

Remove duplicated definition of the `try_wrap_function_wrapper` function in:
```
from ddtrace.appsec._iast._patches import try_wrap_function_wrapper

from ddtrace.appsec._common_module_patches import try_wrap_function_wrapper
```

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
