### PR TITLE
feat(llmobs): support metadata field for custom evaluation metrics

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -740,7 +740,8 @@ class LLMObs(Service):
         :param tags: A dictionary of string key-value pairs to tag the evaluation metric with.
         :param str ml_app: The name of the ML application
         :param int timestamp_ms: The timestamp in milliseconds when the evaluation metric result was generated.
-        :param dict metadata: A dictionary of additional metadata to include with the evaluation metric.
+        :param dict metadata: A JSON serializable dictionary of key-value metadata pairs relevant to the
+                                evaluation metric.
         """
         if cls.enabled is False:
             log.warning(

--- a/releasenotes/notes/metadata-for-eval-metrics-3d3bac0e0738fdc2.yaml
+++ b/releasenotes/notes/metadata-for-eval-metrics-3d3bac0e0738fdc2.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    LLM Observability: This introduces the ability to add metadata to evaluation metrics via the `submit_evaluation` method.

--- a/releasenotes/notes/metadata-for-eval-metrics-3d3bac0e0738fdc2.yaml
+++ b/releasenotes/notes/metadata-for-eval-metrics-3d3bac0e0738fdc2.yaml
@@ -1,4 +1,5 @@
 ---
 features:
   - |
-    LLM Observability: This introduces the ability to add metadata to evaluation metrics via the `submit_evaluation` method.
+    LLM Observability: This introduces the ability to add metadata for evaluation metrics via the `submit_evaluation` method.
+    For more information, see [submitting evaluations with the SDK.](https://docs.datadoghq.com/llm_observability/submit_evaluations/#submitting-evaluations-with-the-sdk)

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -224,6 +224,7 @@ def _expected_llmobs_eval_metric_event(
     score_value=None,
     numerical_value=None,
     tags=None,
+    metadata=None,
 ):
     eval_metric_event = {
         "span_id": span_id,
@@ -250,7 +251,8 @@ def _expected_llmobs_eval_metric_event(
 
     if ml_app is not None:
         eval_metric_event["ml_app"] = ml_app
-
+    if metadata is not None:
+        eval_metric_event["metadata"] = metadata
     return eval_metric_event
 
 

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -1124,6 +1124,17 @@ def test_submit_evaluation_invalid_tags_raises_warning(LLMObs, mock_logs):
     mock_logs.warning.assert_called_once_with("tags must be a dictionary of string key-value pairs.")
 
 
+def test_submit_evaluation_invalid_metadata_raises_warning(LLMObs, mock_logs):
+    LLMObs.submit_evaluation(
+        span_context={"span_id": "123", "trace_id": "456"},
+        label="toxicity",
+        metric_type="categorical",
+        value="high",
+        metadata=1,
+    )
+    mock_logs.warning.assert_called_once_with("metadata must be json serializable dictionary.")
+
+
 @pytest.mark.parametrize(
     "ddtrace_global_config",
     [dict(_llmobs_ml_app="test_app_name")],
@@ -1166,6 +1177,55 @@ def test_submit_evaluation_metric_tags(LLMObs, mock_llmobs_eval_metric_writer):
         value="high",
         tags={"foo": "bar", "bee": "baz", "ml_app": "ml_app_override"},
         ml_app="ml_app_override",
+    )
+    mock_llmobs_eval_metric_writer.enqueue.assert_called_with(
+        _expected_llmobs_eval_metric_event(
+            ml_app="ml_app_override",
+            span_id="123",
+            trace_id="456",
+            label="toxicity",
+            metric_type="categorical",
+            categorical_value="high",
+            tags=["ddtrace.version:{}".format(ddtrace.__version__), "ml_app:ml_app_override", "foo:bar", "bee:baz"],
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "ddtrace_global_config",
+    [dict(ddtrace="1.2.3", env="test_env", service="test_service", _llmobs_ml_app="test_app_name")],
+)
+def test_submit_evaluation_metric_with_metadata_enqueues_metric(LLMObs, mock_llmobs_eval_metric_writer):
+    LLMObs.submit_evaluation(
+        span_context={"span_id": "123", "trace_id": "456"},
+        label="toxicity",
+        metric_type="categorical",
+        value="high",
+        tags={"foo": "bar", "bee": "baz", "ml_app": "ml_app_override"},
+        ml_app="ml_app_override",
+        metadata={"foo": ["bar", "baz"]},
+    )
+    mock_llmobs_eval_metric_writer.enqueue.assert_called_with(
+        _expected_llmobs_eval_metric_event(
+            ml_app="ml_app_override",
+            span_id="123",
+            trace_id="456",
+            label="toxicity",
+            metric_type="categorical",
+            categorical_value="high",
+            tags=["ddtrace.version:{}".format(ddtrace.__version__), "ml_app:ml_app_override", "foo:bar", "bee:baz"],
+            metadata={"foo": ["bar", "baz"]},
+        )
+    )
+    mock_llmobs_eval_metric_writer.reset()
+    LLMObs.submit_evaluation(
+        span_context={"span_id": "123", "trace_id": "456"},
+        label="toxicity",
+        metric_type="categorical",
+        value="high",
+        tags={"foo": "bar", "bee": "baz", "ml_app": "ml_app_override"},
+        ml_app="ml_app_override",
+        metadata="invalid",
     )
     mock_llmobs_eval_metric_writer.enqueue.assert_called_with(
         _expected_llmobs_eval_metric_event(


### PR DESCRIPTION
The evaluation metric api supports a `metadata` field now which represents arbitrary metadata that can be tied to an evaluation metric.

This PR adds support for that field via the `submit_evaluation` method

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
