### PR TITLE
fix(profiling): get rid of leaky string table

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profile.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profile.hpp
@@ -4,12 +4,10 @@
 #include "types.hpp"
 
 #include <atomic>
-#include <deque>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <string_view>
-#include <unordered_set>
 #include <vector>
 
 extern "C"

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profile.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profile.hpp
@@ -19,10 +19,6 @@ extern "C"
 
 namespace Datadog {
 
-// Unordered containers don't get heterogeneous lookup until gcc-10, so for now use this
-// strategy to dedup + store strings.
-using StringTable = std::unordered_set<std::string_view>;
-
 // Serves to collect individual samples, as well as lengthen the scope of string data
 class Profile
 {
@@ -32,11 +28,6 @@ class Profile
     // - ddog_profile
     std::atomic<bool> first_time{ true };
     std::mutex profile_mtx{};
-
-    // Storage for strings
-    std::deque<std::string> string_storage{};
-    StringTable strings{};
-    std::mutex string_table_mtx{};
 
     // Configuration
     SampleType type_mask{ 0 };
@@ -68,9 +59,6 @@ class Profile
     size_t get_sample_type_length();
     ddog_prof_Profile& profile_borrow();
     void profile_release();
-
-    // String table manipulation
-    std::string_view insert_or_get(std::string_view str);
 
     // constref getters
     const ValueIndex& val();

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
@@ -19,7 +19,13 @@ namespace internal {
 
 struct StringArena
 {
-    static constexpr size_t DEFAULT_SIZE = 1024;
+    // TODO: pick a reasonable default size and explain it. Goal is to be big
+    // enough to accommodate "average" sample string data without need for much
+    // growth (new allocs), but without too much wasted space in the typical case.
+    // User-provided things like function and task names can be arbitrarily-sized.
+    // Basically want (# of frames) * (name + filename size) + (# of labels) * (reasonable label size)
+    // where the sizes are a reasonable expected value.
+    static constexpr size_t DEFAULT_SIZE = 64 * 1024;
     // Strings are backed by fixed-size chunks. The chunks can't grow, or they'll
     // move and invalidate pointers into the arena.  So, if we need more space, we
     // add more chunks.

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profile.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profile.cpp
@@ -162,21 +162,6 @@ Datadog::Profile::one_time_init(SampleType type, unsigned int _max_nframes)
     first_time.store(false);
 }
 
-std::string_view
-Datadog::Profile::insert_or_get(std::string_view str)
-{
-    const std::lock_guard<std::mutex> lock(string_table_mtx); // Serialize access
-
-    auto str_it = strings.find(str);
-    if (str_it != strings.end()) {
-        return *str_it;
-    }
-
-    string_storage.emplace_back(str);
-    strings.insert(string_storage.back());
-    return string_storage.back();
-}
-
 const Datadog::ValueIndex&
 Datadog::Profile::val()
 {

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
@@ -19,6 +19,10 @@ Datadog::internal::StringArena::reset()
     // Free chunks. Keep the first one around so it's easy to reuse this without
     // needing new allocations every time. We can completely drop it to get rid
     // of everything
+    // TODO - we could consider keeping more around if it's not too costly.
+    // The goal is to not retain more than we need _on average_. If we have
+    // mostly small samples and then a rare huge one, we can end up with
+    // all samples in our pool using as much memory as the largets ones we've seen
     chunks.front().clear();
     chunks.erase(++chunks.begin(), chunks.end());
 }

--- a/releasenotes/notes/profiling-fix-unbounded-string-buffer-d18056263f3e4bdc.yaml
+++ b/releasenotes/notes/profiling-fix-unbounded-string-buffer-d18056263f3e4bdc.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    profiling: fix unbounded memory usage growth caused by keeping arbitrary
+     user-generated strings (e.g. asyncio Task names) in an internal table and
+     never removing them.


### PR DESCRIPTION
Profiler samples typically contain several strings, for sample labels
(task name, endpoint/resource, etc) and frame info. Those strings tend
to be repeated. We build samples across several API calls, from Python,
Cython, C Python extensions, and C++ code, making it hard to reason
about the lifetimes of the strings we get. So, it's easier to just copy
the strings we need while building a sample. And it's preferably to only
store one copy. So, our libdatadog wrapper uses a string table, which
addresses both of these concerns. However, nothing is ever removed from
the table. And some things like task names can have new values each
time, meaning we have unbounded memory growth.

I previously tried to fix this by periodically clearing the string
table. However, this comes with its own new problems. We can construct
samples in parallel with profile uploading. So if we try to clear the
table when we upload the profile, or really any other time, we need to
make sure in-progress samples keep their strings around until the sample
is flushed to libdatadog. And we need to handle forking so we don't leak
a whole string table on fork.

It turns out we don't really need that string table at all. Libdatadog
already interns strings once the sample makes it into the libdatadog
profile. That solves the duplicate string problem. We still want to copy
strings while building the sample, but we can just do that on a
per-sample basis, and the strings only need to be alive while we build a
sample. We can use a small amount of scratch space for each sample to
copy strings. We will likely only have a few samples in flight at any
time, and we already pool the samples. So we can reuse this scratch
memory effectively. We'll only use as memory in proportion to the
number of samples being built concurrently.

So, this commit implements a simple string arena for each sample object
to use. We may want to tweak the default buffer size and how much memory
we keep around when resetting the arena. We could even deduplicate,
since we might see some duplicates per-sample from frame info.

PROF-10824

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
