### PR TITLE
chore(ci_visibility): add support for pytest_bdd to v2 plugin

### DIFF
--- a/ddtrace/contrib/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/pytest/_plugin_v2.py
@@ -196,6 +196,12 @@ def pytest_configure(config: pytest_Config) -> None:
             enable_test_visibility(config=dd_config.pytest)
             if _is_pytest_cov_enabled(config):
                 patch_coverage()
+
+            # pytest-bdd plugin support
+            if config.pluginmanager.hasplugin("pytest-bdd"):
+                from ddtrace.contrib.pytest._pytest_bdd_subplugin import _PytestBddSubPlugin
+
+                config.pluginmanager.register(_PytestBddSubPlugin(), "_datadog-pytest-bdd")
         else:
             # If the pytest ddtrace plugin is not enabled, we should disable CI Visibility, as it was enabled during
             # pytest_load_initial_conftests

--- a/ddtrace/contrib/pytest/_pytest_bdd_subplugin.py
+++ b/ddtrace/contrib/pytest/_pytest_bdd_subplugin.py
@@ -1,0 +1,110 @@
+"""Provides functionality to support the pytest-bdd plugin as part of the ddtrace integration
+
+NOTE: This replaces the previous ddtrace.pytest_bdd plugin.
+
+This plugin mainly modifies the names of the test, its suite, and parameters. It does not, however modify the tests'
+suite from the perspective of Test Visibility data.
+
+The plugin is only instantiated and added if the pytest-bdd plugin itself is installed and enabled, because the hook
+implementations will cause errors unless the hookspecs are added by the original plugin.
+"""
+from pathlib import Path
+import sys
+
+import pytest
+
+from ddtrace.contrib.pytest._utils import _get_test_id_from_item
+from ddtrace.contrib.pytest_bdd import get_version
+from ddtrace.contrib.pytest_bdd._plugin import _extract_span
+from ddtrace.contrib.pytest_bdd._plugin import _get_step_func_args_json
+from ddtrace.contrib.pytest_bdd._plugin import _store_span
+from ddtrace.contrib.pytest_bdd.constants import FRAMEWORK
+from ddtrace.contrib.pytest_bdd.constants import STEP_KIND
+from ddtrace.ext import test
+from ddtrace.internal.logger import get_logger
+from ddtrace.internal.test_visibility.api import InternalTest
+from ddtrace.internal.test_visibility.api import InternalTestSession
+
+
+log = get_logger(__name__)
+
+
+def _get_workspace_relative_path(feature_path_str: str) -> Path:
+    feature_path = Path(feature_path_str).resolve()
+    workspace_path = InternalTestSession.get_workspace_path()
+    if workspace_path:
+        try:
+            return feature_path.relative_to(workspace_path)
+        except ValueError:  # noqa: E722
+            log.debug("Feature path %s is not relative to workspace path %s", feature_path, workspace_path)
+    return feature_path
+
+
+class _PytestBddSubPlugin:
+    def __init__(self):
+        self.framework_version = get_version()
+
+    @staticmethod
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_bdd_before_scenario(request, feature, scenario):
+        test_id = _get_test_id_from_item(request.node)
+        feature_path = _get_workspace_relative_path(scenario.feature.filename)
+        codeowners = InternalTestSession.get_path_codeowners(feature_path)
+
+        InternalTest.overwrite_attributes(
+            test_id, name=scenario.name, suite_name=str(feature_path), codeowners=codeowners
+        )
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_bdd_before_step(self, request, feature, scenario, step, step_func):
+        feature_test_id = _get_test_id_from_item(request.node)
+
+        feature_span = InternalTest.get_span(feature_test_id)
+
+        tracer = InternalTestSession.get_tracer()
+        if tracer is None:
+            return
+
+        span = tracer.start_span(
+            step.type,
+            resource=step.name,
+            span_type=STEP_KIND,
+            child_of=feature_span,
+            activate=True,
+        )
+        span.set_tag_str("component", "pytest_bdd")
+
+        span.set_tag(test.FRAMEWORK, FRAMEWORK)
+        span.set_tag(test.FRAMEWORK_VERSION, self.framework_version)
+
+        feature_path = _get_workspace_relative_path(scenario.feature.filename)
+
+        span.set_tag(test.FILE, str(feature_path))
+        span.set_tag(test.CODEOWNERS, InternalTestSession.get_path_codeowners(feature_path))
+
+        _store_span(step_func, span)
+
+    @staticmethod
+    @pytest.hookimpl(trylast=True)
+    def pytest_bdd_after_step(request, feature, scenario, step, step_func, step_func_args):
+        span = _extract_span(step_func)
+        if span is not None:
+            step_func_args_json = _get_step_func_args_json(step, step_func, step_func_args)
+            if step_func_args:
+                span.set_tag(test.PARAMETERS, step_func_args_json)
+            span.finish()
+
+    @staticmethod
+    def pytest_bdd_step_error(request, feature, scenario, step, step_func, step_func_args, exception):
+        span = _extract_span(step_func)
+        if span is not None:
+            if hasattr(exception, "__traceback__"):
+                tb = exception.__traceback__
+            else:
+                # PY2 compatibility workaround
+                _, _, tb = sys.exc_info()
+            step_func_args_json = _get_step_func_args_json(step, step_func, step_func_args)
+            if step_func_args:
+                span.set_tag(test.PARAMETERS, step_func_args_json)
+            span.set_exc_info(type(exception), exception, tb)
+            span.finish()

