### PR TITLE
ci: reduce API requests in download wheel job

### DIFF
--- a/.gitlab/download-wheels-from-gh-actions.sh
+++ b/.gitlab/download-wheels-from-gh-actions.sh
@@ -37,7 +37,7 @@ echo "Found RUN_ID: $RUN_ID"
 mkdir pywheels
 cd pywheels
 
-if ! gh run download $RUN_ID --repo DataDog/dd-trace-py ; then
+if [ $(gh run view $RUN_ID --exit-status --json status --jq .status) != "completed" ]; then
   echo "Waiting for workflow to finish"
 
   # Give time to the job to finish
@@ -45,12 +45,11 @@ if ! gh run download $RUN_ID --repo DataDog/dd-trace-py ; then
 
   # wait for run to finish
   gh run watch $RUN_ID --interval 60 --exit-status 1 --repo DataDog/dd-trace-py
-
-  echo "Github workflow finished. Downloading wheels"
-
-  # download all wheels
-  gh run download $RUN_ID --repo DataDog/dd-trace-py
 fi
+
+echo "Github workflow finished. Downloading wheels"
+# download all wheels
+gh run download $RUN_ID --repo DataDog/dd-trace-py
 
 cd ..
 

--- a/.gitlab/download-wheels-from-gh-actions.sh
+++ b/.gitlab/download-wheels-from-gh-actions.sh
@@ -6,20 +6,26 @@ if [ -z "$CI_COMMIT_SHA" ]; then
   exit 1
 fi
 
-echo "Querying for RUN_ID"
+RUN_ID=$(gh run ls --repo DataDog/dd-trace-py --commit=$CI_COMMIT_SHA --workflow=build_deploy.yml --json databaseId --jq "first (.[]) | .databaseId")
+if [ -n "$RUN_ID" ]; then
+  # The job has not started yet. Give it time to start
+  sleep 180 # 3 minutes
 
-timeout=600 # 10 minutes
-start_time=$(date +%s)
-end_time=$((start_time + timeout))
-# Loop for 10 minutes waiting for run to appear in github
-while [ $(date +%s) -lt $end_time ]; do
-  RUN_ID=$(gh run ls --repo DataDog/dd-trace-py --commit=$CI_COMMIT_SHA --workflow=build_deploy.yml --json databaseId --jq "first (.[]) | .databaseId")
-  if [ -n "$RUN_ID" ]; then
-    break;
-  fi
-  echo "Waiting for RUN_ID"
-  sleep 20
-done
+  echo "Querying for RUN_ID"
+
+  timeout=600 # 10 minutes
+  start_time=$(date +%s)
+  end_time=$((start_time + timeout))
+  # Loop for 10 minutes waiting for run to appear in github
+  while [ $(date +%s) -lt $end_time ]; do
+    RUN_ID=$(gh run ls --repo DataDog/dd-trace-py --commit=$CI_COMMIT_SHA --workflow=build_deploy.yml --json databaseId --jq "first (.[]) | .databaseId")
+    if [ -n "$RUN_ID" ]; then
+      break;
+    fi
+    echo "Waiting for RUN_ID"
+    sleep 60
+  done
+fi
 
 if [ -z "$RUN_ID" ]; then
   echo "RUN_ID not found"
@@ -27,18 +33,24 @@ if [ -z "$RUN_ID" ]; then
 fi
 
 echo "Found RUN_ID: $RUN_ID"
-echo "Waiting for workflow to finish"
-
-# wait for run to finish
-gh run watch $RUN_ID --interval 45 --exit-status 1 --repo DataDog/dd-trace-py
 
 mkdir pywheels
 cd pywheels
 
-echo "Github workflow finished. Downloading wheels"
+if ! gh run download $RUN_ID --repo DataDog/dd-trace-py ; then
+  echo "Waiting for workflow to finish"
 
-# download all wheels
-gh run download $RUN_ID --repo DataDog/dd-trace-py
+  # Give time to the job to finish
+  sleep 600 # 10 minutes
+
+  # wait for run to finish
+  gh run watch $RUN_ID --interval 60 --exit-status 1 --repo DataDog/dd-trace-py
+
+  echo "Github workflow finished. Downloading wheels"
+
+  # download all wheels
+  gh run download $RUN_ID --repo DataDog/dd-trace-py
+fi
 
 cd ..
 

--- a/ddtrace/internal/ci_visibility/telemetry/git.py
+++ b/ddtrace/internal/ci_visibility/telemetry/git.py
@@ -69,7 +69,7 @@ def record_settings_response(
     if require_git:
         response_tags.append(("require_git", "1"))
     if itr_enabled:
-        response_tags.append(("itrskip_enabled", "1"))
+        response_tags.append(("itr_enabled", "1"))
     if early_flake_detection_enabled:
         response_tags.append(("early_flake_detection_enabled", "1"))
 


### PR DESCRIPTION
We reduce the number of requests to the GitHub API made by the GitLab wheel download workflow to reduce the chances of going over the request rate limit. We also make sure that the job re-runs reactively when the GitHub workflow has completed.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
