### PR TITLE
chore: use `guess-next-dev` instead of `release-branch-semver` for versioning [2.16]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ Homepage = "https://github.com/DataDog/dd-trace-py"
 "Source Code" = "https://github.com/DataDog/dd-trace-py/"
 
 [tool.setuptools_scm]
-version_scheme = "release-branch-semver"  # Must be "release-branch-semver" for now in main, see https://github.com/DataDog/dd-trace-py/issues/8801
+version_scheme = "guess-next-dev"
 write_to = "ddtrace/_version.py"
 
 [tool.cython-lint]


### PR DESCRIPTION
We need to use `guess-next-dev` for versioning for release branches in order to ensure that system tests can work with them.

This is a manual PR, but the goal is to automate this PR generation (probably in the `release.py` script)

**Great context from internal ticket:**
> Using "release-branch-semver" will allow the main branch to have its version computed from last tag adding +1 to minor and .dev decorator. This is what we want. The problem is that algorithm is used on any branch that is not a release branch. So it will also be used on any branch that targets a release branch, meaning all backport PRs.
>
> Using "guess-next-dev" will set any non release branch to the same minor version as last tag. This works for backport branches but not for main that will get the same minor version as last release.
>
>
> Why is version miscomputation a problem?
> System tests are enabling new feature tests based on version. In the first case, the version on backports are one minor ahead, leading to possibly run system tests for the next version, causing errors for missing features. On the second case, most possibly system tests won’t be running the new tests for the main branch, which can be ever more problematic (CI green but feature just got silently broken).

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
