### PR TITLE
chore(ci_visibility): fix module path collection

### DIFF
--- a/ddtrace/contrib/pytest/_utils.py
+++ b/ddtrace/contrib/pytest/_utils.py
@@ -99,7 +99,13 @@ def _get_test_parameters_json(item) -> t.Optional[str]:
 
 
 def _get_module_path_from_item(item: pytest.Item) -> Path:
-    return Path(item.nodeid.rpartition("/")[0]).absolute()
+    try:
+        item_path = getattr(item, "path", None)
+        if item_path is not None:
+            return item.path.absolute().parent
+        return Path(item.module.__file__).absolute().parent
+    except Exception:  # noqa: E722
+        return Path.cwd()
 
 
 def _get_session_command(session: pytest.Session):

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -1463,8 +1463,14 @@ class PytestTestCase(TracerTestCase):
         os.chdir(str(package_outer_dir))
         with open("test_outer_abc.py", "w+") as fd:
             fd.write(
-                """def test_ok():
-                assert True"""
+                textwrap.dedent(
+                    """
+                import pytest
+
+                @pytest.mark.parametrize("paramslash", ["c/d", "/d/c", "f/"])
+                def test_ok_1(paramslash):
+                    assert True"""
+                )
             )
         os.mkdir("test_inner_package")
         os.chdir("test_inner_package")
@@ -1472,14 +1478,22 @@ class PytestTestCase(TracerTestCase):
             pass
         with open("test_inner_abc.py", "w+") as fd:
             fd.write(
-                """def test_ok():
-                assert True"""
+                textwrap.dedent(
+                    """
+                import pytest
+
+                @pytest.mark.parametrize("slashparam", ["a/b", "/b/a", "a/"])
+                def test_ok_2(slashparam):
+                    assert True
+
+                """
+                )
             )
         self.testdir.chdir()
         self.inline_run("--ddtrace")
         spans = self.pop_spans()
 
-        assert len(spans) == 7
+        assert len(spans) == 11
         test_module_spans = sorted(
             [span for span in spans if span.get_tag("type") == "test_module_end"],
             key=lambda s: s.get_tag("test.module"),
@@ -1493,6 +1507,15 @@ class PytestTestCase(TracerTestCase):
         )
         assert test_suite_spans[0].get_tag("test.suite") == "test_inner_abc.py"
         assert test_suite_spans[1].get_tag("test.suite") == "test_outer_abc.py"
+
+        test_spans = _get_spans_from_list(spans, "test")
+        for test_span in test_spans:
+            if test_span.get_tag("test.name").startswith("test_ok_1"):
+                assert test_span.get_tag("test.module_path") == "test_outer_package"
+            elif test_span.get_tag("test.name").startswith("test_ok_2"):
+                assert test_span.get_tag("test.module_path") == "test_outer_package/test_inner_package"
+            else:
+                raise ValueError("Unexpected span name")
 
     def test_pytest_module_path_empty(self):
         """


### PR DESCRIPTION
Fixes the way module path was being computed. Now uses the parent of the `item`'s `path` attribute if available, and if not, uses `item.module.__path__`'s parent. Otherwise it defaults to the current directory.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
