### PR TITLE
chore(profiling): revert simplify usage of cancellation token

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -153,6 +153,14 @@ jobs:
         if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'other'
         run: ./run.sh CROSSED_TRACING_LIBRARIES
 
+      - name: Run PROFILING
+        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'other'
+        run: |
+          cat /proc/sys/kernel/perf_event_paranoid
+          sudo sysctl kernel.perf_event_paranoid=1
+          sudo sysctl -p
+          ./run.sh PROFILING
+
       - name: Run REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES
         if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'remote-config'
         run: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_ASM_FEATURES

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader.hpp
@@ -24,9 +24,7 @@ class Uploader
   private:
     static inline std::mutex upload_lock{};
     std::string errmsg;
-    static inline std::unique_ptr<ddog_CancellationToken, DdogCancellationTokenDeleter> cancel{
-        ddog_CancellationToken_new()
-    };
+    static inline std::unique_ptr<ddog_CancellationToken, DdogCancellationTokenDeleter> cancel;
     static inline std::atomic<uint64_t> upload_seq{ 0 };
     std::string output_filename;
     std::unique_ptr<ddog_prof_Exporter, DdogProfExporterDeleter> ddog_exporter;

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
@@ -110,6 +110,7 @@ Datadog::Uploader::upload(ddog_prof_Profile& profile)
     }
 
     // If we're here, we're about to create a new upload, so cancel any inflight ones
+    const std::lock_guard<std::mutex> lock_guard(upload_lock);
     cancel_inflight();
 
     // Create a new cancellation token.  Maybe we can get away without doing this, but
@@ -123,8 +124,6 @@ Datadog::Uploader::upload(ddog_prof_Profile& profile)
     // The upload operation sets up some global state in libdatadog (the tokio runtime), so
     // we ensure exclusivity here.
     {
-        const std::lock_guard<std::mutex> lock_guard(upload_lock);
-
         // Build and check the response object
         ddog_prof_Exporter_Request* req = build_res.ok; // NOLINT (cppcoreguidelines-pro-type-union-access)
         ddog_prof_Exporter_SendResult res =

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
@@ -115,9 +115,10 @@ Datadog::Uploader::upload(ddog_prof_Profile& profile)
     // Create a new cancellation token.  Maybe we can get away without doing this, but
     // since we're recreating the uploader fresh every time anyway, we recreate one more thing.
     // NB wrapping this in a unique_ptr to easily add RAII semantics; maybe should just wrap it in a
-    // class instead.
-    std::unique_ptr<ddog_CancellationToken, DdogCancellationTokenDeleter> cancel_for_request(
-      ddog_CancellationToken_clone(cancel.get()));
+    // class instead
+    cancel.reset(ddog_CancellationToken_new());
+    std::unique_ptr<ddog_CancellationToken, DdogCancellationTokenDeleter> cancel_for_request;
+    cancel_for_request.reset(ddog_CancellationToken_clone(cancel.get()));
 
     // The upload operation sets up some global state in libdatadog (the tokio runtime), so
     // we ensure exclusivity here.
@@ -156,7 +157,7 @@ Datadog::Uploader::unlock()
 void
 Datadog::Uploader::cancel_inflight()
 {
-    ddog_CancellationToken_cancel(cancel.get());
+    cancel.reset();
 }
 
 void

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
@@ -109,21 +109,21 @@ Datadog::Uploader::upload(ddog_prof_Profile& profile)
         return false;
     }
 
-    // If we're here, we're about to create a new upload, so cancel any inflight ones
-    const std::lock_guard<std::mutex> lock_guard(upload_lock);
-    cancel_inflight();
-
-    // Create a new cancellation token.  Maybe we can get away without doing this, but
-    // since we're recreating the uploader fresh every time anyway, we recreate one more thing.
-    // NB wrapping this in a unique_ptr to easily add RAII semantics; maybe should just wrap it in a
-    // class instead
-    cancel.reset(ddog_CancellationToken_new());
-    std::unique_ptr<ddog_CancellationToken, DdogCancellationTokenDeleter> cancel_for_request;
-    cancel_for_request.reset(ddog_CancellationToken_clone(cancel.get()));
-
     // The upload operation sets up some global state in libdatadog (the tokio runtime), so
     // we ensure exclusivity here.
     {
+        // If we're here, we're about to create a new upload, so cancel any inflight ones
+        const std::lock_guard<std::mutex> lock_guard(upload_lock);
+        cancel_inflight();
+
+        // Create a new cancellation token.  Maybe we can get away without doing this, but
+        // since we're recreating the uploader fresh every time anyway, we recreate one more thing.
+        // NB wrapping this in a unique_ptr to easily add RAII semantics; maybe should just wrap it in a
+        // class instead
+        cancel.reset(ddog_CancellationToken_new());
+        std::unique_ptr<ddog_CancellationToken, DdogCancellationTokenDeleter> cancel_for_request;
+        cancel_for_request.reset(ddog_CancellationToken_clone(cancel.get()));
+
         // Build and check the response object
         ddog_prof_Exporter_Request* req = build_res.ok; // NOLINT (cppcoreguidelines-pro-type-union-access)
         ddog_prof_Exporter_SendResult res =

--- a/tests/profiling_v2/collector/test_threading.py
+++ b/tests/profiling_v2/collector/test_threading.py
@@ -83,7 +83,7 @@ def test_patch():
 
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="only works on linux")
-@pytest.mark.subprocess(err=None)
+@pytest.mark.subprocess()
 def test_user_threads_have_native_id():
     from os import getpid
     from threading import Thread


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#11644 and fix tsan errors

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)


