### PR TITLE
chore(iast): separate iast and asm listens

### DIFF
--- a/ddtrace/appsec/__init__.py
+++ b/ddtrace/appsec/__init__.py
@@ -1,13 +1,22 @@
 _APPSEC_TO_BE_LOADED = True
+_IAST_TO_BE_LOADED = True
 
 
 def load_appsec():
     """Lazily load the appsec module listeners."""
     from ddtrace.appsec._asm_request_context import asm_listen
-    from ddtrace.appsec._iast._iast_request_context import iast_listen
 
     global _APPSEC_TO_BE_LOADED
     if _APPSEC_TO_BE_LOADED:
         asm_listen()
-        iast_listen()
         _APPSEC_TO_BE_LOADED = False
+
+
+def load_iast():
+    """Lazily load the iast module listeners."""
+    from ddtrace.appsec._iast._iast_request_context import iast_listen
+
+    global _IAST_TO_BE_LOADED
+    if _IAST_TO_BE_LOADED:
+        iast_listen()
+        _IAST_TO_BE_LOADED = False

--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -1,18 +1,10 @@
-from collections.abc import MutableMapping
-import functools
 import io
 import json
 
-from wrapt import when_imported
-from wrapt import wrap_function_wrapper as _w
 import xmltodict
 
 from ddtrace.appsec._asm_request_context import get_blocked
 from ddtrace.appsec._constants import SPAN_DATA_NAMES
-from ddtrace.appsec._iast._iast_request_context import in_iast_context
-from ddtrace.appsec._iast._patch import if_iast_taint_returned_object_for
-from ddtrace.appsec._iast._patch import if_iast_taint_yield_tuple_for
-from ddtrace.appsec._iast._utils import _is_iast_enabled
 from ddtrace.contrib import trace_utils
 from ddtrace.contrib.trace_utils import _get_request_header_user_agent
 from ddtrace.contrib.trace_utils import _set_url_tag
@@ -25,13 +17,6 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import http as http_utils
 from ddtrace.internal.utils.http import parse_form_multipart
 from ddtrace.settings.asm import config as asm_config
-
-
-MessageMapContainer = None
-try:
-    from google._upb._message import MessageMapContainer  # type: ignore[no-redef]
-except ImportError:
-    pass
 
 
 log = get_logger(__name__)
@@ -69,12 +54,6 @@ def _on_set_http_meta(
     response_headers,
     response_cookies,
 ):
-    if _is_iast_enabled():
-        from ddtrace.appsec._iast.taint_sinks.insecure_cookie import asm_check_cookies
-
-        if response_cookies:
-            asm_check_cookies(response_cookies)
-
     if asm_config._asm_enabled and span.span_type == SpanTypes.WEB:
         # avoid circular import
         from ddtrace.appsec._asm_request_context import set_waf_address
