### PR TITLE
chore(pin): remove all deprecated references [3.0]

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -64,7 +64,7 @@ __all__ = [
 ]
 
 
-_DEPRECATED_MODULE_ATTRIBUTES = [
+_DEPRECATED_TRACE_ATTRIBUTES = [
     "Span",
     "Tracer",
     "Pin",
@@ -72,10 +72,12 @@ _DEPRECATED_MODULE_ATTRIBUTES = [
 
 
 def __getattr__(name):
-    if name in _DEPRECATED_MODULE_ATTRIBUTES:
+    if name in _DEPRECATED_TRACE_ATTRIBUTES:
         debtcollector.deprecate(
             ("%s.%s is deprecated" % (__name__, name)),
+            message="Import from ddtrace.trace instead.",
             category=DDTraceDeprecationWarning,
+            removal_version="3.0.0",
         )
 
     if name in globals():

--- a/ddtrace/contrib/aredis/__init__.py
+++ b/ddtrace/contrib/aredis/__init__.py
@@ -50,7 +50,7 @@ Global Configuration
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To configure particular aredis instances use the :class:`Pin <ddtrace.Pin>` API::
+To configure particular aredis instances use the :class:`Pin <ddtrace.trace.Pin>` API::
 
     import aredis
     from ddtrace.trace import Pin

--- a/ddtrace/contrib/httpx/__init__.py
+++ b/ddtrace/contrib/httpx/__init__.py
@@ -57,7 +57,7 @@ Global Configuration
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To configure particular ``httpx`` client instances use the :class:`Pin <ddtrace.Pin>` API::
+To configure particular ``httpx`` client instances use the :class:`Pin <ddtrace.trace.Pin>` API::
 
     import httpx
     from ddtrace.trace import Pin

--- a/ddtrace/contrib/internal/mongoengine/trace.py
+++ b/ddtrace/contrib/internal/mongoengine/trace.py
@@ -23,12 +23,12 @@ class WrappedConnect(wrapt.ObjectProxy):
 
     def __init__(self, connect):
         super(WrappedConnect, self).__init__(connect)
-        ddtrace.Pin(_SERVICE, tracer=ddtrace.tracer).onto(self)
+        ddtrace.trace.Pin(_SERVICE, tracer=ddtrace.tracer).onto(self)
 
     def __call__(self, *args, **kwargs):
         client = self.__wrapped__(*args, **kwargs)
-        pin = ddtrace.Pin.get_from(self)
+        pin = ddtrace.trace.Pin.get_from(self)
         if pin:
-            ddtrace.Pin(service=pin.service, tracer=pin.tracer).onto(client)
+            ddtrace.trace.Pin(service=pin.service, tracer=pin.tracer).onto(client)
 
         return client

--- a/ddtrace/contrib/internal/pylibmc/client.py
+++ b/ddtrace/contrib/internal/pylibmc/client.py
@@ -51,7 +51,7 @@ class TracedClient(ObjectProxy):
         super(TracedClient, self).__init__(client)
 
         schematized_service = schematize_service_name(service)
-        pin = ddtrace.Pin(service=schematized_service, tracer=tracer)
+        pin = ddtrace.trace.Pin(service=schematized_service, tracer=tracer)
         pin.onto(self)
 
         # attempt to collect the pool of urls this client talks to
@@ -64,7 +64,7 @@ class TracedClient(ObjectProxy):
         # rewrap new connections.
         cloned = self.__wrapped__.clone(*args, **kwargs)
         traced_client = TracedClient(cloned)
-        pin = ddtrace.Pin.get_from(self)
+        pin = ddtrace.trace.Pin.get_from(self)
         if pin:
             pin.clone().onto(traced_client)
         return traced_client
@@ -155,7 +155,7 @@ class TracedClient(ObjectProxy):
 
     def _span(self, cmd_name):
         """Return a span timing the given command."""
-        pin = ddtrace.Pin.get_from(self)
+        pin = ddtrace.trace.Pin.get_from(self)
         if not pin or not pin.enabled():
             return self._no_span()
 

--- a/ddtrace/contrib/internal/pymongo/client.py
+++ b/ddtrace/contrib/internal/pymongo/client.py
@@ -61,7 +61,7 @@ def _trace_mongo_client_init(func, args, kwargs):
         pin.onto(client._topology)
 
     def __getddpin__(client):
-        return ddtrace.Pin.get_from(client._topology)
+        return ddtrace.trace.Pin.get_from(client._topology)
 
     # Set a pin on the mongoclient pin on the topology object
     # This allows us to pass the same pin to the server objects
@@ -103,7 +103,7 @@ def _trace_topology_select_server(func, args, kwargs):
     # Ensure the pin used on the traced mongo client is passed down to the topology instance
     # This allows us to pass the same pin in traced server objects.
     topology_instance = get_argument_value(args, kwargs, 0, "self")
-    pin = ddtrace.Pin.get_from(topology_instance)
+    pin = ddtrace.trace.Pin.get_from(topology_instance)
 
     if pin is not None:
         pin.onto(server)
@@ -125,7 +125,7 @@ def _datadog_trace_operation(operation, wrapped):
             log.exception("error parsing query")
 
     # Gets the pin from the mogno client (through the topology object)
-    pin = ddtrace.Pin.get_from(wrapped)
+    pin = ddtrace.trace.Pin.get_from(wrapped)
     # if we couldn't parse or shouldn't trace the message, just go.
     if not cmd or not pin or not pin.enabled():
         return None
@@ -220,7 +220,7 @@ def _trace_socket_command(func, args, kwargs):
     except Exception:
         log.exception("error parsing spec. skipping trace")
 
-    pin = ddtrace.Pin.get_from(socket_instance)
+    pin = ddtrace.trace.Pin.get_from(socket_instance)
     # skip tracing if we don't have a piece of data we need
     if not dbname or not cmd or not pin or not pin.enabled():
         return func(*args, **kwargs)
@@ -239,7 +239,7 @@ def _trace_socket_write_command(func, args, kwargs):
     except Exception:
         log.exception("error parsing msg")
 
-    pin = ddtrace.Pin.get_from(socket_instance)
+    pin = ddtrace.trace.Pin.get_from(socket_instance)
     # if we couldn't parse it, don't try to trace it.
     if not cmd or not pin or not pin.enabled():
         return func(*args, **kwargs)
@@ -252,7 +252,7 @@ def _trace_socket_write_command(func, args, kwargs):
 
 
 def _trace_cmd(cmd, socket_instance, address):
-    pin = ddtrace.Pin.get_from(socket_instance)
+    pin = ddtrace.trace.Pin.get_from(socket_instance)
     s = pin.tracer.trace(
         schematize_database_operation("pymongo.cmd", database_provider="mongodb"),
         span_type=SpanTypes.MONGODB,

--- a/ddtrace/contrib/internal/tornado/application.py
+++ b/ddtrace/contrib/internal/tornado/application.py
@@ -55,4 +55,4 @@ def tracer_config(__init__, app, args, kwargs):
         tracer.set_tags(tags)
 
     # configure the PIN object for template rendering
-    ddtrace.Pin(service=service, tracer=tracer).onto(template)
+    ddtrace.trace.Pin(service=service, tracer=tracer).onto(template)

--- a/ddtrace/contrib/redis/__init__.py
+++ b/ddtrace/contrib/redis/__init__.py
@@ -52,7 +52,7 @@ Global Configuration
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To configure particular redis instances use the :class:`Pin <ddtrace.Pin>` API::
+To configure particular redis instances use the :class:`Pin <ddtrace.trace.Pin>` API::
 
     import redis
     from ddtrace.trace import Pin

--- a/ddtrace/contrib/yaaredis/__init__.py
+++ b/ddtrace/contrib/yaaredis/__init__.py
@@ -50,7 +50,7 @@ Global Configuration
 Instance Configuration
 ~~~~~~~~~~~~~~~~~~~~~~
 
-To configure particular yaaredis instances use the :class:`Pin <ddtrace.Pin>` API::
+To configure particular yaaredis instances use the :class:`Pin <ddtrace.trace.Pin>` API::
 
     import yaaredis
     from ddtrace.trace import Pin

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -19,7 +19,7 @@ Tracing
 .. autoclass:: ddtrace.Span
     :members:
 
-.. autoclass:: ddtrace.Pin
+.. autoclass:: ddtrace.trace.Pin
     :members:
 
 .. autoclass:: ddtrace.trace.Context


### PR DESCRIPTION
## Motivation

Ensure deprecation warnings are only logged when users manually use deprecated interfaces.

## Description

This change ensures we do not use the deprecated `ddtrace.Pin` reference in docs and integrations.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
