### PR TITLE
chore(iast): restore Match tests

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -262,7 +262,7 @@ if _is_iast_propagation_debug_enabled():
 
 def copy_ranges_to_string(s: str, ranges: Sequence[TaintRange]) -> str:
     for r in ranges:
-        if s in r.source.value:
+        if r.source.value and s in r.source.value:
             s = _taint_pyobject_base(
                 pyobject=s, source_name=r.source.name, source_value=r.source.value, source_origin=r.source.origin
             )

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -261,6 +261,8 @@ if _is_iast_propagation_debug_enabled():
 
 
 def copy_ranges_to_string(s: str, ranges: Sequence[TaintRange]) -> str:
+    if not isinstance(s, IAST.TAINTEABLE_TYPES):  # type: ignore[misc]
+        return s
     for r in ranges:
         if r.source.value and s in r.source.value:
             s = _taint_pyobject_base(

--- a/tests/appsec/iast/aspects/test_re_aspects.py
+++ b/tests/appsec/iast/aspects/test_re_aspects.py
@@ -23,10 +23,6 @@ from ddtrace.appsec._iast._taint_tracking.aspects import re_sub_aspect
 from ddtrace.appsec._iast._taint_tracking.aspects import re_subn_aspect
 from ddtrace.appsec._iast._taint_tracking.aspects import split_aspect
 
-
-pytest.skip(reason="TAINTEABLE_TYPES Match contains errors. APPSEC-55239", allow_module_level=True)
-
-
 def test_re_findall_aspect_tainted_string():
     tainted_foobarbaz = taint_pyobject(
         pyobject="/foo/bar/baaz.jpeg",

--- a/tests/appsec/iast/aspects/test_re_aspects.py
+++ b/tests/appsec/iast/aspects/test_re_aspects.py
@@ -23,6 +23,7 @@ from ddtrace.appsec._iast._taint_tracking.aspects import re_sub_aspect
 from ddtrace.appsec._iast._taint_tracking.aspects import re_subn_aspect
 from ddtrace.appsec._iast._taint_tracking.aspects import split_aspect
 
+
 def test_re_findall_aspect_tainted_string():
     tainted_foobarbaz = taint_pyobject(
         pyobject="/foo/bar/baaz.jpeg",
@@ -577,8 +578,9 @@ def test_re_finditer_aspect_tainted_bytes():
     res_iterator = re_finditer_aspect(None, 1, OPTION_RE, tainted_multipart)
     assert isinstance(res_iterator, typing.Iterator), f"res_iterator is of type {type(res_iterator)}"
 
-    for i in res_no_tainted:
-        assert i.group(0) == b'; filename="test.txt"'
+    res_list = list(res_no_tainted)
+    assert res_list[0].group(0) == b' name="files"'
+    assert res_list[1].group(0) == b'; filename="test.txt"'
 
     try:
         tainted_item = next(res_iterator)


### PR DESCRIPTION
IAST context refactor found a problem with tainted re.Match objects https://github.com/DataDog/dd-trace-py/pull/10988/files#diff-85e91d30afa95f5cf701f8187200d0bdcec50d55999ef03708d49fa5a5ccb1d6R127

It looks this PR fixed the problem https://github.com/DataDog/dd-trace-py/pull/11042 So, this PR enables again Match 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
