### PR TITLE
fix(iast): backport fix from 10706 to 2.9

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/_native.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/_native.cpp
@@ -71,15 +71,16 @@ PYBIND11_MODULE(_native, m)
         }
     }
 
-  initializer = make_unique<Initializer>();
-  // Create an atexit callback to clean up the Initializer before the
-  // interpreter finishes
-  auto atexit_register = py::module_::import("atexit").attr("register");
-  atexit_register(py::cpp_function([]() {
-    initializer->reset_context();
-    initializer.reset();
-  }));
-  initializer->create_context();
+    initializer = make_unique<Initializer>();
+    initializer = make_unique<Initializer>();
+    // Create an atexit callback to clean up the Initializer before the
+    // interpreter finishes
+    auto atexit_register = py::module_::import("atexit").attr("register");
+    atexit_register(py::cpp_function([]() {
+        initializer->reset_context();
+        initializer.reset();
+    }));
+    initializer->create_context();
 
     m.doc() = "Native Python module";
 

--- a/ddtrace/appsec/_iast/_taint_tracking/_native.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/_native.cpp
@@ -2,8 +2,7 @@
  * IAST Native Module
  * This C++ module contains IAST propagation features:
  * - Taint tracking: propagation of a tainted variable.
- * - Aspects: common string operations are replaced by functions that propagate
- * the taint variables.
+ * - Aspects: common string operations are replaced by functions that propagate the taint variables.
  * - Taint ranges: Information related to tainted values.
  */
 #include <memory>
@@ -20,41 +19,39 @@
 #include "TaintTracking/_taint_tracking.h"
 #include "TaintedOps/TaintedOps.h"
 
-#define PY_MODULE_NAME_ASPECTS                                                 \
-  PY_MODULE_NAME "."                                                           \
-                 "aspects"
+#define PY_MODULE_NAME_ASPECTS                                                                                         \
+    PY_MODULE_NAME "."                                                                                                 \
+                   "aspects"
 
 using namespace pybind11::literals;
 namespace py = pybind11;
 
 static PyMethodDef AspectsMethods[] = {
-    {"add_aspect", ((PyCFunction)api_add_aspect), METH_FASTCALL, "aspect add"},
-    {"extend_aspect", ((PyCFunction)api_extend_aspect), METH_FASTCALL,
-     "aspect extend"},
-    {"index_aspect", ((PyCFunction)api_index_aspect), METH_FASTCALL,
-     "aspect index"},
-    {"join_aspect", ((PyCFunction)api_join_aspect), METH_FASTCALL,
-     "aspect join"},
-    {"slice_aspect", ((PyCFunction)api_slice_aspect), METH_FASTCALL,
-     "aspect slice"},
-    {nullptr, nullptr, 0, nullptr}};
+    { "add_aspect", ((PyCFunction)api_add_aspect), METH_FASTCALL, "aspect add" },
+    { "extend_aspect", ((PyCFunction)api_extend_aspect), METH_FASTCALL, "aspect extend" },
+    { "index_aspect", ((PyCFunction)api_index_aspect), METH_FASTCALL, "aspect index" },
+    { "join_aspect", ((PyCFunction)api_join_aspect), METH_FASTCALL, "aspect join" },
+    { "slice_aspect", ((PyCFunction)api_slice_aspect), METH_FASTCALL, "aspect slice" },
+    { nullptr, nullptr, 0, nullptr }
+};
 
-static struct PyModuleDef aspects = {PyModuleDef_HEAD_INIT,
-                                     .m_name = PY_MODULE_NAME_ASPECTS,
-                                     .m_doc = "Taint tracking Aspects",
-                                     .m_size = -1, .m_methods = AspectsMethods};
+static struct PyModuleDef aspects = { PyModuleDef_HEAD_INIT,
+                                      .m_name = PY_MODULE_NAME_ASPECTS,
+                                      .m_doc = "Taint tracking Aspects",
+                                      .m_size = -1,
+                                      .m_methods = AspectsMethods };
 
 static PyMethodDef OpsMethods[] = {
-    {"new_pyobject_id", (PyCFunction)api_new_pyobject_id, METH_FASTCALL,
-     "new pyobject id"},
-    {"set_ranges_from_values", ((PyCFunction)api_set_ranges_from_values),
-     METH_FASTCALL, "set_ranges_from_values"},
-    {nullptr, nullptr, 0, nullptr}};
+    { "new_pyobject_id", (PyCFunction)api_new_pyobject_id, METH_FASTCALL, "new pyobject id" },
+    { "set_ranges_from_values", ((PyCFunction)api_set_ranges_from_values), METH_FASTCALL, "set_ranges_from_values" },
+    { nullptr, nullptr, 0, nullptr }
+};
 
-static struct PyModuleDef ops = {PyModuleDef_HEAD_INIT,
-                                 .m_name = PY_MODULE_NAME_ASPECTS,
-                                 .m_doc = "Taint tracking operations",
-                                 .m_size = -1, .m_methods = OpsMethods};
+static struct PyModuleDef ops = { PyModuleDef_HEAD_INIT,
+                                  .m_name = PY_MODULE_NAME_ASPECTS,
+                                  .m_doc = "Taint tracking operations",
+                                  .m_size = -1,
+                                  .m_methods = OpsMethods };
 
 /**
  * This function initializes the native module.

--- a/releasenotes/notes/initializer-atexit-a04b2c908d3e8eeb.yaml
+++ b/releasenotes/notes/initializer-atexit-a04b2c908d3e8eeb.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Code Security: ensure the ``Initializer`` object is always reset and freed before the Python runtime.
+other:
+  - |
+    For any change which does not fall into any of the above categories. Since changes falling into this category are 
+    likely rare and not very similar to each other, no specific format other than a required scope is provided. 
+    The author is requested to use their best judgment to ensure a quality release note.
+    Format: <scope>: <add_release_note_here>.
+

--- a/releasenotes/notes/initializer-atexit-a04b2c908d3e8eeb.yaml
+++ b/releasenotes/notes/initializer-atexit-a04b2c908d3e8eeb.yaml
@@ -2,10 +2,4 @@
 fixes:
   - |
     Code Security: ensure the ``Initializer`` object is always reset and freed before the Python runtime.
-other:
-  - |
-    For any change which does not fall into any of the above categories. Since changes falling into this category are 
-    likely rare and not very similar to each other, no specific format other than a required scope is provided. 
-    The author is requested to use their best judgment to ensure a quality release note.
-    Format: <scope>: <add_release_note_here>.
 


### PR DESCRIPTION
## Description

Partial backport of the `Initializer atexit` fix from https://github.com/DataDog/dd-trace-py/pull/10706.

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
