### PR TITLE
chore(iast): python debug dockerfile update

### DIFF
--- a/docker/Dockerfile_py311_debug_mode
+++ b/docker/Dockerfile_py311_debug_mode
@@ -62,7 +62,7 @@ RUN git clone --depth 1 --branch v3.11.6 https://github.com/python/cpython/ "${P
 RUN wget https://bootstrap.pypa.io/get-pip.py
 RUN python3.11d get-pip.py --break-system-packages
 
-# Verifica la instalación de Python y pip
+# Verify Python and pip installation
 RUN python3.11d --version && python3.11d -m pip --version
 
 RUN python3.11d -c "import sys;sys.gettotalrefcount()"

--- a/docker/Dockerfile_py311_debug_mode
+++ b/docker/Dockerfile_py311_debug_mode
@@ -72,7 +72,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
 ENV PATH="/root/.cargo/bin:$PATH"
 
 RUN python3.11d -m pip install --break-system-packages setuptools cython wheel cmake pytest pytest-cov hypothesis pytest-memray\
-    "memray==1.12.0" \
+    "memray==1.14.0" \
     "requests==2.31.0" \
     "bytecode>=0.14.0" \
     "envier~=0.5" \

--- a/docker/Dockerfile_py311_debug_mode
+++ b/docker/Dockerfile_py311_debug_mode
@@ -1,8 +1,7 @@
 # DEV: Use `debian:slim` instead of an `alpine` image to support installing wheels from PyPI
 #      this drastically improves test execution time since python dependencies don't all
 #      have to be built from source all the time (grpcio takes forever to install)
-FROM debian:buster-20221219-slim
-
+FROM debian:bookworm-slim
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
 ENV LANG C.UTF-8
@@ -28,7 +27,6 @@ RUN \
       gnupg \
       jq \
       libbz2-dev \
-      libenchant-dev \
       libffi-dev \
       liblzma-dev \
       libmemcached-dev \
@@ -42,13 +40,13 @@ RUN \
       libssh-dev \
       libssl-dev \
       patch \
-      python-openssl\
       unixodbc-dev \
       wget \
       zlib1g-dev \
       valgrind \
