### PR TITLE
chore: add debugger scenarios in system-tests ci

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       matrix:
         weblog-variant: [flask-poc, uwsgi-poc , django-poc, fastapi, python3.12]
-        scenario: [remote-config, appsec, appsec-1, other, debugger]
+        scenario: [remote-config, appsec, appsec-1, other, debugger-1, debugger-2]
 
       fail-fast: false
     env:
@@ -222,31 +222,31 @@ jobs:
         run: ./run.sh APPSEC_RASP
 
       - name: Run DEBUGGER_PROBES_STATUS
-        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger'
+        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger-1'
         run: ./run.sh DEBUGGER_PROBES_STATUS
 
       - name: Run DEBUGGER_METHOD_PROBES_SNAPSHOT
-        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger'
+        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger-1'
         run: ./run.sh DEBUGGER_METHOD_PROBES_SNAPSHOT
 
       - name: Run DEBUGGER_LINE_PROBES_SNAPSHOT
-        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger'
+        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger-1'
         run: ./run.sh DEBUGGER_LINE_PROBES_SNAPSHOT
 
       - name: Run DEBUGGER_MIX_LOG_PROBE
-        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger'
+        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger-1'
         run: ./run.sh DEBUGGER_MIX_LOG_PROBE
 
       - name: Run DEBUGGER_PII_REDACTION
-        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger'
+        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger-1'
         run: ./run.sh DEBUGGER_PII_REDACTION
 
       - name: Run DEBUGGER_EXPRESSION_LANGUAGE
-        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger'
+        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger-1'
         run: ./run.sh DEBUGGER_EXPRESSION_LANGUAGE
 
       - name: Run DEBUGGER_EXCEPTION_REPLAY
-        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger'
+        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger-2'
         run: ./run.sh DEBUGGER_EXCEPTION_REPLAY
 
       # The compress step speed up a lot the upload artifact process

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       matrix:
         weblog-variant: [flask-poc, uwsgi-poc , django-poc, fastapi, python3.12]
-        scenario: [remote-config, appsec, appsec-1, other]
+        scenario: [remote-config, appsec, appsec-1, other, debugger]
 
       fail-fast: false
     env:
@@ -220,6 +220,34 @@ jobs:
       - name: Run APPSEC_RASP
         if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'appsec-1'
         run: ./run.sh APPSEC_RASP
+
+      - name: Run DEBUGGER_PROBES_STATUS
+        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger'
+        run: ./run.sh DEBUGGER_PROBES_STATUS
+
+      - name: Run DEBUGGER_METHOD_PROBES_SNAPSHOT
+        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger'
+        run: ./run.sh DEBUGGER_METHOD_PROBES_SNAPSHOT
+
+      - name: Run DEBUGGER_LINE_PROBES_SNAPSHOT
+        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger'
+        run: ./run.sh DEBUGGER_LINE_PROBES_SNAPSHOT
+
+      - name: Run DEBUGGER_MIX_LOG_PROBE
+        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger'
+        run: ./run.sh DEBUGGER_MIX_LOG_PROBE
+
+      - name: Run DEBUGGER_PII_REDACTION
+        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger'
+        run: ./run.sh DEBUGGER_PII_REDACTION
+
+      - name: Run DEBUGGER_EXPRESSION_LANGUAGE
+        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger'
+        run: ./run.sh DEBUGGER_EXPRESSION_LANGUAGE
+
+      - name: Run DEBUGGER_EXCEPTION_REPLAY
+        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'debugger'
+        run: ./run.sh DEBUGGER_EXCEPTION_REPLAY
 
       # The compress step speed up a lot the upload artifact process
       - name: Compress artifact


### PR DESCRIPTION
Recently, several error has been introduced in debuggers features, those errros has been caught by system-tests nightlies.

By adding those scenario in the dd-trace-py's CI, we'll prevent those errors to reach `main` branch.

Needs DataDog/system-tests#3354

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
