### PR TITLE
undo change that breaks stuff under 3.13

### DIFF
--- a/ddtrace/debugging/_debugger.py
+++ b/ddtrace/debugging/_debugger.py
@@ -6,7 +6,6 @@ import os
 from pathlib import Path
 import sys
 import threading
-from types import CodeType
 from types import FunctionType
 from types import ModuleType
 from types import TracebackType
@@ -73,9 +72,6 @@ class DebuggerError(Exception):
 
 class DebuggerModuleWatchdog(ModuleWatchdog):
     _locations: Set[str] = set()
-
-    def transform(self, code: CodeType, module: ModuleType) -> CodeType:
-        return FunctionDiscovery.transformer(code, module)
 
     @classmethod
     def register_origin_hook(cls, origin: Path, hook: ModuleHookType) -> None:

--- a/ddtrace/debugging/_function/discovery.py
+++ b/ddtrace/debugging/_function/discovery.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 from wrapt import FunctionWrapper
 
-from ddtrace.internal.compat import PYTHON_VERSION_INFO
 from ddtrace.internal.utils.inspection import undecorated
 
 
@@ -13,7 +12,6 @@ try:
 except ImportError:
     from typing_extensions import Protocol  # type: ignore[assignment]
 
-from types import CodeType
 from types import FunctionType
 from types import ModuleType
 from typing import Any
@@ -29,7 +27,6 @@ from typing import cast
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.module import origin
 from ddtrace.internal.safety import _isinstance
-from ddtrace.internal.utils.inspection import collect_code_objects
 from ddtrace.internal.utils.inspection import linenos
 
 
@@ -51,8 +48,6 @@ class FullyNamed(Protocol):
 
 class FullyNamedFunction(FullyNamed):
     """A fully named function object."""
-
-    __qualname__: str
 
     def __call__(self, *args, **kwargs):
         pass
@@ -124,48 +119,7 @@ def _local_name(name: str, f: FunctionType) -> str:
     return func_name
 
 
