### PR TITLE
docs: use `$HOME/.asdf/bin` instead of `/usr/local/bin` for installing hatch

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ build:
   commands:
     - git fetch --unshallow || true
     - mkdir -p $HOME/.local/bin
-    - ls $HOME
+    - ls -a $HOME
     - curl -L https://github.com/pypa/hatch/releases/download/hatch-v1.12.0/hatch-x86_64-unknown-linux-gnu.tar.gz | tar zx
     - install -t $HOME/.asdf/bin hatch
     - hatch -q

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,10 +4,15 @@ build:
   tools:
     python: "3.10"
     rust: "1.78"
+  jobs:
+    pre_create_environment:
+      - mkdir -p $HOME/.local/bin
+      - export PATH="$HOME/.local/bin:$PATH"
+      - echo $PATH
   commands:
     - git fetch --unshallow || true
     - curl -L https://github.com/pypa/hatch/releases/download/hatch-v1.12.0/hatch-x86_64-unknown-linux-gnu.tar.gz | tar zx
-    - install -t $HOME/.asdf/bin hatch
+    - install -t $HOME/.local/bin hatch
     - hatch -q
     - hatch -v run docs:sphinx-build -W -b html docs docs/_build/html
     - mv docs/_build $READTHEDOCS_OUTPUT

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,9 @@ build:
   commands:
     - git fetch --unshallow || true
     - mkdir -p $HOME/.local/bin
-    - ls -a $HOME
+    - echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+    - . ~/.bashrc
+    - echo $PATH
     - curl -L https://github.com/pypa/hatch/releases/download/hatch-v1.12.0/hatch-x86_64-unknown-linux-gnu.tar.gz | tar zx
     - install -t $HOME/.asdf/bin hatch
     - hatch -q

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,15 +4,10 @@ build:
   tools:
     python: "3.10"
     rust: "1.78"
-  jobs:
-    pre_create_environment:
-      - mkdir -p $HOME/.local/bin
-      - export PATH="$HOME/.local/bin:$PATH"
-      - echo $PATH
   commands:
     - git fetch --unshallow || true
     - curl -L https://github.com/pypa/hatch/releases/download/hatch-v1.12.0/hatch-x86_64-unknown-linux-gnu.tar.gz | tar zx
-    - install -t $HOME/.local/bin hatch
+    - install -t $HOME/.asdf/bin hatch
     - hatch -q
     - hatch -v run docs:sphinx-build -W -b html docs docs/_build/html
     - mv docs/_build $READTHEDOCS_OUTPUT

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,10 +6,6 @@ build:
     rust: "1.78"
   commands:
     - git fetch --unshallow || true
-    - mkdir -p $HOME/.local/bin
-    - echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
-    - . ~/.bashrc
-    - echo $PATH
     - curl -L https://github.com/pypa/hatch/releases/download/hatch-v1.12.0/hatch-x86_64-unknown-linux-gnu.tar.gz | tar zx
     - install -t $HOME/.asdf/bin hatch
     - hatch -q

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,11 +5,14 @@ build:
     python: "3.10"
   commands:
     - git fetch --unshallow || true
-    - git rev-parse --abbrev-ref HEAD
+    - mkdir -p $HOME/.local/bin
     - curl -L https://github.com/pypa/hatch/releases/download/hatch-v1.12.0/hatch-x86_64-unknown-linux-gnu.tar.gz | tar zx
-    - install -t /home/docs/.asdf/bin hatch
+    - echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
+    - source ~/.bashrc
+    - install -t $HOME/.local/bin/ hatch
     - hatch -q
     - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
     - echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$BASH_ENV"
+    - source ~/.bashrc
     - hatch -v run docs:sphinx-build -W -b html docs docs/_build/html
     - mv docs/_build $READTHEDOCS_OUTPUT

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,16 +3,11 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+    rust: "1.78"
   commands:
     - git fetch --unshallow || true
-    - mkdir -p $HOME/.local/bin
     - curl -L https://github.com/pypa/hatch/releases/download/hatch-v1.12.0/hatch-x86_64-unknown-linux-gnu.tar.gz | tar zx
-    - echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-    - source ~/.bashrc
-    - install -t $HOME/.local/bin/ hatch
+    - install -t $HOME/docs/.asdf/bin hatch
     - hatch -q
-    - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
-    - echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$BASH_ENV"
-    - source ~/.bashrc
     - hatch -v run docs:sphinx-build -W -b html docs docs/_build/html
     - mv docs/_build $READTHEDOCS_OUTPUT

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,12 +5,10 @@ build:
     python: "3.10"
   commands:
     - git fetch --unshallow || true
-    - mkdir -p $HOME/.local/bin
+    - export CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
     - curl -L https://github.com/pypa/hatch/releases/download/hatch-v1.12.0/hatch-x86_64-unknown-linux-gnu.tar.gz | tar zx
