### PR TITLE
fix(ci_visibility): get default environment from agent when DD_ENV is not set

### DIFF
--- a/releasenotes/notes/ci_visibility-get_agent_default_env-bf4a11283dccdf87.yaml
+++ b/releasenotes/notes/ci_visibility-get_agent_default_env-bf4a11283dccdf87.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    CI Visibility: fixes an issue where the CIVisbility service would incorrectly default the tracer env to ``None``
+    in  EVP proxy mode if ``DD_ENV`` was not specified but the agent had a default environment set to a value other
+    than ``none`` (eg: using ``DD_APM_ENV`` in the agent's environment).


### PR DESCRIPTION
This fixes an issue where, if we are in EVP mode, and the agent has a custom default environment set (eg: using `DD_APM_ENV`), but `DD_ENV` is not set in the environment, we would incorrectly set the environment to `None`.

Instead, we now query the agent's info page and use the `config.default_env` key to choose the environment value.

In somewhat-related changes, we now also explicitly default the environment to `"none"` in agentless mode if it is not set by the user, whereas before we would use a `None` value which would serialize to `null`, and we would rely on the backend to perform the `null` -> `"none"` change. Since the backend was already enforcing this behavior, it should be a no-op from the user's perspective.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
