### PR TITLE
fix(profiling): remove slow getpid call from memalloc path

### DIFF
--- a/releasenotes/notes/profiling-remove-getpid-from-memalloc-74f54043accdfc9e.yaml
+++ b/releasenotes/notes/profiling-remove-getpid-from-memalloc-74f54043accdfc9e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: Removed a system call from the memory allocation profiler, used to detect forks,
+    which ran on every allocation and resulted in a significant slowdown.


### PR DESCRIPTION
memalloc uses getpid to detect whether the process has forked, so that
we can unlock the memalloc lock in the child process (if it isn't
already locked). Unfortunately the getpid call is quite slow. From the
man page: "calls to getpid() always invoke the actual system call,
rather than returning a cached value." Furthermore, we _always_ attempt
to take the lock for allocations, even if we aren't going to sample
them. So this is basically adding a syscall to every allocation.

Move this logic out of the allocation path. Switch to using
pthread_atfork handlers to ensure that the lock is held prior to
forking, and unlock it in the parent and child after forking. This
(maybe) has the added benefit of making sure the data structures are in
a consistent state in the child process after forking. Unclear if that's
an issue prior to this change, though. I may be missing some code that
resets the profiler on fork anyway?

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
