### PR TITLE
chore(asm): move waf info report to asm_context and add return code in ddwaf_result

### DIFF
--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -221,9 +221,8 @@ def finalize_asm_env(env: ASM_Environment) -> None:
         info = env.waf_info()
         try:
             if info.errors:
-                errors = json.dumps(info.errors)
-                env.span.set_tag_str(APPSEC.EVENT_RULE_ERRORS, errors)
-                log.debug("Error in ASM In-App WAF: %s", errors)
+                env.span.set_tag_str(APPSEC.EVENT_RULE_ERRORS, info.errors)
+                log.debug("Error in ASM In-App WAF: %s", info.errors)
             env.span.set_tag_str(APPSEC.EVENT_RULE_VERSION, info.version)
             env.span.set_metric(APPSEC.EVENT_RULE_LOADED, info.loaded)
             env.span.set_metric(APPSEC.EVENT_RULE_ERROR_COUNT, info.failed)

--- a/tests/appsec/appsec/test_processor.py
+++ b/tests/appsec/appsec/test_processor.py
@@ -533,41 +533,6 @@ def test_ddwaf_info_with_3_errors():
         assert info.errors == {"missing key 'name'": ["crs-942-100", "crs-913-120"]}
 
 
-def test_ddwaf_info_with_json_decode_errors(tracer, caplog):
-    config = rules.Config()
-    config.http_tag_query_string = True
-
-    with caplog.at_level(logging.WARNING), mock.patch(
-        "ddtrace.appsec._processor.json.dumps", side_effect=JSONDecodeError("error", "error", 0)
-    ), mock.patch.object(DDWaf, "info"):
-        with asm_context(tracer=tracer, config=config_asm) as span:
-            set_http_meta(
-                span,
-                config,
-                method="PATCH",
-                url="http://localhost/api/unstable/role_requests/dab1e9ae-9d99-11ed-bfdf-da7ad0900000?_authentication_token=2b0297348221f294de3a047e2ecf1235abb866b6",  # noqa: E501
-                status_code="200",
-                raw_uri="http://localhost/api/unstable/role_requests/dab1e9ae-9d99-11ed-bfdf-da7ad0900000?_authentication_token=2b0297348221f294de3a047e2ecf1235abb866b6",  # noqa: E501
-                request_headers={
-                    "host": "localhost",
-                    "user-agent": "aa",
-                    "content-length": "73",
-                },
-                response_headers={
-                    "content-length": "501",
-                    "x-ratelimit-remaining": "363",
-                    "x-ratelimit-name": "role_api",
-                    "x-ratelimit-limit": "500",
-                    "x-ratelimit-period": "60",
-                    "content-type": "application/json",
-                    "x-ratelimit-reset": "16",
-                },
-                request_body={"_authentication_token": "2b0297348221f294de3a047e2ecf1235abb866b6"},
-            )
-
-    assert "Error parsing data ASM In-App WAF metrics report" in caplog.text
-
-
 def test_ddwaf_run_contained_typeerror(tracer, caplog):
     config = rules.Config()
     config.http_tag_query_string = True

--- a/tests/appsec/appsec/test_processor.py
+++ b/tests/appsec/appsec/test_processor.py
@@ -502,7 +502,7 @@ def test_ddwaf_info():
         info = _ddwaf.info
         assert info.loaded == len(rules_json["rules"])
         assert info.failed == 0
-        assert info.errors == {}
+        assert info.errors == ""
         assert info.version == "rules_good"
 
 
@@ -518,7 +518,7 @@ def test_ddwaf_info_with_2_errors():
         expected_dict = sorted(
             {"missing key 'conditions'": ["crs-913-110"], "missing key 'tags'": ["crs-942-100"]}.items()
         )
-        assert sorted(info.errors.items()) == expected_dict
+        assert sorted(json.loads(info.errors).items()) == expected_dict
         assert info.version == "5.5.5"
 
 
@@ -530,7 +530,7 @@ def test_ddwaf_info_with_3_errors():
         info = _ddwaf.info
         assert info.loaded == 1
         assert info.failed == 2
-        assert info.errors == {"missing key 'name'": ["crs-942-100", "crs-913-120"]}
+        assert json.loads(info.errors) == {"missing key 'name'": ["crs-942-100", "crs-913-120"]}
 
 
 def test_ddwaf_run_contained_typeerror(tracer, caplog):


### PR DESCRIPTION
- move span tag logic for ddwaf info data from processor to asm context to do it only once per request. 
- move serialisation of errors from processor to waf interface to do it only when waf is initialised or updated.
- remove warnings log for span tag logic and corresponding test. (json errors are impossible now due to ddwaf_object use)
- add return code from ddwaf_run into DDWaf_result object


Preparatory PR for APPSEC-55199

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
