### PR TITLE
fix flask.request span not finished

### DIFF
--- a/ddtrace/contrib/internal/wsgi/wsgi.py
+++ b/ddtrace/contrib/internal/wsgi/wsgi.py
@@ -109,7 +109,7 @@ class _DDWSGIMiddlewareBase(object):
             environ=environ,
             middleware=self,
             span_key="req_span",
-        ) as ctx:
+        ) as ctx, ctx.span:
             ctx.set_item("wsgi.construct_url", construct_url)
 
             def blocked_view():

--- a/releasenotes/notes/wsgi_span_unfinished-e8d0e84bba3cb010.yaml
+++ b/releasenotes/notes/wsgi_span_unfinished-e8d0e84bba3cb010.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Tracer: This fix resolves a rare issue where the flask.request span was not properly finished.


### PR DESCRIPTION
In rare occasions, the flask.request span was found to be unfinished. This would lead to some missing traces.
The problem was found on the APPSEC_STANDALONE system tests scenario, while using flask with gunicorn.

APPSEC-56162

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
