### PR TITLE
ci: update image and standardize to using both hash and sha256

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -4,7 +4,7 @@ default_resource_class: &default_resource_class medium
 ubuntu_base_image: &ubuntu_base_img ubuntu-2004:2023.04.2
 cimg_base_image: &cimg_base_image cimg/base:2022.08
 python310_image: &python310_image cimg/python:3.10.12
-ddtrace_dev_image: &ddtrace_dev_image ghcr.io/datadog/dd-trace-py/testrunner@sha256:8ca43d46ff34e078bd7bc0662e74e6be38547a98140a5cd4203805f6b214b583
+ddtrace_dev_image: &ddtrace_dev_image ghcr.io/datadog/dd-trace-py/testrunner:0c2f350d1526294eb6a7b782967698dbcbfb2548@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
 redis_image: &redis_image redis:4.0-alpine@sha256:3e99741f293147ff406657dda7644c2b88564b80a498cd00da8f905743449c9f
 memcached_image: &memcached_image memcached:1.5-alpine@sha256:48cb7207e3d34871893fa1628f3a4984375153e9942facf82e25935b0a633c8a
 cassandra_image: &cassandra_image cassandra:3.11.7@sha256:495e5752526f7e75d3ad85b6a6bbf3b79714321b17a44255a216c341e3baae11

--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -4,7 +4,7 @@ default_resource_class: &default_resource_class medium
 ubuntu_base_image: &ubuntu_base_img ubuntu-2004:2023.04.2
 cimg_base_image: &cimg_base_image cimg/base:2022.08
 python310_image: &python310_image cimg/python:3.10.12
-ddtrace_dev_image: &ddtrace_dev_image ghcr.io/datadog/dd-trace-py/testrunner:0c2f350d1526294eb6a7b782967698dbcbfb2548@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
+ddtrace_dev_image: &ddtrace_dev_image ghcr.io/datadog/dd-trace-py/testrunner:47c7b5287da25643e46652e6d222a40a52f2382a@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
 redis_image: &redis_image redis:4.0-alpine@sha256:3e99741f293147ff406657dda7644c2b88564b80a498cd00da8f905743449c9f
 memcached_image: &memcached_image memcached:1.5-alpine@sha256:48cb7207e3d34871893fa1628f3a4984375153e9942facf82e25935b0a633c8a
 cassandra_image: &cassandra_image cassandra:3.11.7@sha256:495e5752526f7e75d3ad85b6a6bbf3b79714321b17a44255a216c341e3baae11

--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -4,7 +4,7 @@ default_resource_class: &default_resource_class medium
 ubuntu_base_image: &ubuntu_base_img ubuntu-2004:2023.04.2
 cimg_base_image: &cimg_base_image cimg/base:2022.08
 python310_image: &python310_image cimg/python:3.10.12
-ddtrace_dev_image: &ddtrace_dev_image ghcr.io/datadog/dd-trace-py/testrunner:47c7b5287da25643e46652e6d222a40a52f2382a@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
+ddtrace_dev_image: &ddtrace_dev_image ghcr.io/datadog/dd-trace-py/testrunner:47c7b5287da25643e46652e6d222a40a52f2382a@sha256:3a02dafeff9cd72966978816d1b39b54f5517af4049396923b95c8452f604269
 redis_image: &redis_image redis:4.0-alpine@sha256:3e99741f293147ff406657dda7644c2b88564b80a498cd00da8f905743449c9f
 memcached_image: &memcached_image memcached:1.5-alpine@sha256:48cb7207e3d34871893fa1628f3a4984375153e9942facf82e25935b0a633c8a
 cassandra_image: &cassandra_image cassandra:3.11.7@sha256:495e5752526f7e75d3ad85b6a6bbf3b79714321b17a44255a216c341e3baae11

--- a/.github/workflows/requirements-locks.yml
+++ b/.github/workflows/requirements-locks.yml
@@ -11,7 +11,7 @@ jobs:
   validate:
     name: Check requirements lockfiles
     runs-on: ubuntu-latest
-    container: ghcr.io/datadog/dd-trace-py/testrunner@sha256:8ca43d46ff34e078bd7bc0662e74e6be38547a98140a5cd4203805f6b214b583
+    container: ghcr.io/datadog/dd-trace-py/testrunner:0c2f350d1526294eb6a7b782967698dbcbfb2548@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/requirements-locks.yml
+++ b/.github/workflows/requirements-locks.yml
@@ -11,7 +11,7 @@ jobs:
   validate:
     name: Check requirements lockfiles
     runs-on: ubuntu-latest
-    container: ghcr.io/datadog/dd-trace-py/testrunner:47c7b5287da25643e46652e6d222a40a52f2382a@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
+    container: ghcr.io/datadog/dd-trace-py/testrunner:47c7b5287da25643e46652e6d222a40a52f2382a@sha256:3a02dafeff9cd72966978816d1b39b54f5517af4049396923b95c8452f604269
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/requirements-locks.yml
+++ b/.github/workflows/requirements-locks.yml
@@ -11,7 +11,7 @@ jobs:
   validate:
     name: Check requirements lockfiles
     runs-on: ubuntu-latest
-    container: ghcr.io/datadog/dd-trace-py/testrunner:0c2f350d1526294eb6a7b782967698dbcbfb2548@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
+    container: ghcr.io/datadog/dd-trace-py/testrunner:47c7b5287da25643e46652e6d222a40a52f2382a@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.gitlab/testrunner.yml
+++ b/.gitlab/testrunner.yml
@@ -1,5 +1,5 @@
 .testrunner:
