### PR TITLE
chore(profiling): ddup.upload() optionally gets tracer object

### DIFF
--- a/ddtrace/internal/datadog/profiling/ddup/_ddup.pyi
+++ b/ddtrace/internal/datadog/profiling/ddup/_ddup.pyi
@@ -3,6 +3,7 @@ from typing import Optional
 from typing import Union
 from .._types import StringType
 from ddtrace._trace.span import Span
+from ddtrace._trace.tracer import Tracer
 
 def config(
     env: StringType,
@@ -16,7 +17,7 @@ def config(
     enable_code_provenance: Optional[bool],
 ) -> None: ...
 def start() -> None: ...
-def upload() -> None: ...
+def upload(tracer: Optional[Tracer]) -> None: ...
 
 class SampleHandle:
     def push_cputime(self, value: int, count: int) -> None: ...

--- a/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
+++ b/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
@@ -20,6 +20,7 @@ from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
 from ddtrace.internal.packages import get_distributions
 from ddtrace.internal.runtime import get_runtime_id
 from ddtrace._trace.span import Span
+from ddtrace._trace.tracer import Tracer
 
 
 ctypedef void (*func_ptr_t)(string_view)
@@ -396,16 +397,16 @@ def _get_endpoint(tracer)-> str:
     return endpoint
 
 
-def upload() -> None:
+def upload(tracer: Optional[Tracer] = ddtrace.tracer) -> None:
     call_func_with_str(ddup_set_runtime_id, get_runtime_id())
 
-    processor = ddtrace.tracer._endpoint_call_counter_span_processor
+    processor = tracer._endpoint_call_counter_span_processor
     endpoint_counts, endpoint_to_span_ids = processor.reset()
 
     call_ddup_profile_set_endpoints(endpoint_to_span_ids)
     call_ddup_profile_add_endpoint_counts(endpoint_counts)
 
-    endpoint = _get_endpoint(ddtrace.tracer)
+    endpoint = _get_endpoint(tracer)
     call_func_with_str(ddup_config_url, endpoint)
 
     with nogil:

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -311,6 +311,7 @@ class _ProfilerInstance(service.Service):
                 recorder=r,
                 exporters=exporters,
                 before_flush=self._collectors_snapshot,
+                tracer=self.tracer,
             )
 
     def _collectors_snapshot(self):

--- a/tests/profiling_v2/collector/test_asyncio.py
+++ b/tests/profiling_v2/collector/test_asyncio.py
@@ -7,7 +7,6 @@ import uuid
 import pytest
 
 from ddtrace import ext
-from ddtrace import tracer
 from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.profiling.collector import asyncio as collector_asyncio
 from tests.profiling.collector import pprof_utils
@@ -85,7 +84,7 @@ class TestAsyncioLockCollector:
             ],
         )
 
-    async def test_asyncio_lock_events_tracer(self):
+    async def test_asyncio_lock_events_tracer(self, tracer):
         tracer._endpoint_call_counter_span_processor.enable()
         resource = str(uuid.uuid4())
         span_type = ext.SpanTypes.WEB
@@ -103,7 +102,7 @@ class TestAsyncioLockCollector:
             lock_ctx = asyncio.Lock()  # !CREATE! test_asyncio_lock_events_tracer_3
             async with lock_ctx:  # !ACQUIRE! !RELEASE! test_asyncio_lock_events_tracer_3
                 pass
-        ddup.upload()
+        ddup.upload(tracer=tracer)
 
         linenos_1 = get_lock_linenos("test_asyncio_lock_events_tracer_1")
         linenos_2 = get_lock_linenos("test_asyncio_lock_events_tracer_2")

--- a/tests/profiling_v2/collector/test_stack.py
+++ b/tests/profiling_v2/collector/test_stack.py
@@ -9,7 +9,6 @@ import uuid
 import pytest
 
 from ddtrace import ext
-from ddtrace import tracer
 from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.profiling.collector import stack
 from ddtrace.settings.profiling import config
