### PR TITLE
chore(profiling): remove `stack_v2_enabled=False` tests

### DIFF
--- a/tests/profiling_v2/collector/test_stack.py
+++ b/tests/profiling_v2/collector/test_stack.py
@@ -82,7 +82,7 @@ def test_stack_locations(tmp_path):
     def foo():
         bar()
 
-    with stack.StackCollector(None, _stack_collector_v2_enabled=stack_v2_enabled):
+    with stack.StackCollector(None, _stack_collector_v2_enabled=True):
         for _ in range(10):
             foo()
     ddup.upload()
@@ -241,7 +241,7 @@ def test_push_non_web_span(tmp_path, tracer):
         tracer=tracer,
         endpoint_collection_enabled=True,
         ignore_profiler=True,  # this is not necessary, but it's here to trim samples
-        _stack_collector_v2_enabled=stack_v2_enabled,
+        _stack_collector_v2_enabled=True,
     ):
         with tracer.trace("foobar", resource=resource, span_type=span_type) as span:
             span_id = span.span_id

--- a/tests/profiling_v2/collector/test_stack.py
+++ b/tests/profiling_v2/collector/test_stack.py
@@ -61,9 +61,8 @@ def test_collect_truncate():
         assert len(sample.location_id) <= max_nframes + 2, len(sample.location_id)
 
 
-@pytest.mark.parametrize("stack_v2_enabled", [True, False])
-def test_stack_locations(stack_v2_enabled, tmp_path):
-    if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
+def test_stack_locations(tmp_path):
+    if sys.version_info[:2] == (3, 7):
         pytest.skip("stack_v2 is not supported on Python 3.7")
 
     test_name = "test_stack_locations"
@@ -117,9 +116,8 @@ def test_stack_locations(stack_v2_enabled, tmp_path):
     pprof_utils.assert_profile_has_sample(profile, samples=samples, expected_sample=expected_sample)
 
 
-@pytest.mark.parametrize("stack_v2_enabled", [True, False])
-def test_push_span(stack_v2_enabled, tmp_path, tracer):
-    if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
+def test_push_span(tmp_path, tracer):
+    if sys.version_info[:2] == (3, 7):
         pytest.skip("stack_v2 is not supported on Python 3.7")
 
     test_name = "test_push_span"
@@ -140,7 +138,7 @@ def test_push_span(stack_v2_enabled, tmp_path, tracer):
         tracer=tracer,
         endpoint_collection_enabled=True,
         ignore_profiler=True,  # this is not necessary, but it's here to trim samples
-        _stack_collector_v2_enabled=stack_v2_enabled,
+        _stack_collector_v2_enabled=True,
     ):
         with tracer.trace("foobar", resource=resource, span_type=span_type) as span:
             span_id = span.span_id
@@ -221,9 +219,8 @@ def test_push_span_unregister_thread(tmp_path, monkeypatch, tracer):
         unregister_thread.assert_called_with(thread_id)
 
 
-@pytest.mark.parametrize("stack_v2_enabled", [True, False])
-def test_push_non_web_span(stack_v2_enabled, tmp_path, tracer):
-    if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
+def test_push_non_web_span(tmp_path, tracer):
+    if sys.version_info[:2] == (3, 7):
         pytest.skip("stack_v2 is not supported on Python 3.7")
 
     tracer._endpoint_call_counter_span_processor.enable()
@@ -269,10 +266,9 @@ def test_push_non_web_span(stack_v2_enabled, tmp_path, tracer):
         )
 
 
-@pytest.mark.parametrize("stack_v2_enabled", [True, False])
-def test_push_span_none_span_type(stack_v2_enabled, tmp_path, tracer):
+def test_push_span_none_span_type(tmp_path, tracer):
     # Test for https://github.com/DataDog/dd-trace-py/issues/11141
-    if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
+    if sys.version_info[:2] == (3, 7):
         pytest.skip("stack_v2 is not supported on Python 3.7")
 
     test_name = "test_push_span_none_span_type"
@@ -292,7 +288,7 @@ def test_push_span_none_span_type(stack_v2_enabled, tmp_path, tracer):
         tracer=tracer,
         endpoint_collection_enabled=True,
         ignore_profiler=True,  # this is not necessary, but it's here to trim samples
