### PR TITLE
ci: clean up github mq configs and add dd mq configs

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -10,6 +10,7 @@ on:
       # before merging/releasing
       - build_deploy*
       - 'upgrade-latest-*'
+      - 'mq-working-branch**'
   pull_request:
   release:
     types:

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -1,9 +1,6 @@
 name: Build Python 3
 
 on:
-  merge_group:
-    # Trigger jobs when PR is added to merge queue
-    types: [checks_requested]
   workflow_call:
     inputs:
       cibw_build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,13 +4,11 @@ on:
   push:
     branches:
       - main
+      - 'mq-working-branch**'
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
       - main
-  merge_group:
-    # Trigger jobs when PR is added to merge queue
-    types: [checks_requested]
 
 jobs:
   analyze:

--- a/.github/workflows/django-overhead-profile.yml
+++ b/.github/workflows/django-overhead-profile.yml
@@ -3,14 +3,13 @@ on:
   push:
     branches:
       - main
+      - 'mq-working-branch**'
   pull_request:
     paths:
       - 'ddtrace/**'
       - 'scripts/profiles/django-simple/**'
       - '.github/workflows/django-overhead-profile.yml'
-  merge_group:
-    # Trigger jobs when PR is added to merge queue
-    types: [checks_requested]
+
 jobs:
   django-overhead-profile:
     runs-on: ubuntu-latest

--- a/.github/workflows/encoders-profile.yml
+++ b/.github/workflows/encoders-profile.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'mq-working-branch**'
   pull_request:
     paths:
       - 'ddtrace/internal/_encoding.pyx'

--- a/.github/workflows/encoders-profile.yml
+++ b/.github/workflows/encoders-profile.yml
@@ -9,9 +9,7 @@ on:
       - 'ddtrace/internal/_encoding.pyx'
       - 'scripts/profiles/encoders/**'
       - '.github/workflows/encoders-profile.yml'
-  merge_group:
-    # Trigger jobs when PR is added to merge queue
-    types: [checks_requested]
+
 jobs:
   encoders-profile:
     runs-on: ubuntu-latest

--- a/.github/workflows/flask-overhead-profile.yml
+++ b/.github/workflows/flask-overhead-profile.yml
@@ -3,14 +3,13 @@ on:
   push:
     branches:
       - main
+      - 'mq-working-branch**'
   pull_request:
     paths:
       - 'ddtrace/**'
       - 'scripts/profiles/flask-simple/**'
       - '.github/workflows/flask-overhead-profile.yml'
-  merge_group:
-    # Trigger jobs when PR is added to merge queue
-    types: [checks_requested]
+
 jobs:
   flask-overhead-profile:
     runs-on: ubuntu-latest

--- a/.github/workflows/pypa_musllinux_1_2_i686.yml
+++ b/.github/workflows/pypa_musllinux_1_2_i686.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'mq-working-branch**'
     paths:
       - 'docker/**'
   merge_group:

--- a/.github/workflows/pypa_musllinux_1_2_i686.yml
+++ b/.github/workflows/pypa_musllinux_1_2_i686.yml
@@ -8,9 +8,6 @@ on:
       - 'mq-working-branch**'
     paths:
       - 'docker/**'
-  merge_group:
-    # Trigger jobs when PR is added to merge queue
-    types: [checks_requested]
 
 jobs:
   build-and-publish:

--- a/.github/workflows/requirements-locks.yml
+++ b/.github/workflows/requirements-locks.yml
@@ -3,11 +3,10 @@ on:
   push:
     branches:
       - main
+      - 'mq-working-branch**'
   pull_request:
     types: [opened, reopened, synchronize]
-  merge_group:
-    # Trigger jobs when PR is added to merge queue
-    types: [checks_requested]
+
 jobs:
   validate:
     name: Check requirements lockfiles

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     paths:
       - src/**
-  merge_group:
-    # Trigger jobs when PR is added to merge queue
-    types: [checks_requested]
 
 jobs:
   check:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -9,9 +9,6 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: '00 04 * * 2-6'
-  merge_group:
-    # Trigger jobs when PR is added to merge queue
-    types: [checks_requested]
 
 jobs:
   system-tests-build-agent:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'mq-working-branch**'
   pull_request:
   workflow_dispatch: {}
   schedule:

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -6,9 +6,6 @@ on:
       - main
       - 'mq-working-branch**'
   pull_request:
-  merge_group:
-    # Trigger jobs when PR is added to merge queue
-    types: [checks_requested]
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'mq-working-branch**'
   pull_request:
   merge_group:
     # Trigger jobs when PR is added to merge queue

--- a/.github/workflows/testrunner.yml
+++ b/.github/workflows/testrunner.yml
@@ -5,11 +5,9 @@ on:
   push:
     branches:
       - 'main'
+      - 'mq-working-branch**'
     paths:
       - 'docker/**'
-  merge_group:
-    # Trigger jobs when PR is added to merge queue
-    types: [checks_requested]
 
 jobs:
   build-and-publish:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - main
+      - 'mq-working-branch**'
   pull_request:
   workflow_dispatch: {}
-  merge_group:
-    # Trigger jobs when PR is added to merge queue
-    types: [checks_requested]
 
 jobs:
   unit-tests:


### PR DESCRIPTION
GitHub jobs are not running when PRs are added to the DD MQ. We need to add a branch trigger for `'mq-working-branch**'` for them to run on the merge queue.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
