### PR TITLE
refactor(profiling): remove pytest.mark.subprocess from v2/test_stack.py [backport 2.14]

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack_v2/include/thread_span_links.hpp
+++ b/ddtrace/internal/datadog/profiling/stack_v2/include/thread_span_links.hpp
@@ -38,6 +38,7 @@ class ThreadSpanLinks
 
     void link_span(uint64_t thread_id, uint64_t span_id, uint64_t local_root_span_id, std::string span_type);
     const std::optional<Span> get_active_span_from_thread_id(uint64_t thread_id);
+    void reset();
 
     static void postfork_child();
 
@@ -48,8 +49,6 @@ class ThreadSpanLinks
     // Private Constructor/Destructor
     ThreadSpanLinks() = default;
     ~ThreadSpanLinks() = default;
-
-    void reset();
 };
 
 }

--- a/ddtrace/internal/datadog/profiling/stack_v2/src/stack_v2.cpp
+++ b/ddtrace/internal/datadog/profiling/stack_v2/src/stack_v2.cpp
@@ -34,6 +34,11 @@ stack_v2_stop(PyObject* self, PyObject* args)
     (void)self;
     (void)args;
     Sampler::get().stop();
+    // Explicitly clear ThreadSpanLinks. The memory should be cleared up
+    // when the program exits as ThreadSpanLinks is a static singleton instance.
+    // However, this was necessary to make sure that the state is not shared
+    // across tests, as the tests are run in the same process.
+    ThreadSpanLinks::get_instance().reset();
     Py_RETURN_NONE;
 }
 

--- a/tests/profiling_v2/collector/test_stack.py
+++ b/tests/profiling_v2/collector/test_stack.py
@@ -1,17 +1,24 @@
+import os
+import sys
+import time
+import uuid
+
 import pytest
 
+from ddtrace import ext
+from ddtrace import tracer
+from ddtrace.internal.datadog.profiling import ddup
+from ddtrace.profiling.collector import stack
+from tests.profiling.collector import pprof_utils
 
-@pytest.mark.subprocess(env=dict(DD_PROFILING_STACK_V2_ENABLED="true"))
-def test_stack_v2_locations():
-    import os
-    import time
 
-    from ddtrace.internal.datadog.profiling import ddup
-    from ddtrace.profiling.collector import stack
-    from tests.profiling.collector import pprof_utils
+@pytest.mark.parametrize("stack_v2_enabled", [True, False])
+def test_stack_v2_locations(stack_v2_enabled, tmp_path):
+    if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
+        pytest.skip("stack_v2 is not supported on Python 3.7")
 
     test_name = "test_locations"
-    pprof_prefix = "/tmp/" + test_name
+    pprof_prefix = str(tmp_path / test_name)
     output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
@@ -27,7 +34,7 @@ def test_stack_v2_locations():
     def foo():
         bar()
 
-    with stack.StackCollector(None):
+    with stack.StackCollector(None, _stack_collector_v2_enabled=stack_v2_enabled):
         for _ in range(5):
             foo()
     ddup.upload()
@@ -52,35 +59,24 @@ def test_stack_v2_locations():
     ]
 
     assert pprof_utils.has_sample_with_locations(
-        profile, samples, expected_locations
+        profile, expected_locations
     ), "Sample with expected locations not found"
 
 
-# Tests here are marked as subprocess as they are flaky when not marked as such,
-# similar to test_user_threads_have_native_id in test_threading.py. For some
-# reason, when the Span is created, it's not linked to the MainThread, and the
-# profiler can't find the corresponding Span for the MainThread.
-@pytest.mark.subprocess()
-def test_push_span():
-    import os
-    import time
-    import uuid
-
-    from ddtrace import ext
-    from ddtrace import tracer
-    from ddtrace.internal.datadog.profiling import ddup
-    from ddtrace.profiling.collector import stack
-    from tests.profiling.collector import pprof_utils
+@pytest.mark.parametrize("stack_v2_enabled", [True, False])
+def test_push_span(stack_v2_enabled, tmp_path):
+    if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
+        pytest.skip("stack_v2 is not supported on Python 3.7")
 
     test_name = "test_push_span"
-    pprof_prefix = "/tmp/" + test_name
+    pprof_prefix = str(tmp_path / test_name)
     output_filename = pprof_prefix + "." + str(os.getpid())
+
+    tracer._endpoint_call_counter_span_processor.enable()
 
     assert ddup.is_available
     ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
     ddup.start()
-
-    tracer._endpoint_call_counter_span_processor.enable()
 
     resource = str(uuid.uuid4())
     span_type = ext.SpanTypes.WEB
@@ -90,6 +86,7 @@ def test_push_span():
         tracer=tracer,
         endpoint_collection_enabled=True,
         ignore_profiler=True,  # this is not necessary, but it's here to trim samples
