### PR TITLE
experimental: tracing sidecar [WIP DO NOT Review]

### DIFF
--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -898,7 +898,7 @@ class SpanLowOverhead(SpanBase):
         return super().finish(finish_time)
 
 
-if config._trace_low_cpu_mode:
+if config._sidecar_enabled:
     Span = SpanLowOverhead
 else:
     Span = SpanBase

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -790,7 +790,7 @@ class Tracer(object):
 
         links = context._span_links if not parent else []
 
-        if config._trace_low_cpu_mode:
+        if config._sidecar_enabled:
             on_finish = []
         else:
             on_finish = [self._on_span_finish]
@@ -865,7 +865,7 @@ class Tracer(object):
             self._services.add(service)
 
         # Only call span processors if the tracer is enabled (even if APM opted out)
-        if (not config._trace_low_cpu_mode) and (self.enabled or self._apm_opt_out):
+        if (not config._sidecar_enabled) and (self.enabled or self._apm_opt_out):
             for p in chain(self._span_processors, SpanProcessor.__processors__, self._deferred_processors):
                 p.on_span_start(span)
         self._hooks.emit(self.__class__.start_span, span)

--- a/ddtrace/bootstrap/preload.py
+++ b/ddtrace/bootstrap/preload.py
@@ -4,8 +4,6 @@ Add all monkey-patching that needs to run by default here
 """
 
 import os  # noqa:I001
-import subprocess
-import sys
 
 from ddtrace import config  # noqa:F401
 from ddtrace.appsec._iast._utils import _is_iast_enabled

--- a/ddtrace/bootstrap/preload.py
+++ b/ddtrace/bootstrap/preload.py
@@ -4,6 +4,8 @@ Add all monkey-patching that needs to run by default here
 """
 
 import os  # noqa:I001
+import subprocess
+import sys
 
 from ddtrace import config  # noqa:F401
 from ddtrace.appsec._iast._utils import _is_iast_enabled
@@ -18,6 +20,7 @@ from ddtrace.internal.utils.formats import parse_tags_str  # noqa:F401
 from ddtrace.settings.asm import config as asm_config  # noqa:F401
 from ddtrace.settings.crashtracker import config as crashtracker_config
 from ddtrace import tracer
+from ddtrace.ddsidecar_utils import start_sidecar_server
 
 
 import typing as t
@@ -48,6 +51,9 @@ manager.run_protocol()
 # Post preload operations
 register_post_preload(manager.post_preload_products)
 
+
+if config._trace_low_cpu_mode:
+    start_sidecar_server()
 
 # TODO: Migrate the following product logic to the new product plugin interface
 

--- a/ddtrace/bootstrap/preload.py
+++ b/ddtrace/bootstrap/preload.py
@@ -50,7 +50,7 @@ manager.run_protocol()
 register_post_preload(manager.post_preload_products)
 
 
-if config._trace_low_cpu_mode:
+if config._sidecar_enabled:
     start_sidecar_server()
 
 # TODO: Migrate the following product logic to the new product plugin interface

--- a/ddtrace/ddsidecar.py
+++ b/ddtrace/ddsidecar.py
@@ -2,7 +2,7 @@ import os
 
 
 # Ensure low overhead mode is disabled for sidecar.
-assert os.environ.get("DD_TRACE_LOW_CPU_MODE", "").lower() in ("0", "", "false")
+assert os.environ.get("DD_SIDECAR_ENABLED", "").lower() in ("0", "", "false")
 
 from http.server import BaseHTTPRequestHandler  # noqa: E402
 from itertools import chain  # noqa: E402

