### PR TITLE
feat: iast execute source metric

### DIFF
--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -153,6 +153,7 @@ class IAST_SPAN_TAGS(metaclass=Constant_Class):
 
     TELEMETRY_REQUEST_TAINTED: Literal["_dd.iast.telemetry.request.tainted"] = "_dd.iast.telemetry.request.tainted"
     TELEMETRY_EXECUTED_SINK: Literal["_dd.iast.telemetry.executed.sink"] = "_dd.iast.telemetry.executed.sink"
+    TELEMETRY_EXECUTED_SOURCE: Literal["_dd.iast.telemetry.executed.source"] = "_dd.iast.telemetry.executed.source"
 
 
 class WAF_DATA_NAMES(metaclass=Constant_Class):

--- a/ddtrace/appsec/_iast/_iast_request_context.py
+++ b/ddtrace/appsec/_iast/_iast_request_context.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Dict
 from typing import Optional
 
 from ddtrace._trace.span import Span
@@ -47,6 +48,7 @@ class IASTEnvironment:
 
         self.request_enabled: bool = False
         self.iast_reporter: Optional[IastSpanReporter] = None
+        self.iast_span_metrics: Dict[str, int] = {}
 
 
 def _get_iast_context() -> Optional[IASTEnvironment]:

--- a/ddtrace/appsec/_iast/_metrics.py
+++ b/ddtrace/appsec/_iast/_metrics.py
@@ -153,7 +153,7 @@ def _metric_key_as_snake_case(key):
 
 def increment_iast_span_metric(prefix: str, metric_key: str, counter: int = 1) -> None:
     data = get_iast_span_metrics()
-    full_key = prefix + "." + _parse_metric_key(metric_key)
+    full_key = prefix + "." + _metric_key_as_snake_case(metric_key)
     result = data.get(full_key, 0)
     data[full_key] = result + counter
 

--- a/ddtrace/appsec/_iast/_metrics.py
+++ b/ddtrace/appsec/_iast/_metrics.py
@@ -132,22 +132,39 @@ def _set_span_tag_iast_executed_sink(span):
 
     if data is not None:
         for key, value in data.items():
-            if key.startswith(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK):
+            if key.startswith(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK) or key.startswith(
+                IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE
+            ):
                 span.set_tag(key, value)
 
     reset_iast_span_metrics()
 
 
+def _parse_metric_key(key):
+    from ._taint_tracking import OriginType
+
+    if isinstance(key, OriginType):
+        from ._taint_tracking import origin_to_str
+
+        key = origin_to_str(key)
+    key = key.replace(".", "_")
+    return key.lower()
+
+
 def increment_iast_span_metric(prefix: str, metric_key: str, counter: int = 1) -> None:
     data = get_iast_span_metrics()
-    full_key = prefix + "." + metric_key.lower()
+    full_key = prefix + "." + _parse_metric_key(metric_key)
     result = data.get(full_key, 0)
     data[full_key] = result + counter
 
 
 def get_iast_span_metrics() -> Dict:
-    return _IAST_SPAN_METRICS
+    from ddtrace.appsec._iast._iast_request_context import _get_iast_context
+
+    env = _get_iast_context()
+    return env.iast_span_metrics if env else dict()
 
 
 def reset_iast_span_metrics() -> None:
-    _IAST_SPAN_METRICS.clear()
+    metrics = get_iast_span_metrics()
+    metrics.clear()

--- a/ddtrace/appsec/_iast/_metrics.py
+++ b/ddtrace/appsec/_iast/_metrics.py
@@ -140,7 +140,7 @@ def _set_span_tag_iast_executed_sink(span):
     reset_iast_span_metrics()
 
 
-def _parse_metric_key(key):
+def _metric_key_as_snake_case(key):
     from ._taint_tracking import OriginType
 
     if isinstance(key, OriginType):

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -9,9 +9,11 @@ from ddtrace.internal._unpatched import _threading as threading
 from ddtrace.internal.logger import get_logger
 
 from ..._constants import IAST
+from ..._constants import IAST_SPAN_TAGS
 from .._iast_request_context import is_iast_request_enabled
 from .._metrics import _set_iast_error_metric
 from .._metrics import _set_metric_iast_executed_source
+from .._metrics import increment_iast_span_metric
 from .._utils import _is_iast_debug_enabled
 from .._utils import _is_iast_propagation_debug_enabled
 from .._utils import _is_python_version_supported
@@ -181,6 +183,7 @@ def taint_pyobject(pyobject: Any, source_name: Any, source_value: Any, source_or
 
         res = _taint_pyobject_base(pyobject, source_name, source_value, source_origin)
         _set_metric_iast_executed_source(source_origin)
+        increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE, source_origin)
         return res
     except ValueError as e:
         log.debug("Tainting object error (pyobject type %s): %s", type(pyobject), e)

--- a/tests/appsec/iast/test_telemetry.py
+++ b/tests/appsec/iast/test_telemetry.py
@@ -170,6 +170,7 @@ def test_metric_request_tainted(no_request_sampling, telemetry_writer):
     assert filtered_metrics == ["executed.source", "request.tainted"]
     assert len(filtered_metrics) == 2, "Expected 2 generate_metrics"
     assert span.get_metric(IAST_SPAN_TAGS.TELEMETRY_REQUEST_TAINTED) > 0
+    assert span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_parameter") > 0
 
 
 @pytest.mark.skip_iast_check_logs


### PR DESCRIPTION
- Attach execute source in the span metrics
- Refactor IAST span metrics to use iast context instead of a global variable


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
