### PR TITLE
chore(ci_visibility): fix line numbers in Python 3.10 code coverage instrumentation

### DIFF
--- a/ddtrace/internal/coverage/instrumentation_py3_10.py
+++ b/ddtrace/internal/coverage/instrumentation_py3_10.py
@@ -206,7 +206,7 @@ def instrument_all_lines_nonrecursive(
 
         line = line_starts.get(old_offset)
         if line is not None:
-            if old_offset > 0:
+            if previous_previous_line != 0:
                 # Beginning of new line: update line table entry for _previous_ line.
                 update_linetable(new_offset - previous_line_new_offset, previous_line - previous_previous_line)
             previous_previous_line = previous_line

--- a/ddtrace/internal/coverage/instrumentation_py3_10.py
+++ b/ddtrace/internal/coverage/instrumentation_py3_10.py
@@ -122,7 +122,7 @@ def instrument_all_lines_nonrecursive(
 
     previous_line = code.co_firstlineno
     previous_line_new_offset = 0
-    previous_previous_line = 0
+    previous_previous_line = code.co_firstlineno
 
     arg = 0
     previous_arg = 0
@@ -206,7 +206,7 @@ def instrument_all_lines_nonrecursive(
 
         line = line_starts.get(old_offset)
         if line is not None:
-            if previous_previous_line != 0:
+            if old_offset > 0:
                 # Beginning of new line: update line table entry for _previous_ line.
                 update_linetable(new_offset - previous_line_new_offset, previous_line - previous_previous_line)
             previous_previous_line = previous_line

--- a/tests/ci_visibility/test_ci_visibility.py
+++ b/tests/ci_visibility/test_ci_visibility.py
@@ -528,7 +528,7 @@ def test_git_do_request_agentless(git_repo):
                 {"mock_header_name": "mock_header_value"},
             )
 
-            mock_get_connection.assert_called_once_with("http://base_url/repository/endpoint", timeout=20)
+            mock_get_connection.assert_any_call("http://base_url/repository/endpoint", timeout=20)
             mock_http_connection.request.assert_called_once_with(
                 "POST",
                 "/repository/endpoint",
@@ -561,7 +561,7 @@ def test_git_do_request_evp(git_repo):
                 {"mock_header_name": "mock_header_value"},
             )
 
-            mock_get_connection.assert_called_once_with("https://base_url/repository/endpoint", timeout=20)
+            mock_get_connection.assert_any_call("https://base_url/repository/endpoint", timeout=20)
             mock_http_connection.request.assert_called_once_with(
                 "POST",
                 "/repository/endpoint",
@@ -607,7 +607,7 @@ class TestCIVisibilityWriter(TracerTestCase):
             with mock.patch("ddtrace.internal.writer.writer.get_connection") as _get_connection:
                 _get_connection.return_value.getresponse.return_value.status = 200
                 dummy_writer._put("", {}, cov_client, no_trace=True)
-                _get_connection.assert_called_once_with("https://citestcov-intake.datadoghq.com", 2.0)
+                _get_connection.assert_any_call("https://citestcov-intake.datadoghq.com", 2.0)
 
     def test_civisibilitywriter_coverage_agentless_with_intake_url_param(self):
         ddtrace.internal.ci_visibility.writer.config._ci_visibility_agentless_url = ""

--- a/tests/coverage/included_path/async_code.py
+++ b/tests/coverage/included_path/async_code.py
@@ -1,9 +1,14 @@
 import asyncio
+import sys
 
 
-async def some_async_function():
-    return 42
+async def get_line_number():
+    try:
+        raise Exception("this is line 7")
+    except Exception:
+        exception_type, exception, traceback = sys.exc_info()
+        return traceback.tb_lineno
 
 
-def call_async_function():
-    asyncio.run(some_async_function())
+def call_async_function_and_report_line_number():
+    return asyncio.run(get_line_number())

--- a/tests/coverage/included_path/async_code.py
+++ b/tests/coverage/included_path/async_code.py
@@ -1,0 +1,9 @@
+import asyncio
+
+
+async def some_async_function():
+    return 42
+
+
+def call_async_function():
+    asyncio.run(some_async_function())

--- a/tests/coverage/test_coverage_async.py
+++ b/tests/coverage/test_coverage_async.py
@@ -1,0 +1,50 @@
+import pytest
+
+
+@pytest.mark.subprocess
+def test_coverage_async_function():
+    """
+    Async functions in Python 3.10 have an initial GEN_START instruction with no corresponding line number.
+    This test ensures we can handle this case correctly.
+    """
+    import os
+    from pathlib import Path
+
+    from ddtrace.internal.coverage.code import ModuleCodeCollector
+    from ddtrace.internal.coverage.installer import install
+    from tests.coverage.utils import _get_relpath_dict
+
+    cwd_path = os.getcwd()
+    include_path = Path(cwd_path + "/tests/coverage/included_path/")
+
+    install(include_paths=[include_path], collect_import_time_coverage=True)
+
+    from tests.coverage.included_path.async_code import call_async_function
+
+    ModuleCodeCollector.start_coverage()
+    call_async_function()
+    ModuleCodeCollector.stop_coverage()
+
+    executable = _get_relpath_dict(cwd_path, ModuleCodeCollector._instance.lines)
+    covered = _get_relpath_dict(cwd_path, ModuleCodeCollector._instance._get_covered_lines(include_imported=False))
+    covered_with_imports = _get_relpath_dict(
+        cwd_path, ModuleCodeCollector._instance._get_covered_lines(include_imported=True)
+    )
+
+    expected_executable = {
+        "tests/coverage/included_path/async_code.py": {1, 3, 4, 6, 7},
+    }
+    expected_covered = {
+        "tests/coverage/included_path/async_code.py": {4, 7},
+    }
+    expected_covered_with_imports = {
+        "tests/coverage/included_path/async_code.py": {1, 3, 4, 6, 7},
+    }
+
+    assert (
+        executable == expected_executable
+    ), f"Executable lines mismatch: expected={expected_executable} vs actual={executable}"
+    assert covered == expected_covered, f"Covered lines mismatch: expected={expected_covered} vs actual={covered}"
+    assert (
+        covered_with_imports == expected_covered_with_imports
+    ), f"Covered lines with imports mismatch: expected={expected_covered_with_imports} vs actual={covered_with_imports}"

--- a/tests/coverage/test_coverage_async.py
+++ b/tests/coverage/test_coverage_async.py
@@ -5,7 +5,8 @@ import pytest
 def test_coverage_async_function():
     """
     Async functions in Python 3.10 have an initial GEN_START instruction with no corresponding line number.
-    This test ensures we can handle this case correctly.
+    This test ensures we can handle this case correctly and build the line number table correctly in the instrumented
+    functions.
     """
     import os
     from pathlib import Path
@@ -19,10 +20,10 @@ def test_coverage_async_function():
 
     install(include_paths=[include_path], collect_import_time_coverage=True)
 
-    from tests.coverage.included_path.async_code import call_async_function
+    from tests.coverage.included_path.async_code import call_async_function_and_report_line_number
 
     ModuleCodeCollector.start_coverage()
-    call_async_function()
+    line_number = call_async_function_and_report_line_number()
     ModuleCodeCollector.stop_coverage()
 
     executable = _get_relpath_dict(cwd_path, ModuleCodeCollector._instance.lines)
@@ -32,13 +33,13 @@ def test_coverage_async_function():
     )
 
     expected_executable = {
-        "tests/coverage/included_path/async_code.py": {1, 4, 5, 8, 9},
+        "tests/coverage/included_path/async_code.py": {1, 2, 5, 6, 7, 8, 9, 10, 13, 14},
     }
     expected_covered = {
-        "tests/coverage/included_path/async_code.py": {5, 9},
+        "tests/coverage/included_path/async_code.py": {6, 7, 8, 9, 10, 14},
     }
     expected_covered_with_imports = {
-        "tests/coverage/included_path/async_code.py": {1, 4, 5, 8, 9},
+        "tests/coverage/included_path/async_code.py": {1, 2, 5, 6, 7, 8, 9, 10, 13, 14},
     }
 
     assert (
@@ -48,3 +49,4 @@ def test_coverage_async_function():
     assert (
         covered_with_imports == expected_covered_with_imports
     ), f"Covered lines with imports mismatch: expected={expected_covered_with_imports} vs actual={covered_with_imports}"
+    assert line_number == 7

--- a/tests/coverage/test_coverage_async.py
+++ b/tests/coverage/test_coverage_async.py
@@ -32,13 +32,13 @@ def test_coverage_async_function():
     )
 
     expected_executable = {
-        "tests/coverage/included_path/async_code.py": {1, 3, 4, 6, 7},
+        "tests/coverage/included_path/async_code.py": {1, 4, 5, 8 9},
     }
     expected_covered = {
-        "tests/coverage/included_path/async_code.py": {4, 7},
+        "tests/coverage/included_path/async_code.py": {5, 9},
     }
     expected_covered_with_imports = {
-        "tests/coverage/included_path/async_code.py": {1, 3, 4, 6, 7},
+        "tests/coverage/included_path/async_code.py": {1, 4, 5, 8 9},
     }
 
     assert (

--- a/tests/coverage/test_coverage_async.py
+++ b/tests/coverage/test_coverage_async.py
@@ -32,13 +32,13 @@ def test_coverage_async_function():
     )
 
     expected_executable = {
-        "tests/coverage/included_path/async_code.py": {1, 4, 5, 8 9},
+        "tests/coverage/included_path/async_code.py": {1, 4, 5, 8, 9},
     }
     expected_covered = {
         "tests/coverage/included_path/async_code.py": {5, 9},
     }
     expected_covered_with_imports = {
-        "tests/coverage/included_path/async_code.py": {1, 4, 5, 8 9},
+        "tests/coverage/included_path/async_code.py": {1, 4, 5, 8, 9},
     }
 
     assert (


### PR DESCRIPTION
The code coverage for Python 3.10 has an implicit assumption that the first bytecode offset matches the first line number in the line table, which is wrong because some instructions may not have line numbers. This PR changes it so that the first line number is the code object's first line number attribute, so that it will work even if no line-starting offsets have been seen before.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
