### PR TITLE
ci(asm): appsec_integrations suite improvments

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -521,7 +521,7 @@ jobs:
 
   appsec_integrations:
     <<: *machine_executor
-    parallelism: 7
+    parallelism: 13
     steps:
       - run_test:
           pattern: 'appsec_integrations'

--- a/tests/appsec/integrations/test_flask_entrypoint_iast_patches.py
+++ b/tests/appsec/integrations/test_flask_entrypoint_iast_patches.py
@@ -1,5 +1,7 @@
 import pytest
 
+from tests.utils import flaky
+
 
 @pytest.mark.subprocess()
 def test_ddtrace_iast_flask_patch():
@@ -146,6 +148,7 @@ def test_ddtrace_iast_flask_app_create_app_patch_all():
         del sys.modules["tests.appsec.iast.fixtures.entrypoint.views"]
 
 
+@flaky(1736035200)
 @pytest.mark.subprocess(check_logs=False)
 def test_ddtrace_iast_flask_app_create_app_patch_all_enable_iast_propagation():
     import dis


### PR DESCRIPTION
1. Increase parallelism to reduce the time to run the suite, there are 13 riot hashes. Each job takes about 30 minutes, where 10 minutes spent for building dd-trace-py and the rest spent for running 2 riot hashes. 
3. Mark a test flaky, it failed 3 times in a row for an unrelated change [ci(profiling): explicitly set cpucount for uwsgi build](https://github.com/DataDog/dd-trace-py/pull/11402), [run 1](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/77339/workflows/b138b8df-bdb5-4cfc-a6ae-e8d8f204661b/jobs/4357608), [run 2](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/77339/workflows/8e33c607-89cb-4bab-89b1-acb6d0931856/jobs/4357577), [run 3](https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/77339/workflows/b5609072-9b15-4c46-ae11-10c7c0039ada/jobs/4357516). 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
