### PR TITLE
chore(span): make fields immutable after serialization

### DIFF
--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -349,7 +349,7 @@ class SpanAggregator(SpanProcessor):
                 # and should be considered immutable. Updating the span after this point
                 # will may not be reflected in the encoded span.
                 for span in spans:
-                    span._make_immutable()
+                    span._serialized = False
                 return
 
             log.debug("trace %d has %d spans, %d finished", span.trace_id, len(trace.spans), trace.num_finished)

--- a/ddtrace/_trace/types.py
+++ b/ddtrace/_trace/types.py
@@ -11,35 +11,3 @@ log = get_logger(__name__)
 _TagNameType = Union[Text, bytes]
 _MetaDictType = Dict[_TagNameType, Text]
 _MetricDictType = Dict[_TagNameType, NumericType]
-
-
-class _ImmutableDict(dict):
-    def __setitem__(self, name, value):
-        # log a warning when trying to set an attribute on an immutable map, do not raise a ValueError
-        log.warning("Map is immutable, ignoring set attribute %s and value %r", name, value)
-
-
-class _ImmutableList(list):
-    def __setitem__(self, name, value):
-        # log a warning when trying to set an attribute on an immutable list, do not raise a ValueError
-        log.warning("List is immutable, ignoring set attribute %s and value %r", name, value)
-
-    def append(self, value):
-        # log a warning when trying to append to an immutable list, do not raise a ValueError
-        log.warning("List is immutable, ignoring append of value %r", value)
-
-    def extend(self, values):
-        # log a warning when trying to extend an immutable list, do not raise a ValueError
-        log.warning("List is immutable, ignoring extend with iterable %r", values)
-
-    def insert(self, index, value):
-        # log a warning when trying to insert into an immutable list, do not raise a ValueError
-        log.warning("List is immutable, ignoring insert at index %d with value %r", index, value)
-
-    def remove(self, value):
-        # log a warning when trying to remove from an immutable list, do not raise a ValueError
-        log.warning("List is immutable, ignoring remove of value %r", value)
-
-    def pop(self, index=-1):
-        # log a warning when trying to pop from an immutable list, do not raise a ValueError
-        log.warning("List is immutable, ignoring pop at index %d", index)

--- a/ddtrace/_trace/types.py
+++ b/ddtrace/_trace/types.py
@@ -3,8 +3,43 @@ from typing import Text
 from typing import Union
 
 from ddtrace.internal.compat import NumericType
+from ddtrace.internal.logger import get_logger
 
+
+log = get_logger(__name__)
 
 _TagNameType = Union[Text, bytes]
 _MetaDictType = Dict[_TagNameType, Text]
 _MetricDictType = Dict[_TagNameType, NumericType]
+
+
+class _ImmutableDict(dict):
+    def __setitem__(self, name, value):
+        # log a warning when trying to set an attribute on an immutable map, do not raise a ValueError
+        log.warning("Map is immutable, ignoring set attribute %s and value %r", name, value)
+
+
+class _ImmutableList(list):
+    def __setitem__(self, name, value):
+        # log a warning when trying to set an attribute on an immutable list, do not raise a ValueError
+        log.warning("List is immutable, ignoring set attribute %s and value %r", name, value)
+
+    def append(self, value):
+        # log a warning when trying to append to an immutable list, do not raise a ValueError
+        log.warning("List is immutable, ignoring append of value %r", value)
+
+    def extend(self, values):
+        # log a warning when trying to extend an immutable list, do not raise a ValueError
+        log.warning("List is immutable, ignoring extend with iterable %r", values)
+
+    def insert(self, index, value):
+        # log a warning when trying to insert into an immutable list, do not raise a ValueError
+        log.warning("List is immutable, ignoring insert at index %d with value %r", index, value)
+
+    def remove(self, value):
+        # log a warning when trying to remove from an immutable list, do not raise a ValueError
+        log.warning("List is immutable, ignoring remove of value %r", value)
+
+    def pop(self, index=-1):
+        # log a warning when trying to pop from an immutable list, do not raise a ValueError
+        log.warning("List is immutable, ignoring pop at index %d", index)

--- a/tests/contrib/djangorestframework/test_appsec.py
+++ b/tests/contrib/djangorestframework/test_appsec.py
@@ -11,7 +11,6 @@ from tests.utils import override_global_config
 @pytest.mark.skipif(django.VERSION < (1, 10), reason="requires django version >= 1.10")
 def test_djangorest_request_body_urlencoded(client, test_spans, tracer):
     with override_global_config(dict(_asm_enabled=True)):
-        tracer._asm_enabled = True
         # Hack: need to pass an argument to configure so that the processors are recreated
         tracer.configure(api_version="v0.4")
         payload = urlencode({"mytestingbody_key": "mytestingbody_value"})
@@ -29,7 +28,6 @@ def test_djangorest_request_body_urlencoded(client, test_spans, tracer):
 @pytest.mark.skipif(django.VERSION < (1, 10), reason="requires django version >= 1.10")
 def test_djangorest_request_body_custom_parser(client, test_spans, tracer):
     with override_global_config(dict(_asm_enabled=True)):
-        tracer._asm_enabled = True
         # Hack: need to pass an argument to configure so that the processors are recreated
         tracer.configure(api_version="v0.4")
         payload, content_type = (

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -888,7 +888,7 @@ def test_span_make_immutable():
     s._add_event("message")
     s.set_link(trace_id=11, span_id=12)
     s._set_ctx_item("ctx1", "val1")
-    s._make_immutable()
+    s._serialized = False
 
     s.service = "new-service"
     s.resource = "new-resource"
@@ -923,11 +923,10 @@ def test_span_make_immutable_warning():
     """
     with mock.patch("ddtrace._trace.span.log") as log:
         s = Span("test.span")
-        s._make_immutable()
+        s._serialized = False
         s.name = "new-name"
         log.warning.assert_called_once_with(
-            "Span with the name %s has been serialized and is now immutable, ignoring set attribute %s and value %r",
+            "Span with the name %s has been serialized and is now immutable, " "ignoring call to Span.%s",
             "test.span",
             "name",
-            "new-name",
         )


### PR DESCRIPTION
## Description

Currently a span object object can be modified after the trace data has been encoded and sent to the agent. 

This PR attempts to resolve this issue by introducing a `_serialized` Span property and `@_is_serialized()` annotation. `Span._serialized` is set to `True` after a span is encoded and sent to the TraceWriter. 

ddtrace will log a warning if a Span is modified after serialization. It will not raise an exception. This is to maintain backwards compatibility and prevent ddtrace from crashing applications.

## Risks

- Performance
- Generating noisy debug logs that are not actionable (ex: if spans are modified after Span.finish(...) in a ddtrace integration).
- Custom implementation of _ImmutableDict and _ImmutableList are incomplete/buggy/slow


## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
