### PR TITLE
Add option for simpler GraphQL resource names

### DIFF
--- a/ddtrace/contrib/graphql/__init__.py
+++ b/ddtrace/contrib/graphql/__init__.py
@@ -35,9 +35,9 @@ Global Configuration
    Enabling instrumentation for resolvers will produce a ``graphql.resolve`` span for every graphql field.
    For complex graphql queries this could produce large traces.
 
-.. py:data:: ddtrace.config.graphql["simplify_resources"]
+.. py:data:: ddtrace.config.graphql["simplify_resource_name"]
 
-   To enable this option, set ``DD_TRACE_GRAPHQL_SIMPLIFY_RESOURCES`` to True.
+   To enable this option, set ``DD_TRACE_GRAPHQL_SIMPLIFY_RESOURCE_NAME`` to True.
 
    Default: ``False``
 

--- a/ddtrace/contrib/graphql/__init__.py
+++ b/ddtrace/contrib/graphql/__init__.py
@@ -35,6 +35,15 @@ Global Configuration
    Enabling instrumentation for resolvers will produce a ``graphql.resolve`` span for every graphql field.
    For complex graphql queries this could produce large traces.
 
+.. py:data:: ddtrace.config.graphql["simplify_resources"]
+
+   To enable this option, set ``DD_TRACE_GRAPHQL_SIMPLIFY_RESOURCES`` to True.
+
+   Default: ``False``
+
+   When True, resource names on GraphQL spans will be reduced to just the query or mutation name, if provided. Otherwise
+   the entire query will be used.
+
 
 To configure the graphql integration using the
 ``Pin`` API::
