### PR TITLE
fix(profiling): handle `Span`s with `None` span type for stack v2 endpoint profiling [backport 2.13]

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack_v2/src/stack_v2.cpp
+++ b/ddtrace/internal/datadog/profiling/stack_v2/src/stack_v2.cpp
@@ -91,7 +91,7 @@ _stack_v2_link_span(PyObject* self, PyObject* args, PyObject* kwargs)
     uint64_t thread_id;
     uint64_t span_id;
     uint64_t local_root_span_id;
-    const char* span_type;
+    const char* span_type = nullptr;
 
     PyThreadState* state = PyThreadState_Get();
 
@@ -104,8 +104,14 @@ _stack_v2_link_span(PyObject* self, PyObject* args, PyObject* kwargs)
     static const char* const_kwlist[] = { "span_id", "local_root_span_id", "span_type", NULL };
     static char** kwlist = const_cast<char**>(const_kwlist);
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "KKs", kwlist, &span_id, &local_root_span_id, &span_type)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "KKz", kwlist, &span_id, &local_root_span_id, &span_type)) {
         return NULL;
+    }
+
+    // From Python, span_type is a string or None, and when given None, it is passed as a nullptr.
+    static const std::string empty_string = "";
+    if (span_type == nullptr) {
+        span_type = empty_string.c_str();
     }
 
     ThreadSpanLinks::get_instance().link_span(thread_id, span_id, local_root_span_id, std::string(span_type));

--- a/releasenotes/notes/profiling-stack-v2-endpoint-span-type-none-48a1196296be3742.yaml
+++ b/releasenotes/notes/profiling-stack-v2-endpoint-span-type-none-48a1196296be3742.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: resolves an issue where endpoint profiling for stack v2 throws
+    ``TypeError`` exception when it is given a ``Span`` with ``None`` span_type.


### PR DESCRIPTION
Manual backport of #11164 to 2.13

Fixes #11141

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
