### PR TITLE
chore(ci): update `beautifulsoup` framework test to use local `ddtrace` not PyPI latest

### DIFF
--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -974,7 +974,7 @@ jobs:
           git clone -b 4.12.3 https://git.launchpad.net/beautifulsoup
       - name: Install ddtrace
         if: needs.needs-run.outputs.outcome == 'success'
-        run: pip install ddtrace
+        run: pip3 install ../ddtrace
       - name: Pytest fix
         if: needs.needs-run.outputs.outcome == 'success'
         run: pip install pytest==8.2.1

--- a/.github/workflows/test_frameworks.yml
+++ b/.github/workflows/test_frameworks.yml
@@ -974,7 +974,7 @@ jobs:
           git clone -b 4.12.3 https://git.launchpad.net/beautifulsoup
       - name: Install ddtrace
         if: needs.needs-run.outputs.outcome == 'success'
-        run: pip3 install ../ddtrace
+        run: pip3 install ./ddtrace
       - name: Pytest fix
         if: needs.needs-run.outputs.outcome == 'success'
         run: pip install pytest==8.2.1


### PR DESCRIPTION
The `beautifulsoup` framework tests were using `pip install ddtrace` to install `ddtrace`, which was using the `latest` version of `ddtrace` from PyPI instead of the local version from the branch ([see example here](https://github.com/DataDog/dd-trace-py/actions/runs/11462716535/job/31894873509#step:5:19)).

This PR fixes this to run `pip3 install ./ddtrace` instead so we're testing with the current version of `ddtrace` for the branch that triggered the test.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
