### PR TITLE
ci: add timeout minutes to `sanic` and `starlette` suites

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -626,7 +626,7 @@ jobs:
     name: Starlette 0.38.4 (with ${{ matrix.suffix }})
     runs-on: "ubuntu-latest"
     needs: needs-run
-    timeout-minutes: 15
+    timeout-minutes: 30
     env:
       DD_TESTING_RAISE: true
       DD_PROFILING_ENABLED: ${{ matrix.profiling }}

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -123,6 +123,7 @@ jobs:
     name: Sanic 24.6 (with ${{ matrix.suffix }})
     runs-on: ubuntu-20.04
     needs: needs-run
+    timeout-minutes: 15
     env:
       DD_PROFILING_ENABLED: ${{ matrix.profiling }}
       DD_IAST_ENABLED: ${{ matrix.iast }}
@@ -625,6 +626,7 @@ jobs:
     name: Starlette 0.38.4 (with ${{ matrix.suffix }})
     runs-on: "ubuntu-latest"
     needs: needs-run
+    timeout-minutes: 15
     env:
       DD_TESTING_RAISE: true
       DD_PROFILING_ENABLED: ${{ matrix.profiling }}


### PR DESCRIPTION
CI: Adds timeouts to the framework test suites so they don't hang like:

https://github.com/DataDog/dd-trace-py/actions/runs/11250518980/job/31279581076?pr=10899

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