--- a/ddtrace/ddsidecar.py
+++ b/ddtrace/ddsidecar.py
@@ -1,0 +1,230 @@
+# This is a sidecar server that listens for trace data from the Datadog tracer.
+# It should be run in a separate process from the tracer.
+# Ex: DD_INSTRUMENTATION_TELEMETRY_ENABLED=false DD_REMOTE_CONFIGURATION_ENABLED=false DD_TRACE_DEBUG=true python ddtrace/ddsidecar.py
+import os
+
+
+# Ensure low overhead mode is disabled for sidecar.
+assert os.environ.get("DD_TRACE_LOW_CPU_MODE") in ("0", "", "false", None)
+
+from http.server import BaseHTTPRequestHandler  # noqa: E402
+from itertools import chain  # noqa: E402
+import json  # noqa: E402
+import socketserver  # noqa: E402
+from typing import Any  # noqa: E402
+from typing import Dict  # noqa: E402
+from urllib.parse import urlparse  # noqa: E402
+
+import ddtrace  # noqa: E402
+from ddtrace._trace.processor import SpanProcessor  # noqa: E402
+
+
+# Initialize global variables
+spans: Dict[int, ddtrace.Span] = {}
+from ddtrace.ddsidecar_utils import SIDECAR_HOST  # noqa: E402
+from ddtrace.ddsidecar_utils import SIDECAR_PORT  # noqa: E402
+from ddtrace.ddsidecar_utils import kill_process_on_port  # noqa: E402
+
+
+# Create the HTTP request handler class
+class SideCarHTTPRequestHandler(BaseHTTPRequestHandler):
+    def _send_response(self, code: int, data: Any):
+        """Helper to send JSON response"""
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(data).encode())
+
+    def do_POST(self):
+        """Handle POST requests"""
+        content_length = int(self.headers["Content-Length"])
+        body = self.rfile.read(content_length)
+        # print("reading body", body)
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError:
+            self.send_response(400)
+            self.end_headers()
+            return
+
+        parsed_path = urlparse(self.path)
+        path = parsed_path.path
+
+        # print(path)
+
+        if path == "/trace/span/start":
+            self.trace_span_start(data)
+        elif path == "/trace/span/finish":
+            self.trace_span_finish(data)
+        elif path == "/trace/span/set_meta":
+            self.trace_span_set_meta(data)
+        elif path == "/trace/span/set_metric":
+            self.trace_span_set_metric(data)
+        elif path == "/trace/span/set_resource":
+            self.trace_span_set_resource(data)
+        elif path == "/trace/span/set_service":
+            self.trace_span_set_service(data)
+        elif path == "/trace/span/set_error":
+            self.trace_span_set_error(data)
+        elif path == "/trace/span/set_type":
+            self.trace_span_set_type(data)
+        elif path == "/trace/span/set_start_ns":
+            self.trace_span_set_start_ns(data)
+        elif path == "/trace/span/set_duration_ns":
+            self.trace_span_set_duration_ns(data)
+        elif path == "/trace/span/set_event":
+            self.trace_span_set_event(data)
+        elif path == "/trace/span/set_link":
+            self.trace_span_set_link(data)
+        elif path == "/trace/span/flush":
+            self.trace_spans_flush(data)
+        # elif path == "/trace/delete":
+        #     self.trace_delete(data)
+        elif path == "/alive":
+            self._send_response(200, {})
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def trace_span_start(self, args: dict):
+        """Start a new span"""
+        parent_id = args.get("parent_id", -1)
+        if parent_id in spans:
+            context = spans[parent_id].context
+        else:
+            context = None
+
+        span = ddtrace.Span(
+            args["name"],
+            trace_id=args["trace_id"],
+            parent_id=args["parent_id"],
+            span_id=args["span_id"],
+            service=args.get("service"),
+            span_type=args.get("type"),
+            resource=args.get("resource"),
+            span_api=args.get("span_api", "datadog"),
+            start=args.get("start"),
+            context=context,
+            on_finish=[ddtrace.tracer._on_span_finish],
+        )
+
+        if ddtrace.tracer.enabled or ddtrace.tracer._apm_opt_out:
+            for p in chain(
+                ddtrace.tracer._span_processors, SpanProcessor.__processors__, ddtrace.tracer._deferred_processors
+            ):
+                p.on_span_start(span)
+        ddtrace.tracer._hooks.emit(ddtrace.tracer.__class__.start_span, span)
+
+        spans[span.span_id] = span
+
+        self._send_response(200, {"span_id": span.span_id, "trace_id": span.trace_id})
+
+    def trace_span_finish(self, args: dict):
+        """Finish an existing span"""
+        global spans
+        span = spans.get(args["span_id"])
+        if span:
+            span.finish(args.get("finish_time"))
+            # print("finished span", span._pprint())
+            spans.pop(args["span_id"], None)
+        self._send_response(200, {})
+
+    def trace_span_set_meta(self, args: dict):
+        """Set metadata on a span"""
+        span = spans.get(args["span_id"])
+        if span:
+            span.set_tag(args["key"], args["value"])
+        self._send_response(200, {})
+
+    def trace_span_set_metric(self, args: dict):
+        """Set metric on a span"""
+        span = spans.get(args["span_id"])
+        if span:
+            span.set_metric(args["key"], args["value"])
+        self._send_response(200, {})
+
+    def trace_span_set_resource(self, args: dict):
+        """Set resource for a span"""
+        span = spans.get(args["span_id"])
+        if span:
+            span.resource = args["resource"]
+        self._send_response(200, {})
+
+    def trace_span_set_service(self, args: dict):
+        """Set service for a span"""
+        span = spans.get(args["span_id"])
+        if span:
+            span.service = args["service"]
+        self._send_response(200, {})
+
+    def trace_span_set_error(self, args: dict):
+        """Set error flag on the span"""
+        span = spans.get(args["span_id"])
+        if span:
+            span.error = int(args["error"])
+        self._send_response(200, {})
+
+    def trace_span_set_start_ns(self, args: dict):
+        """Set the start_ns (start timestamp in nanoseconds) of the span"""
+        span = spans.get(args["span_id"])
+        if span:
+            span.start_ns = float(args["start_ns"])
+        self._send_response(200, {})
+
+    def trace_span_set_type(self, args: dict):
+        """Set the type of the span"""
+        span = spans.get(args["span_id"])
+        if span:
+            span.span_type = args["type"]
+        self._send_response(200, {})
+
+    def trace_span_set_duration_ns(self, args: dict):
+        """Set the duration_ns (duration in nanoseconds) of the span"""
+        span = spans.get(args["span_id"])
+        if span:
+            span.duration_ns = args["duration_ns"]
+        self._send_response(200, {})
+
+    def trace_span_set_event(self, args: dict):
+        """Set event on the span"""
+        span = spans.get(args["span_id"])
+        if span:
+            name = args["name"]
+            attributes = json.loads(args.get("attributes") or "{}")
+            timestamp = args.get("timestamp")
+            span._add_event(name, attributes, timestamp)
+        self._send_response(200, {})
+
+    def trace_span_set_link(self, args: dict):
+        """Set link on the span"""
+        span = spans.get(args["span_id"])
+        if span:
+            span_id = int(args["linked_span_id"])
+            trace_id = int(args["linked_trace_id"])
+            attributes = json.loads(args.get("attributes") or "{}")
+            tracestate = args.get("tracestate")
+            flags = int(args.get("flags", 0)) or None
+            span.set_link(trace_id, span_id, attributes, tracestate, flags)
+            # print(span._links)
+        self._send_response(200, {})
+
+    def trace_spans_flush(self, args: dict):
+        """Flush all spans"""
+        ddtrace.tracer.flush()
+        self._send_response(200, {})
+
+    # def trace_delete(self, args: list):
+    #     """Delete spans"""
+    #     global spans
+
+    #     for id in json.loads(args.get("span_ids", "[]")):
+    #         spans.pop(id, None)
+    #     #print("remaining spans:", spans)
+    #     self._send_response(200, {})
+
+
+if __name__ == "__main__":
+    kill_process_on_port(SIDECAR_PORT)
+    with socketserver.TCPServer((SIDECAR_HOST, int(SIDECAR_PORT)), SideCarHTTPRequestHandler) as httpd:
+        print("Serving at port", SIDECAR_PORT)
+        httpd.serve_forever()

