### PR TITLE
fix: add schematize service name for django caching

### DIFF
--- a/ddtrace/contrib/internal/django/patch.py
+++ b/ddtrace/contrib/internal/django/patch.py
@@ -215,7 +215,7 @@ def traced_cache(django, pin, func, instance, args, kwargs):
         "django.cache",
         span_name="django.cache",
         span_type=SpanTypes.CACHE,
-        service=config.django.cache_service_name,
+        service=schematize_service_name(config.django.cache_service_name),
         resource=utils.resource_from_cache_prefix(func_name(func), instance),
         tags=tags,
         pin=pin,

--- a/releasenotes/notes/django-cache-service-name-schematization-bef19b44b7414016.yaml
+++ b/releasenotes/notes/django-cache-service-name-schematization-bef19b44b7414016.yaml
@@ -1,0 +1,29 @@
+---
+#instructions:
+#    The style guide below provides explanations, instructions, and templates to write your own release note.
+#    Once finished, all irrelevant sections (including this instruction section) should be removed,
+#    and the release note should be committed with the rest of the changes.
+#
+#    The main goal of a release note is to provide a brief overview of a change and provide actionable steps to the user.
+#    The release note should clearly communicate what the change is, why the change was made, and how a user can migrate their code.
+#
+#    The release note should also clearly distinguish between announcements and user instructions. Use:
+#    * Past tense for previous/existing behavior (ex: ``resulted, caused, failed``)
+#    * Third person present tense for the change itself (ex: ``adds, fixes, upgrades``)
+#    * Active present infinitive for user instructions (ex: ``set, use, add``)
+#
+#    Release notes should:
+#    * Use plain language
+#    * Be concise
+#    * Include actionable steps with the necessary code changes
+#    * Include relevant links (bug issues, upstream issues or release notes, documentation pages)
+#    * Use full sentences with sentence-casing and punctuation.
+#    * Before using Datadog specific acronyms/terminology, a release note must first introduce them with a definition.
+#
+#    Release notes should not:
+#    * Be vague. Example: ``fixes an issue in tracing``.
+#    * Use overly technical language
+#    * Use dynamic links (``stable/latest/1.x`` URLs). Instead, use static links (specific version, commit hash) whenever possible so that they don't break in the future.
+fixes:
+  - |
+    Fixes issue where django cache is represented as django service rather than the third party service.

--- a/releasenotes/notes/django-cache-service-name-schematization-bef19b44b7414016.yaml
+++ b/releasenotes/notes/django-cache-service-name-schematization-bef19b44b7414016.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fixes issue where django cache is represented as django service rather than the third party service.
+    django: Fixes issue where django cache is represented as a django service rather than the third party service.

--- a/releasenotes/notes/django-cache-service-name-schematization-bef19b44b7414016.yaml
+++ b/releasenotes/notes/django-cache-service-name-schematization-bef19b44b7414016.yaml
@@ -1,29 +1,4 @@
 ---
-#instructions:
-#    The style guide below provides explanations, instructions, and templates to write your own release note.
-#    Once finished, all irrelevant sections (including this instruction section) should be removed,
-#    and the release note should be committed with the rest of the changes.
-#
-#    The main goal of a release note is to provide a brief overview of a change and provide actionable steps to the user.
-#    The release note should clearly communicate what the change is, why the change was made, and how a user can migrate their code.
-#
-#    The release note should also clearly distinguish between announcements and user instructions. Use:
-#    * Past tense for previous/existing behavior (ex: ``resulted, caused, failed``)
-#    * Third person present tense for the change itself (ex: ``adds, fixes, upgrades``)
-#    * Active present infinitive for user instructions (ex: ``set, use, add``)
-#
-#    Release notes should:
-#    * Use plain language
-#    * Be concise
-#    * Include actionable steps with the necessary code changes
-#    * Include relevant links (bug issues, upstream issues or release notes, documentation pages)
-#    * Use full sentences with sentence-casing and punctuation.
-#    * Before using Datadog specific acronyms/terminology, a release note must first introduce them with a definition.
-#
-#    Release notes should not:
-#    * Be vague. Example: ``fixes an issue in tracing``.
-#    * Use overly technical language
-#    * Use dynamic links (``stable/latest/1.x`` URLs). Instead, use static links (specific version, commit hash) whenever possible so that they don't break in the future.
 fixes:
   - |
     Fixes issue where django cache is represented as django service rather than the third party service.

--- a/releasenotes/notes/django-cache-service-name-schematization-bef19b44b7414016.yaml
+++ b/releasenotes/notes/django-cache-service-name-schematization-bef19b44b7414016.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    django: Fixes issue where django cache is represented as a django service rather than the third party service.
+    tracing(django): Fixes issue where django cache is represented as a django service rather than the third party service.

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -775,18 +775,13 @@ def test_cache_service_schematization(test_spans):
 
     cache = django.core.cache.caches["default"]
 
-    env = os.environ.copy()
-
-    env["DD_SERVICE"] = "custom-service-name"
-
-    cache.set("test_key", "test_value")
-    expected_service_name = schematize_service_name(config.django.cache_service_name)
-
-    spans = test_spans.get_spans()
-    assert spans
-
-    span = spans[0]
-    assert span.service == expected_service_name
+    with override_config("django", dict(cache_service_name="test-cache-service")):
+        cache.get("missing_key")
+        spans = test_spans.get_spans()
+        assert spans
+        span = spans[0]
+        expected_service_name = schematize_service_name(config.django.cache_service_name)
+        assert span.service == expected_service_name
 
 
 def test_cache_get_rowcount_existing_key(test_spans):

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -771,8 +771,6 @@ def test_cache_get(test_spans):
 
 
 def test_cache_service_schematization(test_spans):
-    from ddtrace import config
-
     cache = django.core.cache.caches["default"]
 
     with override_config("django", dict(cache_service_name="test-cache-service")):

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -30,6 +30,7 @@ from ddtrace.contrib.django.utils import get_request_uri
 from ddtrace.ext import http
 from ddtrace.ext import user
 from ddtrace.internal.compat import ensure_text
+from ddtrace.internal.schema import schematize_service_name
 from ddtrace.propagation._utils import get_wsgi_header
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from ddtrace.propagation.http import HTTP_HEADER_SAMPLING_PRIORITY
@@ -1347,6 +1348,31 @@ def test_cache_set_many(test_spans):
     assert span_set_many.get_tag("django.cache.backend") == "django.core.cache.backends.locmem.LocMemCache"
     assert "first_key" in span_set_many.get_tag("django.cache.key")
     assert "second_key" in span_set_many.get_tag("django.cache.key")
+
+
+def test_schematized_service_name_cache(test_spans):
+    from ddtrace import config
+
+    cache = django.core.cache.caches["default"]
+    schema_version = "v1"
+    global_service_name = "custom-service"
+
+    config.django.cache_service_name = "default-cache"
+    if schema_version is not None:
+        config._service_name_schema_version = schema_version
+    if global_service_name is not None:
+        config.service = global_service_name
+
+    expected_service_name = schematize_service_name(config.django.cache_service_name)
+
+    cache.set("test_key", "test_value")
+
+    spans = test_spans.get_spans()
+    assert spans
+
+    span = spans[0]
+    assert span.service == expected_service_name
+    assert span.name == "django.cache"
 
 
 def test_cache_delete_many(test_spans):


### PR DESCRIPTION
Currently, we treat django caching as a separate service.
This is a quick fix so that behavior aligns with our public docs; inferred services connected to django should be directly connected to the third-party service not django. 
The service name should adhere to the name rule from `schematize_service_name` rather than `django`.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
