### PR TITLE
ci: fix flaky test_custom_traceback_size_with_error on Python 3.13

### DIFF
--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -283,10 +283,16 @@ class SpanTestCase(TracerTestCase):
                 assert 0, "should have failed"
 
             stack = s.get_tag(ERROR_STACK)
+            assert stack, "No error stack collected"
             # one header "Traceback (most recent call last):" and one footer "ZeroDivisionError: division by zero"
             header_and_footer_lines = 2
+            # Python 3.13 adds extra lines to the traceback:
+            #   File dd-trace-py/tests/tracer/test_span.py", line 279, in test_custom_traceback_size_with_error
+            #     wrapper()
+            #     ~~~~~~~^^
+            multiplier = 3 if "~~" in stack else 2
             assert (
-                len(stack.splitlines()) == tb_length_limit * 2 + header_and_footer_lines
+                len(stack.splitlines()) == tb_length_limit * multiplier + header_and_footer_lines
             ), "stacktrace should contain two lines per entry"
 
     def test_ctx_mgr(self):


### PR DESCRIPTION
Under newer Python versions we sometimes get tracebacks that contain pointers, we need to account for these in the assertion.

```
Traceback (most recent call last):
  File "dd-trace-py/tests/tracer/test_span.py", line 279, in test_custom_traceback_size_with_error
    wrapper()
    ~~~~~~~^^
  File "dd-trace-py/tests/tracer/test_span.py", line 276, in wrapper
    divide_by_zero()
    ~~~~~~~~~~~~~~^^
ZeroDivisionError: division by zero
```


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