--- a/ddtrace/ddsidecar_utils.py
+++ b/ddtrace/ddsidecar_utils.py
@@ -1,0 +1,136 @@
+from concurrent.futures import ThreadPoolExecutor
+import http
+import json
+import multiprocessing
+import os
+import subprocess
+import time
+
+from ddtrace.vendor import psutil
+
+
+# Port on which the sidecar server will run
+SIDECAR_PORT = os.getenv("DD_TRACE_SIDECAR_PORT", "8129")
+# Host on which the sidecar server will run
+# Using localhost here prevents outside connections to the sidecar server.
+SIDECAR_HOST = "127.0.0.1"
+
+# Create a ThreadPoolExecutor with a maximum of 10 workers
+executor = ThreadPoolExecutor(max_workers=100)
+
+
+def kill_process_on_port(port):
+    for proc in psutil.process_iter(attrs=["pid", "name", "connections"]):
+        try:
+            if not proc.info["connections"]:
+                continue
+            # Iterate through the connections of each process
+            for conn in proc.info["connections"]:
+                # Check if the connection is in the listening state and on the desired port
+                if conn.status == "LISTEN" and conn.laddr.port == int(port):
+                    print(f"Killing process {proc.info['name']} with PID {proc.info['pid']} on port {port}")
+                    proc.terminate()  # Terminate the process
+                    proc.wait()  # Wait for the process to terminate
+                    return
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue
+
+
+# Function to start the HTTP server
+def start_sidecar_server():
+    # The command to start a simple HTTP server on port 8000
+    kill_process_on_port(SIDECAR_PORT)
+    subprocess.run(["python3", "-m", "ddtrace.ddsidecar", SIDECAR_PORT])
+
+
+def run_tracing_sidecar():
+    server_process = multiprocessing.Process(target=start_sidecar_server)
+    server_process.start()
+
+    # Give the server some time to start up
+    time.sleep(1)
+    assert is_sidecar_alive(), "sidecar failed to start"
+
+
+def is_sidecar_alive():
+    # Send a GET request to the root endpoint
+    conn = http.client.HTTPConnection("localhost", SIDECAR_PORT)
+    conn.request("POST", "/alive")
+    response = conn.getresponse()
+    return response.status == 200
+
+
+# Function to send the request (for use in ThreadPoolExecutor)
+def send_request_threadpool(path, body):
+    # Create a connection to the local server
+    conn = http.client.HTTPConnection("localhost", SIDECAR_PORT)
+
+    # Send a POST request to the path with the body
+    conn.request("POST", path, body=json.dumps(body))
+
+    # Get the response
+    response = conn.getresponse()
+    response_str = response.read().decode("utf-8")
+
+    # Print the response status and body for debugging
+    assert response.status == 200, f"Response Status: {response.status}, Response Body: {response_str}"
+    conn.close()
+
+
+def update_sidecar(path, body):
+    # Create a connection to the local server
+    # Submit the request function for asynchronous execution
+    executor.submit(send_request_threadpool, path, body)
+
+
+# Syncronous version of the function above
+# def update_sidecar(path, body):
+#     # Create a connection to the local server
+#     conn = http.client.HTTPConnection("localhost", SIDECAR_PORT)
+#     # Send a GET request to the root endpoint
+#     conn.request("POST", path, body=json.dumps(body))
+#     # Get the response
+#     response = conn.getresponse()
+#     response_str = response.read().decode("utf-8")
+#     # Print the response status and body
+#     assert response.status == 200, f"Response Status: {response.status}, Response Body: {response_str}"
+#     conn.close()
+#     if response_str:
+#         return json.loads(response_str)
+#     return {}
+
+
+## Benchmark script
+## Run with DD_TRACE_LOW_CPU_MODE=false python ... and DD_TRACE_LOW_CPU_MODE=true python ...
+
+# import timeit
+# from ddtrace import tracer
+
+
+# def setup_create_span():
+#     return tracer.trace(name="spanname", resource="blah", service="myapp", span_type="web")
+
+# def create_and_finish_span():
+#     span = tracer.trace(name="spanname", resource="blah", service="myapp", span_type="web")
+#     span.finish()
+
+# # Helper function to time the functions
+# def time_function(func, setup, number=100):
+#     return timeit.timeit(func, globals=globals(), setup=setup, number=number)
+
+# if __name__ == "__main__":
+#     # Setup code to create the span before each benchmark
+#     setup_code = "span = setup_create_span()"
+
+#     # Running the benchmarks
+#     print("Benchmark Results:")
+#     print(f"Create Span: {time_function('create_and_finish_span()', ''):.6f} seconds")
+#     print(f"Set Tag: {time_function('span.set_tag("k", "v")', setup_code):.6f} seconds")
+#     print(f"Set Metric: {time_function('span.set_metric("k", 1)', setup_code):.6f} seconds")
+#     print(f"Set Link: {time_function('span.set_link(trace_id=20, span_id=10)', setup_code):.6f} seconds")
+#     print(f"Add Event: {time_function('span._add_event(name="hi")', setup_code):.6f} seconds")
+#     print(f"Set Resource: {time_function('span.resource = 1', setup_code):.6f} seconds")
+#     print(f"Set Service: {time_function('span.service = 2', setup_code):.6f} seconds")
+#     print(f"Set Span Type: {time_function('span.span_type = "web"', setup_code):.6f} seconds")
+#     print(f"Set Start NS: {time_function('span.start_ns = 10000', setup_code):.6f} seconds")
+#     print(f"Set Duration NS: {time_function('span.duration_ns = 10000', setup_code):.6f} seconds")