-        _stack_collector_v2_enabled=stack_v2_enabled,
+        _stack_collector_v2_enabled=True,
     ):
         # Explicitly set None span_type as the default could change in the
         # future.
@@ -484,9 +480,8 @@ def test_exception_collection_trace(stack_v2_enabled, tmp_path, tracer):
             )
 
 
-@pytest.mark.parametrize("stack_v2_enabled", [True, False])
-def test_collect_once_with_class(stack_v2_enabled, tmp_path):
-    if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
+def test_collect_once_with_class(tmp_path):
+    if sys.version_info[:2] == (3, 7):
         pytest.skip("stack_v2 is not supported on Python 3.7")
 
     class SomeClass(object):
@@ -506,7 +501,7 @@ def test_collect_once_with_class(stack_v2_enabled, tmp_path):
     ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
     ddup.start()
 
-    with stack.StackCollector(None, ignore_profiler=True, _stack_collector_v2_enabled=stack_v2_enabled):
+    with stack.StackCollector(None, ignore_profiler=True, _stack_collector_v2_enabled=True):
         SomeClass.sleep_class()
 
     ddup.upload()
@@ -521,7 +516,7 @@ def test_collect_once_with_class(stack_v2_enabled, tmp_path):
         expected_sample=pprof_utils.StackEvent(
             thread_id=_thread.get_ident(),
             thread_name="MainThread",
-            class_name="SomeClass" if not stack_v2_enabled else None,
+            class_name=None,
             locations=[
                 pprof_utils.StackLocation(
                     function_name="sleep_instance",
@@ -543,9 +538,8 @@ def test_collect_once_with_class(stack_v2_enabled, tmp_path):
     )
 
 
-@pytest.mark.parametrize("stack_v2_enabled", [True, False])
-def test_collect_once_with_class_not_right_type(stack_v2_enabled, tmp_path):
-    if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
+def test_collect_once_with_class_not_right_type(tmp_path):
+    if sys.version_info[:2] == (3, 7):
         pytest.skip("stack_v2 is not supported on Python 3.7")
 
     class SomeClass(object):
@@ -565,7 +559,7 @@ def test_collect_once_with_class_not_right_type(stack_v2_enabled, tmp_path):
     ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
     ddup.start()
 
-    with stack.StackCollector(None, ignore_profiler=True, _stack_collector_v2_enabled=stack_v2_enabled):
+    with stack.StackCollector(None, ignore_profiler=True, _stack_collector_v2_enabled=True):
         SomeClass.sleep_class(123)
 
     ddup.upload()

--- a/tests/profiling_v2/collector/test_stack.py
+++ b/tests/profiling_v2/collector/test_stack.py
@@ -29,7 +29,6 @@ TESTING_GEVENT = os.getenv("DD_PROFILE_TEST_GEVENT", False) and (
     env=dict(
         DD_PROFILING_MAX_FRAMES="5",
         DD_PROFILING_OUTPUT_PPROF="/tmp/test_collect_truncate",
-        DD_PROFILING_STACK_V2_ENABLED="1",
     )
 )
 @pytest.mark.skipif(sys.version_info[:2] == (3, 7), reason="stack_v2 is not supported on Python 3.7")
@@ -516,7 +515,6 @@ def test_collect_once_with_class(tmp_path):
         expected_sample=pprof_utils.StackEvent(
             thread_id=_thread.get_ident(),
             thread_name="MainThread",
-            class_name=None,
             locations=[
                 pprof_utils.StackLocation(
                     function_name="sleep_instance",
@@ -531,7 +529,7 @@ def test_collect_once_with_class(tmp_path):
                 pprof_utils.StackLocation(
                     function_name="test_collect_once_with_class",
                     filename="test_stack.py",
-                    line_no=test_collect_once_with_class.__code__.co_firstlineno + 23,
+                    line_no=test_collect_once_with_class.__code__.co_firstlineno + 22,
                 ),
             ],
         ),
@@ -574,9 +572,6 @@ def test_collect_once_with_class_not_right_type(tmp_path):
         expected_sample=pprof_utils.StackEvent(
             thread_id=_thread.get_ident(),
             thread_name="MainThread",
-            # stack v1 relied on using cls and self to figure out class name
-            # so we can't find it here.
-            class_name=None,
             locations=[
                 pprof_utils.StackLocation(
                     function_name="sleep_instance",
@@ -591,7 +586,7 @@ def test_collect_once_with_class_not_right_type(tmp_path):
                 pprof_utils.StackLocation(
                     function_name="test_collect_once_with_class_not_right_type",
                     filename="test_stack.py",
-                    line_no=test_collect_once_with_class_not_right_type.__code__.co_firstlineno + 23,
+                    line_no=test_collect_once_with_class_not_right_type.__code__.co_firstlineno + 22,
                 ),
             ],
         ),

--- a/tests/profiling_v2/collector/test_stack_asyncio.py
+++ b/tests/profiling_v2/collector/test_stack_asyncio.py
@@ -7,7 +7,6 @@ import pytest
 @pytest.mark.subprocess(
     env=dict(
         DD_PROFILING_OUTPUT_PPROF="/tmp/test_stack_asyncio",
-        DD_PROFILING_STACK_V2_ENABLED="true",
     ),
 )
 def test_asyncio():

--- a/tests/profiling_v2/test_accuracy.py
+++ b/tests/profiling_v2/test_accuracy.py
@@ -4,57 +4,7 @@ import sys
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(DD_PROFILING_MAX_TIME_USAGE_PCT="100", DD_PROFILING_OUTPUT_PPROF="/tmp/test_accuracy_libdd.pprof")
-)
-def test_accuracy_libdd():
-    import collections
-    import os
-
-    from ddtrace.profiling import profiler
-    from tests.profiling.collector import pprof_utils
-    from tests.profiling.test_accuracy import assert_almost_equal
-    from tests.profiling.test_accuracy import spend_16
-
-    # Set this to 100 so we don't sleep too often and mess with the precision.
-    p = profiler.Profiler()
-    p.start()
-    spend_16()
-    p.stop()
-    wall_times = collections.defaultdict(lambda: 0)
-    cpu_times = collections.defaultdict(lambda: 0)
-    profile = pprof_utils.parse_profile(os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid()))
-
-    for sample in profile.sample:
-        wall_time_index = pprof_utils.get_sample_type_index(profile, "wall-time")
-
-        wall_time_spent_ns = sample.value[wall_time_index]
-        cpu_time_index = pprof_utils.get_sample_type_index(profile, "cpu-time")
-        cpu_time_spent_ns = sample.value[cpu_time_index]
-
-        for location_id in sample.location_id:
-            location = pprof_utils.get_location_with_id(profile, location_id)
-            line = location.line[0]
-            function = pprof_utils.get_function_with_id(profile, line.function_id)
-            function_name = profile.string_table[function.name]
-            wall_times[function_name] += wall_time_spent_ns
-            cpu_times[function_name] += cpu_time_spent_ns
-
-    assert_almost_equal(wall_times["spend_3"], 9e9)
-    assert_almost_equal(wall_times["spend_1"], 2e9)
-    assert_almost_equal(wall_times["spend_4"], 4e9)
-    assert_almost_equal(wall_times["spend_16"], 16e9)
-    assert_almost_equal(wall_times["spend_7"], 7e9)
-
-    assert_almost_equal(wall_times["spend_cpu_2"], 2e9, tolerance=0.09)
-    assert_almost_equal(wall_times["spend_cpu_3"], 3e9, tolerance=0.09)
-    assert_almost_equal(cpu_times["spend_cpu_2"], 2e9, tolerance=0.09)
-    assert_almost_equal(cpu_times["spend_cpu_3"], 3e9, tolerance=0.09)
-
-
-@pytest.mark.subprocess(
-    env=dict(DD_PROFILING_STACK_V2_ENABLED="1", DD_PROFILING_OUTPUT_PPROF="/tmp/test_accuracy_stack_v2.pprof")
-)
+@pytest.mark.subprocess(env=dict(DD_PROFILING_OUTPUT_PPROF="/tmp/test_accuracy_stack_v2.pprof"))
 @pytest.mark.skipif(sys.version_info[:2] == (3, 7), reason="stack_v2 is not supported on Python 3.7")
 def test_accuracy_stack_v2():
     import collections

--- a/tests/profiling_v2/test_gunicorn.py
+++ b/tests/profiling_v2/test_gunicorn.py
@@ -52,9 +52,6 @@ def _run_gunicorn(*args):
 def gunicorn(monkeypatch):
     monkeypatch.setenv("DD_PROFILING_IGNORE_PROFILER", "1")
     monkeypatch.setenv("DD_PROFILING_ENABLED", "1")
-    # This was needed for the gunicorn process to start and print worker startup
-    # messages. Without this, the test can't find the worker PIDs.
-    monkeypatch.setenv("DD_PROFILING_STACK_V2_ENABLED", "1")
 
     yield _run_gunicorn
 

--- a/tests/profiling_v2/test_main.py
+++ b/tests/profiling_v2/test_main.py
@@ -155,7 +155,7 @@ methods = multiprocessing.get_all_start_methods()
     "method",
     set(methods) - {"forkserver", "fork"},
 )
-def test_multiprocessing( method, tmp_path):
+def test_multiprocessing(method, tmp_path):
     if sys.version_info[:2] == (3, 7):
         pytest.skip("stack_v2 is not supported on Python 3.7")
     filename = str(tmp_path / "pprof")

--- a/tests/profiling_v2/test_main.py
+++ b/tests/profiling_v2/test_main.py
@@ -11,13 +11,11 @@ from tests.utils import call_program
 from tests.utils import flaky
 
 
-@pytest.mark.parametrize("stack_v2_enabled", [True, False])
-def test_call_script(stack_v2_enabled):
-    if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
+def test_call_script():
+    if sys.version_info[:2] == (3, 7):
         pytest.skip("stack_v2 is not supported on Python 3.7")
     env = os.environ.copy()
     env["DD_PROFILING_ENABLED"] = "1"
-    env["DD_PROFILING_STACK_V2_ENABLED"] = "1" if stack_v2_enabled else "0"
     stdout, stderr, exitcode, _ = call_program(
         "ddtrace-run", sys.executable, os.path.join(os.path.dirname(__file__), "simple_program.py"), env=env
     )
@@ -28,28 +26,25 @@ def test_call_script(stack_v2_enabled):
     hello, interval, pid, stack_v2 = list(s.strip() for s in stdout.decode().strip().split("\n"))
     assert hello == "hello world", stdout.decode().strip()
     assert float(interval) >= 0.01, stdout.decode().strip()
-    assert stack_v2 == str(stack_v2_enabled)
+    assert stack_v2 == str(True)
 
 
 @pytest.mark.skipif(not os.getenv("DD_PROFILE_TEST_GEVENT", False), reason="Not testing gevent")
-@pytest.mark.parametrize("stack_v2_enabled", [True, False])
-def test_call_script_gevent(stack_v2_enabled):
-    if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
+def test_call_script_gevent():
+    if sys.version_info[:2] == (3, 7):
         pytest.skip("stack_v2 is not supported on Python 3.7")
-    if sys.version_info[:2] == (3, 8) and stack_v2_enabled:
+    if sys.version_info[:2] == (3, 8):
         pytest.skip("this test is flaky on 3.8 with stack v2")
     env = os.environ.copy()
     env["DD_PROFILING_ENABLED"] = "1"
-    env["DD_PROFILING_STACK_V2_ENABLED"] = "1" if stack_v2_enabled else "0"
     stdout, stderr, exitcode, pid = call_program(
         sys.executable, os.path.join(os.path.dirname(__file__), "simple_program_gevent.py"), env=env
     )
     assert exitcode == 0, (stdout, stderr)
 
 
-@pytest.mark.parametrize("stack_v2_enabled", [True, False])
-def test_call_script_pprof_output(stack_v2_enabled, tmp_path):
-    if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
+def test_call_script_pprof_output(tmp_path):
+    if sys.version_info[:2] == (3, 7):
         pytest.skip("stack_v2 is not supported on Python 3.7")
 
     """This checks if the pprof output and atexit register work correctly.
@@ -61,7 +56,6 @@ def test_call_script_pprof_output(stack_v2_enabled, tmp_path):
     env["DD_PROFILING_OUTPUT_PPROF"] = filename
     env["DD_PROFILING_CAPTURE_PCT"] = "1"
     env["DD_PROFILING_ENABLED"] = "1"
-    env["DD_PROFILING_STACK_V2_ENABLED"] = "1" if stack_v2_enabled else "0"
     stdout, stderr, exitcode, _ = call_program(
         "ddtrace-run",
         sys.executable,
@@ -78,17 +72,15 @@ def test_call_script_pprof_output(stack_v2_enabled, tmp_path):
     assert len(samples) > 0
 
 
-@pytest.mark.parametrize("stack_v2_enabled", [True, False])
 @pytest.mark.skipif(sys.platform == "win32", reason="fork only available on Unix")
-def test_fork(stack_v2_enabled, tmp_path):
-    if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
+def test_fork(tmp_path):
+    if sys.version_info[:2] == (3, 7):
         pytest.skip("stack_v2 is not supported on Python 3.7")
 
     filename = str(tmp_path / "pprof")
     env = os.environ.copy()
     env["DD_PROFILING_OUTPUT_PPROF"] = filename
     env["DD_PROFILING_CAPTURE_PCT"] = "100"
-    env["DD_PROFILING_STACK_V2_ENABLED"] = "1" if stack_v2_enabled else "0"
     stdout, stderr, exitcode, pid = call_program(
         "python", os.path.join(os.path.dirname(__file__), "simple_program_fork.py"), env=env
     )
@@ -144,14 +136,12 @@ def test_fork(stack_v2_enabled, tmp_path):
     )
 
 
-@pytest.mark.parametrize("stack_v2_enabled", [True, False])
 @pytest.mark.skipif(sys.platform == "win32", reason="fork only available on Unix")
 @pytest.mark.skipif(not os.getenv("DD_PROFILE_TEST_GEVENT", False), reason="Not testing gevent")
-def test_fork_gevent(stack_v2_enabled):
-    if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
+def test_fork_gevent():
+    if sys.version_info[:2] == (3, 7):
         pytest.skip("stack_v2 is not supported on Python 3.7")
     env = os.environ.copy()
-    env["DD_PROFILING_STACK_V2_ENABLED"] = "1" if stack_v2_enabled else "0"
     stdout, stderr, exitcode, pid = call_program(
         "python", os.path.join(os.path.dirname(__file__), "../profiling", "gevent_fork.py"), env=env
     )
@@ -161,20 +151,18 @@ def test_fork_gevent(stack_v2_enabled):
 methods = multiprocessing.get_all_start_methods()
 
 
-@pytest.mark.parametrize("stack_v2_enabled", [True, False])
 @pytest.mark.parametrize(
     "method",
     set(methods) - {"forkserver", "fork"},
 )
-def test_multiprocessing(stack_v2_enabled, method, tmp_path):
-    if sys.version_info[:2] == (3, 7) and stack_v2_enabled:
+def test_multiprocessing( method, tmp_path):
+    if sys.version_info[:2] == (3, 7):
         pytest.skip("stack_v2 is not supported on Python 3.7")
     filename = str(tmp_path / "pprof")
     env = os.environ.copy()
     env["DD_PROFILING_OUTPUT_PPROF"] = filename
     env["DD_PROFILING_ENABLED"] = "1"
     env["DD_PROFILING_CAPTURE_PCT"] = "1"
-    env["DD_PROFILING_STACK_V2_ENABLED"] = "1" if stack_v2_enabled else "0"
     stdout, stderr, exitcode, _ = call_program(
         "ddtrace-run",
         sys.executable,
@@ -208,8 +196,6 @@ def test_memalloc_no_init_error_on_fork():
     os.waitpid(pid, 0)
 
 
-# Not parametrizing with stack_v2_enabled as subprocess mark doesn't support
-# parametrized tests and this only tests our start up code.
 @pytest.mark.subprocess(
     ddtrace_run=True,
     env=dict(


### PR DESCRIPTION
`profile 16/20` has been flaky with the following test
```
FAILED tests/profiling_v2/test_main.py::test_call_script_gevent[False] - AssertionError: (b'', b'')
assert -11 == 0
```
Since the test is for stack v1+libdd exporter and we don't plan to fix stack v1, we're removing those tests. 


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
