### PR TITLE
fix(setup): suppress int-ptr conversion errors for stack profiler v1

### DIFF
--- a/releasenotes/notes/fix-profiler-int-ptr-conversion-4377fbd8724eeaec.yaml
+++ b/releasenotes/notes/fix-profiler-int-ptr-conversion-4377fbd8724eeaec.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Updates setup.py to ignore int-ptr conversion warnings for the profiler stack.pyx file.
+    This is important because gcc 14 makes these conversions an error, alpine 3.21.0 ships with gcc 14,
+    and any patch version of a Python alpine image cut after December 5th, 2024, will have this issue.

--- a/setup.py
+++ b/setup.py
@@ -612,7 +612,7 @@ setup(
                 "ddtrace.profiling.collector.stack",
                 sources=["ddtrace/profiling/collector/stack.pyx"],
                 language="c",
-                extra_compile_args=extra_compile_args,
+                extra_compile_args=extra_compile_args + ["-Wno-int-conversion"],
             ),
             Cython.Distutils.Extension(
                 "ddtrace.profiling.collector._traceback",

--- a/setup.py
+++ b/setup.py
@@ -612,7 +612,11 @@ setup(
                 "ddtrace.profiling.collector.stack",
                 sources=["ddtrace/profiling/collector/stack.pyx"],
                 language="c",
-                extra_compile_args=extra_compile_args + ["-Wno-int-conversion"],
+                # cython generated code errors on build in toolchains that are strict about int->ptr conversion
+                # OTOH, the MSVC toolchain is different.  In a perfect world we'd deduce the underlying toolchain and
+                # emit the right flags, but as a compromise we assume Windows implies MSVC and everything else is on a
+                # GNU-like toolchain
+                extra_compile_args = extra_compile_args + (["-Wno-int-conversion"] if CURRENT_OS != "Windows" else [])
             ),
             Cython.Distutils.Extension(
                 "ddtrace.profiling.collector._traceback",

--- a/setup.py
+++ b/setup.py
@@ -616,7 +616,7 @@ setup(
                 # OTOH, the MSVC toolchain is different.  In a perfect world we'd deduce the underlying toolchain and
                 # emit the right flags, but as a compromise we assume Windows implies MSVC and everything else is on a
                 # GNU-like toolchain
-                extra_compile_args = extra_compile_args + (["-Wno-int-conversion"] if CURRENT_OS != "Windows" else [])
+                extra_compile_args=extra_compile_args + (["-Wno-int-conversion"] if CURRENT_OS != "Windows" else []),
             ),
             Cython.Distutils.Extension(
                 "ddtrace.profiling.collector._traceback",


### PR DESCRIPTION
The root issue is that
* Alpine 3.21.0 was released on Dec 5
* Alpine 3.21.0 includes an update to gcc (gcc 14)
* gcc 14 is more strict (yay!) about pointer<->integer conversions.  However, cython does not generate code with the proper incantation to avoid compiler errors (I blame pthreads having opaque pointer types)
* Subsequently, any and every python-alpine container image (even and especially patch versions) cut after Dec 5 will have the updated Alpine image, which will have the updated gcc, which will start to break during builds.

This PR effectively undoes the gcc 14 behavior by making int<->ptr conversions less strict again (only for the stack.c cython-generated file which is currently throwing the error).

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
