### PR TITLE
chore(ci_visibility): fetch quarantine status from backend

### DIFF
--- a/ddtrace/contrib/internal/aiohttp/middlewares.py
+++ b/ddtrace/contrib/internal/aiohttp/middlewares.py
@@ -2,6 +2,7 @@ from aiohttp import web
 from aiohttp.web_urldispatcher import SystemRoute
 
 from ddtrace import config
+from ddtrace.contrib.asyncio import context_provider
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import http
 from ddtrace.internal import core
@@ -59,9 +60,8 @@ async def trace_middleware(app, handler):
             request[REQUEST_CONFIG_KEY] = app[CONFIG_KEY]
             try:
                 response = await handler(request)
-                if not config.aiohttp["disable_stream_timing_for_mem_leak"]:
-                    if isinstance(response, web.StreamResponse):
-                        request.task.add_done_callback(lambda _: finish_request_span(request, response))
+                if isinstance(response, web.StreamResponse):
+                    request.task.add_done_callback(lambda _: finish_request_span(request, response))
                 return response
             except Exception:
                 req_span.set_traceback()

--- a/ddtrace/internal/ci_visibility/_api_client.py
+++ b/ddtrace/internal/ci_visibility/_api_client.py
@@ -554,7 +554,7 @@ class _TestVisibilityAPIClientBase(abc.ABC):
         return unique_test_ids
 
     def fetch_test_management_tests(self) -> t.Optional[t.Set[InternalTestId]]:
