### PR TITLE
ci(profiling): ignore deprecated function `tp_print` warning

### DIFF
--- a/ddtrace/internal/datadog/profiling/crashtracker/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/crashtracker/CMakeLists.txt
@@ -46,6 +46,10 @@ add_library(${EXTENSION_NAME} SHARED ${CRASHTRACKER_CPP_SRC})
 add_ddup_config(${EXTENSION_NAME})
 # Cython generates code that produces errors for the following, so relax compile options
 target_compile_options(${EXTENSION_NAME} PRIVATE -Wno-old-style-cast -Wno-shadow -Wno-address)
+# tp_print is marked deprecated in Python 3.8, but cython still generates code using it
+if("${Python3_VERSION_MINOR}" STREQUAL "8")
+    target_compile_options(${EXTENSION_NAME} PRIVATE -Wno-deprecated-declarations)
+endif()
 
 # cmake may mutate the name of the library (e.g., lib- and -.so for dynamic libraries). This suppresses that behavior,
 # which is required to ensure all paths can be inferred correctly by setup.py.

--- a/ddtrace/internal/datadog/profiling/ddup/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/ddup/CMakeLists.txt
@@ -49,6 +49,10 @@ add_library(${EXTENSION_NAME} SHARED ${DDUP_CPP_SRC})
 add_ddup_config(${EXTENSION_NAME})
 # Cython generates code that produces errors for the following, so relax compile options
 target_compile_options(${EXTENSION_NAME} PRIVATE -Wno-old-style-cast -Wno-shadow -Wno-address)
+# tp_print is marked deprecated in Python 3.8, but cython still generates code using it
+if("${Python3_VERSION_MINOR}" STREQUAL "8")
+    target_compile_options(${EXTENSION_NAME} PRIVATE -Wno-deprecated-declarations)
+endif()
 
 # cmake may mutate the name of the library (e.g., lib- and -.so for dynamic libraries). This suppresses that behavior,
 # which is required to ensure all paths can be inferred correctly by setup.py.


### PR DESCRIPTION
## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
