### PR TITLE
fix(iast): backport fix from 10706 to 2.11

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/_native.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/_native.cpp
@@ -72,6 +72,12 @@ PYBIND11_MODULE(_native, m)
     }
 
     initializer = make_unique<Initializer>();
+    // Create an atexit callback to clean up the Initializer before the interpreter finishes
+    auto atexit_register = py::module_::import("atexit").attr("register");
+    atexit_register(py::cpp_function([]() {
+        initializer->reset_context();
+        initializer.reset();
+    }));
     initializer->create_context();
 
     m.doc() = "Native Python module";

--- a/releasenotes/notes/initializer-atexit-4c10671e585ac3e7.yaml
+++ b/releasenotes/notes/initializer-atexit-4c10671e585ac3e7.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Code Security: ensure the ``Initializer`` object is always reset and freed before the Python runtime.
+other:
+  - |
+    For any change which does not fall into any of the above categories. Since changes falling into this category are 
+    likely rare and not very similar to each other, no specific format other than a required scope is provided. 
+    The author is requested to use their best judgment to ensure a quality release note.
+    Format: <scope>: <add_release_note_here>.

--- a/releasenotes/notes/initializer-atexit-4c10671e585ac3e7.yaml
+++ b/releasenotes/notes/initializer-atexit-4c10671e585ac3e7.yaml
@@ -2,9 +2,4 @@
 fixes:
   - |
     Code Security: ensure the ``Initializer`` object is always reset and freed before the Python runtime.
-other:
-  - |
-    For any change which does not fall into any of the above categories. Since changes falling into this category are 
-    likely rare and not very similar to each other, no specific format other than a required scope is provided. 
-    The author is requested to use their best judgment to ensure a quality release note.
-    Format: <scope>: <add_release_note_here>.
+


### PR DESCRIPTION
## Description

Partial backport of the `Initializer` `atexit` fix from https://github.com/DataDog/dd-trace-py/pull/10706.

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
