### PR TITLE
fix(profiling): remove `_self_acquired_at` after use

### DIFF
--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -185,6 +185,7 @@ class _ProfiledLock(wrapt.ObjectProxy):
             # _self_acquired_at is only set when the acquire was captured
             # if it's not set, we're not capturing the release
             start = self._self_acquired_at
+            del self._self_acquired_at
 
         try:
             return inner_func(*args, **kwargs)

--- a/releasenotes/notes/profiling-lock-acquired-at-remove-c8b5b96130a46ca8.yaml
+++ b/releasenotes/notes/profiling-lock-acquired-at-remove-c8b5b96130a46ca8.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: resolves an issue where lock release would have been captured
+    with a wrong acquire timestamp


### PR DESCRIPTION
## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
