### PR TITLE
feat(tracing): add flag to revert aiohttp behavior to avoid mem leak

### DIFF
--- a/ddtrace/contrib/internal/aiohttp/middlewares.py
+++ b/ddtrace/contrib/internal/aiohttp/middlewares.py
@@ -1,4 +1,3 @@
-from aiohttp import web
 from aiohttp.web_urldispatcher import SystemRoute
 
 from ddtrace import config
@@ -70,8 +69,6 @@ async def trace_middleware(app, handler):
         request[REQUEST_CONFIG_KEY] = app[CONFIG_KEY]
         try:
             response = await handler(request)
-            if isinstance(response, web.StreamResponse):
-                request.task.add_done_callback(lambda _: finish_request_span(request, response))
             return response
         except Exception:
             request_span.set_traceback()
@@ -80,7 +77,11 @@ async def trace_middleware(app, handler):
     return attach_context
 
 
-def finish_request_span(request, response):
+async def on_prepare(request, response):
+    """
+    The on_prepare signal is used to close the request span that is created during
+    the trace middleware execution.
+    """
     # safe-guard: discard if we don't have a request span
     request_span = request.get(REQUEST_SPAN_KEY, None)
     if not request_span:
@@ -134,18 +135,6 @@ def finish_request_span(request, response):
     )
 
     request_span.finish()
-
-
-async def on_prepare(request, response):
-    """
-    The on_prepare signal is used to close the request span that is created during
-    the trace middleware execution.
-    """
-    # NB isinstance is not appropriate here because StreamResponse is a parent of the other
-    # aiohttp response types
-    if type(response) is web.StreamResponse and not response.task.done():
-        return
-    finish_request_span(request, response)
 
 
 def trace_app(app, tracer, service="aiohttp-web"):


### PR DESCRIPTION
https://github.com/DataDog/dd-trace-py/pull/7551 introduced a potential memory leak when using aiohttp integration.



## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
