### PR TITLE
chore(telemetry): fix namespace on otel metrics

### DIFF
--- a/ddtrace/settings/_otel_remapper.py
+++ b/ddtrace/settings/_otel_remapper.py
@@ -28,6 +28,7 @@ from ..constants import ENV_KEY
 from ..constants import VERSION_KEY
 from ..internal.logger import get_logger
 from ..internal.telemetry import telemetry_writer
+from ..internal.telemetry.constants import TELEMETRY_NAMESPACE_TAG_TRACER
 
 
 log = get_logger(__name__)
@@ -168,7 +169,10 @@ def otel_remapping():
             if otel_env.startswith("OTEL_") and otel_env != "OTEL_PYTHON_CONTEXT":
                 log.warning("OpenTelemetry configuration %s is not supported by Datadog.", otel_env)
                 telemetry_writer.add_count_metric(
-                    "tracer", "otel.env.unsupported", 1, (("config_opentelemetry", otel_env.lower()),)
+                    TELEMETRY_NAMESPACE_TAG_TRACER,
+                    "otel.env.unsupported",
+                    1,
+                    (("config_opentelemetry", otel_env.lower()),),
                 )
             continue
 
@@ -181,7 +185,7 @@ def otel_remapping():
                 otel_value,
             )
             telemetry_writer.add_count_metric(
-                "tracer",
+                TELEMETRY_NAMESPACE_TAG_TRACER,
                 "otel.env.hiding",
                 1,
                 (("config_opentelemetry", otel_env.lower()), ("config_datadog", dd_env.lower())),
@@ -201,7 +205,7 @@ def otel_remapping():
                 otel_value,
             )
             telemetry_writer.add_count_metric(
-                "tracer",
+                TELEMETRY_NAMESPACE_TAG_TRACER,
                 "otel.env.invalid",
                 1,
                 (("config_opentelemetry", otel_env.lower()), ("config_datadog", dd_env.lower())),


### PR DESCRIPTION
The namespace for otel metrics should be "tracers" and not "tracer". 

This regression was caught by system tests: https://github.com/DataDog/system-tests/pull/3497. No additional tests are required. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
