### PR TITLE
ci: fix urllib3 list index error

### DIFF
--- a/tests/contrib/urllib3/test_urllib3.py
+++ b/tests/contrib/urllib3/test_urllib3.py
@@ -532,7 +532,6 @@ class TestUrllib3(BaseUrllib3TestCase):
         # Check that distributed tracing headers are passed down; raise an error rather than make the
         # request since we don't care about the response at all
         config.urllib3["distributed_tracing"] = True
-        self.tracer.enabled = False
         with mock.patch(
             "urllib3.connectionpool.HTTPConnectionPool._make_request", side_effect=ValueError
         ) as m_make_request:


### PR DESCRIPTION
This change removes an apparent programming error that caused this test failure:
```
    def test_distributed_tracing_apm_opt_out_true(self):                                                                                                                                                               
        """Tests distributed tracing headers are passed by default"""                                                                                                                                                  
        # Check that distributed tracing headers are passed down; raise an error rather than make the                                                                                                                  
        # request since we don't care about the response at all                                                                                                                                                        
        config.urllib3["distributed_tracing"] = True                                                                                                                                                                   
        self.tracer.enabled = False                                                                                                                                                                                    
        with mock.patch(                                                                                                                                                                                               
            "urllib3.connectionpool.HTTPConnectionPool._make_request", side_effect=ValueError                                                                                                                          
        ) as m_make_request:                                                                                                                                                                                           
            with pytest.raises(ValueError):                                                                                                                                                                            
                self.http.request("GET", URL_200)                                                                                                                                                                      
                                                                                                                                                                                                                       
            spans = self.pop_spans()                                                                                                                                                                                   
>           s = spans[0]                                                                                                                                                                                               
E           IndexError: list index out of range                                                                                                                                                                        
                                                                                                                                                                                                                       
tests/contrib/urllib3/test_urllib3.py:543: IndexError                   
```

Since the test looks at a span, it follows that the tracer should be enabled to generate that span.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
