### PR TITLE
feat(asm): meta struct enable by default for 3.0

### DIFF
--- a/ddtrace/settings/asm.py
+++ b/ddtrace/settings/asm.py
@@ -73,7 +73,7 @@ class ASMConfig(Env):
     _iast_propagation_debug = Env.var(bool, IAST.ENV_PROPAGATION_DEBUG, default=False, private=True)
     _iast_telemetry_report_lvl = Env.var(str, IAST.ENV_TELEMETRY_REPORT_LVL, default=TELEMETRY_INFORMATION_NAME)
     _appsec_standalone_enabled = Env.var(bool, APPSEC.STANDALONE_ENV, default=False)
-    _use_metastruct_for_triggers = False
+    _use_metastruct_for_triggers = True
 
     _automatic_login_events_mode = Env.var(str, APPSEC.AUTOMATIC_USER_EVENTS_TRACKING, default="", parser=str.lower)
     # Deprecation phase, to be removed in ddtrace 3.0.0

--- a/releasenotes/notes/msgpack_for_appsec-e09c17e9cb568379.yaml
+++ b/releasenotes/notes/msgpack_for_appsec-e09c17e9cb568379.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    ASM: This introduces use of meta struct for appsec event reports. This will improve performances.
+    ASM will now require at least agent version 7.35.0 to work as expected.


### PR DESCRIPTION
Enable by default the use of metastruct field for appsec reports.
This will prevent ASM from working with old Datadog agents < 7.35.0 (released on April 2022)
https://github.com/DataDog/datadog-agent/releases/tag/7.35.0

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
