### PR TITLE
feat(lib-injection): add SSI denylist using requirements.json

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,13 @@ include:
   - local: ".gitlab/dogfood.yml"
   - local: ".gitlab/release.yml"
 
+requirements_json_test:
+  rules:
+    - when: on_success
+  variables:
+    REQUIREMENTS_BLOCK_JSON_PATH: ".gitlab/requirements_block.json"
+    REQUIREMENTS_ALLOW_JSON_PATH: ".gitlab/requirements_allow.json"
+
 package-oci:
   needs: [ download_dependency_wheels, download_ddtrace_artifacts ]
 

--- a/.gitlab/requirements_allow.json
+++ b/.gitlab/requirements_allow.json
@@ -1,0 +1,10 @@
+[
+    {"name": "min glibc x64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "glibc:2.17"}},
+    {"name": "ok glibc x64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "glibc:2.23"}},
+    {"name": "high glibc x64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "glibc:3.0"}},
+    {"name": "musl x64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "musl:1.2.2"}},
+    {"name": "min glibc arm64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "arm64", "libc":  "glibc:2.17"}},
+    {"name": "ok glibc arm64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "arm64", "libc":  "glibc:2.23"}},
+    {"name": "high glibc arm64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "arm64", "libc":  "glibc:3.0"}},
+    {"name": "musl arm64", "filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "arm64", "libc":  "musl:1.2.2"}}
+  ]

--- a/.gitlab/requirements_block.json
+++ b/.gitlab/requirements_block.json
@@ -1,0 +1,11 @@
+[
+  {"name": "unsupported 2.x glibc x64","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "glibc:2.16"}},
+  {"name": "unsupported 1.x glibc x64","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "glibc:1.22"}},
+  {"name": "unsupported 2.x.x glibc x64","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x64", "libc":  "glibc:2.16.9"}},
+  {"name": "unsupported 2.x glibc arm64","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "arm64", "libc":  "glibc:2.15"}},
+  {"name": "unsupported 2.x.x glibc x64","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "arm64", "libc":  "glibc:2.14.9"}},
+  {"name": "glibx x86","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x86", "libc":  "glibc:2.23"}},
+  {"name": "musl x86","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "x86", "libc":  "musl:1.2.2"}},
+  {"name": "glibx arm","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "arm", "libc":  "glibc:2.23"}},
+  {"name": "musl arm","filepath":  "/some/path", "args": [], "envars":  [], "host": {"os": "linux", "arch": "arm", "libc":  "musl:1.2.2"}}
+]

--- a/lib-injection/sources/requirements.json
+++ b/lib-injection/sources/requirements.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "https://raw.githubusercontent.com/DataDog/auto_inject/refs/heads/main/preload_go/cmd/library_requirements_tester/testdata/requirements_schema.json",
+    "version": 1,
+    "native_deps": {
+      "glibc": [{
+        "arch": "x64",
+        "supported": true,
+        "description": "From manylinux_2_17",
+        "min": "2.17"
+      },
+      {
+        "arch": "arm64",
+        "supported": true,
+        "description": "From manylinux_2_17",
+        "min": "2.17"
+      }],
+      "musl": [{
+        "arch": "x64",
+        "supported": true,
+        "description": "From musllinux_1_2 "
+      },{
+        "arch": "arm64",
+        "supported": true,
+        "description": "From alpmusllinux_1_2 "
+      }]
+    },
+    "deny": []
+}

--- a/releasenotes/notes/add-requirements-json-038073d722697e32.yaml
+++ b/releasenotes/notes/add-requirements-json-038073d722697e32.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add requirements.json to SSI artifact for bailing out on unsupported systems.


### PR DESCRIPTION
Adds the `requirements.json` implementation for SSI.

Ensures we bail-out of instrumentation when the machine doesn't meet the glibc requirements.

Tests are handled by the onepipeline, they're essentially unit tests, but are sufficient for now - onboarding tests will handle the "integration test" aspect in due course.

I'm not sure if this needs backporting or not, will defer to you.

https://datadoghq.atlassian.net/browse/APMLP-134

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
