### PR TITLE
fix(profiling): reduce lock profiler log spam

### DIFF
--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -298,7 +298,7 @@ class _ProfiledLock(wrapt.ObjectProxy):
 
             if not self._self_name:
                 self._self_name = ""
-                LOG.warning(
+                LOG.debug(
                     "Failed to get lock variable name, we only support local/global variables and their attributes."
                 )
 

--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -269,7 +269,7 @@ class _ProfiledLock(wrapt.ObjectProxy):
 
     # Get lock acquire/release call location and variable name the lock is assigned to
     def _maybe_update_self_name(self):
-        if self._self_name:
+        if self._self_name is not None:
             return
         try:
             # We expect the call stack to be like this:

--- a/releasenotes/notes/profiling-reduce-lock-profiler-log-spam-5931d957ff1becd4.yaml
+++ b/releasenotes/notes/profiling-reduce-lock-profiler-log-spam-5931d957ff1becd4.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: The lock profiler would log a warning if it couldn't determine a name for a lock.
+    This lead to excessive log spam. Downgrade this to a debug log.

--- a/releasenotes/notes/profiling-reduce-lock-profiler-log-spam-5931d957ff1becd4.yaml
+++ b/releasenotes/notes/profiling-reduce-lock-profiler-log-spam-5931d957ff1becd4.yaml
@@ -1,5 +1,7 @@
 ---
 fixes:
   - |
-    profiling: The lock profiler would log a warning if it couldn't determine a name for a lock.
-    This lead to excessive log spam. Downgrade this to a debug log.
+    profiling: The lock profiler would log a warning if it couldn't determine a
+      name for a lock, and it would try determining a name multiple times for
+      the same lock.  This lead to excessive log spam. Downgrade this to a
+      debug log and only try to determine the name once.


### PR DESCRIPTION
The lock profiler would log a warning if it couldn't determine a
name for a lock, and it would try determining a name multiple times for
the same lock.  This lead to excessive log spam. Downgrade this to a
debug log and only try to determine the name once.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

PROF-10898