### PR TITLE
perf(iast): only patch common modules if iast is enabled

### DIFF
--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -234,10 +234,10 @@ def patch_all(**patch_modules):
         patch_iast()
         enable_iast_propagation()
 
-    if asm_config._ep_enabled or asm_config._iast_enabled:
-        from ddtrace.appsec._common_module_patches import patch_common_modules
+        if asm_config._ep_enabled:
+            from ddtrace.appsec._common_module_patches import patch_common_modules
 
-        patch_common_modules()
+            patch_common_modules()
 
 
 def patch(raise_errors=True, patch_modules_prefix=DEFAULT_MODULES_PREFIX, **patch_modules):

--- a/ddtrace/settings/asm.py
+++ b/ddtrace/settings/asm.py
@@ -159,8 +159,6 @@ class ASMConfig(Env):
     )
     _iast_lazy_taint = Env.var(bool, IAST.LAZY_TAINT, default=False)
     _deduplication_enabled = Env.var(bool, "_DD_APPSEC_DEDUPLICATION_ENABLED", default=True)
-
-    # default will be set to True once the feature is GA. For now it's always False
     _ep_enabled = Env.var(bool, EXPLOIT_PREVENTION.EP_ENABLED, default=True)
     _ep_stack_trace_enabled = Env.var(bool, EXPLOIT_PREVENTION.STACK_TRACE_ENABLED, default=True)
     # for max_stack_traces, 0 == unlimited


### PR DESCRIPTION
Avoids patching `builtins.open`, `_io.BytesIO.read`, `_io.StringIO.read`  and `os.system` when IAST is disabled.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
