### PR TITLE
ci(gevent): improve ddtrace-run test assertion message

### DIFF
--- a/.gitlab/services.yml
+++ b/.gitlab/services.yml
@@ -15,7 +15,7 @@
     name: registry.ddbuild.io/images/mirror/dd-apm-test-agent/ddapm-test-agent:v1.20.0
     alias: testagent
     variables:
-      LOG_LEVEL: DEBUG
+      LOG_LEVEL: INFO
       SNAPSHOT_DIR: ${CI_PROJECT_DIR}/tests/snapshots
       SNAPSHOT_CI: 1
       PORT: 9126

--- a/.gitlab/services.yml
+++ b/.gitlab/services.yml
@@ -15,7 +15,7 @@
     name: registry.ddbuild.io/images/mirror/dd-apm-test-agent/ddapm-test-agent:v1.20.0
     alias: testagent
     variables:
-      LOG_LEVEL: INFO
+      LOG_LEVEL: DEBUG
       SNAPSHOT_DIR: ${CI_PROJECT_DIR}/tests/snapshots
       SNAPSHOT_CI: 1
       PORT: 9126

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -411,6 +411,6 @@ class TestGeventTracer(TracerTestCase):
 
         p.wait()
         stdout, stderr = p.stdout.read(), p.stderr.read()
-        assert p.returncode == 0, stderr.decode()
+        assert p.returncode == 0, f"stdout: {stdout.decode()}\n\nstderr: {stderr.decode()}"
         assert b"Test success" in stdout, stdout.decode()
         assert b"RecursionError" not in stderr, stderr.decode()

--- a/tests/contrib/suitespec.yml
+++ b/tests/contrib/suitespec.yml
@@ -631,7 +631,7 @@ suites:
       - '@gevent'
       - tests/contrib/gevent/*
     runner: riot
-    snapshot: true
+    snapshot: false
   graphene:
     paths:
       - '@bootstrap'


### PR DESCRIPTION
This job can fail with exit code `-11`, but no additional context is provided, likely because there isn't anything on `stderr` ?

This updates the job to output stderr and stdout when the resulting process signal is not `0`.

I was unable to reproduce the issue locally, so this is an attempt to collect more data when it fails on CI.

Example failure:

```
>       assert p.returncode == 0, stderr.decode()
E       AssertionError: 
E       assert -11 == 0
E        +  where -11 = <subprocess.Popen object at 0x7f3144d97eb0>.returncode
```

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
