### PR TITLE
chore: upgrade ddsketch/libdatadog to v14.1.0

### DIFF
--- a/src/core/Cargo.lock
+++ b/src/core/Cargo.lock
@@ -34,8 +34,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "datadog-ddsketch"
-version = "11.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=bfeef6d3f079c4f3f191176068353f82d5702b1d#bfeef6d3f079c4f3f191176068353f82d5702b1d"
+version = "14.1.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v14.1.0#106fe1aee81c912e3201b7d138d57dabdfed4295"
 dependencies = [
  "prost",
 ]

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -10,9 +10,7 @@ opt-level = 3
 
 [dependencies]
 pyo3 = { version = "0.21.2", features = ["extension-module"] }
-
-# TODO: Use latest version tag instead of a specific commit
-datadog-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "bfeef6d3f079c4f3f191176068353f82d5702b1d" }
+datadog-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "v14.1.0" }
 
 [build-dependencies]
 pyo3-build-config = "0.21.2"


### PR DESCRIPTION
Overdue to stop referencing a specific commit rather than a release tag.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
