### PR TITLE
chore(profiling): set `OBJC_DISABLE_INITIALIZE_FORK_SAFETY` for testing native on mac 

### DIFF
--- a/ddtrace/internal/datadog/profiling/build_standalone.sh
+++ b/ddtrace/internal/datadog/profiling/build_standalone.sh
@@ -15,6 +15,11 @@ highest_gxx=""
 highest_clang=""
 highest_clangxx=""
 
+if [[ $OSTYPE == 'darwin'* ]]; then
+  # Needed for some of ForkDeathTests to pass on Mac
+  export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+fi
+
 # Function to find the highest version of compilers
 # Note that the product of this check is ignored if the user passes CC/CXX
 find_highest_compiler_version() {


### PR DESCRIPTION
## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
