### PR TITLE
Revert "fix(tracing): only extract distributed headers if a trace is not already started"

### DIFF
--- a/ddtrace/contrib/trace_utils.py
+++ b/ddtrace/contrib/trace_utils.py
@@ -561,18 +561,6 @@ def activate_distributed_headers(tracer, int_config=None, request_headers=None, 
     if override is False:
         return None
 
-    # Only extract and activate if we don't already have an activate span
-    # DEV: Only do this if there is an active Span, an active Context is fine to override
-    # DEV: Use _DD_TRACE_EXTRACT_IGNORE_ACTIVE_SPAN env var to override the default behavior
-    current_span = tracer.current_span()
-    if current_span and not config._extract_ignore_active_span:
-        log.debug(
-            "will not extract distributed headers, a Span(trace_id%d, span_id=%d) is already active",
-            current_span.trace_id,
-            current_span.span_id,
-        )
-        return
-
     if override or (int_config and distributed_tracing_enabled(int_config)):
         context = HTTPPropagator.extract(request_headers)
 

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -558,9 +558,6 @@ class Config(object):
 
         self._propagation_extract_first = _get_config("DD_TRACE_PROPAGATION_EXTRACT_FIRST", False, asbool)
 
-        # When True any active span is ignored when extracting trace context from headers
-        self._extract_ignore_active_span = asbool(os.getenv("_DD_TRACE_EXTRACT_IGNORE_ACTIVE_SPAN", False))
-
         # Datadog tracer tags propagation
         x_datadog_tags_max_length = _get_config("DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH", 512, int)
         if x_datadog_tags_max_length < 0:

--- a/releasenotes/notes/fix-unncessary-header-extraction-c1facf2b30331afb.yaml
+++ b/releasenotes/notes/fix-unncessary-header-extraction-c1facf2b30331afb.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    tracing: Fix scenarios when distributed tracing headers would be extracted and possibly activated when a trace was already started.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -160,7 +160,6 @@ def override_global_config(values):
         "_llmobs_enabled",
         "_llmobs_sample_rate",
         "_llmobs_ml_app",
-        "_extract_ignore_active_span",
         "_llmobs_agentless_enabled",
         "_data_streams_enabled",
     ]


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#9456


This PR was merged automatically even though there was a failing system test. https://github.com/DataDog/dd-trace-py/actions/runs/12836948874/job/35799900676

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
