### PR TITLE
Update snapshot tests server address

### DIFF
--- a/ddtrace/contrib/internal/aiohttp/patch.py
+++ b/ddtrace/contrib/internal/aiohttp/patch.py
@@ -105,6 +105,7 @@ async def _traced_clientsession_request(aiohttp, pin, func, instance, args, kwar
             method=method,
             url=str(url),
             target_host=host,
+            server_address=host,
             query=query,
             request_headers=headers,
         )

--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -431,6 +431,7 @@ def set_http_meta(
     method=None,  # type: Optional[str]
     url=None,  # type: Optional[str]
     target_host=None,  # type: Optional[str]
+    server_address=None,  # type: Optional[str]
     status_code=None,  # type: Optional[Union[int, str]]
     status_msg=None,  # type: Optional[str]
     query=None,  # type: Optional[str]
@@ -473,6 +474,9 @@ def set_http_meta(
 
     if target_host is not None:
         span.set_tag_str(net.TARGET_HOST, target_host)
+
+    if server_address is not None:
+        span.set_tag_str(net.SERVER_ADDRESS, server_address)
 
     if status_code is not None:
         try:

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request.json
@@ -19,6 +19,7 @@
       "language": "python",
       "out.host": "localhost",
       "runtime-id": "de4fa08308ec4bc3a437ed78b9f99c47",
+      "server.address": "localhost",
       "span.kind": "client"
     },
     "metrics": {

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request_post.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_200_request_post.json
@@ -19,6 +19,7 @@
       "language": "python",
       "out.host": "localhost",
       "runtime-id": "de4fa08308ec4bc3a437ed78b9f99c47",
+      "server.address": "localhost",
       "span.kind": "client"
     },
     "metrics": {

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_500_request.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_500_request.json
@@ -19,6 +19,7 @@
       "language": "python",
       "out.host": "localhost",
       "runtime-id": "de4fa08308ec4bc3a437ed78b9f99c47",
+      "server.address": "localhost",
       "span.kind": "client"
     },
     "metrics": {

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_auth_200_request.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_auth_200_request.json
@@ -19,6 +19,7 @@
       "language": "python",
       "out.host": "localhost",
       "runtime-id": "de4fa08308ec4bc3a437ed78b9f99c47",
+      "server.address": "localhost",
       "span.kind": "client"
     },
     "metrics": {

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[None].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[None].json
@@ -19,6 +19,7 @@
       "language": "python",
       "out.host": "localhost",
       "runtime-id": "38ad32edbcf9402caa80d653ecca8028",
+      "server.address": "localhost",
       "span.kind": "client"
     },
     "metrics": {

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v0].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v0].json
@@ -19,6 +19,7 @@
       "language": "python",
       "out.host": "localhost",
       "runtime-id": "d0a85359bd8643f7b8f3bd198b9352f6",
+      "server.address": "localhost",
       "span.kind": "client"
     },
     "metrics": {

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v1].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_global_service_name_env[v1].json
@@ -21,6 +21,7 @@
       "out.host": "localhost",
       "peer.service": "localhost",
       "runtime-id": "6ada2da1ec9f42fc8d07b3f421d526fe",
+      "server.address": "localhost",
       "span.kind": "client"
     },
     "metrics": {

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_service_name_pin.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_service_name_pin.json
@@ -20,6 +20,7 @@
       "language": "python",
       "out.host": "localhost",
       "runtime-id": "5f1ca8c9f4274d8d95d181a61c9ba731",
+      "server.address": "localhost",
       "span.kind": "client"
     },
     "metrics": {

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_service_name_split_by_domain.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_configure_service_name_split_by_domain.json
@@ -20,6 +20,7 @@
       "language": "python",
       "out.host": "localhost",
       "runtime-id": "4c401c35daea4876be809e40a325baeb",
+      "server.address": "localhost",
       "span.kind": "client"
     },
     "metrics": {

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_multiple.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_multiple.json
@@ -19,6 +19,7 @@
       "language": "python",
       "out.host": "localhost",
       "runtime-id": "de4fa08308ec4bc3a437ed78b9f99c47",
+      "server.address": "localhost",
       "span.kind": "client"
     },
     "metrics": {

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_parenting.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_parenting.json
@@ -40,6 +40,7 @@
          "http.status_msg": "OK",
          "http.url": "http://localhost:8001/status/200",
          "out.host": "localhost",
+         "server.address": "localhost",
          "span.kind": "client"
        },
        "duration": 2486123,

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_query_string.json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_trace_query_string.json
@@ -20,6 +20,7 @@
       "language": "python",
       "out.host": "localhost",
       "runtime-id": "de4fa08308ec4bc3a437ed78b9f99c47",
+      "server.address": "localhost",
       "span.kind": "client"
     },
     "metrics": {

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[None].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[None].json
@@ -19,6 +19,7 @@
       "language": "python",
       "out.host": "localhost",
       "runtime-id": "80475ea11c124fb39f39268c1a8dd6e6",
+      "server.address": "localhost",
       "span.kind": "client"
     },
     "metrics": {

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v0].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v0].json
@@ -19,6 +19,7 @@
       "language": "python",
       "out.host": "localhost",
       "runtime-id": "46c94f5e0ef041cfb59591463f097660",
+      "server.address": "localhost",
       "span.kind": "client"
     },
     "metrics": {

--- a/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v1].json
+++ b/tests/snapshots/tests.contrib.aiohttp.test_aiohttp_client.test_unspecified_service_name_env[v1].json
@@ -21,6 +21,7 @@
       "out.host": "localhost",
       "peer.service": "localhost",
       "runtime-id": "df73bafc708a46ab8bd75faf673a61e2",
+      "server.address": "localhost",
       "span.kind": "client"
     },
     "metrics": {

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg2_query_default.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg2_query_default.json
@@ -48,6 +48,7 @@
          "db.system": "postgresql",
          "db.user": "postgres",
          "out.host": "127.0.0.1",
+         "server.address": "127.0.0.1",
          "span.kind": "client"
        },
        "metrics": {

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg3_query_default.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg3_query_default.json
@@ -48,6 +48,7 @@
          "db.system": "postgresql",
          "db.user": "postgres",
          "out.host": "127.0.0.1",
+         "server.address": "127.0.0.1",
          "span.kind": "client"
        },
        "metrics": {


### PR DESCRIPTION
Continuation of #10064 to add `server.address` tags to DB clients to comply with OTel standards.

Update `django` and `aiohttp` snapshots, and modify the logic to set `server_address` using the existing internal method.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
