### PR TITLE
fix(asm): standalone missing tag

### DIFF
--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -136,7 +136,9 @@ class TraceSamplingProcessor(TraceProcessor):
             root_ctx = chunk_root._context
 
             if self.apm_opt_out:
-                chunk_root.set_metric(MK_APM_ENABLED, 0)
+                for span in trace:
+                    if span._local_root_value is None:
+                        span.set_metric(MK_APM_ENABLED, 0)
 
             # only trace sample if we haven't already sampled
             if root_ctx and root_ctx.sampling_priority is None:

--- a/releasenotes/notes/fix_asm_standalone_span_tag-60b38c1d9d2efbaa.yaml
+++ b/releasenotes/notes/fix_asm_standalone_span_tag-60b38c1d9d2efbaa.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ASM: This fix resolves an issue where some root span where not appropriately tagged for ASM standalone.


### PR DESCRIPTION
This fix resolves a possibly missing ASM standalone tag on root spans.
It was only detected previously on uwsgi on nightly system tests.
- ensure that all root spans are tagged.

APPSEC-55222

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
