### PR TITLE
chore(ci_visibility): reset tmppath_result_key fixture if need be

### DIFF
--- a/ddtrace/contrib/pytest/_retry_utils.py
+++ b/ddtrace/contrib/pytest/_retry_utils.py
@@ -8,6 +8,7 @@ from _pytest.logging import caplog_records_key
 from _pytest.runner import CallInfo
 import pytest
 
+from ddtrace.contrib.pytest._types import tmppath_result_key
 from ddtrace.contrib.pytest._utils import _TestOutcome
 from ddtrace.ext.test_visibility.api import TestExcInfo
 from ddtrace.ext.test_visibility.api import TestStatus
@@ -59,6 +60,8 @@ def _get_outcome_from_retry(
             _outcome_exc_info = TestExcInfo(setup_call.excinfo.type, setup_call.excinfo.value, setup_call.excinfo.tb)
             item.stash[caplog_records_key] = {}
             item.stash[caplog_handler_key] = {}
+            if tmppath_result_key is not None:
+                item.stash[tmppath_result_key] = {}
     if setup_report.outcome == outcomes.SKIPPED:
         _outcome_status = TestStatus.SKIP
 
@@ -71,6 +74,8 @@ def _get_outcome_from_retry(
                 _outcome_exc_info = TestExcInfo(call_call.excinfo.type, call_call.excinfo.value, call_call.excinfo.tb)
                 item.stash[caplog_records_key] = {}
                 item.stash[caplog_handler_key] = {}
+                if tmppath_result_key is not None:
+                    item.stash[tmppath_result_key] = {}
         elif call_report.outcome == outcomes.SKIPPED:
             _outcome_status = TestStatus.SKIP
         elif call_report.outcome == outcomes.PASSED:
@@ -88,6 +93,8 @@ def _get_outcome_from_retry(
                 )
                 item.stash[caplog_records_key] = {}
                 item.stash[caplog_handler_key] = {}
+                if tmppath_result_key is not None:
+                    item.stash[tmppath_result_key] = {}
 
     item._initrequest()
 

--- a/ddtrace/contrib/pytest/_types.py
+++ b/ddtrace/contrib/pytest/_types.py
@@ -13,3 +13,8 @@ else:
     from _pytest.runner import CallInfo as pytest_CallInfo  # noqa: F401
 
 _pytest_report_teststatus_return_type = t.Optional[t.Tuple[str, str, t.Tuple[str, t.Mapping[str, bool]]]]
+
+if _get_pytest_version_tuple() >= (7, 4, 0):
+    from _pytest.tmpdir import tmppath_result_key  # noqa: F401
+else:
+    tmppath_result_key = None


### PR DESCRIPTION
In versions > 7.4 of `pytest`, the `tmppath_result_key` key may be stashed on items, which means it needs to be reinstantiated if we retry it.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
