### PR TITLE
chore(ci_visibility): add unique tests request to test vis API client

### DIFF
--- a/ddtrace/internal/ci_visibility/_api_client.py
+++ b/ddtrace/internal/ci_visibility/_api_client.py
@@ -88,13 +88,6 @@ class EarlyFlakeDetectionSettings:
 
 
 @dataclasses.dataclass(frozen=True)
-class UniqueTestsData:
-    test_modules: t.Dict[str, TestModuleId]
-    test_suites: t.Dict[str, TestSuiteId]
-    test_cases: t.Dict[str, InternalTestId]
-
-
-@dataclasses.dataclass(frozen=True)
 class TestVisibilityAPISettings:
     __test__ = False
     coverage_enabled: bool = False
@@ -313,10 +306,7 @@ class _TestVisibilityAPIClientBase(abc.ABC):
             try:
                 sw.stop()  # Stop the timer before parsing the response
                 response_bytes = len(response.body)
-                if isinstance(response.body, bytes):
-                    parsed = json.loads(response.body.decode())
-                else:
-                    parsed = json.loads(response.body)
+                parsed = json.loads(response.body)
                 return parsed
             except JSONDecodeError:
                 error_type = ERROR_TYPES.BAD_JSON
@@ -331,10 +321,10 @@ class _TestVisibilityAPIClientBase(abc.ABC):
         """
 
         metric_names = APIRequestMetricNames(
-            GIT_TELEMETRY.SETTINGS_COUNT,
-            GIT_TELEMETRY.SETTINGS_MS,
-            GIT_TELEMETRY.SETTINGS_RESPONSE,
-            GIT_TELEMETRY.SETTINGS_ERRORS,
+            count=GIT_TELEMETRY.SETTINGS_COUNT,
+            duration=GIT_TELEMETRY.SETTINGS_MS,
+            response_bytes=None,
+            error=GIT_TELEMETRY.SETTINGS_ERRORS,
         )
 
         payload = {
@@ -412,10 +402,10 @@ class _TestVisibilityAPIClientBase(abc.ABC):
             timeout = DEFAULT_ITR_SKIPPABLE_TIMEOUT
 
         metric_names = APIRequestMetricNames(
-            SKIPPABLE_TESTS_TELEMETRY.REQUEST,
-            SKIPPABLE_TESTS_TELEMETRY.REQUEST_MS,
-            SKIPPABLE_TESTS_TELEMETRY.RESPONSE_TESTS,
-            SKIPPABLE_TESTS_TELEMETRY.REQUEST_ERRORS,
+            count=SKIPPABLE_TESTS_TELEMETRY.REQUEST,
+            duration=SKIPPABLE_TESTS_TELEMETRY.REQUEST_MS,
+            response_bytes=SKIPPABLE_TESTS_TELEMETRY.RESPONSE_BYTES,
+            error=SKIPPABLE_TESTS_TELEMETRY.REQUEST_ERRORS,
         )
 
         payload = {
@@ -448,7 +438,7 @@ class _TestVisibilityAPIClientBase(abc.ABC):
 
         meta = skippable_response.get("meta")
         if meta is None:
-            log.debug("SKippable tests response did not contain metadata field, no tests will be skipped")
+            log.debug("Skippable tests response did not contain metadata field, no tests will be skipped")
             record_api_request_error(metric_names.error, ERROR_TYPES.BAD_JSON)
             return None
 
@@ -480,10 +470,10 @@ class _TestVisibilityAPIClientBase(abc.ABC):
 
     def fetch_unique_tests(self) -> t.Optional[t.Set[InternalTestId]]:
         metric_names = APIRequestMetricNames(
-            EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST,
-            EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST_MS,
-            EARLY_FLAKE_DETECTION_TELEMETRY.RESPONSE_BYTES,
-            EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST_ERRORS,
+            count=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST,
+            duration=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST_MS,
+            response_bytes=EARLY_FLAKE_DETECTION_TELEMETRY.RESPONSE_BYTES,
+            error=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST_ERRORS,
         )
 
         unique_test_ids: t.Set[InternalTestId] = set()

--- a/ddtrace/internal/ci_visibility/_api_client.py
+++ b/ddtrace/internal/ci_visibility/_api_client.py
@@ -21,12 +21,18 @@ from ddtrace.internal.ci_visibility.constants import SETTING_ENDPOINT
 from ddtrace.internal.ci_visibility.constants import SKIPPABLE_ENDPOINT
 from ddtrace.internal.ci_visibility.constants import SUITE
 from ddtrace.internal.ci_visibility.constants import TEST
+from ddtrace.internal.ci_visibility.constants import UNIQUE_TESTS_ENDPOINT
 from ddtrace.internal.ci_visibility.errors import CIVisibilityAuthenticationException
 from ddtrace.internal.ci_visibility.git_data import GitData
+from ddtrace.internal.ci_visibility.telemetry.api_request import APIRequestMetricNames
+from ddtrace.internal.ci_visibility.telemetry.api_request import record_api_request
+from ddtrace.internal.ci_visibility.telemetry.api_request import record_api_request_error
 from ddtrace.internal.ci_visibility.telemetry.constants import ERROR_TYPES
-from ddtrace.internal.ci_visibility.telemetry.git import record_settings
-from ddtrace.internal.ci_visibility.telemetry.itr import record_itr_skippable_request
-from ddtrace.internal.ci_visibility.telemetry.itr import record_itr_skippable_request_error
+from ddtrace.internal.ci_visibility.telemetry.constants import GIT_TELEMETRY
+from ddtrace.internal.ci_visibility.telemetry.early_flake_detection import EARLY_FLAKE_DETECTION_TELEMETRY
+from ddtrace.internal.ci_visibility.telemetry.early_flake_detection import record_early_flake_detection_tests_count
+from ddtrace.internal.ci_visibility.telemetry.git import record_settings_response
+from ddtrace.internal.ci_visibility.telemetry.itr import SKIPPABLE_TESTS_TELEMETRY
 from ddtrace.internal.ci_visibility.telemetry.itr import record_skippable_count
 from ddtrace.internal.ci_visibility.utils import combine_url_path
 from ddtrace.internal.logger import get_logger
@@ -56,6 +62,7 @@ _BASE_HEADERS: t.Dict[str, str] = {
 
 _SKIPPABLE_ITEM_ID_TYPE = t.Union[InternalTestId, TestSuiteId]
 _CONFIGURATIONS_TYPE = t.Dict[str, t.Union[str, t.Dict[str, str]]]
+_UNIQUE_TESTS_TYPE = t.Set[InternalTestId]
 
 _NETWORK_ERRORS = (TimeoutError, socket.timeout, RemoteDisconnected)
 
@@ -78,6 +85,13 @@ class EarlyFlakeDetectionSettings:
     slow_test_retries_30s: int = 3
     slow_test_retries_5m: int = 2
     faulty_session_threshold: float = 30.0
+
+
+@dataclasses.dataclass(frozen=True)
+class UniqueTestsData:
+    test_modules: t.Dict[str, TestModuleId]
+    test_suites: t.Dict[str, TestSuiteId]
+    test_cases: t.Dict[str, InternalTestId]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -272,11 +286,57 @@ class _TestVisibilityAPIClientBase(abc.ABC):
             if conn is not None:
                 conn.close()
 
+    def _do_request_with_telemetry(
+        self,
+        method: str,
+        endpoint: str,
+        payload: str,
+        metric_names: APIRequestMetricNames,
+        timeout: t.Optional[float] = None,
+    ) -> t.Any:
+        """Performs a request with telemetry submitted according to given names"""
+        sw = StopWatch()
+        sw.start()
+        error_type: t.Optional[ERROR_TYPES] = None
+        response_bytes: t.Optional[int] = None
+        try:
+            try:
+                response = self._do_request(method, endpoint, payload, timeout=timeout)
+            except _NETWORK_ERRORS:
+                error_type = ERROR_TYPES.TIMEOUT
+                raise
+            if response.status >= 400:
+                error_type = ERROR_TYPES.CODE_4XX if response.status < 500 else ERROR_TYPES.CODE_5XX
+                if response.status == 403:
+                    raise CIVisibilityAuthenticationException()
+                raise ValueError("API response status code: %d", response.status)
+            try:
+                sw.stop()  # Stop the timer before parsing the response
+                response_bytes = len(response.body)
+                if isinstance(response.body, bytes):
+                    parsed = json.loads(response.body.decode())
+                else:
+                    parsed = json.loads(response.body)
+                return parsed
+            except JSONDecodeError:
+                error_type = ERROR_TYPES.BAD_JSON
+                raise
+        finally:
+            record_api_request(metric_names, sw.elapsed() * 1000, response_bytes=response_bytes, error=error_type)
+
     def fetch_settings(self) -> TestVisibilityAPISettings:
         """Fetches settings from the test visibility API endpoint
 
         This raises encountered exceptions because fetch_settings may be used multiple times during a session.
         """
+
+        metric_names = APIRequestMetricNames(
+            GIT_TELEMETRY.SETTINGS_COUNT,
+            GIT_TELEMETRY.SETTINGS_MS,
+            GIT_TELEMETRY.SETTINGS_RESPONSE,
+            GIT_TELEMETRY.SETTINGS_ERRORS,
+        )
+
         payload = {
             "data": {
                 "id": str(uuid4()),
@@ -293,56 +353,40 @@ class _TestVisibilityAPIClientBase(abc.ABC):
             }
         }
 
-        sw = StopWatch()
-        sw.start()
-        try:
-            response = self._do_request("POST", SETTING_ENDPOINT, json.dumps(payload), timeout=self._timeout)
-        except _NETWORK_ERRORS:
-            record_settings(sw.elapsed() * 1000, error=ERROR_TYPES.TIMEOUT)
-            raise
-        if response.status >= 400:
-            error_code = ERROR_TYPES.CODE_4XX if response.status < 500 else ERROR_TYPES.CODE_5XX
-            record_settings(sw.elapsed() * 1000, error=error_code)
-            if response.status == 403:
-                raise CIVisibilityAuthenticationException()
-            raise ValueError("API response status code: %d", response.status)
-        try:
-            if isinstance(response.body, bytes):
-                parsed = json.loads(response.body.decode())
-            else:
-                parsed = json.loads(response.body)
-        except JSONDecodeError:
-            record_settings(sw.elapsed() * 1000, error=ERROR_TYPES.BAD_JSON)
-            raise
+        parsed_response = self._do_request_with_telemetry(
+            "POST", SETTING_ENDPOINT, json.dumps(payload), metric_names, timeout=self._timeout
+        )
 
-        if "errors" in parsed:
-            record_settings(sw.elapsed() * 1000, error=ERROR_TYPES.UNKNOWN)
+        if "errors" in parsed_response:
+            record_api_request_error(metric_names.error, ERROR_TYPES.UNKNOWN)
             raise ValueError("Settings response contained an error, disabling Intelligent Test Runner")
 
-        log.debug("Parsed API response: %s", parsed)
+        log.debug("Parsed API response: %s", parsed_response)
 
         try:
-            attributes = parsed["data"]["attributes"]
+            attributes = parsed_response["data"]["attributes"]
             coverage_enabled = attributes["code_coverage"]
             skipping_enabled = attributes["tests_skipping"]
             require_git = attributes["require_git"]
             itr_enabled = attributes["itr_enabled"]
             flaky_test_retries_enabled = attributes["flaky_test_retries_enabled"]
-            early_flake_detection = EarlyFlakeDetectionSettings(
-                enabled=attributes["early_flake_detection"]["enabled"],
-                faulty_session_threshold=attributes["early_flake_detection"]["faulty_session_threshold"],
-                slow_test_retries_5s=attributes["early_flake_detection"]["slow_test_retries"]["5s"],
-                slow_test_retries_10s=attributes["early_flake_detection"]["slow_test_retries"]["10s"],
-                slow_test_retries_30s=attributes["early_flake_detection"]["slow_test_retries"]["30s"],
-                slow_test_retries_5m=attributes["early_flake_detection"]["slow_test_retries"]["5m"],
-            )
+
+            if attributes["early_flake_detection"]["enabled"]:
+                early_flake_detection = EarlyFlakeDetectionSettings(
+                    enabled=attributes["early_flake_detection"]["enabled"],
+                    faulty_session_threshold=attributes["early_flake_detection"]["faulty_session_threshold"],
+                    slow_test_retries_5s=attributes["early_flake_detection"]["slow_test_retries"]["5s"],
+                    slow_test_retries_10s=attributes["early_flake_detection"]["slow_test_retries"]["10s"],
+                    slow_test_retries_30s=attributes["early_flake_detection"]["slow_test_retries"]["30s"],
+                    slow_test_retries_5m=attributes["early_flake_detection"]["slow_test_retries"]["5m"],
+                )
+            else:
+                early_flake_detection = EarlyFlakeDetectionSettings()
         except KeyError:
-            record_settings(sw.elapsed() * 1000, error=ERROR_TYPES.UNKNOWN)
+            record_api_request_error(metric_names.error, ERROR_TYPES.UNKNOWN)
             raise
 
-        record_settings(sw.elapsed() * 1000, coverage_enabled, skipping_enabled, require_git, itr_enabled)
-
-        return TestVisibilityAPISettings(
+        api_settings = TestVisibilityAPISettings(
             coverage_enabled=coverage_enabled,
             skipping_enabled=skipping_enabled,
             require_git=require_git,
@@ -351,9 +395,32 @@ class _TestVisibilityAPIClientBase(abc.ABC):
             early_flake_detection=early_flake_detection,
         )
 
-    def _do_skippable_request(self, timeout: float) -> t.Optional[_SkippableResponse]:
+        record_settings_response(
+            api_settings.coverage_enabled,
+            api_settings.skipping_enabled,
+            api_settings.require_git,
+            api_settings.itr_enabled,
+            api_settings.early_flake_detection.enabled,
+        )
+
+        return api_settings
+
+    def fetch_skippable_items(
+        self, timeout: t.Optional[float] = None, ignore_test_parameters: bool = False
+    ) -> t.Optional[ITRData]:
+        if timeout is None:
+            timeout = DEFAULT_ITR_SKIPPABLE_TIMEOUT
+
+        metric_names = APIRequestMetricNames(
+            SKIPPABLE_TESTS_TELEMETRY.REQUEST,
+            SKIPPABLE_TESTS_TELEMETRY.REQUEST_MS,
+            SKIPPABLE_TESTS_TELEMETRY.RESPONSE_TESTS,
+            SKIPPABLE_TESTS_TELEMETRY.REQUEST_ERRORS,
+        )
+
         payload = {
             "data": {
+                "id": str(uuid4()),
                 "type": "test_params",
                 "attributes": {
                     "service": self._service,
@@ -366,60 +433,12 @@ class _TestVisibilityAPIClientBase(abc.ABC):
             }
         }
 
-        error_type: t.Optional[ERROR_TYPES] = None
-        response_bytes: int = 0
-        sw = StopWatch()
-
         try:
-            try:
-                sw.start()
-                response = self._do_request("POST", SKIPPABLE_ENDPOINT, json.dumps(payload), timeout)
-                sw.stop()
-            except _NETWORK_ERRORS as e:
-                sw.stop()
-                log.warning("Error while fetching skippable tests: ", exc_info=True)
-                error_type = ERROR_TYPES.NETWORK if isinstance(e, RemoteDisconnected) else ERROR_TYPES.TIMEOUT
-                return None
-
-            if response.status >= 400:
-                error_type = ERROR_TYPES.CODE_4XX if response.status < 500 else ERROR_TYPES.CODE_5XX
-                log.warning("Skippable tests request responded with status %d", response.status)
-                return None
-            try:
-                response_bytes = len(response.body)
-                if isinstance(response.body, bytes):
-                    parsed = json.loads(response.body.decode())
-                else:
-                    parsed = json.loads(response.body)
-            except json.JSONDecodeError:
-                log.warning("Skippable tests request responded with invalid JSON '%s'", response.body)
-                error_type = ERROR_TYPES.BAD_JSON
-                return None
-
-            return parsed
-
-        except Exception:
-            log.warning("Error retrieving skippable test data, no tests will be skipped", exc_info=True)
-            error_type = ERROR_TYPES.UNKNOWN
-            return None
-
-        finally:
-            record_itr_skippable_request(
-                sw.elapsed() * 1000,
-                response_bytes,
-                TEST if self._itr_skipping_level == ITR_SKIPPING_LEVEL.TEST else SUITE,
-                error=error_type,
+            skippable_response: _SkippableResponse = self._do_request_with_telemetry(
+                "POST", SKIPPABLE_ENDPOINT, json.dumps(payload), metric_names, timeout
             )
-
-    def fetch_skippable_items(
-        self, timeout: t.Optional[float] = None, ignore_test_parameters: bool = False
-    ) -> t.Optional[ITRData]:
-        if timeout is None:
-            timeout = DEFAULT_ITR_SKIPPABLE_TIMEOUT
-
-        error_type: t.Optional[ERROR_TYPES] = None
-
-        skippable_response = self._do_skippable_request(timeout)
+        except Exception:  # noqa: E722
+            return None
 
         covered_files: t.Optional[t.Dict[str, CoverageLines]] = None
 
@@ -427,41 +446,94 @@ class _TestVisibilityAPIClientBase(abc.ABC):
             # We did not fetch any data, but telemetry has already been recorded, and a warning has been logged
             return None
 
+        meta = skippable_response.get("meta")
+        if meta is None:
+            log.debug("SKippable tests response did not contain metadata field, no tests will be skipped")
+            record_api_request_error(metric_names.error, ERROR_TYPES.BAD_JSON)
+            return None
+
+        correlation_id = meta.get("correlation_id")
+        if correlation_id is None:
+            log.debug("Skippable tests response missing correlation_id")
+        else:
+            log.debug("Skippable tests response correlation_id: %s", correlation_id)
+
+        covered_files_data = meta.get("coverage")
+        if covered_files_data is not None:
+            covered_files = _parse_covered_files(covered_files_data)
+
+        items_to_skip_data = skippable_response.get("data")
+        if items_to_skip_data is None:
+            log.warning("Skippable tests request missing data, no tests will be skipped")
+            record_api_request_error(metric_names.error, ERROR_TYPES.BAD_JSON)
+            return None
+
+        if self._itr_skipping_level == ITR_SKIPPING_LEVEL.TEST:
+            items_to_skip = _parse_skippable_tests(items_to_skip_data, ignore_test_parameters)
+        else:
+            items_to_skip = _parse_skippable_suites(items_to_skip_data)
+        return ITRData(
+            correlation_id=correlation_id,
+            covered_files=covered_files,
+            skippable_items=items_to_skip,
+        )
+
+    def fetch_unique_tests(self) -> t.Optional[t.Set[InternalTestId]]:
+        metric_names = APIRequestMetricNames(
+            EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST,
+            EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST_MS,
+            EARLY_FLAKE_DETECTION_TELEMETRY.RESPONSE_BYTES,
+            EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST_ERRORS,
+        )
+
+        unique_test_ids: t.Set[InternalTestId] = set()
+
+        payload = {
+            "data": {
+                "id": str(uuid4()),
+                "type": "ci_app_libraries_tests_request",
+                "attributes": {
+                    "service": self._service,
+                    "env": self._dd_env,
+                    "repository_url": self._git_data.repository_url,
+                    "configurations": self._configurations,
+                },
+            }
+        }
+
         try:
-            meta = skippable_response.get("meta")
-            if meta is None:
-                log.debug("SKippable tests response did not contain metadata field, no tests will be skipped")
-                error_type = ERROR_TYPES.BAD_JSON
-                return None
-
-            correlation_id = meta.get("correlation_id")
-            if correlation_id is None:
-                log.debug("Skippable tests response missing correlation_id")
-            else:
-                log.debug("Skippable tests response correlation_id: %s", correlation_id)
-
-            covered_files_data = meta.get("coverage")
-            if covered_files_data is not None:
-                covered_files = _parse_covered_files(covered_files_data)
-
-            items_to_skip_data = skippable_response.get("data")
-            if items_to_skip_data is None:
-                log.warning("Skippable tests request missing data, no tests will be skipped")
-                error_type = ERROR_TYPES.BAD_JSON
-                return None
-
-            if self._itr_skipping_level == ITR_SKIPPING_LEVEL.TEST:
-                items_to_skip = _parse_skippable_tests(items_to_skip_data, ignore_test_parameters)
-            else:
-                items_to_skip = _parse_skippable_suites(items_to_skip_data)
-            return ITRData(
-                correlation_id=correlation_id,
-                covered_files=covered_files,
-                skippable_items=items_to_skip,
+            parsed_response = self._do_request_with_telemetry(
+                "POST", UNIQUE_TESTS_ENDPOINT, json.dumps(payload), metric_names
             )
-        finally:
-            if error_type is not None:
-                record_itr_skippable_request_error(error_type)
+        except Exception:  # noqa: E722
+            return None
+
+        if "errors" in parsed_response:
+            record_api_request_error(metric_names.error, ERROR_TYPES.UNKNOWN)
+            log.debug("Unique tests response contained an error")
+            return None
+
+        try:
+            tests_data = parsed_response["data"]["attributes"]["tests"]
+        except KeyError:
+            record_api_request_error(metric_names.error, ERROR_TYPES.UNKNOWN)
+            return None
+
+        try:
+            for module, suites in tests_data.items():
+                module_id = TestModuleId(module)
+                for suite, tests in suites.items():
+                    suite_id = TestSuiteId(module_id, suite)
+                    for test in tests:
+                        unique_test_ids.add(InternalTestId(suite_id, test))
+        except Exception:  # noqa: E722
+            log.debug("Failed to parse unique tests data", exc_info=True)
+            record_api_request_error(metric_names.error, ERROR_TYPES.UNKNOWN)
+            return None
+
+        record_early_flake_detection_tests_count(len(unique_test_ids))
+
+        return unique_test_ids
 
 
 class AgentlessTestVisibilityAPIClient(_TestVisibilityAPIClientBase):

--- a/ddtrace/internal/ci_visibility/constants.py
+++ b/ddtrace/internal/ci_visibility/constants.py
@@ -46,6 +46,7 @@ AGENTLESS_DEFAULT_SITE = "datadoghq.com"
 GIT_API_BASE_PATH = "/api/v2/git"
 SETTING_ENDPOINT = "/api/v2/libraries/tests/services/setting"
 SKIPPABLE_ENDPOINT = "/api/v2/ci/tests/skippable"
+UNIQUE_TESTS_ENDPOINT = "/api/v2/ci/libraries/tests"
 
 # Intelligent Test Runner constants
 ITR_UNSKIPPABLE_REASON = "datadog_itr_unskippable"

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -195,6 +195,7 @@ class CIVisibility(Service):
         self._should_upload_git_metadata = True
         self._itr_meta = {}  # type: Dict[str, Any]
         self._itr_data: Optional[ITRData] = None
+        self._unique_tests: Set[InternalTestId] = set()
 
         self._session: Optional[TestVisibilitySession] = None
 
@@ -269,6 +270,10 @@ class CIVisibility(Service):
             "API-provided settings: Intelligent Test Runner: %s, test skipping: %s",
             self._api_settings.itr_enabled,
             self._api_settings.skipping_enabled,
+        )
+        log.info(
+            "API-provided settings: early flake detection enabled: %s",
+            self._api_settings.early_flake_detection.enabled,
         )
         log.info("Detected configurations: %s", str(self._configurations))
 

--- a/ddtrace/internal/ci_visibility/telemetry/api_request.py
+++ b/ddtrace/internal/ci_visibility/telemetry/api_request.py
@@ -1,0 +1,46 @@
+import dataclasses
+from typing import Optional
+
+from ddtrace.internal.ci_visibility.telemetry.constants import CIVISIBILITY_TELEMETRY_NAMESPACE as _NAMESPACE
+from ddtrace.internal.ci_visibility.telemetry.constants import ERROR_TYPES
+from ddtrace.internal.logger import get_logger
+from ddtrace.internal.telemetry import telemetry_writer
+
+
+log = get_logger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class APIRequestMetricNames:
+    count: str
+    duration: str
+    response_bytes: str
+    error: str
+
+
+def record_api_request(
+    metric_names: APIRequestMetricNames,
+    duration: float,
+    response_bytes: Optional[int] = None,
+    error: Optional[ERROR_TYPES] = None,
+):
+    log.debug(
+        "Recording early flake detection telemetry for %s: %s, %s, %s",
+        metric_names.count,
+        duration,
+        response_bytes,
+        error,
+    )
+
+    telemetry_writer.add_count_metric(_NAMESPACE, f"{metric_names.count}", 1)
+    telemetry_writer.add_distribution_metric(_NAMESPACE, f"{metric_names.duration}", duration)
+    if response_bytes is not None:
+        telemetry_writer.add_distribution_metric(_NAMESPACE, f"{metric_names.response_bytes}", response_bytes)
+
+    if error is not None:
+        record_api_request_error(metric_names.error, error)
+
+
+def record_api_request_error(error_metric_name: str, error: ERROR_TYPES):
+    log.debug("Recording early flake detection request error telemetry: %s", error)
+    telemetry_writer.add_count_metric(_NAMESPACE, error_metric_name, 1, (("error_type", error),))

--- a/ddtrace/internal/ci_visibility/telemetry/api_request.py
+++ b/ddtrace/internal/ci_visibility/telemetry/api_request.py
@@ -14,7 +14,7 @@ log = get_logger(__name__)
 class APIRequestMetricNames:
     count: str
     duration: str
-    response_bytes: str
+    response_bytes: Optional[str]
     error: str
 
 
@@ -35,7 +35,10 @@ def record_api_request(
     telemetry_writer.add_count_metric(_NAMESPACE, f"{metric_names.count}", 1)
     telemetry_writer.add_distribution_metric(_NAMESPACE, f"{metric_names.duration}", duration)
     if response_bytes is not None:
-        telemetry_writer.add_distribution_metric(_NAMESPACE, f"{metric_names.response_bytes}", response_bytes)
+        if metric_names.response_bytes is not None:
+            # We don't always want to record response bytes (for settings requests), so assume that no metric name
+            # means we don't want to record it.
+            telemetry_writer.add_distribution_metric(_NAMESPACE, f"{metric_names.response_bytes}", response_bytes)
 
     if error is not None:
         record_api_request_error(metric_names.error, error)

--- a/ddtrace/internal/ci_visibility/telemetry/early_flake_detection.py
+++ b/ddtrace/internal/ci_visibility/telemetry/early_flake_detection.py
@@ -1,0 +1,24 @@
+from enum import Enum
+
+from ddtrace.internal.ci_visibility.telemetry.constants import CIVISIBILITY_TELEMETRY_NAMESPACE as _NAMESPACE
+from ddtrace.internal.logger import get_logger
+from ddtrace.internal.telemetry import telemetry_writer
+
+
+log = get_logger(__name__)
+
+EARLY_FLAKE_DETECTION_TELEMETRY_PREFIX = "early_flake_detection."
+RESPONSE_TESTS = f"{EARLY_FLAKE_DETECTION_TELEMETRY_PREFIX}response_tests"
+
+
+class EARLY_FLAKE_DETECTION_TELEMETRY(str, Enum):
+    REQUEST = "early_flake_detection.request"
+    REQUEST_MS = "early_flake_detection.request_ms"
+    REQUEST_ERRORS = "early_flake_detection.request_errors"
+    RESPONSE_BYTES = "early_flake_detection.response_bytes"
+    RESPONSE_TESTS = "early_flake_detection.response_tests"
+
+
+def record_early_flake_detection_tests_count(early_flake_detection_count: int):
+    log.debug("Recording early flake detection tests count telemetry: %s", early_flake_detection_count)
+    telemetry_writer.add_count_metric(_NAMESPACE, RESPONSE_TESTS, early_flake_detection_count)

--- a/ddtrace/internal/ci_visibility/telemetry/git.py
+++ b/ddtrace/internal/ci_visibility/telemetry/git.py
@@ -45,22 +45,20 @@ def record_objects_pack_data(num_files: int, num_bytes: int) -> None:
     telemetry_writer.add_distribution_metric(_NAMESPACE, GIT_TELEMETRY.OBJECTS_PACK_FILES, num_files)
 
 
-def record_settings(
-    duration: float,
+def record_settings_response(
     coverage_enabled: Optional[bool] = False,
     skipping_enabled: Optional[bool] = False,
     require_git: Optional[bool] = False,
     itr_enabled: Optional[bool] = False,
-    error: Optional[ERROR_TYPES] = None,
+    early_flake_detection_enabled: Optional[bool] = False,
 ) -> None:
     log.debug(
-        "Recording settings telemetry: %s, %s, %s, %s, %s, %s",
-        duration,
+        "Recording settings telemetry: %s, %s, %s, %s, %s",
         coverage_enabled,
         skipping_enabled,
         require_git,
         itr_enabled,
-        error,
+        early_flake_detection_enabled,
     )
     # Telemetry "booleans" are true if they exist, otherwise false
     response_tags = []
@@ -72,13 +70,8 @@ def record_settings(
         response_tags.append(("require_git", "1"))
     if itr_enabled:
         response_tags.append(("itrskip_enabled", "1"))
+    if early_flake_detection_enabled:
+        response_tags.append(("early_flake_detection_enabled", "1"))
 
-    telemetry_writer.add_count_metric(_NAMESPACE, GIT_TELEMETRY.SETTINGS_COUNT, 1)
-    telemetry_writer.add_distribution_metric(_NAMESPACE, GIT_TELEMETRY.SETTINGS_MS, duration)
-
-    telemetry_writer.add_count_metric(
-        _NAMESPACE, GIT_TELEMETRY.SETTINGS_RESPONSE, 1, tuple(response_tags) if response_tags else None
-    )
-    if error is not None:
-        error_tags = (("error", error),)
-        telemetry_writer.add_count_metric(_NAMESPACE, GIT_TELEMETRY.SETTINGS_ERRORS, 1, error_tags)
+    if response_tags:
+        telemetry_writer.add_count_metric(_NAMESPACE, GIT_TELEMETRY.SETTINGS_RESPONSE, 1, tuple(response_tags))

--- a/ddtrace/internal/ci_visibility/telemetry/itr.py
+++ b/ddtrace/internal/ci_visibility/telemetry/itr.py
@@ -1,10 +1,8 @@
 from enum import Enum
 import functools
-from typing import Optional
 
 from ddtrace.internal.ci_visibility.constants import SUITE
 from ddtrace.internal.ci_visibility.telemetry.constants import CIVISIBILITY_TELEMETRY_NAMESPACE as _NAMESPACE
-from ddtrace.internal.ci_visibility.telemetry.constants import ERROR_TYPES
 from ddtrace.internal.ci_visibility.telemetry.constants import EVENT_TYPES
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.telemetry import telemetry_writer
@@ -63,37 +61,3 @@ def record_skippable_count(skippable_count: int, skipping_level: str):
         else SKIPPABLE_TESTS_TELEMETRY.RESPONSE_TESTS
     )
     telemetry_writer.add_count_metric(_NAMESPACE, skippable_count_metric, skippable_count)
-
-
-def record_itr_skippable_request_error(error: ERROR_TYPES):
-    log.debug("Recording itr skippable request error telemetry")
-    telemetry_writer.add_count_metric(_NAMESPACE, SKIPPABLE_TESTS_TELEMETRY.REQUEST_ERRORS, 1, (("error_type", error),))
-
-
-def record_itr_skippable_request(
-    duration: float,
-    response_bytes: int,
-    skipping_level: str,
-    skippable_count: Optional[int] = None,
-    error: Optional[ERROR_TYPES] = None,
-):
-    log.debug(
-        "Recording itr skippable request telemetry: %s, %s, %s, %s, %s",
-        duration,
-        response_bytes,
-        skippable_count,
-        skipping_level,
-        error,
-    )
-
-    telemetry_writer.add_count_metric(_NAMESPACE, SKIPPABLE_TESTS_TELEMETRY.REQUEST, 1)
-    telemetry_writer.add_distribution_metric(_NAMESPACE, SKIPPABLE_TESTS_TELEMETRY.REQUEST_MS, duration)
-    telemetry_writer.add_distribution_metric(_NAMESPACE, SKIPPABLE_TESTS_TELEMETRY.RESPONSE_BYTES, response_bytes)
-
-    if error is not None:
-        record_itr_skippable_request_error(error)
-        # If there was an error, assume no skippable items can be counted
-        return
-
-    if skippable_count is not None:
-        record_skippable_count(skippable_count, skipping_level)

--- a/tests/ci_visibility/api_client/test_ci_visibility_api_client_setting_responses.py
+++ b/tests/ci_visibility/api_client/test_ci_visibility_api_client_setting_responses.py
@@ -51,15 +51,26 @@ class TestTestVisibilityAPIClientSettingResponses(TestTestVisibilityAPIClientBas
             [
                 _get_setting_api_response(tests_skipping=True, itr_enabled=True, efd_detection_enabled=True),
                 TestVisibilityAPISettings(
-                    skipping_enabled=True, itr_enabled=True, early_flake_detection=EarlyFlakeDetectionSettings(True)
+                    skipping_enabled=True,
+                    itr_enabled=True,
+                    early_flake_detection=EarlyFlakeDetectionSettings(enabled=True),
                 ),
             ],
             # EFD matrix-y-testing
+            # EFD should have default values regardless of whether it's present in the response
+            [
+                _get_setting_api_response(tests_skipping=True, itr_enabled=True, efd_present=False),
+                TestVisibilityAPISettings(skipping_enabled=True, itr_enabled=True),
+            ],
+            [
+                _get_setting_api_response(tests_skipping=True, itr_enabled=True, efd_present=True),
+                TestVisibilityAPISettings(skipping_enabled=True, itr_enabled=True),
+            ],
             [
                 _get_setting_api_response(
                     code_coverage=True,
                     flaky_test_retries_enabled=True,
-                    efd_detection_enabled=False,
+                    efd_detection_enabled=True,
                     efd_5s=10,
                     efd_10s=25,
                     efd_30s=15,
@@ -70,7 +81,7 @@ class TestTestVisibilityAPIClientSettingResponses(TestTestVisibilityAPIClientBas
                     coverage_enabled=True,
                     flaky_test_retries_enabled=True,
                     early_flake_detection=EarlyFlakeDetectionSettings(
-                        enabled=False,
+                        enabled=True,
                         slow_test_retries_5s=10,
                         slow_test_retries_10s=25,
                         slow_test_retries_30s=15,
@@ -79,6 +90,8 @@ class TestTestVisibilityAPIClientSettingResponses(TestTestVisibilityAPIClientBas
                     ),
                 ),
             ],
+            # If EFD is not enabled, the defaults should be returned even if the response has values (because we
+            # ignore whatever other values are in the response on the assumption they will not be used)
             [
                 _get_setting_api_response(
                     efd_detection_enabled=False,
@@ -91,11 +104,6 @@ class TestTestVisibilityAPIClientSettingResponses(TestTestVisibilityAPIClientBas
                 TestVisibilityAPISettings(
                     early_flake_detection=EarlyFlakeDetectionSettings(
                         enabled=False,
-                        slow_test_retries_5s=1,
-                        slow_test_retries_10s=2,
-                        slow_test_retries_30s=3,
-                        slow_test_retries_5m=4,
-                        faulty_session_threshold=5,
                     ),
                 ),
             ],

--- a/tests/ci_visibility/api_client/test_ci_visibility_api_client_unique_tests_responses.py
+++ b/tests/ci_visibility/api_client/test_ci_visibility_api_client_unique_tests_responses.py
@@ -1,0 +1,106 @@
+"""NOTE: this lives in its own file simply because some of the test variables are unwieldy"""
+from http.client import RemoteDisconnected
+import socket
+import textwrap
+from unittest import mock
+
+import pytest
+
+from ddtrace.internal.utils.http import Response
+from tests.ci_visibility.api_client._util import TestTestVisibilityAPIClientBase
+from tests.ci_visibility.api_client._util import _get_tests_api_response
+from tests.ci_visibility.api_client._util import _make_fqdn_test_ids
+
+
+class TestTestVisibilityAPIClientUniqueTestResponses(TestTestVisibilityAPIClientBase):
+    """Tests that setting responses from the API client are parsed properly"""
+
+    @pytest.mark.parametrize(
+        "unique_test_response,expected_tests",
+        [
+            # Defaults
+            (_get_tests_api_response({}), set()),
+            # Single item
+            (
+                _get_tests_api_response({"module1": {"suite1.py": ["test1"]}}),
+                set(_make_fqdn_test_ids([("module1", "suite1.py", "test1")])),
+            ),
+            # Multiple unique items
+            (
+                _get_tests_api_response({"module1": {"suite1.py": ["test1"]}}),
+                set(_make_fqdn_test_ids([("module1", "suite1.py", "test1")])),
+            ),
+            (
+                _get_tests_api_response({"module1": {"suite1.py": ["test1"]}, "module2": {"suite2.py": ["test2"]}}),
+                set(_make_fqdn_test_ids([("module1", "suite1.py", "test1"), ("module2", "suite2.py", "test2")])),
+            ),
+            # Multiple items with same name
+            (
+                _get_tests_api_response(
+                    {
+                        "module1": {
+                            "suite1.py": ["test1", "test2"],
+                            "suite2.py": ["test1"],
+                        },
+                        "module2": {
+                            "suite1.py": ["test1"],
+                            "suite2.py": ["test1", "test2"],
+                        },
+                    }
+                ),
+                set(
+                    _make_fqdn_test_ids(
+                        [
+                            ("module1", "suite1.py", "test1"),
+                            ("module1", "suite1.py", "test2"),
+                            ("module1", "suite2.py", "test1"),
+                            ("module2", "suite1.py", "test1"),
+                            ("module2", "suite2.py", "test1"),
+                            ("module2", "suite2.py", "test2"),
+                        ]
+                    )
+                ),
+            ),
+        ],
+    )
+    def test_civisibility_api_client_unique_tests_parsed(self, unique_test_response, expected_tests):
+        """Tests that the client correctly returns unique tests from API response"""
+        client = self._get_test_client()
+        with mock.patch.object(client, "_do_request", return_value=unique_test_response):
+            assert client.fetch_unique_tests() == expected_tests
+
+    @pytest.mark.parametrize(
+        "do_request_side_effect",
+        [
+            TimeoutError,
+            socket.timeout,
+            RemoteDisconnected,
+            Response(403),
+            Response(500),
+            Response(200, "this is not json"),
+            Response(200, '{"valid_json": "invalid_structure"}'),
+            Response(200, '{"errors": "there was an error"}'),
+            Response(
+                200,
+                textwrap.dedent(
+                    """
+                {
+                    "data": {
+                    "id": "J0ucvcSApX8",
+                    "type": "ci_app_libraries_tests",
+                    "attributes": {
+                        "potatoes_but_not_tests": {}
+                        }
+                    }
+                }
+            """
+                ),
+            ),
+        ],
+    )
+    def test_civisibility_api_client_unique_tests_errors(self, do_request_side_effect):
+        """Tests that the client correctly handles errors in the unique test API response"""
+        client = self._get_test_client()
+        with mock.patch.object(client, "_do_request", side_effect=[do_request_side_effect]):
+            settings = client.fetch_unique_tests()
+            assert settings is None

--- a/tests/ci_visibility/api_client/test_ci_visibility_api_client_unique_tests_responses.py
+++ b/tests/ci_visibility/api_client/test_ci_visibility_api_client_unique_tests_responses.py
@@ -13,7 +13,7 @@ from tests.ci_visibility.api_client._util import _make_fqdn_test_ids
 
 
 class TestTestVisibilityAPIClientUniqueTestResponses(TestTestVisibilityAPIClientBase):
-    """Tests that setting responses from the API client are parsed properly"""
+    """Tests that unique tests responses from the API client are parsed properly"""
 
     @pytest.mark.parametrize(
         "unique_test_response,expected_tests",

--- a/tests/ci_visibility/test_ci_visibility.py
+++ b/tests/ci_visibility/test_ci_visibility.py
@@ -1019,6 +1019,8 @@ def test_fetch_tests_to_skip_custom_configurations(dd_ci_visibility_agentless_ur
         "ddtrace.internal.ci_visibility.git_client._build_git_packfiles_with_details"
     ) as mock_build_packfiles, mock.patch(
         "ddtrace.internal.ci_visibility.recorder.ddconfig", _get_default_civisibility_ddconfig()
+    ), mock.patch(
+        "ddtrace.internal.ci_visibility._api_client.uuid4", return_value="checkoutmyuuid4"
     ):
         mock_build_packfiles.return_value.__enter__.return_value = "myprefix", _GitSubprocessDetails("", "", 10, 0)
         CIVisibility.enable(service="test-service")
@@ -1026,6 +1028,7 @@ def test_fetch_tests_to_skip_custom_configurations(dd_ci_visibility_agentless_ur
         expected_data_arg = json.dumps(
             {
                 "data": {
+                    "id": "checkoutmyuuid4",
                     "type": "test_params",
                     "attributes": {
                         "service": "test-service",
@@ -1052,7 +1055,7 @@ def test_fetch_tests_to_skip_custom_configurations(dd_ci_visibility_agentless_ur
             "POST",
             "/api/v2/ci/tests/skippable",
             expected_data_arg,
-            20,
+            timeout=20.0,
         )
         CIVisibility.disable()
 


### PR DESCRIPTION
This adds the unique tests request (`self.fetch_unique_tests()`) to the API client to support Early Flake Detection work.

A refactor wraps the client's `_do_request()` method is also wrapped in `_do_request_with_telemetry()` to DRY the three `_do_request()` callers. The telemetry calls are also refactored into a `api_request` telemetry module.

This also fixes the test verifying the skippable API request payload which had been shamefully copy/pasted and was actually not testing what it was supposed to.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
