### PR TITLE
ci: fix flaky es search query

### DIFF
--- a/tests/contrib/elasticsearch/test_elasticsearch.py
+++ b/tests/contrib/elasticsearch/test_elasticsearch.py
@@ -167,7 +167,12 @@ class ElasticsearchPatchTest(TracerTestCase):
             es.index(id=10, body={"name": "ten", "created": datetime.date(2016, 1, 1)}, **args)
             es.index(id=11, body={"name": "eleven", "created": datetime.date(2016, 2, 1)}, **args)
             es.index(id=12, body={"name": "twelve", "created": datetime.date(2016, 3, 1)}, **args)
-            result = es.search(sort=["name:desc"], size=100, body={"query": {"match_all": {}}}, **args)
+            result = es.search(
+                sort={"name": {"order": "desc", "unmapped_type": "keyword"}},
+                size=100,
+                body={"query": {"match_all": {}}},
+                **args,
+            )
 
         assert len(result["hits"]["hits"]) == 3, result
         spans = self.get_spans()


### PR DESCRIPTION
It seems sometimes we don't have the index/mapping set up properly. I didn't try to dig into why since it shouldn't matter too much for this specific test case anyways.

The solution is in the query to specify the type of the `name` field if it is unmapped.


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
