### PR TITLE
ci: move PyPI artifact uploading to GitLab

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -77,25 +77,3 @@ jobs:
         run: python $GITHUB_WORKSPACE/tests/smoke_test.py
         # Move out of the workspace to avoid importing ddtrace from the source
         working-directory: /
-
-  upload_pypi:
-    needs:
-      - build_wheels
-      - test_alpine_sdist
-    runs-on: ubuntu-latest
-    if: (github.event_name == 'release' && github.event.action == 'published')
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: dist
-          merge-multiple: true
-
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
-          # To test: repository_url: https://test.pypi.org/legacy/
-          # Setting skip_existing will prevent the deploy from erring out early
-          # due to a duplicate wheel being present which will ensure that the rest
-          # of the wheels will be uploaded if some are uploaded manually.
-          skip_existing: true

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -33,15 +33,15 @@ variables:
       - pywheels/*.whl
       - pywheels/*.tar.gz
 
-release_pypi_test:
+# Can be used to validate uploading of artifacts
+# release_pypi_test:
+#   extends: .release_pypi
+#   dependencies: [ "download_ddtrace_artifacts" ]
+#   variables:
+#     PYPI_REPOSITORY: testpypi
+
+release_pypi_prod:
   extends: .release_pypi
   dependencies: [ "download_ddtrace_artifacts" ]
   variables:
-    PYPI_REPOSITORY: testpypi
-
-# TODO: Replace GitHub Action PyPI upload with this job
-# release_pypi_prod:
-#   extends: .release_pypi
-#   needs: [ "release_pypi_test" ]
-#   variables:
-#     PYPI_REPOSITORY: pypi
+    PYPI_REPOSITORY: pypi


### PR DESCRIPTION
Moving the artifact uploading to GitLab means we can include other GitLab validations as requirements to uploading to PyPI.

We have validated this by first having the pipeline upload to test.pypi.org.

This was enabled for the 2.12.2 release, and we can validate the artifacts uploaded were the same:

- pypi.org: https://pypi.org/project/ddtrace/2.12.2/#files
- test.pypi.org: https://test.pypi.org/project/ddtrace/2.12.2/#files

All files were downloaded, and the sha256 sums were validated to be the same.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
