### PR TITLE
ci(botocore): fix flaky botocore tests

### DIFF
--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -22,8 +22,8 @@ from moto import mock_stepfunctions
 import pytest
 
 from ddtrace._trace._span_pointer import _SpanPointer
-from ddtrace._trace.utils_botocore import span_tags
 from ddtrace._trace._span_pointer import _SpanPointerDirection
+from ddtrace._trace.utils_botocore import span_tags
 from tests.utils import get_128_bit_trace_id_from_headers
 
 

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -22,6 +22,7 @@ from moto import mock_stepfunctions
 import pytest
 
 from ddtrace._trace._span_pointer import _SpanPointer
+from ddtrace._trace.utils_botocore import span_tags
 from ddtrace._trace._span_pointer import _SpanPointerDirection
 from tests.utils import get_128_bit_trace_id_from_headers
 
@@ -3780,6 +3781,7 @@ class BotocoreTest(TracerTestCase):
     @mock_sqs
     def test_aws_payload_tagging_sqs(self):
         with self.override_config("botocore", dict(payload_tagging_request="all", payload_tagging_response="all")):
+            span_tags._PAYLOAD_TAGGER.validated = False
             Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(self.sqs_client)
             message_attributes = {
                 "one": {"DataType": "String", "StringValue": "one"},
@@ -3825,6 +3827,7 @@ class BotocoreTest(TracerTestCase):
     @mock_sns
     @mock_sqs
     def test_aws_payload_tagging_sns(self):
+        span_tags._PAYLOAD_TAGGER.validated = False
         with self.override_config("botocore", dict(payload_tagging_request="all", payload_tagging_response="all")):
             region = "us-east-1"
             sns = self.session.create_client("sns", region_name=region, endpoint_url="http://localhost:4566")
@@ -3872,6 +3875,7 @@ class BotocoreTest(TracerTestCase):
     @mock_sns
     @mock_sqs
     def test_aws_payload_tagging_sns_valid_config(self):
+        span_tags._PAYLOAD_TAGGER.validated = False
         with self.override_config(
             "botocore",
             dict(
@@ -3924,6 +3928,7 @@ class BotocoreTest(TracerTestCase):
     @pytest.mark.snapshot(ignores=snapshot_ignores)
     @mock_s3
     def test_aws_payload_tagging_s3(self):
+        span_tags._PAYLOAD_TAGGER.validated = False
         with self.override_config("botocore", dict(payload_tagging_request="all", payload_tagging_response="all")):
             s3 = self.session.create_client("s3", region_name="us-west-2")
             Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(s3)
@@ -3953,6 +3958,12 @@ class BotocoreTest(TracerTestCase):
     @pytest.mark.snapshot(ignores=snapshot_ignores)
     @mock_s3
     def test_aws_payload_tagging_s3_invalid_config(self):
+        # Setting the validated flag to False ensures the payload config is re-validated
+        # FIXME: Ensure AWSPayloadTagging._REQUEST_REDACTION_PATHS_DEFAULTS is always in sync with
+        # config.botocore.payload_tagging_request
+        # FIXME: Ensure AWSPayloadTagging._RESPONSE_REDACTION_PATHS_DEFAULTS is always in sync with
+        # config.botocore.payload_tagging_response
+        span_tags._PAYLOAD_TAGGER.validated = False
         with self.override_config(
             "botocore",
             dict(payload_tagging_request="non_json_path", payload_tagging_response="$..Attr ibutes.PlatformCredential"),
@@ -3974,6 +3985,7 @@ class BotocoreTest(TracerTestCase):
         with self.override_config(
             "botocore", dict(payload_tagging_request="$..bucket", payload_tagging_response="$..HTTPHeaders")
         ):
+            span_tags._PAYLOAD_TAGGER.validated = False
             s3 = self.session.create_client("s3", region_name="us-west-2")
             Pin(service=self.TEST_SERVICE, tracer=self.tracer).onto(s3)
 
@@ -3988,6 +4000,7 @@ class BotocoreTest(TracerTestCase):
     @pytest.mark.snapshot(ignores=snapshot_ignores)
     @mock_events
     def test_aws_payload_tagging_eventbridge(self):
+        span_tags._PAYLOAD_TAGGER.validated = False
         with self.override_config("botocore", dict(payload_tagging_request="all", payload_tagging_response="all")):
             bridge = self.session.create_client("events", region_name="us-east-1", endpoint_url="http://localhost:4566")
             bridge.create_event_bus(Name="a-test-bus")
@@ -4031,6 +4044,7 @@ class BotocoreTest(TracerTestCase):
     @mock_kinesis
     def test_aws_payload_tagging_kinesis(self):
         with self.override_config("botocore", dict(payload_tagging_request="all", payload_tagging_response="all")):
+            span_tags._PAYLOAD_TAGGER.validated = False
             client = self.session.create_client("kinesis", region_name="us-east-1")
             stream_name = "test"
 


### PR DESCRIPTION
Botocore sensitive data redaction sets `AWSPayloadTagging.request_redaction_paths` and `AWSPayloadTagging.response_redaction_paths` the first time [AWSPayloadTagging.expand_payload_as_tags(...)](https://github.com/DataDog/dd-trace-py/blob/4970e6d0e8f6787e841576e6229ee572d743e9e8/ddtrace/_trace/utils_botocore/aws_payload_tagging.py#L83) is called.
 
In tests overriding `config.botocore.payload_tagging_request` and `config.botocore.payload_tagging_request` using `tests.utils.override_config(..)` is not sufficient. We also need to set `ddtrace._trace.utils_botocore.span_tags._PAYLOAD_TAGGER.validated` to `False`. This ensures the overriden botocore configurations are actually used.

Note: This PR does not fix the underlying issue of `AWSPayloadTagging` configurations becoming out of sync with `ddtrace.config.botocore`. We will need to address this bug in a future PR.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