-class _FunctionCodePair:
-    """Function-Code Pair
-
-    This class allows us to resolve a code object to a function object by
-    querying the GC on-demand.
-    """
-
-    __slots__ = ("function", "code")
-
-    def __init__(self, code: Optional[CodeType] = None, function: Optional[FunctionType] = None) -> None:
-        if code is not None and function is not None and function.__code__ is not code:
-            raise ValueError("Function and code objects do not match")
-
-        self.function = function
-        self.code = function.__code__ if function is not None else code
-
-    def resolve(self) -> FullyNamedFunction:
-        import gc
-
-        if self.function is not None:
-            return cast(FullyNamedFunction, self.function)
-
-        code = self.code
-        functions = [_ for _ in gc.get_referrers(code) if isinstance(_, FunctionType) and _.__code__ is code]
-        n = len(functions)
-        if n == 0:
-            msg = f"Cannot resolve code object to function: {code}"
-            raise ValueError(msg)
-        if n > 1:
-            # This can happen for functions that are created at runtime rather
-            # than compile time. We do not support this case deliberately for
-            # now.
-            msg = f"Multiple functions found for code object {code}"
-            raise ValueError(msg)
-
-        f = cast(FullyNamedFunction, functions[0])
-        f.__fullname__ = f"{f.__module__}.{f.__qualname__}"
-
-        return f
-
-
-def _collect_functions(module: ModuleType) -> Dict[str, _FunctionCodePair]:
+def _collect_functions(module: ModuleType) -> Dict[str, FullyNamedFunction]:
     """Collect functions from a given module.
 
     All the collected functions are augmented with a ``__fullname__`` attribute
@@ -206,9 +160,7 @@ def _collect_functions(module: ModuleType) -> Dict[str, _FunctionCodePair]:
                         # try to retrieve any potentially decorated function so
                         # that we don't end up returning the decorator function
                         # instead of the original function.
-                        functions[fullname] = _FunctionCodePair(
-                            function=cast(FunctionType, undecorated(f, name, path) if name == k else o)
-                        )
+                        functions[fullname] = undecorated(f, name, path) if name == k else o
 
                 try:
                     if f.__closure__:
@@ -237,46 +189,28 @@ class FunctionDiscovery(defaultdict):
 
     def __init__(self, module: ModuleType) -> None:
         super().__init__(list)
+        self._module = module
+        self._fullname_index = {}
 
+        functions = _collect_functions(module)
+        seen_functions = set()
         module_path = origin(module)
         if module_path is None:
             # We are not going to collect anything because no code objects will
             # match the origin.
             return
 
-        self._module = module
-        self._fullname_index = _collect_functions(module)
-        if PYTHON_VERSION_INFO < (3, 11):
-            self._name_index: Dict[str, List[_FunctionCodePair]] = defaultdict(list)
-        self._cached: Dict[int, List[FullyNamedFunction]] = {}
-
-        # Create the line to function mapping
-        if hasattr(module, "__dd_code__"):
-            for code in module.__dd_code__:
-                fcp = _FunctionCodePair(code=code)
-                if PYTHON_VERSION_INFO >= (3, 11):
-                    # From this version of Python we can derive the qualified
-                    # name of the function directly from the code object.
-                    fullname = f"{module.__name__}.{code.co_qualname}"
-                    self._fullname_index[fullname] = fcp
-                else:
-                    self._name_index[code.co_name].append(fcp)
-                for lineno in linenos(code):
-                    self[lineno].append(_FunctionCodePair(code=code))
-        else:
-            # If the module was already loaded we don't have its code object
-            seen_functions = set()
-            for _, fcp in self._fullname_index.items():
-                function = fcp.resolve()
-                if (
-                    function not in seen_functions
-                    and Path(cast(FunctionType, function).__code__.co_filename).resolve() == module_path
-                ):
-                    # We only map line numbers for functions that actually belong to
-                    # the module.
-                    for lineno in linenos(cast(FunctionType, function)):
-                        self[lineno].append(_FunctionCodePair(function=cast(FunctionType, function)))
-                seen_functions.add(function)
+        for fname, function in functions.items():
+            if (
+                function not in seen_functions
+                and Path(cast(FunctionType, function).__code__.co_filename).resolve() == module_path
+            ):
+                # We only map line numbers for functions that actually belong to
+                # the module.
+                for lineno in linenos(cast(FunctionType, function)):
+                    self[lineno].append(function)
+            self._fullname_index[fname] = function
+            seen_functions.add(function)
 
     def at_line(self, line: int) -> List[FullyNamedFunction]:
         """Get the functions at the given line.
