### PR TITLE
chore(ci): bump riot version and pin virtualenv==20.26.6 for hatch use with python3.7 [2.11]

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -80,7 +80,7 @@ commands:
     description: "Install riot"
     steps:
       # Make sure we install and run riot on Python 3
-      - run: pip3 install riot==0.19.1
+      - run: pip3 install riot==0.20.0
 
   setup_rust:
     description: "Install rust toolchain"

--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -91,7 +91,7 @@ commands:
   setup_hatch:
     description: "Install hatch"
     steps:
-      - run: pip3 install hatch~=1.8.0 hatch-containers==0.7.0
+      - run: pip3 install hatch~=1.8.0 hatch-containers==0.7.0 virtualenv==20.26.6
 
   start_docker_services:
     description: "Start Docker services"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: Generate config
           command: |
             export GIT_COMMIT_DESC=$(git log -n 1 $CIRCLE_SHA1)
-            pip3 install riot==0.19.1
+            pip3 install riot==0.20.0
             riot -P -v run --pass-env -s circleci-gen-config -- -v
       - continuation/continue:
           configuration_path: .circleci/config.gen.yml

--- a/.github/workflows/requirements-locks.yml
+++ b/.github/workflows/requirements-locks.yml
@@ -23,7 +23,7 @@ jobs:
         run: pyenv global 3.10 3.7 3.8 3.9 3.11 3.12
 
       - name: Install Dependencies
-        run: pip install --upgrade pip && pip install riot
+        run: pip install --upgrade pip && pip install riot==0.20.0
 
       - name: Generate riot locks
         run: scripts/compile-and-prune-test-requirements

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -40,5 +40,8 @@ jobs:
       - name: Install hatch
         run: pip install hatch
 
+      - name: Install virtualenv
+        run: pip install virtualenv==20.26.6
+
       - name: Run tests
         run: hatch run ddtrace_unit_tests:test

--- a/hatch.toml
+++ b/hatch.toml
@@ -182,7 +182,6 @@ dependencies = [
     "hypothesis",
     "django{matrix:django}",
     "virtualenv<20.27.0", # python 3.7 support dropped in 20.27.0
-    "typing-extensions==3.7.4"
 ]
 
 [envs.appsec_threats_django.scripts]
@@ -229,7 +228,6 @@ dependencies = [
     "Werkzeug{matrix:werkzeug:}",
     "flask{matrix:flask}",
     "virtualenv<20.27.0", # python 3.7 support dropped in 20.27.0
-    "typing-extensions==3.7.4"
 ]
 
 [envs.appsec_threats_flask.scripts]
@@ -273,7 +271,6 @@ dependencies = [
     "anyio{matrix:anyio:}",
     "fastapi{matrix:fastapi}",
     "virtualenv<20.27.0", # python 3.7 support dropped in 20.27.0
-    "typing-extensions==3.7.4"
 ]
 
 [envs.appsec_threats_fastapi.scripts]
@@ -308,8 +305,6 @@ dependencies = [
     "requests",
     "hypothesis",
     "virtualenv<20.27.0", # python 3.7 support dropped in 20.27.0
-    "typing-extensions==3.7.4"
-
 ]
 
 [envs.ddtrace_unit_tests.env-vars]

--- a/hatch.toml
+++ b/hatch.toml
@@ -181,7 +181,6 @@ dependencies = [
     "requests",
     "hypothesis",
     "django{matrix:django}",
-    "virtualenv<20.27.0", # python 3.7 support dropped in 20.27.0
 ]
 
 [envs.appsec_threats_django.scripts]
@@ -227,7 +226,6 @@ dependencies = [
     "MarkupSafe{matrix:markupsafe:}",
     "Werkzeug{matrix:werkzeug:}",
     "flask{matrix:flask}",
-    "virtualenv<20.27.0", # python 3.7 support dropped in 20.27.0
 ]
 
 [envs.appsec_threats_flask.scripts]
@@ -270,7 +268,6 @@ dependencies = [
     "httpx",
     "anyio{matrix:anyio:}",
     "fastapi{matrix:fastapi}",
-    "virtualenv<20.27.0", # python 3.7 support dropped in 20.27.0
 ]
 
 [envs.appsec_threats_fastapi.scripts]
@@ -304,7 +301,6 @@ dependencies = [
     "pytest-cov",
     "requests",
     "hypothesis",
-    "virtualenv<20.27.0", # python 3.7 support dropped in 20.27.0
 ]
 
 [envs.ddtrace_unit_tests.env-vars]

--- a/hatch.toml
+++ b/hatch.toml
@@ -180,7 +180,7 @@ dependencies = [
     "pytest-cov",
     "requests",
     "hypothesis",
-    "django{matrix:django}",
+    "django{matrix:django}"
 ]
 
 [envs.appsec_threats_django.scripts]
@@ -225,7 +225,7 @@ dependencies = [
     "hypothesis",
     "MarkupSafe{matrix:markupsafe:}",
     "Werkzeug{matrix:werkzeug:}",
-    "flask{matrix:flask}",
+    "flask{matrix:flask}"
 ]
 
 [envs.appsec_threats_flask.scripts]
@@ -267,7 +267,7 @@ dependencies = [
     "hypothesis",
     "httpx",
     "anyio{matrix:anyio:}",
-    "fastapi{matrix:fastapi}",
+    "fastapi{matrix:fastapi}"
 ]
 
 [envs.appsec_threats_fastapi.scripts]

