### PR TITLE
chore(ci) : remove legacy name form images to prune

### DIFF
--- a/.github/workflows/lib-inject-prune.yml
+++ b/.github/workflows/lib-inject-prune.yml
@@ -41,7 +41,6 @@ jobs:
           - 'dd-lib-python-init-test-django-uwsgi'
           - 'dd-lib-python-init-test-app'
           - 'dd-python-agent-init'
-          - 'dd-lib-python-init-test-protobuf-old'
     steps:
     - name: Prune registry
       uses: vlaurin/action-ghcr-prune@0a539594d122b915e71c59733a5b115bfaaf5d52 #v0.5.0


### PR DESCRIPTION
This name does not exists anymore, and makes the CI fail for now 3 months

https://github.com/DataDog/dd-trace-py/actions/workflows/lib-inject-prune.yml


## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
