### PR TITLE
chore(telemetry): fixes namespace for span pointer metric

### DIFF
--- a/ddtrace/_trace/telemetry.py
+++ b/ddtrace/_trace/telemetry.py
@@ -6,7 +6,7 @@ from ddtrace.internal.telemetry import telemetry_writer
 
 def record_span_pointer_calculation(context: str, span_pointer_count: int) -> None:
     telemetry_writer.add_count_metric(
-        namespace="tracer",
+        namespace="tracers",
         name="span_pointer_calculation",
         value=1,
         tags=(("context", context), ("count", _span_pointer_count_to_tag(span_pointer_count))),
@@ -45,7 +45,7 @@ def record_span_pointer_calculation_issue(
         tags += additional_tags
 
     telemetry_writer.add_count_metric(
-        namespace="tracer",
+        namespace="tracers",
         name="span_pointer_calculation.issue",
         value=1,
         tags=tags,


### PR DESCRIPTION
This metric is currently generating invalid payloads and is being dropped by the tracer-telemetry-intake service.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
