### PR TITLE
chore(ci): enable quality gates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ stages:
   - package
   - tests-gen
   - tests-trigger
+  - quality-gate
   - shared-pipeline
   - benchmarks
   - macrobenchmarks
@@ -87,3 +88,21 @@ deploy_to_di_backend:manual:
     UPSTREAM_COMMIT_AUTHOR: $CI_COMMIT_AUTHOR
     UPSTREAM_TAG: $CI_COMMIT_TAG
     UPSTREAM_PACKAGE_JOB: build
+
+check_new_flaky_tests:
+  stage: quality-gate
+  extends: .testrunner
+  variables:
+      DD_SITE: datadoghq.com
+      DD_API_KEY: invalid_but_this_is_fine
+      DD_APP_KEY: invalid_but_fine
+  script:
+    - curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
+    - export DD_SITE=datadoghq.com
+    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.${CI_PROJECT_NAME}.dd-api-key-qualitygate --with-decryption --query "Parameter.Value" --out text)
+    - export DD_APP_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.${CI_PROJECT_NAME}.dd-app-key-qualitygate --with-decryption --query "Parameter.Value" --out text)
+    - datadog-ci gate evaluate
+  except:
+    - main
+    - '[0-9].[0-9]*'
+    - 'mq-working-branch**'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,10 +92,6 @@ deploy_to_di_backend:manual:
 check_new_flaky_tests:
   stage: quality-gate
   extends: .testrunner
-  variables:
-      DD_SITE: datadoghq.com
-      DD_API_KEY: invalid_but_this_is_fine
-      DD_APP_KEY: invalid_but_fine
   script:
     - curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" --output "/usr/local/bin/datadog-ci" && chmod +x /usr/local/bin/datadog-ci
     - export DD_SITE=datadoghq.com


### PR DESCRIPTION
Enable Quality Gates to prevent new flaky tests from being merged into main or release branches.

Example branches: 
https://github.com/DataDog/dd-trace-py/tree/erikayasuda/qg-simple-delayed-fix
https://github.com/DataDog/dd-trace-py/tree/erikayasuda/qg-simple-quick-fix

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
