### PR TITLE
ci: use hatch to execute needs_testrun.py

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -143,6 +143,9 @@ extra-dependencies = [
 test = [
     "python -m doctest {args} scripts/get-target-milestone.py scripts/needs_testrun.py tests/suitespec.py",
 ]
+needs_testrun = [
+  "scripts/needs_testrun.py {args}",
+]
 
 [envs.meta-testing]
 python = "3.10"

--- a/scripts/needs_testrun.py
+++ b/scripts/needs_testrun.py
@@ -270,8 +270,13 @@ def extract_git_commit_selections(git_commit_message: str) -> t.Set[str]:
 def main() -> bool:
     argp = ArgumentParser()
 
+    try:
+        default_pr_number = _get_pr_number()
+    except RuntimeError:
+        default_pr_number = None
+
     argp.add_argument("suite", help="The suite to use", type=str)
-    argp.add_argument("--pr", help="The PR number", type=int, default=_get_pr_number())
+    argp.add_argument("--pr", help="The PR number", type=int, default=default_pr_number)
     argp.add_argument(
         "--sha", help="Commit hash to use as diff base (defaults to PR merge root)", type=lambda v: v or None
     )
@@ -281,6 +286,9 @@ def main() -> bool:
 
     if args.verbose:
         LOGGER.setLevel(logging.INFO)
+
+    if not args.pr:
+        raise RuntimeError("Could not determine PR number")
 
     return needs_testrun(args.suite, args.pr, sha=args.sha)
 

--- a/scripts/run-test-suite
+++ b/scripts/run-test-suite
@@ -47,7 +47,7 @@ set -e
 if ! [[ -v CIRCLECI && $CIRCLE_BRANCH =~ main ]]; then
     if [[ -f "$CHECKPOINT_FILENAME" ]]; then
         latest_success_commit=$(cat $CHECKPOINT_FILENAME)
-        if ! ./scripts/needs_testrun.py $CIRCLE_JOB --sha $latest_success_commit; then
+        if ! hatch run scripts:needs_testrun $CIRCLE_JOB --sha $latest_success_commit; then
             echo "The $CIRCLE_JOB job succeeded at commit $latest_success_commit."
             echo "None of the changes on this branch since that commit affect the $CIRCLE_JOB job."
             echo "Skipping this job."

--- a/scripts/run-test-suite-hatch
+++ b/scripts/run-test-suite-hatch
@@ -33,7 +33,7 @@ set -e
 if ! [[ -v CIRCLECI && $CIRCLE_BRANCH =~ main ]]; then
     if [[ -f "$CHECKPOINT_FILENAME" ]]; then
         latest_success_commit=$(cat $CHECKPOINT_FILENAME)
-        if ! ./scripts/needs_testrun.py $CIRCLE_JOB --sha $latest_success_commit; then
+        if ! hatch run scripts:needs_testrun $CIRCLE_JOB --sha $latest_success_commit; then
             echo "The $CIRCLE_JOB job succeeded at commit $latest_success_commit."
             echo "None of the changes on this branch since that commit affect the $CIRCLE_JOB job."
             echo "Skipping this job."


### PR DESCRIPTION
This will fix issues like: https://app.circleci.com/pipelines/github/DataDog/dd-trace-py/79203/workflows/9f43a358-af41-4d77-8b7b-c931654756d5/jobs/4383102?invite=true#step-108-449_45

> ModuleNotFoundError: No module named 'ruamel'

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
