### PR TITLE
fix(iast): add google.auth to the IAST denylist [backport 2.14]

### DIFF
--- a/ddtrace/appsec/_iast/_ast/ast_patching.py
+++ b/ddtrace/appsec/_iast/_ast/ast_patching.py
@@ -306,6 +306,7 @@ IAST_DENYLIST: Tuple[Text, ...] = (
     "pydantic_core.",
     "pydantic_settings.",
     "tomli.",
+    "google.auth.crypt.",
 )
 
 

--- a/releasenotes/notes/iast-fi-import-error-google-37815bda58036c08.yaml
+++ b/releasenotes/notes/iast-fi-import-error-google-37815bda58036c08.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Code Security: This fix resolves an issue where importing the ``google.cloud.storage.batch`` module would fail raising an ImportError

--- a/tests/appsec/iast_packages/packages/pkg_google_api_core.py
+++ b/tests/appsec/iast_packages/packages/pkg_google_api_core.py
@@ -9,6 +9,12 @@ from flask import request
 from .utils import ResultResponse
 
 
+try:
+    from google.cloud.storage.batch import Batch  # noqa:F401
+except ModuleNotFoundError:
+    pass
+
+
 pkg_google_api_core = Blueprint("package_google_api_core", __name__)
 
 

--- a/tests/appsec/iast_packages/test_packages.py
+++ b/tests/appsec/iast_packages/test_packages.py
@@ -255,7 +255,7 @@ PACKAGES = [
     PackageForTesting("fsspec", "2024.5.0", "", "/", ""),
     PackageForTesting(
         "google-auth",
-        "2.29.0",
+        "2.35.0",
         "",
         "",
         "",
@@ -265,12 +265,14 @@ PACKAGES = [
     ),
     PackageForTesting(
         "google-api-core",
-        "2.19.0",
+        "2.22.0",
         "",
         "",
         "",
         import_name="google",
         import_module_to_validate="google.auth.iam",
+        extras=[("google-cloud-storage", "2.18.2")],
+        test_e2e=True,
     ),
     PackageForTesting(
         "google-api-python-client",


### PR DESCRIPTION
Backport e33e2355e97b2bbd40d4223bb6d0c79f8da5b8a4 from #11240 to 2.14.

This fix resolves an issue where importing the
``google.cloud.storage.batch`` module would fail raising an AttributeError

```
  File "site-packages/google/auth/crypt/rsa.py", line 22, in <module>
    RSASigner = _cryptography_rsa.RSASigner
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'google.auth.crypt._cryptography_rsa' has no attribute 'RSASigner'
```
tests_packages are working in this branch:

https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/76358/workflows/427a6bbc-f088-4779-b6fd-35e8e6f988d5/jobs/4346061


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
