### PR TITLE
feat(provider): expose context provider in ddtrace.trace

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -166,12 +166,14 @@ ddtrace/internal/remoteconfig       @DataDog/remote-config @DataDog/apm-core-pyt
 tests/internal/remoteconfig         @DataDog/remote-config @DataDog/apm-core-python
 
 # API SDK
+ddtrace/trace/                                    @DataDog/apm-sdk-api-python
 ddtrace/_trace/                                    @DataDog/apm-sdk-api-python
 ddtrace/opentelemetry/                             @DataDog/apm-sdk-api-python
 ddtrace/internal/opentelemetry                     @DataDog/apm-sdk-api-python
 ddtrace/opentracer/                                @DataDog/apm-sdk-api-python
 ddtrace/propagation/                               @DataDog/apm-sdk-api-python
 ddtrace/filters.py                                 @DataDog/apm-sdk-api-python
+ddtrace/provider.py                                @DataDog/apm-sdk-api-python
 ddtrace/pin.py                                     @DataDog/apm-sdk-api-python
 ddtrace/sampler.py                                 @DataDog/apm-sdk-api-python
 ddtrace/sampling_rule.py                           @DataDog/apm-sdk-api-python

--- a/ddtrace/provider.py
+++ b/ddtrace/provider.py
@@ -7,7 +7,8 @@ from ddtrace.vendor.debtcollector import deprecate
 
 
 deprecate(
-    "The context provider interface is deprecated.",
-    message="The trace context is an internal interface and will no longer be supported.",
+    "The context provider interface is deprecated",
+    message="Import BaseContextProvider from `ddtrace.trace` instead.",
     category=DDTraceDeprecationWarning,
+    removal_version="3.0.0",
 )

--- a/ddtrace/trace/__init__.py
+++ b/ddtrace/trace/__init__.py
@@ -1,6 +1,7 @@
 from ddtrace._trace.context import Context
 from ddtrace._trace.filters import TraceFilter
 from ddtrace._trace.pin import Pin
+from ddtrace._trace.provider import BaseContextProvider
 from ddtrace._trace.span import Span
 from ddtrace._trace.tracer import Tracer
 
@@ -15,4 +16,5 @@ __all__ = [
     "Tracer",
     "Span",
     "tracer",
+    "BaseContextProvider",
 ]

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -221,7 +221,7 @@ context management.
 
 If there is a case where the default is insufficient then a custom context
 provider can be used. It must implement the
-:class:`ddtrace.provider.BaseContextProvider` interface and can be configured
+:class:`ddtrace.trace.BaseContextProvider` interface and can be configured
 with::
 
     tracer.configure(context_provider=MyContextProvider)

--- a/releasenotes/notes/feat-expose-base-context-provider-530ebec2225f6c8d.yaml
+++ b/releasenotes/notes/feat-expose-base-context-provider-530ebec2225f6c8d.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    tracing: Moves ``ddtrace.provider.BaseContextProvider`` to ``ddtrace.trace.BaseContextProvider``. 
+    The ``ddtrace.provider`` module is deprecated and will be removed in v3.0.0.


### PR DESCRIPTION
ddtrace v3.0 is set to remove `ddtrace.providers` module from the public API. However we should still allow users to use their own ContextProviders. This PR ensures the BaseContextProvider remains in the public API and can be used in `tracer.configure(...)`. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
