### PR TITLE
fix(postgres): remove require modules to resolve circular imports (backport #10658 to 2.12)

### DIFF
--- a/ddtrace/contrib/psycopg/__init__.py
+++ b/ddtrace/contrib/psycopg/__init__.py
@@ -60,19 +60,18 @@ To configure the psycopg integration on an per-connection basis use the
     cursor = db.cursor()
     cursor.execute("select * from users where id = 1")
 """
-from ...internal.utils.importlib import require_modules
+# Required to allow users to import from `ddtrace.contrib.psycopg.patch` directly
+import warnings as _w
 
 
-required_modules = ["psycopg", "psycopg2"]
-with require_modules(required_modules) as missing_modules:
-    # If psycopg and/or psycopg2 is available, patch these modules
-    if len(missing_modules) < len(required_modules):
-        # Required to allow users to import from `ddtrace.contrib.openai.patch` directly
-        from . import patch as _  # noqa: F401, I001
+with _w.catch_warnings():
+    _w.simplefilter("ignore", DeprecationWarning)
+    from . import patch as _  # noqa: F401, I001
 
-        # Expose public methods
-        from ..internal.psycopg.patch import get_version
-        from ..internal.psycopg.patch import get_versions
-        from ..internal.psycopg.patch import patch
+# Expose public methods
+from ddtrace.contrib.internal.psycopg.patch import get_version
+from ddtrace.contrib.internal.psycopg.patch import get_versions
+from ddtrace.contrib.internal.psycopg.patch import patch
 
-        __all__ = ["patch", "get_version", "get_versions"]
+
+__all__ = ["patch", "get_version", "get_versions"]

--- a/releasenotes/notes/fix-postgres-circular-req-0904bf22c32c785d.yaml
+++ b/releasenotes/notes/fix-postgres-circular-req-0904bf22c32c785d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    postgres: Fixes circular imports raised when psycopg automatic instrumentation is enabled.


### PR DESCRIPTION
Backports #10658

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
