### PR TITLE
ci: hardcode git repo URL in GitLab jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ stages:
 variables:
   REPO_LANG: python # "python" is used everywhere rather than "py"
   TESTRUNNER_IMAGE: registry.ddbuild.io/images/mirror/dd-trace-py/testrunner:ecc5741ff3e7c8a30363fcd9cca79a371dcea5b4
+  DD_GIT_REPOSITORY_URL: https://github.com/DataDog/dd-trace-py.git
   # CI_DEBUG_SERVICES: "true"
 
 .testrunner:


### PR DESCRIPTION
Hardcodes the repo URL to https://github.com/DataDog/dd-trace-py.git in GitLab CI jobs.

Currently, the URL for GitLab CI jobs is https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py.git , which creates inconsistencies with CI runs in CircleCI and GitHub Actions, and breaks some Datadog UI features (eg "Open in GitHub").

The `DD_GIT_REPOSITORY_URL` (see [docs](https://docs.datadoghq.com/tests/setup/python/?tab=ciproviderwithautoinstrumentationsupport#collecting-git-metadata)) overrides the normally-discovered URL. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
