### PR TITLE
fix(profiler): initialize memory collector until after libdatadog

### DIFF
--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -347,10 +347,6 @@ class _ProfilerInstance(service.Service):
 
             for module, hook in self._collectors_on_import:
                 ModuleWatchdog.register_module_hook(module, hook)
-
-        if self._memory_collector_enabled:
-            self._collectors.append(memalloc.MemoryCollector(r))
-
         exporters = self._build_default_exporters()
 
         if exporters or self._export_libdd_enabled:
@@ -363,6 +359,11 @@ class _ProfilerInstance(service.Service):
                 exporters=exporters,
                 before_flush=self._collectors_snapshot,
             )
+
+        # The memory allocation profiler can't be enabled until after the exporters are built, since it optionally
+        # depends on the libdd exporter.
+        if self._memory_collector_enabled:
+            self._collectors.append(memalloc.MemoryCollector(r))
 
     def _collectors_snapshot(self):
         for c in self._collectors:

--- a/ddtrace/releasenotes/notes/fix-profiler-memalloc-init-f097d604fb2af519.yaml
+++ b/ddtrace/releasenotes/notes/fix-profiler-memalloc-init-f097d604fb2af519.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a bug in the profiler where the memory profiler could start before the
+    libdatadog exporter was enabled.


### PR DESCRIPTION
The current implementation of this system has a pretty negligent state initialization sequence.

In particular, the memory allocation profiler relies on libdatadog in some circumstances, and should be initialized _after_ it.

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
