### PR TITLE
ci: wait longer for opensearch to start

### DIFF
--- a/tests/contrib/elasticsearch/test_elasticsearch.py
+++ b/tests/contrib/elasticsearch/test_elasticsearch.py
@@ -41,14 +41,16 @@ else:
 
 
 def wait_for_es(host: str, port: int):
-    for _ in range(20):
+    # Wait for up to 160 seconds for ES to start.
+    # DEV: Elasticsearch is pretty quick, but OpenSearch can take a long time to start.
+    for _ in range(80):
         try:
             conn = HTTPConnection(f"{host}:{port}")
             conn.request("GET", "/")
             conn.getresponse()
             return
         except Exception:
-            time.sleep(1)
+            time.sleep(2)
     raise Exception(f"Could not connect to ES at {host}:{port}")
 
 


### PR DESCRIPTION
Previously we would wait up to 20 seconds to Elasticsearch to start, apparently OpenSearch might need longer to start up. So we are updating the logic to wait up to 160 seconds with 2 second sleeps between checks.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
