### PR TITLE
chore: [SVLS-5261] change Span._links to a list

### DIFF
--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -52,6 +52,7 @@ from ddtrace.internal.sampling import set_sampling_decision_maker
 from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.vendor.debtcollector import deprecate
 
+
 _NUMERIC_TAGS = (ANALYTICS_SAMPLE_RATE_KEY,)
 
 

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -620,13 +620,15 @@ class Span(object):
         if attributes is None:
             attributes = dict()
 
-        self._set_link_object(SpanLink(
-            trace_id=trace_id,
-            span_id=span_id,
-            tracestate=tracestate,
-            flags=flags,
-            attributes=attributes,
-        ))
+        self._set_link_object(
+            SpanLink(
+                trace_id=trace_id,
+                span_id=span_id,
+                tracestate=tracestate,
+                flags=flags,
+                attributes=attributes,
+            )
+        )
 
     def _set_link_object(self, link: SpanLink) -> None:
         # We will be changing this behavior to allow certain kinds of span

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -52,7 +52,6 @@ from ddtrace.internal.sampling import set_sampling_decision_maker
 from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.vendor.debtcollector import deprecate
 
-
 _NUMERIC_TAGS = (ANALYTICS_SAMPLE_RATE_KEY,)
 
 
@@ -195,9 +194,11 @@ class Span(object):
 
         self._context: Optional[Context] = context._with_span(self) if context else None
 
-        self._links: Dict[int, SpanLink] = {}
+        self._links: List[SpanLink] = []
         if links:
-            self._links = {link.span_id: link for link in links}
+            for new_link in links:
+                self._set_link_object(new_link)
+
         self._events: List[SpanEvent] = []
         self._parent: Optional["Span"] = None
         self._ignored_exceptions: Optional[List[Type[Exception]]] = None
@@ -574,7 +575,7 @@ class Span(object):
             ("error", self.error),
             ("tags", dict(sorted(self._meta.items()))),
             ("metrics", dict(sorted(self._metrics.items()))),
