### PR TITLE
chore(llmobs): fix omitted test assertion from backport #10694 to 2.13

### DIFF
--- a/tests/contrib/openai/test_openai_llmobs.py
+++ b/tests/contrib/openai/test_openai_llmobs.py
@@ -761,6 +761,7 @@ class TestLLMObsOpenaiV1:
             error_message=span.get_tag("error.message"),
             error_stack=span.get_tag("error.stack"),
             tags={"ml_app": "<ml-app-name>"},
+            integration="openai",
         )
         mock_llmobs_writer.enqueue.assert_called_with(expected_span)
         actual_span = mock_llmobs_writer.enqueue.call_args[0][0]


### PR DESCRIPTION
This PR follows up on #10727, which accidentally omitted a `integration="openai"` line in a backported test case. Due to all the other changes to the OpenAI integration which were backported at the same time, this line got omitted during the merge conflict resolution.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
