### PR TITLE
add test case for dd_llmobs_disabled in test_llmobs_service.py

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -155,13 +155,11 @@ class LLMObs(Service):
         if cls.enabled:
             log.debug("%s already enabled", cls.__name__)
             return
+
         if os.getenv("DD_LLMOBS_ENABLED") and not asbool(os.getenv("DD_LLMOBS_ENABLED")):
             log.debug("LLMObs.enable() called when DD_LLMOBS_ENABLED is set to false or 0, not starting LLMObs service")
             return
 
-        if cls.enabled:
-            log.debug("%s already enabled", cls.__name__)
-            return
         # grab required values for LLMObs
         config._dd_site = site or config._dd_site
         config._dd_api_key = api_key or config._dd_api_key

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -152,9 +152,11 @@ class LLMObs(Service):
         :param str env: Your environment name.
         :param str service: Your service name.
         """
+        if cls.enabled:
+            log.debug("%s already enabled", cls.__name__)
+            return
         if os.getenv("DD_LLMOBS_ENABLED") and not asbool(os.getenv("DD_LLMOBS_ENABLED")):
             log.debug("LLMObs.enable() called when DD_LLMOBS_ENABLED is set to false or 0, not starting LLMObs service")
-            cls.enabled = False
             return
 
         if cls.enabled:

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -152,14 +152,14 @@ class LLMObs(Service):
         :param str env: Your environment name.
         :param str service: Your service name.
         """
+        if os.getenv("DD_LLMOBS_ENABLED") and not asbool(os.getenv("DD_LLMOBS_ENABLED")):
+            log.debug("LLMObs.enable() called when DD_LLMOBS_ENABLED is set to false or 0, not starting LLMObs service")
+            cls.enabled = False
+            return
+
         if cls.enabled:
             log.debug("%s already enabled", cls.__name__)
             return
-
-        if os.getenv("DD_LLMOBS_ENABLED") and not asbool(os.getenv("DD_LLMOBS_ENABLED")):
-            log.debug("LLMObs.enable() called when DD_LLMOBS_ENABLED is set to false or 0, not starting LLMObs service")
-            return
-
         # grab required values for LLMObs
         config._dd_site = site or config._dd_site
         config._dd_api_key = api_key or config._dd_api_key

--- a/tests/llmobs/conftest.py
+++ b/tests/llmobs/conftest.py
@@ -116,6 +116,20 @@ def LLMObs(mock_llmobs_span_writer, mock_llmobs_eval_metric_writer, ddtrace_glob
 
 
 @pytest.fixture
+def LLMObsDisabled(mock_llmobs_span_writer, mock_llmobs_eval_metric_writer, ddtrace_global_config, monkeypatch):
+    monkeypatch.setenv("DD_LLMOBS_ENABLED", "0")
+    global_config = default_global_config()
+    global_config.update(ddtrace_global_config)
+    yield llmobs_service
+
+
+@pytest.fixture
+def mock_on_span_finish():
+    with mock.patch("ddtrace._trace.tracer.Tracer._on_span_finish") as m:
+        yield m
+
+
+@pytest.fixture
 def AgentlessLLMObs(mock_llmobs_span_agentless_writer, mock_llmobs_eval_metric_writer, ddtrace_global_config):
     global_config = default_global_config()
     global_config.update(ddtrace_global_config)

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -213,19 +213,15 @@ def test_llm_span(LLMObs, mock_llmobs_span_writer):
     )
 
 
-def test_llm_span_with_dd_llmobs_disabled(LLMObs, mock_llmobs_span_writer, monkeypatch):
-    monkeypatch.setenv("DD_LLMOBS_ENABLED", "0")
-    assert llmobs_service.enabled
-    LLMObs.enable()
-
-    with LLMObs.llm(model_name="test_model", name="test_llm_call", model_provider="test_provider") as span:
+def test_llm_span_with_dd_llmobs_disabled(LLMObsDisabled, mock_on_span_finish):
+    with LLMObsDisabled.llm(model_name="test_model", name="test_llm_call", model_provider="test_provider") as span:
         assert span.name == "test_llm_call"
         assert span.resource == "llm"
         assert span.span_type == "llm"
         assert span.get_tag(SPAN_KIND) == "llm"
         assert span.get_tag(MODEL_NAME) == "test_model"
         assert span.get_tag(MODEL_PROVIDER) == "test_provider"
-
+    mock_on_span_finish.assert_called_once()
     assert not llmobs_service.enabled
 
 

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -215,6 +215,7 @@ def test_llm_span(LLMObs, mock_llmobs_span_writer):
 
 def test_llm_span_with_dd_llmobs_disabled(LLMObs, mock_llmobs_span_writer, monkeypatch):
     monkeypatch.setenv("DD_LLMOBS_ENABLED", "0")
+    assert llmobs_service.enabled
     LLMObs.enable()
 
     with LLMObs.llm(model_name="test_model", name="test_llm_call", model_provider="test_provider") as span:
@@ -225,11 +226,7 @@ def test_llm_span_with_dd_llmobs_disabled(LLMObs, mock_llmobs_span_writer, monke
         assert span.get_tag(MODEL_NAME) == "test_model"
         assert span.get_tag(MODEL_PROVIDER) == "test_provider"
 
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_llm_span_event(span, "llm", model_name="test_model", model_provider="test_provider")
-    )
     assert not llmobs_service.enabled
-
 
 
 def test_llm_span_agentless(AgentlessLLMObs, mock_llmobs_span_agentless_writer):

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -213,6 +213,25 @@ def test_llm_span(LLMObs, mock_llmobs_span_writer):
     )
 
 
+def test_llm_span_with_dd_llmobs_disabled(LLMObs, mock_llmobs_span_writer, monkeypatch):
+    monkeypatch.setenv("DD_LLMOBS_ENABLED", "0")
+    LLMObs.enable()
+
+    with LLMObs.llm(model_name="test_model", name="test_llm_call", model_provider="test_provider") as span:
+        assert span.name == "test_llm_call"
+        assert span.resource == "llm"
+        assert span.span_type == "llm"
+        assert span.get_tag(SPAN_KIND) == "llm"
+        assert span.get_tag(MODEL_NAME) == "test_model"
+        assert span.get_tag(MODEL_PROVIDER) == "test_provider"
+
+    mock_llmobs_span_writer.enqueue.assert_called_with(
+        _expected_llmobs_llm_span_event(span, "llm", model_name="test_model", model_provider="test_provider")
+    )
+    assert not llmobs_service.enabled
+
+
+
 def test_llm_span_agentless(AgentlessLLMObs, mock_llmobs_span_agentless_writer):
     with AgentlessLLMObs.llm(model_name="test_model", name="test_llm_call", model_provider="test_provider") as span:
         assert span.name == "test_llm_call"


### PR DESCRIPTION
## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

As I mentioned in this issue https://github.com/DataDog/dd-trace-py/issues/10859, LLM observability data is being sent even though DD_LLMOBS_ENABLED is set to "0".
To reproduce this issue, I created a test case.
Since I am not familiar with `dd-trace-py` codebase, this code might not be correct.
Please let me know if I have misunderstood anything.