-            ("links", ", ".join([str(link) for _, link in self._links.items()])),
+            ("links", ", ".join([str(link) for link in self._links])),
             ("events", ", ".join([str(e) for e in self._events])),
         ]
         return " ".join(
@@ -619,20 +620,34 @@ class Span(object):
         if attributes is None:
             attributes = dict()
 
-        if span_id in self._links:
-            log.debug(
-                "Span %d already linked to span %d. Overwriting existing link: %s",
-                self.span_id,
-                span_id,
-                str(self._links[span_id]),
-            )
-        self._links[span_id] = SpanLink(
+        self._set_link_object(SpanLink(
             trace_id=trace_id,
             span_id=span_id,
             tracestate=tracestate,
             flags=flags,
             attributes=attributes,
-        )
+        ))
+
+    def _set_link_object(self, link: SpanLink) -> None:
+        # We will be changing this behavior to allow certain kinds of span
+        # links to coexist in the _links list even if they have the same
+        # span_id. For now, we are basically reimplementing the old
+        # dictionary-like behavior.
+
+        try:
+            existing_link_idx_with_same_span_id = [link.span_id for link in self._links].index(link.span_id)
+
+            log.debug(
+                "Span %d already linked to span %d. Overwriting existing link: %s",
+                self.span_id,
+                link.span_id,
+                str(self._links[existing_link_idx_with_same_span_id]),
+            )
+
+            self._links[existing_link_idx_with_same_span_id] = link
+
+        except ValueError:
+            self._links.append(link)
 
     def finish_with_ancestors(self) -> None:
         """Finish this span along with all (accessible) ancestors of this span.

--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -568,7 +568,7 @@ cdef class MsgpackEncoderV03(MsgpackEncoderBase):
         if ret != 0:
             return ret
 
-        for _, link in span_links():
+        for link in span_links:
             # SpanLink.to_dict() returns all serializable span link fields
             # v0.4 encoding is disabled by default. SpanLinks.to_dict() is optimizied for the v0.5 format.
             d = link.to_dict()

--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -563,12 +563,12 @@ cdef class MsgpackEncoderV03(MsgpackEncoderBase):
     cdef void * get_dd_origin_ref(self, str dd_origin):
         return string_to_buff(dd_origin)
 
-    cdef inline int _pack_links(self, object span_links):
+    cdef inline int _pack_links(self, list span_links):
         ret = msgpack_pack_array(&self.pk, len(span_links))
         if ret != 0:
             return ret
 
-        for _, link in span_links.items():
+        for _, link in span_links():
             # SpanLink.to_dict() returns all serializable span link fields
             # v0.4 encoding is disabled by default. SpanLinks.to_dict() is optimizied for the v0.5 format.
             d = link.to_dict()
@@ -905,7 +905,7 @@ cdef class MsgpackEncoderV05(MsgpackEncoderBase):
 
         span_links = ""
         if span._links:
-            span_links = json_dumps([link.to_dict() for _, link in span._links.items()])
+            span_links = json_dumps([link.to_dict() for link in span._links])
 
         span_events = ""
         if span._events:

--- a/tests/contrib/fastapi/test_fastapi.py
+++ b/tests/contrib/fastapi/test_fastapi.py
@@ -582,8 +582,10 @@ def test_background_task(snapshot_client_with_tracer, tracer, test_spans):
     background_span = spans[1][0]
     # background task should link to the request span
     assert background_span.parent_id is None
-    assert background_span._links[request_span.span_id].trace_id == request_span.trace_id
-    assert background_span._links[request_span.span_id].span_id == request_span.span_id
+    [link, *others] = [link for link in background_span._links if link.span_ie == request_span.span_id]
+    assert not others
+    assert link.trace_id == request_span.trace_id
+    assert link.span_id == request_span.span_id
     assert background_span.name == "fastapi.background_task"
     assert background_span.resource == "custom_task"
 

--- a/tests/contrib/fastapi/test_fastapi.py
+++ b/tests/contrib/fastapi/test_fastapi.py
@@ -582,7 +582,7 @@ def test_background_task(snapshot_client_with_tracer, tracer, test_spans):
     background_span = spans[1][0]
     # background task should link to the request span
     assert background_span.parent_id is None
-    [link, *others] = [link for link in background_span._links if link.span_ie == request_span.span_id]
+    [link, *others] = [link for link in background_span._links if link.span_id == request_span.span_id]
     assert not others
     assert link.trace_id == request_span.trace_id
     assert link.span_id == request_span.span_id

--- a/tests/contrib/starlette/test_starlette.py
+++ b/tests/contrib/starlette/test_starlette.py
@@ -542,8 +542,10 @@ def test_background_task(snapshot_client_with_tracer, tracer, test_spans):
     # background task should link to the request span
     assert background_span
     assert background_span.parent_id is None
-    assert background_span._links[request_span.span_id].trace_id == request_span.trace_id
-    assert background_span._links[request_span.span_id].span_id == request_span.span_id
+    [link, *others] = [link for link in background_span._links if link.span_id == request_span.span_id]
+    assert not others
+    assert link.trace_id == request_span.trace_id
+    assert link.span_id == request_span.span_id
     assert background_span.name == "starlette.background_task"
     assert background_span.resource == "custom_task"
 

--- a/tests/opentelemetry/test_trace.py
+++ b/tests/opentelemetry/test_trace.py
@@ -92,7 +92,8 @@ def test_otel_start_span_with_span_links(oteltracer):
     # assert that span3 has the expected links
     ddspan3 = span3._ddspan
     for span_context, attributes in ((span1_context, attributes1), (span2_context, attributes2)):
-        link = ddspan3._links.get(span_context.span_id)
+        [link, *others] = [link for link in ddspan3._links if link.span_id == span_context.span_id]
+        assert not others
         assert link.trace_id == span_context.trace_id
         assert link.span_id == span_context.span_id
         assert link.tracestate == span_context.trace_state.to_header()

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -479,7 +479,9 @@ def test_span_link_v04_encoding():
     )
     assert span._links
     # Drop one attribute so SpanLink.dropped_attributes_count is serialized
-    span._links.get(6)._drop_attribute("drop_me")
+    [link_6, *others] = [link for link in span._links if link.span_id == 6]
+    assert not others
+    link_6._drop_attribute("drop_me")
     # Finish the span to ensure a duration exists.
     span.finish()
 
@@ -585,7 +587,9 @@ def test_span_link_v05_encoding():
 
     assert len(span._links) == 2
     # Drop one attribute so SpanLink.dropped_attributes_count is serialized
-    span._links.get((2**64) - 1)._drop_attribute("drop_me")
+    [link_bignum, *others] = [link for link in span._links if link.span_id == (2**64) - 1]
+    assert not others
+    link_bignum._drop_attribute("drop_me")
 
     # Finish the span to ensure a duration exists.
     span.finish()

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -2495,14 +2495,14 @@ def test_span_links_set_on_root_span_not_child(fastapi_client, tracer, fastapi_t
 
     spans = fastapi_test_spans.pop_traces()
     assert spans[0][0].name == "fastapi.request"
-    assert spans[0][0]._links.get(67667974448284343) == SpanLink(
+    assert [link for link in spans[0][0]._links if link.span_id == 67667974448284343] == [SpanLink(
         trace_id=171395628812617415352188477958425669623,
         span_id=67667974448284343,
         tracestate="dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE",
         flags=1,
         attributes={"reason": "terminated_context", "context_headers": "tracecontext"},
-    )
-    assert spans[0][1]._links == {}
+    )]
+    assert spans[0][1]._links == []
     assert spans[0][1].context._span_links == []
 
 

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -2495,13 +2495,15 @@ def test_span_links_set_on_root_span_not_child(fastapi_client, tracer, fastapi_t
 
     spans = fastapi_test_spans.pop_traces()
     assert spans[0][0].name == "fastapi.request"
-    assert [link for link in spans[0][0]._links if link.span_id == 67667974448284343] == [SpanLink(
-        trace_id=171395628812617415352188477958425669623,
-        span_id=67667974448284343,
-        tracestate="dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE",
-        flags=1,
-        attributes={"reason": "terminated_context", "context_headers": "tracecontext"},
-    )]
+    assert [link for link in spans[0][0]._links if link.span_id == 67667974448284343] == [
+        SpanLink(
+            trace_id=171395628812617415352188477958425669623,
+            span_id=67667974448284343,
+            tracestate="dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE",
+            flags=1,
+            attributes={"reason": "terminated_context", "context_headers": "tracecontext"},
+        )
+    ]
     assert spans[0][1]._links == []
     assert spans[0][1].context._span_links == []
 

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -403,13 +403,15 @@ class SpanTestCase(TracerTestCase):
         }
         s1.link_span(s2.context, link_attributes)
 
-        assert [link for link in s1._links if link.span_id == s2.span_id] == [SpanLink(
-            trace_id=s2.trace_id,
-            span_id=s2.span_id,
-            tracestate="dd=s:1,congo=t61rcWkgMzE",
-            flags=1,
-            attributes=link_attributes,
-        )]
+        assert [link for link in s1._links if link.span_id == s2.span_id] == [
+            SpanLink(
+                trace_id=s2.trace_id,
+                span_id=s2.span_id,
+                tracestate="dd=s:1,congo=t61rcWkgMzE",
+                flags=1,
+                attributes=link_attributes,
+            )
+        ]
 
     def test_init_with_span_links(self):
         links = [

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -403,13 +403,13 @@ class SpanTestCase(TracerTestCase):
         }
         s1.link_span(s2.context, link_attributes)
 
-        assert s1._links.get(s2.span_id) == SpanLink(
+        assert [link for link in s1._links if link.span_id == s2.span_id] == [SpanLink(
             trace_id=s2.trace_id,
             span_id=s2.span_id,
             tracestate="dd=s:1,congo=t61rcWkgMzE",
             flags=1,
             attributes=link_attributes,
-        )
+        )]
 
     def test_init_with_span_links(self):
         links = [
@@ -420,11 +420,12 @@ class SpanTestCase(TracerTestCase):
         ]
         s = Span(name="test.span", links=links)
 
-        assert len(s._links) == 3
-        assert s._links.get(10) == links[0]
-        assert s._links.get(20) == links[1]
-        # duplicate links are overwritten (last one wins)
-        assert s._links.get(30) == links[3]
+        assert s._links == [
+            links[0],
+            links[1],
+            # duplicate links are overwritten (last one wins)
+            links[3],
+        ]
 
     def test_set_span_link(self):
         s = Span(name="test.span")
@@ -441,11 +442,12 @@ class SpanTestCase(TracerTestCase):
             mock.ANY,
         )
 
-        assert len(s._links) == 3
-        assert s._links.get(10) == SpanLink(trace_id=1, span_id=10)
-        assert s._links.get(20) == SpanLink(trace_id=1, span_id=20)
-        # duplicate links are overwritten (last one wins)
-        assert s._links.get(30) == SpanLink(trace_id=2, span_id=30, flags=1)
+        assert s._links == [
+            SpanLink(trace_id=1, span_id=10),
+            SpanLink(trace_id=1, span_id=20),
+            # duplicate links are overwritten (last one wins)
+            SpanLink(trace_id=2, span_id=30, flags=1),
+        ]
 
     # span links cannot have a span_id or trace_id value of 0 or less
     def test_span_links_error_with_id_0(self):


### PR DESCRIPTION
We are going to be using the `Span._links` structure to store Span Pointers soon. Span Pointers will have look like SpanLinks but will have `(trace_id=0, span_id=0)` so we cannot keep them in the old `_links` dictionary keyed by `span_id`.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