@@ -44,6 +53,7 @@ To configure the graphql integration using the
 
     Pin.override(graphql, service="mygraphql")
 """
+
 from ddtrace.internal.utils.importlib import require_modules
 
 

--- a/ddtrace/contrib/internal/graphql/patch.py
+++ b/ddtrace/contrib/internal/graphql/patch.py
@@ -61,7 +61,7 @@ config._add(
     dict(
         _default_service=schematize_service_name("graphql"),
         resolvers_enabled=asbool(os.getenv("DD_TRACE_GRAPHQL_RESOLVERS_ENABLED", default=False)),
-        simplify_resource=asbool(os.getenv("DD_TRACE_GRAPHQL_SIMPLIFY_RESOURCES", default=False)),
+        simplify_resource_name=asbool(os.getenv("DD_TRACE_GRAPHQL_SIMPLIFY_RESOURCE_NAME", default=False)),
     ),
 )
 
@@ -170,7 +170,7 @@ def _traced_execute(func, args, kwargs):
         document = get_argument_value(args, kwargs, 1, "document")
     source_str = _get_source_str(document)
     resource = source_str
-    if config.graphql.simplify_resource:
+    if config.graphql.simplify_resource_name:
         # queries can look like:
         # query Name(args) {...
         # query Name {...

--- a/ddtrace/contrib/internal/graphql/patch.py
+++ b/ddtrace/contrib/internal/graphql/patch.py
@@ -61,6 +61,7 @@ config._add(
     dict(
         _default_service=schematize_service_name("graphql"),
         resolvers_enabled=asbool(os.getenv("DD_TRACE_GRAPHQL_RESOLVERS_ENABLED", default=False)),
+        simplify_resource=asbool(os.getenv("DD_TRACE_GRAPHQL_SIMPLIFY_RESOURCES", default=False)),
     ),
 )
 
@@ -168,10 +169,22 @@ def _traced_execute(func, args, kwargs):
     else:
         document = get_argument_value(args, kwargs, 1, "document")
     source_str = _get_source_str(document)
+    resource = source_str
+    if config.graphql.simplify_resource:
+        # queries can look like:
+        # query Name(args) {...
+        # query Name {...
+        # query {...
+        # simplified names only make sense for the first two. the last one should just default to the full query
+        # split on either the query body brace or the arg parens
+        resource = re.split("[({]", resource, maxsplit=1)[0]
+        resource = resource.strip()
+        if resource in ("query", "mutation"):
+            resource = source_str
 
     with pin.tracer.trace(
         name="graphql.execute",
-        resource=source_str,
+        resource=resource,
         service=trace_utils.int_service(pin, config.graphql),
         span_type=SpanTypes.GRAPHQL,
     ) as span:

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_simple_resource_names[no-name].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_simple_resource_names[no-name].json
@@ -1,0 +1,58 @@
+[[
+  {
+    "name": "graphql.parse",
+    "service": "graphql",
+    "resource": "graphql.parse",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "graphql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6704d09800000000",
+      "component": "graphql",
+      "graphql.source": "query { hello }",
+      "language": "python",
+      "runtime-id": "1827a5391f4e49098f51092c2bff10f2"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 39155
+    },
+    "duration": 208383,
+    "start": 1728368792959860894
+  }],
+[
+  {
+    "name": "graphql.execute",
+    "service": "graphql",
+    "resource": "query { hello }",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "graphql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6704d09800000000",
+      "component": "graphql",
+      "graphql.operation.type": "query",
+      "graphql.source": "query { hello }",
+      "language": "python",
+      "runtime-id": "1827a5391f4e49098f51092c2bff10f2"
+    },
+    "metrics": {
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 39155
+    },
+    "duration": 170810,
+    "start": 1728368792960462650
+  }]]

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_simple_resource_names[query-name-with-arg].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_simple_resource_names[query-name-with-arg].json
@@ -1,0 +1,59 @@
+[[
+  {
+    "name": "graphql.parse",
+    "service": "graphql",
+    "resource": "graphql.parse",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "graphql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6704d09800000000",
+      "component": "graphql",
+      "graphql.source": "query Name($arg: String) { hello }",
+      "language": "python",
+      "runtime-id": "1827a5391f4e49098f51092c2bff10f2"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 39155
+    },
+    "duration": 161928,
+    "start": 1728368792981910765
+  }],
+[
+  {
+    "name": "graphql.execute",
+    "service": "graphql",
+    "resource": "query Name",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "graphql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6704d09800000000",
+      "component": "graphql",
+      "graphql.operation.name": "Name",
+      "graphql.operation.type": "query",
+      "graphql.source": "query Name($arg: String) { hello }",
+      "language": "python",
+      "runtime-id": "1827a5391f4e49098f51092c2bff10f2"
+    },
+    "metrics": {
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 39155
+    },
+    "duration": 148166,
+    "start": 1728368792982168023
+  }]]

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_simple_resource_names[query-name].json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_simple_resource_names[query-name].json
@@ -1,0 +1,59 @@
+[[
+  {
+    "name": "graphql.parse",
+    "service": "graphql",
+    "resource": "graphql.parse",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "graphql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6704d09800000000",
+      "component": "graphql",
+      "graphql.source": "query Name { hello }",
+      "language": "python",
+      "runtime-id": "1827a5391f4e49098f51092c2bff10f2"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 39155
+    },
+    "duration": 110426,
+    "start": 1728368792975497665
+  }],
+[
+  {
+    "name": "graphql.execute",
+    "service": "graphql",
+    "resource": "query Name",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "graphql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6704d09800000000",
+      "component": "graphql",
+      "graphql.operation.name": "Name",
+      "graphql.operation.type": "query",
+      "graphql.source": "query Name { hello }",
+      "language": "python",
+      "runtime-id": "1827a5391f4e49098f51092c2bff10f2"
+    },
+    "metrics": {
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 39155
+    },
+    "duration": 142495,
+    "start": 1728368792975699668
+  }]]


### PR DESCRIPTION
The current ddtrace GraphQL integration sets the full query as the resource name. This is fragile for monitoring and metrics purposes because a simple field change will result in a completely new name. In addition, it's kind of unsightly to see a resource name that's so long.

As an example, take a look at [ddtrace-graphql](https://github.com/beezz/ddtrace-graphql). Normally, I'd just use that, but it's out of date and incompatible with the latest versions of ddtrace as well as graphql.

Addresses #10875

## Checklist
- [x] PR author has checked that all the criteria below are met
- The change includes tests OR the PR description describes a testing strategy
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
