### PR TITLE
chore(ci): update rust min version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,8 +59,8 @@ CURRENT_OS = platform.system()
 
 LIBDDWAF_VERSION = "1.21.0"
 
-# DEV: update this accordingly when src/core upgrades, see
-# https://github.com/DataDog/dd-trace-py/commit/83ded1333930e17a87f88c2d81efa02401d526e2
+# DEV: update this accordingly when src/core upgrades libdatadog dependency. 
+# libdatadog v14.1.0 requires rust 1.76.
 RUST_MINIMUM_VERSION = "1.76"  
 
 # Set macOS SDK default deployment target to 10.14 for C++17 support (if unset, may default to 10.9)

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,9 @@ CURRENT_OS = platform.system()
 
 LIBDDWAF_VERSION = "1.21.0"
 
-RUST_MINIMUM_VERSION = "1.76"  # Safe guess:  1.71 is about a year old as of 2024-07-03
+# DEV: update this accordingly when src/core upgrades, see
+# https://github.com/DataDog/dd-trace-py/commit/83ded1333930e17a87f88c2d81efa02401d526e2
+RUST_MINIMUM_VERSION = "1.76"  
 
 # Set macOS SDK default deployment target to 10.14 for C++17 support (if unset, may default to 10.9)
 if CURRENT_OS == "Darwin":

--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,9 @@ CURRENT_OS = platform.system()
 
 LIBDDWAF_VERSION = "1.21.0"
 
-# DEV: update this accordingly when src/core upgrades libdatadog dependency. 
+# DEV: update this accordingly when src/core upgrades libdatadog dependency.
 # libdatadog v14.1.0 requires rust 1.76.
-RUST_MINIMUM_VERSION = "1.76"  
+RUST_MINIMUM_VERSION = "1.76"
 
 # Set macOS SDK default deployment target to 10.14 for C++17 support (if unset, may default to 10.9)
 if CURRENT_OS == "Darwin":

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ CURRENT_OS = platform.system()
 
 LIBDDWAF_VERSION = "1.21.0"
 
-RUST_MINIMUM_VERSION = "1.71"  # Safe guess:  1.71 is about a year old as of 2024-07-03
+RUST_MINIMUM_VERSION = "1.76"  # Safe guess:  1.71 is about a year old as of 2024-07-03
 
 # Set macOS SDK default deployment target to 10.14 for C++17 support (if unset, may default to 10.9)
 if CURRENT_OS == "Darwin":


### PR DESCRIPTION
https://github.com/DataDog/dd-trace-py/commit/83ded1333930e17a87f88c2d81efa02401d526e2

bumped rust min version to 1.76.0

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
