### PR TITLE
chore(iast): flaky test

### DIFF
--- a/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
@@ -53,7 +53,14 @@ class TestOperatorJoinReplacement(object):
 
         result = mod.do_join(string_input, it)
         # order it's not constant
-        assert result in ("b-joiner-c-joiner-a", "c-joiner-a-joiner-b", "a-joiner-b-joiner-c", "b-joiner-a-joiner-c")
+        assert result in (
+            "a-joiner-c-joiner-b",
+            "a-joiner-b-joiner-c",
+            "b-joiner-c-joiner-a",
+            "b-joiner-a-joiner-c",
+            "c-joiner-a-joiner-b",
+            "c-joiner-b-joiner-a",
+        )
         ranges = get_tainted_ranges(result)
         assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "-joiner-"
         assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "-joiner-"


### PR DESCRIPTION
Fix flaky test with tuple elements order

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
