### PR TITLE
fix(iast): check context is enable in request and builtins patched funcions

### DIFF
--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -14,7 +14,6 @@ from wrapt import resolve_path
 import ddtrace
 from ddtrace.appsec._asm_request_context import get_blocked
 from ddtrace.appsec._constants import WAF_ACTIONS
-from ddtrace.appsec._iast._iast_request_context import is_iast_request_enabled
 from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
 from ddtrace.appsec._iast.constants import VULN_PATH_TRAVERSAL
 from ddtrace.internal import core
@@ -61,6 +60,8 @@ def wrapped_read_F3E51D71B4EC16EF(original_read_callable, instance, args, kwargs
     """
     wrapper for _io.BytesIO and _io.StringIO read function
     """
+    from ddtrace.appsec._iast._iast_request_context import is_iast_request_enabled
+
     result = original_read_callable(*args, **kwargs)
     if asm_config._iast_enabled and is_iast_request_enabled():
         from ddtrace.appsec._iast._taint_tracking import OriginType
@@ -88,6 +89,8 @@ def wrapped_open_CFDDB7ABBA9081B6(original_open_callable, instance, args, kwargs
     """
     wrapper for open file function
     """
+    from ddtrace.appsec._iast._iast_request_context import is_iast_request_enabled
+
     if asm_config._iast_enabled and is_iast_request_enabled():
         try:
             from ddtrace.appsec._iast.taint_sinks.path_traversal import check_and_report_path_traversal
@@ -177,6 +180,8 @@ def wrapped_request_D8CB81E472AF98A2(original_request_callable, instance, args, 
     wrapper for third party requests.request function
     https://requests.readthedocs.io
     """
+    from ddtrace.appsec._iast._iast_request_context import is_iast_request_enabled
+
     if asm_config._iast_enabled and is_iast_request_enabled():
         from ddtrace.appsec._iast.taint_sinks.ssrf import _iast_report_ssrf
 
@@ -217,6 +222,8 @@ def wrapped_system_5542593D237084A7(original_command_callable, instance, args, k
     """
     command = args[0] if args else kwargs.get("command", None)
     if command is not None:
+        from ddtrace.appsec._iast._iast_request_context import is_iast_request_enabled
+
         if asm_config._iast_enabled and is_iast_request_enabled():
             from ddtrace.appsec._iast.taint_sinks.command_injection import _iast_report_cmdi
 

--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -14,6 +14,7 @@ from wrapt import resolve_path
 import ddtrace
 from ddtrace.appsec._asm_request_context import get_blocked
 from ddtrace.appsec._constants import WAF_ACTIONS
+from ddtrace.appsec._iast._iast_request_context import is_iast_request_enabled
 from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
 from ddtrace.appsec._iast.constants import VULN_PATH_TRAVERSAL
 from ddtrace.internal import core
@@ -61,7 +62,7 @@ def wrapped_read_F3E51D71B4EC16EF(original_read_callable, instance, args, kwargs
     wrapper for _io.BytesIO and _io.StringIO read function
     """
     result = original_read_callable(*args, **kwargs)
-    if asm_config._iast_enabled:
+    if asm_config._iast_enabled and is_iast_request_enabled():
         from ddtrace.appsec._iast._taint_tracking import OriginType
         from ddtrace.appsec._iast._taint_tracking import Source
         from ddtrace.appsec._iast._taint_tracking import get_tainted_ranges
@@ -87,7 +88,7 @@ def wrapped_open_CFDDB7ABBA9081B6(original_open_callable, instance, args, kwargs
     """
     wrapper for open file function
     """
-    if asm_config._iast_enabled:
+    if asm_config._iast_enabled and is_iast_request_enabled():
         try:
             from ddtrace.appsec._iast.taint_sinks.path_traversal import check_and_report_path_traversal
 
@@ -176,7 +177,7 @@ def wrapped_request_D8CB81E472AF98A2(original_request_callable, instance, args, 
     wrapper for third party requests.request function
     https://requests.readthedocs.io
     """
-    if asm_config._iast_enabled:
+    if asm_config._iast_enabled and is_iast_request_enabled():
         from ddtrace.appsec._iast.taint_sinks.ssrf import _iast_report_ssrf
 
         _iast_report_ssrf(original_request_callable, *args, **kwargs)
@@ -216,7 +217,7 @@ def wrapped_system_5542593D237084A7(original_command_callable, instance, args, k
     """
     command = args[0] if args else kwargs.get("command", None)
     if command is not None:
-        if asm_config._iast_enabled:
+        if asm_config._iast_enabled and is_iast_request_enabled():
             from ddtrace.appsec._iast.taint_sinks.command_injection import _iast_report_cmdi
 
             _iast_report_cmdi(command)

--- a/releasenotes/notes/iast-fix-iast-propagation-error-2-ba4a998133269a7c.yaml
+++ b/releasenotes/notes/iast-fix-iast-propagation-error-2-ba4a998133269a7c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    ASM: This fix resolves an issue where AppSec was using a patched request and builtins functions, 
+    creating telemetry errors.


### PR DESCRIPTION
This fix resolves an issue where AppSec was using a patched request and builtins functions,  creating telemetry errors.
## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
