### PR TITLE
ci: check for benchmark regressions on PRs

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -78,6 +78,20 @@ benchmarks-pr-comment:
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA # The commit revision the project is built for.
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-py
 
+check-big-regressions:
+  stage: benchmarks
+  needs: [ microbenchmarks, benchmark-serverless ]
+  when: on_success
+  tags: ["arch:amd64"]
+  image: $MICROBENCHMARKS_CI_IMAGE
+  script:
+    - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
+    - git clone --branch dd-trace-py https://github.com/DataDog/benchmarking-platform /platform && cd /platform
+    - bp-runner bp-runner.fail-on-regression.yml --debug
+  variables:
+    # Gitlab and BP specific env vars. Do not modify.
+    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-py
+
 benchmark-serverless:
   stage: benchmarks
   image: $SLS_CI_IMAGE

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -25,7 +25,6 @@ variables:
     paths:
       - reports/
     expire_in: 3 months
-  allow_failure: true  # Allow failure, so partial results are uploaded
   variables:
     UPSTREAM_PROJECT_ID: $CI_PROJECT_ID # The ID of the current project. This ID is unique across all projects on the GitLab instance.
     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME # "dd-trace-py"

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -84,6 +84,7 @@ check-big-regressions:
   tags: ["arch:amd64"]
   image: $MICROBENCHMARKS_CI_IMAGE
   script:
+    - export ARTIFACTS_DIR="$(pwd)/reports/"
     - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
     - git clone --branch dd-trace-py https://github.com/DataDog/benchmarking-platform /platform && cd /platform
     - bp-runner bp-runner.fail-on-regression.yml --debug

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -80,7 +80,7 @@ benchmarks-pr-comment:
 check-big-regressions:
   stage: benchmarks
   needs: [ microbenchmarks, benchmark-serverless ]
-  when: on_success
+  when: always
   tags: ["arch:amd64"]
   image: $MICROBENCHMARKS_CI_IMAGE
   script:

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -1127,7 +1127,7 @@ class HTTPPropagator(object):
         :param dict headers: HTTP headers to extract tracing attributes.
         :return: New `Context` with propagated attributes.
         """
-        time.sleep(1)
+        time.sleep(0.2)
         context = Context()
         if not headers or not config._propagation_style_extract:
             return context

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -1,7 +1,6 @@
 import itertools
 import re
 import sys
-import time
 from typing import Any  # noqa:F401
 from typing import Dict  # noqa:F401
 from typing import FrozenSet  # noqa:F401
@@ -1127,7 +1126,6 @@ class HTTPPropagator(object):
         :param dict headers: HTTP headers to extract tracing attributes.
         :return: New `Context` with propagated attributes.
         """
-        time.sleep(0.2)
         context = Context()
         if not headers or not config._propagation_style_extract:
             return context

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -1,6 +1,7 @@
 import itertools
 import re
 import sys
+import time
 from typing import Any  # noqa:F401
 from typing import Dict  # noqa:F401
 from typing import FrozenSet  # noqa:F401
@@ -1126,6 +1127,7 @@ class HTTPPropagator(object):
         :param dict headers: HTTP headers to extract tracing attributes.
         :return: New `Context` with propagated attributes.
         """
+        time.sleep(1)
         context = Context()
         if not headers or not config._propagation_style_extract:
             return context


### PR DESCRIPTION
APMSP-1689

This PR also needs https://github.com/DataDog/benchmarking-platform/pull/125

After merging we will check and block PRs that introduce a microbenchmark regression of >20%.



## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
