### PR TITLE
fix(lib-injection): max runtime version check

### DIFF
--- a/lib-injection/sources/sitecustomize.py
+++ b/lib-injection/sources/sitecustomize.py
@@ -203,9 +203,11 @@ def runtime_version_is_supported(python_runtime, python_version):
     supported_versions = RUNTIMES_ALLOW_LIST.get(python_runtime, {})
     if not supported_versions:
         return False
-    return (
-        supported_versions["min"].version <= parse_version(python_version).version < supported_versions["max"].version
-    )
+
+    # Use the next max version as the upper bound
+    max_version = list(supported_versions["max"].version)
+    max_version[-1] += 1
+    return supported_versions["min"].version <= parse_version(python_version).version < tuple(max_version)
 
 
 def package_is_compatible(package_name, package_version):

--- a/releasenotes/notes/fix-max-runtime-version-check-2a0c6d085efd1aac.yaml
+++ b/releasenotes/notes/fix-max-runtime-version-check-2a0c6d085efd1aac.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix an issue with the check of the maximum runtime version supported.


### PR DESCRIPTION
We fix the logic for the maximum runtime version supported when doing auto-injection of the library.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