--- a/ddtrace/contrib/pytest_bdd/plugin.py
+++ b/ddtrace/contrib/pytest_bdd/plugin.py
@@ -1,9 +1,20 @@
+from ddtrace import DDTraceDeprecationWarning
+from ddtrace.contrib.pytest._utils import _USE_PLUGIN_V2
 from ddtrace.contrib.pytest.plugin import is_enabled as is_ddtrace_enabled
+from ddtrace.vendor.debtcollector import deprecate
 
 
 def pytest_configure(config):
     if config.pluginmanager.hasplugin("pytest-bdd") and config.pluginmanager.hasplugin("ddtrace"):
-        if is_ddtrace_enabled(config):
+        if not _USE_PLUGIN_V2:
             from ._plugin import _PytestBddPlugin
 
-            config.pluginmanager.register(_PytestBddPlugin(), "_datadog-pytest-bdd")
+            if is_ddtrace_enabled(config):
+                deprecate(
+                    "the ddtrace.pytest_bdd plugin is deprecated",
+                    message="it will be integrated with the main pytest ddtrace plugin",
+                    removal_version="3.0.0",
+                    category=DDTraceDeprecationWarning,
+                )
+
+                config.pluginmanager.register(_PytestBddPlugin(), "_datadog-pytest-bdd")

--- a/ddtrace/contrib/pytest_bdd/plugin.py
+++ b/ddtrace/contrib/pytest_bdd/plugin.py
@@ -7,9 +7,9 @@ from ddtrace.vendor.debtcollector import deprecate
 def pytest_configure(config):
     if config.pluginmanager.hasplugin("pytest-bdd") and config.pluginmanager.hasplugin("ddtrace"):
         if not _USE_PLUGIN_V2:
-            from ._plugin import _PytestBddPlugin
-
             if is_ddtrace_enabled(config):
