### PR TITLE
fix: remove flaky marker from an aiohttp integration test

### DIFF
--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -5,6 +5,7 @@ import pytest
 
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import SAMPLING_PRIORITY_KEY
+from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.aiohttp.middlewares import CONFIG_KEY
 from ddtrace.contrib.aiohttp.middlewares import trace_app
 from ddtrace.contrib.aiohttp.middlewares import trace_middleware
@@ -359,7 +360,6 @@ async def test_wrapped_coroutine(app_tracer, aiohttp_client):
     assert span.duration > 0.25, "span.duration={0}".format(span.duration)
 
 
-@flaky(1735812000)
 async def test_distributed_tracing(app_tracer, aiohttp_client):
     app, tracer = app_tracer
     client = await aiohttp_client(app)
@@ -381,7 +381,7 @@ async def test_distributed_tracing(app_tracer, aiohttp_client):
     # with the right trace_id and parent_id
     assert span.trace_id == 100
     assert span.parent_id == 42
-    assert span.get_metric(SAMPLING_PRIORITY_KEY) is None
+    assert span.get_metric(SAMPLING_PRIORITY_KEY) is USER_KEEP
 
 
 @flaky(1735812000)


### PR DESCRIPTION
Due to the update in https://github.com/DataDog/dd-trace-py/pull/8465, the current default sampling priority when extracting headers is **USER_KEEP** rather than `None`: https://github.com/DataDog/dd-trace-py/blob/223c261250ef1bd1a7547cd0d6311efc153a2395/ddtrace/propagation/http.py#L316 .

The `test_distributed_tracing` test was failing due to this error:
```
FAILED tests/contrib/aiohttp/test_middleware.py::test_distributed_tracing - AssertionError: assert 2 is None
```

That's because the previous test assumed **no sampling priority** would be added to the span but the update changed that.

I don't think this should be a flaky test, so I'm removing the marker and adjusting with the current logic.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
