### PR TITLE
feat(tracer): [SVLS-5672] DynamoDB PutItem pointers

### DIFF
--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 import wrapt
 
+from ddtrace import config
 from ddtrace._trace._span_pointer import _SpanPointerDescription
 from ddtrace._trace.span import Span
 from ddtrace._trace.utils import extract_DD_context_from_messages
@@ -631,6 +632,7 @@ def _on_botocore_patched_api_call_success(ctx, response):
     set_botocore_response_metadata_tags(span, response)
 
     for span_pointer_description in extract_span_pointers_from_successful_botocore_response(
+        dynamodb_primary_key_names_for_tables=config.botocore.dynamodb_primary_key_names_for_tables,
         endpoint_name=ctx.get_item("endpoint_name"),
         operation_name=ctx.get_item("operation"),
         request_parameters=ctx.get_item("params"),

--- a/ddtrace/contrib/botocore/__init__.py
+++ b/ddtrace/contrib/botocore/__init__.py
@@ -119,9 +119,23 @@ Configuration
     for the associated table. The set may have exactly one or two elements,
     depending on the Table's Primary Key schema.
 
+    In python this would look like:
+
+        ddtrace.config.botocore['dynamodb_primary_key_names_for_tables'] = {
+            'table_name': {'key1', 'key2'},
+            'other_table': {'other_key'},
+        }
+
     Can also be enabled with the ``DD_BOTOCORE_DYNAMODB_TABLE_PRIMARY_KEYS``
     environment variable which is parsed as a JSON object with strings for keys
     and lists of strings for values.
+
+    This would look something like:
+
+        export DD_BOTOCORE_DYNAMODB_TABLE_PRIMARY_KEYS='{
+            "table_name": ["key1", "key2"],
+            "other_table": ["other_key"]
+        }'
 
     Default: ``{}``
 

--- a/ddtrace/contrib/botocore/__init__.py
+++ b/ddtrace/contrib/botocore/__init__.py
@@ -108,6 +108,23 @@ Configuration
 
    Default: ``128``
 