--- a/hatch.toml
+++ b/hatch.toml
@@ -182,6 +182,7 @@ dependencies = [
     "hypothesis",
     "django{matrix:django}",
     "virtualenv<20.27.0", # python 3.7 support dropped in 20.27.0
+    "typing-extensions==3.7.4"
 ]
 
 [envs.appsec_threats_django.scripts]
@@ -228,6 +229,7 @@ dependencies = [
     "Werkzeug{matrix:werkzeug:}",
     "flask{matrix:flask}",
     "virtualenv<20.27.0", # python 3.7 support dropped in 20.27.0
+    "typing-extensions==3.7.4"
 ]
 
 [envs.appsec_threats_flask.scripts]
@@ -271,6 +273,7 @@ dependencies = [
     "anyio{matrix:anyio:}",
     "fastapi{matrix:fastapi}",
     "virtualenv<20.27.0", # python 3.7 support dropped in 20.27.0
+    "typing-extensions==3.7.4"
 ]
 
 [envs.appsec_threats_fastapi.scripts]
@@ -305,6 +308,8 @@ dependencies = [
     "requests",
     "hypothesis",
     "virtualenv<20.27.0", # python 3.7 support dropped in 20.27.0
+    "typing-extensions==3.7.4"
+
 ]
 
 [envs.ddtrace_unit_tests.env-vars]

--- a/hatch.toml
+++ b/hatch.toml
@@ -22,7 +22,7 @@ dependencies = [
     "ddapm-test-agent>=1.2.0",
     "packaging==23.1",
     "pygments==2.16.1",
-    "riot==0.19.1",
+    "riot==0.20.0",
     "ruff==0.1.3",
     "clang-format==18.1.5",
 ]

--- a/hatch.toml
+++ b/hatch.toml
@@ -180,7 +180,8 @@ dependencies = [
     "pytest-cov",
     "requests",
     "hypothesis",
-    "django{matrix:django}"
+    "django{matrix:django}",
+    "virtualenv<20.27.0", # python 3.7 support dropped in 20.27.0
 ]
 
 [envs.appsec_threats_django.scripts]
@@ -225,7 +226,8 @@ dependencies = [
     "hypothesis",
     "MarkupSafe{matrix:markupsafe:}",
     "Werkzeug{matrix:werkzeug:}",
-    "flask{matrix:flask}"
+    "flask{matrix:flask}",
+    "virtualenv<20.27.0", # python 3.7 support dropped in 20.27.0
 ]
 
 [envs.appsec_threats_flask.scripts]
@@ -267,7 +269,8 @@ dependencies = [
     "hypothesis",
     "httpx",
     "anyio{matrix:anyio:}",
-    "fastapi{matrix:fastapi}"
+    "fastapi{matrix:fastapi}",
+    "virtualenv<20.27.0", # python 3.7 support dropped in 20.27.0
 ]
 
 [envs.appsec_threats_fastapi.scripts]
@@ -301,6 +304,7 @@ dependencies = [
     "pytest-cov",
     "requests",
     "hypothesis",
+    "virtualenv<20.27.0", # python 3.7 support dropped in 20.27.0
 ]
 
 [envs.ddtrace_unit_tests.env-vars]

--- a/scripts/ddtest
+++ b/scripts/ddtest
@@ -12,8 +12,7 @@ fi
 # retry docker pull if fails
 for i in {1..3}; do docker-compose pull -q testrunner && break || sleep 3; done
 
-# TODO(DEV): Install riot in the docker image
-FULL_CMD="pip install -q --disable-pip-version-check riot==0.20.0 && $CMD"
+FULL_CMD="pip install -q --disable-pip-version-check riot==0.20.0 hatch && $CMD"
 
 
 # install and upgrade riot in case testrunner image has not been updated

--- a/scripts/ddtest
+++ b/scripts/ddtest
@@ -12,7 +12,8 @@ fi
 # retry docker pull if fails
 for i in {1..3}; do docker-compose pull -q testrunner && break || sleep 3; done
 
-FULL_CMD="pip install -q --disable-pip-version-check riot==0.19.1 hatch && $CMD"
+# TODO(DEV): Install riot in the docker image
+FULL_CMD="pip install -q --disable-pip-version-check riot==0.20.0 && $CMD"
 
 
 # install and upgrade riot in case testrunner image has not been updated

--- a/scripts/ddtest
+++ b/scripts/ddtest
@@ -12,7 +12,7 @@ fi
 # retry docker pull if fails
 for i in {1..3}; do docker-compose pull -q testrunner && break || sleep 3; done
 
-FULL_CMD="pip install -q --disable-pip-version-check riot==0.20.0 hatch && $CMD"
+FULL_CMD="pip install -q --disable-pip-version-check riot==0.20.0 hatch~=1.8.0 virtualenv==20.26.6 && $CMD"
 
 
 # install and upgrade riot in case testrunner image has not been updated


### PR DESCRIPTION
This PR is a combination of this backport PR https://github.com/DataDog/dd-trace-py/pull/11085 and an additional `virtualenv` version pinning fix that were required to unblock the CI for the 2.11 release branch.

The reason the original backport PR was not sufficient to fix the CI for 2.11 unlike 2.13+ was because of some discrepancies with CircleCI vs. GitLab. Since 2.11 and 2.12 still run the `appsec_threat_*` tests via CircleCI, it was somehow still using the newer `virtualenv==20.27.0` instead of `virtualenv==20.26.0` that we attempted to pin in the previous backport. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
