### PR TITLE
fix(lib-injection): ensure any user defined sitecustomize.py is loaded after injection

### DIFF
--- a/releasenotes/notes/fix-lib-injection-user-sitecustomize-4ebc76e1b722490f.yaml
+++ b/releasenotes/notes/fix-lib-injection-user-sitecustomize-4ebc76e1b722490f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    lib-injection: Ensure any user defined ``sitecustomize.py`` are preserved when auto-injecting.


### PR DESCRIPTION
Right now we do not preserve any user defined `sitecustomize.py`.

In theory we should be because we `import ddtrace.bootstrap.sitecustomize` which has this logic built-in, but only if the `.../site-packages/ddtrace/bootstrap/` directory exists in the `sys.path`.

The fix here is easy, that we ensure that the `ddtrace/bootstrap` directory is added to the `sys.path` first before `import ddtrace.bootstrap.sitecustomize`.


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
