### PR TITLE
chore(ci_visibility): fix telemetry for events and API requests

### DIFF
--- a/ddtrace/internal/ci_visibility/_api_client.py
+++ b/ddtrace/internal/ci_visibility/_api_client.py
@@ -390,6 +390,7 @@ class _TestVisibilityAPIClientBase(abc.ABC):
             api_settings.skipping_enabled,
             api_settings.require_git,
             api_settings.itr_enabled,
+            api_settings.flaky_test_retries_enabled,
             api_settings.early_flake_detection.enabled,
         )
 

--- a/ddtrace/internal/ci_visibility/_api_client.py
+++ b/ddtrace/internal/ci_visibility/_api_client.py
@@ -321,10 +321,10 @@ class _TestVisibilityAPIClientBase(abc.ABC):
         """
 
         metric_names = APIRequestMetricNames(
-            count=GIT_TELEMETRY.SETTINGS_COUNT,
-            duration=GIT_TELEMETRY.SETTINGS_MS,
+            count=GIT_TELEMETRY.SETTINGS_COUNT.value,
+            duration=GIT_TELEMETRY.SETTINGS_MS.value,
             response_bytes=None,
-            error=GIT_TELEMETRY.SETTINGS_ERRORS,
+            error=GIT_TELEMETRY.SETTINGS_ERRORS.value,
         )
 
         payload = {
@@ -402,10 +402,10 @@ class _TestVisibilityAPIClientBase(abc.ABC):
             timeout = DEFAULT_ITR_SKIPPABLE_TIMEOUT
 
         metric_names = APIRequestMetricNames(
-            count=SKIPPABLE_TESTS_TELEMETRY.REQUEST,
-            duration=SKIPPABLE_TESTS_TELEMETRY.REQUEST_MS,
-            response_bytes=SKIPPABLE_TESTS_TELEMETRY.RESPONSE_BYTES,
-            error=SKIPPABLE_TESTS_TELEMETRY.REQUEST_ERRORS,
+            count=SKIPPABLE_TESTS_TELEMETRY.REQUEST.value,
+            duration=SKIPPABLE_TESTS_TELEMETRY.REQUEST_MS.value,
+            response_bytes=SKIPPABLE_TESTS_TELEMETRY.RESPONSE_BYTES.value,
+            error=SKIPPABLE_TESTS_TELEMETRY.REQUEST_ERRORS.value,
         )
 
         payload = {
@@ -470,10 +470,10 @@ class _TestVisibilityAPIClientBase(abc.ABC):
 
     def fetch_unique_tests(self) -> t.Optional[t.Set[InternalTestId]]:
         metric_names = APIRequestMetricNames(
-            count=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST,
-            duration=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST_MS,
-            response_bytes=EARLY_FLAKE_DETECTION_TELEMETRY.RESPONSE_BYTES,
-            error=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST_ERRORS,
+            count=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST.value,
+            duration=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST_MS.value,
+            response_bytes=EARLY_FLAKE_DETECTION_TELEMETRY.RESPONSE_BYTES.value,
+            error=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST_ERRORS.value,
         )
 
         unique_test_ids: t.Set[InternalTestId] = set()

--- a/ddtrace/internal/ci_visibility/telemetry/early_flake_detection.py
+++ b/ddtrace/internal/ci_visibility/telemetry/early_flake_detection.py
@@ -7,9 +7,6 @@ from ddtrace.internal.telemetry import telemetry_writer
 
 log = get_logger(__name__)
 
-EARLY_FLAKE_DETECTION_TELEMETRY_PREFIX = "early_flake_detection."
-RESPONSE_TESTS = f"{EARLY_FLAKE_DETECTION_TELEMETRY_PREFIX}response_tests"
-
 
 class EARLY_FLAKE_DETECTION_TELEMETRY(str, Enum):
     REQUEST = "early_flake_detection.request"
@@ -21,4 +18,6 @@ class EARLY_FLAKE_DETECTION_TELEMETRY(str, Enum):
 
 def record_early_flake_detection_tests_count(early_flake_detection_count: int):
     log.debug("Recording early flake detection tests count telemetry: %s", early_flake_detection_count)
-    telemetry_writer.add_count_metric(_NAMESPACE, RESPONSE_TESTS, early_flake_detection_count)
+    telemetry_writer.add_distribution_metric(
+        _NAMESPACE, EARLY_FLAKE_DETECTION_TELEMETRY.RESPONSE_TESTS.value, early_flake_detection_count
+    )

--- a/ddtrace/internal/ci_visibility/telemetry/events.py
+++ b/ddtrace/internal/ci_visibility/telemetry/events.py
@@ -31,6 +31,27 @@ def _record_event(
     is_retry: Optional[bool] = False,
     early_flake_detection_abort_reason: Optional[str] = None,
 ):
+    log.debug(
+        "Recording event telemetry: event=%s"
+        ", event_type=%s"
+        ", test_framework=%s"
+        ", has_codeowners=%s"
+        ", is_unsuported_ci=%s"
+        ", is_benchmark=%s"
+        ", is_new=%s"
+        ", is_retry=%s"
+        ", early_flake_detection_abort_reason=%s",
+        event,
+        event_type,
+        test_framework,
+        has_codeowners,
+        is_unsupported_ci,
+        is_benchmark,
+        is_new,
+        is_retry,
+        early_flake_detection_abort_reason,
+    )
+
     if has_codeowners and event_type != EVENT_TYPES.SESSION:
         log.debug("has_codeowners tag can only be set for sessions, but event type is %s", event_type)
     if is_unsupported_ci and event_type != EVENT_TYPES.SESSION:
@@ -52,9 +73,9 @@ def _record_event(
             "early_flake_detection_abort_reason tag can only be set for tests and session finish events",
         )
 
-    _tags: List[Tuple[str, str]] = [("event_type", event_type)]
+    _tags: List[Tuple[str, str]] = [("event_type", event_type.value)]
     if test_framework and test_framework != TEST_FRAMEWORKS.MANUAL:
-        _tags.append(("test_framework", test_framework))
+        _tags.append(("test_framework", str(test_framework.value)))
     if event_type == EVENT_TYPES.SESSION:
         _tags.append(("has_codeowners", "1" if has_codeowners else "0"))
         _tags.append(("is_unsupported_ci", "1" if has_codeowners else "0"))
@@ -74,7 +95,7 @@ def _record_event(
     ):
         _tags.append(("early_flake_detection_abort_reason", early_flake_detection_abort_reason))
 
-    telemetry_writer.add_count_metric(_NAMESPACE, event, 1, tuple(_tags))
+    telemetry_writer.add_count_metric(_NAMESPACE, event.value, 1, tuple(_tags))
 
 
 def record_event_created(

--- a/ddtrace/internal/ci_visibility/telemetry/git.py
+++ b/ddtrace/internal/ci_visibility/telemetry/git.py
@@ -51,27 +51,31 @@ def record_settings_response(
     require_git: Optional[bool] = False,
     itr_enabled: Optional[bool] = False,
     early_flake_detection_enabled: Optional[bool] = False,
+    flaky_test_retries_enabled: Optional[bool] = False,
 ) -> None:
     log.debug(
-        "Recording settings telemetry: %s, %s, %s, %s, %s",
+        "Recording settings telemetry: %s, %s, %s, %s, %s, %s",
         coverage_enabled,
         skipping_enabled,
         require_git,
         itr_enabled,
         early_flake_detection_enabled,
+        flaky_test_retries_enabled,
     )
     # Telemetry "booleans" are true if they exist, otherwise false
     response_tags = []
     if coverage_enabled:
-        response_tags.append(("coverage_enabled", "1"))
+        response_tags.append(("coverage_enabled", "true"))
     if skipping_enabled:
-        response_tags.append(("itrskip_enabled", "1"))
+        response_tags.append(("itrskip_enabled", "true"))
     if require_git:
-        response_tags.append(("require_git", "1"))
+        response_tags.append(("require_git", "true"))
     if itr_enabled:
-        response_tags.append(("itr_enabled", "1"))
+        response_tags.append(("itr_enabled", "true"))
     if early_flake_detection_enabled:
-        response_tags.append(("early_flake_detection_enabled", "1"))
+        response_tags.append(("early_flake_detection_enabled", "true"))
+    if flaky_test_retries_enabled:
+        response_tags.append(("flaky_test_retries_enabled", "true"))
 
     if response_tags:
         telemetry_writer.add_count_metric(_NAMESPACE, GIT_TELEMETRY.SETTINGS_RESPONSE, 1, tuple(response_tags))

--- a/ddtrace/internal/ci_visibility/utils.py
+++ b/ddtrace/internal/ci_visibility/utils.py
@@ -9,6 +9,7 @@ from ddtrace import config as ddconfig
 from ddtrace.contrib.internal.coverage.constants import PCT_COVERED_KEY
 from ddtrace.ext import test
 from ddtrace.internal.ci_visibility.constants import CIVISIBILITY_LOG_FILTER_RE
+from ddtrace.internal.ci_visibility.telemetry.constants import TEST_FRAMEWORKS
 from ddtrace.internal.logger import get_logger
 
 
@@ -147,3 +148,10 @@ def combine_url_path(*args: str):
     NOTE: this is custom-built for its current usage in the Test Visibility codebase. Use with care.
     """
     return "/".join(str(segment).strip("/") for segment in args)
+
+
+def _get_test_framework_telemetry_name(test_framework: str) -> TEST_FRAMEWORKS:
+    for framework in TEST_FRAMEWORKS:
+        if framework.value == test_framework:
+            return framework
+    return TEST_FRAMEWORKS.MANUAL


### PR DESCRIPTION
This fixes some internal telemetry that was using enum names instead of their value, which was creating metrics or tags with the wrong names.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
