### PR TITLE
ci: update the benchmark-serverless script path to reflect the changes made on the sls side

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -98,7 +98,7 @@ benchmark-serverless:
   needs: [ "benchmark-serverless-trigger" ]
   script:
     - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/serverless-tools.git ./serverless-tools && cd ./serverless-tools
-    - ./ci/check_trigger_status.sh
+    - ./.gitlab/check_trigger_status.sh
   except:
     - main  # fails on main - ideally it would succeed
 


### PR DESCRIPTION
We were noticing that our benchmark-serverless jobs are failing due to:
```
/scripts-358-782374990/step_script: line 204: ./ci/check_trigger_status.sh: No such file or directory
```
This is due to the change made on the serverless side from [this PR](https://github.com/DataDog/serverless-tools/pull/47), and the because the [benchmark-serverless job calls it with the original path](https://github.com/DataDog/dd-trace-py/blob/b9228864ef7dc44d84f061316191a763d636972b/.gitlab/benchmarks.yml#L101) it was failing.

This will update it to reflect the new `.gitlab` path.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
