### PR TITLE
chore(llmobs): fix faithfulness evaluator behavior on process exit

### DIFF
--- a/ddtrace/llmobs/_evaluators/ragas/faithfulness.py
+++ b/ddtrace/llmobs/_evaluators/ragas/faithfulness.py
@@ -107,7 +107,7 @@ class RagasFaithfulnessEvaluator:
         if not span_event:
             return
         score_result = self.evaluate(span_event)
-        if score_result:
+        if score_result is not None:
             self.llmobs_service.submit_evaluation(
                 span_context={"trace_id": span_event.get("trace_id"), "span_id": span_event.get("span_id")},
                 label=RagasFaithfulnessEvaluator.LABEL,

--- a/ddtrace/llmobs/_evaluators/runner.py
+++ b/ddtrace/llmobs/_evaluators/runner.py
@@ -72,9 +72,6 @@ class EvaluatorRunner(PeriodicService):
         """
         self.periodic(_wait_sync=True)
         self.executor.shutdown(wait=True)
-        # flush remaining evaluation spans & evaluations
-        self.llmobs_service._instance._llmobs_span_writer.periodic()
-        self.llmobs_service._instance._llmobs_eval_metric_writer.periodic()
 
     def recreate(self) -> "EvaluatorRunner":
         return self.__class__(

--- a/ddtrace/llmobs/_evaluators/runner.py
+++ b/ddtrace/llmobs/_evaluators/runner.py
@@ -1,11 +1,9 @@
-import atexit
 from concurrent import futures
 import os
 from typing import Dict
 
 from ddtrace import Span
 from ddtrace.internal import forksafe
-from ddtrace.internal import service
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.periodic import PeriodicService
 from ddtrace.llmobs._evaluators.sampler import EvaluatorRunnerSampler
@@ -66,12 +64,14 @@ class EvaluatorRunner(PeriodicService):
             return
         super(EvaluatorRunner, self).start()
         logger.debug("started %r to %r", self.__class__.__name__)
-        atexit.register(self.on_shutdown)
 
-    def stop(self, *args, **kwargs):
-        if self.status == service.ServiceStatus.STOPPED:
-            return
-        super(EvaluatorRunner, self).stop()
+    def _stop_service(self) -> None:
+        """
+        Ensures all spans are evaluated & evaluation metrics are submitted when evaluator runner
+        is stopped by the LLM Obs instance
+        """
+        self.periodic(_wait_syncronously=False)
+        self.executor.shutdown(wait=True)
 
     def recreate(self) -> "EvaluatorRunner":
         return self.__class__(
@@ -79,9 +79,6 @@ class EvaluatorRunner(PeriodicService):
             llmobs_service=self.llmobs_service,
             evaluators=self.evaluators,
         )
-
-    def on_shutdown(self):
-        self.executor.shutdown()
 
     def enqueue(self, span_event: Dict, span: Span) -> None:
         with self._lock:
@@ -92,7 +89,12 @@ class EvaluatorRunner(PeriodicService):
                 return
             self._buffer.append((span_event, span))
 
-    def periodic(self) -> None:
+    def periodic(self, _wait_syncronously=False) -> None:
+        """
+        :param bool _wait_syncronously: if `True`, each evaluator is run for each span in the buffer
+        synchronously. This param is only set to `True` for when the evaluator runner is stopped by the LLM Obs
+        instance on process exit and we want to block until all spans are evaluated and metrics are submitted.
+        """
         with self._lock:
             if not self._buffer:
                 return
@@ -100,17 +102,20 @@ class EvaluatorRunner(PeriodicService):
             self._buffer = []
 
         try:
-            self.run(span_events_and_spans)
+            if not _wait_syncronously:
+                for evaluator in self.evaluators:
+                    self.executor.map(
+                        lambda span_event: evaluator.run_and_submit_evaluation(span_event),
+                        [
+                            span_event
+                            for span_event, span in span_events_and_spans
+                            if self.sampler.sample(evaluator.LABEL, span)
+                        ],
+                    )
+            else:
+                for evaluator in self.evaluators:
+                    for span_event, span in span_events_and_spans:
+                        if self.sampler.sample(evaluator.LABEL, span):
+                            evaluator.run_and_submit_evaluation(span_event)
         except RuntimeError as e:
             logger.debug("failed to run evaluation: %s", e)
-
-    def run(self, span_events_and_spans):
-        for evaluator in self.evaluators:
-            self.executor.map(
-                lambda span: evaluator.run_and_submit_evaluation(span),
-                [
-                    span_event
-                    for span_event, span in span_events_and_spans
-                    if self.sampler.sample(evaluator.LABEL, span)
-                ],
-            )

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -158,9 +158,6 @@ class LLMObs(Service):
     def _stop_service(self) -> None:
         try:
             self._evaluator_runner.stop()
-            # flush evaluation spans & evaluations
-            self._llmobs_span_writer.periodic()
-            self._llmobs_eval_metric_writer.periodic()
         except ServiceStatusError:
             log.debug("Error stopping evaluator runner")
 

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -158,6 +158,9 @@ class LLMObs(Service):
     def _stop_service(self) -> None:
         try:
             self._evaluator_runner.stop()
+            # flush remaining evaluation spans & evaluations
+            self._instance._llmobs_span_writer.periodic()
+            self._instance._llmobs_eval_metric_writer.periodic()
         except ServiceStatusError:
             log.debug("Error stopping evaluator runner")
 

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -157,15 +157,18 @@ class LLMObs(Service):
 
     def _stop_service(self) -> None:
         try:
+            self._evaluator_runner.stop()
+            # flush evaluation spans & evaluations
+            self._llmobs_span_writer.periodic()
+            self._llmobs_eval_metric_writer.periodic()
+        except ServiceStatusError:
+            log.debug("Error stopping evaluator runner")
+
+        try:
             self._llmobs_span_writer.stop()
             self._llmobs_eval_metric_writer.stop()
         except ServiceStatusError:
             log.debug("Error stopping LLMObs writers")
-
-        try:
-            self._evaluator_runner.stop()
-        except ServiceStatusError:
-            log.debug("Error stopping evaluator runner")
 
         try:
             forksafe.unregister(self._child_after_fork)
@@ -269,8 +272,8 @@ class LLMObs(Service):
         log.debug("Disabling %s", cls.__name__)
         atexit.unregister(cls.disable)
 
-        cls.enabled = False
         cls._instance.stop()
+        cls.enabled = False
         cls._instance.tracer.deregister_on_start_span(cls._instance._do_annotations)
         telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.LLMOBS, False)
 

--- a/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_evaluator_runner.send_score_metric.yaml
+++ b/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_evaluator_runner.send_score_metric.yaml
@@ -2,7 +2,7 @@ interactions:
 - request:
     body: '{"data": {"type": "evaluation_metric", "attributes": {"metrics": [{"span_id":
       "123", "trace_id": "1234", "label": "dummy", "metric_type": "score", "timestamp_ms":
-      1728480443772, "score_value": 1.0, "ml_app": "unnamed-ml-app", "tags": ["ddtrace.version:2.14.0.dev196+g7cf7989ab",
+      1729569649880, "score_value": 1.0, "ml_app": "unnamed-ml-app", "tags": ["ddtrace.version:2.15.0.dev219+ge047e25bb.d20241022",
       "ml_app:unnamed-ml-app"]}]}}}'
     headers:
       Content-Type:
@@ -13,16 +13,16 @@ interactions:
     uri: https://api.datad0g.com/api/intake/llm-obs/v1/eval-metric
   response:
     body:
-      string: '{"data":{"id":"ccf36d1a-6153-4042-ba2d-a5ec5896a6ac","type":"evaluation_metric","attributes":{"metrics":[{"id":"bYp4oTawxz","trace_id":"1234","span_id":"123","timestamp_ms":1728480443772,"ml_app":"unnamed-ml-app","metric_type":"score","label":"dummy","score_value":1,"tags":["ddtrace.version:2.14.0.dev196+g7cf7989ab","ml_app:unnamed-ml-app"]}]}}}'
+      string: '{"data":{"id":"2131dbc0-d085-401c-8b2d-8506a9ac8c13","type":"evaluation_metric","attributes":{"metrics":[{"id":"YutAyQc6F4","trace_id":"1234","span_id":"123","timestamp_ms":1729569649880,"ml_app":"unnamed-ml-app","metric_type":"score","label":"dummy","score_value":1,"tags":["ddtrace.version:2.15.0.dev219+ge047e25bb.d20241022","ml_app:unnamed-ml-app"]}]}}}'
     headers:
       content-length:
-      - '347'
+      - '357'
       content-security-policy:
       - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub293163a918901030b79492fe1ab424cf&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatad0g.com
       content-type:
       - application/vnd.api+json
       date:
-      - Wed, 09 Oct 2024 13:27:25 GMT
+      - Tue, 22 Oct 2024 04:00:50 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       vary:

--- a/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_ragas_faithfulness_evaluator.emits_traces_and_evaluations_on_exit
+++ b/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_ragas_faithfulness_evaluator.emits_traces_and_evaluations_on_exit
@@ -1,0 +1,315 @@
+interactions:
+- request:
+    body: '{"messages": [{"content": "Given a question, an answer, and sentences from
+      the answer analyze the complexity of each sentence given under ''sentences''
+      and break down each sentence into one or more fully understandable statements
+      while also ensuring no pronouns are used in each statement. Format the outputs
+      in JSON.\n\nThe output should be a well-formatted JSON instance that conforms
+      to the JSON schema below.\n\nAs an example, for the schema {\"properties\":
+      {\"foo\": {\"title\": \"Foo\", \"description\": \"a list of strings\", \"type\":
+      \"array\", \"items\": {\"type\": \"string\"}}}, \"required\": [\"foo\"]}\nthe
+      object {\"foo\": [\"bar\", \"baz\"]} is a well-formatted instance of the schema.
+      The object {\"properties\": {\"foo\": [\"bar\", \"baz\"]}} is not well-formatted.\n\nHere
+      is the output JSON schema:\n```\n{\"type\": \"array\", \"items\": {\"$ref\":
+      \"#/definitions/Statements\"}, \"definitions\": {\"Statements\": {\"title\":
+      \"Statements\", \"type\": \"object\", \"properties\": {\"sentence_index\": {\"title\":
+      \"Sentence Index\", \"description\": \"Index of the sentence from the statement
+      list\", \"type\": \"integer\"}, \"simpler_statements\": {\"title\": \"Simpler
+      Statements\", \"description\": \"the simpler statements\", \"type\": \"array\",
+      \"items\": {\"type\": \"string\"}}}, \"required\": [\"sentence_index\", \"simpler_statements\"]}}}\n```\n\nDo
+      not return any preamble or explanations, return only a pure JSON string surrounded
+      by triple backticks (```).\n\nExamples:\n\nquestion: \"Who was Albert Einstein
+      and what is he best known for?\"\nanswer: \"He was a German-born theoretical
+      physicist, widely acknowledged to be one of the greatest and most influential
+      physicists of all time. He was best known for developing the theory of relativity,
+      he also made important contributions to the development of the theory of quantum
+      mechanics.\"\nsentences: \"\\n        0:He was a German-born theoretical physicist,
+      widely acknowledged to be one of the greatest and most influential physicists
+      of all time. \\n        1:He was best known for developing the theory of relativity,
+      he also made important contributions to the development of the theory of quantum
+      mechanics.\\n        \"\nanalysis: ```[{\"sentence_index\": 0, \"simpler_statements\":
+      [\"Albert Einstein was a German-born theoretical physicist.\", \"Albert Einstein
+      is recognized as one of the greatest and most influential physicists of all
+      time.\"]}, {\"sentence_index\": 1, \"simpler_statements\": [\"Albert Einstein
+      was best known for developing the theory of relativity.\", \"Albert Einstein
+      also made important contributions to the development of the theory of quantum
+      mechanics.\"]}]```\n\nYour actual task:\n\nquestion: \"What is the capital of
+      France?\"\nanswer: \"The capital of France is Paris\"\nsentences: \"\"\nanalysis:
+      \n", "role": "user"}], "model": "gpt-4o-mini", "n": 1, "stream": false, "temperature":
+      1e-08}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '2919'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.52.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.52.0
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.13
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA2yRwW7bMBBE7/oKYs9WICuOlfjWS9oAbdCiRS+WIdHUSmJCkSx33TYw/O8FZcV2
+        kVx4mOE87iz3iRCgG1gJUL1kNXiTfvic6edf+ePL9T09fXn4k30qvt1+/P7z4XHxG2EWE277hIpf
+        U1fKDd4ga2ePtgooGSN1XuR3N8U8y/PRGFyDJsY6z+nCpYO2Os2zfJFmRTq/ndK90woJVmKdCCHE
+        fjzjnLbBv7AS2exVGZBIdgir0yUhIDgTFZBEmlhahtnZVM4y2nH0uq7X+xIIo6KwGvHlyBclkI6d
+        QkUsGQe0TNFal/CjR6Gk1yyNcK24D9IqFJrEVxk0XZWwOWzqur58NGC7IxmL250xk344tTCu88Ft
+        afJPequtpr4KKMnZODGx8zC6h0SIzbit3X8LAB/c4Lli94w2ApfZ/MiD8yed3Xw5mexYmotUXsze
+        4VUNstSGLvYNSqoem3M0Sy7KvX30PcSxoLbdG0oykYBeiHGoWm07DD7o4w+2vsJ82+DNNS4RkkPy
+        DwAA//8DAOKY+kfPAgAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8d66b6a96ad219e3-EWR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Oct 2024 04:23:42 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=TwJWv0VlFgYhSrHloW8LdJ6JUNJWbQ9nkeRO3_WDNVU-1729571022-1.0.1.1-NvYdRul3AN.8E0RonkQqN1EYZ63N75lmFZwCtTThtEFA7TlZd4qTQuFWhhY1nqk2gCPiNUiLS7VGYB1sUpkHsg;
+        path=/; expires=Tue, 22-Oct-24 04:53:42 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=byA2EoT_oWDpk4tFKSXrkcOdDKdykmZORW7YjDB4dhg-1729571022845-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - datadog-staging
+      openai-processing-ms:
+      - '438'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149999323'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_827abd219d27dfb125b0af8ee2cb37da
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"content": "Your task is to judge the faithfulness of a
+      series of statements based on a given context. For each statement you must return
+      verdict as 1 if the statement can be directly inferred based on the context
+      or 0 if the statement can not be directly inferred based on the context.\n\nThe
+      output should be a well-formatted JSON instance that conforms to the JSON schema
+      below.\n\nAs an example, for the schema {\"properties\": {\"foo\": {\"title\":
+      \"Foo\", \"description\": \"a list of strings\", \"type\": \"array\", \"items\":
+      {\"type\": \"string\"}}}, \"required\": [\"foo\"]}\nthe object {\"foo\": [\"bar\",
+      \"baz\"]} is a well-formatted instance of the schema. The object {\"properties\":
+      {\"foo\": [\"bar\", \"baz\"]}} is not well-formatted.\n\nHere is the output
+      JSON schema:\n```\n{\"type\": \"array\", \"items\": {\"$ref\": \"#/definitions/StatementFaithfulnessAnswer\"},
+      \"definitions\": {\"StatementFaithfulnessAnswer\": {\"title\": \"StatementFaithfulnessAnswer\",
+      \"type\": \"object\", \"properties\": {\"statement\": {\"title\": \"Statement\",
+      \"description\": \"the original statement, word-by-word\", \"type\": \"string\"},
+      \"reason\": {\"title\": \"Reason\", \"description\": \"the reason of the verdict\",
+      \"type\": \"string\"}, \"verdict\": {\"title\": \"Verdict\", \"description\":
+      \"the verdict(0/1) of the faithfulness.\", \"type\": \"integer\"}}, \"required\":
+      [\"statement\", \"reason\", \"verdict\"]}}}\n```\n\nDo not return any preamble
+      or explanations, return only a pure JSON string surrounded by triple backticks
+      (```).\n\nExamples:\n\ncontext: \"John is a student at XYZ University. He is
+      pursuing a degree in Computer Science. He is enrolled in several courses this
+      semester, including Data Structures, Algorithms, and Database Management. John
+      is a diligent student and spends a significant amount of time studying and completing
+      assignments. He often stays late in the library to work on his projects.\"\nstatements:
+      ```[\"John is majoring in Biology.\", \"John is taking a course on Artificial
+      Intelligence.\", \"John is a dedicated student.\", \"John has a part-time job.\"]```\nanswer:
+      ```[{\"statement\": \"John is majoring in Biology.\", \"reason\": \"John''s
+      major is explicitly mentioned as Computer Science. There is no information suggesting
+      he is majoring in Biology.\", \"verdict\": 0}, {\"statement\": \"John is taking
+      a course on Artificial Intelligence.\", \"reason\": \"The context mentions the
+      courses John is currently enrolled in, and Artificial Intelligence is not mentioned.
+      Therefore, it cannot be deduced that John is taking a course on AI.\", \"verdict\":
+      0}, {\"statement\": \"John is a dedicated student.\", \"reason\": \"The context
+      states that he spends a significant amount of time studying and completing assignments.
+      Additionally, it mentions that he often stays late in the library to work on
+      his projects, which implies dedication.\", \"verdict\": 1}, {\"statement\":
+      \"John has a part-time job.\", \"reason\": \"There is no information given in
+      the context about John having a part-time job.\", \"verdict\": 0}]```\n\ncontext:
+      \"Photosynthesis is a process used by plants, algae, and certain bacteria to
+      convert light energy into chemical energy.\"\nstatements: ```[\"Albert Einstein
+      was a genius.\"]```\nanswer: ```[{\"statement\": \"Albert Einstein was a genius.\",
+      \"reason\": \"The context and statement are unrelated\", \"verdict\": 0}]```\n\nYour
+      actual task:\n\ncontext: \"The capital of France is Paris.\"\nstatements: \"[\\\"The
+      capital of France is Paris.\\\"]\"\nanswer: \n", "role": "user"}], "model":
+      "gpt-4o-mini", "n": 1, "stream": false, "temperature": 1e-08}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '3661'
+      content-type:
+      - application/json
+      cookie:
+      - __cf_bm=TwJWv0VlFgYhSrHloW8LdJ6JUNJWbQ9nkeRO3_WDNVU-1729571022-1.0.1.1-NvYdRul3AN.8E0RonkQqN1EYZ63N75lmFZwCtTThtEFA7TlZd4qTQuFWhhY1nqk2gCPiNUiLS7VGYB1sUpkHsg;
+        _cfuvid=byA2EoT_oWDpk4tFKSXrkcOdDKdykmZORW7YjDB4dhg-1729571022845-0.0.1.1-604800000
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.52.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.52.0
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.13
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA2xSwY7TMBC95ytGc25WaVpItzcQAiEhgRAcYLtqXGfSDDi2ZU9Xu6r678hptina
+        vfjw3rznN88+ZgDIDa4BdadE997k774UbL6vrK/eLj//9Px++ZV/uw+fnorq1wJnSeF2f0jLs+pG
+        u94bEnb2TOtASii5zqvy9k01L8rFQPSuIZNkey/50uU9W87LolzmRZXPV6O6c6wp4hruMgCA43Cm
+        nLahR1xDMXtGeopR7QnXlyEADM4kBFWMHEVZwdlEameF7BC9ruu74wajKKGerGxwDRv80RFo5VmU
+        AdfCx6CsJuAI31TgeLPBGWwwkIrOToKLRxpU0HAgLRDIk3CqJTlJR8C2daFXA+SDe+CGGmA7cEOy
+        RxlveKDQsB4yzU/3dV1fLxGoPUSVirQHY0b8dGnFuL0PbhdH/oK3bDl223P41EAU53FgTxnA/dD+
+        4b9C0QfXe9mK+0s2GVbV6uyH06NP7OJ2JMWJMhO+mlezV/y2DYliE6/eD7XSHTWTtMiulnt56WsW
+        5wXZ7l+4ZKMTxqco1G9btnsKPvD5R7R+u1yVuixVtdOYnbJ/AAAA//8DACNMKfQfAwAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8d66b6ad2c5b19e3-EWR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 22 Oct 2024 04:23:43 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - datadog-staging
+      openai-processing-ms:
+      - '657'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149999151'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_3d0cc9525b0b534b946cedb75b3904b7
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"data": {"type": "evaluation_metric", "attributes": {"metrics": [{"span_id":
+      "2937446749154480568", "trace_id": "671728ce0000000026b8700bb23f78e1", "label":
+      "ragas_faithfulness", "metric_type": "score", "timestamp_ms": 1729571023600,
+      "score_value": 1.0, "ml_app": "unnamed-ml-app", "tags": ["ddtrace.version:2.15.0.dev219+ge047e25bb.d20241022",
+      "ml_app:unnamed-ml-app"]}]}}}'
+    headers:
+      Content-Type:
+      - application/json
+      DD-API-KEY:
+      - XXXXXX
+    method: POST
+    uri: https://api.datad0g.com/api/intake/llm-obs/v1/eval-metric
+  response:
+    body:
+      string: '{"data":{"id":"777f52ef-c83e-4be9-930f-ea63b8bd5080","type":"evaluation_metric","attributes":{"metrics":[{"id":"2x42DOBhXP","trace_id":"671728ce0000000026b8700bb23f78e1","span_id":"2937446749154480568","timestamp_ms":1729571023600,"ml_app":"unnamed-ml-app","metric_type":"score","label":"ragas_faithfulness","score_value":1,"tags":["ddtrace.version:2.15.0.dev219+ge047e25bb.d20241022","ml_app:unnamed-ml-app"]}]}}}'
+    headers:
+      content-length:
+      - '414'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub293163a918901030b79492fe1ab424cf&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatad0g.com
+      content-type:
+      - application/vnd.api+json
+      date:
+      - Tue, 22 Oct 2024 04:23:44 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 202
+      message: Accepted
+version: 1

--- a/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_ragas_faithfulness_evaluator.emits_traces_and_evaluations_on_exit.yaml
+++ b/tests/llmobs/llmobs_cassettes/tests.llmobs.test_llmobs_ragas_faithfulness_evaluator.emits_traces_and_evaluations_on_exit.yaml
@@ -73,19 +73,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA2yRwW7bMBBE7/oKYs9WICuOlfjWS9oAbdCiRS+WIdHUSmJCkSx33TYw/O8FZcV2
-        kVx4mOE87iz3iRCgG1gJUL1kNXiTfvic6edf+ePL9T09fXn4k30qvt1+/P7z4XHxG2EWE277hIpf
-        U1fKDd4ga2ePtgooGSN1XuR3N8U8y/PRGFyDJsY6z+nCpYO2Os2zfJFmRTq/ndK90woJVmKdCCHE
-        fjzjnLbBv7AS2exVGZBIdgir0yUhIDgTFZBEmlhahtnZVM4y2nH0uq7X+xIIo6KwGvHlyBclkI6d
-        QkUsGQe0TNFal/CjR6Gk1yyNcK24D9IqFJrEVxk0XZWwOWzqur58NGC7IxmL250xk344tTCu88Ft
-        afJPequtpr4KKMnZODGx8zC6h0SIzbit3X8LAB/c4Lli94w2ApfZ/MiD8yed3Xw5mexYmotUXsze
-        4VUNstSGLvYNSqoem3M0Sy7KvX30PcSxoLbdG0oykYBeiHGoWm07DD7o4w+2vsJ82+DNNS4RkkPy
-        DwAA//8DAOKY+kfPAgAA
+        H4sIAAAAAAAAA2yRW4vbMBCF3/0rxDzHi+2mySZvbUOhsPRGoSxxsBV5bKuVJaGZ9ELIfy9yvEnK
+        7oseztH5NGd0TIQA3cBagOolq8Gb9M3D5tPi1zuz+r0qHjavv27a74+vPj5+sG8z8wVmMeH2P1Dx
+        U+pOucEbZO3s2VYBJWOk5stitchXy3w+GoNr0MRY5zmdu3TQVqdFVszTbJnm91O6d1ohwVpsEyGE
+        OI5nnNM2+AfWIps9KQMSyQ5hfbkkBARnogKSSBNLyzC7mspZRjuOXtf19lgCYVQUViO+HPmiBNKx
+        U6iIJeOAlila2xK+9SiU9JqlEa4V74O0CoUm8VkGTXcl7E67uq5vHw3YHkjG4vZgzKSfLi2M63xw
+        e5r8i95qq6mvAkpyNk5M7DyM7ikRYjdu6/DfAsAHN3iu2P1EG4GLLD/z4PpJV7dYTCY7luYmVSxn
+        L/CqBllqQzf7BiVVj801miU35Z4/+hLiXFDb7hklmUhAf4lxqFptOww+6PMPtr6a3xeqKORyryA5
+        Jf8AAAD//wMAn6C7Cc8CAAA=
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 8d66b6a96ad219e3-EWR
+      - 8d6b5b701f294367-EWR
       Connection:
       - keep-alive
       Content-Encoding:
@@ -93,14 +93,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 22 Oct 2024 04:23:42 GMT
+      - Tue, 22 Oct 2024 17:55:15 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=TwJWv0VlFgYhSrHloW8LdJ6JUNJWbQ9nkeRO3_WDNVU-1729571022-1.0.1.1-NvYdRul3AN.8E0RonkQqN1EYZ63N75lmFZwCtTThtEFA7TlZd4qTQuFWhhY1nqk2gCPiNUiLS7VGYB1sUpkHsg;
-        path=/; expires=Tue, 22-Oct-24 04:53:42 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=iQaF937ylY7BvvBCyWYQoxiJwi1nBp5.LILrHLw1uno-1729619715-1.0.1.1-jS4Dz7yc_ud.hKZlJ_CAZkSQesqzVkfrA5F30zI7CtJsbEKyAiuVlpX0CPf816UtlhXQEW8T5nsc.UvnsCOzOw;
+        path=/; expires=Tue, 22-Oct-24 18:25:15 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=byA2EoT_oWDpk4tFKSXrkcOdDKdykmZORW7YjDB4dhg-1729571022845-0.0.1.1-604800000;
+      - _cfuvid=wQzHCwLW6CPU768K_tlLklWp36I8zYCVJkKlAMtnMkk-1729619715162-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -113,7 +113,7 @@ interactions:
       openai-organization:
       - datadog-staging
       openai-processing-ms:
-      - '438'
+      - '496'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -131,7 +131,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 0s
       x-request-id:
-      - req_827abd219d27dfb125b0af8ee2cb37da
+      - req_33b8cddecaab8b8bc36e90f58f844636
     status:
       code: 200
       message: OK
@@ -193,8 +193,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=TwJWv0VlFgYhSrHloW8LdJ6JUNJWbQ9nkeRO3_WDNVU-1729571022-1.0.1.1-NvYdRul3AN.8E0RonkQqN1EYZ63N75lmFZwCtTThtEFA7TlZd4qTQuFWhhY1nqk2gCPiNUiLS7VGYB1sUpkHsg;
-        _cfuvid=byA2EoT_oWDpk4tFKSXrkcOdDKdykmZORW7YjDB4dhg-1729571022845-0.0.1.1-604800000
+      - __cf_bm=iQaF937ylY7BvvBCyWYQoxiJwi1nBp5.LILrHLw1uno-1729619715-1.0.1.1-jS4Dz7yc_ud.hKZlJ_CAZkSQesqzVkfrA5F30zI7CtJsbEKyAiuVlpX0CPf816UtlhXQEW8T5nsc.UvnsCOzOw;
+        _cfuvid=wQzHCwLW6CPU768K_tlLklWp36I8zYCVJkKlAMtnMkk-1729619715162-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -220,19 +220,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA2xSwY7TMBC95ytGc25WaVpItzcQAiEhgRAcYLtqXGfSDDi2ZU9Xu6r678hptina
-        vfjw3rznN88+ZgDIDa4BdadE997k774UbL6vrK/eLj//9Px++ZV/uw+fnorq1wJnSeF2f0jLs+pG
-        u94bEnb2TOtASii5zqvy9k01L8rFQPSuIZNkey/50uU9W87LolzmRZXPV6O6c6wp4hruMgCA43Cm
-        nLahR1xDMXtGeopR7QnXlyEADM4kBFWMHEVZwdlEameF7BC9ruu74wajKKGerGxwDRv80RFo5VmU
-        AdfCx6CsJuAI31TgeLPBGWwwkIrOToKLRxpU0HAgLRDIk3CqJTlJR8C2daFXA+SDe+CGGmA7cEOy
-        RxlveKDQsB4yzU/3dV1fLxGoPUSVirQHY0b8dGnFuL0PbhdH/oK3bDl223P41EAU53FgTxnA/dD+
-        4b9C0QfXe9mK+0s2GVbV6uyH06NP7OJ2JMWJMhO+mlezV/y2DYliE6/eD7XSHTWTtMiulnt56WsW
-        5wXZ7l+4ZKMTxqco1G9btnsKPvD5R7R+u1yVuixVtdOYnbJ/AAAA//8DACNMKfQfAwAA
+        H4sIAAAAAAAAA2xSQW7bMBC86xWLPVuBpTqR7VuAoGiBAmmLHhrEgUVTK2tdiSTIdZDA8N8Lyorl
+        ILnwMLMznB3ykAAgV7gE1I0S3bk2vf1xd19M/c3u4frhu/37Tet73qm7383r7fwXTqLCbnak5U11
+        pW3nWhK25kRrT0ooumZFvrjJFkV23ROdraiNsq2TdGbTjg2n+TSfpdMizeaDurGsKeASHhMAgEN/
+        xpymohdcwnTyhnQUgtoSLs9DAOhtGxFUIXAQZQQnI6mtETJ99LIsHw8rDKKEOjKywiWs8E9DoJVj
+        US3YGr56ZTQBB/ipPIerFU5ghZ5UsGYUnD3ioIKKPWkBT46EYy3RSRoCNrX1neoh5+0zV1QBm57r
+        k73IcMMz+Yp1nyk7PpVlebmEp3ofVCzS7Nt2wI/nVlq7dd5uwsCf8ZoNh2Z9Ch8bCGId9uwxAXjq
+        29+/KxSdt52Ttdh/ZKJhUcxPfjg++sh+WQykWFHtiM+zYvKJ37oiUdyGi/dDrXRD1SidJhfLfbz0
+        M4vTgmy2H1ySwQnDaxDq1jWbLXnn+fQjareezXOd56rYaEyOyX8AAAD//wMAUtzROh8DAAA=
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 8d66b6ad2c5b19e3-EWR
+      - 8d6b5b744e034367-EWR
       Connection:
       - keep-alive
       Content-Encoding:
@@ -240,7 +240,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 22 Oct 2024 04:23:43 GMT
+      - Tue, 22 Oct 2024 17:55:16 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -254,7 +254,7 @@ interactions:
       openai-organization:
       - datadog-staging
       openai-processing-ms:
-      - '657'
+      - '749'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -272,14 +272,14 @@ interactions:
       x-ratelimit-reset-tokens:
       - 0s
       x-request-id:
-      - req_3d0cc9525b0b534b946cedb75b3904b7
+      - req_fbb01161a03eb6f478ff52314b72cfd6
     status:
       code: 200
       message: OK
 - request:
     body: '{"data": {"type": "evaluation_metric", "attributes": {"metrics": [{"span_id":
-      "2937446749154480568", "trace_id": "671728ce0000000026b8700bb23f78e1", "label":
-      "ragas_faithfulness", "metric_type": "score", "timestamp_ms": 1729571023600,
+      "6877142543397072040", "trace_id": "6717e70200000000a99ea8ad36f4f36d", "label":
+      "ragas_faithfulness", "metric_type": "score", "timestamp_ms": 1729619716093,
       "score_value": 1.0, "ml_app": "unnamed-ml-app", "tags": ["ddtrace.version:2.15.0.dev219+ge047e25bb.d20241022",
       "ml_app:unnamed-ml-app"]}]}}}'
     headers:
@@ -291,7 +291,7 @@ interactions:
     uri: https://api.datad0g.com/api/intake/llm-obs/v1/eval-metric
   response:
     body:
-      string: '{"data":{"id":"777f52ef-c83e-4be9-930f-ea63b8bd5080","type":"evaluation_metric","attributes":{"metrics":[{"id":"2x42DOBhXP","trace_id":"671728ce0000000026b8700bb23f78e1","span_id":"2937446749154480568","timestamp_ms":1729571023600,"ml_app":"unnamed-ml-app","metric_type":"score","label":"ragas_faithfulness","score_value":1,"tags":["ddtrace.version:2.15.0.dev219+ge047e25bb.d20241022","ml_app:unnamed-ml-app"]}]}}}'
+      string: '{"data":{"id":"99fa371c-457c-4d2b-8d4c-61657e0ffd48","type":"evaluation_metric","attributes":{"metrics":[{"id":"CbapxUnzcX","trace_id":"6717e70200000000a99ea8ad36f4f36d","span_id":"6877142543397072040","timestamp_ms":1729619716093,"ml_app":"unnamed-ml-app","metric_type":"score","label":"ragas_faithfulness","score_value":1,"tags":["ddtrace.version:2.15.0.dev219+ge047e25bb.d20241022","ml_app:unnamed-ml-app"]}]}}}'
     headers:
       content-length:
       - '414'
@@ -300,7 +300,7 @@ interactions:
       content-type:
       - application/vnd.api+json
       date:
-      - Tue, 22 Oct 2024 04:23:44 GMT
+      - Tue, 22 Oct 2024 17:55:17 GMT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       vary:

--- a/tests/llmobs/test_llmobs_ragas_faithfulness_evaluator.py
+++ b/tests/llmobs/test_llmobs_ragas_faithfulness_evaluator.py
@@ -162,6 +162,7 @@ def test_llmobs_with_faithfulness_emits_traces_and_evals_on_exit(mock_writer_log
             "DD_API_KEY": os.getenv("DD_API_KEY", "dummy-api-key"),
             "DD_SITE": "datad0g.com",
             "PYTHONPATH": ":".join(pypath),
+            "OPENAI_API_KEY": os.getenv("OPENAI_API_KEY", "dummy-openai-api-key"),
             "DD_LLMOBS_ML_APP": "unnamed-ml-app",
             "_DD_LLMOBS_EVALUATOR_INTERVAL": "5",
             "_DD_LLMOBS_EVALUATORS": "ragas_faithfulness",
@@ -180,7 +181,7 @@ from tests.llmobs._utils import _llm_span_with_expected_ragas_inputs_in_messages
 from tests.llmobs._utils import logs_vcr
 
 ctx = logs_vcr.use_cassette(
-    "tests.llmobs.test_llmobs_ragas_faithfulness_evaluator.emits_traces_and_evaluations_on_exit"
+    "tests.llmobs.test_llmobs_ragas_faithfulness_evaluator.emits_traces_and_evaluations_on_exit.yaml"
 )
 ctx.__enter__()
 atexit.register(lambda: ctx.__exit__())

--- a/tests/llmobs/test_llmobs_ragas_faithfulness_evaluator.py
+++ b/tests/llmobs/test_llmobs_ragas_faithfulness_evaluator.py
@@ -1,3 +1,5 @@
+import os
+
 import mock
 import pytest
 
@@ -148,3 +150,52 @@ def test_ragas_faithfulness_emits_traces(ragas, LLMObs):
 
     assert spans[3]["parent_id"] == spans[2]["span_id"]  # create statements prompt (task)
     assert spans[5]["parent_id"] == spans[4]["span_id"]  # create verdicts prompt (task)
+
+
+def test_llmobs_with_faithfulness_emits_traces_and_evals_on_exit(mock_writer_logs, run_python_code_in_subprocess):
+    env = os.environ.copy()
+    pypath = [os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))]
+    if "PYTHONPATH" in env:
+        pypath.append(env["PYTHONPATH"])
+    env.update(
+        {
+            "DD_API_KEY": os.getenv("DD_API_KEY", "dummy-api-key"),
+            "DD_SITE": "datad0g.com",
+            "PYTHONPATH": ":".join(pypath),
+            "DD_LLMOBS_ML_APP": "unnamed-ml-app",
+            "_DD_LLMOBS_EVALUATOR_INTERVAL": "5",
+            "_DD_LLMOBS_EVALUATORS": "ragas_faithfulness",
+            "DD_LLMOBS_AGENTLESS_ENABLED": "true",
+        }
+    )
+    out, err, status, pid = run_python_code_in_subprocess(
+        """
+import os
+import time
+import atexit
+import mock
+from ddtrace.llmobs import LLMObs
+from ddtrace.internal.utils.http import Response
+from tests.llmobs._utils import _llm_span_with_expected_ragas_inputs_in_messages
+from tests.llmobs._utils import logs_vcr
+
+ctx = logs_vcr.use_cassette(
+    "tests.llmobs.test_llmobs_ragas_faithfulness_evaluator.emits_traces_and_evaluations_on_exit"
+)
+ctx.__enter__()
+atexit.register(lambda: ctx.__exit__())
+with mock.patch(
+    "ddtrace.internal.writer.HTTPWriter._send_payload",
+    return_value=Response(
+        status=200,
+        body="{}",
+    ),
+):
+    LLMObs.enable()
+    LLMObs._instance._evaluator_runner.enqueue(_llm_span_with_expected_ragas_inputs_in_messages(), None)
+""",
+        env=env,
+    )
+    assert status == 0, err
+    assert out == b""
+    assert err == b""


### PR DESCRIPTION
This PR fixes behavior where the last span generated right before process exit was not being evaluated by the ragas faithfulness evaluator.

Previous behavior:
1. On process exit, `LLMObs.disable()` is called
2. `LLMObs.disabled` is set to `True`
3. Eval metric writers and span writers are stopped
4. Evaluator runner is stopped

There is a problem here where span & eval metric writers are stopped & LLM Obs disabled is set to true while the eval runner has not finished tracing & evaluating the span events in it's buffer.

### Fix attempt 1
1. Make sure eval runner is stopped **_BEFORE_** eval metric writer and span writers are stopped
2. Make sure `LLMOBs.disabled` is set to false only after the eval runner is stopped
3. Within `_stop_service` call `self.periodic` and `self.executor.shutdown(wait=True)`

The assumption here is that periodic will schedule all the evaluation job threads, and calling shutdown with `wait=True` will block until the threads are finished

This didn’t work though; after `self.executor.map` was called to create the job threads, the app exited without the `run_and_submit_evaluation` faithfulness function even being called. Could there be some issue with scheduling these threads while the process is exiting?

### Fix attempt 2 (this PR)
Same steps as 1) and 2)

For step 3, we add a `_wait_syncronously` argument to `periodic`. Setting `_wait_synchrousnly=True` turns periodic into a blocking function that synchronously runs each evaluation metric over every span. This ensures the last span events in the evaluator run buffer are evaluated, metrics are enqueued to the metric writer & the eval metric writer & span writers are flushed before we disable llmobs.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
