### PR TITLE
chore: unbreak moved private function imports

### DIFF
--- a/ddtrace/_trace/utils_botocore/span_pointers/__init__.py
+++ b/ddtrace/_trace/utils_botocore/span_pointers/__init__.py
@@ -7,6 +7,12 @@ from ddtrace._trace._span_pointer import _SpanPointerDescription
 from ddtrace._trace.utils_botocore.span_pointers.dynamodb import _DynamoDBItemFieldName
 from ddtrace._trace.utils_botocore.span_pointers.dynamodb import _DynamoDBTableName
 from ddtrace._trace.utils_botocore.span_pointers.dynamodb import _extract_span_pointers_for_dynamodb_response
+
+# We are importing this function here because it used to live in this module
+# and was imported from here in datadog-lambda-python. Once the import is fixed
+# in the next release of that library, we should be able to remove this unused
+# import from here as well.
+from ddtrace._trace.utils_botocore.span_pointers.s3 import _aws_s3_object_span_pointer_description  # noqa: F401
 from ddtrace._trace.utils_botocore.span_pointers.s3 import _extract_span_pointers_for_s3_response
 
 


### PR DESCRIPTION
https://github.com/DataDog/dd-trace-py/pull/11008 rearranged a bunch of code, but some of that code was already being used outside of this repo. Let's unbreak those imports for now.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
