### PR TITLE
perf(er): cache user code checks

### DIFF
--- a/ddtrace/debugging/_origin/span.py
+++ b/ddtrace/debugging/_origin/span.py
@@ -209,7 +209,7 @@ class SpanCodeOriginProcessor(SpanProcessor):
             code = frame.f_code
             filename = code.co_filename
 
-            if is_user_code(Path(filename)):
+            if is_user_code(filename):
                 n = next(seq)
                 if n >= co_config.max_user_frames:
                     break


### PR DESCRIPTION
The creation of Path objects in CPython < 3.11 is known to be slow and inefficient. We implement an overload of the helper function that takes a plain string as argument and caches the results to avoid creating Path objects repeatedly.

## Before

<img width="1156" alt="Screenshot 2024-11-25 at 14 31 36" src="https://github.com/user-attachments/assets/4c044abd-b51e-410b-a20e-ddd3e03d9f8c">

## After

<img width="1156" alt="Screenshot 2024-11-25 at 14 32 52" src="https://github.com/user-attachments/assets/7cfcb9a2-bfc7-4d52-b6de-36a34efcf977">


## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
