### PR TITLE
chore: easier memleak testing so gitlab does not timeout

### DIFF
--- a/.gitlab/tests/appsec.yml
+++ b/.gitlab/tests/appsec.yml
@@ -54,7 +54,7 @@ appsec threats fastapi:
 
 appsec aggregated leak testing:
   extends: .test_base_hatch
-  parallel: 6
+  parallel: 5
   variables:
     SUITE_NAME: "appsec_aggregated_leak_testing"
   retry: 2

--- a/.gitlab/tests/appsec.yml
+++ b/.gitlab/tests/appsec.yml
@@ -29,6 +29,8 @@ appsec iast memcheck:
   parallel: 5
   variables:
     SUITE_NAME: "appsec_iast_memcheck"
+    CI_DEBUG_TRACE: "true" 
+    PYTEST_ADDOPTS: "-v -s" 
   retry: 2
 
 appsec threats django:

--- a/hatch.toml
+++ b/hatch.toml
@@ -331,7 +331,7 @@ test = [
 ]
 
 [[envs.appsec_aggregated_leak_testing.matrix]]
-python = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
 
 # if you add or remove a version here, please also update the parallelism parameter

--- a/scripts/iast/test_leak_functions.py
+++ b/scripts/iast/test_leak_functions.py
@@ -61,13 +61,13 @@ def test_iast_leaks(iterations: int, fail_percent: float, print_every: int):
         percent_increase = ((final_rss - half_rss) / half_rss) * 100
         if percent_increase > fail_percent:
             print(
-                f"Failed: memory increase from half-point ({half_iterations} iterations) is "
+                f"Failed: memory increase from reference-point ({mem_reference_iterations} iterations) is "
                 f"{percent_increase:.2f}% which is greater than {fail_percent}%"
             )
             return 1
 
         print(
-            f"Success: memory increase is {percent_increase:.2f}% from half-point ({half_iterations} "
+            f"Success: memory increase is {percent_increase:.2f}% from reference-point ({mem_reference_iterations} "
             f"iterations) which is less than {fail_percent}%"
         )
         return 0

--- a/scripts/iast/test_leak_functions.py
+++ b/scripts/iast/test_leak_functions.py
@@ -23,13 +23,14 @@ def parse_arguments():
 
 
 def test_iast_leaks(iterations: int, fail_percent: float, print_every: int):
-    if iterations < 100000:
+    if iterations < 60000:
         print(
-            "Warning: running with %d iterations. At least 100.000 are recommended to stabilize the RSS info"
-            % iterations
+            "Error: not running with %d iterations. At least 60.000 are needed to stabilize the RSS info" % iterations
         )
+        sys.exit(1)
+
     try:
-        half_iterations = iterations // 2
+        mem_reference_iterations = 50000
         print("Test %d iterations" % iterations)
         current_rss = 0
         half_rss = 0
@@ -44,8 +45,9 @@ def test_iast_leaks(iterations: int, fail_percent: float, print_every: int):
             assert is_pyobject_tainted(result)
             reset_context()
 
-            if i == half_iterations:
+            if i == mem_reference_iterations:
                 half_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+                print("Reference usage taken at %d iterations: %f" % (i, half_rss))
 
             current_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
 

--- a/tests/appsec/iast_aggregated_memcheck/test_aggregated_memleaks.py
+++ b/tests/appsec/iast_aggregated_memcheck/test_aggregated_memleaks.py
@@ -5,4 +5,4 @@ def test_aggregated_leaks():
     with override_env({"DD_IAST_ENABLED": "True"}):
         from scripts.iast.test_leak_functions import test_iast_leaks
 
-        assert test_iast_leaks(100000, 2.0, 100) == 0
+        assert test_iast_leaks(75000, 2.0, 100) == 0


### PR DESCRIPTION
## Description

- Remove Python 3.7 for memleak testing since it have a tendency to timeout.
- Lower the number of iterations to 75.000. Now the reference RSS will always be taken at 50k iterations and no less than 60k total iterations will be allowed.
- Add some verbosity options so the output and progress of the script can be seen from the gitlab page.

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
