### PR TITLE
chore: prefer `docker compose` instead of older `docker-compose`

### DIFF
--- a/docs/contributing-integrations.rst
+++ b/docs/contributing-integrations.rst
@@ -114,7 +114,7 @@ Many of the tests are based on "snapshots": saved copies of actual traces sent t
 
 1. Update the library and test code to generate new traces.
 2. Delete the snapshot file corresponding to your test at ``tests/snapshots/<snapshot_file>`` (if applicable).
-3. Use `docker-compose up -d testagent` to start the APM test agent, and then re-run the test. Use `--pass-env` as described
+3. Use `docker compose up -d testagent` to start the APM test agent, and then re-run the test. Use `--pass-env` as described
    `here <https://github.com/datadog/dd-apm-test-agent?tab=readme-ov-file#running-the-tests>`_ to ensure that your test run can talk to the test agent.
 
 Once the run finishes, the snapshot file will have been regenerated.
@@ -173,7 +173,7 @@ are not yet any expected spans stored for it, so we need to create some.
 
 .. code-block:: bash
 
-   $ docker-compose up -d testagent <container>
+   $ docker compose up -d testagent <container>
    $ scripts/ddtest
    > DD_AGENT_PORT=9126 riot -v run --pass-env <test_suite_name>
 

--- a/docs/contributing-testing.rst
+++ b/docs/contributing-testing.rst
@@ -72,7 +72,7 @@ How do I run only the tests I care about?
 3. Find the directive in the file `./circleci/config.templ.yml <https://github.com/DataDog/dd-trace-py/blob/733a80eeb08c631967d3b17502cf0d6a9239c5cb/.circleci/config.templ.yml#L799>`_
    whose ``pattern`` is equal to the suite name. Note the ``docker_services`` section of the directive, if present -
    these are the "suite services".
-4. Start the suite services, if applicable, with ``$ docker-compose up -d service1 service2``.
+4. Start the suite services, if applicable, with ``$ docker compose up -d service1 service2``.
 5. Start the test-runner Docker container with ``$ scripts/ddtest``.
 6. In the test-runner shell, run the tests with ``$ riot -v run --pass-env -p 3.10 <suite_name> -- -s -vv -k 'test_name1 or test_name2'``.
 
@@ -102,7 +102,7 @@ To fix this:
 .. code-block:: bash
 
     # outside of the testrunner shell
-    $ docker-compose up -d testagent
+    $ docker compose up -d testagent
 
     # inside the testrunner shell, started with scripts/ddtest
     $ DD_AGENT_PORT=9126 riot -v run --pass-env ...

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -10,8 +10,7 @@ The best way to suggest a change to the library is to open a
 You may also consider opening an `issue <https://github.com/DataDog/dd-trace-py/issues>`_
 if you'd like to report a bug or request a new feature.
 
-Before working on the library, install `docker <https://www.docker.com/products/docker>`_
-and `docker-compose <https://www.docker.com/products/docker-compose>`_.
+Before working on the library, install `docker <https://www.docker.com/products/docker>`_.
 
 Thanks for working with us!
 

--- a/lib-injection/README.md
+++ b/lib-injection/README.md
@@ -50,7 +50,7 @@ To test this feature locally use the provided `docker-compose.yml`.
 export DDTRACE_PYTHON_VERSION=v1.16.1
 export APP_CONTEXT=$REPO_ROOT/tests/lib-injection/dd-lib-python-init-test-django
 export TEMP_DIR="/tmp/ddtrace"
-rm -rf $TEMP_DIR && docker-compose up --build lib_inject && docker-compose up --build
+rm -rf $TEMP_DIR && docker compose up --build lib_inject && docker compose up --build
 ```
 
 Note that the `lib_inject` step is separate to ensure the files are copied to the volume before the app starts up.

--- a/scripts/ddtest
+++ b/scripts/ddtest
@@ -10,7 +10,7 @@ then
 fi
 
 # retry docker pull if fails
-for i in {1..3}; do docker-compose pull -q testrunner && break || sleep 3; done
+for i in {1..3}; do docker compose pull -q testrunner && break || sleep 3; done
 
 # TODO(DEV): Install riot in the docker image
 FULL_CMD="pip install -q --disable-pip-version-check riot==0.19.1 && $CMD"
@@ -19,7 +19,7 @@ FULL_CMD="pip install -q --disable-pip-version-check riot==0.19.1 && $CMD"
 # install and upgrade riot in case testrunner image has not been updated
 # DEV: Use `--no-TTY` and `--quiet-pull` when running in CircleCI
 if [[ "${CIRCLECI}" = "true" ]]; then
-    docker-compose run \
+    docker compose run \
                    -e CIRCLE_NODE_TOTAL \
                    -e CIRCLE_NODE_INDEX \
                    -e CIRCLE_WORKFLOW_ID \
@@ -43,7 +43,7 @@ if [[ "${CIRCLECI}" = "true" ]]; then
                    testrunner \
                    bash -c "ulimit -c unlimited || true && $FULL_CMD || (./scripts/bt && false)"
 else
-    docker-compose run \
+    docker compose run \
                    -e DD_TRACE_AGENT_URL \
                    --rm \
                    -i \

--- a/scripts/ddtest
+++ b/scripts/ddtest
@@ -9,8 +9,14 @@ then
     CMD=bash
 fi
 
+# Check if 'docker compose' is available (Docker version 20.10+)
+if docker compose version &>/dev/null; then
+    compose_cmd="docker compose"
+else
+    compose_cmd="docker-compose"
+fi
 # retry docker pull if fails
-for i in {1..3}; do docker compose pull -q testrunner && break || sleep 3; done
+for i in {1..3}; do $compose_cmd pull -q testrunner && break || sleep 3; done
 
 # TODO(DEV): Install riot in the docker image
 FULL_CMD="pip install -q --disable-pip-version-check riot==0.19.1 && $CMD"
@@ -19,7 +25,7 @@ FULL_CMD="pip install -q --disable-pip-version-check riot==0.19.1 && $CMD"
 # install and upgrade riot in case testrunner image has not been updated
 # DEV: Use `--no-TTY` and `--quiet-pull` when running in CircleCI
 if [[ "${CIRCLECI}" = "true" ]]; then
-    docker compose run \
+    $compose_cmd run \
                    -e CIRCLE_NODE_TOTAL \
                    -e CIRCLE_NODE_INDEX \
                    -e CIRCLE_WORKFLOW_ID \
@@ -43,7 +49,7 @@ if [[ "${CIRCLECI}" = "true" ]]; then
                    testrunner \
                    bash -c "ulimit -c unlimited || true && $FULL_CMD || (./scripts/bt && false)"
 else
-    docker compose run \
+    $compose_cmd run \
                    -e DD_TRACE_AGENT_URL \
                    --rm \
                    -i \


### PR DESCRIPTION
With newer versions of Docker (20.10+), `docker compose` is used instead of `docker-compose`. Using `docker-compose` with the newer version of Docker will cause an error, and the `scripts/ddtest` will not run. This PR updates the script to check if `docker compose` is available, and if so will use that. Otherwise, it will default to using the original `docker-compose` command.

Docs have also been updated to use `docker compose` instead.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
