### PR TITLE
ci: fix CircleCI dynamic job selection

### DIFF
--- a/scripts/gen_circleci_config.py
+++ b/scripts/gen_circleci_config.py
@@ -17,10 +17,13 @@ def gen_required_suites(template: dict) -> None:
     required_suites = template["requires_tests"]["requires"] = []
     for_each_testrun_needed(
         suites=sorted(
-            set(n.rpartition("::")[-1] for n, s in get_suites().items() if not s.get("skip", False))
-            & set(template["jobs"].keys())
+            set(
+                n
+                for n, s in get_suites().items()
+                if not s.get("skip", False) and n.rpartition("::")[-1] in template["jobs"]
+            )
         ),
-        action=lambda suite: required_suites.append(suite),
+        action=lambda suite: required_suites.append(suite.rpartition("::")[-1]),
         git_selections=extract_git_commit_selections(os.getenv("GIT_COMMIT_DESC", "")),
     )
 


### PR DESCRIPTION
We fix a residual issue in #11668 whereby no suites where actually dynamically selected for CircleCI.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
