### PR TITLE
chore(profiling): rewrite that one test not to use naked waitpid

### DIFF
--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -2,7 +2,6 @@
 import multiprocessing
 import os
 import sys
-import time
 
 import pytest
 
@@ -113,6 +112,7 @@ def test_multiprocessing(method, tmp_path, monkeypatch):
 )
 def test_memalloc_no_init_error_on_fork():
     import os
+    import time
 
     pid = os.fork()
     if not pid:


### PR DESCRIPTION
When we switched to gitlab, this one test started hanging indefinitely.  I think we should have better waits.  This fixes precisely one of them.

Backporting a few versions because this could have CI issues.

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