@@ -193,270 +172,13 @@ def _on_request_span_modifier(
     return req_body
 
 
-def _on_request_init(wrapped, instance, args, kwargs):
-    wrapped(*args, **kwargs)
-    if _is_iast_enabled() and in_iast_context():
-        try:
-            from ddtrace.appsec._iast._taint_tracking import OriginType
-            from ddtrace.appsec._iast._taint_tracking import origin_to_str
-            from ddtrace.appsec._iast._taint_tracking import taint_pyobject
-
-            instance.query_string = taint_pyobject(
-                pyobject=instance.query_string,
-                source_name=origin_to_str(OriginType.QUERY),
-                source_value=instance.query_string,
-                source_origin=OriginType.QUERY,
-            )
-            instance.path = taint_pyobject(
-                pyobject=instance.path,
-                source_name=origin_to_str(OriginType.PATH),
-                source_value=instance.path,
-                source_origin=OriginType.PATH,
-            )
-        except Exception:
-            log.debug("Unexpected exception while tainting pyobject", exc_info=True)
-
-
-def _on_flask_patch(flask_version):
-    if _is_iast_enabled():
-        from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_source
-        from ddtrace.appsec._iast._patch import _patched_dictionary
-        from ddtrace.appsec._iast._patch import try_wrap_function_wrapper
-        from ddtrace.appsec._iast._taint_tracking import OriginType
-
-        try_wrap_function_wrapper(
-            "werkzeug.datastructures",
-            "Headers.items",
-            functools.partial(if_iast_taint_yield_tuple_for, (OriginType.HEADER_NAME, OriginType.HEADER)),
-        )
-        _set_metric_iast_instrumented_source(OriginType.HEADER_NAME)
-        _set_metric_iast_instrumented_source(OriginType.HEADER)
-
-        try_wrap_function_wrapper(
-            "werkzeug.datastructures",
-            "ImmutableMultiDict.__getitem__",
-            functools.partial(if_iast_taint_returned_object_for, OriginType.PARAMETER),
-        )
-        _set_metric_iast_instrumented_source(OriginType.PARAMETER)
-
-        try_wrap_function_wrapper(
-            "werkzeug.datastructures",
-            "EnvironHeaders.__getitem__",
-            functools.partial(if_iast_taint_returned_object_for, OriginType.HEADER),
-        )
-        _set_metric_iast_instrumented_source(OriginType.HEADER)
-
-        if flask_version >= (2, 0, 0):
-            # instance.query_string: raising an error on werkzeug/_internal.py "AttributeError: read only property"
-            try_wrap_function_wrapper("werkzeug.wrappers.request", "Request.__init__", _on_request_init)
-
-        _set_metric_iast_instrumented_source(OriginType.PATH)
-        _set_metric_iast_instrumented_source(OriginType.QUERY)
-
-        # Instrumented on _ddtrace.appsec._asm_request_context._on_wrapped_view
-        _set_metric_iast_instrumented_source(OriginType.PATH_PARAMETER)
-
-        try_wrap_function_wrapper(
-            "werkzeug.wrappers.request",
-            "Request.get_data",
-            functools.partial(_patched_dictionary, OriginType.BODY, OriginType.BODY),
-        )
-        try_wrap_function_wrapper(
-            "werkzeug.wrappers.request",
-            "Request.get_json",
-            functools.partial(_patched_dictionary, OriginType.BODY, OriginType.BODY),
-        )
-
-        _set_metric_iast_instrumented_source(OriginType.BODY)
-
-        if flask_version < (2, 0, 0):
-            _w(
-                "werkzeug._internal",
-                "_DictAccessorProperty.__get__",
-                functools.partial(if_iast_taint_returned_object_for, OriginType.QUERY),
-            )
-            _set_metric_iast_instrumented_source(OriginType.QUERY)
-
-
-def _on_django_func_wrapped(fn_args, fn_kwargs, first_arg_expected_type, *_):
-    # If IAST is enabled and we're wrapping a Django view call, taint the kwargs (view's
-    # path parameters)
-    if _is_iast_enabled() and fn_args and isinstance(fn_args[0], first_arg_expected_type):
-        from ddtrace.appsec._iast._taint_tracking import OriginType  # noqa: F401
-        from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
-        from ddtrace.appsec._iast._taint_tracking import origin_to_str
-        from ddtrace.appsec._iast._taint_tracking import taint_pyobject
-        from ddtrace.appsec._iast._taint_utils import taint_structure
-
-        if not in_iast_context():
-            return
-
-        http_req = fn_args[0]
-
-        http_req.COOKIES = taint_structure(http_req.COOKIES, OriginType.COOKIE_NAME, OriginType.COOKIE)
-        http_req.GET = taint_structure(http_req.GET, OriginType.PARAMETER_NAME, OriginType.PARAMETER)
-        http_req.POST = taint_structure(http_req.POST, OriginType.BODY, OriginType.BODY)
-        if (
-            getattr(http_req, "_body", None) is not None
-            and len(getattr(http_req, "_body", None)) > 0
-            and not is_pyobject_tainted(getattr(http_req, "_body", None))
-        ):
-            try:
-                http_req._body = taint_pyobject(
-                    http_req._body,
-                    source_name=origin_to_str(OriginType.BODY),
-                    source_value=http_req._body,
-                    source_origin=OriginType.BODY,
-                )
-            except AttributeError:
-                log.debug("IAST can't set attribute http_req._body", exc_info=True)
-        elif (
-            getattr(http_req, "body", None) is not None
-            and len(getattr(http_req, "body", None)) > 0
-            and not is_pyobject_tainted(getattr(http_req, "body", None))
-        ):
-            try:
-                http_req.body = taint_pyobject(
-                    http_req.body,
-                    source_name=origin_to_str(OriginType.BODY),
-                    source_value=http_req.body,
-                    source_origin=OriginType.BODY,
-                )
-            except AttributeError:
-                log.debug("IAST can't set attribute http_req.body", exc_info=True)
-
-        http_req.headers = taint_structure(http_req.headers, OriginType.HEADER_NAME, OriginType.HEADER)
-        http_req.path = taint_pyobject(
-            http_req.path, source_name="path", source_value=http_req.path, source_origin=OriginType.PATH
-        )
-        http_req.path_info = taint_pyobject(
-            http_req.path_info,
-            source_name=origin_to_str(OriginType.PATH),
-            source_value=http_req.path,
-            source_origin=OriginType.PATH,
-        )
-        http_req.environ["PATH_INFO"] = taint_pyobject(
-            http_req.environ["PATH_INFO"],
-            source_name=origin_to_str(OriginType.PATH),
-            source_value=http_req.path,
-            source_origin=OriginType.PATH,
-        )
-        http_req.META = taint_structure(http_req.META, OriginType.HEADER_NAME, OriginType.HEADER)
-        if fn_kwargs:
-            try:
-                for k, v in fn_kwargs.items():
-                    fn_kwargs[k] = taint_pyobject(
-                        v, source_name=k, source_value=v, source_origin=OriginType.PATH_PARAMETER
-                    )
-            except Exception:
-                log.debug("IAST: Unexpected exception while tainting path parameters", exc_info=True)
-
-
-def _on_wsgi_environ(wrapped, _instance, args, kwargs):
-    if _is_iast_enabled() and args and in_iast_context():
-        from ddtrace.appsec._iast._taint_tracking import OriginType
-        from ddtrace.appsec._iast._taint_utils import taint_structure
-
-        return wrapped(*((taint_structure(args[0], OriginType.HEADER_NAME, OriginType.HEADER),) + args[1:]), **kwargs)
-
-    return wrapped(*args, **kwargs)
-
-
-def _on_django_patch():
-    if _is_iast_enabled():
-        try:
-            from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_source
-            from ddtrace.appsec._iast._taint_tracking import OriginType
-
-            # we instrument those sources on _on_django_func_wrapped
-            _set_metric_iast_instrumented_source(OriginType.HEADER_NAME)
-            _set_metric_iast_instrumented_source(OriginType.HEADER)
-            _set_metric_iast_instrumented_source(OriginType.PATH_PARAMETER)
-            _set_metric_iast_instrumented_source(OriginType.PATH)
-            _set_metric_iast_instrumented_source(OriginType.COOKIE)
-            _set_metric_iast_instrumented_source(OriginType.COOKIE_NAME)
-            _set_metric_iast_instrumented_source(OriginType.PARAMETER)
-            _set_metric_iast_instrumented_source(OriginType.PARAMETER_NAME)
-            _set_metric_iast_instrumented_source(OriginType.BODY)
-            when_imported("django.http.request")(
-                lambda m: trace_utils.wrap(
-                    m,
-                    "QueryDict.__getitem__",
-                    functools.partial(if_iast_taint_returned_object_for, OriginType.PARAMETER),
-                )
-            )
-        except Exception:
-            log.debug("Unexpected exception while patch IAST functions", exc_info=True)
-
-
-def _custom_protobuf_getattribute(self, name):
-    from ddtrace.appsec._iast._taint_tracking import OriginType
-    from ddtrace.appsec._iast._taint_tracking import taint_pyobject
-    from ddtrace.appsec._iast._taint_utils import taint_structure
-
-    ret = type(self).__saved_getattr(self, name)
-    if isinstance(ret, (str, bytes, bytearray)):
-        ret = taint_pyobject(
-            pyobject=ret,
-            source_name=OriginType.GRPC_BODY,
-            source_value=ret,
-            source_origin=OriginType.GRPC_BODY,
-        )
-    elif MessageMapContainer is not None and isinstance(ret, MutableMapping):
-        if isinstance(ret, MessageMapContainer) and len(ret):
-            # Patch the message-values class
-            first_key = next(iter(ret))
-            value_type = type(ret[first_key])
-            _patch_protobuf_class(value_type)
-        else:
-            ret = taint_structure(ret, OriginType.GRPC_BODY, OriginType.GRPC_BODY)
-
-    return ret
-
-
-_custom_protobuf_getattribute.__datadog_custom = True  # type: ignore[attr-defined]
-
-
-# Used to replace the Protobuf message class "getattribute" with a custom one that taints the return
-# of the original __getattribute__ method
-def _patch_protobuf_class(cls):
-    getattr_method = getattr(cls, "__getattribute__")
-    if not getattr_method:
-        return
-
-    if not hasattr(getattr_method, "__datadog_custom"):
-        try:
-            # Replace the class __getattribute__ method with our custom one
-            # (replacement is done at the class level because it would incur on a recursive loop with the instance)
-            cls.__saved_getattr = getattr_method
-            cls.__getattribute__ = _custom_protobuf_getattribute
-        except TypeError:
-            # Avoid failing on Python 3.12 while patching immutable types
-            pass
-
-
-def _on_grpc_response(message):
-    if not _is_iast_enabled():
-        return
-
-    msg_cls = type(message)
-    _patch_protobuf_class(msg_cls)
-
-
 def _on_grpc_server_response(message):
-    if not _is_iast_enabled():
-        return
-
     from ddtrace.appsec._asm_request_context import set_waf_address
 
     set_waf_address(SPAN_DATA_NAMES.GRPC_SERVER_RESPONSE_MESSAGE, message)
-    _on_grpc_response(message)
 
 
 def _on_grpc_server_data(headers, request_message, method, metadata):
-    if not _is_iast_enabled():
-        return
-
     from ddtrace.appsec._asm_request_context import set_headers
     from ddtrace.appsec._asm_request_context import set_waf_address
 
@@ -580,19 +302,13 @@ def _on_start_response_blocked(ctx, flask_config, response_headers, status):
 def listen():
     core.on("set_http_meta_for_asm", _on_set_http_meta)
     core.on("flask.request_call_modifier", _on_request_span_modifier, "request_body")
-    core.on("flask.request_init", _on_request_init)
+
     core.on("flask.blocked_request_callable", _on_flask_blocked_request)
 
     core.on("flask.start_response.blocked", _on_start_response_blocked)
 
-    core.on("django.func.wrapped", _on_django_func_wrapped)
-    core.on("django.wsgi_environ", _on_wsgi_environ, "wrapped_result")
-    core.on("django.patch", _on_django_patch)
-    core.on("flask.patch", _on_flask_patch)
-
     core.on("asgi.request.parse.body", _on_asgi_request_parse_body, "await_receive_and_body")
 
-    core.on("grpc.client.response.message", _on_grpc_response)
     core.on("grpc.server.response.message", _on_grpc_server_response)
     core.on("grpc.server.data", _on_grpc_server_data)
 

--- a/ddtrace/appsec/_iast/_handlers.py
+++ b/ddtrace/appsec/_iast/_handlers.py
@@ -1,0 +1,289 @@
+from collections.abc import MutableMapping
+import functools
+
+from wrapt import when_imported
+from wrapt import wrap_function_wrapper as _w
+
+from ddtrace.appsec._handlers import log
+from ddtrace.appsec._iast import _is_iast_enabled
+from ddtrace.appsec._iast._iast_request_context import in_iast_context
+from ddtrace.appsec._iast._patch import if_iast_taint_returned_object_for
+from ddtrace.appsec._iast._patch import if_iast_taint_yield_tuple_for
+from ddtrace.contrib import trace_utils
+
+
+MessageMapContainer = None
+try:
+    from google._upb._message import MessageMapContainer  # type: ignore[no-redef]
+except ImportError:
+    pass
+
+
+def _on_set_http_meta_iast(
+    span,
+    request_ip,
+    raw_uri,
+    route,
+    method,
+    request_headers,
+    request_cookies,
+    parsed_query,
+    request_path_params,
+    request_body,
+    status_code,
+    response_headers,
+    response_cookies,
+):
+    if _is_iast_enabled():
+        from ddtrace.appsec._iast.taint_sinks.insecure_cookie import asm_check_cookies
+
+        if response_cookies:
+            asm_check_cookies(response_cookies)
+
+
+def _on_request_init(wrapped, instance, args, kwargs):
+    wrapped(*args, **kwargs)
+    if _is_iast_enabled() and in_iast_context():
+        try:
+            from ddtrace.appsec._iast._taint_tracking import OriginType
+            from ddtrace.appsec._iast._taint_tracking import origin_to_str
+            from ddtrace.appsec._iast._taint_tracking import taint_pyobject
+
+            instance.query_string = taint_pyobject(
+                pyobject=instance.query_string,
+                source_name=origin_to_str(OriginType.QUERY),
+                source_value=instance.query_string,
+                source_origin=OriginType.QUERY,
+            )
+            instance.path = taint_pyobject(
+                pyobject=instance.path,
+                source_name=origin_to_str(OriginType.PATH),
+                source_value=instance.path,
+                source_origin=OriginType.PATH,
+            )
+        except Exception:
+            log.debug("Unexpected exception while tainting pyobject", exc_info=True)
+
+
+def _on_flask_patch(flask_version):
+    if _is_iast_enabled():
+        from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_source
+        from ddtrace.appsec._iast._patch import _patched_dictionary
+        from ddtrace.appsec._iast._patch import try_wrap_function_wrapper
+        from ddtrace.appsec._iast._taint_tracking import OriginType
+
+        try_wrap_function_wrapper(
+            "werkzeug.datastructures",
+            "Headers.items",
+            functools.partial(if_iast_taint_yield_tuple_for, (OriginType.HEADER_NAME, OriginType.HEADER)),
+        )
+        _set_metric_iast_instrumented_source(OriginType.HEADER_NAME)
+        _set_metric_iast_instrumented_source(OriginType.HEADER)
+
+        try_wrap_function_wrapper(
+            "werkzeug.datastructures",
+            "ImmutableMultiDict.__getitem__",
+            functools.partial(if_iast_taint_returned_object_for, OriginType.PARAMETER),
+        )
+        _set_metric_iast_instrumented_source(OriginType.PARAMETER)
+
+        try_wrap_function_wrapper(
+            "werkzeug.datastructures",
+            "EnvironHeaders.__getitem__",
+            functools.partial(if_iast_taint_returned_object_for, OriginType.HEADER),
+        )
+        _set_metric_iast_instrumented_source(OriginType.HEADER)
+
+        if flask_version >= (2, 0, 0):
+            # instance.query_string: raising an error on werkzeug/_internal.py "AttributeError: read only property"
+            try_wrap_function_wrapper("werkzeug.wrappers.request", "Request.__init__", _on_request_init)
+
+        _set_metric_iast_instrumented_source(OriginType.PATH)
+        _set_metric_iast_instrumented_source(OriginType.QUERY)
+
+        # Instrumented on _ddtrace.appsec._asm_request_context._on_wrapped_view
+        _set_metric_iast_instrumented_source(OriginType.PATH_PARAMETER)
+
+        try_wrap_function_wrapper(
+            "werkzeug.wrappers.request",
+            "Request.get_data",
+            functools.partial(_patched_dictionary, OriginType.BODY, OriginType.BODY),
+        )
+        try_wrap_function_wrapper(
+            "werkzeug.wrappers.request",
+            "Request.get_json",
+            functools.partial(_patched_dictionary, OriginType.BODY, OriginType.BODY),
+        )
+
+        _set_metric_iast_instrumented_source(OriginType.BODY)
+
+        if flask_version < (2, 0, 0):
+            _w(
+                "werkzeug._internal",
+                "_DictAccessorProperty.__get__",
+                functools.partial(if_iast_taint_returned_object_for, OriginType.QUERY),
+            )
+            _set_metric_iast_instrumented_source(OriginType.QUERY)
+
+
+def _on_wsgi_environ(wrapped, _instance, args, kwargs):
+    if _is_iast_enabled() and args and in_iast_context():
+        from ddtrace.appsec._iast._taint_tracking import OriginType
+        from ddtrace.appsec._iast._taint_utils import taint_structure
+
+        return wrapped(*((taint_structure(args[0], OriginType.HEADER_NAME, OriginType.HEADER),) + args[1:]), **kwargs)
+
+    return wrapped(*args, **kwargs)
+
+
+def _on_django_patch():
+    if _is_iast_enabled():
+        try:
+            from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_source
+            from ddtrace.appsec._iast._taint_tracking import OriginType
+
+            # we instrument those sources on _on_django_func_wrapped
+            _set_metric_iast_instrumented_source(OriginType.HEADER_NAME)
+            _set_metric_iast_instrumented_source(OriginType.HEADER)
+            _set_metric_iast_instrumented_source(OriginType.PATH_PARAMETER)
+            _set_metric_iast_instrumented_source(OriginType.PATH)
+            _set_metric_iast_instrumented_source(OriginType.COOKIE)
+            _set_metric_iast_instrumented_source(OriginType.COOKIE_NAME)
+            _set_metric_iast_instrumented_source(OriginType.PARAMETER)
+            _set_metric_iast_instrumented_source(OriginType.PARAMETER_NAME)
+            _set_metric_iast_instrumented_source(OriginType.BODY)
+            when_imported("django.http.request")(
+                lambda m: trace_utils.wrap(
+                    m,
+                    "QueryDict.__getitem__",
+                    functools.partial(if_iast_taint_returned_object_for, OriginType.PARAMETER),
+                )
+            )
+        except Exception:
+            log.debug("Unexpected exception while patch IAST functions", exc_info=True)
+
+
+def _on_django_func_wrapped(fn_args, fn_kwargs, first_arg_expected_type, *_):
+    # If IAST is enabled and we're wrapping a Django view call, taint the kwargs (view's
+    # path parameters)
+    if _is_iast_enabled() and fn_args and isinstance(fn_args[0], first_arg_expected_type):
+        from ddtrace.appsec._iast._taint_tracking import OriginType  # noqa: F401
+        from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
+        from ddtrace.appsec._iast._taint_tracking import origin_to_str
+        from ddtrace.appsec._iast._taint_tracking import taint_pyobject
+        from ddtrace.appsec._iast._taint_utils import taint_structure
+
+        if not in_iast_context():
+            return
+
+        http_req = fn_args[0]
+
+        http_req.COOKIES = taint_structure(http_req.COOKIES, OriginType.COOKIE_NAME, OriginType.COOKIE)
+        http_req.GET = taint_structure(http_req.GET, OriginType.PARAMETER_NAME, OriginType.PARAMETER)
+        http_req.POST = taint_structure(http_req.POST, OriginType.BODY, OriginType.BODY)
+        if (
+            getattr(http_req, "_body", None) is not None
+            and len(getattr(http_req, "_body", None)) > 0
+            and not is_pyobject_tainted(getattr(http_req, "_body", None))
+        ):
+            try:
+                http_req._body = taint_pyobject(
+                    http_req._body,
+                    source_name=origin_to_str(OriginType.BODY),
+                    source_value=http_req._body,
+                    source_origin=OriginType.BODY,
+                )
+            except AttributeError:
+                log.debug("IAST can't set attribute http_req._body", exc_info=True)
+        elif (
+            getattr(http_req, "body", None) is not None
+            and len(getattr(http_req, "body", None)) > 0
+            and not is_pyobject_tainted(getattr(http_req, "body", None))
+        ):
+            try:
+                http_req.body = taint_pyobject(
+                    http_req.body,
+                    source_name=origin_to_str(OriginType.BODY),
+                    source_value=http_req.body,
+                    source_origin=OriginType.BODY,
+                )
+            except AttributeError:
+                log.debug("IAST can't set attribute http_req.body", exc_info=True)
+
+        http_req.headers = taint_structure(http_req.headers, OriginType.HEADER_NAME, OriginType.HEADER)
+        http_req.path = taint_pyobject(
+            http_req.path, source_name="path", source_value=http_req.path, source_origin=OriginType.PATH
+        )
+        http_req.path_info = taint_pyobject(
+            http_req.path_info,
+            source_name=origin_to_str(OriginType.PATH),
+            source_value=http_req.path,
+            source_origin=OriginType.PATH,
+        )
+        http_req.environ["PATH_INFO"] = taint_pyobject(
+            http_req.environ["PATH_INFO"],
+            source_name=origin_to_str(OriginType.PATH),
+            source_value=http_req.path,
+            source_origin=OriginType.PATH,
+        )
+        http_req.META = taint_structure(http_req.META, OriginType.HEADER_NAME, OriginType.HEADER)
+        if fn_kwargs:
+            try:
+                for k, v in fn_kwargs.items():
+                    fn_kwargs[k] = taint_pyobject(
+                        v, source_name=k, source_value=v, source_origin=OriginType.PATH_PARAMETER
+                    )
+            except Exception:
+                log.debug("IAST: Unexpected exception while tainting path parameters", exc_info=True)
+
+
+def _custom_protobuf_getattribute(self, name):
+    from ddtrace.appsec._iast._taint_tracking import OriginType
+    from ddtrace.appsec._iast._taint_tracking import taint_pyobject
+    from ddtrace.appsec._iast._taint_utils import taint_structure
+
+    ret = type(self).__saved_getattr(self, name)
+    if isinstance(ret, (str, bytes, bytearray)):
+        ret = taint_pyobject(
+            pyobject=ret,
+            source_name=OriginType.GRPC_BODY,
+            source_value=ret,
+            source_origin=OriginType.GRPC_BODY,
+        )
+    elif MessageMapContainer is not None and isinstance(ret, MutableMapping):
+        if isinstance(ret, MessageMapContainer) and len(ret):
+            # Patch the message-values class
+            first_key = next(iter(ret))
+            value_type = type(ret[first_key])
+            _patch_protobuf_class(value_type)
+        else:
+            ret = taint_structure(ret, OriginType.GRPC_BODY, OriginType.GRPC_BODY)
+
+    return ret
+
+
+_custom_protobuf_getattribute.__datadog_custom = True  # type: ignore[attr-defined]
+
+
+# Used to replace the Protobuf message class "getattribute" with a custom one that taints the return
+# of the original __getattribute__ method
+def _patch_protobuf_class(cls):
+    getattr_method = getattr(cls, "__getattribute__")
+    if not getattr_method:
+        return
+
+    if not hasattr(getattr_method, "__datadog_custom"):
+        try:
+            # Replace the class __getattribute__ method with our custom one
+            # (replacement is done at the class level because it would incur on a recursive loop with the instance)
+            cls.__saved_getattr = getattr_method
+            cls.__getattribute__ = _custom_protobuf_getattribute
+        except TypeError:
+            # Avoid failing on Python 3.12 while patching immutable types
+            pass
+
+
+def _on_grpc_response(message):
+    if _is_iast_enabled():
+        msg_cls = type(message)
+        _patch_protobuf_class(msg_cls)

--- a/ddtrace/appsec/_iast/_handlers.py
+++ b/ddtrace/appsec/_iast/_handlers.py
@@ -4,12 +4,15 @@ import functools
 from wrapt import when_imported
 from wrapt import wrap_function_wrapper as _w
 
-from ddtrace.appsec._handlers import log
 from ddtrace.appsec._iast import _is_iast_enabled
-from ddtrace.appsec._iast._iast_request_context import in_iast_context
-from ddtrace.appsec._iast._patch import if_iast_taint_returned_object_for
-from ddtrace.appsec._iast._patch import if_iast_taint_yield_tuple_for
-from ddtrace.contrib import trace_utils
+from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_source
+from ddtrace.appsec._iast._patch import _iast_instrument_starlette_request
+from ddtrace.appsec._iast._patch import _iast_instrument_starlette_request_body
+from ddtrace.appsec._iast._patch import _iast_instrument_starlette_url
+from ddtrace.appsec._iast._patch import _patched_dictionary
+from ddtrace.appsec._iast._patch import try_wrap_function_wrapper
+from ddtrace.appsec._iast._taint_utils import taint_structure
+from ddtrace.internal.logger import get_logger
 
 
 MessageMapContainer = None
@@ -17,6 +20,9 @@ try:
     from google._upb._message import MessageMapContainer  # type: ignore[no-redef]
 except ImportError:
     pass
+
+
+log = get_logger(__name__)
 
 
 def _on_set_http_meta_iast(
@@ -42,6 +48,8 @@ def _on_set_http_meta_iast(
 
 
 def _on_request_init(wrapped, instance, args, kwargs):
+    from ddtrace.appsec._iast._iast_request_context import in_iast_context
+
     wrapped(*args, **kwargs)
     if _is_iast_enabled() and in_iast_context():
         try:
@@ -67,9 +75,6 @@ def _on_request_init(wrapped, instance, args, kwargs):
 
 def _on_flask_patch(flask_version):
     if _is_iast_enabled():
-        from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_source
-        from ddtrace.appsec._iast._patch import _patched_dictionary
-        from ddtrace.appsec._iast._patch import try_wrap_function_wrapper
         from ddtrace.appsec._iast._taint_tracking import OriginType
 
         try_wrap_function_wrapper(
@@ -127,9 +132,10 @@ def _on_flask_patch(flask_version):
 
 
 def _on_wsgi_environ(wrapped, _instance, args, kwargs):
+    from ddtrace.appsec._iast._iast_request_context import in_iast_context
+
     if _is_iast_enabled() and args and in_iast_context():
         from ddtrace.appsec._iast._taint_tracking import OriginType
-        from ddtrace.appsec._iast._taint_utils import taint_structure
 
         return wrapped(*((taint_structure(args[0], OriginType.HEADER_NAME, OriginType.HEADER),) + args[1:]), **kwargs)
 
@@ -139,7 +145,6 @@ def _on_wsgi_environ(wrapped, _instance, args, kwargs):
 def _on_django_patch():
     if _is_iast_enabled():
         try:
-            from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_source
             from ddtrace.appsec._iast._taint_tracking import OriginType
 
             # we instrument those sources on _on_django_func_wrapped
@@ -153,7 +158,7 @@ def _on_django_patch():
             _set_metric_iast_instrumented_source(OriginType.PARAMETER_NAME)
             _set_metric_iast_instrumented_source(OriginType.BODY)
             when_imported("django.http.request")(
-                lambda m: trace_utils.wrap(
+                lambda m: try_wrap_function_wrapper(
                     m,
                     "QueryDict.__getitem__",
                     functools.partial(if_iast_taint_returned_object_for, OriginType.PARAMETER),
@@ -167,11 +172,11 @@ def _on_django_func_wrapped(fn_args, fn_kwargs, first_arg_expected_type, *_):
     # If IAST is enabled and we're wrapping a Django view call, taint the kwargs (view's
     # path parameters)
     if _is_iast_enabled() and fn_args and isinstance(fn_args[0], first_arg_expected_type):
+        from ddtrace.appsec._iast._iast_request_context import in_iast_context
         from ddtrace.appsec._iast._taint_tracking import OriginType  # noqa: F401
         from ddtrace.appsec._iast._taint_tracking import is_pyobject_tainted
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
         from ddtrace.appsec._iast._taint_tracking import taint_pyobject
-        from ddtrace.appsec._iast._taint_utils import taint_structure
 
         if not in_iast_context():
             return
@@ -240,7 +245,6 @@ def _on_django_func_wrapped(fn_args, fn_kwargs, first_arg_expected_type, *_):
 def _custom_protobuf_getattribute(self, name):
     from ddtrace.appsec._iast._taint_tracking import OriginType
     from ddtrace.appsec._iast._taint_tracking import taint_pyobject
-    from ddtrace.appsec._iast._taint_utils import taint_structure
 
     ret = type(self).__saved_getattr(self, name)
     if isinstance(ret, (str, bytes, bytearray)):
@@ -287,3 +291,106 @@ def _on_grpc_response(message):
     if _is_iast_enabled():
         msg_cls = type(message)
         _patch_protobuf_class(msg_cls)
+
+
+def if_iast_taint_yield_tuple_for(origins, wrapped, instance, args, kwargs):
+    if _is_iast_enabled():
+        from ._iast_request_context import is_iast_request_enabled
+        from ._taint_tracking import taint_pyobject
+
+        if not is_iast_request_enabled():
+            for key, value in wrapped(*args, **kwargs):
+                yield key, value
+        else:
+            for key, value in wrapped(*args, **kwargs):
+                new_key = taint_pyobject(pyobject=key, source_name=key, source_value=key, source_origin=origins[0])
+                new_value = taint_pyobject(
+                    pyobject=value, source_name=key, source_value=value, source_origin=origins[1]
+                )
+                yield new_key, new_value
+
+    else:
+        for key, value in wrapped(*args, **kwargs):
+            yield key, value
+
+
+def if_iast_taint_returned_object_for(origin, wrapped, instance, args, kwargs):
+    value = wrapped(*args, **kwargs)
+    from ._iast_request_context import is_iast_request_enabled
+
+    if _is_iast_enabled() and is_iast_request_enabled():
+        try:
+            from ._taint_tracking import is_pyobject_tainted
+            from ._taint_tracking import taint_pyobject
+
+            if not is_pyobject_tainted(value):
+                name = str(args[0]) if len(args) else "http.request.body"
+                from ddtrace.appsec._iast._taint_tracking import OriginType
+
+                if origin == OriginType.HEADER and name.lower() in ["cookie", "cookies"]:
+                    origin = OriginType.COOKIE
+                return taint_pyobject(pyobject=value, source_name=name, source_value=value, source_origin=origin)
+        except Exception:
+            log.debug("Unexpected exception while tainting pyobject", exc_info=True)
+    return value
+
+
+def _on_iast_fastapi_patch():
+    from ddtrace.appsec._iast._taint_tracking import OriginType
+
+    # Cookies sources
+    try_wrap_function_wrapper(
+        "starlette.requests",
+        "cookie_parser",
+        functools.partial(_patched_dictionary, OriginType.COOKIE_NAME, OriginType.COOKIE),
+    )
+    _set_metric_iast_instrumented_source(OriginType.COOKIE)
+    _set_metric_iast_instrumented_source(OriginType.COOKIE_NAME)
+
+    # Parameter sources
+    try_wrap_function_wrapper(
+        "starlette.datastructures",
+        "QueryParams.__getitem__",
+        functools.partial(if_iast_taint_returned_object_for, OriginType.PARAMETER),
+    )
+    try_wrap_function_wrapper(
+        "starlette.datastructures",
+        "QueryParams.get",
+        functools.partial(if_iast_taint_returned_object_for, OriginType.PARAMETER),
+    )
+    _set_metric_iast_instrumented_source(OriginType.PARAMETER)
+
+    # Header sources
+    try_wrap_function_wrapper(
+        "starlette.datastructures",
+        "Headers.__getitem__",
+        functools.partial(if_iast_taint_returned_object_for, OriginType.HEADER),
+    )
+    try_wrap_function_wrapper(
+        "starlette.datastructures",
+        "Headers.get",
+        functools.partial(if_iast_taint_returned_object_for, OriginType.HEADER),
+    )
+    _set_metric_iast_instrumented_source(OriginType.HEADER)
+
+    # Path source
+    try_wrap_function_wrapper("starlette.datastructures", "URL.__init__", _iast_instrument_starlette_url)
+    _set_metric_iast_instrumented_source(OriginType.PATH)
+
+    # Body source
+    try_wrap_function_wrapper("starlette.requests", "Request.__init__", _iast_instrument_starlette_request)
+    try_wrap_function_wrapper("starlette.requests", "Request.body", _iast_instrument_starlette_request_body)
+    try_wrap_function_wrapper(
+        "starlette.datastructures",
+        "FormData.__getitem__",
+        functools.partial(if_iast_taint_returned_object_for, OriginType.BODY),
+    )
+    try_wrap_function_wrapper(
+        "starlette.datastructures",
+        "FormData.get",
+        functools.partial(if_iast_taint_returned_object_for, OriginType.BODY),
+    )
+    _set_metric_iast_instrumented_source(OriginType.BODY)
+
+    # Instrumented on _iast_starlette_scope_taint
+    _set_metric_iast_instrumented_source(OriginType.PATH_PARAMETER)

--- a/ddtrace/appsec/_iast/_iast_request_context.py
+++ b/ddtrace/appsec/_iast/_iast_request_context.py
@@ -6,6 +6,13 @@ from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast import _is_iast_enabled
 from ddtrace.appsec._iast import oce
+from ddtrace.appsec._iast._handlers import _on_django_func_wrapped
+from ddtrace.appsec._iast._handlers import _on_django_patch
+from ddtrace.appsec._iast._handlers import _on_flask_patch
+from ddtrace.appsec._iast._handlers import _on_grpc_response
+from ddtrace.appsec._iast._handlers import _on_request_init
+from ddtrace.appsec._iast._handlers import _on_set_http_meta_iast
+from ddtrace.appsec._iast._handlers import _on_wsgi_environ
 from ddtrace.appsec._iast._metrics import _set_metric_iast_request_tainted
 from ddtrace.appsec._iast._metrics import _set_span_tag_iast_executed_sink
 from ddtrace.appsec._iast._metrics import _set_span_tag_iast_request_tainted
@@ -151,6 +158,20 @@ def _iast_start_request(span=None, *args, **kwargs):
         log.debug("[IAST] Error starting IAST context", exc_info=True)
 
 
+def _on_grpc_server_response(message):
+    _on_grpc_response(message)
+
+
 def iast_listen():
+    core.on("grpc.client.response.message", _on_grpc_response)
+    core.on("grpc.server.response.message", _on_grpc_server_response)
+
+    core.on("set_http_meta_for_asm", _on_set_http_meta_iast)
+    core.on("django.patch", _on_django_patch)
+    core.on("django.wsgi_environ", _on_wsgi_environ, "wrapped_result")
+    core.on("django.func.wrapped", _on_django_func_wrapped)
+    core.on("flask.patch", _on_flask_patch)
+    core.on("flask.request_init", _on_request_init)
+
     core.on("context.ended.wsgi.__call__", _iast_end_request)
     core.on("context.ended.asgi.__call__", _iast_end_request)

--- a/ddtrace/appsec/_iast/_patch.py
+++ b/ddtrace/appsec/_iast/_patch.py
@@ -1,4 +1,3 @@
-import functools
 import sys
 from typing import Callable
 from typing import Text
@@ -8,10 +7,7 @@ from wrapt import FunctionWrapper
 from ddtrace.appsec._common_module_patches import wrap_object
 from ddtrace.internal.logger import get_logger
 
-from ._iast_request_context import is_iast_request_enabled
-from ._metrics import _set_metric_iast_instrumented_source
 from ._taint_utils import taint_structure
-from ._utils import _is_iast_enabled
 
 
 log = get_logger(__name__)
@@ -45,111 +41,10 @@ def try_wrap_function_wrapper(module: Text, name: Text, wrapper: Callable):
         log.debug("IAST patching. Module %s.%s not exists", module, name)
 
 
-def if_iast_taint_returned_object_for(origin, wrapped, instance, args, kwargs):
-    value = wrapped(*args, **kwargs)
-
-    if _is_iast_enabled() and is_iast_request_enabled():
-        try:
-            from ._taint_tracking import is_pyobject_tainted
-            from ._taint_tracking import taint_pyobject
-
-            if not is_pyobject_tainted(value):
-                name = str(args[0]) if len(args) else "http.request.body"
-                from ddtrace.appsec._iast._taint_tracking import OriginType
-
-                if origin == OriginType.HEADER and name.lower() in ["cookie", "cookies"]:
-                    origin = OriginType.COOKIE
-                return taint_pyobject(pyobject=value, source_name=name, source_value=value, source_origin=origin)
-        except Exception:
-            log.debug("Unexpected exception while tainting pyobject", exc_info=True)
-    return value
-
-
-def if_iast_taint_yield_tuple_for(origins, wrapped, instance, args, kwargs):
-    if _is_iast_enabled():
-        from ._taint_tracking import taint_pyobject
-
-        if not is_iast_request_enabled():
-            for key, value in wrapped(*args, **kwargs):
-                yield key, value
-        else:
-            for key, value in wrapped(*args, **kwargs):
-                new_key = taint_pyobject(pyobject=key, source_name=key, source_value=key, source_origin=origins[0])
-                new_value = taint_pyobject(
-                    pyobject=value, source_name=key, source_value=value, source_origin=origins[1]
-                )
-                yield new_key, new_value
-
-    else:
-        for key, value in wrapped(*args, **kwargs):
-            yield key, value
-
-
 def _patched_dictionary(origin_key, origin_value, original_func, instance, args, kwargs):
     result = original_func(*args, **kwargs)
 
     return taint_structure(result, origin_key, origin_value, override_pyobject_tainted=True)
-
-
-def _on_iast_fastapi_patch():
-    from ddtrace.appsec._iast._taint_tracking import OriginType
-
-    # Cookies sources
-    try_wrap_function_wrapper(
-        "starlette.requests",
-        "cookie_parser",
-        functools.partial(_patched_dictionary, OriginType.COOKIE_NAME, OriginType.COOKIE),
-    )
-    _set_metric_iast_instrumented_source(OriginType.COOKIE)
-    _set_metric_iast_instrumented_source(OriginType.COOKIE_NAME)
-
-    # Parameter sources
-    try_wrap_function_wrapper(
-        "starlette.datastructures",
-        "QueryParams.__getitem__",
-        functools.partial(if_iast_taint_returned_object_for, OriginType.PARAMETER),
-    )
-    try_wrap_function_wrapper(
-        "starlette.datastructures",
-        "QueryParams.get",
-        functools.partial(if_iast_taint_returned_object_for, OriginType.PARAMETER),
-    )
-    _set_metric_iast_instrumented_source(OriginType.PARAMETER)
-
-    # Header sources
-    try_wrap_function_wrapper(
-        "starlette.datastructures",
-        "Headers.__getitem__",
-        functools.partial(if_iast_taint_returned_object_for, OriginType.HEADER),
-    )
-    try_wrap_function_wrapper(
-        "starlette.datastructures",
-        "Headers.get",
-        functools.partial(if_iast_taint_returned_object_for, OriginType.HEADER),
-    )
-    _set_metric_iast_instrumented_source(OriginType.HEADER)
-
-    # Path source
-    try_wrap_function_wrapper("starlette.datastructures", "URL.__init__", _iast_instrument_starlette_url)
-    _set_metric_iast_instrumented_source(OriginType.PATH)
-
-    # Body source
-    try_wrap_function_wrapper("starlette.requests", "Request.__init__", _iast_instrument_starlette_request)
-    try_wrap_function_wrapper("starlette.requests", "Request.body", _iast_instrument_starlette_request_body)
-    try_wrap_function_wrapper(
-        "starlette.datastructures",
-        "FormData.__getitem__",
-        functools.partial(if_iast_taint_returned_object_for, OriginType.BODY),
-    )
-    try_wrap_function_wrapper(
-        "starlette.datastructures",
-        "FormData.get",
-        functools.partial(if_iast_taint_returned_object_for, OriginType.BODY),
-    )
-    _set_metric_iast_instrumented_source(OriginType.BODY)
-
-    # Instrumented on _iast_starlette_scope_taint
-    _set_metric_iast_instrumented_source(OriginType.PATH_PARAMETER)
 
 
 def _iast_instrument_starlette_url(wrapped, instance, args, kwargs):

--- a/ddtrace/appsec/_iast/processor.py
+++ b/ddtrace/appsec/_iast/processor.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 
 from ddtrace._trace.processor import SpanProcessor
 from ddtrace._trace.span import Span
-from ddtrace.appsec import load_appsec
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.logger import get_logger
 
@@ -16,9 +15,9 @@ log = get_logger(__name__)
 @dataclass(eq=False)
 class AppSecIastSpanProcessor(SpanProcessor):
     def __post_init__(self) -> None:
-        from ddtrace.appsec import load_appsec
+        from ddtrace.appsec import load_iast
 
-        load_appsec()
+        load_iast()
 
     def on_span_start(self, span: Span):
         if span.span_type != SpanTypes.WEB:
@@ -37,6 +36,3 @@ class AppSecIastSpanProcessor(SpanProcessor):
         if span.span_type != SpanTypes.WEB:
             return
         _iast_end_request(span=span)
-
-
-load_appsec()

--- a/ddtrace/contrib/internal/fastapi/patch.py
+++ b/ddtrace/contrib/internal/fastapi/patch.py
@@ -87,7 +87,7 @@ def patch():
         _w("starlette.routing", "Mount.handle", traced_handler)
 
     if _is_iast_enabled():
-        from ddtrace.appsec._iast._patch import _on_iast_fastapi_patch
+        from ddtrace.appsec._iast._handlers import _on_iast_fastapi_patch
 
         _on_iast_fastapi_patch()
 

--- a/tests/appsec/iast/conftest.py
+++ b/tests/appsec/iast/conftest.py
@@ -53,7 +53,7 @@ def _end_iast_context_and_oce(span=None):
     oce.release_request()
 
 
-def iast_context(env, request_sampling="100", deduplication=False):
+def iast_context(env, request_sampling="100", deduplication=False, asm_enabled=False):
     try:
         from ddtrace.contrib.langchain.patch import patch as langchain_patch
         from ddtrace.contrib.langchain.patch import unpatch as langchain_unpatch
@@ -78,7 +78,9 @@ def iast_context(env, request_sampling="100", deduplication=False):
 
     env.update({"DD_IAST_REQUEST_SAMPLING": request_sampling, "_DD_APPSEC_DEDUPLICATION_ENABLED": str(deduplication)})
     VulnerabilityBase._reset_cache_for_testing()
-    with override_global_config(dict(_iast_enabled=True, _deduplication_enabled=deduplication)), override_env(env):
+    with override_global_config(
+        dict(_asm_enabled=asm_enabled, _iast_enabled=True, _deduplication_enabled=deduplication)
+    ), override_env(env):
         _start_iast_context_and_oce(MockSpan())
         weak_hash_patch()
         weak_cipher_patch()

--- a/tests/appsec/iast/test_grpc_iast.py
+++ b/tests/appsec/iast/test_grpc_iast.py
@@ -24,7 +24,7 @@ _GRPC_VERSION = tuple([int(i) for i in _GRPC_VERSION.split(".")])
 
 @pytest.fixture(autouse=True)
 def iast_c_context():
-    yield from iast_context(dict(DD_IAST_ENABLED="true"))
+    yield from iast_context(dict(DD_IAST_ENABLED="true"), asm_enabled=True)
 
 
 def _check_test_range(value):
@@ -151,8 +151,8 @@ class GrpcTestIASTCase(GrpcBaseTestCase):
         with mock.patch.dict("sys.modules", {"google._upb._message": None}), override_env({"DD_IAST_ENABLED": "True"}):
             from collections import UserDict
 
-            from ddtrace.appsec._handlers import _custom_protobuf_getattribute
-            from ddtrace.appsec._handlers import _patch_protobuf_class
+            from ddtrace.appsec._iast._handlers import _custom_protobuf_getattribute
+            from ddtrace.appsec._iast._handlers import _patch_protobuf_class
 
             class MyUserDict(UserDict):
                 pass
@@ -164,9 +164,7 @@ class GrpcTestIASTCase(GrpcBaseTestCase):
             _custom_protobuf_getattribute(mutable_mapping, "data")
 
     def test_address_server_data(self):
-        with override_env({"DD_IAST_ENABLED": "True"}), override_global_config(
-            dict(_asm_enabled=True)
-        ), override_config("grpc", dict(service_name="myclientsvc")), override_config(
+        with override_config("grpc", dict(service_name="myclientsvc")), override_config(
             "grpc_server", dict(service_name="myserversvc")
         ):
             with mock.patch("ddtrace.appsec._asm_request_context.set_waf_address") as mock_set_waf_addr:

--- a/tests/appsec/iast/test_telemetry.py
+++ b/tests/appsec/iast/test_telemetry.py
@@ -4,7 +4,7 @@ from ddtrace.appsec._common_module_patches import patch_common_modules
 from ddtrace.appsec._common_module_patches import unpatch_common_modules
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._constants import IAST_SPAN_TAGS
-from ddtrace.appsec._handlers import _on_django_patch
+from ddtrace.appsec._iast._handlers import _on_django_patch
 from ddtrace.appsec._iast._metrics import TELEMETRY_DEBUG_VERBOSITY
 from ddtrace.appsec._iast._metrics import TELEMETRY_INFORMATION_VERBOSITY
 from ddtrace.appsec._iast._metrics import TELEMETRY_MANDATORY_VERBOSITY

--- a/tests/appsec/integrations/test_flask_telemetry.py
+++ b/tests/appsec/integrations/test_flask_telemetry.py
@@ -1,4 +1,4 @@
-from ddtrace.appsec._handlers import _on_flask_patch
+from ddtrace.appsec._iast._handlers import _on_flask_patch
 from tests.appsec.appsec_utils import flask_server
 from tests.utils import override_global_config
 

--- a/tests/contrib/fastapi/test_fastapi_appsec_iast.py
+++ b/tests/contrib/fastapi/test_fastapi_appsec_iast.py
@@ -16,7 +16,7 @@ import pytest
 
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast import oce
-from ddtrace.appsec._iast._patch import _on_iast_fastapi_patch
+from ddtrace.appsec._iast._handlers import _on_iast_fastapi_patch
 from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.contrib.internal.fastapi.patch import patch as patch_fastapi
 from ddtrace.contrib.sqlite3.patch import patch as patch_sqlite_sqli


### PR DESCRIPTION
Before this PR, IAST and ASM hooks were mixed together inside `asm_listen`. Now, all the IAST and ASM logic has been separated

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