-  image: registry.ddbuild.io/images/mirror/dd-trace-py/testrunner:47c7b5287da25643e46652e6d222a40a52f2382a@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
+  image: registry.ddbuild.io/images/mirror/dd-trace-py/testrunner:47c7b5287da25643e46652e6d222a40a52f2382a@sha256:3a02dafeff9cd72966978816d1b39b54f5517af4049396923b95c8452f604269
   # DEV: we have a larger pool of amd64 runners, prefer that over arm64
   tags: [ "arch:amd64" ]
   timeout: 20m

--- a/.gitlab/testrunner.yml
+++ b/.gitlab/testrunner.yml
@@ -1,5 +1,5 @@
 .testrunner:
-  image: registry.ddbuild.io/images/mirror/dd-trace-py/testrunner:7a2e802af76051f82d698919d2837eff18dbb48e
+  image: registry.ddbuild.io/images/mirror/dd-trace-py/testrunner:0c2f350d1526294eb6a7b782967698dbcbfb2548@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
   # DEV: we have a larger pool of amd64 runners, prefer that over arm64
   tags: [ "arch:amd64" ]
   timeout: 20m

--- a/.gitlab/testrunner.yml
+++ b/.gitlab/testrunner.yml
@@ -1,5 +1,5 @@
 .testrunner:
-  image: registry.ddbuild.io/images/mirror/dd-trace-py/testrunner:0c2f350d1526294eb6a7b782967698dbcbfb2548@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
+  image: registry.ddbuild.io/images/mirror/dd-trace-py/testrunner:47c7b5287da25643e46652e6d222a40a52f2382a@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
   # DEV: we have a larger pool of amd64 runners, prefer that over arm64
   tags: [ "arch:amd64" ]
   timeout: 20m

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -9,7 +9,7 @@ variables:
   # CI_DEBUG_SERVICES: "true"
 
 .testrunner:
-  image: registry.ddbuild.io/images/mirror/dd-trace-py/testrunner:47c7b5287da25643e46652e6d222a40a52f2382a@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
+  image: registry.ddbuild.io/images/mirror/dd-trace-py/testrunner:47c7b5287da25643e46652e6d222a40a52f2382a@sha256:3a02dafeff9cd72966978816d1b39b54f5517af4049396923b95c8452f604269
   # DEV: we have a larger pool of amd64 runners, prefer that over arm64
   tags: [ "arch:amd64" ]
   timeout: 20m

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -9,7 +9,7 @@ variables:
   # CI_DEBUG_SERVICES: "true"
 
 .testrunner:
-  image: registry.ddbuild.io/images/mirror/dd-trace-py/testrunner:0c2f350d1526294eb6a7b782967698dbcbfb2548@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
+  image: registry.ddbuild.io/images/mirror/dd-trace-py/testrunner:47c7b5287da25643e46652e6d222a40a52f2382a@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
   # DEV: we have a larger pool of amd64 runners, prefer that over arm64
   tags: [ "arch:amd64" ]
   timeout: 20m

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -9,7 +9,7 @@ variables:
   # CI_DEBUG_SERVICES: "true"
 
 .testrunner:
-  image: registry.ddbuild.io/images/mirror/dd-trace-py/testrunner:7a2e802af76051f82d698919d2837eff18dbb48e
+  image: registry.ddbuild.io/images/mirror/dd-trace-py/testrunner:0c2f350d1526294eb6a7b782967698dbcbfb2548@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
   # DEV: we have a larger pool of amd64 runners, prefer that over arm64
   tags: [ "arch:amd64" ]
   timeout: 20m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,7 +152,7 @@ services:
           - "127.0.0.1:5433:5433"
 
     testrunner:
-        image: ghcr.io/datadog/dd-trace-py/testrunner@sha256:8ca43d46ff34e078bd7bc0662e74e6be38547a98140a5cd4203805f6b214b583
+        image: ghcr.io/datadog/dd-trace-py/testrunner:0c2f350d1526294eb6a7b782967698dbcbfb2548@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
         command: bash
         environment:
             - TOX_SKIP_DIST=True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,7 +152,7 @@ services:
           - "127.0.0.1:5433:5433"
 
     testrunner:
-        image: ghcr.io/datadog/dd-trace-py/testrunner:0c2f350d1526294eb6a7b782967698dbcbfb2548@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
+        image: ghcr.io/datadog/dd-trace-py/testrunner:47c7b5287da25643e46652e6d222a40a52f2382a@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
         command: bash
         environment:
             - TOX_SKIP_DIST=True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,7 +152,7 @@ services:
           - "127.0.0.1:5433:5433"
 
     testrunner:
-        image: ghcr.io/datadog/dd-trace-py/testrunner:47c7b5287da25643e46652e6d222a40a52f2382a@sha256:8b7ef2861d95558bf3065caa0f9624f83b15f22940f9d738aefa88731cd948f5
+        image: ghcr.io/datadog/dd-trace-py/testrunner:47c7b5287da25643e46652e6d222a40a52f2382a@sha256:3a02dafeff9cd72966978816d1b39b54f5517af4049396923b95c8452f604269
         command: bash
         environment:
             - TOX_SKIP_DIST=True


### PR DESCRIPTION
This updates the image to the one built in 47c7b5287da25643e46652e6d222a40a52f2382a , with:
- fixed MariaDB repo
- new `azure-functions-core-tools-4` for serverless 
- new `google-chrome-stable` installation to support the Selenium contrib

Additionally, it switches all references to image to include the `label@digest` syntax in order to make easier to:
- know which commit an image comes from
- keep the digest in order to disambiguate any potential case where the same label has different digests 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
