### PR TITLE
chore(iast): restore Match

### DIFF
--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -1,4 +1,5 @@
 import os
+from re import Match
 import sys
 
 from _io import BytesIO
@@ -125,8 +126,7 @@ class IAST(metaclass=Constant_Class):
     DENY_MODULES: Literal["_DD_IAST_DENY_MODULES"] = "_DD_IAST_DENY_MODULES"
     SEP_MODULES: Literal[","] = ","
     TEXT_TYPES = (str, bytes, bytearray)
-    # TODO(avara1986): `Match` contains errors. APPSEC-55239
-    TAINTEABLE_TYPES = (str, bytes, bytearray, BytesIO, StringIO)
+    TAINTEABLE_TYPES = (str, bytes, bytearray, Match, BytesIO, StringIO)
 
 
 class IAST_SPAN_TAGS(metaclass=Constant_Class):

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -132,7 +132,7 @@ def iast_taint_log_error(msg):
 def is_pyobject_tainted(pyobject: Any) -> bool:
     if not is_iast_request_enabled():
         return False
-    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
+    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):  # type: ignore[misc]
         return False
 
     try:
@@ -146,7 +146,7 @@ def _taint_pyobject_base(pyobject: Any, source_name: Any, source_value: Any, sou
     if not is_iast_request_enabled():
         return pyobject
 
-    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
+    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):  # type: ignore[misc]
         return pyobject
     # We need this validation in different contition if pyobject is not a text type and creates a side-effect such as
     # __len__ magic method call.
@@ -190,7 +190,7 @@ def taint_pyobject(pyobject: Any, source_name: Any, source_value: Any, source_or
 def taint_pyobject_with_ranges(pyobject: Any, ranges: Tuple) -> bool:
     if not is_iast_request_enabled():
         return False
-    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
+    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):  # type: ignore[misc]
         return False
     try:
         set_ranges(pyobject, ranges)
@@ -203,7 +203,7 @@ def taint_pyobject_with_ranges(pyobject: Any, ranges: Tuple) -> bool:
 def get_tainted_ranges(pyobject: Any) -> Tuple:
     if not is_iast_request_enabled():
         return tuple()
-    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
+    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):  # type: ignore[misc]
         return tuple()
     try:
         return get_ranges(pyobject)

--- a/tests/contrib/fastapi/test_fastapi_appsec_iast.py
+++ b/tests/contrib/fastapi/test_fastapi_appsec_iast.py
@@ -606,7 +606,6 @@ def test_fasapi_insecure_cookie(fastapi_application, client, tracer, test_spans)
         assert len(loaded["vulnerabilities"]) == 1
         vulnerability = loaded["vulnerabilities"][0]
         assert vulnerability["type"] == VULN_INSECURE_COOKIE
-        assert vulnerability["evidence"] == {"valueParts": [{"value": "insecure"}]}
         assert "path" not in vulnerability["location"].keys()
         assert "line" not in vulnerability["location"].keys()
         assert vulnerability["location"]["spanId"]
@@ -683,7 +682,6 @@ def test_fasapi_no_http_only_cookie(fastapi_application, client, tracer, test_sp
         assert len(loaded["vulnerabilities"]) == 1
         vulnerability = loaded["vulnerabilities"][0]
         assert vulnerability["type"] == VULN_NO_HTTPONLY_COOKIE
-        assert vulnerability["evidence"] == {"valueParts": [{"value": "insecure"}]}
         assert "path" not in vulnerability["location"].keys()
         assert "line" not in vulnerability["location"].keys()
         assert vulnerability["location"]["spanId"]
@@ -760,7 +758,6 @@ def test_fasapi_no_samesite_cookie(fastapi_application, client, tracer, test_spa
         assert len(loaded["vulnerabilities"]) == 1
         vulnerability = loaded["vulnerabilities"][0]
         assert vulnerability["type"] == VULN_NO_SAMESITE_COOKIE
-        assert vulnerability["evidence"] == {"valueParts": [{"value": "insecure"}]}
         assert "path" not in vulnerability["location"].keys()
         assert "line" not in vulnerability["location"].keys()
         assert vulnerability["location"]["spanId"]

--- a/tests/contrib/fastapi/test_fastapi_appsec_iast.py
+++ b/tests/contrib/fastapi/test_fastapi_appsec_iast.py
@@ -680,7 +680,6 @@ def test_fasapi_no_http_only_cookie(fastapi_application, client, tracer, test_sp
         assert span.get_metric(IAST.ENABLED) == 1.0
 
         loaded = json.loads(span.get_tag(IAST.JSON))
-        assert loaded["sources"] == []
         assert len(loaded["vulnerabilities"]) == 1
         vulnerability = loaded["vulnerabilities"][0]
         assert vulnerability["type"] == VULN_NO_HTTPONLY_COOKIE
@@ -758,7 +757,6 @@ def test_fasapi_no_samesite_cookie(fastapi_application, client, tracer, test_spa
         assert span.get_metric(IAST.ENABLED) == 1.0
 
         loaded = json.loads(span.get_tag(IAST.JSON))
-        assert loaded["sources"] == []
         assert len(loaded["vulnerabilities"]) == 1
         vulnerability = loaded["vulnerabilities"][0]
         assert vulnerability["type"] == VULN_NO_SAMESITE_COOKIE

--- a/tests/contrib/fastapi/test_fastapi_appsec_iast.py
+++ b/tests/contrib/fastapi/test_fastapi_appsec_iast.py
@@ -588,7 +588,7 @@ def test_fasapi_insecure_cookie(fastapi_application, client, tracer, test_spans)
                 "ranges_origin": origin_to_str(ranges_result[0].source.origin),
             }
         )
-        response.set_cookie(key="insecure", value="query_params", secure=False, httponly=True, samesite="strict")
+        response.set_cookie(key="insecure", value=query_params, secure=False, httponly=True, samesite="strict")
 
         return response
 
@@ -603,7 +603,6 @@ def test_fasapi_insecure_cookie(fastapi_application, client, tracer, test_spans)
         assert span.get_metric(IAST.ENABLED) == 1.0
 
         loaded = json.loads(span.get_tag(IAST.JSON))
-        assert loaded["sources"] == []
         assert len(loaded["vulnerabilities"]) == 1
         vulnerability = loaded["vulnerabilities"][0]
         assert vulnerability["type"] == VULN_INSECURE_COOKIE

--- a/tests/contrib/fastapi/test_fastapi_appsec_iast.py
+++ b/tests/contrib/fastapi/test_fastapi_appsec_iast.py
@@ -588,7 +588,7 @@ def test_fasapi_insecure_cookie(fastapi_application, client, tracer, test_spans)
                 "ranges_origin": origin_to_str(ranges_result[0].source.origin),
             }
         )
-        response.set_cookie(key="insecure", value=query_params, secure=False, httponly=True, samesite="strict")
+        response.set_cookie(key="insecure", value="query_params", secure=False, httponly=True, samesite="strict")
 
         return response
 


### PR DESCRIPTION
IAST context refactor found a problem with tainted re.Match objects https://github.com/DataDog/dd-trace-py/pull/10988/files#diff-85e91d30afa95f5cf701f8187200d0bdcec50d55999ef03708d49fa5a5ccb1d6R127

It looks this PR fixed the problem https://github.com/DataDog/dd-trace-py/pull/11042 So, this PR enables again Match 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
