### PR TITLE
fix(er): include nonlocals in snapshots

### DIFF
--- a/ddtrace/debugging/_safety.py
+++ b/ddtrace/debugging/_safety.py
@@ -1,5 +1,6 @@
 from inspect import CO_VARARGS
 from inspect import CO_VARKEYWORDS
+from itertools import chain
 from types import FrameType
 from typing import Any
 from typing import Dict
@@ -23,11 +24,11 @@ def get_args(frame: FrameType) -> Iterator[Tuple[str, Any]]:
 
 def get_locals(frame: FrameType) -> Iterator[Tuple[str, Any]]:
     code = frame.f_code
+    _locals = frame.f_locals
     nargs = code.co_argcount + bool(code.co_flags & CO_VARARGS) + bool(code.co_flags & CO_VARKEYWORDS)
-    names = code.co_varnames[nargs:]
-    values = (frame.f_locals.get(name) for name in names)
-
-    return zip(names, values)
+    return (
+        (name, _locals.get(name)) for name in chain(code.co_varnames[nargs:], code.co_freevars, code.co_cellvars)
+    )  # include freevars and cellvars
 
 
 def get_globals(frame: FrameType) -> Iterator[Tuple[str, Any]]:

--- a/releasenotes/notes/fix-er-include-nonlocals-bbeecfbbbde35496.yaml
+++ b/releasenotes/notes/fix-er-include-nonlocals-bbeecfbbbde35496.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    exception replay: include missing nonlocal variables in snapshot log messages.

--- a/tests/debugging/test_safety.py
+++ b/tests/debugging/test_safety.py
@@ -15,7 +15,10 @@ def test_get_args():
         assert set(dict(_safety.get_args(inspect.currentframe().f_back)).keys()) == args
 
     def assert_locals(_locals):
-        assert set(dict(_safety.get_locals(inspect.currentframe().f_back)).keys()) == _locals
+        assert set(dict(_safety.get_locals(inspect.currentframe().f_back)).keys()) == _locals | {
+            "assert_args",
+            "assert_locals",
+        }
 
     def assert_globals(_globals):
         assert set(dict(_safety.get_globals(inspect.currentframe().f_back)).keys()) == _globals


### PR DESCRIPTION
We include nonlocal variables in snapshots to provide for better visibility into exception occurrences.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
