### PR TITLE
chore(llmobs): ensure propagated parent IDs are still using span tags

### DIFF
--- a/ddtrace/llmobs/_integrations/base.py
+++ b/ddtrace/llmobs/_integrations/base.py
@@ -133,7 +133,7 @@ class BaseLLMIntegration:
                 # The LLMObs parent ID tag is not set at span start time. We need to manually set the parent ID tag now
                 # in these cases to avoid conflicting with the later propagated tags.
                 parent_id = _get_llmobs_parent_id(span) or "undefined"
-                span.set_tag_str(PARENT_ID_KEY, str(parent_id))
+                span._set_ctx_item(PARENT_ID_KEY, str(parent_id))
         return span
 
     @classmethod

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -36,7 +36,7 @@ class BedrockIntegration(BaseLLMIntegration):
         operation: str = "",
     ) -> None:
         """Extract prompt/response tags from a completion and set them as temporary "_ml_obs.*" tags."""
-        if span._get_ctx_item(PROPAGATED_PARENT_ID_KEY) is None:
+        if span.get_tag(PROPAGATED_PARENT_ID_KEY) is None:
             parent_id = _get_llmobs_parent_id(span) or "undefined"
             span._set_ctx_item(PARENT_ID_KEY, parent_id)
         parameters = {}

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -410,7 +410,7 @@ class LLMObs(Service):
         if ml_app is None:
             ml_app = _get_ml_app(span)
         span._set_ctx_item(ML_APP, ml_app)
-        if span._get_ctx_item(PROPAGATED_PARENT_ID_KEY) is None:
+        if span.get_tag(PROPAGATED_PARENT_ID_KEY) is None:
             # For non-distributed traces or spans in the first service of a distributed trace,
             # The LLMObs parent ID tag is not set at span start time. We need to manually set the parent ID tag now
             # in these cases to avoid conflicting with the later propagated tags.


### PR DESCRIPTION
This PR makes a small revert to #11543 where accessing propagated parent IDs (for distributed tracing) were unwittingly changed to access via the span store object, even though automatic context propagation results are always added to the span as tags (not the store).

While all other LLMObs SDK data is added/accessed via the span store, `_dd.p.llmobs_parent_id` is automatically added by the tracer internals so we'll continue using this for now until our overall context management solution removes this problem entirely.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
