### PR TITLE
chore(ci): exclude pinned packages from auto-updating requirements

### DIFF
--- a/scripts/freshvenvs.py
+++ b/scripts/freshvenvs.py
@@ -123,7 +123,7 @@ def _get_updatable_packages_implementing(modules: typing.Set[str]) -> typing.Set
         if not _venv_sets_latest_for_package(v, package):
             pinned_packages.add(package)
 
-    packages = {m for m in modules if "." not in m}
+    packages = {m for m in modules if "." not in m and m not in pinned_packages}
     return packages
 
 


### PR DESCRIPTION
Fix to skip over pinned packages when selecting modules to update. This logic was accidentally removed in #11372 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