+
+.. py:data:: ddtrace.config.botocore['dynamodb_primary_key_names_for_tables']
+
+    This enables DynamoDB API calls to be instrumented with span pointers. Many
+    DynamoDB API calls do not include the Item's Primary Key fields as separate
+    values, so they need to be provided to the tracer separately. This field
+    should be structured as a ``dict`` keyed by the table names as ``str``.
+    Each value should be the ``set`` of primary key field names (as ``str``)
+    for the associated table. The set may have exactly one or two elements,
+    depending on the Table's Primary Key schema.
+
+    Can also be enabled with the ``DD_BOTOCORE_DYNAMODB_TABLE_PRIMARY_KEYS``
+    environment variable which is parsed as a JSON object with strings for keys
+    and lists of strings for values.
+
+    Default: ``{}``
+
 """
 
 

--- a/ddtrace/contrib/botocore/__init__.py
+++ b/ddtrace/contrib/botocore/__init__.py
@@ -119,7 +119,7 @@ Configuration
     for the associated table. The set may have exactly one or two elements,
     depending on the Table's Primary Key schema.
 
-    In python this would look like:
+    In python this would look like::
 
         ddtrace.config.botocore['dynamodb_primary_key_names_for_tables'] = {
             'table_name': {'key1', 'key2'},
@@ -130,7 +130,7 @@ Configuration
     environment variable which is parsed as a JSON object with strings for keys
     and lists of strings for values.
 
-    This would look something like:
+    This would look something like::
 
         export DD_BOTOCORE_DYNAMODB_TABLE_PRIMARY_KEYS='{
             "table_name": ["key1", "key2"],

--- a/releasenotes/notes/span-pointers-aws-dynamodb-putitem-f4be08418bc99093.yaml
+++ b/releasenotes/notes/span-pointers-aws-dynamodb-putitem-f4be08418bc99093.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    botocore: Adds span pointers for successful DynamoDB ``PutItem`` spans. Table Primary Keys need to be provided with the ``ddtrace.config.botocore.dynamodb_primary_key_names_for_tables`` option or the ``DD_BOTOCORE_DYNAMODB_TABLE_PRIMARY_KEYS`` environment variable.

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -266,6 +266,74 @@ class BotocoreTest(TracerTestCase):
         assert span.service == "test-botocore-tracing.dynamodb"
         assert span.resource == "botocore.parsers.parse"
 
+        span = spans[2]
+        assert span.get_tag("aws.operation") == "PutItem"
+        # Since the dynamodb_primary_key_names_for_tables isn't configured, we
+        # cannot create span pointers for this item.
+        assert not span._links
+
+    @pytest.mark.skipif(
+        PYTHON_VERSION_INFO < (3, 8),
+        reason="Skipping for older py versions whose latest supported moto versions don't have the right dynamodb api",
+    )
+    @mock_dynamodb
+    def test_dynamodb_put_get_with_table_primary_key_mapping(self):
+        ddb = self.session.create_client("dynamodb", region_name="us-west-2")
+        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(ddb)
+
+        with self.override_config(
+            "botocore",
+            dict(
+                instrument_internals=True,
+                dynamodb_primary_key_names_for_tables={
+                    "foobar": {"myattr"},
+                },
+            ),
+        ):
+            ddb.create_table(
+                TableName="foobar",
+                AttributeDefinitions=[{"AttributeName": "myattr", "AttributeType": "S"}],
+                KeySchema=[{"AttributeName": "myattr", "KeyType": "HASH"}],
+                BillingMode="PAY_PER_REQUEST",
+            )
+            ddb.put_item(TableName="foobar", Item={"myattr": {"S": "baz"}})
+            ddb.get_item(TableName="foobar", Key={"myattr": {"S": "baz"}})
+
+        spans = self.get_spans()
+        assert spans
+        span = spans[0]
+        assert len(spans) == 6
+        assert_is_measured(span)
+        assert span.get_tag("aws.operation") == "CreateTable"
+        assert span.get_tag("component") == "botocore"
+        assert span.get_tag("span.kind"), "client"
+        assert_span_http_status_code(span, 200)
+        assert span.service == "test-botocore-tracing.dynamodb"
+        assert span.resource == "dynamodb.createtable"
+
+        span = spans[1]
+        assert span.name == "botocore.parsers.parse"
+        assert span.get_tag("component") == "botocore"
+        assert span.get_tag("span.kind"), "client"
+        assert span.service == "test-botocore-tracing.dynamodb"
+        assert span.resource == "botocore.parsers.parse"
+
+        span = spans[2]
+        assert span.get_tag("aws.operation") == "PutItem"
+        # This span pointer is only available if the
+        # dynamodb_primary_key_names_for_tables is properly configured with the
+        # table and its primary key field names.
+        assert span._links == [
+            _SpanPointer(
+                pointer_kind="aws.dynamodb.item",
+                pointer_direction=_SpanPointerDirection.DOWNSTREAM,
+                # We have more detailed tests for the hashing behavior
+                # elsewhere. Here we just want to make sure that the pointer is
+                # correctly attached to the span.
+                pointer_hash="de960284e8cba01c46f87b102ab1c9cb",
+            ),
+        ]
+
     @mock_s3
     def test_s3_client(self):
         s3 = self.session.create_client("s3", region_name="us-west-2")

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -334,6 +334,59 @@ class BotocoreTest(TracerTestCase):
             ),
         ]
 
+    @pytest.mark.skipif(
+        PYTHON_VERSION_INFO < (3, 8),
+        reason="Skipping for older py versions whose latest supported moto versions don't have the right dynamodb api",
+    )
+    @mock_dynamodb
+    def test_dynamodb_put_get_with_broken_table_primary_key_mapping(self):
+        ddb = self.session.create_client("dynamodb", region_name="us-west-2")
+        Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(ddb)
+
+        with self.override_config(
+            "botocore",
+            dict(
+                instrument_internals=True,
+                dynamodb_primary_key_names_for_tables={
+                    "foobar": {"myattr", "other_attr", "impossible_third_attr"},
+                },
+            ),
+        ):
+            ddb.create_table(
+                TableName="foobar",
+                AttributeDefinitions=[{"AttributeName": "myattr", "AttributeType": "S"}],
+                KeySchema=[{"AttributeName": "myattr", "KeyType": "HASH"}],
+                BillingMode="PAY_PER_REQUEST",
+            )
+            ddb.put_item(TableName="foobar", Item={"myattr": {"S": "baz"}})
+            ddb.get_item(TableName="foobar", Key={"myattr": {"S": "baz"}})
+
+        spans = self.get_spans()
+        assert spans
+        span = spans[0]
+        assert len(spans) == 6
+        assert_is_measured(span)
+        assert span.get_tag("aws.operation") == "CreateTable"
+        assert span.get_tag("component") == "botocore"
+        assert span.get_tag("span.kind"), "client"
+        assert_span_http_status_code(span, 200)
+        assert span.service == "test-botocore-tracing.dynamodb"
+        assert span.resource == "dynamodb.createtable"
+
+        span = spans[1]
+        assert span.name == "botocore.parsers.parse"
+        assert span.get_tag("component") == "botocore"
+        assert span.get_tag("span.kind"), "client"
+        assert span.service == "test-botocore-tracing.dynamodb"
+        assert span.resource == "botocore.parsers.parse"
+
+        span = spans[2]
+        assert span.get_tag("aws.operation") == "PutItem"
+        # The rest of the logic should have worked but since the config is
+        # malformed with unexpectedly three key attributes, we cannot actually
+        # create the span pointers.
+        assert not span._links
+
     @mock_s3
     def test_s3_client(self):
         s3 = self.session.create_client("s3", region_name="us-west-2")


### PR DESCRIPTION
PutItem is a bit tricky since it doesn't have a separate primary key section. The primary key is mixed into the Item itself. So we need a way for our customers to identify the primary key field names for a table. We'll start by doing this with configuration, and we may add a way for the user to opt in to us making a (cached) DescribeTable call on their behalf.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
