### PR TITLE
chore: migrate dramatiq test suite from circleci to gitlab

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -667,15 +667,6 @@ jobs:
           snapshot: true
           docker_services: "memcached redis"
 
-  dramatiq:
-    <<: *machine_executor
-    parallelism: 2
-    steps:
-      - run_test:
-          pattern: "dramatiq"
-          snapshot: true
-          docker_services: "redis"
-
   httplib:
     <<: *machine_executor
     steps:

--- a/.gitlab/tests/contrib.yml
+++ b/.gitlab/tests/contrib.yml
@@ -28,6 +28,15 @@ dogpile_cache:
   variables:
     SUITE_NAME: "dogpile_cache"
 
+dramatiq:
+  extends: .test_base_riot_snapshot
+  services:
+    - !reference [.test_base_riot_snapshot, services]
+    - !reference [.services, redis]
+  variables:
+    SUITE_NAME: "dramatiq"
+    TEST_REDIS_HOST: "redis"
+
 elasticsearch:
   extends: .test_base_riot_snapshot
   parallel: 17


### PR DESCRIPTION
This PR migrates the dramatiq test suite from CircleCI to GitLab for cost reasons.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