-    # Cleaning up apt cache space
-  && rm -rf /var/lib/apt/lists/*
+      gawk \
+      wget \
+      software-properties-common
 
 # Install pyenv and necessary Python versions
 # `--with-pydebug`: [Add options](https://docs.python.org/3/using/configure.html#python-debug-build) like count references, sanity checks...
@@ -61,16 +59,29 @@ RUN git clone --depth 1 --branch v3.11.6 https://github.com/python/cpython/ "${P
   && make install \
   && cd -
 
-RUN python3.11 -m pip install -U pip \
-    && python3.11 -m pip install setuptools cython wheel cmake pytest pytest-cov hypothesis pytest-memray\
-    memray==1.12.0 \
-    requests==2.31.0 \
-    bytecode>=0.14.0 \
-    envier~=0.5 \
-    opentelemetry-api>=1 \
-    protobuf>=3 \
+RUN wget https://bootstrap.pypa.io/get-pip.py
+RUN python3.11d get-pip.py --break-system-packages
+
+# Verifica la instalación de Python y pip
+RUN python3.11d --version && python3.11d -m pip --version
+
+RUN python3.11d -c "import sys;sys.gettotalrefcount()"
+
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
+ENV PATH="/root/.cargo/bin:$PATH"
+
+RUN python3.11d -m pip install --break-system-packages setuptools cython wheel cmake pytest pytest-cov hypothesis pytest-memray\
+    "memray==1.12.0" \
+    "requests==2.31.0" \
+    "bytecode>=0.14.0" \
+    "envier~=0.5" \
+    "opentelemetry-api>=1" \
+    "protobuf>=3" \
     typing_extensions \
-    xmltodict>=0.12
+    "xmltodict>=0.12" \
+    setuptools-rust \
+    wrapt
 
 
 CMD ["/bin/bash"]

--- a/scripts/iast/.env
+++ b/scripts/iast/.env
@@ -1,6 +1,6 @@
 export PATH=$PATH:$PWD
 export PYTHONPATH=$PYTHONPATH:$PWD
-export PYTHON_VERSION=python3.11
+export PYTHON_VERSION=python3.11d
 export PYTHONMALLOC=malloc
 export DD_COMPILE_DEBUG=true
 export DD_TRACE_ENABLED=true

--- a/scripts/iast/run_memory.sh
+++ b/scripts/iast/run_memory.sh
@@ -1,3 +1,3 @@
 PYTHON="${PYTHON_VERSION:-python3.11}"
 $PYTHON -m pip install -r scripts/iast/requirements.txt
-$PYTHON scripts/iast/test_leak_functions.py 1000000
+$PYTHON scripts/iast/test_leak_functions.py --iterations 1000000 --print_every 250

--- a/scripts/iast/run_memory.sh
+++ b/scripts/iast/run_memory.sh
@@ -1,3 +1,5 @@
+set -o xtrace
+
 PYTHON="${PYTHON_VERSION:-python3.11}"
 $PYTHON -m pip install -r scripts/iast/requirements.txt
 $PYTHON scripts/iast/test_leak_functions.py --iterations 1000000 --print_every 250

--- a/scripts/iast/run_memray.sh
+++ b/scripts/iast/run_memray.sh
@@ -1,4 +1,6 @@
+set -o xtrace
+
 PYTHON="${PYTHON_VERSION:-python3.11d}"
 $PYTHON -m pip install -r scripts/iast/requirements.txt
 $PYTHON -m memray run --trace-python-allocators --aggregate --native -o lel.bin -f scripts/iast/test_leak_functions.py --iterations 100
-$PYTHON -m memray flamegraph lel.bin --leaks -f
+# $PYTHON -m memray flamegraph lel.bin --leaks -f

--- a/scripts/iast/run_memray.sh
+++ b/scripts/iast/run_memray.sh
@@ -1,4 +1,4 @@
-PYTHON="${PYTHON_VERSION:-python3.11}"
+PYTHON="${PYTHON_VERSION:-python3.11d}"
 $PYTHON -m pip install -r scripts/iast/requirements.txt
-$PYTHON -m memray run --trace-python-allocators --aggregate --native -o lel.bin -f scripts/iast/test_leak_functions.py 100
+$PYTHON -m memray run --trace-python-allocators --aggregate --native -o lel.bin -f scripts/iast/test_leak_functions.py --iterations 100
 $PYTHON -m memray flamegraph lel.bin --leaks -f

--- a/scripts/iast/run_references.sh
+++ b/scripts/iast/run_references.sh
@@ -1,4 +1,4 @@
 set -o xtrace
+
 PYTHON="${PYTHON_VERSION:-python3.11d}"
-$PYTHON -m pip install wrapt
 ${PYTHON} -m ddtrace.commands.ddtrace_run ${PYTHON} scripts/iast/test_references.py

--- a/scripts/iast/run_references.sh
+++ b/scripts/iast/run_references.sh
@@ -1,4 +1,4 @@
-PYTHON="${PYTHON_VERSION:-python3.11}"
-# $PYTHON setup.py build_ext --inplace
-${PYTHON} -m pip install -r scripts/iast/requirements.txt
+set -o xtrace
+PYTHON="${PYTHON_VERSION:-python3.11d}"
+$PYTHON -m pip install wrapt
 ${PYTHON} -m ddtrace.commands.ddtrace_run ${PYTHON} scripts/iast/test_references.py

--- a/scripts/iast/test_references.py
+++ b/scripts/iast/test_references.py
@@ -9,7 +9,7 @@ from ddtrace.appsec._iast._taint_tracking import reset_context
 
 
 def test_main():
-    for i in range(100):
+    for i in range(1000):
         gc.collect()
         a = sys.gettotalrefcount()
         try:


### PR DESCRIPTION
Update Python in debug mode dockerfile and scripts.
- Migrate to debian:bookworm-slim due to ddtrace core needs glibc-2.29
- .sh files are not running the last version of *.py files. Now the py files needs arguments


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
