### PR TITLE
chore(ci_visibility): fix inadequate pytest test and fix broken git check

### DIFF
--- a/ddtrace/internal/ci_visibility/git_client.py
+++ b/ddtrace/internal/ci_visibility/git_client.py
@@ -108,7 +108,7 @@ class CIVisibilityGitClient(object):
         # type: (Optional[str]) -> Optional[str]
         try:
             return extract_workspace_path(cwd=cwd)
-        except ValueError:
+        except (FileNotFoundError, ValueError):
             return None
 
     def upload_git_metadata(self, cwd=None):

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -4086,7 +4086,11 @@ class PytestTestCase(PytestTestCaseBase):
             )
 
         self.testdir.chdir()
-        with mock.patch("ddtrace.ext.git._get_executable_path", return_value=None):
+        with mock.patch("ddtrace.ext.git._get_executable_path", return_value=None), mock.patch(
+            "ddtrace.internal.ci_visibility.recorder.ddconfig",
+            _get_default_civisibility_ddconfig(),
+        ) as mock_ddconfig:
+            mock_ddconfig._ci_visibility_agentless_enabled = True
             self.inline_run("--ddtrace")
 
             spans = self.pop_spans()


### PR DESCRIPTION
This makes sure that `CIVisibilityGitClient.upload_git_metadata()` does not cause a crash if the `git` binary is absent (which could happen after #11175).

It also fixes the `test_pytest_without_git_does_not_crash` test that allowed #11175 to slip through because, since the migration to GitLab, the overall environment in which tests ran is no longer in agentless mode, which meant `_should_upload_git_metadata()` was false, and effectively wasn't exercising `pytest` "without `git`".

There is no release note here since #11175 has not been released yet. The backports for that PR will be updated to cherry-pick this commit, so this PR is also not backported.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
