### PR TITLE
fix(iast): partial matches on function names should not be patched [backport 2.11]

### DIFF
--- a/ddtrace/appsec/_iast/_ast/visitor.py
+++ b/ddtrace/appsec/_iast/_ast/visitor.py
@@ -261,7 +261,7 @@ class AstVisitor(ast.NodeTransformer):
         if function_name in self._taint_sink_replace_disabled:
             return False
 
-        return any(allowed in function_name for allowed in self._taint_sink_replace_any)
+        return function_name in self._taint_sink_replace_any
 
     def _add_original_function_as_arg(self, call_node: ast.Call, is_function: bool) -> Any:
         """

--- a/releasenotes/notes/iast-aspects-partial-matches-f43dc04584ca6788.yaml
+++ b/releasenotes/notes/iast-aspects-partial-matches-f43dc04584ca6788.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Code security: This fix resolves an issue where partial matches on function names we aimed to patch were being patched instead of full matches on them.

--- a/tests/appsec/iast/_ast/test_ast_patching.py
+++ b/tests/appsec/iast/_ast/test_ast_patching.py
@@ -155,3 +155,18 @@ def test_module_path_none(caplog):
     with caplog.at_level(logging.DEBUG), mock.patch("ddtrace.internal.module.Path.resolve", side_effect=AttributeError):
         assert ("", "") == astpatch_module(__import__("tests.appsec.iast.fixtures.ast.str.class_str", fromlist=[None]))
         assert "astpatch_source couldn't find the module: tests.appsec.iast.fixtures.ast.str.class_str" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        ("tests.appsec.iast.fixtures.ast.other.globals_builtin"),
+    ],
+)
+def test_astpatch_globals_module_unchanged(module_name):
+    module_path, new_source = astpatch_module(__import__(module_name, fromlist=[None]))
+    assert ("", "") == (module_path, new_source)
+    if ("", "") != (module_path, new_source):
+        new_code = astunparse.unparse(new_source)
+        assert not new_code.startswith("\nimport ddtrace.appsec._iast")
+        assert "ddtrace_taint_sinks.ast_function(globals, 0)" not in new_code

--- a/tests/appsec/iast/_ast/test_ast_patching.py
+++ b/tests/appsec/iast/_ast/test_ast_patching.py
@@ -164,9 +164,9 @@ def test_module_path_none(caplog):
     ],
 )
 def test_astpatch_globals_module_unchanged(module_name):
+    """
+    This is a regression test for partially matching function names:
+    ``globals()`` was being incorrectly patched with the aspect for ``glob()``
+    """
     module_path, new_source = astpatch_module(__import__(module_name, fromlist=[None]))
     assert ("", "") == (module_path, new_source)
-    if ("", "") != (module_path, new_source):
-        new_code = astunparse.unparse(new_source)
-        assert not new_code.startswith("\nimport ddtrace.appsec._iast")
-        assert "ddtrace_taint_sinks.ast_function(globals, 0)" not in new_code

--- a/tests/appsec/iast/fixtures/ast/other/globals_builtin.py
+++ b/tests/appsec/iast/fixtures/ast/other/globals_builtin.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+_globals = globals()


### PR DESCRIPTION
backport of #11015
Code Security: This PR fixes an issue where partial matches of the functions we want to patch would be patched instead of exact matches
## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

(cherry picked from commit a72b931245ba24a30687d8c31c257777332238ae)