--- a/ddtrace/ddsidecar_utils.py
+++ b/ddtrace/ddsidecar_utils.py
@@ -40,7 +40,7 @@ def start_sidecar_server():
     global SIDECAR_PROCESS
     kill_process_on_port(config._trace_sidecar_port)
     env = os.environ.copy()
-    env["DD_TRACE_LOW_CPU_MODE"] = "false"
+    env["DD_SIDECAR_ENABLED"] = "false"
     env["DD_INSTRUMENTATION_TELEMETRY_ENABLED"] = "false"
     env["DD_REMOTE_CONFIGURATION_ENABLED"] = "false"
     env["DD_TRACE_DEBUG"] = "true"

--- a/ddtrace/ddsidecar_utils.py
+++ b/ddtrace/ddsidecar_utils.py
@@ -6,18 +6,15 @@ import subprocess
 import sys
 import time
 
+from ddtrace import config
 from ddtrace.vendor import psutil
 
 
-
-# Port on which the sidecar server will run
-SIDECAR_PORT = os.getenv("DD_TRACE_SIDECAR_PORT", "8129")
 # Host on which the sidecar server will run
 # Using localhost here prevents outside connections to the sidecar server.
 SIDECAR_HOST = "127.0.0.1"
 # Create a ThreadPoolExecutor with a maximum of 10 workers
