### PR TITLE
fix(di): use enum value for evaluate_at property

### DIFF
--- a/ddtrace/debugging/_probe/remoteconfig.py
+++ b/ddtrace/debugging/_probe/remoteconfig.py
@@ -24,6 +24,7 @@ from ddtrace.debugging._probe.model import LogLineProbe
 from ddtrace.debugging._probe.model import MetricFunctionProbe
 from ddtrace.debugging._probe.model import MetricLineProbe
 from ddtrace.debugging._probe.model import Probe
+from ddtrace.debugging._probe.model import ProbeEvaluateTimingForMethod
 from ddtrace.debugging._probe.model import ProbeType
 from ddtrace.debugging._probe.model import SpanDecoration
 from ddtrace.debugging._probe.model import SpanDecorationFunctionProbe
@@ -102,7 +103,7 @@ class ProbeFactory(object):
 
         args["module"] = where.get("type") or where["typeName"]
         args["func_qname"] = where.get("method") or where["methodName"]
-        args["evaluate_at"] = attribs.get("evaluateAt")
+        args["evaluate_at"] = ProbeEvaluateTimingForMethod[attribs.get("evaluateAt", "DEFAULT")]
 
         return cls.__function_class__(**args)
 

--- a/releasenotes/notes/fix-span-decoration-probe-timing-dc4ce0664fa645b9.yaml
+++ b/releasenotes/notes/fix-span-decoration-probe-timing-dc4ce0664fa645b9.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: Fixes an issue that prevented dynamic span tags
+    probes from adding the requested tags to the requested span.


### PR DESCRIPTION
We make sure that we get the value from the enum for the evaluate_at property so that proper validation and comparison can be performed. Currently, the timing value is stored as a plain string, whereas the logic that handles them expects one of the possible enum values, thus making the check fail always.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
