### PR TITLE
fix(profiling): clear sample pool after fork

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample_manager.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample_manager.cpp
@@ -74,6 +74,12 @@ void
 Datadog::SampleManager::postfork_child()
 {
     Datadog::Sample::postfork_child();
+    if (sample_pool != nullptr) {
+        // Clear the pool to make sure it's in a consistent state.
+        // Suppose there was a thread that was adding/removing sample from the pool
+        // and the fork happened in the middle of that operation.
+        sample_pool = std::make_unique<SynchronizedSamplePool>(sample_pool_capacity);
+    }
 }
 
 void

--- a/releasenotes/notes/profiling-sample-pool-461a108e068dea5b.yaml
+++ b/releasenotes/notes/profiling-sample-pool-461a108e068dea5b.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    profiling: fixes an issue where the sample pool could deadlock after ``fork()``
+      by clearing it in the child process.
+


### PR DESCRIPTION
Tested with native tests

`crossbeam::ArrayQueue` uses Rust `std::sync::atomic` which doesn't seem to be consistent across `fork()` calls as `std::mutex` from C++ isn't. So we need to make sure, an equivalent of `std::mutex::unlock()` happens after fork. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
