### PR TITLE
chore: change release note type from feature to fix

### DIFF
--- a/releasenotes/notes/iast-feat-iast-telemetry-error-f6ba4a6aadf96ec9.yaml
+++ b/releasenotes/notes/iast-feat-iast-telemetry-error-f6ba4a6aadf96ec9.yaml
@@ -1,5 +1,5 @@
 ---
-features:
+fixes:
   - |
     Code Security (IAST): Always report a telemetry log error when an IAST propagation error raises, 
     regardless of whether the _DD_IAST_DEBUG environment variable is enabled or not.


### PR DESCRIPTION
The release note for https://github.com/DataDog/dd-trace-py/pull/10784 (original: https://github.com/DataDog/dd-trace-py/pull/10740) was marked as a new feature when it should have been a fix. In order to conform to SemVer, we cannot be adding new features to patch releases. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
