### PR TITLE
chore(llmobs): make sure namespace is string

### DIFF
--- a/ddtrace/llmobs/_evaluators/ragas/faithfulness.py
+++ b/ddtrace/llmobs/_evaluators/ragas/faithfulness.py
@@ -139,7 +139,7 @@ class RagasFaithfulnessEvaluator:
             raise NotImplementedError("Failed to load dependencies for `ragas_faithfulness` evaluator") from e
         finally:
             telemetry_writer.add_count_metric(
-                namespace=TELEMETRY_APM_PRODUCT.LLMOBS,
+                namespace=TELEMETRY_APM_PRODUCT.LLMOBS.value,
                 name="evaluators.init",
                 value=1,
                 tags=(
@@ -165,7 +165,7 @@ class RagasFaithfulnessEvaluator:
             return
         score_result_or_failure = self.evaluate(span_event)
         telemetry_writer.add_count_metric(
-            TELEMETRY_APM_PRODUCT.LLMOBS,  # type: ignore
+            TELEMETRY_APM_PRODUCT.LLMOBS.value,
             "evaluators.run",
             1,
             tags=(

--- a/ddtrace/llmobs/_evaluators/runner.py
+++ b/ddtrace/llmobs/_evaluators/runner.py
@@ -56,7 +56,7 @@ class EvaluatorRunner(PeriodicService):
                     raise e
                 finally:
                     telemetry_writer.add_count_metric(
-                        namespace=TELEMETRY_APM_PRODUCT.LLMOBS,  # type: ignore
+                        namespace=TELEMETRY_APM_PRODUCT.LLMOBS.value,
                         name="evaluators.init",
                         value=1,
                         tags=(

--- a/ddtrace/llmobs/_evaluators/sampler.py
+++ b/ddtrace/llmobs/_evaluators/sampler.py
@@ -67,7 +67,7 @@ class EvaluatorRunnerSampler:
                 TELEMETRY_LOG_LEVEL.ERROR, message="Evaluator sampling parsing failure because: {}".format(msg)
             )
             telemetry_writer.add_count_metric(
-                namespace=TELEMETRY_APM_PRODUCT.LLMOBS,
+                namespace=TELEMETRY_APM_PRODUCT.LLMOBS.value,
                 name="evaluators.error",
                 value=1,
                 tags=(("reason", "sampling_rule_parsing_failure"),),
@@ -104,7 +104,7 @@ class EvaluatorRunnerSampler:
             span_name = rule.get(EvaluatorRunnerSamplingRule.SPAN_NAME_KEY, SamplingRule.NO_RULE)
             evaluator_label = rule.get(EvaluatorRunnerSamplingRule.EVALUATOR_LABEL_KEY, SamplingRule.NO_RULE)
             telemetry_writer.add_distribution_metric(
-                TELEMETRY_APM_PRODUCT.LLMOBS,  # type: ignore
+                TELEMETRY_APM_PRODUCT.LLMOBS.value,
                 "evaluators.rule_sample_rate",
                 sample_rate,
                 tags=(("evaluator_label", evaluator_label), ("span_name", span_name)),


### PR DESCRIPTION
Make sure namespace is a string, not the enum object for ragas telemetry

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
