### PR TITLE
chore(iast): adjust C++ unit tests for macos compatibility

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/tests/test_helpers.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/tests/test_helpers.cpp
@@ -316,7 +316,8 @@ TEST_F(AsFormattedEvidenceCheck, DefaultTagMappingModeIsMapper)
     Source source("source1", "sample_value", OriginType::BODY);
     TaintRangeRefs taint_ranges = { std::make_shared<TaintRange>(5, 2, source) };
 
-    const std::string expected_result = "This :+-<3485454368>is<3485454368>-+: a test string.";
+    auto taint_range_1_hash = taint_ranges[0]->get_hash();
+    const std::string expected_result = "This :+-<" + std::to_string(taint_range_1_hash) + ">is<" + std::to_string(taint_range_1_hash) + ">-+: a test string.";
     const std::string result = as_formatted_evidence(text, taint_ranges);
     EXPECT_STREQ(result.c_str(), expected_result.c_str());
 }
@@ -331,8 +332,10 @@ TEST_F(AsFormattedEvidenceCheck, MultipleRangesWithMapper)
         std::make_shared<TaintRange>(10, 4, source2),
     };
 
+    auto taint_range_1_hash = taint_ranges[0]->get_hash();
+    auto taint_range_2_hash = taint_ranges[1]->get_hash();
     const std::string expected_result =
-      "This :+-<3485454368>is<3485454368>-+: a :+-<891889858>test<891889858>-+: string.";
+      "This :+-<" + std::to_string(taint_range_1_hash) + ">is<" + std::to_string(taint_range_1_hash) + ">-+: a :+-<" + std::to_string(taint_range_2_hash) + ">test<" + std::to_string(taint_range_2_hash) + ">-+: string.";
     const std::string result = as_formatted_evidence(text, taint_ranges);
     EXPECT_STREQ(result.c_str(), expected_result.c_str());
 }
@@ -400,7 +403,8 @@ TEST_F(AllAsFormattedEvidenceCheck, SingleTaintRangeWithMapper)
     TaintRangeRefs taint_ranges = { std::make_shared<TaintRange>(5, 2, source) };
     api_set_ranges(text, taint_ranges);
 
-    const py::str expected_result("This :+-<3485454368>is<3485454368>-+: a test string.");
+    auto taint_range_1_hash = taint_ranges[0]->get_hash();
+    const py::str expected_result("This :+-<" + std::to_string(taint_range_1_hash) + ">is<" + std::to_string(taint_range_1_hash) + ">-+: a test string.");
     const py::str result = all_as_formatted_evidence(text, TagMappingMode::Mapper);
 
     EXPECT_STREQ(AnyTextObjectToString(result).c_str(), AnyTextObjectToString(expected_result).c_str());


### PR DESCRIPTION
IAST: hashes in linux and macos can have different values, this PR adjusts the tests so they should pass on both operating systems.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
