### PR TITLE
chore(tracer): remove x-forwarded from ip resolution

### DIFF
--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -1,6 +1,7 @@
 """
 This module contains utility functions for writing ddtrace integrations.
 """
+
 from collections import deque
 import ipaddress
 import re
@@ -66,7 +67,6 @@ IP_PATTERNS = (
     "x-real-ip",
     "true-client-ip",
     "x-client-ip",
-    "x-forwarded",
     "forwarded-for",
     "x-cluster-client-ip",
     "fastly-client-ip",

--- a/releasenotes/notes/remove_x-forwarded_from_ip_resolution-d63292c0fda42dd9.yaml
+++ b/releasenotes/notes/remove_x-forwarded_from_ip_resolution-d63292c0fda42dd9.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    Tracer: Removed x-forwarded from headers used for client IP resolution (but not from collected headers).
+      We lack evidence of actual usage, and whether this should follow RFC 7239 or regular XFF list format.


### PR DESCRIPTION
Removed x-forwarded from headers used for client IP resolution (but not from collected headers).
We lack evidence of actual usage, and whether this should follow RFC 7239 or regular XFF list format.

Also:
- add unit test for priority over all ip headers. check that x-forwarded is now ignored.

APPSEC-55824

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
