### PR TITLE
tracing: add span links for batch messaging operations

### DIFF
--- a/ddtrace/_trace/utils.py
+++ b/ddtrace/_trace/utils.py
@@ -4,12 +4,11 @@ from ddtrace.propagation.http import HTTPPropagator
 
 
 def extract_DD_context_from_messages(messages, extract_from_message: Callable):
-    ctx = None
-    if len(messages) >= 1:
-        message = messages[0]
+    contexts = []
+    for message in messages:
         context_json = extract_from_message(message)
         if context_json is not None:
-            child_of = HTTPPropagator.extract(context_json)
-            if child_of.trace_id is not None:
-                ctx = child_of
-    return ctx
+            ctx = HTTPPropagator.extract(context_json)
+            if ctx.trace_id is not None:
+                contexts.append(ctx)
+    return contexts

--- a/ddtrace/contrib/internal/botocore/patch.py
+++ b/ddtrace/contrib/internal/botocore/patch.py
@@ -243,7 +243,7 @@ def patched_api_call_fallback(original_func, instance, args, kwargs, function_va
         span_key="instrumented_api_call",
     ) as ctx, ctx.span:
         core.dispatch("botocore.patched_api_call.started", [ctx])
-        if args and config.botocore["distributed_tracing"]:
+        if args and (config.botocore["distributed_tracing"] or config.botocore.span_links_enabled):
             prep_context_injection(ctx, endpoint_name, operation, trace_operation, params)
 
         try:

--- a/ddtrace/contrib/internal/botocore/patch.py
+++ b/ddtrace/contrib/internal/botocore/patch.py
@@ -104,6 +104,7 @@ config._add(
         "empty_poll_enabled": asbool(os.getenv("DD_BOTOCORE_EMPTY_POLL_ENABLED", default=True)),
         "dynamodb_primary_key_names_for_tables": _load_dynamodb_primary_key_names_for_tables(),
         "add_span_pointers": asbool(os.getenv("DD_BOTOCORE_ADD_SPAN_POINTERS", default=True)),
+        "span_links_enabled": asbool(os.getenv("DD_BOTOCORE_ADD_SPAN_POINTERS", default=config._span_links_enabled)),
     },
 )
 

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -687,3 +687,16 @@ def _convert_to_string(attr):
         else:
             return ensure_text(attr)
     return attr
+
+
+def extract_context_and_set_span_links(messages, getter, span):
+    for message in messages:
+        ctx = HTTPPropagator.extract(dict(getter(message)))
+
+        if ctx.trace_id and ctx.span_id:
+            span.link_span(ctx)
+            log.debug(
+                "Successfully linked span %d to context with span id %d.",
+                span.span_id,
+                ctx.span_id,
+            )

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -621,6 +621,7 @@ class Config(object):
         self._inject_force = _get_config("DD_INJECT_FORCE", False, asbool)
         self._lib_was_injected = False
         self._inject_was_attempted = _get_config("_DD_INJECT_WAS_ATTEMPTED", False, asbool)
+        self._span_links_enabled = _get_config("DD_TRACE_SPAN_LINKS_ENABLED", True, asbool)
 
     def __getattr__(self, name) -> Any:
         if name in self._DEPRECATED_ATTRS:


### PR DESCRIPTION
## Motivation

Span links are generally available. Given that span links do not modify the trace structure (unlike parent-child propagation), we should be able to add links to any messaging consumer spans by default if a context is found in the message without this being a breaking change. We should also always inject tracing context (possibly with an explicit option to turn off injection to save bytes through queues), since our ideal state is to always connect distributed contexts.

Pros of this PR:
- Distributed context is always maintained on a consumer trace (if available), allowing users to follow a consume trace upstream
- No-Touch solution: No need for setting `DD_[INTEGRATION]_PROPAGATION_ENABLED` (many integrations where propagation was added later rely on this config as enabling by default is a breaking change, such as Kafka and AWS). Also, a [quick github search](https://github.com/search?q=DD_KAFKA_PROPAGATION_ENABLED&type=code) shows 0 github repositories outside of Datadog using this setting for Kafka python.
- Wider use-cases than parent-child propagation: Span links allow us to support distributed contexts for Fan-in and Fan-Out scenarios which previously were not supportable
- On the consumer side of things, I see no risks in always using Span Links by default. Even if the consumer is also using parent-child propagation, there is no harm in also setting a link to the producer span.

Cons of this PR:
- Span Links are only useful if trace context is injected to the carrier. Many integrations are configured to not currently inject context by default, is it a breaking change to change them to always inject?
- More bytes through messaging queues if we always inject, users may complain

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
