### PR TITLE
chore(ci): switch ubuntu runner image in generate package versions workflow

### DIFF
--- a/.github/workflows/generate-package-versions.yml
+++ b/.github/workflows/generate-package-versions.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   generate-package-versions:
     name: Generate package versions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: write


### PR DESCRIPTION
`ubuntu-latest` was upgraded to use `ubuntu-24.04`. This is incompatible with `python 3.7`, which we still test and support (and is needed for the `Generate Package Versions` workflow in order to build all the riot environments). 

This PR switches to using the `ubuntu-22.04` image (the previous latest). When we drop 3.7 support, we can switch back to `ubuntu-latest`. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
