### PR TITLE
chore: fix last version calculation for release script

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -332,7 +332,8 @@ def create_notebook(dd_repo, name, rn, base):
             "We need DD_API_KEY_STAGING and DD_APP_KEY_STAGING values. Please follow the instructions in the script."
         )
     if int(name[-1]) == 1:
-        last_version = base[:-1] + str(int(base[-1]) - 1)
+        major, minor = base.split(".", maxsplit=1)
+        last_version = f"{major}.{str(int(minor) - 1)}"
     else:
         print(
             "Since this is not the RC1 for this release."


### PR DESCRIPTION
Small bug in the release script where if the tens place bumped up, the last version calculation would fail. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
