### PR TITLE
feat(iast): add support for cookie vulnerability for FastAPI

### DIFF
--- a/ddtrace/appsec/_iast/_iast_request_context.py
+++ b/ddtrace/appsec/_iast/_iast_request_context.py
@@ -111,20 +111,20 @@ def is_iast_request_enabled():
 
 def _iast_end_request(ctx=None, span=None, *args, **kwargs):
     try:
+        if span:
+            req_span = span
+        else:
+            req_span = ctx.get_item("req_span")
+
         if _is_iast_enabled():
-            if span:
-                req_span = span
-            else:
-                req_span = ctx.get_item("req_span")
+            req_span.set_metric(IAST.ENABLED, 1.0)
             exist_data = req_span.get_tag(IAST.JSON)
             if not exist_data:
                 if not is_iast_request_enabled():
-                    req_span.set_metric(IAST.ENABLED, 0.0)
                     end_iast_context(req_span)
                     oce.release_request()
                     return
 
-                req_span.set_metric(IAST.ENABLED, 1.0)
                 report_data: Optional[IastSpanReporter] = get_iast_reporter()
 
                 if report_data:
@@ -142,6 +142,8 @@ def _iast_end_request(ctx=None, span=None, *args, **kwargs):
                     req_span.set_tag_str(ORIGIN_KEY, APPSEC.ORIGIN_VALUE)
 
                 oce.release_request()
+        else:
+            req_span.set_metric(IAST.ENABLED, 0.0)
     except Exception:
         log.debug("[IAST] Error finishing IAST context", exc_info=True)
 

--- a/ddtrace/appsec/_iast/taint_sinks/insecure_cookie.py
+++ b/ddtrace/appsec/_iast/taint_sinks/insecure_cookie.py
@@ -2,9 +2,12 @@ from typing import Dict
 from typing import Optional
 
 from ..._constants import IAST_SPAN_TAGS
+from .. import _is_iast_enabled
 from .. import oce
+from .._iast_request_context import is_iast_request_enabled
 from .._metrics import _set_metric_iast_executed_sink
 from .._metrics import increment_iast_span_metric
+from .._taint_tracking import iast_taint_log_error
 from ..constants import VULN_INSECURE_COOKIE
 from ..constants import VULN_NO_HTTPONLY_COOKIE
 from ..constants import VULN_NO_SAMESITE_COOKIE
@@ -33,35 +36,44 @@ class NoSameSite(VulnerabilityBase):
 def asm_check_cookies(cookies: Optional[Dict[str, str]]) -> None:
     if not cookies:
         return
+    if _is_iast_enabled() and is_iast_request_enabled():
+        try:
+            for cookie_key, cookie_value in cookies.items():
+                lvalue = cookie_value.lower().replace(" ", "")
+                # If lvalue starts with ";" means that the cookie is empty, like ';httponly;path=/;samesite=strict'
+                if lvalue == "" or lvalue.startswith(";") or lvalue.startswith('""'):
+                    continue
 
-    for cookie_key, cookie_value in cookies.items():
-        lvalue = cookie_value.lower().replace(" ", "")
-        # If lvalue starts with ";" means that the cookie is empty, like ';httponly;path=/;samesite=strict'
-        if lvalue == "" or lvalue.startswith(";"):
-            continue
+                if ";secure" not in lvalue:
+                    increment_iast_span_metric(
+                        IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, InsecureCookie.vulnerability_type
+                    )
+                    _set_metric_iast_executed_sink(InsecureCookie.vulnerability_type)
+                    InsecureCookie.report(evidence_value=cookie_key)
 
-        if ";secure" not in lvalue:
-            increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, InsecureCookie.vulnerability_type)
-            _set_metric_iast_executed_sink(InsecureCookie.vulnerability_type)
-            InsecureCookie.report(evidence_value=cookie_key)
+                if ";httponly" not in lvalue:
+                    increment_iast_span_metric(
+                        IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, NoHttpOnlyCookie.vulnerability_type
+                    )
+                    _set_metric_iast_executed_sink(NoHttpOnlyCookie.vulnerability_type)
+                    NoHttpOnlyCookie.report(evidence_value=cookie_key)
 
-        if ";httponly" not in lvalue:
-            increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, NoHttpOnlyCookie.vulnerability_type)
-            _set_metric_iast_executed_sink(NoHttpOnlyCookie.vulnerability_type)
-            NoHttpOnlyCookie.report(evidence_value=cookie_key)
+                if ";samesite=" in lvalue:
+                    ss_tokens = lvalue.split(";samesite=")
+                    if len(ss_tokens) <= 1:
+                        report_samesite = True
+                    else:
+                        ss_tokens[1] = ss_tokens[1].lower()
+                        if ss_tokens[1].startswith("strict") or ss_tokens[1].startswith("lax"):
+                            report_samesite = False
+                        else:
+                            report_samesite = True
+                else:
+                    report_samesite = True
 
