### PR TITLE
ci: update the circleci `pre_check` job to run style checks on `.cpp` and `.h` file changes

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.cpp
@@ -70,10 +70,12 @@ new_pyobject_id(PyObject* tainted_object)
         return nullptr;
 
     // Check that it's aligned correctly
-    if (reinterpret_cast<uintptr_t>(tainted_object) % alignof(PyObject) != 0) return tainted_object;
+    if (reinterpret_cast<uintptr_t>(tainted_object) % alignof(PyObject) != 0)
+        return tainted_object;
 
     // Try to safely access ob_type
-    if (const PyObject* temp = tainted_object;!temp->ob_type) return tainted_object;
+    if (const PyObject* temp = tainted_object; !temp->ob_type)
+        return tainted_object;
 
     py::gil_scoped_acquire acquire;
 

--- a/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/Utils/StringUtils.h
@@ -52,14 +52,16 @@ is_text(const PyObject* pyptr)
     };
 
     // Check that it's aligned correctly
-    if (reinterpret_cast<uintptr_t>(pyptr) % alignof(PyObject) != 0) return false;;
+    if (reinterpret_cast<uintptr_t>(pyptr) % alignof(PyObject) != 0)
+        return false;
+    ;
 
     // Try to safely access ob_type
-    if (const PyObject* temp = pyptr;!temp->ob_type) return false;
+    if (const PyObject* temp = pyptr; !temp->ob_type)
+        return false;
 
     return PyUnicode_Check(pyptr) or PyBytes_Check(pyptr) or PyByteArray_Check(pyptr);
 }
-
 
 inline bool
 is_tainteable(const PyObject* pyptr)

--- a/ddtrace/appsec/_iast/_taint_tracking/tests/test_other.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/tests/test_other.cpp
@@ -1,7 +1,7 @@
-#include <gtest/gtest.h>
 #include <Python.h>
+#include <gtest/gtest.h>
+#include <iostream> // jjj
 #include <tests/test_common.hpp>
-#include <iostream>  // jjj
 
 using PyByteArray_Check = PyEnvCheck;
 
@@ -66,12 +66,7 @@ TEST_F(PyByteArray_Check, WithOtherTypes)
     if (PY_VERSION_HEX >= 0x03080000) {
         // PyByteArray_Check is bugged for user-defined classes in Python 3.7
         // Test with a user-defined class
-        PyRun_String(
-            "class TestClass:\n    pass\n\ntest_instance = TestClass()",
-            Py_file_input,
-            globals,
-            locals
-        );
+        PyRun_String("class TestClass:\n    pass\n\ntest_instance = TestClass()", Py_file_input, globals, locals);
         PyObject* user_obj = PyDict_GetItemString(locals, "test_instance");
         EXPECT_FALSE(PyByteArray_Check(user_obj)) << "Failed for user-defined class";
     }
@@ -87,12 +82,7 @@ TEST_F(PyByteArray_Check, WithOtherTypes)
     Py_DECREF(complex_obj);
 
     // Test with Function
-    PyRun_String(
-        "def test_function():\n    pass",
-        Py_file_input,
-        globals,
-        locals
-    );
+    PyRun_String("def test_function():\n    pass", Py_file_input, globals, locals);
     PyObject* func_obj = PyDict_GetItemString(locals, "test_function");
     EXPECT_FALSE(PyByteArray_Check(func_obj)) << "Failed for Function type";
     Py_DECREF(globals);

--- a/scripts/gen_circleci_config.py
+++ b/scripts/gen_circleci_config.py
@@ -49,7 +49,7 @@ def gen_pre_checks(template: dict) -> None:
     check(
         name="Style",
         command="hatch run lint:style",
-        paths={"docker*", "*.py", "*.pyi", "hatch.toml", "pyproject.toml", "*.cpp", "*.h"},
+        paths={"docker*", "*.py", "*.pyi", "hatch.toml", "pyproject.toml", "**.cpp", "**.h"},
     )
     check(
         name="Typing",

--- a/scripts/gen_circleci_config.py
+++ b/scripts/gen_circleci_config.py
@@ -49,7 +49,7 @@ def gen_pre_checks(template: dict) -> None:
     check(
         name="Style",
         command="hatch run lint:style",
-        paths={"docker*", "*.py", "*.pyi", "hatch.toml", "pyproject.toml"},
+        paths={"docker*", "*.py", "*.pyi", "hatch.toml", "pyproject.toml", "*.cpp", "*.h"},
     )
     check(
         name="Typing",

--- a/scripts/gen_circleci_config.py
+++ b/scripts/gen_circleci_config.py
@@ -49,7 +49,7 @@ def gen_pre_checks(template: dict) -> None:
     check(
         name="Style",
         command="hatch run lint:style",
-        paths={"docker*", "*.py", "*.pyi", "hatch.toml", "pyproject.toml", "**/*.cpp", "**/*.h"},
+        paths={"docker*", "*.py", "*.pyi", "hatch.toml", "pyproject.toml", "*.cpp", "*.h"},
     )
     check(
         name="Typing",

--- a/scripts/gen_circleci_config.py
+++ b/scripts/gen_circleci_config.py
@@ -49,7 +49,7 @@ def gen_pre_checks(template: dict) -> None:
     check(
         name="Style",
         command="hatch run lint:style",
-        paths={"docker*", "*.py", "*.pyi", "hatch.toml", "pyproject.toml", "**.cpp", "**.h"},
+        paths={"docker*", "*.py", "*.pyi", "hatch.toml", "pyproject.toml", "**/*.cpp", "**/*.h"},
     )
     check(
         name="Typing",


### PR DESCRIPTION
This PR updates the Circleci `pre_check` job to run style checks on `.cpp` and `.h` file changes.

The `pre_check` job is consistently failing on the main branch due to these style check failures. This means the other CircleCI jobs do not run on the main branch, since `pre_check` is the prerequisite. Example failure [here](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/73979/workflows/87f87583-5cb6-4b24-872d-fa6f671602c7/jobs/4322936).

This PR updates the triggers for style checks, and also tweaks the files causing the style failures to conform to them.

Tested by creating a dummy PR and committing failing changes and then passing changes. See test PR [here](https://github.com/DataDog/dd-trace-py/pull/10916).
See passing style check [here](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/74098/workflows/3f3a1104-521b-4960-8558-373d010fb295/jobs/4324057).

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
