### PR TITLE
chore(libdatadog): bump libdatadog to v15.0.0

### DIFF
--- a/ddtrace/internal/datadog/profiling/cmake/FindLibdatadog.cmake
+++ b/ddtrace/internal/datadog/profiling/cmake/FindLibdatadog.cmake
@@ -17,17 +17,17 @@ include(FetchContent)
 # Set version if not already set
 if(NOT DEFINED TAG_LIBDATADOG)
     set(TAG_LIBDATADOG
-        "v14.3.1"
+        "v15.0.0"
         CACHE STRING "libdatadog github tag")
 endif()
 
 if(NOT DEFINED DD_CHECKSUMS)
     set(DD_CHECKSUMS
-        "57f83aff275628bb1af89c22bb4bd696726daf2a9e09b6cd0d966b29e65a7ad6 libdatadog-aarch64-alpine-linux-musl.tar.gz"
-        "2be2efa98dfc32f109abdd79242a8e046a7a300c77634135eb293e000ecd4a4c libdatadog-aarch64-apple-darwin.tar.gz"
-        "36db8d50ccabb71571158ea13835c0f1d05d30b32135385f97c16343cfb6ddd4 libdatadog-aarch64-unknown-linux-gnu.tar.gz"
-        "2f61fd21cf2f8147743e414b4a8c77250a17be3aecc42a69ffe54f0a603d5c92 libdatadog-x86_64-alpine-linux-musl.tar.gz"
-        "f01f05600591063eba4faf388f54c155ab4e6302e5776c7855e3734955f7daf7 libdatadog-x86_64-unknown-linux-gnu.tar.gz")
+        "d5b969b293e5a9e5e36404a553bbafdd55ff6af0b089698bd989a878534df0c7 libdatadog-aarch64-alpine-linux-musl.tar.gz"
+        "4540ffb8ccb671550a39ba79226117086582c1eaf9714180a9e26bd6bb175860 libdatadog-aarch64-apple-darwin.tar.gz"
+        "31bceab4f56873b03b3728760d30e3abc493d32ca8fdc9e1f2ec2147ef4d5424 libdatadog-aarch64-unknown-linux-gnu.tar.gz"
+        "530348c4b02cc7096de2231476ec12db82e2cc6de12a87e5b28af47ea73d4e56 libdatadog-x86_64-alpine-linux-musl.tar.gz"
+        "5073ffc657bc4698f8bdd4935475734577bfb18c54dcbebc4f7d8c7595626e52 libdatadog-x86_64-unknown-linux-gnu.tar.gz")
 endif()
 
 # Determine platform-specific tarball name in a way that conforms to the libdatadog naming scheme in Github releases

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/crashtracker.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/crashtracker.cpp
@@ -207,8 +207,8 @@ Datadog::Crashtracker::start()
 
     auto result = ddog_crasht_init(config, receiver_config, metadata);
     ddog_Vec_Tag_drop(tags);
-    if (result.tag != DDOG_CRASHT_RESULT_OK) { // NOLINT (cppcoreguidelines-pro-type-union-access)
-        auto err = result.err;                 // NOLINT (cppcoreguidelines-pro-type-union-access)
+    if (result.tag != DDOG_VOID_RESULT_OK) { // NOLINT (cppcoreguidelines-pro-type-union-access)
+        auto err = result.err;               // NOLINT (cppcoreguidelines-pro-type-union-access)
         std::string errmsg = err_to_msg(&err, "Error initializing crash tracker");
         std::cerr << errmsg << std::endl;
         ddog_Error_drop(&err);

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/receiver_interface.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/receiver_interface.cpp
@@ -18,8 +18,8 @@ crashtracker_receiver_entry() // cppcheck-suppress unusedFunction
 {
     // Assumes that this will be called only in the receiver binary, which is a
     // fresh process
-    ddog_crasht_Result new_result = ddog_crasht_receiver_entry_point_stdin();
-    if (new_result.tag != DDOG_CRASHT_RESULT_OK) {
+    ddog_VoidResult new_result = ddog_crasht_receiver_entry_point_stdin();
+    if (new_result.tag != DDOG_VOID_RESULT_OK) {
         ddog_CharSlice message = ddog_Error_message(&new_result.err);
 
         //`write` may not write what we want it to write, but there's nothing we can do about it,

--- a/releasenotes/notes/libdatadog-v15.0.0-1004e5bb7f452d9a.yaml
+++ b/releasenotes/notes/libdatadog-v15.0.0-1004e5bb7f452d9a.yaml
@@ -1,0 +1,2 @@
+upgrade:
+  - Bumps libdatadog dependency to v15.0.0.

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,8 @@ CURRENT_OS = platform.system()
 LIBDDWAF_VERSION = "1.22.0"
 
 # DEV: update this accordingly when src/core upgrades libdatadog dependency.
-# libdatadog v14.1.0 requires rust 1.76.
-RUST_MINIMUM_VERSION = "1.76"
+# libdatadog v15.0.0 requires rust 1.78.
+RUST_MINIMUM_VERSION = "1.78"
 
 # Set macOS SDK default deployment target to 10.14 for C++17 support (if unset, may default to 10.9)
 if CURRENT_OS == "Darwin":

--- a/src/core/Cargo.lock
+++ b/src/core/Cargo.lock
@@ -28,8 +28,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "datadog-ddsketch"
-version = "14.3.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v14.3.1#48240f2588665a03c2061879345566ec7e70fabf"
+version = "15.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v15.0.0#0ef49864317b0728648b2b7f26fe2f1deeeeebc4"
 dependencies = [
  "prost",
 ]

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -10,7 +10,7 @@ opt-level = 3
 
 [dependencies]
 pyo3 = { version = "0.22.3", features = ["extension-module"] }
-datadog-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "v14.3.1" }
+datadog-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "v15.0.0" }
 
 [build-dependencies]
 pyo3-build-config = "0.21.2"


### PR DESCRIPTION
This PR bumps libdatadog to the [newly released v15.0.0](https://github.com/DataDog/libdatadog/releases/tag/v15.0.0). This will let us leverage new features such as library_config in following PRs.

Nothing should change much, so it is fine to only test this PR for non-regression.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