-executor = ThreadPoolExecutor(max_workers=100)
-
+executor = ThreadPoolExecutor(max_workers=10)
 
 SIDECAR_PROCESS = None
 
@@ -39,11 +36,9 @@ def kill_process_on_port(port):
             continue
 
 
-# Function to start the HTTP server
 def start_sidecar_server():
     global SIDECAR_PROCESS
-    # The command to start a simple HTTP server on port 8000
-    kill_process_on_port(SIDECAR_PORT)
+    kill_process_on_port(config._trace_sidecar_port)
     env = os.environ.copy()
     env["DD_TRACE_LOW_CPU_MODE"] = "false"
     env["DD_INSTRUMENTATION_TELEMETRY_ENABLED"] = "false"
@@ -65,24 +60,20 @@ def start_sidecar_server():
 
 def is_sidecar_alive():
     # Send a GET request to the root endpoint
-    conn = http.client.HTTPConnection("localhost", SIDECAR_PORT)
+    conn = http.client.HTTPConnection("localhost", config._trace_sidecar_port)
     conn.request("POST", "/alive", body="{}")
     response = conn.getresponse()
     return response.status == 200
 
 
-# Function to send the request (for use in ThreadPoolExecutor)
 def send_request_threadpool(path, body):
     # Create a connection to the local server
-    conn = http.client.HTTPConnection("localhost", SIDECAR_PORT)
-
+    conn = http.client.HTTPConnection("localhost", config._trace_sidecar_port)
     # Send a POST request to the path with the body
     conn.request("POST", path, body=json.dumps(body))
-
     # Get the response
     response = conn.getresponse()
     response_str = response.read().decode("utf-8")
-
     # Print the response status and body for debugging
     assert response.status == 200, f"Response Status: {response.status}, Response Body: {response_str}"
     conn.close()
@@ -92,56 +83,3 @@ def update_sidecar(path, body):
     # Create a connection to the local server
     # Submit the request function for asynchronous execution
     executor.submit(send_request_threadpool, path, body)
