### PR TITLE
ci: enable vpa for jobs in the package stage

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -1,4 +1,10 @@
+.enable_vpa_for_package_stage:
+  variables:
+    KUBERNETES_POD_ANNOTATIONS_1: vpa.datadoghq.com/updateMode=Auto
+    KUBERNETES_POD_LABELS_1: admission.datadoghq.com/mutate-resources-using-vpa=gitlab-job-pod
+
 download_ddtrace_artifacts:
+  extends: .enable_vpa_for_package_stage
   image: registry.ddbuild.io/github-cli:v27480869-eafb11d-2.43.0
   tags: [ "arch:amd64" ]
   stage: package
@@ -13,6 +19,7 @@ download_ddtrace_artifacts:
       - "pywheels/*.tar.gz"
 
 download_dependency_wheels:
+  extends: .enable_vpa_for_package_stage
   image: registry.ddbuild.io/images/mirror/python:$PYTHON_IMAGE_TAG
   tags: [ "arch:amd64" ]
   stage: package


### PR DESCRIPTION
# Motivation
By observing this dashboard, filtering jobs by the `package` stage, I could see that most of those jobs use less CPU that the one requested. In an effort to make saving through right sizing CI workloads we, CI team, started to use VPA for it.

Data obtained from [here](https://app.datadoghq.com/dashboard/er4-5bc-ui2/cipo-ci-jobs-vpa-migration?fromUser=true&refresh_mode=sliding&tpl_var_ci_project_name%5B0%5D=dd-trace-py&tpl_var_ci-job-stage%5B0%5D=package&from_ts=1736244545810&to_ts=1736849345810&live=true)

# Changes
- Enable VPA for the jobs in the package stage.

# Tests
- Check in this [job](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/765145272) that the labels were added correctly

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)