-        metric_names = APIRequestMetricNames(
+        metric_names = APIRequestMetricNames(  # ꙮ
             count=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST.value,
             duration=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST_MS.value,
             response_bytes=EARLY_FLAKE_DETECTION_TELEMETRY.RESPONSE_BYTES.value,
@@ -581,7 +581,7 @@ class _TestVisibilityAPIClientBase(abc.ABC):
 
         if "errors" in parsed_response:
             record_api_request_error(metric_names.error, ERROR_TYPES.UNKNOWN)
-            log.debug("Test management tests response contained an error")
+            log.debug("Test Management tests response contained an error")
             return None
 
         try:
@@ -603,11 +603,11 @@ class _TestVisibilityAPIClientBase(abc.ABC):
                         test_properties[test_id] = TestProperties(quarantined=properties.get("quarantined", False))
 
         except Exception:  # noqa: E722
-            log.debug("Failed to parse test management tests data", exc_info=True)
+            log.debug("Failed to parse Test Management tests data", exc_info=True)
             record_api_request_error(metric_names.error, ERROR_TYPES.UNKNOWN)
             return None
 
-        # record_early_flake_detection_tests_count(len(unique_test_ids))
+        # record_early_flake_detection_tests_count(len(unique_test_ids)) # ꙮ
 
         return test_properties
 

--- a/ddtrace/internal/ci_visibility/_api_client.py
+++ b/ddtrace/internal/ci_visibility/_api_client.py
@@ -553,7 +553,7 @@ class _TestVisibilityAPIClientBase(abc.ABC):
 
         return unique_test_ids
 
-    def fetch_test_management_tests(self) -> t.Optional[t.Set[InternalTestId]]:
+    def fetch_test_management_tests(self) -> t.Optional[t.Dict[InternalTestId, TestProperties]]:
         metric_names = APIRequestMetricNames(  # ꙮ
             count=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST.value,
             duration=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST_MS.value,

--- a/ddtrace/internal/ci_visibility/_api_client.py
+++ b/ddtrace/internal/ci_visibility/_api_client.py
@@ -554,13 +554,6 @@ class _TestVisibilityAPIClientBase(abc.ABC):
         return unique_test_ids
 
     def fetch_test_management_tests(self) -> t.Optional[t.Dict[InternalTestId, TestProperties]]:
-        metric_names = APIRequestMetricNames(  # ꙮ
-            count=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST.value,
-            duration=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST_MS.value,
-            response_bytes=EARLY_FLAKE_DETECTION_TELEMETRY.RESPONSE_BYTES.value,
-            error=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST_ERRORS.value,
-        )
-
         test_properties: t.Dict[InternalTestId, TestProperties] = {}
         payload = {
             "data": {
@@ -606,8 +599,6 @@ class _TestVisibilityAPIClientBase(abc.ABC):
             log.debug("Failed to parse Test Management tests data", exc_info=True)
             record_api_request_error(metric_names.error, ERROR_TYPES.UNKNOWN)
             return None
-
-        # record_early_flake_detection_tests_count(len(unique_test_ids)) # ꙮ
 
         return test_properties
 

--- a/ddtrace/internal/ci_visibility/_api_client.py
+++ b/ddtrace/internal/ci_visibility/_api_client.py
@@ -36,6 +36,8 @@ from ddtrace.internal.ci_visibility.telemetry.early_flake_detection import recor
 from ddtrace.internal.ci_visibility.telemetry.git import record_settings_response
 from ddtrace.internal.ci_visibility.telemetry.itr import SKIPPABLE_TESTS_TELEMETRY
 from ddtrace.internal.ci_visibility.telemetry.itr import record_skippable_count
+from ddtrace.internal.ci_visibility.telemetry.test_management import TEST_MANAGEMENT_TELEMETRY
+from ddtrace.internal.ci_visibility.telemetry.test_management import record_test_management_tests_count
 from ddtrace.internal.ci_visibility.utils import combine_url_path
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.test_visibility._internal_item_ids import InternalTestId
@@ -554,6 +556,13 @@ class _TestVisibilityAPIClientBase(abc.ABC):
         return unique_test_ids
 
     def fetch_test_management_tests(self) -> t.Optional[t.Dict[InternalTestId, TestProperties]]:
+        metric_names = APIRequestMetricNames(
+            count=TEST_MANAGEMENT_TELEMETRY.REQUEST.value,
+            duration=TEST_MANAGEMENT_TELEMETRY.REQUEST_MS.value,
+            response_bytes=TEST_MANAGEMENT_TELEMETRY.RESPONSE_BYTES.value,
+            error=TEST_MANAGEMENT_TELEMETRY.REQUEST_ERRORS.value,
+        )
+
         test_properties: t.Dict[InternalTestId, TestProperties] = {}
         payload = {
             "data": {
@@ -599,6 +608,8 @@ class _TestVisibilityAPIClientBase(abc.ABC):
             log.debug("Failed to parse Test Management tests data", exc_info=True)
             record_api_request_error(metric_names.error, ERROR_TYPES.UNKNOWN)
             return None
+
+        record_test_management_tests_count(len(test_properties))
 
         return test_properties
 

--- a/ddtrace/internal/ci_visibility/constants.py
+++ b/ddtrace/internal/ci_visibility/constants.py
@@ -48,7 +48,7 @@ GIT_API_BASE_PATH = "/api/v2/git"
 SETTING_ENDPOINT = "/api/v2/libraries/tests/services/setting"
 SKIPPABLE_ENDPOINT = "/api/v2/ci/tests/skippable"
 UNIQUE_TESTS_ENDPOINT = "/api/v2/ci/libraries/tests"
-DETAILED_TESTS_ENDPOINT = "/api/v2/ci/libraries/tests/detailed"
+TEST_MANAGEMENT_TESTS_ENDPOINT = "/api/v2/test/libraries/test-management/tests"
 
 # Intelligent Test Runner constants
 ITR_UNSKIPPABLE_REASON = "datadog_itr_unskippable"

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -516,7 +516,7 @@ class CIVisibility(Service):
         try:
             if self._api_client is not None:
                 return self._api_client.fetch_test_management_tests()
-            log.warning("API client not initialized, cannot fetch unique tests")
+            log.warning("API client not initialized, cannot fetch tests from Test Management")
         except Exception:
             log.debug("Error fetching unique tests", exc_info=True)
         return None
@@ -650,7 +650,7 @@ class CIVisibility(Service):
         if self._api_settings.quarantine.enabled:
             test_properties = self._fetch_test_management_tests()
             if test_properties is None:
-                log.warning("Failed to fetch test management properties")
+                log.warning("Failed to fetch quarantined tests from Test Management")
             else:
                 self._test_properties = test_properties
 

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -39,6 +39,7 @@ from ddtrace.internal.ci_visibility._api_client import EarlyFlakeDetectionSettin
 from ddtrace.internal.ci_visibility._api_client import EVPProxyTestVisibilityAPIClient
 from ddtrace.internal.ci_visibility._api_client import ITRData
 from ddtrace.internal.ci_visibility._api_client import QuarantineSettings
+from ddtrace.internal.ci_visibility._api_client import TestProperties
 from ddtrace.internal.ci_visibility._api_client import TestVisibilityAPISettings
 from ddtrace.internal.ci_visibility._api_client import _TestVisibilityAPIClientBase
 from ddtrace.internal.ci_visibility.api._module import TestVisibilityModule
@@ -210,6 +211,7 @@ class CIVisibility(Service):
         self._itr_meta = {}  # type: Dict[str, Any]
         self._itr_data: Optional[ITRData] = None
         self._unique_test_ids: Set[InternalTestId] = set()
+        self._test_properties: Dict[InternalTestId, TestProperties] = {}
 
         self._session: Optional[TestVisibilitySession] = None
 
@@ -510,6 +512,15 @@ class CIVisibility(Service):
             log.debug("Error fetching unique tests", exc_info=True)
         return None
 
+    def _fetch_test_management_tests(self) -> Optional[Dict[InternalTestId, TestProperties]]:
+        try:
+            if self._api_client is not None:
+                return self._api_client.fetch_test_management_tests()
+            log.warning("API client not initialized, cannot fetch unique tests")
+        except Exception:
+            log.debug("Error fetching unique tests", exc_info=True)
+        return None
+
     def _should_skip_path(self, path, name, test_skipping_mode=None):
         """This method supports legacy usage of the CIVisibility service and should be removed
 
@@ -635,6 +646,13 @@ class CIVisibility(Service):
                 "Auto Test Retries is enabled by API but disabled by "
                 "DD_CIVISIBILITY_FLAKY_RETRY_ENABLED environment variable"
             )
+
+        if self._api_settings.quarantine.enabled:
+            test_properties = self._fetch_test_management_tests()
+            if test_properties is None:
+                log.warning("Failed to fetch test management properties")
+            else:
+                self._test_properties = test_properties
 
     def _stop_service(self):
         # type: () -> None
@@ -942,8 +960,11 @@ class CIVisibility(Service):
         if instance is None:
             return False
 
-        # TODO: retrieve this information from the API, once it is available in the backend.
-        return False
+        test_properties = instance._test_properties.get(test_id)
+        if test_properties is None:
+            return False
+
+        return test_properties.quarantined
 
 
 def _requires_civisibility_enabled(func):

--- a/ddtrace/internal/ci_visibility/telemetry/test_management.py
+++ b/ddtrace/internal/ci_visibility/telemetry/test_management.py
@@ -1,0 +1,25 @@
+from enum import Enum
+
+from ddtrace.internal.logger import get_logger
+from ddtrace.internal.telemetry import telemetry_writer
+from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
+
+
+log = get_logger(__name__)
+
+
+class TEST_MANAGEMENT_TELEMETRY(str, Enum):
+    REQUEST = "test_management.request"
+    REQUEST_MS = "test_management.request_ms"
+    REQUEST_ERRORS = "test_management.request_errors"
+    RESPONSE_BYTES = "test_management.response_bytes"
+    RESPONSE_TESTS = "test_management.response_tests"
+
+
+def record_test_management_tests_count(test_management_count: int):
+    log.debug("Recording Test Management tests count telemetry: %s", test_management_count)
+    telemetry_writer.add_distribution_metric(
+        TELEMETRY_NAMESPACE.CIVISIBILITY,
+        TEST_MANAGEMENT_TELEMETRY.RESPONSE_TESTS.value,
+        test_management_count,
+    )

--- a/ddtrace/internal/test_visibility/_internal_item_ids.py
+++ b/ddtrace/internal/test_visibility/_internal_item_ids.py
@@ -1,8 +1,6 @@
-import dataclasses
-
 from ddtrace.ext.test_visibility import api as ext_api
 
 
-@dataclasses.dataclass(frozen=True)
-class InternalTestId(ext_api.TestId):
-    pass
+# TODO(vitor-de-araujo): InternalTestId exists for historical reasons; it used to consist of TestId + EFD retry number.
+# The retry number is not part of the test id anymore, so these types can be unified, and in the future removed.
+InternalTestId = ext_api.TestId

--- a/tests/ci_visibility/api_client/_util.py
+++ b/tests/ci_visibility/api_client/_util.py
@@ -105,19 +105,19 @@ def _get_tests_api_response(tests_body: t.Optional[t.Dict] = None):
     return Response(200, json.dumps(response))
 
 
-def _get_detailed_tests_api_response(modules: t.Dict):
-    response = {"data": {"id": "J0ucvcSApX8", "type": "ci_app_libraries_tests", "attributes": {"modules": []}}}
+def _get_test_management_tests_api_response(modules: t.Dict):
+    response = {"data": {"id": "J0ucvcSApX8", "type": "ci_app_libraries_tests", "attributes": {"modules": {}}}}
 
     for module_id, suites in modules.items():
-        module = {"id": module_id, "suites": []}
-        response["data"]["attributes"]["modules"].append(module)
+        module = {"suites": {}}
+        response["data"]["attributes"]["modules"][module_id] = module
 
         for suite_id, tests in suites.items():
-            suite = {"id": suite_id, "tests": []}
-            module["suites"].append(suite)
+            suite = {"tests": {}}
+            module["suites"][suite_id] = suite
 
-            for test_id in tests:
-                suite["tests"].append({"id": test_id})
+            for test_id, test_properties in tests.items():
+                suite["tests"][test_id] = {"properties": test_properties}
 
     return Response(200, json.dumps(response))
 

--- a/tests/ci_visibility/api_client/_util.py
+++ b/tests/ci_visibility/api_client/_util.py
@@ -105,23 +105,6 @@ def _get_tests_api_response(tests_body: t.Optional[t.Dict] = None):
     return Response(200, json.dumps(response))
 
 
-def _get_test_management_tests_api_response(modules: t.Dict):
-    response = {"data": {"id": "J0ucvcSApX8", "type": "ci_app_libraries_tests", "attributes": {"modules": {}}}}
-
-    for module_id, suites in modules.items():
-        module = {"suites": {}}
-        response["data"]["attributes"]["modules"][module_id] = module
-
-        for suite_id, tests in suites.items():
-            suite = {"tests": {}}
-            module["suites"][suite_id] = suite
-
-            for test_id, test_properties in tests.items():
-                suite["tests"][test_id] = {"properties": test_properties}
-
-    return Response(200, json.dumps(response))
-
-
 def _make_fqdn_internal_test_id(module_name: str, suite_name: str, test_name: str, parameters: t.Optional[str] = None):
     """An easy way to create a test id "from the bottom up"
 

--- a/tests/ci_visibility/api_client/test_ci_visibility_api_client_test_management_responses.py
+++ b/tests/ci_visibility/api_client/test_ci_visibility_api_client_test_management_responses.py
@@ -9,12 +9,11 @@ import pytest
 from ddtrace.internal.ci_visibility._api_client import TestProperties
 from ddtrace.internal.utils.http import Response
 from tests.ci_visibility.api_client._util import TestTestVisibilityAPIClientBase
-from tests.ci_visibility.api_client._util import _get_test_management_tests_api_response
 from tests.ci_visibility.api_client._util import _make_fqdn_internal_test_id
 
 
 class TestTestVisibilityAPIClientTestManagementResponses(TestTestVisibilityAPIClientBase):
-    """Tests that unique tests responses from the API client are parsed properly"""
+    """Tests that Test Management tests responses from the API client are parsed properly"""
 
     def test_api_client_test_management_tests_parsed(self):
         response_dict = {
@@ -70,7 +69,6 @@ class TestTestVisibilityAPIClientTestManagementResponses(TestTestVisibilityAPICl
         with mock.patch.object(client, "_do_request", return_value=mock_response):
             assert client.fetch_test_management_tests() == expected_tests
 
-
     @pytest.mark.parametrize(
         "do_request_side_effect",
         [
@@ -101,7 +99,7 @@ class TestTestVisibilityAPIClientTestManagementResponses(TestTestVisibilityAPICl
         ],
     )
     def test_api_client_test_management_tests_errors(self, do_request_side_effect):
-        """Tests that the client correctly handles errors in the unique test API response"""
+        """Tests that the client correctly handles errors in the Test Management test API response"""
         client = self._get_test_client()
         with mock.patch.object(client, "_do_request", side_effect=[do_request_side_effect]):
             settings = client.fetch_test_management_tests()

--- a/tests/ci_visibility/api_client/test_ci_visibility_api_client_test_management_responses.py
+++ b/tests/ci_visibility/api_client/test_ci_visibility_api_client_test_management_responses.py
@@ -1,0 +1,108 @@
+from http.client import RemoteDisconnected
+import json
+import socket
+import textwrap
+from unittest import mock
+
+import pytest
+
+from ddtrace.internal.ci_visibility._api_client import TestProperties
+from ddtrace.internal.utils.http import Response
+from tests.ci_visibility.api_client._util import TestTestVisibilityAPIClientBase
+from tests.ci_visibility.api_client._util import _get_test_management_tests_api_response
+from tests.ci_visibility.api_client._util import _make_fqdn_internal_test_id
+
+
+class TestTestVisibilityAPIClientTestManagementResponses(TestTestVisibilityAPIClientBase):
+    """Tests that unique tests responses from the API client are parsed properly"""
+
+    def test_api_client_test_management_tests_parsed(self):
+        response_dict = {
+            "data": {
+                "id": "J0ucvcSApX8",
+                "type": "ci_app_libraries_tests",
+                "attributes": {
+                    "modules": {
+                        "module1": {
+                            "suites": {
+                                "suite1.py": {
+                                    "tests": {
+                                        "test1": {"properties": {"quarantined": True}},
+                                        "test2": {"properties": {"quarantined": False}},
+                                        "test3": {"properties": {}},
+                                        "test4": {},
+                                    }
+                                },
+                                "suite2.py": {
+                                    "tests": {
+                                        "test1": {"properties": {"quarantined": False}},
+                                        "test5": {"properties": {"quarantined": True}},
+                                    }
+                                },
+                            }
+                        },
+                        "module2": {
+                            "suites": {
+                                "suite1.py": {
+                                    "tests": {
+                                        "test1": {"properties": {"quarantined": False}},
+                                    }
+                                }
+                            }
+                        },
+                    }
+                },
+            }
+        }
+        mock_response = Response(200, json.dumps(response_dict))
+
+        expected_tests = {
+            _make_fqdn_internal_test_id("module1", "suite1.py", "test1"): TestProperties(quarantined=True),
+            _make_fqdn_internal_test_id("module1", "suite1.py", "test2"): TestProperties(quarantined=False),
+            _make_fqdn_internal_test_id("module1", "suite1.py", "test3"): TestProperties(quarantined=False),
+            _make_fqdn_internal_test_id("module1", "suite1.py", "test4"): TestProperties(quarantined=False),
+            _make_fqdn_internal_test_id("module1", "suite2.py", "test1"): TestProperties(quarantined=False),
+            _make_fqdn_internal_test_id("module1", "suite2.py", "test5"): TestProperties(quarantined=True),
+            _make_fqdn_internal_test_id("module2", "suite1.py", "test1"): TestProperties(quarantined=False),
+        }
+
+        client = self._get_test_client()
+        with mock.patch.object(client, "_do_request", return_value=mock_response):
+            assert client.fetch_test_management_tests() == expected_tests
+
+
+    @pytest.mark.parametrize(
+        "do_request_side_effect",
+        [
+            TimeoutError,
+            socket.timeout,
+            RemoteDisconnected,
+            Response(403),
+            Response(500),
+            Response(200, "this is not json"),
+            Response(200, '{"valid_json": "invalid_structure"}'),
+            Response(200, '{"errors": "there was an error"}'),
+            Response(
+                200,
+                textwrap.dedent(
+                    """
+                {
+                    "data": {
+                    "id": "J0ucvcSApX8",
+                    "type": "ci_app_libraries_tests",
+                    "attributes": {
+                        "potatoes_but_not_tests": {}
+                        }
+                    }
+                }
+            """
+                ),
+            ),
+        ],
+    )
+    def test_api_client_test_management_tests_errors(self, do_request_side_effect):
+        """Tests that the client correctly handles errors in the unique test API response"""
+        client = self._get_test_client()
+        with mock.patch.object(client, "_do_request", side_effect=[do_request_side_effect]):
+            settings = client.fetch_test_management_tests()
+            assert settings is None


### PR DESCRIPTION
Fetch quarantine status from the new Test Management endpoint, instead of relying on pytest marks.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
