### PR TITLE
chore(ci): remove unused type ignore comments

### DIFF
--- a/ddtrace/llmobs/_evaluators/ragas/faithfulness.py
+++ b/ddtrace/llmobs/_evaluators/ragas/faithfulness.py
@@ -165,7 +165,7 @@ class RagasFaithfulnessEvaluator:
             return
         score_result_or_failure = self.evaluate(span_event)
         telemetry_writer.add_count_metric(
-            TELEMETRY_APM_PRODUCT.LLMOBS,  # type: ignore
+            TELEMETRY_APM_PRODUCT.LLMOBS,
             "evaluators.run",
             1,
             tags=(

--- a/ddtrace/llmobs/_evaluators/runner.py
+++ b/ddtrace/llmobs/_evaluators/runner.py
@@ -56,7 +56,7 @@ class EvaluatorRunner(PeriodicService):
                     raise e
                 finally:
                     telemetry_writer.add_count_metric(
-                        namespace=TELEMETRY_APM_PRODUCT.LLMOBS,  # type: ignore
+                        namespace=TELEMETRY_APM_PRODUCT.LLMOBS,
                         name="evaluators.init",
                         value=1,
                         tags=(

--- a/ddtrace/llmobs/_evaluators/sampler.py
+++ b/ddtrace/llmobs/_evaluators/sampler.py
@@ -104,7 +104,7 @@ class EvaluatorRunnerSampler:
             span_name = rule.get(EvaluatorRunnerSamplingRule.SPAN_NAME_KEY, SamplingRule.NO_RULE)
             evaluator_label = rule.get(EvaluatorRunnerSamplingRule.EVALUATOR_LABEL_KEY, SamplingRule.NO_RULE)
             telemetry_writer.add_distribution_metric(
-                TELEMETRY_APM_PRODUCT.LLMOBS,  # type: ignore
+                TELEMETRY_APM_PRODUCT.LLMOBS,
                 "evaluators.rule_sample_rate",
                 sample_rate,
                 tags=(("evaluator_label", evaluator_label), ("span_name", span_name)),


### PR DESCRIPTION
We started to see typing check failures in the `pre_check` test. This was probably due to side effects that were uncaught from not requiring branches to be updated with main before merging. This PR aims to fix the issue that the typing check is complaining about, but the actual fix to prevent this will be to require main updates on branches before merging (this is already done if using the merge queue, but not manual merges).


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
