### PR TITLE
ci: fix needs_testrun tests. do not record all requests

### DIFF
--- a/scripts/needs_testrun.py
+++ b/scripts/needs_testrun.py
@@ -36,7 +36,7 @@ def get_base_branch(pr_number: int) -> str:
     >>> with vcr.use_cassette(
     ...   "scripts/vcr/needs_testrun.yaml",
     ...   filter_headers=["authorization", "user-agent"],
-    ...   record_mode="all"):
+    ...   record_mode="none"):
     ...     get_base_branch(6412)
     ...     get_base_branch(11534)
     ...     get_base_branch(11690)
@@ -135,7 +135,7 @@ def get_changed_files(pr_number: int, sha: t.Optional[str] = None) -> t.Set[str]
     >>> with vcr.use_cassette(
     ...   "scripts/vcr/needs_testrun.yaml",
     ...   filter_headers=["authorization", "user-agent"],
-    ...   record_mode="all"):
+    ...   record_mode="none"):
     ...     sorted(get_changed_files(6388))  # doctest: +NORMALIZE_WHITESPACE
     ['ddtrace/debugging/_expressions.py',
     'releasenotes/notes/fix-debugger-expressions-none-literal-30f3328d2e386f40.yaml',
@@ -165,7 +165,7 @@ def needs_testrun(suite: str, pr_number: int, sha: t.Optional[str] = None) -> bo
     >>> with vcr.use_cassette(
     ...   "scripts/vcr/needs_testrun.yaml",
     ...   filter_headers=["authorization", "user-agent"],
-    ...   record_mode="all"):
+    ...   record_mode="none"):
     ...     needs_testrun("debugger", 6485)
     ...     needs_testrun("debugger", 6388)
     ...     needs_testrun("foobar", 6412)


### PR DESCRIPTION
`record_mode="all"` is great for the first run to collect all requests, but `none` is better since it'll block any unknown requests.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
