### PR TITLE
chore(iast): return earlier if there are no ranges in some aspects

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectFormat.cpp
@@ -24,41 +24,40 @@ api_format_aspect(StrType& candidate_text,
     }
 
     auto [ranges_orig, candidate_text_ranges] = are_all_text_all_ranges(candidate_text.ptr(), parameter_list);
-
-    if (!ranges_orig.empty() or !candidate_text_ranges.empty()) {
-        auto new_template =
-          int_as_formatted_evidence<StrType>(candidate_text, candidate_text_ranges, TagMappingMode::Mapper);
-
-        py::list new_args;
-        py::dict new_kwargs;
-        for (const auto arg : args) {
-            if (is_text(arg.ptr())) {
-                auto str_arg = py::cast<py::str>(arg);
-                auto n_arg = all_as_formatted_evidence<py::str>(str_arg, TagMappingMode::Mapper);
-                new_args.append(n_arg);
-            } else {
-                new_args.append(arg);
-            }
-        }
-        for (auto [key, value] : kwargs) {
-            if (is_text(value.ptr())) {
-                auto str_value = py::cast<py::str>(value);
-                auto n_value = all_as_formatted_evidence<py::str>(str_value, TagMappingMode::Mapper);
-                new_kwargs[key] = n_value;
-            } else {
-                new_kwargs[key] = value;
-            }
-        }
-        StrType new_template_format =
-          py::getattr(new_template, "format")(*(py::cast<py::tuple>(new_args)), **new_kwargs);
-        std::tuple result = convert_escaped_text_to_taint_text<StrType>(new_template_format, ranges_orig);
-        StrType result_text = get<0>(result);
-        TaintRangeRefs result_ranges = get<1>(result);
-        PyObject* new_result = new_pyobject_id(result_text.ptr());
-        set_ranges(new_result, result_ranges, tx_map);
-        return py::reinterpret_steal<StrType>(new_result);
+    if (ranges_orig.empty() and candidate_text_ranges.empty()) {
+        return py::getattr(candidate_text, "format")(*args, **kwargs);
     }
-    return py::getattr(candidate_text, "format")(*args, **kwargs);
+
+    auto new_template =
+      int_as_formatted_evidence<StrType>(candidate_text, candidate_text_ranges, TagMappingMode::Mapper);
+
+    py::list new_args;
+    py::dict new_kwargs;
+    for (const auto arg : args) {
+        if (is_text(arg.ptr())) {
+            auto str_arg = py::cast<py::str>(arg);
+            auto n_arg = all_as_formatted_evidence<py::str>(str_arg, TagMappingMode::Mapper);
+            new_args.append(n_arg);
+        } else {
+            new_args.append(arg);
+        }
+    }
+    for (auto [key, value] : kwargs) {
+        if (is_text(value.ptr())) {
+            auto str_value = py::cast<py::str>(value);
+            auto n_value = all_as_formatted_evidence<py::str>(str_value, TagMappingMode::Mapper);
+            new_kwargs[key] = n_value;
+        } else {
+            new_kwargs[key] = value;
+        }
+    }
+    StrType new_template_format = py::getattr(new_template, "format")(*(py::cast<py::tuple>(new_args)), **new_kwargs);
+    std::tuple result = convert_escaped_text_to_taint_text<StrType>(new_template_format, ranges_orig);
+    StrType result_text = get<0>(result);
+    TaintRangeRefs result_ranges = get<1>(result);
+    PyObject* new_result = new_pyobject_id(result_text.ptr());
+    set_ranges(new_result, result_ranges, tx_map);
+    return py::reinterpret_steal<StrType>(new_result);
 }
 
 void

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectIndex.h
@@ -2,6 +2,10 @@
 #include "TaintedOps/TaintedOps.h"
 
 PyObject*
-index_aspect(PyObject* result_o, PyObject* candidate_text, PyObject* idx, const TaintRangeMapTypePtr& tx_taint_map);
+index_aspect(PyObject* result_o,
+             const PyObject* candidate_text,
+             PyObject* idx,
+             const TaintRangeRefs& ranges,
+             const TaintRangeMapTypePtr& tx_taint_map);
 PyObject*
 api_index_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs);

--- a/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Aspects/AspectOperatorAdd.cpp
@@ -95,6 +95,14 @@ api_add_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
             return result_o;
         }
 
+        // Early return if there are no ranges
+        auto [ranges_candidate_text, ranges_error_canditate_text] = get_ranges(candidate_text, tx_map);
+        auto [ranges_text_to_add, ranges_error_text_to_add] = get_ranges(text_to_add, tx_map);
+        if (ranges_error_canditate_text or ranges_error_text_to_add or
+            (ranges_candidate_text.empty() and ranges_text_to_add.empty())) {
+            return result_o;
+        }
+
         // Quickly skip if both are noninterned-unicodes and not tainted
         if (is_notinterned_notfasttainted_unicode(candidate_text) &&
             is_notinterned_notfasttainted_unicode(text_to_add)) {
@@ -126,6 +134,16 @@ api_add_inplace_aspect(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
         }
 
         if (not args_are_text_and_same_type(candidate_text, text_to_add)) {
+            return result_o;
+        }
+
+        // Early return if there are no ranges
+        auto [ranges_candidate_text, ranges_error_canditate_text] = get_ranges(candidate_text, tx_map);
+        if (ranges_error_canditate_text) {
+            return result_o;
+        }
+        auto [ranges_text_to_add, ranges_error_text_to_add] = get_ranges(text_to_add, tx_map);
+        if (ranges_error_text_to_add or (ranges_candidate_text.empty() and ranges_text_to_add.empty())) {
             return result_o;
         }
 


### PR DESCRIPTION
## Description

Return earlier if there are no ranges in some aspects, specifically the index, operator add and format aspects. This hopefully should improve performance in the most common case.

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
