### PR TITLE
feature(ci_visibility): announce beta of new pytest plugin

### DIFF
--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -4,7 +4,7 @@ stages:
 variables:
   RIOT_RUN_CMD: riot -P -v run --exitfirst --pass-env -s
   REPO_LANG: python # "python" is used everywhere rather than "py"
-  _DD_CIVISIBILITY_USE_PYTEST_V2: "true"
+  DD_PYTEST_USE_NEW_PLUGIN_BETA: "true"
   PYTEST_ADDOPTS: "-s"
   # CI_DEBUG_SERVICES: "true"
 

--- a/ddtrace/contrib/pytest/_plugin_v1.py
+++ b/ddtrace/contrib/pytest/_plugin_v1.py
@@ -22,6 +22,7 @@ from _pytest.nodes import get_fslocation_from_item
 import pytest
 
 import ddtrace
+from ddtrace import DDTraceDeprecationWarning
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib.internal.coverage.data import _coverage_data
 from ddtrace.contrib.internal.coverage.patch import patch as patch_coverage
@@ -70,6 +71,7 @@ from ddtrace.internal.coverage.code import ModuleCodeCollector
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.inspection import undecorated
+from ddtrace.vendor.debtcollector import deprecate
 
 
 log = get_logger(__name__)
@@ -446,6 +448,12 @@ def pytest_load_initial_conftests(early_config, parser, args):
 
 
 def pytest_configure(config):
+    deprecate(
+        "This version of the pytest ddtrace plugin is slated for deprecation",
+        message="set DD_PYTEST_PREVIEW_PLUGIN=true in your environment to preview the next version of the plugin.",
+        removal_version="3.0.0",
+        category=DDTraceDeprecationWarning,
+    )
     unpatch_unittest()
     if is_enabled(config):
         ddtrace.config.test_visibility._itr_skipping_ignore_parameters = True

--- a/ddtrace/contrib/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/pytest/_plugin_v2.py
@@ -4,6 +4,7 @@ import typing as t
 
 import pytest
 
+from ddtrace import DDTraceDeprecationWarning
 from ddtrace import config as dd_config
 from ddtrace.contrib.coverage import patch as patch_coverage
 from ddtrace.contrib.internal.coverage.constants import PCT_COVERED_KEY
@@ -56,6 +57,7 @@ from ddtrace.internal.test_visibility.api import InternalTestModule
 from ddtrace.internal.test_visibility.api import InternalTestSession
 from ddtrace.internal.test_visibility.api import InternalTestSuite
 from ddtrace.internal.test_visibility.coverage_lines import CoverageLines
+from ddtrace.vendor.debtcollector import deprecate
 
 
 if _pytest_version_supports_retries():
@@ -175,6 +177,15 @@ def pytest_load_initial_conftests(early_config, parser, args):
 
 
 def pytest_configure(config: pytest_Config) -> None:
+    # The only way we end up in pytest_configure is if the environment variable is being used, and logging the warning
+    # now ensures it shows up in output regardless of the use of the -s flag
+    deprecate(
+        "The DD_PYTEST_PREVIEW_PLUGIN environment variable will be deprecated",
+        message="The preview version of the pytest ddtrace plugin and will become the default version.",
+        removal_version="3.0.0",
+        category=DDTraceDeprecationWarning,
+    )
+
     try:
         if is_enabled(config):
             unpatch_unittest()

--- a/ddtrace/contrib/pytest/_utils.py
+++ b/ddtrace/contrib/pytest/_utils.py
@@ -30,7 +30,7 @@ log = get_logger(__name__)
 
 _NODEID_REGEX = re.compile("^(((?P<module>.*)/)?(?P<suite>[^/]*?))::(?P<name>.*?)$")
 
-_USE_PLUGIN_V2 = asbool(os.environ.get("_DD_CIVISIBILITY_USE_PYTEST_V2", "false"))
+_USE_PLUGIN_V2 = asbool(os.environ.get("DD_PYTEST_PREVIEW_PLUGIN", "false"))
 
 
 class _PYTEST_STATUS:

--- a/hatch.toml
+++ b/hatch.toml
@@ -417,7 +417,7 @@ dependencies = [
 ]
 
 [envs.pytest_plugin_v2.env-vars]
-_DD_CIVISIBILITY_USE_PYTEST_V2 = "true"
+DD_PYTEST_USE_NEW_PLUGIN_BETA = "true"
 DD_AGENT_PORT = "9126"
 
 [envs.pytest_plugin_v2.scripts]

