### PR TITLE
fix(iast): avoid potencial attribute error raise errors [backport 2.10]

### DIFF
--- a/ddtrace/appsec/_iast/taint_sinks/command_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/command_injection.py
@@ -3,6 +3,7 @@ import subprocess  # nosec
 from typing import List
 from typing import Union
 
+from ddtrace.contrib import trace_utils
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
 

--- a/ddtrace/appsec/_iast/taint_sinks/command_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/command_injection.py
@@ -3,14 +3,15 @@ import subprocess  # nosec
 from typing import List
 from typing import Union
 
-from ddtrace.contrib import trace_utils
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
 
+from ..._common_module_patches import try_unwrap
 from ..._constants import IAST_SPAN_TAGS
 from .. import oce
 from .._metrics import _set_metric_iast_instrumented_sink
 from .._metrics import increment_iast_span_metric
+from .._patch import try_wrap_function_wrapper
 from ..constants import VULN_CMDI
 from ..processor import AppSecIastSpanProcessor
 from ._base import VulnerabilityBase
@@ -31,10 +32,10 @@ def patch():
         trace_utils.wrap(os, "system", _iast_cmdi_ossystem)
 
         # all os.spawn* variants eventually use this one:
-        trace_utils.wrap(os, "_spawnvef", _iast_cmdi_osspawn)
+        try_wrap_function_wrapper("os", "_spawnvef", _iast_cmdi_osspawn)
 
     if not getattr(subprocess, "_datadog_cmdi_patch", False):
-        trace_utils.wrap(subprocess, "Popen.__init__", _iast_cmdi_subprocess_init)
+        try_wrap_function_wrapper("subprocess", "Popen.__init__", _iast_cmdi_subprocess_init)
 
         os._datadog_cmdi_patch = True
         subprocess._datadog_cmdi_patch = True
@@ -43,9 +44,9 @@ def patch():
 
 
 def unpatch() -> None:
-    trace_utils.unwrap(os, "system")
-    trace_utils.unwrap(os, "_spawnvef")
-    trace_utils.unwrap(subprocess.Popen, "__init__")
+    try_unwrap("os", "system")
+    try_unwrap("os", "_spawnvef")
+    try_unwrap("subprocess", "Popen.__init__")
 
     os._datadog_cmdi_patch = False  # type: ignore[attr-defined]
     subprocess._datadog_cmdi_patch = False  # type: ignore[attr-defined]

--- a/ddtrace/appsec/_iast/taint_sinks/header_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/header_injection.py
@@ -1,7 +1,5 @@
 from typing import Text
 
-from wrapt.importer import when_imported
-
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
 from ddtrace.vendor.wrapt.importer import when_imported

--- a/ddtrace/appsec/_iast/taint_sinks/header_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/header_injection.py
@@ -1,6 +1,7 @@
 from typing import Text
 
-from ddtrace.contrib import trace_utils
+from wrapt.importer import when_imported
+
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
 from ddtrace.vendor.wrapt.importer import when_imported
@@ -12,6 +13,7 @@ from .._metrics import _set_metric_iast_instrumented_sink
 from .._metrics import increment_iast_span_metric
 from .._patch import set_and_check_module_is_patched
 from .._patch import set_module_unpatched
+from .._patch import try_wrap_function_wrapper
 from ..constants import HEADER_NAME_VALUE_SEPARATOR
 from ..constants import VULN_HEADER_INJECTION
 from ..processor import AppSecIastSpanProcessor
@@ -36,23 +38,19 @@ def patch():
 
     @when_imported("wsgiref.headers")
     def _(m):
-        trace_utils.wrap(m, "Headers.add_header", _iast_h)
-        trace_utils.wrap(m, "Headers.__setitem__", _iast_h)
+        try_wrap_function_wrapper(m, "Headers.add_header", _iast_h)
+        try_wrap_function_wrapper(m, "Headers.__setitem__", _iast_h)
 
     @when_imported("werkzeug.datastructures")
     def _(m):
-        trace_utils.wrap(m, "Headers.add", _iast_h)
-        trace_utils.wrap(m, "Headers.set", _iast_h)
+        try_wrap_function_wrapper(m, "Headers.add", _iast_h)
+        try_wrap_function_wrapper(m, "Headers.set", _iast_h)
 
     @when_imported("django.http.response")
     def _(m):
-        trace_utils.wrap(m, "HttpResponse.__setitem__", _iast_h)
-        trace_utils.wrap(m, "HttpResponseBase.__setitem__", _iast_h)
-        try:
-            trace_utils.wrap(m, "ResponseHeaders.__setitem__", _iast_h)
-        except AttributeError:
-            # no ResponseHeaders in django<3
-            pass
+        try_wrap_function_wrapper(m, "HttpResponse.__setitem__", _iast_h)
+        try_wrap_function_wrapper(m, "HttpResponseBase.__setitem__", _iast_h)
+        try_wrap_function_wrapper(m, "ResponseHeaders.__setitem__", _iast_h)
 
     _set_metric_iast_instrumented_sink(VULN_HEADER_INJECTION)
 

--- a/releasenotes/notes/iast-fix-iast-import-error-f26e1451571ecbae.yaml
+++ b/releasenotes/notes/iast-fix-iast-import-error-f26e1451571ecbae.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Code Security: This fixes a bug in the IAST patching process where ``AttributeError`` exceptions were being caught, interfering with the proper application cycle.

--- a/tests/contrib/django/test_django_appsec_snapshots.py
+++ b/tests/contrib/django/test_django_appsec_snapshots.py
@@ -66,6 +66,7 @@ def daphne_client(django_asgi, additional_env=None):
         "error",
         "type",
         "meta.error.stack",
+        "meta.http.request.headers.accept-encoding",
         "meta.http.request.headers.user-agent",
         "meta.http.useragent",
         "meta_struct",
@@ -90,6 +91,7 @@ def test_appsec_enabled():
         "error",
         "type",
         "meta.error.stack",
+        "meta.http.request.headers.accept-encoding",
         "meta.http.request.headers.user-agent",
         "meta.http.response.headers.content-type",  # depends of the Django version
         "meta.http.useragent",


### PR DESCRIPTION
Backport ad0d22344cae524949898ac88f034e2c7e731578 from #10586 to 2.10.

Fix potencial AttributeError exception in IAST functions that wrap with trace_utils.wrap instead of try_wrap_function_wrapper

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
