### PR TITLE
chore:  format release notes so the release script could parse

### DIFF
--- a/releasenotes/notes/ci_visibility-fix_codeowners_including_comments-82d9cb733a2c7285.yaml
+++ b/releasenotes/notes/ci_visibility-fix_codeowners_including_comments-82d9cb733a2c7285.yaml
@@ -1,3 +1,4 @@
 ---
 fixes:
-  - CI Visibility: "fixes a bug where ``CODEOWNERS`` would incorrectly fail to discard line-level trailing comments (eg: ``@code/owner # my comment`` would result in codeowners being parsed as ``@code/owner``, ``#``, ``my``, and ``comment``)"
+  - |
+    CI Visibility: fixes a bug where ``CODEOWNERS`` would incorrectly fail to discard line-level trailing comments (eg: ``@code/owner # my comment`` would result in codeowners being parsed as ``@code/owner``, ``#``, ``my``, and ``comment``)

--- a/releasenotes/notes/ci_visibility-fix_logged_errors_when_gitless-66a6cb3245314f3e.yaml
+++ b/releasenotes/notes/ci_visibility-fix_logged_errors_when_gitless-66a6cb3245314f3e.yaml
@@ -1,4 +1,5 @@
 ---
 fixes:
-  - CI Visibility: fixes unnecessary logging of an exception that would appear when trying to upload git metadata in
+  - |
+    CI Visibility: fixes unnecessary logging of an exception that would appear when trying to upload git metadata in
     an environment without functioning git (eg: missing ``git`` binary or ``.git`` directory)


### PR DESCRIPTION
Release notes with `:` in them need to be entered as a block with `|`, otherwise the release script fails to parse it properly

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
