### PR TITLE
refactor: encapsulate container info

### DIFF
--- a/ddtrace/debugging/_uploader.py
+++ b/ddtrace/debugging/_uploader.py
@@ -12,7 +12,6 @@ from ddtrace.debugging._signal.collector import SignalCollector
 from ddtrace.internal import compat
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.periodic import ForksafeAwakeablePeriodicService
-from ddtrace.internal.runtime import container
 from ddtrace.internal.utils.http import connector
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 
@@ -54,9 +53,6 @@ class LogsIntakeUploaderV1(ForksafeAwakeablePeriodicService):
             "Content-type": "application/json; charset=utf-8",
             "Accept": "text/plain",
         }
-
-        container.update_headers_with_container_info(self._headers, container.get_container_info())
-        container.update_header_with_external_info(self._headers)
 
         if di_config._tags_in_qs and di_config.tags:
             self.ENDPOINT += f"?ddtags={quote(di_config.tags)}"

--- a/ddtrace/internal/http.py
+++ b/ddtrace/internal/http.py
@@ -1,10 +1,15 @@
 from ddtrace.internal.compat import httplib
 from ddtrace.internal.compat import parse
+from ddtrace.internal.runtime import container
 
 
-class BasePathMixin(httplib.HTTPConnection, object):
+class HTTPConnectionMixin:
     """
-    Mixin for HTTPConnection to insert a base path to requested URLs
+    Mixin for HTTP(S) connections for performing internal adjustments.
+
+    Currently this mixin performs the following adjustments:
+    - insert a base path to requested URLs
+    - update headers with container info
     """
 
     _base_path = "/"  # type: str
@@ -12,7 +17,7 @@ class BasePathMixin(httplib.HTTPConnection, object):
     def putrequest(self, method, url, skip_host=False, skip_accept_encoding=False):
         # type: (str, str, bool, bool) -> None
         url = parse.urljoin(self._base_path, url)
-        return super(BasePathMixin, self).putrequest(
+        return super().putrequest(  # type: ignore[misc]
             method, url, skip_host=skip_host, skip_accept_encoding=skip_accept_encoding
         )
 
@@ -23,14 +28,21 @@ class BasePathMixin(httplib.HTTPConnection, object):
         obj._base_path = base_path
         return obj
 
+    def request(self, method, url, body=None, headers={}, *, encode_chunked=False):
+        _headers = headers.copy()
 
-class HTTPConnection(BasePathMixin, httplib.HTTPConnection):
+        container.update_headers(_headers)
+
+        return super().request(method, url, body=body, headers=_headers, encode_chunked=encode_chunked)
+
+
+class HTTPConnection(HTTPConnectionMixin, httplib.HTTPConnection):
     """
     httplib.HTTPConnection wrapper to add a base path to requested URLs
     """
 
 
-class HTTPSConnection(BasePathMixin, httplib.HTTPSConnection):
+class HTTPSConnection(HTTPConnectionMixin, httplib.HTTPSConnection):
     """
     httplib.HTTPSConnection wrapper to add a base path to requested URLs
     """

--- a/ddtrace/internal/processor/stats.py
+++ b/ddtrace/internal/processor/stats.py
@@ -19,7 +19,6 @@ from ..forksafe import Lock
 from ..hostname import get_hostname
 from ..logger import get_logger
 from ..periodic import PeriodicService
-from ..runtime import container
 from ..writer import _human_size
 
 
@@ -108,8 +107,6 @@ class SpanStatsProcessorV06(PeriodicService, SpanProcessor):
             "Datadog-Meta-Tracer-Version": ddtrace.__version__,
             "Content-Type": "application/msgpack",
         }  # type: Dict[str, str]
-        container.update_headers_with_container_info(self._headers, container.get_container_info())
-        container.update_header_with_external_info(self._headers)
         self._hostname = ""
         if config._report_hostname:
             self._hostname = get_hostname()

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -29,7 +29,6 @@ from ddtrace.internal.hostname import get_hostname
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.packages import is_distribution_available
 from ddtrace.internal.remoteconfig.constants import REMOTE_CONFIG_AGENT_ENDPOINT
-from ddtrace.internal.runtime import container
 from ddtrace.internal.service import ServiceStatus
 from ddtrace.internal.utils.time import parse_isoformat
 
@@ -239,9 +238,6 @@ class RemoteConfigClient:
         additional_header_str = os.environ.get("_DD_REMOTE_CONFIGURATION_ADDITIONAL_HEADERS")
         if additional_header_str is not None:
             self._headers.update(parse_tags_str(additional_header_str))
