### PR TITLE
chore(llmobs): assert using span events instead of mocks

### DIFF
--- a/tests/llmobs/conftest.py
+++ b/tests/llmobs/conftest.py
@@ -32,16 +32,6 @@ def pytest_configure(config):
 
 
 @pytest.fixture
-def mock_llmobs_span_writer():
-    patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsSpanWriter")
-    LLMObsSpanWriterMock = patcher.start()
-    m = mock.MagicMock()
-    LLMObsSpanWriterMock.return_value = m
-    yield m
-    patcher.stop()
-
-
-@pytest.fixture
 def mock_llmobs_eval_metric_writer():
     patcher = mock.patch("ddtrace.llmobs._llmobs.LLMObsEvalMetricWriter")
     LLMObsEvalMetricWriterMock = patcher.start()
@@ -128,44 +118,6 @@ def default_global_config():
 
 
 @pytest.fixture
-def LLMObs(
-    mock_llmobs_span_writer, mock_llmobs_eval_metric_writer, mock_llmobs_evaluator_runner, ddtrace_global_config
-):
-    global_config = default_global_config()
-    global_config.update(ddtrace_global_config)
-    with override_global_config(global_config):
-        dummy_tracer = DummyTracer()
-        llmobs_service.enable(_tracer=dummy_tracer)
-        yield llmobs_service
-        llmobs_service.disable()
-
-
-@pytest.fixture
-def AgentlessLLMObs(
-    mock_llmobs_span_writer,
-    mock_llmobs_eval_metric_writer,
-    mock_llmobs_evaluator_runner,
-    ddtrace_global_config,
-):
-    global_config = default_global_config()
-    global_config.update(ddtrace_global_config)
-    global_config.update(dict(_llmobs_agentless_enabled=True))
-    with override_global_config(global_config):
-        dummy_tracer = DummyTracer()
-        llmobs_service.enable(_tracer=dummy_tracer)
-        yield llmobs_service
-        llmobs_service.disable()
-
-
-@pytest.fixture
-def disabled_llmobs():
-    prev = llmobs_service.enabled
-    llmobs_service.enabled = False
-    yield
-    llmobs_service.enabled = prev
-
-
-@pytest.fixture
 def mock_ragas_dependencies_not_present():
     import ragas
 
@@ -177,7 +129,7 @@ def mock_ragas_dependencies_not_present():
 
 
 @pytest.fixture
-def ragas(mock_llmobs_span_writer, mock_llmobs_eval_metric_writer):
+def ragas(mock_llmobs_eval_metric_writer):
     with override_global_config(dict(_dd_api_key="<not-a-real-key>")):
         try:
             import ragas

--- a/tests/llmobs/test_llmobs_decorators.py
+++ b/tests/llmobs/test_llmobs_decorators.py
@@ -19,7 +19,7 @@ def mock_logs():
         yield mock_logs
 
 
