### PR TITLE
chore: improve dynamodb pointer config discoverability

### DIFF
--- a/ddtrace/_trace/utils_botocore/span_pointers/dynamodb.py
+++ b/ddtrace/_trace/utils_botocore/span_pointers/dynamodb.py
@@ -234,7 +234,9 @@ def _extract_primary_key_names_from_configuration(
         return dynamodb_primary_key_names_for_tables[table_name]
     except KeyError as e:
         log.warning(
-            "span pointers: failed to extract %s span pointer: table %s not found in primary key names",
+            "span pointers: failed to extract %s span pointer: table %s not found in primary key names; "
+            "Please set them through ddtrace.config.botocore['dynamodb_primary_key_names_for_tables'] or "
+            "DD_BOTOCORE_DYNAMODB_TABLE_PRIMARY_KEYS",
             operation,
             e,
         )


### PR DESCRIPTION
Unfortunately the config is pretty far away from where we actually use it (since we don't always need to use it). This creates an implicit link between the configuration and the error messaging. But the alternative (feeding the config language down through the stacks, either as a separate parameter or as bundled object for the `dynamodb_primary_key_names_for_tables` variable) seems a bit too heavy-handed unless we absolutely need to do it that way.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