@@ -82,7 +81,7 @@ def test_stack_locations(stack_v2_enabled, tmp_path):
 
 
 @pytest.mark.parametrize("stack_v2_enabled", [True, False])
-def test_push_span(stack_v2_enabled, tmp_path):
+def test_push_span(stack_v2_enabled, tmp_path, tracer):
     if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
         pytest.skip("stack_v2 is not supported on Python 3.7")
 
@@ -111,7 +110,7 @@ def test_push_span(stack_v2_enabled, tmp_path):
             local_root_span_id = span._local_root.span_id
             for _ in range(10):
                 time.sleep(0.1)
-    ddup.upload()
+    ddup.upload(tracer=tracer)
 
     profile = pprof_utils.parse_profile(output_filename)
     samples = pprof_utils.get_samples_with_label_key(profile, "span id")
@@ -129,7 +128,7 @@ def test_push_span(stack_v2_enabled, tmp_path):
         )
 
 
-def test_push_span_unregister_thread(tmp_path, monkeypatch):
+def test_push_span_unregister_thread(tmp_path, monkeypatch, tracer):
     if sys.version_info[:2] == (3, 7):
         pytest.skip("stack_v2 is not supported on Python 3.7")
 
@@ -166,7 +165,7 @@ def test_push_span_unregister_thread(tmp_path, monkeypatch):
                 t.start()
                 t.join()
                 thread_id = t.ident
-        ddup.upload()
+        ddup.upload(tracer=tracer)
 
         profile = pprof_utils.parse_profile(output_filename)
         samples = pprof_utils.get_samples_with_label_key(profile, "span id")
@@ -187,7 +186,7 @@ def test_push_span_unregister_thread(tmp_path, monkeypatch):
 
 
 @pytest.mark.parametrize("stack_v2_enabled", [True, False])
-def test_push_non_web_span(stack_v2_enabled, tmp_path):
+def test_push_non_web_span(stack_v2_enabled, tmp_path, tracer):
     if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
         pytest.skip("stack_v2 is not supported on Python 3.7")
 
@@ -216,7 +215,7 @@ def test_push_non_web_span(stack_v2_enabled, tmp_path):
             local_root_span_id = span._local_root.span_id
             for _ in range(10):
                 time.sleep(0.1)
-    ddup.upload()
+    ddup.upload(tracer=tracer)
 
     profile = pprof_utils.parse_profile(output_filename)
     samples = pprof_utils.get_samples_with_label_key(profile, "span id")
@@ -235,7 +234,7 @@ def test_push_non_web_span(stack_v2_enabled, tmp_path):
 
 
 @pytest.mark.parametrize("stack_v2_enabled", [True, False])
-def test_push_span_none_span_type(stack_v2_enabled, tmp_path):
+def test_push_span_none_span_type(stack_v2_enabled, tmp_path, tracer):
     # Test for https://github.com/DataDog/dd-trace-py/issues/11141
     if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
         pytest.skip("stack_v2 is not supported on Python 3.7")
@@ -266,7 +265,7 @@ def test_push_span_none_span_type(stack_v2_enabled, tmp_path):
             local_root_span_id = span._local_root.span_id
             for _ in range(10):
                 time.sleep(0.1)
-    ddup.upload()
+    ddup.upload(tracer=tracer)
 
     profile = pprof_utils.parse_profile(output_filename)
     samples = pprof_utils.get_samples_with_label_key(profile, "span id")
@@ -398,7 +397,7 @@ def test_exception_collection_threads(stack_v2_enabled, tmp_path):
 
 @pytest.mark.skipif(not stack.FEATURES["stack-exceptions"], reason="Stack exceptions are not supported")
 @pytest.mark.parametrize("stack_v2_enabled", [True, False])
-def test_exception_collection_trace(stack_v2_enabled, tmp_path):
+def test_exception_collection_trace(stack_v2_enabled, tmp_path, tracer):
     if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
         pytest.skip("stack_v2 is not supported on Python 3.7")
 