-
-        container.update_headers_with_container_info(self._headers, container.get_container_info())
-        container.update_header_with_external_info(self._headers)
 
         tags = ddtrace.config.tags.copy()
 

--- a/ddtrace/internal/runtime/container.py
+++ b/ddtrace/internal/runtime/container.py
@@ -1,9 +1,18 @@
 import errno
+from functools import lru_cache
 import os
 import re
+import sys
 from typing import Any
 from typing import Dict
 from typing import Optional
+from typing import Union
+
+
+if sys.version_info >= (3, 8):
+    from typing import Literal  # noqa:F401
+else:
+    from typing_extensions import Literal
 
 from ..constants import CONTAINER_ID_HEADER_NAME
 from ..constants import ENTITY_ID_HEADER_NAME
@@ -130,25 +139,17 @@ class CGroupInfo:
         )
 
 
-def get_container_info(pid="self"):
-    # type: (str) -> Optional[CGroupInfo]
+@lru_cache(64)
+def get_container_info(pid: Union[Literal["self"], int] = "self") -> Optional[CGroupInfo]:
     """
-    Helper to fetch the current container id, if we are running in a container
+    Helper to fetch the current container id, if we are running in a container.
 
     We will parse `/proc/{pid}/cgroup` to determine our container id.
 
-    The results of calling this function are cached
-
-    :param pid: The pid of the cgroup file to parse (default: 'self')
-    :type pid: str | int
-    :returns: The cgroup file info if found, or else None
-    :rtype: :class:`CGroupInfo` | None
+    The results of calling this function are cached.
     """
-
-    cgroup_file = "/proc/{0}/cgroup".format(pid)
-
     try:
-        with open(cgroup_file, mode="r") as fp:
+        with open(f"/proc/{pid}/cgroup", mode="r") as fp:
             for line in fp:
                 info = CGroupInfo.from_line(line)
                 if info and (info.container_id or info.node_inode):
@@ -161,27 +162,26 @@ def get_container_info(pid="self"):
     return None
 
 
-def update_headers_with_container_info(headers: Dict, container_info: Optional[CGroupInfo]) -> None:
+def update_headers(headers: Dict) -> None:
     """Get the container info (either the container ID or the cgroup inode) and add it to the headers."""
-    if container_info is None:
-        return
-    if container_info.container_id:
-        headers.update(
-            {
-                CONTAINER_ID_HEADER_NAME: container_info.container_id,
-                ENTITY_ID_HEADER_NAME: f"ci-{container_info.container_id}",
-            }
-        )
-    elif container_info.node_inode:
-        headers.update(
-            {
-                ENTITY_ID_HEADER_NAME: f"in-{container_info.node_inode}",
-            }
-        )
+    container_info = get_container_info()
+    if container_info is not None:
+        if container_info.container_id:
+            headers.update(
+                {
+                    CONTAINER_ID_HEADER_NAME: container_info.container_id,
+                    ENTITY_ID_HEADER_NAME: f"ci-{container_info.container_id}",
+                }
+            )
+        elif container_info.node_inode:
+            headers.update(
+                {
+                    ENTITY_ID_HEADER_NAME: f"in-{container_info.node_inode}",
+                }
+            )
 
