### PR TITLE
ci: enable code origin for spans in django profile

### DIFF
--- a/.github/workflows/django-overhead-profile.yml
+++ b/.github/workflows/django-overhead-profile.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PREFIX: ${{ github.workspace }}/prefix
+      DD_CODE_ORIGIN_FOR_SPANS_ENABLED: "1"
     defaults:
       run:
         working-directory: ddtrace


### PR DESCRIPTION
We enable Code Origin for Spans in the Django profile job to collect profiling data with the featured turned on.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
