### PR TITLE
ci: fix bm test to reflect behavior of config for propagation

### DIFF
--- a/benchmarks/http_propagation_extract/scenario.py
+++ b/benchmarks/http_propagation_extract/scenario.py
@@ -6,6 +6,7 @@ from ddtrace import config
 from ddtrace.propagation import _utils as utils
 from ddtrace.propagation import http
 
+
 class HTTPPropagationExtract(bm.Scenario):
     headers: str
     extra_headers: int

--- a/benchmarks/http_propagation_extract/scenario.py
+++ b/benchmarks/http_propagation_extract/scenario.py
@@ -6,7 +6,6 @@ from ddtrace import config
 from ddtrace.propagation import _utils as utils
 from ddtrace.propagation import http
 
-
 class HTTPPropagationExtract(bm.Scenario):
     headers: str
     extra_headers: int
@@ -29,6 +28,8 @@ class HTTPPropagationExtract(bm.Scenario):
     def run(self):
         if self.styles:
             config._propagation_style_extract = self.styles.split(",") if ("," in self.styles) else [self.styles]
+            if "none" in config._propagation_style_extract:
+                config._propagation_style_extract.remove("none")
 
         headers = self.generate_headers()
 

--- a/ddtrace/settings/config.py
+++ b/ddtrace/settings/config.py
@@ -150,15 +150,13 @@ def _parse_propagation_styles(styles_str):
                 category=DDTraceDeprecationWarning,
             )
             style = PROPAGATION_STYLE_B3_SINGLE
+        # None has no propagator so we pull it out
         if not style or style == _PROPAGATION_STYLE_NONE:
             continue
         if style not in PROPAGATION_STYLE_ALL:
             log.warning("Unknown DD_TRACE_PROPAGATION_STYLE: {!r}, allowed values are %r", style, PROPAGATION_STYLE_ALL)
             continue
         styles.append(style)
-    # Remove "none" if it's present since it lacks a propagator
-    if _PROPAGATION_STYLE_NONE in styles:
-        styles.remove(_PROPAGATION_STYLE_NONE)
     return styles
 
 


### PR DESCRIPTION
This fixes the benchmarking test to reflect the config change made in this PR: https://github.com/DataDog/dd-trace-py/pull/11925

It also updates the config behavior slightly since the removing of "none" propagation style at the end of the loop was repetitive since we were already excluding that value.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
