### PR TITLE
chore(er): include exception hash

### DIFF
--- a/ddtrace/debugging/_exception/replay.py
+++ b/ddtrace/debugging/_exception/replay.py
@@ -40,7 +40,8 @@ DEBUG_INFO_TAG = "error.debug_info_captured"
 CAPTURE_TRACE_TAG = "_dd.debug.error.trace_captured"
 
 # unique exception id
-EXCEPTION_ID_TAG = "_dd.debug.error.exception_id"
+EXCEPTION_HASH_TAG = "_dd.debug.error.exception_hash"
+EXCEPTION_ID_TAG = "_dd.debug.error.exception_capture_id"
 
 # link to matching snapshot for every frame in the traceback
 FRAME_SNAPSHOT_ID_TAG = "_dd.debug.error.%d.snapshot_id"
@@ -80,9 +81,8 @@ def exception_chain_ident(chain: ExceptionChain) -> int:
     return h
 
 
-def limit_exception(chain: ExceptionChain) -> bool:
+def limit_exception(exc_ident: int) -> bool:
     try:
-        exc_ident = exception_chain_ident(chain)
         hg = EXCEPTION_IDENT_LIMITER.get(exc_ident)
         if hg is None:
             # We haven't seen this exception yet, or it's been evicted
@@ -218,7 +218,8 @@ class SpanExceptionHandler:
             # No exceptions to capture
             return
 
-        if limit_exception(chain):
+        exc_ident = exception_chain_ident(chain)
+        if limit_exception(exc_ident):
             # We have seen this exception recently
             return
 
@@ -272,6 +273,7 @@ class SpanExceptionHandler:
                 _tb = _tb.tb_next
 
             span.set_tag_str(DEBUG_INFO_TAG, "true")
+            span.set_tag_str(EXCEPTION_HASH_TAG, str(exc_ident))
             span.set_tag_str(EXCEPTION_ID_TAG, str(exc_id))
 
     @classmethod


### PR DESCRIPTION
We include the span tag that carries the exception hash, according to the RFC.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
