### PR TITLE
chore(llmobs): fix ragas version tagging

### DIFF
--- a/ddtrace/llmobs/_evaluators/ragas/base.py
+++ b/ddtrace/llmobs/_evaluators/ragas/base.py
@@ -26,8 +26,10 @@ class RagasDependencies:
     def __init__(self):
         import ragas
 
-        self.ragas_version = parse_version(ragas.__version__)
-        if self.ragas_version >= (0, 2, 0) or self.ragas_version < (0, 1, 10):
+        self.ragas_version = ragas.__version__  # type: str
+
+        parsed_version = parse_version(ragas.__version__)
+        if parsed_version >= (0, 2, 0) or parsed_version < (0, 1, 10):
             raise NotImplementedError(
                 "Ragas version: {} is not supported".format(self.ragas_version),
             )


### PR DESCRIPTION
The ragas version was being stored & tagged as a tuple when it is supposed to be a string.

Fix by setting self.ragas_version to a string and then parsing afterwards

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
