### PR TITLE
fix(iast): re.finditer aspect error

### DIFF
--- a/benchmarks/bm/iast_fixtures/str_methods.py
+++ b/benchmarks/bm/iast_fixtures/str_methods.py
@@ -905,7 +905,7 @@ def do_join_generator(mystring: str) -> Text:
     return "".join(gen)
 
 
-def do_join_generator_as_argument(mystring: str, gen: Generator) -> Text:
+def do_join_generator_as_argument(mystring: str, gen: Generator[str, None, None]) -> Text:
     return mystring.join(gen)
 
 

--- a/benchmarks/bm/iast_fixtures/str_methods.py
+++ b/benchmarks/bm/iast_fixtures/str_methods.py
@@ -905,6 +905,10 @@ def do_join_generator(mystring: str) -> Text:
     return "".join(gen)
 
 
+def do_join_generator_as_argument(mystring: str, gen: Generator) -> Text:
+    return mystring.join(gen)
+
+
 def do_join_generator_2(mystring: str) -> Text:
     def parts() -> Generator:
         for i in ["x", "y", "z"]:

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -1,6 +1,7 @@
 from builtins import bytearray as builtin_bytearray
 from builtins import bytes as builtin_bytes
 import codecs
+import itertools
 from re import Match
 from re import Pattern
 from types import BuiltinFunctionType
