### PR TITLE
chore(iast): update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,9 @@ ddtrace/appsec/_iast/_taint_tracking/tests/native_tests*
 ddtrace/appsec/_iast/_taint_tracking/_vendor/pybind11/Makefile
 ddtrace/appsec/_iast/_taint_tracking/_vendor/pybind11/CMakeFiles/*
 ddtrace/appsec/_iast/_taint_tracking/_vendor/pybind11/cmake_install.cmake
+# Those folders are required for tests/appsec/iast_packages/test_packages.py
+template_venv/
+cloned_venvs/
 # CircleCI generated config
 .circleci/config.gen.yml
 


### PR DESCRIPTION
Those folders are required for tests/appsec/iast_packages/test_packages.py
- template_venv/
- cloned_venvs/

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
