### PR TITLE
chore(ci): parallelize unittest github actions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,25 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-         - os: ubuntu-latest
-           archs: x86_64 i686
-         #- os: arm-4core-linux
-         #  archs: aarch64
-         - os: windows-latest
-           archs: AMD64 x86
-         - os: macos-latest
-           archs: arm64
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        # Keep this in sync with hatch.toml
+        python-version: ["3.7", "3.10", "3.12"]
     steps:
       - uses: actions/checkout@v4
         # Include all history and tags
         with:
           fetch-depth: 0
-
-      - uses: actions/setup-python@v5
-        name: Install Python
-        with:
-          python-version: '3.12'
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install latest stable toolchain and rustfmt
@@ -44,4 +33,4 @@ jobs:
           version: "1.12.0"
 
       - name: Run tests
-        run: hatch run ddtrace_unit_tests:test
+        run: hatch run +py=${{ matrix.python-version }} ddtrace_unit_tests:test


### PR DESCRIPTION
1. Use matrix in actions: No need to specify archs as GitHub actions runners only support specific archs for given OSes and we've only been running ubuntu-latest (x86_64), windows-latest (x86_64) and macos-latest (arm64).
2. Pass python version to hatch run.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
