### PR TITLE
ci: add GHA job to check if `main` can be merged to 3.x branches

### DIFF
--- a/.github/workflows/check_safe_main_merge.yml
+++ b/.github/workflows/check_safe_main_merge.yml
@@ -1,0 +1,27 @@
+name: Check for Safe main Merge
+
+on:
+  pull_request:
+    branches:
+      - '3.x-staging'
+
+jobs:
+  check-merge:
+    runs-on: ubuntu-latest
+    steps:
+      # Step 1: Checkout the repository
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Step 2: Fetch the main branch
+      - name: Fetch main branch
+        run: git fetch origin main
+
+      # Step 3: Attempt to merge
+      - name: Check merge conflicts
+        run: |
+          git merge --no-commit --no-ff origin/main || exit 1
+      # Step 4: Clean up the merge (optional)
+      - name: Abort merge
+        if: failure()
+        run: git merge --abort


### PR DESCRIPTION
Creates a GHA job that checks if the `main` branch can be cleanly merged to a 3.x-staging feature branch. This is to avoid scenarios where `main` has changes that conflict with `3.x-staging`, so we can resolve those before merging anything.

This is mainly for the 3.x migration effort. We can clean this job up afterwards.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