@@ -419,7 +418,7 @@ def test_exception_collection_trace(stack_v2_enabled, tmp_path):
             except Exception:
                 time.sleep(1)
 
-    ddup.upload()
+    ddup.upload(tracer=tracer)
 
     profile = pprof_utils.parse_profile(output_filename)
     samples = pprof_utils.get_samples_with_label_key(profile, "exception type")

--- a/tests/profiling_v2/collector/test_threading.py
+++ b/tests/profiling_v2/collector/test_threading.py
@@ -8,7 +8,6 @@ import mock
 import pytest
 
 from ddtrace import ext
-from ddtrace import tracer
 from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.profiling.collector import threading as collector_threading
 from tests.profiling.collector import pprof_utils
@@ -356,7 +355,7 @@ class TestThreadingLockCollector:
             ],
         )
 
-    def test_lock_events_tracer(self):
+    def test_lock_events_tracer(self, tracer):
         tracer._endpoint_call_counter_span_processor.enable()
         resource = str(uuid.uuid4())
         span_type = ext.SpanTypes.WEB
@@ -375,7 +374,7 @@ class TestThreadingLockCollector:
                 span_id = t.span_id
 
             lock2.release()  # !RELEASE! test_lock_events_tracer_2
-        ddup.upload()
+        ddup.upload(tracer=tracer)
 
         linenos1 = get_lock_linenos("test_lock_events_tracer_1")
         linenos2 = get_lock_linenos("test_lock_events_tracer_2")
@@ -419,7 +418,7 @@ class TestThreadingLockCollector:
             ],
         )
 
-    def test_lock_events_tracer_non_web(self):
+    def test_lock_events_tracer_non_web(self, tracer):
         tracer._endpoint_call_counter_span_processor.enable()
         resource = str(uuid.uuid4())
         span_type = ext.SpanTypes.SQL
@@ -435,7 +434,7 @@ class TestThreadingLockCollector:
                 span_id = t.span_id
 
             lock2.release()  # !RELEASE! test_lock_events_tracer_non_web
-        ddup.upload()
+        ddup.upload(tracer=tracer)
 
         linenos2 = get_lock_linenos("test_lock_events_tracer_non_web")
 
@@ -463,7 +462,7 @@ class TestThreadingLockCollector:
             ],
         )
 
-    def test_lock_events_tracer_late_finish(self):
+    def test_lock_events_tracer_late_finish(self, tracer):
         tracer._endpoint_call_counter_span_processor.enable()
         resource = str(uuid.uuid4())
         span_type = ext.SpanTypes.WEB
@@ -482,7 +481,7 @@ class TestThreadingLockCollector:
             lock2.release()  # !RELEASE! test_lock_events_tracer_late_finish_2
         span.resource = resource
         span.finish()
-        ddup.upload()
+        ddup.upload(tracer=tracer)
 
         linenos1 = get_lock_linenos("test_lock_events_tracer_late_finish_1")
         linenos2 = get_lock_linenos("test_lock_events_tracer_late_finish_2")
@@ -520,7 +519,7 @@ class TestThreadingLockCollector:
             ],
         )
 
-    def test_resource_not_collected(self):
+    def test_resource_not_collected(self, tracer):
         tracer._endpoint_call_counter_span_processor.enable()
         resource = str(uuid.uuid4())
         span_type = ext.SpanTypes.WEB
@@ -539,7 +538,7 @@ class TestThreadingLockCollector:
                 lock1.release()  # !RELEASE! test_resource_not_collected_1
                 span_id = t.span_id
             lock2.release()  # !RELEASE! test_resource_not_collected_2
-        ddup.upload()
+        ddup.upload(tracer=tracer)
 
         linenos1 = get_lock_linenos("test_resource_not_collected_1")
         linenos2 = get_lock_linenos("test_resource_not_collected_2")


### PR DESCRIPTION
profiling tests that check for span ids are flaky. I wonder whether sharing tracer instance across tests causes that problem. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
