### PR TITLE
fix(llmobs): fix content arg extraction for vertex ai integration

### DIFF
--- a/ddtrace/contrib/internal/vertexai/_utils.py
+++ b/ddtrace/contrib/internal/vertexai/_utils.py
@@ -183,7 +183,7 @@ def tag_request(span, integration, instance, args, kwargs):
     """
     # instance is either a chat session or a model itself
     model_instance = instance if isinstance(instance, GenerativeModel) else instance._model
-    contents = get_argument_value(args, kwargs, 0, "contents")
+    contents = get_argument_value(args, kwargs, 0, "content")
     history = _get_attr(instance, "_history", [])
     if history:
         if isinstance(contents, list):

--- a/ddtrace/contrib/internal/vertexai/_utils.py
+++ b/ddtrace/contrib/internal/vertexai/_utils.py
@@ -49,7 +49,6 @@ class TracedVertexAIStreamResponse(BaseTracedVertexAIStreamResponse):
             if self._dd_integration.is_pc_sampled_llmobs(self._dd_span):
                 self._kwargs["instance"] = self._model_instance
                 self._kwargs["history"] = self._history
-                self._kwargs["is_chat"] = self.is_chat
                 self._dd_integration.llmobs_set_tags(
                     self._dd_span, args=self._args, kwargs=self._kwargs, response=self._chunks
                 )
@@ -81,7 +80,6 @@ class TracedAsyncVertexAIStreamResponse(BaseTracedVertexAIStreamResponse):
             if self._dd_integration.is_pc_sampled_llmobs(self._dd_span):
                 self._kwargs["instance"] = self._model_instance
                 self._kwargs["history"] = self._history
-                self._kwargs["is_chat"] = self.is_chat
                 self._dd_integration.llmobs_set_tags(
                     self._dd_span, args=self._args, kwargs=self._kwargs, response=self._chunks
                 )

--- a/ddtrace/contrib/internal/vertexai/_utils.py
+++ b/ddtrace/contrib/internal/vertexai/_utils.py
@@ -177,13 +177,13 @@ def _tag_request_content(span, integration, content, content_idx):
         tag_request_content_part_google("vertexai", span, integration, part, part_idx, content_idx)
 
 
-def tag_request(span, integration, instance, args, kwargs):
+def tag_request(span, integration, instance, args, kwargs, is_chat):
     """Tag the generation span with request details.
     Includes capturing generation configuration, system prompt, and messages.
     """
     # instance is either a chat session or a model itself
     model_instance = instance if isinstance(instance, GenerativeModel) else instance._model
-    contents = get_argument_value(args, kwargs, 0, "content")
+    contents = get_argument_value(args, kwargs, 0, "content" if is_chat else "contents")
     history = _get_attr(instance, "_history", [])
     if history:
         if isinstance(contents, list):

--- a/ddtrace/contrib/internal/vertexai/_utils.py
+++ b/ddtrace/contrib/internal/vertexai/_utils.py
@@ -49,6 +49,7 @@ class TracedVertexAIStreamResponse(BaseTracedVertexAIStreamResponse):
             if self._dd_integration.is_pc_sampled_llmobs(self._dd_span):
                 self._kwargs["instance"] = self._model_instance
                 self._kwargs["history"] = self._history
+                self._kwargs["is_chat"] = self.is_chat
                 self._dd_integration.llmobs_set_tags(
                     self._dd_span, args=self._args, kwargs=self._kwargs, response=self._chunks
                 )
@@ -80,6 +81,7 @@ class TracedAsyncVertexAIStreamResponse(BaseTracedVertexAIStreamResponse):
             if self._dd_integration.is_pc_sampled_llmobs(self._dd_span):
                 self._kwargs["instance"] = self._model_instance
                 self._kwargs["history"] = self._history
+                self._kwargs["is_chat"] = self.is_chat
                 self._dd_integration.llmobs_set_tags(
                     self._dd_span, args=self._args, kwargs=self._kwargs, response=self._chunks
                 )

--- a/ddtrace/contrib/internal/vertexai/patch.py
+++ b/ddtrace/contrib/internal/vertexai/patch.py
@@ -64,7 +64,7 @@ def _traced_generate(vertexai, pin, func, instance, args, kwargs, model_instance
     # history must be copied since it is modified during the LLM interaction
     history = getattr(instance, "history", [])[:]
     try:
-        tag_request(span, integration, instance, args, kwargs)
+        tag_request(span, integration, instance, args, kwargs, is_chat)
         generations = func(*args, **kwargs)
         if stream:
             return TracedVertexAIStreamResponse(
@@ -99,7 +99,7 @@ async def _traced_agenerate(vertexai, pin, func, instance, args, kwargs, model_i
     # history must be copied since it is modified during the LLM interaction
     history = getattr(instance, "history", [])[:]
     try:
-        tag_request(span, integration, instance, args, kwargs)
+        tag_request(span, integration, instance, args, kwargs, is_chat)
         generations = await func(*args, **kwargs)
         if stream:
             return TracedAsyncVertexAIStreamResponse(

--- a/ddtrace/contrib/internal/vertexai/patch.py
+++ b/ddtrace/contrib/internal/vertexai/patch.py
@@ -80,6 +80,7 @@ def _traced_generate(vertexai, pin, func, instance, args, kwargs, model_instance
             if integration.is_pc_sampled_llmobs(span):
                 kwargs["instance"] = model_instance
                 kwargs["history"] = history
+                kwargs["is_chat"] = is_chat
                 integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=generations)
             span.finish()
     return generations
@@ -115,6 +116,7 @@ async def _traced_agenerate(vertexai, pin, func, instance, args, kwargs, model_i
             if integration.is_pc_sampled_llmobs(span):
                 kwargs["instance"] = model_instance
                 kwargs["history"] = history
+                kwargs["is_chat"] = is_chat
                 integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=generations)
             span.finish()
     return generations

--- a/ddtrace/contrib/internal/vertexai/patch.py
+++ b/ddtrace/contrib/internal/vertexai/patch.py
@@ -80,7 +80,6 @@ def _traced_generate(vertexai, pin, func, instance, args, kwargs, model_instance
             if integration.is_pc_sampled_llmobs(span):
                 kwargs["instance"] = model_instance
                 kwargs["history"] = history
-                kwargs["is_chat"] = is_chat
                 integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=generations)
             span.finish()
     return generations
@@ -116,7 +115,6 @@ async def _traced_agenerate(vertexai, pin, func, instance, args, kwargs, model_i
             if integration.is_pc_sampled_llmobs(span):
                 kwargs["instance"] = model_instance
                 kwargs["history"] = history
-                kwargs["is_chat"] = is_chat
                 integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=generations)
             span.finish()
     return generations

--- a/ddtrace/llmobs/_integrations/vertexai.py
+++ b/ddtrace/llmobs/_integrations/vertexai.py
@@ -45,7 +45,7 @@ class VertexAIIntegration(BaseLLMIntegration):
         metadata = llmobs_get_metadata_google(kwargs, instance)
 
         system_instruction = get_system_instructions_from_google_model(instance)
-        input_contents = get_argument_value(args, kwargs, 0, "contents")
+        input_contents = get_argument_value(args, kwargs, 0, "content")
         input_messages = self._extract_input_message(input_contents, history, system_instruction)
 
         output_messages = [{"content": ""}]

--- a/ddtrace/llmobs/_integrations/vertexai.py
+++ b/ddtrace/llmobs/_integrations/vertexai.py
@@ -5,7 +5,8 @@ from typing import List
 from typing import Optional
 
 from ddtrace import Span
-from ddtrace.internal.utils import get_argument_value, ArgumentError
+from ddtrace.internal.utils import ArgumentError
+from ddtrace.internal.utils import get_argument_value
 from ddtrace.llmobs._constants import INPUT_MESSAGES
 from ddtrace.llmobs._constants import METADATA
 from ddtrace.llmobs._constants import METRICS

--- a/ddtrace/llmobs/_integrations/vertexai.py
+++ b/ddtrace/llmobs/_integrations/vertexai.py
@@ -42,10 +42,11 @@ class VertexAIIntegration(BaseLLMIntegration):
     ) -> None:
         instance = kwargs.get("instance", None)
         history = kwargs.get("history", [])
+        is_chat = kwargs.get("is_chat", False)
         metadata = llmobs_get_metadata_google(kwargs, instance)
 
         system_instruction = get_system_instructions_from_google_model(instance)
-        input_contents = get_argument_value(args, kwargs, 0, "content")
+        input_contents = get_argument_value(args, kwargs, 0, "content" if is_chat else "contents")
         input_messages = self._extract_input_message(input_contents, history, system_instruction)
 
         output_messages = [{"content": ""}]

--- a/releasenotes/notes/fix-vertexai-content-extraction-b216207bd8192e5f.yaml
+++ b/releasenotes/notes/fix-vertexai-content-extraction-b216207bd8192e5f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    vertexai: Fixes chat.send_message content keyword argument extraction.

--- a/releasenotes/notes/fix-vertexai-content-extraction-b216207bd8192e5f.yaml
+++ b/releasenotes/notes/fix-vertexai-content-extraction-b216207bd8192e5f.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    vertexai: Fixes chat.send_message content keyword argument extraction.
+    vertexai: Resolves an issue with ``chat.send_message()`` where the content keyword argument was not parsed correctly.

--- a/tests/contrib/vertexai/test_vertexai.py
+++ b/tests/contrib/vertexai/test_vertexai.py
@@ -48,6 +48,17 @@ def test_vertexai_completion(vertexai):
         ),
     )
 
+@pytest.mark.snapshot(token="tests.contrib.vertexai.test_vertexai.test_vertexai_completion")
+def test_vertexai_completion_kw_content(vertexai):
+    llm = vertexai.generative_models.GenerativeModel("gemini-1.5-flash")
+    llm._prediction_client.responses["generate_content"].append(_mock_completion_response(MOCK_COMPLETION_SIMPLE_1))
+    llm.generate_content(
+        contents="Why do bears hibernate?",
+        generation_config=vertexai.generative_models.GenerationConfig(
+            stop_sequences=["x"], max_output_tokens=30, temperature=1.0
+        ),
+    )
+
 
 @pytest.mark.snapshot(
     token="tests.contrib.vertexai.test_vertexai.test_vertexai_completion_error",
@@ -279,6 +290,18 @@ def test_vertexai_chat(vertexai):
     chat = llm.start_chat()
     chat.send_message(
         "Why do bears hibernate?",
+        generation_config=vertexai.generative_models.GenerationConfig(
+            stop_sequences=["x"], max_output_tokens=30, temperature=1.0
+        ),
+    )
+
+@pytest.mark.snapshot(token="tests.contrib.vertexai.test_vertexai.test_vertexai_completion", ignores=["resource"])
+def test_vertexai_chat_kw_content(vertexai):
+    llm = vertexai.generative_models.GenerativeModel("gemini-1.5-flash")
+    llm._prediction_client.responses["generate_content"].append(_mock_completion_response(MOCK_COMPLETION_SIMPLE_1))
+    chat = llm.start_chat()
+    chat.send_message(
+        content="Why do bears hibernate?",
         generation_config=vertexai.generative_models.GenerationConfig(
             stop_sequences=["x"], max_output_tokens=30, temperature=1.0
         ),

--- a/tests/contrib/vertexai/test_vertexai.py
+++ b/tests/contrib/vertexai/test_vertexai.py
@@ -42,17 +42,6 @@ def test_vertexai_completion(vertexai):
     llm = vertexai.generative_models.GenerativeModel("gemini-1.5-flash")
     llm._prediction_client.responses["generate_content"].append(_mock_completion_response(MOCK_COMPLETION_SIMPLE_1))
     llm.generate_content(
-        "Why do bears hibernate?",
-        generation_config=vertexai.generative_models.GenerationConfig(
-            stop_sequences=["x"], max_output_tokens=30, temperature=1.0
-        ),
-    )
-
-@pytest.mark.snapshot(token="tests.contrib.vertexai.test_vertexai.test_vertexai_completion")
-def test_vertexai_completion_kw_content(vertexai):
-    llm = vertexai.generative_models.GenerativeModel("gemini-1.5-flash")
-    llm._prediction_client.responses["generate_content"].append(_mock_completion_response(MOCK_COMPLETION_SIMPLE_1))
-    llm.generate_content(
         contents="Why do bears hibernate?",
         generation_config=vertexai.generative_models.GenerationConfig(
             stop_sequences=["x"], max_output_tokens=30, temperature=1.0
@@ -129,7 +118,7 @@ def test_vertexai_completion_stream(vertexai):
         (_mock_completion_stream_chunk(chunk) for chunk in MOCK_COMPLETION_STREAM_CHUNKS)
     ]
     response = llm.generate_content(
-        "How big is the solar system?",
+        contents="How big is the solar system?",
         generation_config=vertexai.generative_models.GenerationConfig(
             stop_sequences=["x"], max_output_tokens=30, temperature=1.0
         ),
@@ -289,18 +278,6 @@ def test_vertexai_chat(vertexai):
     llm._prediction_client.responses["generate_content"].append(_mock_completion_response(MOCK_COMPLETION_SIMPLE_1))
     chat = llm.start_chat()
     chat.send_message(
-        "Why do bears hibernate?",
-        generation_config=vertexai.generative_models.GenerationConfig(
-            stop_sequences=["x"], max_output_tokens=30, temperature=1.0
-        ),
-    )
-
-@pytest.mark.snapshot(token="tests.contrib.vertexai.test_vertexai.test_vertexai_completion", ignores=["resource"])
-def test_vertexai_chat_kw_content(vertexai):
-    llm = vertexai.generative_models.GenerativeModel("gemini-1.5-flash")
-    llm._prediction_client.responses["generate_content"].append(_mock_completion_response(MOCK_COMPLETION_SIMPLE_1))
-    chat = llm.start_chat()
-    chat.send_message(
         content="Why do bears hibernate?",
         generation_config=vertexai.generative_models.GenerationConfig(
             stop_sequences=["x"], max_output_tokens=30, temperature=1.0
@@ -394,7 +371,7 @@ def test_vertexai_chat_stream(vertexai):
     ]
     chat = llm.start_chat()
     response = chat.send_message(
-        "How big is the solar system?",
+        content="How big is the solar system?",
         generation_config=vertexai.generative_models.GenerationConfig(
             stop_sequences=["x"], max_output_tokens=30, temperature=1.0
         ),

--- a/tests/contrib/vertexai/test_vertexai_llmobs.py
+++ b/tests/contrib/vertexai/test_vertexai_llmobs.py
@@ -30,6 +30,19 @@ class TestLLMObsVertexai:
         assert mock_llmobs_writer.enqueue.call_count == 1
         mock_llmobs_writer.enqueue.assert_called_with(expected_llmobs_span_event(span))
 
+    def test_completion_kw_content(self, vertexai, mock_llmobs_writer, mock_tracer):
+        llm = vertexai.generative_models.GenerativeModel("gemini-1.5-flash")
+        llm._prediction_client.responses["generate_content"].append(_mock_completion_response(MOCK_COMPLETION_SIMPLE_1))
+        llm.generate_content(
+            contents="Why do bears hibernate?",
+            generation_config=vertexai.generative_models.GenerationConfig(
+                stop_sequences=["x"], max_output_tokens=30, temperature=1.0
+            ),
+        )
+        span = mock_tracer.pop_traces()[0][0]
+        assert mock_llmobs_writer.enqueue.call_count == 1
+        mock_llmobs_writer.enqueue.assert_called_with(expected_llmobs_span_event(span))
+
     def test_completion_error(self, vertexai, mock_llmobs_writer, mock_tracer):
         llm = vertexai.generative_models.GenerativeModel("gemini-1.5-flash")
         llm._prediction_client.generate_content = mock.Mock()
@@ -294,6 +307,21 @@ class TestLLMObsVertexai:
         chat = llm.start_chat()
         chat.send_message(
             "Why do bears hibernate?",
+            generation_config=vertexai.generative_models.GenerationConfig(
+                stop_sequences=["x"], max_output_tokens=30, temperature=1.0
+            ),
+        )
+
+        span = mock_tracer.pop_traces()[0][0]
+        assert mock_llmobs_writer.enqueue.call_count == 1
+        mock_llmobs_writer.enqueue.assert_called_with(expected_llmobs_span_event(span))
+    
+    def test_chat_kw_content(self, vertexai, mock_llmobs_writer, mock_tracer):
+        llm = vertexai.generative_models.GenerativeModel("gemini-1.5-flash")
+        llm._prediction_client.responses["generate_content"].append(_mock_completion_response(MOCK_COMPLETION_SIMPLE_1))
+        chat = llm.start_chat()
+        chat.send_message(
+            content="Why do bears hibernate?",
             generation_config=vertexai.generative_models.GenerationConfig(
                 stop_sequences=["x"], max_output_tokens=30, temperature=1.0
             ),

--- a/tests/contrib/vertexai/test_vertexai_llmobs.py
+++ b/tests/contrib/vertexai/test_vertexai_llmobs.py
@@ -21,19 +21,6 @@ class TestLLMObsVertexai:
         llm = vertexai.generative_models.GenerativeModel("gemini-1.5-flash")
         llm._prediction_client.responses["generate_content"].append(_mock_completion_response(MOCK_COMPLETION_SIMPLE_1))
         llm.generate_content(
-            "Why do bears hibernate?",
-            generation_config=vertexai.generative_models.GenerationConfig(
-                stop_sequences=["x"], max_output_tokens=30, temperature=1.0
-            ),
-        )
-        span = mock_tracer.pop_traces()[0][0]
-        assert mock_llmobs_writer.enqueue.call_count == 1
-        mock_llmobs_writer.enqueue.assert_called_with(expected_llmobs_span_event(span))
-
-    def test_completion_kw_content(self, vertexai, mock_llmobs_writer, mock_tracer):
-        llm = vertexai.generative_models.GenerativeModel("gemini-1.5-flash")
-        llm._prediction_client.responses["generate_content"].append(_mock_completion_response(MOCK_COMPLETION_SIMPLE_1))
-        llm.generate_content(
             contents="Why do bears hibernate?",
             generation_config=vertexai.generative_models.GenerationConfig(
                 stop_sequences=["x"], max_output_tokens=30, temperature=1.0
@@ -139,7 +126,7 @@ class TestLLMObsVertexai:
             (_mock_completion_stream_chunk(chunk) for chunk in MOCK_COMPLETION_STREAM_CHUNKS)
         ]
         response = llm.generate_content(
-            "How big is the solar system?",
+            contents="How big is the solar system?",
             generation_config=vertexai.generative_models.GenerationConfig(
                 stop_sequences=["x"], max_output_tokens=30, temperature=1.0
             ),
@@ -306,21 +293,6 @@ class TestLLMObsVertexai:
         llm._prediction_client.responses["generate_content"].append(_mock_completion_response(MOCK_COMPLETION_SIMPLE_1))
         chat = llm.start_chat()
         chat.send_message(
-            "Why do bears hibernate?",
-            generation_config=vertexai.generative_models.GenerationConfig(
-                stop_sequences=["x"], max_output_tokens=30, temperature=1.0
-            ),
-        )
-
-        span = mock_tracer.pop_traces()[0][0]
-        assert mock_llmobs_writer.enqueue.call_count == 1
-        mock_llmobs_writer.enqueue.assert_called_with(expected_llmobs_span_event(span))
-    
-    def test_chat_kw_content(self, vertexai, mock_llmobs_writer, mock_tracer):
-        llm = vertexai.generative_models.GenerativeModel("gemini-1.5-flash")
-        llm._prediction_client.responses["generate_content"].append(_mock_completion_response(MOCK_COMPLETION_SIMPLE_1))
-        chat = llm.start_chat()
-        chat.send_message(
             content="Why do bears hibernate?",
             generation_config=vertexai.generative_models.GenerationConfig(
                 stop_sequences=["x"], max_output_tokens=30, temperature=1.0
@@ -417,7 +389,7 @@ class TestLLMObsVertexai:
         ]
         chat = llm.start_chat()
         response = chat.send_message(
-            "How big is the solar system?",
+            content="How big is the solar system?",
             generation_config=vertexai.generative_models.GenerationConfig(
                 stop_sequences=["x"], max_output_tokens=30, temperature=1.0
             ),


### PR DESCRIPTION
In [MLOS-42](https://datadoghq.atlassian.net/browse/MLOS-42) a customer was experiencing the following error: 
```
ddtrace.internal.utils.ArgumentError: contents (at position 0)
``` 
where the `content` argument was not being extracted properly from the list of keyword arguments inputted into the `chat.send_message` method. 

This is because in the Vertex AI integration, we look for the `contents` keyword argument. However, the content field is titled `content` in the [send_message](https://github.com/google-gemini/generative-ai-python/blob/main/google/generativeai/generative_models.py#L514) method and `contents` in the [generate_content](https://github.com/google-gemini/generative-ai-python/blob/main/google/generativeai/generative_models.py#L239) method, so it is necessary to differentiate between these two cases.

This PR is a small fix that corrects this error by differentiating between chat and completion requests in order to extract either `content` or `contents` respectively.
 
## Testing

### Automatic Testing
I edited some of the currently existing tests to use the keyword argument extraction rather than the positional argument extraction to get the content in order to confirm that this fix resolves the error.

### Manual Testing
Running the following code reproduced the error; furthermore, I confirmed that with this fix, the error is no longer present and the request completes successfully.
```
llm = GenerativeModel("gemini-1.5-flash")
chat = llm.start_chat()
resp = chat.send_message(content="hello")
```

I also verified that the following code which uses the generate_content method is not impacted (continues to work as before) as a result of this fix.

```
llm = GenerativeModel("gemini-1.5-flash")
resp = llm.generate_content(contents="hello")
```


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)


[MLOS-42]: https://datadoghq.atlassian.net/browse/MLOS-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