### PR TITLE
ci(celery): increase amqp task timeout

### DIFF
--- a/tests/contrib/celery/test_tagging.py
+++ b/tests/contrib/celery/test_tagging.py
@@ -102,7 +102,7 @@ def test_amqp_task(instrument_celery, traced_amqp_celery_app):
         shutdown_timeout=30,
     ):
         t = add.delay(4, 4)
-        assert t.get(timeout=2) == 8
+        assert t.get(timeout=30) == 8
 
         # wait for spans to be received
         time.sleep(3)


### PR DESCRIPTION
This job is currently experience issues timing out. It is not 100% clear why it is timing out with a 2 second timeout, but increasing to a higher timeout should help when run under high load/resource constraints.


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