-def test_llm_decorator_with_llmobs_disabled_logs_warning(LLMObs, mock_logs):
+def test_llm_decorator_with_llmobs_disabled_logs_warning(llmobs, mock_logs):
     for decorator_name, decorator in (("llm", llm), ("embedding", embedding)):
 
         @decorator(
@@ -28,13 +28,13 @@ def test_llm_decorator_with_llmobs_disabled_logs_warning(LLMObs, mock_logs):
         def f():
             pass
 
-        LLMObs.disable()
+        llmobs.disable()
         f()
         mock_logs.warning.assert_called_with(SPAN_START_WHILE_DISABLED_WARNING)
         mock_logs.reset_mock()
 
 
-def test_non_llm_decorator_with_llmobs_disabled_logs_warning(LLMObs, mock_logs):
+def test_non_llm_decorator_with_llmobs_disabled_logs_warning(llmobs, mock_logs):
     for decorator_name, decorator in (
         ("task", task),
         ("workflow", workflow),
@@ -47,53 +47,49 @@ def test_non_llm_decorator_with_llmobs_disabled_logs_warning(LLMObs, mock_logs):
         def f():
             pass
 
-        LLMObs.disable()
+        llmobs.disable()
         f()
         mock_logs.warning.assert_called_with(SPAN_START_WHILE_DISABLED_WARNING)
         mock_logs.reset_mock()
 
 
-def test_llm_decorator(LLMObs, mock_llmobs_span_writer):
+def test_llm_decorator(llmobs, llmobs_events):
     @llm(model_name="test_model", model_provider="test_provider", name="test_function", session_id="test_session_id")
     def f():
         pass
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_llm_span_event(
-            span, "llm", model_name="test_model", model_provider="test_provider", session_id="test_session_id"
-        )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_llm_span_event(
+        span, "llm", model_name="test_model", model_provider="test_provider", session_id="test_session_id"
     )
 
 
-def test_llm_decorator_no_model_name_sets_default(LLMObs, mock_llmobs_span_writer):
+def test_llm_decorator_no_model_name_sets_default(llmobs, llmobs_events):
     @llm(model_provider="test_provider", name="test_function", session_id="test_session_id")
     def f():
         pass
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_llm_span_event(
-            span, "llm", model_name="custom", model_provider="test_provider", session_id="test_session_id"
-        )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_llm_span_event(
+        span, "llm", model_name="custom", model_provider="test_provider", session_id="test_session_id"
     )
 
 
-def test_llm_decorator_default_kwargs(LLMObs, mock_llmobs_span_writer):
+def test_llm_decorator_default_kwargs(llmobs, llmobs_events):
     @llm
     def f():
         pass
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_llm_span_event(span, "llm", model_name="custom", model_provider="custom")
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_llm_span_event(
+        span, "llm", model_name="custom", model_provider="custom"
     )
 
 
-def test_embedding_decorator(LLMObs, mock_llmobs_span_writer):
+def test_embedding_decorator(llmobs, llmobs_events):
     @embedding(
         model_name="test_model", model_provider="test_provider", name="test_function", session_id="test_session_id"
     )
@@ -101,173 +97,157 @@ def test_embedding_decorator(LLMObs, mock_llmobs_span_writer):
         pass
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_llm_span_event(
-            span, "embedding", model_name="test_model", model_provider="test_provider", session_id="test_session_id"
-        )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_llm_span_event(
+        span, "embedding", model_name="test_model", model_provider="test_provider", session_id="test_session_id"
     )
 
 
-def test_embedding_decorator_no_model_name_sets_default(LLMObs, mock_llmobs_span_writer):
+def test_embedding_decorator_no_model_name_sets_default(llmobs, llmobs_events):
     @embedding(model_provider="test_provider", name="test_function", session_id="test_session_id")
     def f():
         pass
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_llm_span_event(
-            span, "embedding", model_name="custom", model_provider="test_provider", session_id="test_session_id"
-        )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_llm_span_event(
+        span, "embedding", model_name="custom", model_provider="test_provider", session_id="test_session_id"
     )
 
 
-def test_embedding_decorator_default_kwargs(LLMObs, mock_llmobs_span_writer):
+def test_embedding_decorator_default_kwargs(llmobs, llmobs_events):
     @embedding
     def f():
         pass
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_llm_span_event(span, "embedding", model_name="custom", model_provider="custom")
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_llm_span_event(
+        span, "embedding", model_name="custom", model_provider="custom"
     )
 
 
-def test_retrieval_decorator(LLMObs, mock_llmobs_span_writer):
+def test_retrieval_decorator(llmobs, llmobs_events):
     @retrieval(name="test_function", session_id="test_session_id")
     def f():
         pass
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_non_llm_span_event(span, "retrieval", session_id="test_session_id")
-    )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(span, "retrieval", session_id="test_session_id")
 
 
-def test_retrieval_decorator_default_kwargs(LLMObs, mock_llmobs_span_writer):
+def test_retrieval_decorator_default_kwargs(llmobs, llmobs_events):
     @retrieval()
     def f():
         pass
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(_expected_llmobs_non_llm_span_event(span, "retrieval"))
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(span, "retrieval")
 
 
-def test_task_decorator(LLMObs, mock_llmobs_span_writer):
+def test_task_decorator(llmobs, llmobs_events):
     @task(name="test_function", session_id="test_session_id")
     def f():
         pass
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_non_llm_span_event(span, "task", session_id="test_session_id")
-    )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(span, "task", session_id="test_session_id")
 
 
-def test_task_decorator_default_kwargs(LLMObs, mock_llmobs_span_writer):
+def test_task_decorator_default_kwargs(llmobs, llmobs_events):
     @task()
     def f():
         pass
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(_expected_llmobs_non_llm_span_event(span, "task"))
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(span, "task")
 
 
-def test_tool_decorator(LLMObs, mock_llmobs_span_writer):
+def test_tool_decorator(llmobs, llmobs_events):
     @tool(name="test_function", session_id="test_session_id")
     def f():
         pass
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_non_llm_span_event(span, "tool", session_id="test_session_id")
-    )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(span, "tool", session_id="test_session_id")
 
 
-def test_tool_decorator_default_kwargs(LLMObs, mock_llmobs_span_writer):
+def test_tool_decorator_default_kwargs(llmobs, llmobs_events):
     @tool()
     def f():
         pass
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(_expected_llmobs_non_llm_span_event(span, "tool"))
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(span, "tool")
 
 
-def test_workflow_decorator(LLMObs, mock_llmobs_span_writer):
+def test_workflow_decorator(llmobs, llmobs_events):
     @workflow(name="test_function", session_id="test_session_id")
     def f():
         pass
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_non_llm_span_event(span, "workflow", session_id="test_session_id")
-    )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(span, "workflow", session_id="test_session_id")
 
 
-def test_workflow_decorator_default_kwargs(LLMObs, mock_llmobs_span_writer):
+def test_workflow_decorator_default_kwargs(llmobs, llmobs_events):
     @workflow()
     def f():
         pass
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(_expected_llmobs_non_llm_span_event(span, "workflow"))
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(span, "workflow")
 
 
-def test_agent_decorator(LLMObs, mock_llmobs_span_writer):
+def test_agent_decorator(llmobs, llmobs_events):
     @agent(name="test_function", session_id="test_session_id")
     def f():
         pass
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_llm_span_event(span, "agent", session_id="test_session_id")
-    )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_llm_span_event(span, "agent", session_id="test_session_id")
 
 
-def test_agent_decorator_default_kwargs(LLMObs, mock_llmobs_span_writer):
+def test_agent_decorator_default_kwargs(llmobs, llmobs_events):
     @agent()
     def f():
         pass
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(_expected_llmobs_llm_span_event(span, "agent"))
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_llm_span_event(span, "agent")
 
 
-def test_llm_decorator_with_error(LLMObs, mock_llmobs_span_writer):
+def test_llm_decorator_with_error(llmobs, llmobs_events):
     @llm(model_name="test_model", model_provider="test_provider", name="test_function", session_id="test_session_id")
     def f():
         raise ValueError("test_error")
 
     with pytest.raises(ValueError):
         f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_llm_span_event(
-            span,
-            "llm",
-            model_name="test_model",
-            model_provider="test_provider",
-            session_id="test_session_id",
-            error=span.get_tag("error.type"),
-            error_message=span.get_tag("error.message"),
-            error_stack=span.get_tag("error.stack"),
-        )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_llm_span_event(
+        span,
+        "llm",
+        model_name="test_model",
+        model_provider="test_provider",
+        session_id="test_session_id",
+        error=span.get_tag("error.type"),
+        error_message=span.get_tag("error.message"),
+        error_stack=span.get_tag("error.stack"),
     )
 
 