@@ -965,9 +966,7 @@ def re_findall_aspect(
     return result
 
 
-def re_finditer_aspect(
-    orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any
-) -> Union[TEXT_TYPES, Tuple[TEXT_TYPES, int]]:
+def re_finditer_aspect(orig_function: Optional[Callable], flag_added_args: int, *args: Any, **kwargs: Any) -> Iterator:
     if orig_function is not None and (not flag_added_args or not args):
         # This patch is unexpected, so we fallback
         # to executing the original function
@@ -996,9 +995,9 @@ def re_finditer_aspect(
         string = args[0]
         if is_pyobject_tainted(string):
             ranges = get_ranges(string)
-            for elem in result:
+            result, result_backup = itertools.tee(result)
+            for elem in result_backup:
                 taint_pyobject_with_ranges(elem, ranges)
-
     return result
 
 

--- a/releasenotes/notes/iast-fix-re-finditer-aspect-8925b30073169222.yaml
+++ b/releasenotes/notes/iast-fix-re-finditer-aspect-8925b30073169222.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Code Security: Ensure IAST propagation does not raise side effects related to re.finditer.

--- a/tests/appsec/app.py
+++ b/tests/appsec/app.py
@@ -66,6 +66,7 @@ from tests.appsec.iast_packages.packages.pkg_pynacl import pkg_pynacl
 from tests.appsec.iast_packages.packages.pkg_pyopenssl import pkg_pyopenssl
 from tests.appsec.iast_packages.packages.pkg_pyparsing import pkg_pyparsing
 from tests.appsec.iast_packages.packages.pkg_python_dateutil import pkg_python_dateutil
+from tests.appsec.iast_packages.packages.pkg_python_multipart import pkg_python_multipart
 from tests.appsec.iast_packages.packages.pkg_pytz import pkg_pytz
 from tests.appsec.iast_packages.packages.pkg_pyyaml import pkg_pyyaml
 from tests.appsec.iast_packages.packages.pkg_requests import pkg_requests
@@ -144,6 +145,7 @@ app.register_blueprint(pkg_pynacl)
 app.register_blueprint(pkg_pyopenssl)
 app.register_blueprint(pkg_pyparsing)
 app.register_blueprint(pkg_python_dateutil)
+app.register_blueprint(pkg_python_multipart)
 app.register_blueprint(pkg_pytz)
 app.register_blueprint(pkg_pyyaml)
 app.register_blueprint(pkg_requests)

--- a/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
@@ -311,6 +311,32 @@ class TestOperatorJoinReplacement(object):
         assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "abcde"
         assert result[ranges[2].start : (ranges[2].start + ranges[2].length)] == "abcde"
 
+    def test_string_join_generator_multiples_times(self):
+        base_string = "abcde"
+        gen_string = "--+--"
+        gen = (gen_string for _ in ["1", "2", "3"])
+        result = mod.do_join_generator_as_argument(base_string, gen)
+        assert result == "--+--abcde--+--abcde--+--"
+        assert not get_tainted_ranges(result)
+        result = mod.do_join_generator_as_argument(base_string, gen)
+        assert result == ""
+        # Tainted
+        tainted_base_string = taint_pyobject(
+            pyobject=base_string,
+            source_name="joiner",
+            source_value=base_string,
+            source_origin=OriginType.PARAMETER,
+        )
+        gen = (gen_string for _ in ["1", "2", "3"])
+        result = mod.do_join_generator_as_argument(tainted_base_string, gen)
+        result_2 = mod.do_join_generator_as_argument(tainted_base_string, gen)
+        assert result == "--+--abcde--+--abcde--+--"
+        assert result_2 == ""
+
+        ranges = get_tainted_ranges(result)
+        assert result[ranges[0].start : (ranges[0].start + ranges[0].length)] == "abcde"
+        assert result[ranges[1].start : (ranges[1].start + ranges[1].length)] == "abcde"
+
     def test_string_join_args_kwargs(self):
         # type: () -> None
         # Not tainted

--- a/tests/appsec/iast_packages/packages/pkg_python_multipart.py
+++ b/tests/appsec/iast_packages/packages/pkg_python_multipart.py
@@ -1,0 +1,49 @@
+"""
+isodate==0.6.1
+
+https://pypi.org/project/isodate/
+"""
+
+from flask import Blueprint
+from flask import request
+
+from .utils import ResultResponse
+
+
+pkg_python_multipart = Blueprint("multipart", __name__)
+
+
+@pkg_python_multipart.route("/python-multipart")
+def pkg_multipart_view():
+    from multipart.multipart import parse_options_header
+
+    response = ResultResponse(request.args.get("package_param"))
+
+    try:
+        _, params = parse_options_header(response.package_param)
+
+        response.result1 = str(params[b"boundary"], "utf-8")
+    except Exception as e:
+        response.result1 = f"Error: {str(e)}"
+
+    return response.json()
+
+
+@pkg_python_multipart.route("/python-multipart_propagation")
+def pkg_multipart_propagation_view():
+    from multipart.multipart import parse_options_header
+
+    from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
+
+    response = ResultResponse(request.args.get("package_param"))
+    if not is_pyobject_tainted(response.package_param):
+        response.result1 = "Error: package_param is not tainted"
+        return response.json()
+
+    _, params = parse_options_header(response.package_param)
+    response.result1 = (
+        "OK"
+        if is_pyobject_tainted(params[b"boundary"])
+        else "Error: yaml_string is not tainted: %s" % str(params[b"boundary"], "utf-8")
+    )
+    return response.json()

--- a/tests/appsec/iast_packages/test_packages.py
+++ b/tests/appsec/iast_packages/test_packages.py
@@ -54,7 +54,7 @@ class PackageForTesting:
         import_name=None,
         import_module_to_validate=None,
         test_propagation=False,
-        fixme_propagation_fails=False,
+        fixme_propagation_fails=None,
         expect_no_change=False,
     ):
         self.name = name
@@ -469,6 +469,15 @@ PACKAGES = [
         "And the Easter of that year is: 2004-04-11",
         import_name="dateutil",
         import_module_to_validate="dateutil.relativedelta",
+    ),
+    PackageForTesting(
+        "python-multipart",
+        "0.0.5",  # this version validates APPSEC-55240 issue, don't upgrade it
+        "multipart/form-data; boundary=d8b5635eb590e078a608e083351288a0",
+        "d8b5635eb590e078a608e083351288a0",
+        "",
+        import_module_to_validate="multipart.multipart",
+        test_propagation=True,
     ),
     PackageForTesting(
         "pytz",
@@ -954,7 +963,7 @@ def test_flask_packages_patched(package, venv):
 
 @pytest.mark.parametrize(
     "package",
-    [package for package in PACKAGES if package.test_propagation],
+    [package for package in PACKAGES if package.test_propagation and SKIP_FUNCTION(package)],
     ids=lambda package: package.name,
 )
 def test_flask_packages_propagation(package, venv, printer):
@@ -986,7 +995,7 @@ def test_packages_not_patched_import(package, venv):
         pytest.skip(reason)
         return
 
-    cmdlist = [venv, _INSIDE_ENV_RUNNER_PATH, "unpatched", package.import_name]
+    cmdlist = [venv, _INSIDE_ENV_RUNNER_PATH, "unpatched", package.import_module_to_validate]
 
     # 1. Try with the specified version
     package.install(venv)

--- a/tests/contrib/fastapi/test_fastapi_appsec_iast.py
+++ b/tests/contrib/fastapi/test_fastapi_appsec_iast.py
@@ -6,7 +6,6 @@ import sys
 import typing
 
 from fastapi import Cookie
-from fastapi import File
 from fastapi import Form
 from fastapi import Header
 from fastapi import Request
@@ -493,9 +492,7 @@ def test_path_body_source_pydantic(fastapi_application, client, tracer, test_spa
 
 def test_path_body_body_upload(fastapi_application, client, tracer, test_spans):
     @fastapi_application.post("/uploadfile/")
-    async def create_upload_file(
-        files: typing.List[UploadFile] = File(description="Multiple files as UploadFile"),
-    ):
+    async def create_upload_file(files: typing.List[UploadFile]):
         from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
 
         ranges_result = get_tainted_ranges(files[0])

--- a/tests/contrib/fastapi/test_fastapi_appsec_iast.py
+++ b/tests/contrib/fastapi/test_fastapi_appsec_iast.py
@@ -490,6 +490,7 @@ def test_path_body_source_pydantic(fastapi_application, client, tracer, test_spa
         assert result["ranges_origin"] == "http.request.body"
 
 
+@pytest.mark.skipif(fastapi_version < (0, 65, 0), reason="UploadFile not supported")
 def test_path_body_body_upload(fastapi_application, client, tracer, test_spans):
     @fastapi_application.post("/uploadfile/")
     async def create_upload_file(files: typing.List[UploadFile]):

--- a/tests/contrib/fastapi/test_fastapi_appsec_iast.py
+++ b/tests/contrib/fastapi/test_fastapi_appsec_iast.py
@@ -1,3 +1,4 @@
+import io
 import json
 import logging
 import re
@@ -5,9 +6,11 @@ import sys
 import typing
 
 from fastapi import Cookie
+from fastapi import File
 from fastapi import Form
 from fastapi import Header
 from fastapi import Request
+from fastapi import UploadFile
 from fastapi import __version__ as _fastapi_version
 from fastapi.responses import JSONResponse
 import pytest
@@ -486,6 +489,38 @@ def test_path_body_source_pydantic(fastapi_application, client, tracer, test_spa
         assert result["ranges_start"] == 0
         assert result["ranges_length"] == 8
         assert result["ranges_origin"] == "http.request.body"
+
+
+def test_path_body_body_upload(fastapi_application, client, tracer, test_spans):
+    @fastapi_application.post("/uploadfile/")
+    async def create_upload_file(
+        files: typing.List[UploadFile] = File(description="Multiple files as UploadFile"),
+    ):
+        from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+
+        ranges_result = get_tainted_ranges(files[0])
+        return JSONResponse(
+            {
+                "filenames": [file.filename for file in files],
+                "is_tainted": len(ranges_result),
+            }
+        )
+
+    with override_global_config(dict(_iast_enabled=True)), override_env(IAST_ENV):
+        # disable callback
+        _aux_appsec_prepare_tracer(tracer)
+        tmp = io.BytesIO(b"upload this")
+        resp = client.post(
+            "/uploadfile/",
+            files=(
+                ("files", ("test.txt", tmp)),
+                ("files", ("test2.txt", tmp)),
+            ),
+        )
+        assert resp.status_code == 200
+        result = json.loads(get_response_body(resp))
+        assert result["filenames"] == ["test.txt", "test2.txt"]
+        assert result["is_tainted"] == 0
 
 
 def test_fastapi_sqli_path_param(fastapi_application, client, tracer, test_spans):


### PR DESCRIPTION
Ensure IAST propagation does not raise side effects related to re.finditer.
We detect this error in #10988 PR, when FastAPI headers were empty in framework tests: https://github.com/DataDog/dd-trace-py/actions/runs/11273577079/job/31350947622

We can revert this system tests PR after this PR: https://github.com/DataDog/system-tests/pull/3230

This error was detected in [python-multipart==0.0.05](https://pypi.org/project/python-multipart/0.0.5/)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
