### PR TITLE
feat(tracer): [SVLS-5261] private Span Pointers

### DIFF
--- a/ddtrace/_trace/_span_link.py
+++ b/ddtrace/_trace/_span_link.py
@@ -37,6 +37,14 @@ from ddtrace.internal.utils.formats import flatten_key_value
 log = get_logger(__name__)
 
 
+class SpanLinkKind(Enum):
+    """
+    A collection of standard SpanLink kinds. It's possible to use others, but these should be used when possible.
+    """
+
+    SPAN_POINTER = "span-pointer"  # Should not be used on normal SpanLinks.
+
+
 def _id_not_zero(self, attribute_name, value):
     if not value > 0:
         raise ValueError(f"{attribute_name} must be > 0. Value is {value}")
@@ -129,7 +137,6 @@ class SpanLink:
 # Span Pointers are currently private, so let's put them here for now
 
 
-_SPAN_LINK_KIND_SPAN_POINTER = "span-pointer"
 _SPAN_POINTER_SPAN_LINK_TRACE_ID = 0
 _SPAN_POINTER_SPAN_LINK_SPAN_ID = 0
 
@@ -158,7 +165,7 @@ class _SpanPointer(SpanLink):
             },
         )
 
-        self.kind = _SPAN_LINK_KIND_SPAN_POINTER
+        self.kind = SpanLinkKind.SPAN_POINTER.value
 
     def __post_init__(self):
         # Do not want to do the trace_id and span_id checks that SpanLink does.

--- a/ddtrace/_trace/_span_link.py
+++ b/ddtrace/_trace/_span_link.py
@@ -27,6 +27,7 @@ SpanLinks can be set using :meth:`ddtrace.Span.link_span(...)` Ex::
 import dataclasses
 from enum import Enum
 from typing import Any
+from typing import Dict
 from typing import Optional
 
 from ddtrace.internal.utils.formats import flatten_key_value
@@ -140,7 +141,7 @@ class _SpanPointer(SpanLink):
         pointer_kind: str,
         pointer_direction: _SpanPointerDirection,
         pointer_hash: str,
