### PR TITLE
chore(tracer): add ProductSpanProcessors

### DIFF
--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -106,6 +106,44 @@ class SpanProcessor(metaclass=abc.ABCMeta):
             log.warning("Span processor %r not registered", self)
 
 
+class ProductSpanProcessor:
+    def __init__(self) -> None:
+        log.debug("initialized product span processor %r", self)
+
+    def on_span_start(self, span: Span) -> None:
+        """Called when a span is started.
+
+        This method is useful for making upfront decisions on spans.
+
+        For example, a sampling decision can be made when the span is created
+        based on its resource name.
+        """
+        raise NotImplementedError
+
+    def on_span_finish(self, span: Span) -> None:
+        """Called with the result of any previous processors or initially with
+        the finishing span when a span finishes.
+
+        It can return any data which will be passed to any processors that are
+        applied afterward.
+        """
+        raise NotImplementedError
+
+    def on_fork(self):
+        """Called when the process forks.
+
+        Can be used to re-initialize threads.
+        """
+        pass
+
+    def shutdown(self, timeout: Optional[float]) -> None:
+        """Called when the processor is done being used.
+
+        Any clean-up or flushing should be performed with this method.
+        """
+        raise NotImplementedError
+
+
 class TraceSamplingProcessor(TraceProcessor):
     """Processor that runs both trace and span sampling rules.
 


### PR DESCRIPTION
It has become apparent that there are two different types of SpanProcessor that are utilized in the tracer: tracing related span processors and additional product processors. As there is no current separation of these types, the product logic built on top of tracing is strongly coupled.

I believe it makes sense to decouple these concepts explicitly in the tracer. There is too much ASM code in the tracer module because there does not exist an interface for ASM to interface with the tracer.

LLMObs suffers a similar problem: a traceprocessor is attached via the public `configure()` API but this suffers from conflicts with end-user usage of the same API.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