+        _stack_collector_v2_enabled=stack_v2_enabled,
     ):
         with tracer.trace("foobar", resource=resource, span_type=span_type) as span:
             span_id = span.span_id
@@ -114,82 +111,20 @@ def test_push_span():
         )
 
 
-# pytest.mark.subprocess doesn't support parametrize, so duplicate code here
-@pytest.mark.subprocess(env=dict(DD_PROFILING_STACK_V2_ENABLED="true"))
-def test_push_span_v2():
-    import os
-    import time
-    import uuid
-
-    from ddtrace import ext
-    from ddtrace import tracer
-    from ddtrace.internal.datadog.profiling import ddup
-    from ddtrace.profiling.collector import stack
-    from tests.profiling.collector import pprof_utils
-
-    test_name = "test_push_span_v2"
-    pprof_prefix = "/tmp/" + test_name
-    output_filename = pprof_prefix + "." + str(os.getpid())
-
-    assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
+@pytest.mark.parametrize("stack_v2_enabled", [True, False])
+def test_push_non_web_span(stack_v2_enabled, tmp_path):
+    if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
+        pytest.skip("stack_v2 is not supported on Python 3.7")
 
     tracer._endpoint_call_counter_span_processor.enable()
-
-    resource = str(uuid.uuid4())
-    span_type = ext.SpanTypes.WEB
-
-    with stack.StackCollector(
-        None,
-        tracer=tracer,
-        endpoint_collection_enabled=True,
-        ignore_profiler=True,  # this is not necessary, but it's here to trim samples
-    ):
-        with tracer.trace("foobar", resource=resource, span_type=span_type) as span:
-            span_id = span.span_id
-            local_root_span_id = span._local_root.span_id
-            for _ in range(5):
-                time.sleep(0.01)
-    ddup.upload()
-
-    profile = pprof_utils.parse_profile(output_filename)
-    samples = pprof_utils.get_samples_with_label_key(profile, "span id")
-    assert len(samples) > 0
-    for sample in samples:
-        pprof_utils.assert_stack_event(
-            profile,
-            sample,
-            expected_event=pprof_utils.StackEvent(
-                span_id=span_id,
-                local_root_span_id=local_root_span_id,
-                trace_type=span_type,
-                trace_endpoint=resource,
-            ),
-        )
-
-
-@pytest.mark.subprocess()
-def test_push_non_web_span():
-    import os
-    import time
-    import uuid
-
-    from ddtrace import ext
-    from ddtrace import tracer
-    from ddtrace.internal.datadog.profiling import ddup
-    from ddtrace.profiling.collector import stack
-    from tests.profiling.collector import pprof_utils
 
     test_name = "test_push_non_web_span"
-    pprof_prefix = "/tmp/" + test_name
+    pprof_prefix = str(tmp_path / test_name)
     output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
     ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
     ddup.start()
-
-    tracer._endpoint_call_counter_span_processor.enable()
 
     resource = str(uuid.uuid4())
     span_type = ext.SpanTypes.SQL
@@ -199,6 +134,7 @@ def test_push_non_web_span():
         tracer=tracer,
         endpoint_collection_enabled=True,
         ignore_profiler=True,  # this is not necessary, but it's here to trim samples
+        _stack_collector_v2_enabled=stack_v2_enabled,
     ):
         with tracer.trace("foobar", resource=resource, span_type=span_type) as span:
             span_id = span.span_id
@@ -223,20 +159,14 @@ def test_push_non_web_span():
         )
 
 
-@pytest.mark.subprocess(env=dict(DD_PROFILING_STACK_V2_ENABLED="true"))
-def test_push_span_none_span_type():
+@pytest.mark.parametrize("stack_v2_enabled", [True, False])
+def test_push_span_none_span_type(stack_v2_enabled, tmp_path):
     # Test for https://github.com/DataDog/dd-trace-py/issues/11141
-    import os
-    import time
-    import uuid
-
-    from ddtrace import tracer
-    from ddtrace.internal.datadog.profiling import ddup
-    from ddtrace.profiling.collector import stack
-    from tests.profiling.collector import pprof_utils
+    if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
+        pytest.skip("stack_v2 is not supported on Python 3.7")
 
     test_name = "test_push_span_none_span_type"
-    pprof_prefix = "/tmp/" + test_name
+    pprof_prefix = str(tmp_path / test_name)
     output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
@@ -252,6 +182,7 @@ def test_push_span_none_span_type():
         tracer=tracer,
         endpoint_collection_enabled=True,
         ignore_profiler=True,  # this is not necessary, but it's here to trim samples
+        _stack_collector_v2_enabled=stack_v2_enabled,
     ):
         # Explicitly set None span_type as the default could change in the
         # future.


### PR DESCRIPTION
Manual backport of #11139 to 2.14, to facilitate backporting #11235

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