-def test_non_llm_decorators_with_error(LLMObs, mock_llmobs_span_writer):
+def test_non_llm_decorators_with_error(llmobs, llmobs_events):
     for decorator_name, decorator in [("task", task), ("workflow", workflow), ("tool", tool), ("agent", agent)]:
 
         @decorator(name="test_function", session_id="test_session_id")
@@ -276,23 +256,21 @@ def test_non_llm_decorators_with_error(LLMObs, mock_llmobs_span_writer):
 
         with pytest.raises(ValueError):
             f()
-        span = LLMObs._instance.tracer.pop()[0]
-        mock_llmobs_span_writer.enqueue.assert_called_with(
-            _expected_llmobs_non_llm_span_event(
-                span,
-                decorator_name,
-                session_id="test_session_id",
-                error=span.get_tag("error.type"),
-                error_message=span.get_tag("error.message"),
-                error_stack=span.get_tag("error.stack"),
-            )
+        span = llmobs._instance.tracer.pop()[0]
+        assert llmobs_events[-1] == _expected_llmobs_non_llm_span_event(
+            span,
+            decorator_name,
+            session_id="test_session_id",
+            error=span.get_tag("error.type"),
+            error_message=span.get_tag("error.message"),
+            error_stack=span.get_tag("error.stack"),
         )
 
 
-def test_llm_annotate(LLMObs, mock_llmobs_span_writer):
+def test_llm_annotate(llmobs, llmobs_events):
     @llm(model_name="test_model", model_provider="test_provider", name="test_function", session_id="test_session_id")
     def f():
-        LLMObs.annotate(
+        llmobs.annotate(
             parameters={"temperature": 0.9, "max_tokens": 50},
             input_data=[{"content": "test_prompt"}],
             output_data=[{"content": "test_response"}],
@@ -301,27 +279,25 @@ def test_llm_annotate(LLMObs, mock_llmobs_span_writer):
         )
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_llm_span_event(
-            span,
-            "llm",
-            model_name="test_model",
-            model_provider="test_provider",
-            input_messages=[{"content": "test_prompt"}],
-            output_messages=[{"content": "test_response"}],
-            parameters={"temperature": 0.9, "max_tokens": 50},
-            token_metrics={"input_tokens": 10, "output_tokens": 20, "total_tokens": 30},
-            tags={"custom_tag": "tag_value"},
-            session_id="test_session_id",
-        )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_llm_span_event(
+        span,
+        "llm",
+        model_name="test_model",
+        model_provider="test_provider",
+        input_messages=[{"content": "test_prompt"}],
+        output_messages=[{"content": "test_response"}],
+        parameters={"temperature": 0.9, "max_tokens": 50},
+        token_metrics={"input_tokens": 10, "output_tokens": 20, "total_tokens": 30},
+        tags={"custom_tag": "tag_value"},
+        session_id="test_session_id",
     )
 
 
-def test_llm_annotate_raw_string_io(LLMObs, mock_llmobs_span_writer):
+def test_llm_annotate_raw_string_io(llmobs, llmobs_events):
     @llm(model_name="test_model", model_provider="test_provider", name="test_function", session_id="test_session_id")
     def f():
-        LLMObs.annotate(
+        llmobs.annotate(
             parameters={"temperature": 0.9, "max_tokens": 50},
             input_data="test_prompt",
             output_data="test_response",
@@ -330,24 +306,22 @@ def test_llm_annotate_raw_string_io(LLMObs, mock_llmobs_span_writer):
         )
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_llm_span_event(
-            span,
-            "llm",
-            model_name="test_model",
-            model_provider="test_provider",
-            input_messages=[{"content": "test_prompt"}],
-            output_messages=[{"content": "test_response"}],
-            parameters={"temperature": 0.9, "max_tokens": 50},
-            token_metrics={"input_tokens": 10, "output_tokens": 20, "total_tokens": 30},
-            tags={"custom_tag": "tag_value"},
-            session_id="test_session_id",
-        )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_llm_span_event(
+        span,
+        "llm",
+        model_name="test_model",
+        model_provider="test_provider",
+        input_messages=[{"content": "test_prompt"}],
+        output_messages=[{"content": "test_response"}],
+        parameters={"temperature": 0.9, "max_tokens": 50},
+        token_metrics={"input_tokens": 10, "output_tokens": 20, "total_tokens": 30},
+        tags={"custom_tag": "tag_value"},
+        session_id="test_session_id",
     )
 
 
-def test_non_llm_decorators_no_args(LLMObs, mock_llmobs_span_writer):
+def test_non_llm_decorators_no_args(llmobs, llmobs_events):
     """Test that using the decorators without any arguments, i.e. @tool, works the same as @tool(...)."""
     for decorator_name, decorator in [
         ("task", task),
@@ -362,11 +336,11 @@ def test_non_llm_decorators_no_args(LLMObs, mock_llmobs_span_writer):
             pass
 
         f()
-        span = LLMObs._instance.tracer.pop()[0]
-        mock_llmobs_span_writer.enqueue.assert_called_with(_expected_llmobs_non_llm_span_event(span, decorator_name))
+        span = llmobs._instance.tracer.pop()[0]
+        assert llmobs_events[-1] == _expected_llmobs_non_llm_span_event(span, decorator_name)
 
 
-def test_agent_decorator_no_args(LLMObs, mock_llmobs_span_writer):
+def test_agent_decorator_no_args(llmobs, llmobs_events):
     """Test that using agent decorator without any arguments, i.e. @agent, works the same as @agent(...)."""
 
     @agent
@@ -374,11 +348,11 @@ def test_agent_decorator_no_args(LLMObs, mock_llmobs_span_writer):
         pass
 
     f()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(_expected_llmobs_llm_span_event(span, "agent"))
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_llm_span_event(span, "agent")
 
 
-def test_ml_app_override(LLMObs, mock_llmobs_span_writer):
+def test_ml_app_override(llmobs, llmobs_events):
     """Test that setting ml_app kwarg on the LLMObs decorators will override the DD_LLMOBS_ML_APP value."""
     for decorator_name, decorator in [("task", task), ("workflow", workflow), ("tool", tool)]:
 
@@ -387,9 +361,9 @@ def test_ml_app_override(LLMObs, mock_llmobs_span_writer):
             pass
 
         f()
-        span = LLMObs._instance.tracer.pop()[0]
-        mock_llmobs_span_writer.enqueue.assert_called_with(
-            _expected_llmobs_non_llm_span_event(span, decorator_name, tags={"ml_app": "test_ml_app"})
+        span = llmobs._instance.tracer.pop()[0]
+        assert llmobs_events[-1] == _expected_llmobs_non_llm_span_event(
+            span, decorator_name, tags={"ml_app": "test_ml_app"}
         )
 
     @llm(model_name="test_model", ml_app="test_ml_app")
@@ -397,11 +371,9 @@ def test_ml_app_override(LLMObs, mock_llmobs_span_writer):
         pass
 
     g()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_llm_span_event(
-            span, "llm", model_name="test_model", model_provider="custom", tags={"ml_app": "test_ml_app"}
-        )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[-1] == _expected_llmobs_llm_span_event(
+        span, "llm", model_name="test_model", model_provider="custom", tags={"ml_app": "test_ml_app"}
     )
 
     @embedding(model_name="test_model", ml_app="test_ml_app")
@@ -409,15 +381,13 @@ def test_ml_app_override(LLMObs, mock_llmobs_span_writer):
         pass
 
     h()
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_llm_span_event(
-            span, "embedding", model_name="test_model", model_provider="custom", tags={"ml_app": "test_ml_app"}
-        )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[-1] == _expected_llmobs_llm_span_event(
+        span, "embedding", model_name="test_model", model_provider="custom", tags={"ml_app": "test_ml_app"}
     )
 
 
-async def test_non_llm_async_decorators(LLMObs, mock_llmobs_span_writer):
+async def test_non_llm_async_decorators(llmobs, llmobs_events):
     """Test that decorators work with async functions."""
     for decorator_name, decorator in [
         ("task", task),
@@ -432,11 +402,11 @@ async def test_non_llm_async_decorators(LLMObs, mock_llmobs_span_writer):
             pass
 
         await f()
-        span = LLMObs._instance.tracer.pop()[0]
-        mock_llmobs_span_writer.enqueue.assert_called_with(_expected_llmobs_non_llm_span_event(span, decorator_name))
+        span = llmobs._instance.tracer.pop()[0]
+        assert llmobs_events[-1] == _expected_llmobs_non_llm_span_event(span, decorator_name)
 
 
-async def test_llm_async_decorators(LLMObs, mock_llmobs_span_writer):
+async def test_llm_async_decorators(llmobs, llmobs_events):
     """Test that decorators work with async functions."""
     for decorator_name, decorator in [("llm", llm), ("embedding", embedding)]:
 
@@ -445,15 +415,13 @@ async def test_llm_async_decorators(LLMObs, mock_llmobs_span_writer):
             pass
 
         await f()
-        span = LLMObs._instance.tracer.pop()[0]
-        mock_llmobs_span_writer.enqueue.assert_called_with(
-            _expected_llmobs_llm_span_event(
-                span, decorator_name, model_name="test_model", model_provider="test_provider"
-            )
+        span = llmobs._instance.tracer.pop()[0]
+        assert llmobs_events[-1] == _expected_llmobs_llm_span_event(
+            span, decorator_name, model_name="test_model", model_provider="test_provider"
         )
 
 
-def test_automatic_annotation_non_llm_decorators(LLMObs, mock_llmobs_span_writer):
+def test_automatic_annotation_non_llm_decorators(llmobs, llmobs_events):
     """Test that automatic input/output annotation works for non-LLM decorators."""
     for decorator_name, decorator in (("task", task), ("workflow", workflow), ("tool", tool), ("agent", agent)):
 
@@ -462,19 +430,17 @@ def test_automatic_annotation_non_llm_decorators(LLMObs, mock_llmobs_span_writer
             return prompt
 
         f("test_prompt", "arg_2", kwarg_2=12345)
-        span = LLMObs._instance.tracer.pop()[0]
-        mock_llmobs_span_writer.enqueue.assert_called_with(
-            _expected_llmobs_non_llm_span_event(
-                span,
-                decorator_name,
-                input_value=str({"prompt": "test_prompt", "arg_2": "arg_2", "kwarg_2": 12345}),
-                output_value="test_prompt",
-                session_id="test_session_id",
-            )
+        span = llmobs._instance.tracer.pop()[0]
+        assert llmobs_events[-1] == _expected_llmobs_non_llm_span_event(
+            span,
+            decorator_name,
+            input_value=str({"prompt": "test_prompt", "arg_2": "arg_2", "kwarg_2": 12345}),
+            output_value="test_prompt",
+            session_id="test_session_id",
         )
 
 
-def test_automatic_annotation_retrieval_decorator(LLMObs, mock_llmobs_span_writer):
+def test_automatic_annotation_retrieval_decorator(llmobs, llmobs_events):
     """Test that automatic input annotation works for retrieval decorators."""
 
     @retrieval(session_id="test_session_id")
@@ -482,18 +448,16 @@ def test_automatic_annotation_retrieval_decorator(LLMObs, mock_llmobs_span_write
         return [{"name": "name", "id": "1234567890", "score": 0.9}]
 
     test_retrieval("test_query", "arg_2", kwarg_2=12345)
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_non_llm_span_event(
-            span,
-            "retrieval",
-            input_value=str({"query": "test_query", "arg_2": "arg_2", "kwarg_2": 12345}),
-            session_id="test_session_id",
-        )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
+        span,
+        "retrieval",
+        input_value=str({"query": "test_query", "arg_2": "arg_2", "kwarg_2": 12345}),
+        session_id="test_session_id",
     )
 
 
-def test_automatic_annotation_off_non_llm_decorators(LLMObs, mock_llmobs_span_writer):
+def test_automatic_annotation_off_non_llm_decorators(llmobs, llmobs_events):
     """Test disabling automatic input/output annotation for non-LLM decorators."""
     for decorator_name, decorator in (
         ("task", task),
@@ -508,35 +472,33 @@ def test_automatic_annotation_off_non_llm_decorators(LLMObs, mock_llmobs_span_wr
             return prompt
 
         f("test_prompt", "arg_2", kwarg_2=12345)
-        span = LLMObs._instance.tracer.pop()[0]
-        mock_llmobs_span_writer.enqueue.assert_called_with(
-            _expected_llmobs_non_llm_span_event(span, decorator_name, session_id="test_session_id")
+        span = llmobs._instance.tracer.pop()[0]
+        assert llmobs_events[-1] == _expected_llmobs_non_llm_span_event(
+            span, decorator_name, session_id="test_session_id"
         )
 
 
-def test_automatic_annotation_off_if_manually_annotated(LLMObs, mock_llmobs_span_writer):
+def test_automatic_annotation_off_if_manually_annotated(llmobs, llmobs_events):
     """Test disabling automatic input/output annotation for non-LLM decorators."""
     for decorator_name, decorator in (("task", task), ("workflow", workflow), ("tool", tool), ("agent", agent)):
 
         @decorator(name="test_function", session_id="test_session_id")
         def f(prompt, arg_2, kwarg_1=None, kwarg_2=None):
-            LLMObs.annotate(input_data="my custom input", output_data="my custom output")
+            llmobs.annotate(input_data="my custom input", output_data="my custom output")
             return prompt
 
         f("test_prompt", "arg_2", kwarg_2=12345)
-        span = LLMObs._instance.tracer.pop()[0]
-        mock_llmobs_span_writer.enqueue.assert_called_with(
-            _expected_llmobs_non_llm_span_event(
-                span,
-                decorator_name,
-                session_id="test_session_id",
-                input_value="my custom input",
-                output_value="my custom output",
-            )
+        span = llmobs._instance.tracer.pop()[0]
+        assert llmobs_events[-1] == _expected_llmobs_non_llm_span_event(
+            span,
+            decorator_name,
+            session_id="test_session_id",
+            input_value="my custom input",
+            output_value="my custom output",
         )
 
 
-def test_generator_sync(LLMObs, mock_llmobs_span_writer):
+def test_generator_sync(llmobs, llmobs_events):
     """
     Test that decorators work with generator functions.
     The span should finish after the generator is exhausted.
@@ -556,7 +518,7 @@ def test_generator_sync(LLMObs, mock_llmobs_span_writer):
             for i in range(3):
                 yield i
 
-            LLMObs.annotate(
+            llmobs.annotate(
                 input_data="hello",
                 output_data="world",
             )
@@ -566,7 +528,7 @@ def test_generator_sync(LLMObs, mock_llmobs_span_writer):
             assert e == i
             i += 1
 
-        span = LLMObs._instance.tracer.pop()[0]
+        span = llmobs._instance.tracer.pop()[0]
         if decorator_name == "llm":
             expected_span_event = _expected_llmobs_llm_span_event(
                 span,
@@ -594,10 +556,10 @@ def test_generator_sync(LLMObs, mock_llmobs_span_writer):
                 span, decorator_name, input_value="hello", output_value="world"
             )
 
-        mock_llmobs_span_writer.enqueue.assert_called_with(expected_span_event)
+        assert llmobs_events[-1] == expected_span_event
 
 
-async def test_generator_async(LLMObs, mock_llmobs_span_writer):
+async def test_generator_async(llmobs, llmobs_events):
     """
     Test that decorators work with generator functions.
     The span should finish after the generator is exhausted.
@@ -617,7 +579,7 @@ async def test_generator_async(LLMObs, mock_llmobs_span_writer):
             for i in range(3):
                 yield i
 
-            LLMObs.annotate(
+            llmobs.annotate(
                 input_data="hello",
                 output_data="world",
             )
@@ -627,7 +589,7 @@ async def test_generator_async(LLMObs, mock_llmobs_span_writer):
             assert e == i
             i += 1
 
-        span = LLMObs._instance.tracer.pop()[0]
+        span = llmobs._instance.tracer.pop()[0]
         if decorator_name == "llm":
             expected_span_event = _expected_llmobs_llm_span_event(
                 span,
@@ -655,11 +617,11 @@ async def test_generator_async(LLMObs, mock_llmobs_span_writer):
                 span, decorator_name, input_value="hello", output_value="world"
             )
 
-        mock_llmobs_span_writer.enqueue.assert_called_with(expected_span_event)
+        assert llmobs_events[-1] == expected_span_event
 
 
-def test_generator_sync_with_llmobs_disabled(LLMObs, mock_logs):
-    LLMObs.disable()
+def test_generator_sync_with_llmobs_disabled(llmobs, mock_logs):
+    llmobs.disable()
 
     @workflow()
     def f():
@@ -684,10 +646,11 @@ def test_generator_sync_with_llmobs_disabled(LLMObs, mock_logs):
         i += 1
 
     mock_logs.warning.assert_called_with(SPAN_START_WHILE_DISABLED_WARNING)
+    llmobs.enable()
 
 
-async def test_generator_async_with_llmobs_disabled(LLMObs, mock_logs):
-    LLMObs.disable()
+async def test_generator_async_with_llmobs_disabled(llmobs, mock_logs):
+    llmobs.disable()
 
     @workflow()
     async def f():
@@ -712,9 +675,10 @@ async def test_generator_async_with_llmobs_disabled(LLMObs, mock_logs):
         i += 1
 
     mock_logs.warning.assert_called_with(SPAN_START_WHILE_DISABLED_WARNING)
+    llmobs.enable()
 
 
-def test_generator_sync_finishes_span_on_error(LLMObs, mock_llmobs_span_writer):
+def test_generator_sync_finishes_span_on_error(llmobs, llmobs_events):
     """Tests that"""
 
     @workflow()
@@ -728,19 +692,17 @@ def test_generator_sync_finishes_span_on_error(LLMObs, mock_llmobs_span_writer):
         for _ in f():
             pass
 
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_non_llm_span_event(
-            span,
-            "workflow",
-            error=span.get_tag("error.type"),
-            error_message=span.get_tag("error.message"),
-            error_stack=span.get_tag("error.stack"),
-        )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
+        span,
+        "workflow",
+        error=span.get_tag("error.type"),
+        error_message=span.get_tag("error.message"),
+        error_stack=span.get_tag("error.stack"),
     )
 
 
-async def test_generator_async_finishes_span_on_error(LLMObs, mock_llmobs_span_writer):
+async def test_generator_async_finishes_span_on_error(llmobs, llmobs_events):
     @workflow()
     async def f():
         for i in range(3):
@@ -752,19 +714,17 @@ async def test_generator_async_finishes_span_on_error(LLMObs, mock_llmobs_span_w
         async for _ in f():
             pass
 
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_non_llm_span_event(
-            span,
-            "workflow",
-            error=span.get_tag("error.type"),
-            error_message=span.get_tag("error.message"),
-            error_stack=span.get_tag("error.stack"),
-        )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
+        span,
+        "workflow",
+        error=span.get_tag("error.type"),
+        error_message=span.get_tag("error.message"),
+        error_stack=span.get_tag("error.stack"),
     )
 
 
-def test_generator_sync_send(LLMObs, mock_llmobs_span_writer):
+def test_generator_sync_send(llmobs, llmobs_events):
     @workflow()
     def f():
         while True:
@@ -780,16 +740,11 @@ def test_generator_sync_send(LLMObs, mock_llmobs_span_writer):
     assert gen.send(4) == 16
     gen.close()
 
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_non_llm_span_event(
-            span,
-            "workflow",
-        )
-    )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(span, "workflow")
 
 
-async def test_generator_async_send(LLMObs, mock_llmobs_span_writer):
+async def test_generator_async_send(llmobs, llmobs_events):
     @workflow()
     async def f():
         while True:
@@ -805,16 +760,11 @@ async def test_generator_async_send(LLMObs, mock_llmobs_span_writer):
 
     await gen.aclose()
 
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_non_llm_span_event(
-            span,
-            "workflow",
-        )
-    )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(span, "workflow")
 
 
-def test_generator_sync_throw(LLMObs, mock_llmobs_span_writer):
+def test_generator_sync_throw(llmobs, llmobs_events):
     @workflow()
     def f():
         for i in range(3):
@@ -825,19 +775,17 @@ def test_generator_sync_throw(LLMObs, mock_llmobs_span_writer):
         next(gen)
         gen.throw(ValueError("test_error"))
 
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_non_llm_span_event(
-            span,
-            "workflow",
-            error=span.get_tag("error.type"),
-            error_message=span.get_tag("error.message"),
-            error_stack=span.get_tag("error.stack"),
-        )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
+        span,
+        "workflow",
+        error=span.get_tag("error.type"),
+        error_message=span.get_tag("error.message"),
+        error_stack=span.get_tag("error.stack"),
     )
 
 
-async def test_generator_async_throw(LLMObs, mock_llmobs_span_writer):
+async def test_generator_async_throw(llmobs, llmobs_events):
     @workflow()
     async def f():
         for i in range(3):
@@ -848,19 +796,17 @@ async def test_generator_async_throw(LLMObs, mock_llmobs_span_writer):
         await gen.asend(None)
         await gen.athrow(ValueError("test_error"))
 
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_non_llm_span_event(
-            span,
-            "workflow",
-            error=span.get_tag("error.type"),
-            error_message=span.get_tag("error.message"),
-            error_stack=span.get_tag("error.stack"),
-        )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
+        span,
+        "workflow",
+        error=span.get_tag("error.type"),
+        error_message=span.get_tag("error.message"),
+        error_stack=span.get_tag("error.stack"),
     )
 
 
-def test_generator_exit_exception_sync(LLMObs, mock_llmobs_span_writer):
+def test_generator_exit_exception_sync(llmobs, llmobs_events):
     @workflow()
     def get_next_element(alist):
         for element in alist:
@@ -873,14 +819,12 @@ def test_generator_exit_exception_sync(LLMObs, mock_llmobs_span_writer):
         if element == 5:
             break
 
-    span = LLMObs._instance.tracer.pop()[0]
-    mock_llmobs_span_writer.enqueue.assert_called_with(
-        _expected_llmobs_non_llm_span_event(
-            span,
-            "workflow",
-            input_value=str({"alist": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}),
-            error=span.get_tag("error.type"),
-            error_message=span.get_tag("error.message"),
-            error_stack=span.get_tag("error.stack"),
-        )
+    span = llmobs._instance.tracer.pop()[0]
+    assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
+        span,
+        "workflow",
+        input_value=str({"alist": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}),
+        error=span.get_tag("error.type"),
+        error_message=span.get_tag("error.message"),
+        error_stack=span.get_tag("error.stack"),
     )

--- a/tests/llmobs/test_llmobs_evaluator_runner.py
+++ b/tests/llmobs/test_llmobs_evaluator_runner.py
@@ -34,9 +34,9 @@ def test_evaluator_runner_buffer_limit(mock_evaluator_logs):
     )
 
 
-def test_evaluator_runner_periodic_enqueues_eval_metric(LLMObs, mock_llmobs_eval_metric_writer):
-    evaluator_runner = EvaluatorRunner(interval=0.01, llmobs_service=LLMObs)
-    evaluator_runner.evaluators.append(DummyEvaluator(llmobs_service=LLMObs))
+def test_evaluator_runner_periodic_enqueues_eval_metric(llmobs, mock_llmobs_eval_metric_writer):
+    evaluator_runner = EvaluatorRunner(interval=0.01, llmobs_service=llmobs)
+    evaluator_runner.evaluators.append(DummyEvaluator(llmobs_service=llmobs))
     evaluator_runner.enqueue({"span_id": "123", "trace_id": "1234"}, DUMMY_SPAN)
     evaluator_runner.periodic()
     mock_llmobs_eval_metric_writer.enqueue.assert_called_once_with(
@@ -45,9 +45,9 @@ def test_evaluator_runner_periodic_enqueues_eval_metric(LLMObs, mock_llmobs_eval
 
 
 @pytest.mark.vcr_logs
-def test_evaluator_runner_timed_enqueues_eval_metric(LLMObs, mock_llmobs_eval_metric_writer):
-    evaluator_runner = EvaluatorRunner(interval=0.01, llmobs_service=LLMObs)
-    evaluator_runner.evaluators.append(DummyEvaluator(llmobs_service=LLMObs))
+def test_evaluator_runner_timed_enqueues_eval_metric(llmobs, mock_llmobs_eval_metric_writer):
+    evaluator_runner = EvaluatorRunner(interval=0.01, llmobs_service=llmobs)
+    evaluator_runner.evaluators.append(DummyEvaluator(llmobs_service=llmobs))
     evaluator_runner.start()
 
     evaluator_runner.enqueue({"span_id": "123", "trace_id": "1234"}, DUMMY_SPAN)


### PR DESCRIPTION
Follow up of #11781 to further clean up LLMObs tests, specifically replacing potentially flaky LLMObs span writer mocks and assertions with the test LLMObsSpanWriter dummy class. Also clean up the `tests/llmobs/conftest.py` file which previously contained a ton of rarely used and sometimes redundant fixtures.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
