### PR TITLE
Revert "chore(llmobs): add language tag to span events [backport 2.9]"

### DIFF
--- a/ddtrace/llmobs/_trace_processor.py
+++ b/ddtrace/llmobs/_trace_processor.py
@@ -127,7 +127,6 @@ class LLMObsTraceProcessor(TraceProcessor):
             "ml_app": ml_app,
             "session_id": session_id,
             "ddtrace.version": ddtrace.__version__,
-            "language": "python",
             "error": span.error,
         }
         err_type = span.get_tag(ERROR_TYPE)

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -28,7 +28,6 @@ def _expected_llmobs_tags(span, error=None, tags=None, session_id=None):
         "ml_app:{}".format(tags.get("ml_app", "unnamed-ml-app")),
         "session_id:{}".format(session_id or "{:x}".format(span.trace_id)),
         "ddtrace.version:{}".format(ddtrace.__version__),
-        "language:python",
     ]
     if error:
         expected_tags.append("error:1")


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#10700

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)