-
-def update_header_with_external_info(headers: Dict) -> None:
-    """Get the external environment info from the environment variable and add it to the headers."""
+    # Get the external environment info from the environment variable and add it
+    # to the headers
     external_info = os.environ.get(EXTERNAL_ENV_ENVIRONMENT_VARIABLE)
     if external_info:
         headers.update(

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -23,7 +23,6 @@ from ..agent import get_trace_url
 from ..compat import get_connection_response
 from ..encoding import JSONEncoderV2
 from ..periodic import PeriodicService
-from ..runtime import container
 from ..runtime import get_runtime_id
 from ..service import ServiceStatus
 from ..utils.formats import asbool
@@ -136,8 +135,6 @@ class _TelemetryClient:
         headers["DD-Telemetry-Debug-Enabled"] = request["debug"]
         headers["DD-Telemetry-Request-Type"] = request["request_type"]
         headers["DD-Telemetry-API-Version"] = request["api_version"]
-        container.update_headers_with_container_info(headers, container.get_container_info())
-        container.update_header_with_external_info(headers)
         return headers
 
     def get_endpoint(self, agentless: bool) -> str:

--- a/ddtrace/internal/uds.py
+++ b/ddtrace/internal/uds.py
@@ -2,10 +2,10 @@ import socket
 from typing import Any  # noqa:F401
 
 from .compat import httplib
-from .http import BasePathMixin
+from .http import HTTPConnectionMixin
 
 
-class UDSHTTPConnection(BasePathMixin, httplib.HTTPConnection):
+class UDSHTTPConnection(HTTPConnectionMixin, httplib.HTTPConnection):
     """An HTTP connection established over a Unix Domain Socket."""
 
     # It's "important" to keep the hostname and port arguments here; while there are not used by the connection

--- a/ddtrace/internal/utils/__init__.py
+++ b/ddtrace/internal/utils/__init__.py
@@ -3,6 +3,7 @@ from typing import Dict  # noqa:F401
 from typing import List  # noqa:F401
 from typing import Optional  # noqa:F401
 from typing import Tuple  # noqa:F401
+from typing import Union  # noqa:F401
 
 
 class ArgumentError(Exception):
@@ -13,7 +14,7 @@ class ArgumentError(Exception):
 
 
 def get_argument_value(
-    args: List[Any],
+    args: Union[Tuple[Any], List[Any]],
     kwargs: Dict[str, Any],
     pos: int,
     kw: str,

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -31,7 +31,6 @@ from ..agent import get_connection
 from ..constants import _HTTPLIB_NO_TRACE_REQUEST
 from ..encoding import JSONEncoderV2
 from ..logger import get_logger
-from ..runtime import container
 from ..serverless import in_azure_function
 from ..serverless import in_gcp_function
 from ..sma import SimpleMovingAverage
@@ -493,9 +492,6 @@ class AgentWriter(HTTPWriter):
         }
         if headers:
             _headers.update(headers)
-        self._container_info = container.get_container_info()
-        container.update_headers_with_container_info(_headers, self._container_info)
-        container.update_header_with_external_info(_headers)
 
         _headers.update({"Content-Type": client.encoder.content_type})  # type: ignore[attr-defined]
         additional_header_str = os.environ.get("_DD_TRACE_WRITER_ADDITIONAL_HEADERS")

--- a/ddtrace/profiling/exporter/http.py
+++ b/ddtrace/profiling/exporter/http.py
@@ -15,7 +15,6 @@ import ddtrace
 from ddtrace.internal import agent
 from ddtrace.internal import runtime
 from ddtrace.internal.processor.endpoint_call_counter import EndpointCallCounterProcessor
-from ddtrace.internal.runtime import container
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from ddtrace.profiling import exporter
 from ddtrace.profiling import recorder  # noqa:F401
@@ -67,7 +66,6 @@ class PprofHTTPExporter(pprof.PprofExporter):
         self.version: typing.Optional[str] = version
         self.tags: typing.Dict[str, str] = tags if tags is not None else {}
         self.max_retry_delay: typing.Optional[float] = max_retry_delay
-        self._container_info: typing.Optional[container.CGroupInfo] = container.get_container_info()
         self.endpoint_call_counter_span_processor: typing.Optional[
             EndpointCallCounterProcessor
         ] = endpoint_call_counter_span_processor
@@ -182,9 +180,6 @@ class PprofHTTPExporter(pprof.PprofExporter):
             }
         else:
             headers = {}
-
-        container.update_headers_with_container_info(headers, self._container_info)
-        container.update_header_with_external_info(headers)
 
         profile, libs = super(PprofHTTPExporter, self).export(events, start_time_ns, end_time_ns)
         pprof = io.BytesIO()

--- a/tests/tracer/runtime/test_container.py
+++ b/tests/tracer/runtime/test_container.py
@@ -307,6 +307,7 @@ def test_get_container_info(file_contents, container_id, node_inode):
         if file_contents is None:
             mock_open.side_effect = FileNotFoundError
 
+        get_container_info.cache_clear()
         info = get_container_info()
 
         if info is not None:
@@ -344,6 +345,7 @@ def test_get_container_info_exception(mock_log, mock_from_line):
     # DEV: We need at least 1 line for the loop to call `CGroupInfo.from_line`
     with get_mock_open(read_data="\r\n") as mock_open:
         # Assert calling `get_container_info()` does not bubble up the exception
+        get_container_info.cache_clear()
         assert get_container_info() is None
 
         # Assert we called everything we expected


### PR DESCRIPTION
We encapsulate the logic required to add container information headers to HTTP requests in the connection constructor. This elimiates the need to add the same logic across all products/services that make requests.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
