### PR TITLE
chore(llmobs): add language tag to span events

### DIFF
--- a/ddtrace/llmobs/_trace_processor.py
+++ b/ddtrace/llmobs/_trace_processor.py
@@ -129,6 +129,7 @@ class LLMObsTraceProcessor(TraceProcessor):
             "source": "integration",
             "ml_app": ml_app,
             "ddtrace.version": ddtrace.__version__,
+            "language": "python",
             "error": span.error,
         }
         err_type = span.get_tag(ERROR_TYPE)

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -37,6 +37,7 @@ def _expected_llmobs_tags(span, error=None, tags=None, session_id=None):
         "source:integration",
         "ml_app:{}".format(tags.get("ml_app", "unnamed-ml-app")),
         "ddtrace.version:{}".format(ddtrace.__version__),
+        "language:python",
     ]
     if error:
         expected_tags.append("error:1")


### PR DESCRIPTION
Adds a `language:python` tag to all LLMObs span events, to be used for internal analysis. No changelog needed since this isn't a user-facing functional change or fix (it will just show as an extra tag in the UI).

[MLOB-1543]

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)


[MLOB-1543]: https://datadoghq.atlassian.net/browse/MLOB-1543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