-        extra_attributes: Optional[dict[str, Any]] = None,
+        extra_attributes: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(
             trace_id=_SPAN_POINTER_SPAN_LINK_TRACE_ID,

--- a/ddtrace/_trace/_span_link.py
+++ b/ddtrace/_trace/_span_link.py
@@ -25,6 +25,8 @@ SpanLinks can be set using :meth:`ddtrace.Span.link_span(...)` Ex::
 """
 
 import dataclasses
+from enum import Enum
+from typing import Any
 from typing import Optional
 
 from ddtrace.internal.utils.formats import flatten_key_value
@@ -70,8 +72,8 @@ class SpanLink:
         self.attributes["link.name"] = value
 
     @property
-    def kind(self):
-        return self.attributes["link.kind"]
+    def kind(self) -> Optional[Any]:
+        return self.attributes.get("link.kind")
 
     @kind.setter
     def kind(self, value):
@@ -117,3 +119,45 @@ class SpanLink:
             f"trace_id={self.trace_id} span_id={self.span_id} attributes={attrs_str} "
             f"tracestate={self.tracestate} flags={self.flags} dropped_attributes={self._dropped_attributes}"
         )
+
+
+# Span Pointers are currently private, so let's put them here for now
+
+
+_SPAN_LINK_KIND_SPAN_POINTER = "span-pointer"
+_SPAN_POINTER_SPAN_LINK_TRACE_ID = 0
+_SPAN_POINTER_SPAN_LINK_SPAN_ID = 0
+
+
+class _SpanPointerDirection(Enum):
+    UPSTREAM = "u"
+    DOWNSTREAM = "d"
+
+
+class _SpanPointer(SpanLink):
+    def __init__(
+        self,
+        pointer_kind: str,
+        pointer_direction: _SpanPointerDirection,
+        pointer_hash: str,
+        extra_attributes: Optional[dict[str, Any]] = None,
+    ):
+        super().__init__(
+            trace_id=_SPAN_POINTER_SPAN_LINK_TRACE_ID,
+            span_id=_SPAN_POINTER_SPAN_LINK_SPAN_ID,
+            attributes={
+                "ptr.kind": pointer_kind,
+                "ptr.dir": pointer_direction.value,
+                "ptr.hash": pointer_hash,
+                **(extra_attributes or {}),
+            },
+        )
+
+        self.kind = _SPAN_LINK_KIND_SPAN_POINTER
+
+    def __post_init__(self):
+        if self.trace_id != _SPAN_POINTER_SPAN_LINK_TRACE_ID:
+            raise ValueError(f"span pointer trace_id must be {_SPAN_POINTER_SPAN_LINK_TRACE_ID}")
+
+        if self.span_id != _SPAN_POINTER_SPAN_LINK_SPAN_ID:
+            raise ValueError(f"span pointer span_id must be {_SPAN_POINTER_SPAN_LINK_SPAN_ID}")

--- a/ddtrace/_trace/_span_link.py
+++ b/ddtrace/_trace/_span_link.py
@@ -161,18 +161,5 @@ class _SpanPointer(SpanLink):
         self.kind = _SPAN_LINK_KIND_SPAN_POINTER
 
     def __post_init__(self):
-        if self.trace_id != _SPAN_POINTER_SPAN_LINK_TRACE_ID:
-            log.warning(
-                "span pointer trace_id must be %d, found %d",
-                _SPAN_POINTER_SPAN_LINK_TRACE_ID,
-                self.trace_id,
-            )
-            self.trace_id = _SPAN_POINTER_SPAN_LINK_TRACE_ID
-
-        if self.span_id != _SPAN_POINTER_SPAN_LINK_SPAN_ID:
-            log.warning(
-                "span pointer span_id must be %d, found %d",
-                _SPAN_POINTER_SPAN_LINK_SPAN_ID,
-                self.span_id,
-            )
-            self.span_id = _SPAN_POINTER_SPAN_LINK_SPAN_ID
+        # Do not want to do the trace_id and span_id checks that SpanLink does.
+        pass

--- a/ddtrace/_trace/_span_link.py
+++ b/ddtrace/_trace/_span_link.py
@@ -30,7 +30,11 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 
+from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import flatten_key_value
+
+
+log = get_logger(__name__)
 
 
 def _id_not_zero(self, attribute_name, value):
@@ -73,11 +77,11 @@ class SpanLink:
         self.attributes["link.name"] = value
 
     @property
-    def kind(self) -> Optional[Any]:
+    def kind(self) -> Optional[str]:
         return self.attributes.get("link.kind")
 
     @kind.setter
-    def kind(self, value):
+    def kind(self, value: str) -> None:
         self.attributes["link.kind"] = value
 
     def _drop_attribute(self, key):
@@ -158,7 +162,17 @@ class _SpanPointer(SpanLink):
 
     def __post_init__(self):
         if self.trace_id != _SPAN_POINTER_SPAN_LINK_TRACE_ID:
-            raise ValueError(f"span pointer trace_id must be {_SPAN_POINTER_SPAN_LINK_TRACE_ID}")
+            log.warning(
+                "span pointer trace_id must be %d, found %d",
+                _SPAN_POINTER_SPAN_LINK_TRACE_ID,
+                self.trace_id,
+            )
+            self.trace_id = _SPAN_POINTER_SPAN_LINK_TRACE_ID
 
         if self.span_id != _SPAN_POINTER_SPAN_LINK_SPAN_ID:
-            raise ValueError(f"span pointer span_id must be {_SPAN_POINTER_SPAN_LINK_SPAN_ID}")
+            log.warning(
+                "span pointer span_id must be %d, found %d",
+                _SPAN_POINTER_SPAN_LINK_SPAN_ID,
+                self.span_id,
+            )
+            self.span_id = _SPAN_POINTER_SPAN_LINK_SPAN_ID

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -201,7 +201,7 @@ class Span(object):
         self._links: List[SpanLink] = []
         if links:
             for new_link in links:
-                self._set_link_object(new_link)
+                self._set_link_or_append_pointer(new_link)
 
         self._events: List[SpanEvent] = []
         self._parent: Optional["Span"] = None
@@ -624,7 +624,7 @@ class Span(object):
         if attributes is None:
             attributes = dict()
 
-        self._set_link_object(
+        self._set_link_or_append_pointer(
             SpanLink(
                 trace_id=trace_id,
                 span_id=span_id,
@@ -643,7 +643,7 @@ class Span(object):
     ) -> None:
         # This is a Private API for now.
 
-        self._set_link_object(
+        self._set_link_or_append_pointer(
             _SpanPointer(
                 pointer_kind=pointer_kind,
                 pointer_direction=pointer_direction,
@@ -652,7 +652,7 @@ class Span(object):
             )
         )
 
-    def _set_link_object(self, link: Union[SpanLink, _SpanPointer]) -> None:
+    def _set_link_or_append_pointer(self, link: Union[SpanLink, _SpanPointer]) -> None:
         if link.kind == _SPAN_LINK_KIND_SPAN_POINTER:
             self._links.append(link)
             return

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -198,7 +198,7 @@ class Span(object):
 
         self._context: Optional[Context] = context._with_span(self) if context else None
 
-        self._links: List[SpanLink] = []
+        self._links: List[Union[SpanLink, _SpanPointer]] = []
         if links:
             for new_link in links:
                 self._set_link_or_append_pointer(new_link)

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -14,8 +14,8 @@ from typing import Union
 from typing import cast
 
 from ddtrace import config
-from ddtrace._trace._span_link import _SPAN_LINK_KIND_SPAN_POINTER
 from ddtrace._trace._span_link import SpanLink
+from ddtrace._trace._span_link import SpanLinkKind
 from ddtrace._trace._span_link import _SpanPointer
 from ddtrace._trace._span_link import _SpanPointerDirection
 from ddtrace._trace.context import Context
@@ -653,7 +653,7 @@ class Span(object):
         )
 
     def _set_link_or_append_pointer(self, link: Union[SpanLink, _SpanPointer]) -> None:
-        if link.kind == _SPAN_LINK_KIND_SPAN_POINTER:
+        if link.kind == SpanLinkKind.SPAN_POINTER.value:
             self._links.append(link)
             return
 

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -652,7 +652,7 @@ class Span(object):
             )
         )
 
-    def _set_link_object(self, link: SpanLink | _SpanPointer) -> None:
+    def _set_link_object(self, link: Union[SpanLink, _SpanPointer]) -> None:
         if link.kind == _SPAN_LINK_KIND_SPAN_POINTER:
             self._links.append(link)
             return


### PR DESCRIPTION
Span Pointers are stored alongside Span Links. The API is private for now, so we don't have much documentation and all the new classes are prefixed with underscores.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
