### PR TITLE
chore: fix notebook bug with release script

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -391,7 +391,12 @@ def create_notebook(dd_repo, name, rn, base):
                     author = author.split(" ")
                     author_slack = "@" + author[0] + "." + author[-1]
                     author_dd = author_slack + "@datadoghq.com"
-                pr_num = re.findall(r"\(#(\d{4})\)", commit.commit.message)[0]
+                maybe_pr_num = re.findall(r"\(#(\d+)\)", commit.commit.message)
+                if len(maybe_pr_num) == 0:
+                    print("Could not parse PR number from commit message: ", commit.commit.message)
+                    pr_num = "x"
+                else:
+                    pr_num = maybe_pr_num[0]
                 url = "https://github.com/DataDog/dd-trace-py/pull/{pr_num}".format(pr_num=pr_num)
                 prs_details.append(
                     {"author_slack": author_slack, "author_dd": author_dd, "url": url, "rn_piece": rn_piece}
@@ -402,8 +407,9 @@ def create_notebook(dd_repo, name, rn, base):
     prs_details = sorted(prs_details, key=lambda prd: prd["rn_piece"])
     notebook_rns = ""
     for pr_detail in prs_details:
-        notebook_rns += f"\n- [ ] {pr_detail['rn_piece']}\n  - PR:{pr_detail['url']},"
-        "Tester: {pr_detail['author_dd']}\n  - Findings: "
+        notebook_rns += "\n- [ ] {rn_piece}\n  - PR:{url}\n  - Tester: {author}\n  - Findings: ".format(
+            rn_piece=pr_detail["rn_piece"], url=pr_detail["url"], author=pr_detail["author_dd"]
+        )
 
     # create the review notebook and add the release notes formatted for testing
     # get notebook template
@@ -488,11 +494,11 @@ def _dry(fn: Callable, description: Optional[str] = None) -> Any:
 
 
 if __name__ == "__main__":
-    subprocess.check_output(
-        "git stash",
-        shell=True,
-        cwd=os.pardir,
-    )
+    # subprocess.check_output(
+    #     "git stash",
+    #     shell=True,
+    #     cwd=os.pardir,
+    # )
     start_branch = (
         subprocess.check_output(
             "git rev-parse --abbrev-ref HEAD",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -494,11 +494,11 @@ def _dry(fn: Callable, description: Optional[str] = None) -> Any:
 
 
 if __name__ == "__main__":
-    # subprocess.check_output(
-    #     "git stash",
-    #     shell=True,
-    #     cwd=os.pardir,
-    # )
+    subprocess.check_output(
+        "git stash",
+        shell=True,
+        cwd=os.pardir,
+    )
     start_branch = (
         subprocess.check_output(
             "git rev-parse --abbrev-ref HEAD",


### PR DESCRIPTION
A few clean up things in the release script. Mainly that the regex to grab the PR number from the commit message broke because it was looking for a 4 digit number, but we recently hit 5 digits.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
