### PR TITLE
fix(profiling): reverse locations for stack v2 [backport-2.13]

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
@@ -63,6 +63,8 @@ extern "C"
                          int64_t line);
     void ddup_push_monotonic_ns(Datadog::Sample* sample, int64_t monotonic_ns);
     void ddup_flush_sample(Datadog::Sample* sample);
+    // Stack v2 specific flush, which reverses the locations
+    void ddup_flush_sample_v2(Datadog::Sample* sample);
     void ddup_drop_sample(Datadog::Sample* sample);
 #ifdef __cplusplus
 } // extern "C"

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
@@ -84,7 +84,7 @@ class Sample
     );
 
     // Flushes the current buffer, clearing it
-    bool flush_sample();
+    bool flush_sample(bool reverse_locations = false);
 
     static ddog_prof_Profile& profile_borrow();
     static void profile_release();

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
@@ -272,6 +272,12 @@ ddup_flush_sample(Datadog::Sample* sample) // cppcheck-suppress unusedFunction
 }
 
 void
+ddup_flush_sample_v2(Datadog::Sample* sample) // cppcheck-suppress unusedFunction
+{
+    sample->flush_sample(/*reverse_locations*/ true);
+}
+
+void
 ddup_drop_sample(Datadog::Sample* sample) // cppcheck-suppress unusedFunction
 {
     Datadog::SampleManager::drop_sample(sample);

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
@@ -1,5 +1,6 @@
 #include "sample.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <thread>
 
@@ -104,12 +105,16 @@ Datadog::Sample::clear_buffers()
 }
 
 bool
-Datadog::Sample::flush_sample()
+Datadog::Sample::flush_sample(bool reverse_locations)
 {
     if (dropped_frames > 0) {
         const std::string name =
           "<" + std::to_string(dropped_frames) + " frame" + (1 == dropped_frames ? "" : "s") + " omitted>";
         Sample::push_frame_impl(name, "", 0, 0);
+    }
+
+    if (reverse_locations) {
+        std::reverse(locations.begin(), locations.end());
     }
 
     const ddog_prof_Sample sample = {

--- a/ddtrace/internal/datadog/profiling/stack_v2/src/stack_renderer.cpp
+++ b/ddtrace/internal/datadog/profiling/stack_v2/src/stack_renderer.cpp
@@ -144,7 +144,7 @@ StackRenderer::render_stack_end()
         return;
     }
 
-    ddup_flush_sample(sample);
+    ddup_flush_sample_v2(sample);
     ddup_drop_sample(sample);
     sample = nullptr;
 }

--- a/releasenotes/notes/profiling-stack-v2-upside-down-82ebd3073b5e8e43.yaml
+++ b/releasenotes/notes/profiling-stack-v2-upside-down-82ebd3073b5e8e43.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: fixes an issue where flamegraph was upside down for stack v2,
+      ``DD_PROFILING_STACK_V2_ENABLED``.


### PR DESCRIPTION
Manual backport of #10851 to 2.13

Fixes an issue where flamegraph was upside down for stack v2, when `DD_PROFILING_STACK_V2_ENABLED`

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