--- a/releasenotes/notes/ci_visibility-features-pytest_plugin_beta-f4a607d58d44055c.yaml
+++ b/releasenotes/notes/ci_visibility-features-pytest_plugin_beta-f4a607d58d44055c.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    CI Visibility: beta release of the new version of the pytest plugin, introducing [Auto Test Retries](https://docs.datadoghq.com/tests/flaky_test_management/auto_test_retries) and Early [Flake Detection](https://docs.datadoghq.com/tests/flaky_test_management/early_flake_detection). Coverage collection for [Test Impact Analysis](https://docs.datadoghq.com/tests/test_impact_analysis) (formerly Intelligent Test Runner) now uses an internal collection method instead of [coverage.py](https://github.com/nedbat/coveragepy), with improved dependency discovery. Set the ``DD_PYTEST_USE_NEW_PLUGIN_BETA`` environment variable to ``true`` to use this new version.

--- a/releasenotes/notes/ci_visibility-features-pytest_plugin_beta-f4a607d58d44055c.yaml
+++ b/releasenotes/notes/ci_visibility-features-pytest_plugin_beta-f4a607d58d44055c.yaml
@@ -1,4 +1,12 @@
 ---
 features:
   - |
-    CI Visibility: beta release of the new version of the pytest plugin, introducing [Auto Test Retries](https://docs.datadoghq.com/tests/flaky_test_management/auto_test_retries) and Early [Flake Detection](https://docs.datadoghq.com/tests/flaky_test_management/early_flake_detection). Coverage collection for [Test Impact Analysis](https://docs.datadoghq.com/tests/test_impact_analysis) (formerly Intelligent Test Runner) now uses an internal collection method instead of [coverage.py](https://github.com/nedbat/coveragepy), with improved dependency discovery. Set the ``DD_PYTEST_USE_NEW_PLUGIN_BETA`` environment variable to ``true`` to use this new version.
+    CI Visibility: beta release of the new version of the pytest plugin, introducing the following features:
+      - [Auto Test Retries](https://docs.datadoghq.com/tests/flaky_test_management/auto_test_retries)
+      - Early [Flake Detection](https://docs.datadoghq.com/tests/flaky_test_management/early_flake_detection)
+      - Improved coverage collection for [Test Impact Analysis](https://docs.datadoghq.com/tests/test_impact_analysis) (formerly Intelligent Test Runner) now uses an internal collection method instead of [coverage.py](https://github.com/nedbat/coveragepy), with improved dependency discovery.
+    Set the ``DD_PYTEST_USE_NEW_PLUGIN_BETA`` environment variable to ``true`` to use this new version.
+    **NOTE:** this new version of the plugin introduces breaking changes:
+      - ``module``, ``suite``, and ``test`` names are now parsed from the ``item.nodeid`` attribute 
+      - test names now include the class for class-based tests
+      - Test skipping by Test Impact Analysis (formerly Intelligent Test Runner) is now done at the suite level, instead of at the test level

--- a/riotfile.py
+++ b/riotfile.py
@@ -105,7 +105,7 @@ venv = Venv(
         "DD_INJECT_FORCE": "1",
         "DD_PATCH_MODULES": "unittest:false",
         "CMAKE_BUILD_PARALLEL_LEVEL": "12",
-        "_DD_CIVISIBILITY_USE_PYTEST_V2": "true",
+        "DD_PYTEST_USE_NEW_PLUGIN_BETA": "true",
     },
     venvs=[
         Venv(
@@ -1608,7 +1608,7 @@ venv = Venv(
             },
             env={
                 "DD_AGENT_PORT": "9126",
-                "_DD_CIVISIBILITY_USE_PYTEST_V2": "1",
+                "DD_PYTEST_USE_NEW_PLUGIN_BETA": "1",
             },
             venvs=[
                 Venv(
@@ -1697,7 +1697,7 @@ venv = Venv(
                 "pytest-randomly": latest,
             },
             env={
-                "_DD_CIVISIBILITY_USE_PYTEST_V2": "0",
+                "DD_PYTEST_USE_NEW_PLUGIN_BETA": "0",
             },
             venvs=[
                 Venv(
@@ -1730,7 +1730,7 @@ venv = Venv(
                 "pytest-randomly": latest,
             },
             env={
-                "_DD_CIVISIBILITY_USE_PYTEST_V2": "0",
+                "DD_PYTEST_USE_NEW_PLUGIN_BETA": "0",
             },
             venvs=[
                 Venv(
@@ -2983,7 +2983,7 @@ venv = Venv(
                 "DD_PROFILING_ENABLE_ASSERTS": "1",
                 "DD_PROFILING_EXPORT_LIBDD_ENABLED": "1",
                 # Enable pytest v2 plugin to handle pytest-cpp items in the test suite
-                "_DD_CIVISIBILITY_USE_PYTEST_V2": "1",
+                "DD_PYTEST_USE_NEW_PLUGIN_BETA": "1",
                 "CPUCOUNT": "12",
             },
             pkgs={

--- a/tests/contrib/pytest/test_pytest_snapshot_v2.py
+++ b/tests/contrib/pytest/test_pytest_snapshot_v2.py
@@ -85,7 +85,7 @@ class PytestSnapshotTestCase(TracerTestCase):
                         DD_PATCH_MODULES="sqlite3:false",
                         CI_PROJECT_DIR=str(self.testdir.tmpdir),
                         DD_CIVISIBILITY_AGENTLESS_ENABLED="false",
-                        _DD_CIVISIBILITY_USE_PYTEST_V2="true",
+                        DD_PYTEST_USE_NEW_PLUGIN_BETA="true",
                     )
                 ),
             )
@@ -131,7 +131,7 @@ class PytestSnapshotTestCase(TracerTestCase):
                         DD_PATCH_MODULES="sqlite3:false",
                         CI_PROJECT_DIR=str(self.testdir.tmpdir),
                         DD_CIVISIBILITY_AGENTLESS_ENABLED="false",
-                        _DD_CIVISIBILITY_USE_PYTEST_V2="true",
+                        DD_PYTEST_USE_NEW_PLUGIN_BETA="true",
                     )
                 ),
             )
@@ -167,7 +167,7 @@ class PytestSnapshotTestCase(TracerTestCase):
                         CI_PROJECT_DIR=str(self.testdir.tmpdir),
                         DD_CIVISIBILITY_AGENTLESS_ENABLED="false",
                         DD_PATCH_MODULES="httpx:true",
-                        _DD_CIVISIBILITY_USE_PYTEST_V2="true",
+                        DD_PYTEST_USE_NEW_PLUGIN_BETA="true",
                     )
                 ),
             )


### PR DESCRIPTION
This makes a public announcement the beta of the new version of the `pytest` plugin (referred to as `v2`).

The release plan is to make this version the default in `ddtrace==3.0.0`, as it includes some breaking changes.

The only practical code change being made is renaming the environment variable to something not considered internal, and a pair of deprecation notices.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
