### PR TITLE
fix: set span error metadata only for escaped errors

### DIFF
--- a/ddtrace/internal/opentelemetry/span.py
+++ b/ddtrace/internal/opentelemetry/span.py
@@ -259,16 +259,17 @@ class Span(OtelSpan):
             attrs.update(attributes)
 
         # Set the error type, error message and error stacktrace tags on the span
-        self._ddspan._meta[ERROR_MSG] = attrs["exception.message"]
-        self._ddspan._meta[ERROR_TYPE] = attrs["exception.type"]
-        if "exception.stacktrace" in attrs:
-            self._ddspan._meta[ERROR_STACK] = attrs["exception.stacktrace"]
-        else:
-            self._ddspan._meta[ERROR_STACK] = "".join(
-                traceback.format_exception(
-                    type(exception), exception, exception.__traceback__, limit=config._span_traceback_max_size
+        if escaped is True:
+            self._ddspan._meta[ERROR_MSG] = attrs["exception.message"]
+            self._ddspan._meta[ERROR_TYPE] = attrs["exception.type"]
+            if "exception.stacktrace" in attrs:
+                self._ddspan._meta[ERROR_STACK] = attrs["exception.stacktrace"]
+            else:
+                self._ddspan._meta[ERROR_STACK] = "".join(
+                    traceback.format_exception(
+                        type(exception), exception, exception.__traceback__, limit=config._span_traceback_max_size
+                    )
                 )
-            )
         self.add_event(name="exception", attributes=attrs, timestamp=timestamp)
 
     def __enter__(self):

--- a/ddtrace/internal/opentelemetry/span.py
+++ b/ddtrace/internal/opentelemetry/span.py
@@ -259,7 +259,7 @@ class Span(OtelSpan):
             attrs.update(attributes)
 
         # Set the error type, error message and error stacktrace tags on the span
-        if escaped is True:
+        if escaped:
             self._ddspan._meta[ERROR_MSG] = attrs["exception.message"]
             self._ddspan._meta[ERROR_TYPE] = attrs["exception.type"]
             if "exception.stacktrace" in attrs:

--- a/releasenotes/notes/fix-otel-record-exception-api-17f3a4b23948ec79.yaml
+++ b/releasenotes/notes/fix-otel-record-exception-api-17f3a4b23948ec79.yaml
@@ -1,5 +1,4 @@
 ---
 fixes:
   - |
-    tracing(otel-api): Ensures a call to otel-api record-exception sets
-    the span error metadata only if escaped is True.
+    opentelemetry: Ensures ``Span.record_exception(...)`` sets the span error metadata only if escaped is True.

--- a/releasenotes/notes/fix-otel-record-exception-api-17f3a4b23948ec79.yaml
+++ b/releasenotes/notes/fix-otel-record-exception-api-17f3a4b23948ec79.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    tracing(otel-api): Ensures a call to otel-api record-exception sets
+    the span error metadata only if escaped is True.

--- a/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_record_exception.json
+++ b/tests/snapshots/tests.opentelemetry.test_trace.test_otel_start_span_record_exception.json
@@ -40,9 +40,6 @@
     "meta": {
       "_dd.p.dm": "-0",
       "_dd.p.tid": "6658897400000000",
-      "error.message": "MoonEar Fire!!!",
-      "error.stack": "Fake traceback",
-      "error.type": "RandoException",
       "events": "[{\"name\": \"exception\", \"time_unix_nano\": 1716560281337739000, \"attributes\": {\"exception.type\": \"builtins.IndexError\", \"exception.message\": \"Invalid Operation 2\", \"exception.escaped\": \"False\", \"exception.stuff\": \"thing 2\"}}, {\"name\": \"exception\", \"time_unix_nano\": 1716560271237812000, \"attributes\": {\"exception.type\": \"RandoException\", \"exception.message\": \"MoonEar Fire!!!\", \"exception.escaped\": \"False\", \"exception.stacktrace\": \"Fake traceback\", \"exception.details\": \"This is FAKE, I overwrote the real exception details\"}}]",
       "language": "python",
       "runtime-id": "d0950ce7bda6498183acde9036abb131"


### PR DESCRIPTION
Before this change we set some span error metadata for every call of record_exception. This would set the span as an errored span. However, we can call several times record_exception within a span and we can pass handled exceptions as arguments. In the later case, we want the span not to be errored.

This change aims at addressing this. We will set the relevant metadata only if the error is escaped (which means unhandled).

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