+                from ._plugin import _PytestBddPlugin
+
                 deprecate(
                     "the ddtrace.pytest_bdd plugin is deprecated",
                     message="it will be integrated with the main pytest ddtrace plugin",

--- a/ddtrace/internal/ci_visibility/api/_test.py
+++ b/ddtrace/internal/ci_visibility/api/_test.py
@@ -85,6 +85,9 @@ class TestVisibilityTest(TestVisibilityChildItem[TID], TestVisibilityItemBase):
         self._is_benchmark = False
         self._benchmark_duration_data: Optional[BenchmarkDurationData] = None
 
+        # Some parameters can be overwritten:
+        self._overwritten_suite_name: Optional[str] = None
+
     def __repr__(self) -> str:
         suite_name = self.parent.name if self.parent is not None else "none"
         module_name = self.parent.parent.name if self.parent is not None and self.parent.parent is not None else "none"
@@ -101,6 +104,9 @@ class TestVisibilityTest(TestVisibilityChildItem[TID], TestVisibilityItemBase):
         """Overrides parent tags for cases where they need to be modified"""
         if self._is_benchmark:
             self.set_tag(test.TYPE, BENCHMARK)
+
+        if self._overwritten_suite_name is not None:
+            self.set_tag(test.SUITE, self._overwritten_suite_name)
 
     def _set_efd_tags(self) -> None:
         if self._efd_is_retry:
@@ -201,6 +207,22 @@ class TestVisibilityTest(TestVisibilityChildItem[TID], TestVisibilityItemBase):
         self.count_itr_skipped()
         self.mark_itr_skipped()
         self.finish_test(TestStatus.SKIP)
+
+    def overwrite_attributes(
+        self,
+        name: Optional[str] = None,
+        suite_name: Optional[str] = None,
+        parameters: Optional[str] = None,
+        codeowners: Optional[List[str]] = None,
+    ) -> None:
+        if name is not None:
+            self.name = name
+        if suite_name is not None:
+            self._overwritten_suite_name = suite_name
+        if parameters is not None:
+            self.set_parameters(parameters)
+        if codeowners is not None:
+            self._codeowners = codeowners
 
     def add_coverage_data(self, coverage_data: Dict[Path, CoverageLines]) -> None:
         self._coverage_data.add_covered_files(coverage_data)

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -79,6 +79,7 @@ from ddtrace.internal.test_visibility._efd_mixins import EFDTestMixin
 from ddtrace.internal.test_visibility._efd_mixins import EFDTestStatus
 from ddtrace.internal.test_visibility._internal_item_ids import InternalTestId
 from ddtrace.internal.test_visibility._itr_mixins import ITRMixin
+from ddtrace.internal.test_visibility.api import InternalTest
 from ddtrace.internal.test_visibility.coverage_lines import CoverageLines
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.http import verify_url
@@ -1009,6 +1010,12 @@ def _on_session_get_codeowners() -> Optional[Codeowners]:
 
 
 @_requires_civisibility_enabled
+def _on_session_get_tracer() -> Optional[Tracer]:
+    log.debug("Getting tracer")
+    return CIVisibility.get_tracer()
+
+
+@_requires_civisibility_enabled
 def _on_session_is_atr_enabled() -> bool:
     log.debug("Getting Auto Test Retries enabled")
     return CIVisibility.is_atr_enabled()
@@ -1041,6 +1048,7 @@ def _register_session_handlers():
     core.on("test_visibility.session.start", _on_start_session)
     core.on("test_visibility.session.finish", _on_finish_session)
     core.on("test_visibility.session.get_codeowners", _on_session_get_codeowners, "codeowners")
+    core.on("test_visibility.session.get_tracer", _on_session_get_tracer, "tracer")
     core.on("test_visibility.session.get_path_codeowners", _on_session_get_path_codeowners, "path_codeowners")
     core.on("test_visibility.session.get_workspace_path", _on_session_get_workspace_path, "workspace_path")
     core.on("test_visibility.session.is_atr_enabled", _on_session_is_atr_enabled, "is_atr_enabled")
@@ -1191,6 +1199,18 @@ def _on_set_benchmark_data(set_benchmark_data_args: BenchmarkTestMixin.SetBenchm
     CIVisibility.get_test_by_id(item_id).set_benchmark_data(data, is_benchmark)
 
 
+@_requires_civisibility_enabled
+def _on_test_overwrite_attributes(overwrite_attribute_args: InternalTest.OverwriteAttributesArgs):
+    item_id = overwrite_attribute_args.test_id
+    name = overwrite_attribute_args.name
+    suite_name = overwrite_attribute_args.suite_name
+    parameters = overwrite_attribute_args.parameters
+    codeowners = overwrite_attribute_args.codeowners
+
+    log.debug("Handling overwrite attributes: %s", overwrite_attribute_args)
+    CIVisibility.get_test_by_id(item_id).overwrite_attributes(name, suite_name, parameters, codeowners)
+
+
 def _register_test_handlers():
     log.debug("Registering test handlers")
     core.on("test_visibility.test.discover", _on_discover_test)
@@ -1199,6 +1219,7 @@ def _register_test_handlers():
     core.on("test_visibility.test.finish", _on_finish_test)
     core.on("test_visibility.test.set_parameters", _on_set_test_parameters)
     core.on("test_visibility.test.set_benchmark_data", _on_set_benchmark_data)
+    core.on("test_visibility.test.overwrite_attributes", _on_test_overwrite_attributes)
 
 
 @_requires_civisibility_enabled

--- a/ddtrace/internal/test_visibility/api.py
+++ b/ddtrace/internal/test_visibility/api.py
@@ -3,6 +3,7 @@ import typing as t
 from typing import NamedTuple
 
 from ddtrace import Span
+from ddtrace import Tracer
 from ddtrace.ext.test_visibility import api as ext_api
 from ddtrace.ext.test_visibility._test_visibility_base import TestSessionId
 from ddtrace.ext.test_visibility._utils import _catch_and_log_exceptions
@@ -73,7 +74,15 @@ class InternalTestSession(ext_api.TestSession, EFDSessionMixin, ATRSessionMixin)
 
     @staticmethod
     @_catch_and_log_exceptions
-    def get_workspace_path() -> Path:
+    def get_tracer() -> t.Optional[Tracer]:
+        log.debug("Getting test session tracer")
+        tracer: t.Optional[Tracer] = core.dispatch_with_results("test_visibility.session.get_tracer").tracer.value
+        log.debug("Got test session tracer: %s", tracer)
+        return tracer
+
+    @staticmethod
+    @_catch_and_log_exceptions
+    def get_workspace_path() -> t.Optional[Path]:
         log.debug("Getting session workspace path")
 
         workspace_path: Path = core.dispatch_with_results(
@@ -165,3 +174,32 @@ class InternalTest(ext_api.Test, InternalTestBase, ITRMixin, EFDTestMixin, ATRTe
         is_new = bool(core.dispatch_with_results("test_visibility.test.is_new", (item_id,)).is_new.value)
         log.debug("Test %s is new: %s", item_id, is_new)
         return is_new
+
+    class OverwriteAttributesArgs(NamedTuple):
+        test_id: InternalTestId
+        name: t.Optional[str] = None
+        suite_name: t.Optional[str] = None
+        parameters: t.Optional[str] = None
+        codeowners: t.Optional[t.List[str]] = None
+
+    @staticmethod
+    @_catch_and_log_exceptions
+    def overwrite_attributes(
+        item_id: InternalTestId,
+        name: t.Optional[str] = None,
+        suite_name: t.Optional[str] = None,
+        parameters: t.Optional[str] = None,
+        codeowners: t.Optional[t.List[str]] = None,
+    ):
+        log.debug(
+            "Overwriting attributes for test %s: name=%s" ", suite_name=%s" ", parameters=%s" ", codeowners=%s",
+            item_id,
+            name,
+            suite_name,
+            parameters,
+            codeowners,
+        )
+        core.dispatch(
+            "test_visibility.test.overwrite_attributes",
+            (InternalTest.OverwriteAttributesArgs(item_id, name, suite_name, parameters, codeowners),),
+        )

--- a/riotfile.py
+++ b/riotfile.py
@@ -1695,9 +1695,6 @@ venv = Venv(
                 "more_itertools": "<8.11.0",
                 "pytest-randomly": latest,
             },
-            env={
-                "DD_PYTEST_USE_NEW_PLUGIN_BETA": "0",
-            },
             venvs=[
                 Venv(
                     pys=select_pys(min_version="3.7", max_version="3.9"),
@@ -1708,6 +1705,18 @@ venv = Venv(
                             ">=6.0,<6.1",
                         ]
                     },
+                    venvs=[
+                        Venv(
+                            env={
+                                "DD_PYTEST_USE_NEW_PLUGIN_BETA": "0",
+                            },
+                        ),
+                        Venv(
+                            env={
+                                "DD_PYTEST_USE_NEW_PLUGIN_BETA": "1",
+                            },
+                        ),
+                    ],
                 ),
                 Venv(
                     pys=select_pys(min_version="3.10"),
@@ -1718,6 +1727,18 @@ venv = Venv(
                             ">=6.0,<6.1",
                         ]
                     },
+                    venvs=[
+                        Venv(
+                            env={
+                                "DD_PYTEST_USE_NEW_PLUGIN_BETA": "0",
+                            },
+                        ),
+                        Venv(
+                            env={
+                                "DD_PYTEST_USE_NEW_PLUGIN_BETA": "1",
+                            },
+                        ),
+                    ],
                 ),
             ],
         ),


### PR DESCRIPTION
This adds support for the `pytest-bdd` plugin to the new version of the `pytest` plugin, bypassing the `ddtrace.pytest_bdd` plugin and instantiating a "subplugin" on demand when `pytest-bdd` is detected and `ddtrace` is enabled.

To support the way the legacy `pytest-bdd` plugin worked, new functionality is added:
- `InternalTestSession.get_tracer()` to have access to the tracer used by Test Visibility
- `InternalTest.overwrite_attributes()` to allow overwriting attributes that have already been set (or in the case of the `suite` name, that are automatically set based on test hierarchy)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
