### PR TITLE
chore(profiling): use raw allocator free for traceback buffers

### DIFF
--- a/ddtrace/profiling/collector/_utils.h
+++ b/ddtrace/profiling/collector/_utils.h
@@ -14,7 +14,7 @@ random_range(uint64_t max)
 #define DO_NOTHING(...)
 
 #define p_new(type, count) PyMem_RawMalloc(sizeof(type) * (count))
-#define p_delete(mem_p) PyMem_Free(mem_p);
+#define p_delete(mem_p) PyMem_RawFree(mem_p);
 // Allocate at least 16 and 50% more than requested to avoid allocating items one by one.
 #define p_alloc_nr(x) (((x) + 16) * 3 / 2)
 #define p_realloc(p, count)                                                                                            \


### PR DESCRIPTION
We use `PyMem_Raw*` functions for allocating memory for some of the memory
profiling data structures. However, the array implementation uses
`PyMem_Free` to free the associated memory. This isn't necessarily causing
problems, since the Python object allocator has safeguards to fall back
to `PyMem_RawFree` if it gets a pointer it didn't allocate. But it does
mean that those frees are going through our heap tracker code. And it
can also skew runtime allocation statistics. So just use the right free
function.

Other things to consider: just use plain malloc/realloc/free? Or switch
to C++/Rust for this code and use more proper dynamic array
implementaitons? The preprocessor stuff is a little scary, and C++
templates/Rust generics are a little less scary :)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
