### PR TITLE
ci(profiling): v1/v2 matrix in Django overhead job

### DIFF
--- a/.github/workflows/django-overhead-profile.yml
+++ b/.github/workflows/django-overhead-profile.yml
@@ -13,12 +13,19 @@ on:
 jobs:
   django-overhead-profile:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - suffix: "-v1"
+            stack_v2: "0"
+          - suffix: "-v2"
+            stack_v2: "1"
     env:
       PREFIX: ${{ github.workspace }}/prefix
       DD_CODE_ORIGIN_FOR_SPANS_ENABLED: "1"
       DD_PROFILING_ENABLED: "1"
-      DD_PROFILING_STACK_V2_ENABLED: "1"
-      DD_PROFILING_OUTPUT_PPROF: ${{ github.workspace }}/prefix/artifacts/ddtrace_profile.pprof
+      DD_PROFILING_STACK_V2_ENABLED: ${{ matrix.stack_v2 }}
+      DD_PROFILING_OUTPUT_PPROF: ${{ github.workspace }}/prefix/artifacts/ddtrace_profile
     defaults:
       run:
         working-directory: ddtrace
@@ -41,6 +48,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: django-overhead-profile
+          name: django-overhead-profile${{ matrix.suffix }}
           path: ${{ github.workspace }}/prefix/artifacts
 


### PR DESCRIPTION
We run the Django overhead profile job with the profiler enabled and profile both stack v1 and v2.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