-        if ";samesite=" in lvalue:
-            ss_tokens = lvalue.split(";samesite=")
-            if len(ss_tokens) == 0:
-                report_samesite = True
-            elif ss_tokens[1].startswith("strict") or ss_tokens[1].startswith("lax"):
-                report_samesite = False
-            else:
-                report_samesite = True
-        else:
-            report_samesite = True
-
-        if report_samesite:
-            increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, NoSameSite.vulnerability_type)
-            _set_metric_iast_executed_sink(NoSameSite.vulnerability_type)
-            NoSameSite.report(evidence_value=cookie_key)
+                if report_samesite:
+                    increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, NoSameSite.vulnerability_type)
+                    _set_metric_iast_executed_sink(NoSameSite.vulnerability_type)
+                    NoSameSite.report(evidence_value=cookie_key)
+        except Exception as e:
+            iast_taint_log_error("[IAST] error in asm_check_cookies. {}".format(e))

--- a/ddtrace/contrib/internal/asgi/middleware.py
+++ b/ddtrace/contrib/internal/asgi/middleware.py
@@ -243,7 +243,6 @@ class TraceMiddleware:
                     except Exception:
                         log.debug("failed to extract response cookies", exc_info=True)
 
-                    response_headers = None
                     status_code = message["status"]
                     trace_utils.set_http_meta(
                         span,

--- a/ddtrace/contrib/internal/asgi/middleware.py
+++ b/ddtrace/contrib/internal/asgi/middleware.py
@@ -238,8 +238,8 @@ class TraceMiddleware:
                 if span and message.get("type") == "http.response.start" and "status" in message:
                     cookies = {}
                     try:
-                        cookie_key, *split_cookie = response_headers.get("set-cookie", "").split("=")
-                        cookies[cookie_key] = "=".join(split_cookie)
+                        cookie_key, cookie_value = response_headers.get("set-cookie", "").split("=", maxsplit=1)
+                        cookies[cookie_key] = cookie_value
                     except Exception:
                         log.debug("failed to extract response cookies", exc_info=True)
 

--- a/tests/contrib/fastapi/test_fastapi_appsec_iast.py
+++ b/tests/contrib/fastapi/test_fastapi_appsec_iast.py
@@ -624,7 +624,6 @@ def test_fasapi_insecure_cookie_empty(fastapi_application, client, tracer, test_
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
 
         query_params = request.query_params.get("iast_queryparam")
-        # resp.set_cookie("insecure", "cookie", secure=False, httponly=True, samesite="Strict")
         ranges_result = get_tainted_ranges(query_params)
         response = JSONResponse(
             {
@@ -660,7 +659,6 @@ def test_fasapi_no_http_only_cookie(fastapi_application, client, tracer, test_sp
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
 
         query_params = request.query_params.get("iast_queryparam")
-        # resp.set_cookie("insecure", "cookie", secure=False, httponly=True, samesite="Strict")
         ranges_result = get_tainted_ranges(query_params)
         response = JSONResponse(
             {
@@ -704,7 +702,6 @@ def test_fasapi_no_http_only_cookie_empty(fastapi_application, client, tracer, t
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
 
         query_params = request.query_params.get("iast_queryparam")
-        # resp.set_cookie("insecure", "cookie", secure=False, httponly=True, samesite="Strict")
         ranges_result = get_tainted_ranges(query_params)
         response = JSONResponse(
             {
@@ -740,7 +737,6 @@ def test_fasapi_no_samesite_cookie(fastapi_application, client, tracer, test_spa
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
 
         query_params = request.query_params.get("iast_queryparam")
-        # resp.set_cookie("insecure", "cookie", secure=False, httponly=True, samesite="Strict")
         ranges_result = get_tainted_ranges(query_params)
         response = JSONResponse(
             {

--- a/tests/contrib/fastapi/test_fastapi_appsec_iast.py
+++ b/tests/contrib/fastapi/test_fastapi_appsec_iast.py
@@ -581,7 +581,6 @@ def test_fasapi_insecure_cookie(fastapi_application, client, tracer, test_spans)
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
 
         query_params = request.query_params.get("iast_queryparam")
-        # resp.set_cookie("insecure", "cookie", secure=False, httponly=True, samesite="Strict")
         ranges_result = get_tainted_ranges(query_params)
         response = JSONResponse(
             {

--- a/tests/contrib/fastapi/test_fastapi_appsec_iast.py
+++ b/tests/contrib/fastapi/test_fastapi_appsec_iast.py
@@ -17,6 +17,9 @@ import pytest
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast import oce
 from ddtrace.appsec._iast._handlers import _on_iast_fastapi_patch
+from ddtrace.appsec._iast.constants import VULN_INSECURE_COOKIE
+from ddtrace.appsec._iast.constants import VULN_NO_HTTPONLY_COOKIE
+from ddtrace.appsec._iast.constants import VULN_NO_SAMESITE_COOKIE
 from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.contrib.internal.fastapi.patch import patch as patch_fastapi
 from ddtrace.contrib.sqlite3.patch import patch as patch_sqlite_sqli
@@ -569,3 +572,207 @@ def test_fastapi_sqli_path_param(fastapi_application, client, tracer, test_spans
         assert vulnerability["location"]["line"] == line
         assert vulnerability["location"]["path"] == TEST_FILE_PATH
         assert vulnerability["hash"] == hash_value
+
+
+def test_fasapi_insecure_cookie(fastapi_application, client, tracer, test_spans):
+    @fastapi_application.route("/insecure_cookie/", methods=["GET"])
+    def insecure_cookie(request: Request):
+        from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking import origin_to_str
+
+        query_params = request.query_params.get("iast_queryparam")
+        # resp.set_cookie("insecure", "cookie", secure=False, httponly=True, samesite="Strict")
+        ranges_result = get_tainted_ranges(query_params)
+        response = JSONResponse(
+            {
+                "result": query_params,
+                "is_tainted": len(ranges_result),
+                "ranges_start": ranges_result[0].start,
+                "ranges_length": ranges_result[0].length,
+                "ranges_origin": origin_to_str(ranges_result[0].source.origin),
+            }
+        )
+        response.set_cookie(key="insecure", value=query_params, secure=False, httponly=True, samesite="strict")
+
+        return response
+
+    with override_global_config(dict(_iast_enabled=True, _deduplication_enabled=False)), override_env(IAST_ENV):
+        _aux_appsec_prepare_tracer(tracer)
+        resp = client.get(
+            "/insecure_cookie/?iast_queryparam=insecure",
+        )
+        assert resp.status_code == 200
+
+        span = test_spans.pop_traces()[0][0]
+        assert span.get_metric(IAST.ENABLED) == 1.0
+
+        loaded = json.loads(span.get_tag(IAST.JSON))
+        assert loaded["sources"] == []
+        assert len(loaded["vulnerabilities"]) == 1
+        vulnerability = loaded["vulnerabilities"][0]
+        assert vulnerability["type"] == VULN_INSECURE_COOKIE
+        assert vulnerability["evidence"] == {"valueParts": [{"value": "insecure"}]}
+        assert "path" not in vulnerability["location"].keys()
+        assert "line" not in vulnerability["location"].keys()
+        assert vulnerability["location"]["spanId"]
+        assert vulnerability["hash"]
+
+
+def test_fasapi_insecure_cookie_empty(fastapi_application, client, tracer, test_spans):
+    @fastapi_application.route("/insecure_cookie/", methods=["GET"])
+    def insecure_cookie(request: Request):
+        from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking import origin_to_str
+
+        query_params = request.query_params.get("iast_queryparam")
+        # resp.set_cookie("insecure", "cookie", secure=False, httponly=True, samesite="Strict")
+        ranges_result = get_tainted_ranges(query_params)
+        response = JSONResponse(
+            {
+                "result": query_params,
+                "is_tainted": len(ranges_result),
+                "ranges_start": ranges_result[0].start,
+                "ranges_length": ranges_result[0].length,
+                "ranges_origin": origin_to_str(ranges_result[0].source.origin),
+            }
+        )
+        response.set_cookie(key="insecure", value="", secure=False, httponly=True, samesite="strict")
+
+        return response
+
+    with override_global_config(dict(_iast_enabled=True, _deduplication_enabled=False)), override_env(IAST_ENV):
+        _aux_appsec_prepare_tracer(tracer)
+        resp = client.get(
+            "/insecure_cookie/?iast_queryparam=insecure",
+        )
+        assert resp.status_code == 200
+
+        span = test_spans.pop_traces()[0][0]
+        assert span.get_metric(IAST.ENABLED) == 1.0
+
+        loaded = span.get_tag(IAST.JSON)
+        assert loaded is None
+
+
+def test_fasapi_no_http_only_cookie(fastapi_application, client, tracer, test_spans):
+    @fastapi_application.route("/insecure_cookie/", methods=["GET"])
+    def insecure_cookie(request: Request):
+        from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking import origin_to_str
+
+        query_params = request.query_params.get("iast_queryparam")
+        # resp.set_cookie("insecure", "cookie", secure=False, httponly=True, samesite="Strict")
+        ranges_result = get_tainted_ranges(query_params)
+        response = JSONResponse(
+            {
+                "result": query_params,
+                "is_tainted": len(ranges_result),
+                "ranges_start": ranges_result[0].start,
+                "ranges_length": ranges_result[0].length,
+                "ranges_origin": origin_to_str(ranges_result[0].source.origin),
+            }
+        )
+        response.set_cookie(key="insecure", value=query_params, secure=True, httponly=False, samesite="strict")
+
+        return response
+
+    with override_global_config(dict(_iast_enabled=True, _deduplication_enabled=False)), override_env(IAST_ENV):
+        _aux_appsec_prepare_tracer(tracer)
+        resp = client.get(
+            "/insecure_cookie/?iast_queryparam=insecure",
+        )
+        assert resp.status_code == 200
+
+        span = test_spans.pop_traces()[0][0]
+        assert span.get_metric(IAST.ENABLED) == 1.0
+
+        loaded = json.loads(span.get_tag(IAST.JSON))
+        assert loaded["sources"] == []
+        assert len(loaded["vulnerabilities"]) == 1
+        vulnerability = loaded["vulnerabilities"][0]
+        assert vulnerability["type"] == VULN_NO_HTTPONLY_COOKIE
+        assert vulnerability["evidence"] == {"valueParts": [{"value": "insecure"}]}
+        assert "path" not in vulnerability["location"].keys()
+        assert "line" not in vulnerability["location"].keys()
+        assert vulnerability["location"]["spanId"]
+        assert vulnerability["hash"]
+
+
+def test_fasapi_no_http_only_cookie_empty(fastapi_application, client, tracer, test_spans):
+    @fastapi_application.route("/insecure_cookie/", methods=["GET"])
+    def insecure_cookie(request: Request):
+        from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking import origin_to_str
+
+        query_params = request.query_params.get("iast_queryparam")
+        # resp.set_cookie("insecure", "cookie", secure=False, httponly=True, samesite="Strict")
+        ranges_result = get_tainted_ranges(query_params)
+        response = JSONResponse(
+            {
+                "result": query_params,
+                "is_tainted": len(ranges_result),
+                "ranges_start": ranges_result[0].start,
+                "ranges_length": ranges_result[0].length,
+                "ranges_origin": origin_to_str(ranges_result[0].source.origin),
+            }
+        )
+        response.set_cookie(key="insecure", value="", secure=True, httponly=False, samesite="strict")
+
+        return response
+
+    with override_global_config(dict(_iast_enabled=True)), override_env(IAST_ENV):
+        _aux_appsec_prepare_tracer(tracer)
+        resp = client.get(
+            "/insecure_cookie/?iast_queryparam=insecure",
+        )
+        assert resp.status_code == 200
+
+        span = test_spans.pop_traces()[0][0]
+        assert span.get_metric(IAST.ENABLED) == 1.0
+
+        loaded = span.get_tag(IAST.JSON)
+        assert loaded is None
+
+
+def test_fasapi_no_samesite_cookie(fastapi_application, client, tracer, test_spans):
+    @fastapi_application.route("/insecure_cookie/", methods=["GET"])
+    def insecure_cookie(request: Request):
+        from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking import origin_to_str
+
+        query_params = request.query_params.get("iast_queryparam")
+        # resp.set_cookie("insecure", "cookie", secure=False, httponly=True, samesite="Strict")
+        ranges_result = get_tainted_ranges(query_params)
+        response = JSONResponse(
+            {
+                "result": query_params,
+                "is_tainted": len(ranges_result),
+                "ranges_start": ranges_result[0].start,
+                "ranges_length": ranges_result[0].length,
+                "ranges_origin": origin_to_str(ranges_result[0].source.origin),
+            }
+        )
+        response.set_cookie(key="insecure", value=query_params, secure=True, httponly=True, samesite="none")
+
+        return response
+
+    with override_global_config(dict(_iast_enabled=True, _deduplication_enabled=False)), override_env(IAST_ENV):
+        _aux_appsec_prepare_tracer(tracer)
+        resp = client.get(
+            "/insecure_cookie/?iast_queryparam=insecure",
+        )
+        assert resp.status_code == 200
+
+        span = test_spans.pop_traces()[0][0]
+        assert span.get_metric(IAST.ENABLED) == 1.0
+
+        loaded = json.loads(span.get_tag(IAST.JSON))
+        assert loaded["sources"] == []
+        assert len(loaded["vulnerabilities"]) == 1
+        vulnerability = loaded["vulnerabilities"][0]
+        assert vulnerability["type"] == VULN_NO_SAMESITE_COOKIE
+        assert vulnerability["evidence"] == {"valueParts": [{"value": "insecure"}]}
+        assert "path" not in vulnerability["location"].keys()
+        assert "line" not in vulnerability["location"].keys()
+        assert vulnerability["location"]["spanId"]
+        assert vulnerability["hash"]


### PR DESCRIPTION
This PR adds support for detecting cookies that are not marked as secure, are not using the HttpOnly mark, or are not using one of the secure options of the Samesite= setting

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
