### PR TITLE
fix(anthropic): safely json dump unserializable objects [backport #10659 to 2.12]

### DIFF
--- a/ddtrace/contrib/internal/anthropic/patch.py
+++ b/ddtrace/contrib/internal/anthropic/patch.py
@@ -62,13 +62,10 @@ def traced_chat_model_generate(anthropic, pin, func, instance, args, kwargs):
             if isinstance(message.get("content", None), str):
                 if integration.is_pc_sampled_span(span):
                     span.set_tag_str(
-                        "anthropic.request.messages.%d.content.0.text" % (message_idx),
-                        integration.trunc(message.get("content", "")),
+                        "anthropic.request.messages.%d.content.0.text" % message_idx,
+                        integration.trunc(str(message.get("content", ""))),
                     )
-                span.set_tag_str(
-                    "anthropic.request.messages.%d.content.0.type" % (message_idx),
-                    "text",
-                )
+                span.set_tag_str("anthropic.request.messages.%d.content.0.type" % message_idx, "text")
             elif isinstance(message.get("content", None), list):
                 for block_idx, block in enumerate(message.get("content", [])):
                     if integration.is_pc_sampled_span(span):
@@ -90,12 +87,9 @@ def traced_chat_model_generate(anthropic, pin, func, instance, args, kwargs):
 
                     span.set_tag_str(
                         "anthropic.request.messages.%d.content.%d.type" % (message_idx, block_idx),
-                        _get_attr(block, "type", "text"),
+                        str(_get_attr(block, "type", "text")),
                     )
-            span.set_tag_str(
-                "anthropic.request.messages.%d.role" % (message_idx),
-                message.get("role", ""),
-            )
+            span.set_tag_str("anthropic.request.messages.%d.role" % message_idx, str(message.get("role", "")))
         tag_params_on_span(span, kwargs, integration)
 
         chat_completions = func(*args, **kwargs)
@@ -141,13 +135,10 @@ async def traced_async_chat_model_generate(anthropic, pin, func, instance, args,
             if isinstance(message.get("content", None), str):
                 if integration.is_pc_sampled_span(span):
                     span.set_tag_str(
-                        "anthropic.request.messages.%d.content.0.text" % (message_idx),
-                        integration.trunc(message.get("content", "")),
+                        "anthropic.request.messages.%d.content.0.text" % message_idx,
+                        integration.trunc(str(message.get("content", ""))),
                     )
-                span.set_tag_str(
-                    "anthropic.request.messages.%d.content.0.type" % (message_idx),
-                    "text",
-                )
+                span.set_tag_str("anthropic.request.messages.%d.content.0.type" % message_idx, "text")
             elif isinstance(message.get("content", None), list):
                 for block_idx, block in enumerate(message.get("content", [])):
                     if integration.is_pc_sampled_span(span):
@@ -169,12 +160,9 @@ async def traced_async_chat_model_generate(anthropic, pin, func, instance, args,
 
                     span.set_tag_str(
                         "anthropic.request.messages.%d.content.%d.type" % (message_idx, block_idx),
-                        _get_attr(block, "type", "text"),
+                        str(_get_attr(block, "type", "text")),
                     )
-            span.set_tag_str(
-                "anthropic.request.messages.%d.role" % (message_idx),
-                message.get("role", ""),
-            )
+            span.set_tag_str("anthropic.request.messages.%d.role" % message_idx, str(message.get("role", "")))
         tag_params_on_span(span, kwargs, integration)
 
         chat_completions = await func(*args, **kwargs)

--- a/releasenotes/notes/fix-anthroipc-json-serializable-99af0985bd967e5d.yaml
+++ b/releasenotes/notes/fix-anthroipc-json-serializable-99af0985bd967e5d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    anthropic: Resolves an issue where attempting to tag non-JSON serializable request arguments caused a ``TypeError``. 
+    The Anthropic integration now safely tags non-JSON serializable arguments with a default placeholder text. 

--- a/tests/contrib/anthropic/test_anthropic.py
+++ b/tests/contrib/anthropic/test_anthropic.py
@@ -157,6 +157,23 @@ def test_anthropic_llm_error(anthropic, request_vcr):
             llm.messages.create(model="claude-3-opus-20240229", max_tokens=15, messages=["Invalid content"])
 
 
+@pytest.mark.snapshot(ignores=["meta.error.stack", "resource", "meta.anthropic.request.parameters"])
+def test_anthropic_llm_unserializable_arg(anthropic, request_vcr):
+    """Assert that unserializable arguments will not break integration tagging."""
+
+    class Unserializable:
+        pass
+
+    llm = anthropic.Anthropic()
+    with pytest.raises(TypeError):
+        llm.messages.create(
+            model="claude-3-opus-20240229",
+            max_tokens=15,
+            messages=[{"content": "Valid content but unserializable metadata param", "role": "user"}],
+            metadata=Unserializable(),
+        )
+
+
 @pytest.mark.snapshot(token="tests.contrib.anthropic.test_anthropic.test_anthropic_llm_stream", ignores=["resource"])
 def test_anthropic_llm_sync_stream(anthropic, request_vcr):
     llm = anthropic.Anthropic()

--- a/tests/snapshots/tests.contrib.anthropic.test_anthropic.test_anthropic_llm_unserializable_arg.json
+++ b/tests/snapshots/tests.contrib.anthropic.test_anthropic.test_anthropic_llm_unserializable_arg.json
@@ -1,0 +1,35 @@
+[[
+  {
+    "name": "anthropic.request",
+    "service": "",
+    "resource": "Messages.create",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "",
+    "error": 1,
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "66e893d800000000",
+      "anthropic.request.api_key": "sk-...key>",
+      "anthropic.request.messages.0.content.0.text": "Valid content but unserializable metadata param",
+      "anthropic.request.messages.0.content.0.type": "text",
+      "anthropic.request.messages.0.role": "user",
+      "anthropic.request.model": "claude-3-opus-20240229",
+      "anthropic.request.parameters": "{\"max_tokens\": 15, \"metadata\": \"[Unserializable object: <tests.contrib.anthropic.test_anthropic.test_anthropic_llm_unserializable_arg.<locals>.Unserializable object at 0x10668b340>]\"}",
+      "error.message": "Object of type Unserializable is not JSON serializable",
+      "error.stack": "Traceback (most recent call last):\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/ddtrace/contrib/internal/anthropic/patch.py\", line 96, in traced_chat_model_generate\n    chat_completions = func(*args, **kwargs)\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py3105_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_vcrpy_anthropic/lib/python3.10/site-packages/anthropic/_utils/_utils.py\", line 277, in wrapper\n    return func(*args, **kwargs)\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py3105_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_vcrpy_anthropic/lib/python3.10/site-packages/anthropic/resources/messages.py\", line 899, in create\n    return self._post(\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py3105_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_vcrpy_anthropic/lib/python3.10/site-packages/anthropic/_base_client.py\", line 1239, in post\n    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py3105_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_vcrpy_anthropic/lib/python3.10/site-packages/anthropic/_base_client.py\", line 921, in request\n    return self._request(\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py3105_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_vcrpy_anthropic/lib/python3.10/site-packages/anthropic/_base_client.py\", line 942, in _request\n    request = self._build_request(options)\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py3105_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_vcrpy_anthropic/lib/python3.10/site-packages/anthropic/_base_client.py\", line 484, in _build_request\n    return self._client.build_request(  # pyright: ignore[reportUnknownMemberType]\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py3105_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_vcrpy_anthropic/lib/python3.10/site-packages/httpx/_client.py\", line 357, in build_request\n    return Request(\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py3105_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_vcrpy_anthropic/lib/python3.10/site-packages/httpx/_models.py\", line 340, in __init__\n    headers, stream = encode_request(\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py3105_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_vcrpy_anthropic/lib/python3.10/site-packages/httpx/_content.py\", line 212, in encode_request\n    return encode_json(json)\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py3105_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_vcrpy_anthropic/lib/python3.10/site-packages/httpx/_content.py\", line 175, in encode_json\n    body = json_dumps(json).encode(\"utf-8\")\n  File \"/Users/yun.kim/.pyenv/versions/3.10.5/lib/python3.10/json/__init__.py\", line 231, in dumps\n    return _default_encoder.encode(obj)\n  File \"/Users/yun.kim/.pyenv/versions/3.10.5/lib/python3.10/json/encoder.py\", line 199, in encode\n    chunks = self.iterencode(o, _one_shot=True)\n  File \"/Users/yun.kim/.pyenv/versions/3.10.5/lib/python3.10/json/encoder.py\", line 257, in iterencode\n    return _iterencode(o, 0)\n  File \"/Users/yun.kim/.pyenv/versions/3.10.5/lib/python3.10/json/encoder.py\", line 179, in default\n    raise TypeError(f'Object of type {o.__class__.__name__} '\nTypeError: Object of type Unserializable is not JSON serializable\n",
+      "error.type": "builtins.TypeError",
+      "language": "python",
+      "runtime-id": "bd1dfda00ec74a0a8afbb8cc50cf44ca"
+    },
+    "metrics": {
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 61341
+    },
+    "duration": 25619000,
+    "start": 1726518232787113000
+  }]]


### PR DESCRIPTION
Backports #10659 to 2.12.

Fixes #10420

Ensures that any JSON dumping we do will not crash due to unserializable objects, and safely cast all `set_tag_str()` args as string.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)