-    - export PATH="$HOME/.local/bin:$PATH"
     - echo $PATH
-    - install -t $HOME/.local/bin/ hatch
-    - hatch --version
+    - install -t /home/docs/checkouts/readthedocs.org/user_builds/ddtrace/envs/$CURRENT_BRANCH/bin hatch
     - hatch -q
     - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
     - echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$BASH_ENV"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,7 @@ build:
   commands:
     - git fetch --unshallow || true
     - curl -L https://github.com/pypa/hatch/releases/download/hatch-v1.12.0/hatch-x86_64-unknown-linux-gnu.tar.gz | tar zx
+    - echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
     - install -t $HOME/.local/bin/ hatch
     - hatch -q
     - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,11 +6,8 @@ build:
   commands:
     - git fetch --unshallow || true
     - git rev-parse --abbrev-ref HEAD
-    - export CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-    - echo $CURRENT_BRANCH
     - curl -L https://github.com/pypa/hatch/releases/download/hatch-v1.12.0/hatch-x86_64-unknown-linux-gnu.tar.gz | tar zx
-    - echo $PATH
-    - install -t /home/docs/checkouts/readthedocs.org/user_builds/ddtrace/envs/$CURRENT_BRANCH/bin hatch
+    - install -t /home/docs/.asdf/bin hatch
     - hatch -q
     - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
     - echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$BASH_ENV"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,9 @@ build:
     - mkdir -p $HOME/.local/bin
     - curl -L https://github.com/pypa/hatch/releases/download/hatch-v1.12.0/hatch-x86_64-unknown-linux-gnu.tar.gz | tar zx
     - export PATH="$HOME/.local/bin:$PATH"
+    - echo $PATH
     - install -t $HOME/.local/bin/ hatch
+    - hatch --version
     - hatch -q
     - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
     - echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$BASH_ENV"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ build:
   commands:
     - git fetch --unshallow || true
     - curl -L https://github.com/pypa/hatch/releases/download/hatch-v1.12.0/hatch-x86_64-unknown-linux-gnu.tar.gz | tar zx
-    - install -t /usr/local/bin hatch
+    - install -t $HOME/.local/bin/ hatch
     - hatch -q
     - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
     - echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$BASH_ENV"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ build:
   commands:
     - git fetch --unshallow || true
     - curl -L https://github.com/pypa/hatch/releases/download/hatch-v1.12.0/hatch-x86_64-unknown-linux-gnu.tar.gz | tar zx
-    - install -t $HOME/docs/.asdf/bin hatch
+    - install -t $HOME/.asdf/bin hatch
     - hatch -q
     - hatch -v run docs:sphinx-build -W -b html docs docs/_build/html
     - mv docs/_build $READTHEDOCS_OUTPUT

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,9 @@ build:
     python: "3.10"
   commands:
     - git fetch --unshallow || true
+    - git rev-parse --abbrev-ref HEAD
     - export CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    - echo $CURRENT_BRANCH
     - curl -L https://github.com/pypa/hatch/releases/download/hatch-v1.12.0/hatch-x86_64-unknown-linux-gnu.tar.gz | tar zx
     - echo $PATH
     - install -t /home/docs/checkouts/readthedocs.org/user_builds/ddtrace/envs/$CURRENT_BRANCH/bin hatch

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,8 @@ build:
     rust: "1.78"
   commands:
     - git fetch --unshallow || true
+    - mkdir -p $HOME/.local/bin
+    - ls $HOME
     - curl -L https://github.com/pypa/hatch/releases/download/hatch-v1.12.0/hatch-x86_64-unknown-linux-gnu.tar.gz | tar zx
     - install -t $HOME/.asdf/bin hatch
     - hatch -q

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,8 +5,9 @@ build:
     python: "3.10"
   commands:
     - git fetch --unshallow || true
+    - mkdir -p $HOME/.local/bin
     - curl -L https://github.com/pypa/hatch/releases/download/hatch-v1.12.0/hatch-x86_64-unknown-linux-gnu.tar.gz | tar zx
-    - echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
+    - export PATH="$HOME/.local/bin:$PATH"
     - install -t $HOME/.local/bin/ hatch
     - hatch -q
     - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y


### PR DESCRIPTION
Our ReadTheDocs builds have been failing for a long time due to permission issues when trying to install hatch in `/usr/local/bin` (see example [here](https://app.readthedocs.org/projects/ddtrace/builds/25806367/)). The latest stable version is 2.9.6, and we are currently on 2.14.2.

This PR moves the installation to happen in `$HOME/.asdf/bin` instead, as it's already created and exists on the PATH. I attempted to create `$HOME/.local/bin` instead, but for some reason I'm unable to update the PATH to include this path, so it doesn't work and I needed to use an existing path. 

Resolving this issue also surfaced Rust issues, so I went ahead and fixed that as well.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
