### PR TITLE
ci: optimize ci runtime

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -1,22 +1,3 @@
-build_base_venvs:
-  extends: .testrunner
-  stage: package
-  parallel:
-    matrix:
-      - PYTHON_VERSION: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-  variables:
-    CMAKE_BUILD_PARALLEL_LEVEL: 12
-    PIP_VERBOSE: 1
-  script:
-    - pip install riot==0.20.0
-    - riot -P -v generate --python=$PYTHON_VERSION
-  artifacts:
-    name: venv_$PYTHON_VERSION
-    paths:
-      - .riot/venv_*
-      - ddtrace/**/*.so*
-      - ddtrace/internal/datadog/profiling/crashtracker/crashtracker_exe*
-
 download_ddtrace_artifacts:
   image: registry.ddbuild.io/github-cli:v27480869-eafb11d-2.43.0
   tags: [ "arch:amd64" ]

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -10,17 +10,9 @@ variables:
   PYTEST_ADDOPTS: "-s"
   # CI_DEBUG_SERVICES: "true"
 
-.testrunner:
-  image: registry.ddbuild.io/images/mirror/dd-trace-py/testrunner:0a50e839f4b1600f02157518b8d016451b346578@sha256:5dae9bc7872f69b31b612690f0748c7ad71ab90ef28a754b2ae93d0ba505837b
-  # DEV: we have a larger pool of amd64 runners, prefer that over arm64
-  tags: [ "arch:amd64" ]
-  timeout: 20m
-  before_script:
-    - pyenv global 3.12 3.7 3.8 3.9 3.10 3.11 3.13
-    - export _CI_DD_AGENT_URL=http://${HOST_IP}:8126/
-
-
-{{services.yml}}
+include:
+  - local: ".gitlab/services.yml"
+  - local: ".gitlab/testrunner.yml"
 
 .test_base_hatch:
   extends: .testrunner

--- a/hatch.toml
+++ b/hatch.toml
@@ -155,7 +155,7 @@ extra-dependencies = [
     "hypothesis<6.45.1"
 ]
 [envs.meta-testing.env-vars]
-DD_CIVISIBILITY_FLAKY_RETRY_ENABLED = 0
+DD_CIVISIBILITY_FLAKY_RETRY_ENABLED = "0"
 
 [envs.meta-testing.scripts]
 test = [

--- a/hatch.toml
+++ b/hatch.toml
@@ -154,6 +154,9 @@ extra-dependencies = [
     "pytest-cov",
     "hypothesis<6.45.1"
 ]
+[envs.meta-testing.env-vars]
+DD_CIVISIBILITY_FLAKY_RETRY_ENABLED = 0
+
 [envs.meta-testing.scripts]
 test = [
   "pytest {args} tests/meta"

--- a/hatch.toml
+++ b/hatch.toml
@@ -159,7 +159,7 @@ DD_CIVISIBILITY_FLAKY_RETRY_ENABLED = "0"
 
 [envs.meta-testing.scripts]
 test = [
-  "pytest {args} tests/meta"
+  "pytest {args} --no-ddtrace tests/meta"
 ]
 
 [envs.integration_test]

--- a/hatch.toml
+++ b/hatch.toml
@@ -155,7 +155,7 @@ extra-dependencies = [
     "hypothesis<6.45.1"
 ]
 [envs.meta-testing.scripts]
-meta-testing = [
+test = [
   "pytest {args} tests/meta"
 ]
 

--- a/scripts/gen_gitlab_config.py
+++ b/scripts/gen_gitlab_config.py
@@ -95,9 +95,7 @@ def gen_required_suites() -> None:
         circleci_jobs = set(circleci_config["jobs"].keys())
 
     # Copy the template file
-    TESTS_GEN.write_text(
-        (GITLAB / "tests.yml").read_text().replace(r"{{services.yml}}", (GITLAB / "services.yml").read_text())
-    )
+    TESTS_GEN.write_text((GITLAB / "tests.yml").read_text())
     # Generate the list of suites to run
     with TESTS_GEN.open("a") as f:
         for suite in required_suites:
@@ -161,11 +159,6 @@ def gen_pre_checks() -> None:
         name="Check suitespec coverage",
         command="hatch run lint:suitespec-check",
         paths={"*"},
-    )
-    check(
-        name="conftest",
-        command="hatch run meta-testing:meta-testing",
-        paths={"**conftest.py"},
     )
 
 

--- a/tests/suitespec.yml
+++ b/tests/suitespec.yml
@@ -154,7 +154,8 @@ suites:
   conftest:
     parallelism: 1
     paths:
-      - '**conftest.py'
+      - 'conftest.py'
+      - '**/conftest.py'
     pattern: meta-testing
     runner: hatch
     snapshot: false

--- a/tests/suitespec.yml
+++ b/tests/suitespec.yml
@@ -151,6 +151,13 @@ components:
   vendor:
     - ddtrace/vendor/*
 suites:
+  conftest:
+    parallelism: 1
+    paths:
+      - '**conftest.py'
+    pattern: meta-testing
+    runner: hatch
+    snapshot: false
   ddtracerun:
     parallelism: 6
     paths:


### PR DESCRIPTION
- Remove redundant `build_base_venvs`
    - not needed by any downstream jobs, we have to re-do this in the tests-gen pipeline anyways
- Move conftest hatch job from precheck to hatch stage
    - hatch jobs that have to install dev take a long time to run 6+ mins
- Remove redundant `.testrunner` definition, and need for injecting `services.yml` into `tests.yml` template

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
