### PR TITLE
chore: [SVLS-5262] Span Pointer standard hashing

### DIFF
--- a/ddtrace/_trace/_span_pointer.py
+++ b/ddtrace/_trace/_span_pointer.py
@@ -56,29 +56,9 @@ class _SpanPointer(SpanLink):
         pass
 
 
-class _StandardHashingRules:
-    # This is a bit of a strange class. Its instances behave like simple
-    # function. This allows us to do the hex_digits calculation once. It also
-    # allows us to write tests for the chosen base_hashing_function instead of
-    # having to add runtime sanity checks. This class should be instantiated
-    # only once, internally, and the result stored as a the
-    # _standard_hashing_function "function" below.
+def _standard_hashing_function(*elements: bytes) -> str:
+    if not elements:
+        raise ValueError("elements must not be empty")
 
-    def __init__(self):
-        self.separator = b"|"
-
-        self.bits_per_hex_digit = 4
-        self.desired_bits = 128
-
-        self.hex_digits = self.desired_bits // self.bits_per_hex_digit
-
-        self.base_hashing_function = sha256
-
-    def __call__(self, *elements: bytes) -> str:
-        if not elements:
-            raise ValueError("elements must not be empty")
-
-        return self.base_hashing_function(self.separator.join(elements)).hexdigest()[: self.hex_digits]
-
-
-_standard_hashing_function = _StandardHashingRules()
+    # Please see the tests for more details about this logic.
+    return sha256(b"|".join(elements)).hexdigest()[:32]

--- a/ddtrace/_trace/_span_pointer.py
+++ b/ddtrace/_trace/_span_pointer.py
@@ -87,6 +87,6 @@ def _add_random_suffix(*, prefix: str, minimum_length: int) -> str:
     if len(prefix) >= minimum_length:
         return prefix
 
-    suffix = "".join(random.choice("0123456789abcdef") for _ in range(minimum_length - len(prefix)))
+    suffix = "".join(random.choice("0123456789abcdef") for _ in range(minimum_length - len(prefix)))  # nosec
 
     return prefix + suffix

--- a/tests/tracer/test_span_pointers.py
+++ b/tests/tracer/test_span_pointers.py
@@ -1,3 +1,4 @@
+from hashlib import sha256
 from typing import List
 from typing import NamedTuple
 
@@ -36,13 +37,26 @@ class TestStandardHashingFunction:
     def test_normal_hashing(self, test_case: HashingCase) -> None:
         assert _standard_hashing_function(*test_case.elements) == test_case.result
 
-    def test_validate_hashing_rules(self) -> None:
-        hex_digits_per_byte = 2
-        desired_bytes = _standard_hashing_function.hex_digits // hex_digits_per_byte
+    def test_validate_hash_size(self) -> None:
+        bits_per_hex_digit = 4
+        desired_bits = 128
 
-        bytes_in_digest = _standard_hashing_function.base_hashing_function().digest_size
+        expected_hex_digits = desired_bits // bits_per_hex_digit
 
-        assert bytes_in_digest >= desired_bytes
+        assert len(_standard_hashing_function(b"foo")) == expected_hex_digits
+
+    def test_validate_using_sha256_with_pipe_separator(self) -> None:
+        # We want this test to break if we change the logic of the standard
+        # function in any interesting way. If we want to change this behavior
+        # in the future, we'll need to make a new version of the standard
+        # hashing function.
+
+        bits_per_hex_digit = 4
+        desired_bits = 128
+
+        hex_digits = desired_bits // bits_per_hex_digit
+
+        assert _standard_hashing_function(b"foo", b"bar") == sha256(b"foo|bar").hexdigest()[:hex_digits]
 
     def test_hashing_requries_arguments(self) -> None:
         with pytest.raises(ValueError, match="elements must not be empty"):

--- a/tests/tracer/test_span_pointers.py
+++ b/tests/tracer/test_span_pointers.py
@@ -4,6 +4,7 @@ from typing import NamedTuple
 
 import pytest
 
+from ddtrace._trace._span_pointer import _STANDARD_HASHING_FUNCTION_FAILURE_PREFIX
 from ddtrace._trace._span_pointer import _standard_hashing_function
 
 
@@ -44,6 +45,7 @@ class TestStandardHashingFunction:
         expected_hex_digits = desired_bits // bits_per_hex_digit
 
         assert len(_standard_hashing_function(b"foo")) == expected_hex_digits
+        assert len(_standard_hashing_function("bad-input")) == expected_hex_digits
 
     def test_validate_using_sha256_with_pipe_separator(self) -> None:
         # We want this test to break if we change the logic of the standard
@@ -59,9 +61,7 @@ class TestStandardHashingFunction:
         assert _standard_hashing_function(b"foo", b"bar") == sha256(b"foo|bar").hexdigest()[:hex_digits]
 
     def test_hashing_requries_arguments(self) -> None:
-        with pytest.raises(ValueError, match="elements must not be empty"):
-            _standard_hashing_function()
+        assert _standard_hashing_function().startswith(_STANDARD_HASHING_FUNCTION_FAILURE_PREFIX)
 
     def test_hashing_requires_bytes(self) -> None:
-        with pytest.raises(TypeError, match="expected a bytes-like object"):
-            _standard_hashing_function("foo")
+        assert _standard_hashing_function("foo").startswith(_STANDARD_HASHING_FUNCTION_FAILURE_PREFIX)

--- a/tests/tracer/test_span_pointers.py
+++ b/tests/tracer/test_span_pointers.py
@@ -1,0 +1,53 @@
+from typing import List
+from typing import NamedTuple
+
+import pytest
+
+from ddtrace._trace._span_pointer import _standard_hashing_function
+
+
+class TestStandardHashingFunction:
+    class HashingCase(NamedTuple):
+        name: str
+        elements: List[bytes]
+        result: str
+
+    @pytest.mark.parametrize(
+        "test_case",
+        [
+            HashingCase(
+                name="one foo",
+                elements=[b"foo"],
+                result="2c26b46b68ffc68ff99b453c1d304134",
+            ),
+            HashingCase(
+                name="foo and bar",
+                elements=[b"foo", b"bar"],
+                result="0fc7e25e075c7849f89b9729d1aeada1",
+            ),
+            HashingCase(
+                name="bar and foo, order matters",
+                elements=[b"bar", b"foo"],
+                result="527f4b4996d63db7053fd4b376b782a3",
+            ),
+        ],
+        ids=lambda test_case: test_case.name,
+    )
+    def test_normal_hashing(self, test_case: HashingCase) -> None:
+        assert _standard_hashing_function(*test_case.elements) == test_case.result
+
+    def test_validate_hashing_rules(self) -> None:
+        hex_digits_per_byte = 2
+        desired_bytes = _standard_hashing_function.hex_digits // hex_digits_per_byte
+
+        bytes_in_digest = _standard_hashing_function.base_hashing_function().digest_size
+
+        assert bytes_in_digest >= desired_bytes
+
+    def test_hashing_requries_arguments(self) -> None:
+        with pytest.raises(ValueError, match="elements must not be empty"):
+            _standard_hashing_function()
+
+    def test_hashing_requires_bytes(self) -> None:
+        with pytest.raises(TypeError, match="expected a bytes-like object"):
+            _standard_hashing_function("foo")


### PR DESCRIPTION
Adding a standard hashing function for Span Pointers. This continues to be a private API for now.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
