### PR TITLE
chore(ci_visibility): make codeowners file relative to repo path

### DIFF
--- a/ddtrace/contrib/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/pytest/_plugin_v2.py
@@ -256,8 +256,10 @@ def _pytest_collection_finish(session) -> None:
         InternalTestSuite.discover(suite_id)
 
         item_path = Path(item.path if hasattr(item, "path") else item.fspath).absolute()
+        workspace_path = InternalTestSession.get_workspace_path()
+        repo_relative_path = item_path.relative_to(workspace_path) if workspace_path else item_path
 
-        item_codeowners = InternalTestSession.get_path_codeowners(item_path)
+        item_codeowners = InternalTestSession.get_path_codeowners(repo_relative_path)
 
         source_file_info = _get_source_file_info(item, item_path)
 

--- a/ddtrace/contrib/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/pytest/_plugin_v2.py
@@ -257,7 +257,13 @@ def _pytest_collection_finish(session) -> None:
 
         item_path = Path(item.path if hasattr(item, "path") else item.fspath).absolute()
         workspace_path = InternalTestSession.get_workspace_path()
-        repo_relative_path = item_path.relative_to(workspace_path) if workspace_path else item_path
+        if workspace_path:
+            try:
+                repo_relative_path = item_path.relative_to(workspace_path)
+            except ValueError:
+                repo_relative_path = item_path
+        else:
+            repo_relative_path = item_path
 
         item_codeowners = InternalTestSession.get_path_codeowners(repo_relative_path) if repo_relative_path else None
 

--- a/ddtrace/contrib/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/pytest/_plugin_v2.py
@@ -259,7 +259,7 @@ def _pytest_collection_finish(session) -> None:
         workspace_path = InternalTestSession.get_workspace_path()
         repo_relative_path = item_path.relative_to(workspace_path) if workspace_path else item_path
 
-        item_codeowners = InternalTestSession.get_path_codeowners(repo_relative_path)
+        item_codeowners = InternalTestSession.get_path_codeowners(repo_relative_path) if repo_relative_path else None
 
         source_file_info = _get_source_file_info(item, item_path)
 

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -1031,7 +1031,7 @@ def _on_session_get_path_codeowners(path: Path) -> Optional[List[str]]:
     codeowners = CIVisibility.get_codeowners()
     if codeowners is None:
         return None
-    return codeowners.of(str(path.absolute()))
+    return codeowners.of(str(path))
 
 
 def _register_session_handlers():


### PR DESCRIPTION
This fixes an issue in the new version of the `pytest` plugin where `CODEOWNERS` parsing was incorrect due to the plugin sending absolute paths instead of paths relative to the repo root.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
