### PR TITLE
fix(profiling): handle `Span`s with `None` span type for stack v2 endpoint profiling

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack_v2/src/stack_v2.cpp
+++ b/ddtrace/internal/datadog/profiling/stack_v2/src/stack_v2.cpp
@@ -109,7 +109,7 @@ _stack_v2_link_span(PyObject* self, PyObject* args, PyObject* kwargs)
     }
 
     // From Python, span_type is a string or None, and when given None, it is passed as a nullptr.
-    static std::string empty_string = "";
+    static const std::string empty_string = "";
     if (span_type == nullptr) {
         span_type = empty_string.c_str();
     }

--- a/ddtrace/internal/datadog/profiling/stack_v2/src/stack_v2.cpp
+++ b/ddtrace/internal/datadog/profiling/stack_v2/src/stack_v2.cpp
@@ -91,7 +91,7 @@ _stack_v2_link_span(PyObject* self, PyObject* args, PyObject* kwargs)
     uint64_t thread_id;
     uint64_t span_id;
     uint64_t local_root_span_id;
-    const char* span_type;
+    const char* span_type = nullptr;
 
     PyThreadState* state = PyThreadState_Get();
 
@@ -104,8 +104,14 @@ _stack_v2_link_span(PyObject* self, PyObject* args, PyObject* kwargs)
     static const char* const_kwlist[] = { "span_id", "local_root_span_id", "span_type", NULL };
     static char** kwlist = const_cast<char**>(const_kwlist);
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "KKs", kwlist, &span_id, &local_root_span_id, &span_type)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "KKz", kwlist, &span_id, &local_root_span_id, &span_type)) {
         return NULL;
+    }
+
+    // From Python, span_type is a string or None, and when given None, it is passed as a nullptr.
+    static std::string empty_string = "";
+    if (span_type == nullptr) {
+        span_type = empty_string.c_str();
     }
 
     ThreadSpanLinks::get_instance().link_span(thread_id, span_id, local_root_span_id, std::string(span_type));

--- a/releasenotes/notes/profiling-stack-v2-endpoint-span-type-none-48a1196296be3742.yaml
+++ b/releasenotes/notes/profiling-stack-v2-endpoint-span-type-none-48a1196296be3742.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: resolves an issue where endpoint profiling for stack v2 throws
+    ``TypeError`` exception when it is given a ``Span`` with ``None`` span_type.

--- a/tests/profiling_v2/collector/test_stack.py
+++ b/tests/profiling_v2/collector/test_stack.py
@@ -223,7 +223,7 @@ def test_push_non_web_span():
         )
 
 
-@pytest.mark.subprocess()
+@pytest.mark.subprocess(env=dict(DD_PROFILING_STACK_V2_ENABLED="true"))
 def test_push_span_none_span_type():
     # Test for https://github.com/DataDog/dd-trace-py/issues/11141
     import os

--- a/tests/profiling_v2/collector/test_stack.py
+++ b/tests/profiling_v2/collector/test_stack.py
@@ -221,3 +221,58 @@ def test_push_non_web_span():
                 # trace_endpoint is not set for non-web spans
             ),
         )
+
+
+@pytest.mark.subprocess()
+def test_push_span_none_span_type():
+    # Test for https://github.com/DataDog/dd-trace-py/issues/11141
+    import os
+    import time
+    import uuid
+
+    from ddtrace import tracer
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from tests.profiling.collector import pprof_utils
+
+    test_name = "test_push_span_none_span_type"
+    pprof_prefix = "/tmp/" + test_name
+    output_filename = pprof_prefix + "." + str(os.getpid())
+
+    assert ddup.is_available
+    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
+    ddup.start()
+
+    tracer._endpoint_call_counter_span_processor.enable()
+
+    resource = str(uuid.uuid4())
+
+    with stack.StackCollector(
+        None,
+        tracer=tracer,
+        endpoint_collection_enabled=True,
+        ignore_profiler=True,  # this is not necessary, but it's here to trim samples
+    ):
+        # Explicitly set None span_type as the default could change in the
+        # future.
+        with tracer.trace("foobar", resource=resource, span_type=None) as span:
+            span_id = span.span_id
+            local_root_span_id = span._local_root.span_id
+            for _ in range(5):
+                time.sleep(0.01)
+    ddup.upload()
+
+    profile = pprof_utils.parse_profile(output_filename)
+    samples = pprof_utils.get_samples_with_label_key(profile, "span id")
+    assert len(samples) > 0
+    for sample in samples:
+        pprof_utils.assert_stack_event(
+            profile,
+            sample,
+            expected_event=pprof_utils.StackEvent(
+                span_id=span_id,
+                local_root_span_id=local_root_span_id,
+                # span_type is None
+                # trace_endpoint is not set for non-web spans
+            ),
+        )


### PR DESCRIPTION
Fixes #11141

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
