### PR TITLE
chore(ci): update description of generate package workflow

### DIFF
--- a/.github/workflows/generate-package-versions.yml
+++ b/.github/workflows/generate-package-versions.yml
@@ -100,8 +100,11 @@ jobs:
           title: "chore: update ${{ env.VENV_NAME }} latest version to ${{ env.NEW_LATEST }}"
           labels: changelog/no-changelog
           body: |
-            Update ${{ env.VENV_NAME }} lockfiles and dependency package lockfiles that use `latest`.
-
+            Update ${{ env.VENV_NAME }} lockfiles and dependency package lockfiles.
+            This performs the following updates:
+              1) Some ${{ env.VENV_NAME }} lockfiles use ${{ env.VENV_NAME }} `latest`. This will update ${{ env.VENV_NAME }} and dependencies.
+              2) Some ${{ env.VENV_NAME }} lockfiles use a pinned (non-latest) version of ${{ env.VENV_NAME }}, but require a `latest` dependency version. This will update the dependencies.
+            
             ## Checklist
             - [x] PR author has checked that all the criteria below are met
             - The PR description includes an overview of the change

--- a/.github/workflows/generate-package-versions.yml
+++ b/.github/workflows/generate-package-versions.yml
@@ -99,4 +99,27 @@ jobs:
           base: main
           title: "chore: update ${{ env.VENV_NAME }} latest version to ${{ env.NEW_LATEST }}"
           labels: changelog/no-changelog
-          body-path: .github/PULL_REQUEST_TEMPLATE.md
+          body: |
+            Update ${{ env.VENV_NAME }} lockfiles and dependency package lockfiles that use `latest`.
+
+            ## Checklist
+            - [x] PR author has checked that all the criteria below are met
+            - The PR description includes an overview of the change
+            - The PR description articulates the motivation for the change
+            - The change includes tests OR the PR description describes a testing strategy
+            - The PR description notes risks associated with the change, if any
+            - Newly-added code is easy to change
+            - The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
+            - The change includes or references documentation updates if necessary
+            - Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))
+
+            ## Reviewer Checklist
+            - [ ] Reviewer has checked that all the criteria below are met 
+            - Title is accurate
+            - All changes are related to the pull request's stated goal
+            - Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
+            - Testing strategy adequately addresses listed risks
+            - Newly-added code is easy to change
+            - Release note makes sense to a user of the library
+            - If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
+            - Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

--- a/.github/workflows/generate-package-versions.yml
+++ b/.github/workflows/generate-package-versions.yml
@@ -103,7 +103,7 @@ jobs:
             Update ${{ env.VENV_NAME }} lockfiles and dependency package lockfiles.
             This performs the following updates:
               1) Some ${{ env.VENV_NAME }} lockfiles use ${{ env.VENV_NAME }} `latest`. This will update ${{ env.VENV_NAME }} and dependencies.
-              2) Some ${{ env.VENV_NAME }} lockfiles use a pinned (non-latest) version of ${{ env.VENV_NAME }}, but require a `latest` dependency version. This will update the dependencies.
+              2) Some ${{ env.VENV_NAME }} lockfiles use a pinned (non-latest) version of ${{ env.VENV_NAME }}, but require the `latest` version of another package. This will update all such packages.
             
             ## Checklist
             - [x] PR author has checked that all the criteria below are met


### PR DESCRIPTION
In the auto-generated PRs generated by the [Generate Package Versions](https://github.com/DataDog/dd-trace-py/actions/workflows/generate-package-versions.yml) workflow, some of the modified files might not directly update the selected package to `latest`. Not all lockfiles for a given `venv` will use the `venv` `latest`, but the workflow also updates dependency versions.

This PR modifies the body of the generated PRs for better clarification. Example: #11354

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
