### PR TITLE
fix(ci_visibility): avoid git tracebacks when .git dir is absent

### DIFF
--- a/ddtrace/internal/ci_visibility/git_client.py
+++ b/ddtrace/internal/ci_visibility/git_client.py
@@ -151,6 +151,18 @@ class CIVisibilityGitClient(object):
         return self._metadata_upload_status.value  # type: ignore
 
     @classmethod
+    def _get_git_dir(cls, cwd=None):
+        # type: (Optional[str]) -> Optional[str]
+        if cwd is None:
+            cwd = os.getcwd()
+
+        git_dir = os.path.join(cwd, ".git")
+        if not os.path.exists(git_dir):
+            return None
+
+        return git_dir
+
+    @classmethod
     def _run_protocol(
         cls,
         serializer,  # CIVisibilityGitClientSerializerV1
@@ -166,6 +178,11 @@ class CIVisibilityGitClient(object):
         log.setLevel(log_level)
         _metadata_upload_status.value = METADATA_UPLOAD_STATUS.IN_PROCESS
         try:
+            if not cls._get_git_dir(cwd=cwd):
+                log.debug("Missing .git directory; skipping git metadata upload")
+                _metadata_upload_status.value = METADATA_UPLOAD_STATUS.FAILED
+                return
+
             if _tags is None:
                 _tags = {}
             repo_url = cls._get_repository_url(tags=_tags, cwd=cwd)

--- a/tests/ci_visibility/test_ci_visibility.py
+++ b/tests/ci_visibility/test_ci_visibility.py
@@ -843,6 +843,15 @@ class TestUploadGitMetadata:
             git_client.upload_git_metadata()
             assert git_client.wait_for_metadata_upload_status() == METADATA_UPLOAD_STATUS.UNNECESSARY
 
+    @pytest.mark.parametrize("api_key, requests_mode", api_key_requests_mode_parameters)
+    def test_upload_git_metadata_upload_no_git_dir(self, api_key, requests_mode):
+        with mock.patch.object(CIVisibilityGitClient, "_get_git_dir", mock.Mock(return_value=None)):
+            git_client = CIVisibilityGitClient(api_key, requests_mode)
+            git_client.upload_git_metadata()
+
+            # Notably, this should _not_ raise ValueError
+            assert git_client.wait_for_metadata_upload_status() == METADATA_UPLOAD_STATUS.FAILED
+
 
 def test_get_filtered_revisions():
     with mock.patch(


### PR DESCRIPTION
Fixes #10983.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
  - **TODO**
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
