### PR TITLE
ci: move pr/regression check to benchmarks-report stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ stages:
   - shared-pipeline
   - benchmarks
   - macrobenchmarks
+  - benchmarks-report
   - release
 
 variables:

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -59,8 +59,7 @@ microbenchmarks:
 benchmarks-pr-comment:
   image: $MICROBENCHMARKS_CI_IMAGE
   tags: ["arch:amd64"]
-  stage: benchmarks
-  needs: [ "microbenchmarks" ]
+  stage: benchmarks-report
   when: always
   script:
     - export REPORTS_DIR="$(pwd)/reports/" && (mkdir "${REPORTS_DIR}" || :)
@@ -78,8 +77,7 @@ benchmarks-pr-comment:
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-py
 
 check-big-regressions:
-  stage: benchmarks
-  needs: [ microbenchmarks, benchmark-serverless ]
+  stage: benchmarks-report
   when: always
   tags: ["arch:amd64"]
   image: $MICROBENCHMARKS_CI_IMAGE


### PR DESCRIPTION
We do not always run the serverless benchmarks job, this means that the CI config is invalid in those cases since regression check has an explicit dependency on serverless benchmarks.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