@@ -284,55 +218,14 @@ class FunctionDiscovery(defaultdict):
         Note that, in general, there can be multiple copies of the same
         functions. This can happen as a result, e.g., of using decorators.
         """
-        if line in self._cached:
-            return self._cached[line]
-
-        if line in self:
-            functions = []
-            for fcp in self[line]:
-                try:
-                    functions.append(fcp.resolve())
-                except ValueError:
-                    pass
-
-            if not functions:
-                del self[line]
-            else:
-                self._cached[line] = functions
-
-            return functions
-
-        return []
+        return self[line]
 
     def by_name(self, qualname: str) -> FullyNamedFunction:
         """Get the function by its qualified name."""
-        fullname = f"{self._module.__name__}.{qualname}"
+        fullname = ".".join((self._module.__name__, qualname))
         try:
-            return self._fullname_index[fullname].resolve()
+            return self._fullname_index[fullname]
         except KeyError:
-            if PYTHON_VERSION_INFO < (3, 11):
-                # Check if any code objects whose names match the last part of
-                # the qualified name have a function with the same qualified
-                # name.
-                for name, fcps in self._name_index.items():
-                    if qualname == name or qualname.endswith(f".{name}"):
-                        for fcp in list(fcps):
-                            try:
-                                f = fcp.resolve()
-
-                                # We have resolved the function so we can now
-                                # get its full name
-                                self._fullname_index[f"{self._module.__name__}.{f.__qualname__}"] = fcp
-
-                                # We can remove the entry from the name index
-                                fcps.pop(0)
-
-                                # If this is the function we are looking for,
-                                # return it
-                                if f.__qualname__ == qualname:
-                                    return f
-                            except ValueError:
-                                pass
             raise ValueError("Function '%s' not found" % fullname)
 
     @classmethod
@@ -348,12 +241,4 @@ class FunctionDiscovery(defaultdict):
             return module.__function_discovery__
         except AttributeError:
             fd = module.__function_discovery__ = cls(module)  # type: ignore[attr-defined]
-            if hasattr(module, "__dd_code__"):
-                # We no longer need to keep this collection around
-                del module.__dd_code__
             return fd
-
-    @classmethod
-    def transformer(cls, code: CodeType, module: ModuleType) -> CodeType:
-        module.__dd_code__ = collect_code_objects(code)  # type: ignore[attr-defined]  # type: ignore[attr-defined]
-        return code

--- a/tests/debugging/function/test_discovery.py
+++ b/tests/debugging/function/test_discovery.py
@@ -1,7 +1,6 @@
 import pytest
 
 from ddtrace.debugging._function.discovery import FunctionDiscovery
-from ddtrace.internal.module import ModuleWatchdog
 import tests.submod.stuff as stuff
 
 
@@ -13,7 +12,7 @@ def stuff_discovery():
 def test_abs_stuff():
     import tests.submod.absstuff as absstuff
 
-    assert set(FunctionDiscovery.from_module(absstuff).keys()) >= {7, 11, 16, 19}
+    assert sorted(FunctionDiscovery.from_module(absstuff).keys()) == [7, 11, 16, 19]
 
 
 def test_function_discovery(stuff_discovery):
@@ -107,35 +106,16 @@ def test_discovery_after_external_wrapping(stuff):
     def wrapper(wrapped, inst, args, kwargs):
         pass
 
-    original_function = stuff.Stuff.instancestuff
-
     wrapt.wrap_function_wrapper(stuff, "Stuff.instancestuff", wrapper)
     assert isinstance(stuff.Stuff.instancestuff, (wrapt.BoundFunctionWrapper, wrapt.FunctionWrapper))
 
     code = stuff.Stuff.instancestuff.__code__
-    f, *_ = FunctionDiscovery(stuff).at_line(36)
+    f = FunctionDiscovery(stuff)[36][0]
 
-    assert f is original_function or isinstance(f, (wrapt.BoundFunctionWrapper, wrapt.FunctionWrapper)), f
+    assert isinstance(f, (wrapt.BoundFunctionWrapper, wrapt.FunctionWrapper))
     assert f.__code__ is code
 
 
 def test_property_non_function_getter(stuff_discovery):
     with pytest.raises(ValueError):
         stuff_discovery.by_name("PropertyStuff.foo")
-
-
-def test_custom_decorated_stuff():
-    class DiscoveryModuleWatchdog(ModuleWatchdog):
-        def transform(self, code, module):
-            return FunctionDiscovery.transformer(code, module)
-
-    DiscoveryModuleWatchdog.install()
-
-    import tests.submod.custom_decorated_stuff as custom_decorated_stuff
-
-    fd = FunctionDiscovery.from_module(custom_decorated_stuff)
-
-    (home,) = fd.at_line(17)
-    assert home.__qualname__ == "home"
-
-    DiscoveryModuleWatchdog.uninstall()

--- a/tests/debugging/function/test_store.py
+++ b/tests/debugging/function/test_store.py
@@ -174,17 +174,18 @@ def test_function_inject_wrap_commutativity():
         # Injection
         lo = min(linenos(stuff.modulestuff))
         function = FunctionDiscovery.from_module(stuff).at_line(lo)[0]
-        hook = mock.Mock()()
-        store.inject_hook(function, hook, lo, 42)
+        hook = mock.Mock()
+        probe = mock.Mock()
+        store.inject_hook(function, hook, lo, probe)
 
         # Wrapping
         function = FunctionDiscovery.from_module(stuff).by_name(stuff.modulestuff.__name__)
         assert function.__code__ is stuff.modulestuff.__code__
-        store.wrap(function, MockWrappingContext(function, None, 42))
+        store.wrap(function, MockWrappingContext(function, None, probe))
 
         # Ejection
         assert stuff.modulestuff.__code__ is not code
-        store.eject_hook(stuff.modulestuff, hook, lo, 42)
+        store.eject_hook(stuff.modulestuff, hook, lo, probe)
 
         # Unwrapping
         store.unwrap(stuff.modulestuff)


### PR DESCRIPTION
## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