-
-
-# Syncronous version of the function above
-# def update_sidecar(path, body):
-#     # Create a connection to the local server
-#     conn = http.client.HTTPConnection("localhost", SIDECAR_PORT)
-#     # Send a GET request to the root endpoint
-#     conn.request("POST", path, body=json.dumps(body))
-#     # Get the response
-#     response = conn.getresponse()
-#     response_str = response.read().decode("utf-8")
-#     # Print the response status and body
-#     assert response.status == 200, f"Response Status: {response.status}, Response Body: {response_str}"
-#     conn.close()
-#     if response_str:
-#         return json.loads(response_str)
-#     return {}
-
-
-## Benchmark script
-## Run with DD_TRACE_LOW_CPU_MODE=false python ... and DD_TRACE_LOW_CPU_MODE=true python ...
-
-# import timeit
-# from ddtrace import tracer
-
-
-# def setup_create_span():
-#     return tracer.trace(name="spanname", resource="blah", service="myapp", span_type="web")
-
-# def create_and_finish_span():
-#     span = tracer.trace(name="spanname", resource="blah", service="myapp", span_type="web")
-#     span.finish()
-
-# # Helper function to time the functions
-# def time_function(func, setup, number=100):
-#     return timeit.timeit(func, globals=globals(), setup=setup, number=number)
-
-# if __name__ == "__main__":
-#     # Setup code to create the span before each benchmark
-#     setup_code = "span = setup_create_span()"
-
-#     # Running the benchmarks
-#     print("Benchmark Results:")
-#     print(f"Create Span: {time_function('create_and_finish_span()', ''):.6f} seconds")
-#     print(f"Set Tag: {time_function('span.set_tag("k", "v")', setup_code):.6f} seconds")
-#     print(f"Set Metric: {time_function('span.set_metric("k", 1)', setup_code):.6f} seconds")
-#     print(f"Set Link: {time_function('span.set_link(trace_id=20, span_id=10)', setup_code):.6f} seconds")
-#     print(f"Add Event: {time_function('span._add_event(name="hi")', setup_code):.6f} seconds")
-#     print(f"Set Resource: {time_function('span.resource = 1', setup_code):.6f} seconds")
-#     print(f"Set Service: {time_function('span.service = 2', setup_code):.6f} seconds")
-#     print(f"Set Span Type: {time_function('span.span_type = "web"', setup_code):.6f} seconds")
-#     print(f"Set Start NS: {time_function('span.start_ns = 10000', setup_code):.6f} seconds")
-#     print(f"Set Duration NS: {time_function('span.duration_ns = 10000', setup_code):.6f} seconds")

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -424,6 +424,8 @@ class Config(object):
         self._remote_config_poll_interval = _get_config(
             ["DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS", "DD_REMOTECONFIG_POLL_SECONDS"], 5.0, float
         )
+        self._trace_low_cpu_mode = _get_config("DD_TRACE_LOW_CPU_MODE", False, asbool)
+        self._trace_sidecar_port = _get_config("DD_TRACE_SIDECAR_PORT", "8129", asbool)
         self._trace_api = _get_config("DD_TRACE_API_VERSION")
         if self._trace_api == "v0.3":
             deprecate(

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -424,7 +424,7 @@ class Config(object):
         self._remote_config_poll_interval = _get_config(
             ["DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS", "DD_REMOTECONFIG_POLL_SECONDS"], 5.0, float
         )
-        self._trace_low_cpu_mode = _get_config("DD_TRACE_LOW_CPU_MODE", False, asbool)
+        self._sidecar_enabled = _get_config("DD_SIDECAR_ENABLED", False, asbool)
         self._trace_sidecar_port = _get_config("DD_TRACE_SIDECAR_PORT", "8129", asbool)
         self._trace_api = _get_config("DD_TRACE_API_VERSION")
         if self._trace_api == "v0.3":


### PR DESCRIPTION
This PR introduces a mechanism allows trace data to be aggregated and submitted outside of of the main process.
 
## Current Approach

- When a span is created or one of it's serializable fields is updated an http request is sent from the main process to ddsidecar. The request is sent using python's builtin http client and a threadpool with up to 10 workers. 
- The response is validated in the thread pool and error is logged if a successful status code is not received. 
- ddsidecar serves requests synchronously via python's builtin `socketserver.TCPServer`. 

## Next steps

The current approach does not have an acceptable overhead. Next steps involve:
- iterating on the choice of http clients/servers (ex: aiohttp)
- using mmap for interprocess communication
- using [multiprocessing.connection](https://docs.python.org/3/library/multiprocessing.html#module-multiprocessing.connection)
-  Using a more performant json serializer (or writing my own).
- Using the sidecar implementation in libdatadog. 

I will also experiment with moving tracing operations to the sidecar to offload more heavy operations (ex: tracer.start_span, tracer.flush) and minimizing the number of requests between traced applications and the sidecar.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
