### PR TITLE
feat: add record_exception method in datadog api

### DIFF
--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -1,10 +1,13 @@
 import functools
+from io import StringIO
 from itertools import chain
 import logging
 import os
 from os import environ
 from os import getpid
 from threading import RLock
+from time import time_ns
+import traceback
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -1243,6 +1246,51 @@ class Tracer(object):
         :param dict tags: dict of tags to set at tracer level
         """
         self._tags.update(tags)
+
+    def record_exception(
+        self,
+        exception: Exception,
+        attributes: Optional[Dict[str, str]] = None,
+        timestamp: Optional[int] = None,
+        escaped=False,
+    ) -> None:
+        """
+        Records an exception as an event if the exception is handled (escaped=False)
+        If the exception is not handled (escaped=True), tag the span with an error tuple
+
+        There is no real use case of recording an unhandled exceptions as the tracer does it
+        automatically. It is just to comply with otel spec.
+        """
+        current_span = self.current_span()
+        if current_span is None:
+            return
+
+        if timestamp is None:
+            timestamp = time_ns()
+
+        exc_type, exc_val, exc_tb = type(exception), exception, exception.__traceback__
+
+        if escaped is True:
+            current_span.set_exc_info(exc_type, exc_val, exc_tb)
+
+        # get the traceback
+        buff = StringIO()
+        traceback.print_exception(exc_type, exc_val, exc_tb, file=buff, limit=config._span_traceback_max_size)
+        tb = buff.getvalue()
+
+        # Set exception attributes in a manner that is consistent with the opentelemetry sdk
+        # https://github.com/open-telemetry/opentelemetry-python/blob/v1.24.0/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py#L998
+        attrs = {
+            "exception.type": "%s.%s" % (exception.__class__.__module__, exception.__class__.__name__),
+            "exception.message": str(exception),
+            "exception.escaped": str(escaped),
+            "exception.stacktrace": tb,
+        }
+        if attributes:
+            # User provided attributes must take precedence over attrs
+            attrs.update(attributes)
+
+        current_span._add_event(name="recorded exception", attributes=attrs, timestamp=timestamp)
 
     def shutdown(self, timeout: Optional[float] = None) -> None:
         """Shutdown the tracer and flush finished traces. Avoid calling shutdown multiple times.

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -1255,11 +1255,15 @@ class Tracer(object):
         escaped=False,
     ) -> None:
         """
-        Records an exception as an event if the exception is handled (escaped=False)
-        If the exception is not handled (escaped=True), tag the span with an error tuple
+        Records an exception as span event.
+        If the exception is unhandled, :obj:`escaped` should be set :obj:`True`. It
+        will tag the span with an error tuple.
 
-        There is no real use case of recording an unhandled exceptions as the tracer does it
-        automatically. It is just to comply with otel spec.
+        :param Exception exception: the exception to record<
+        :param dict attributes: optional attributes to add to the span event. It will override
+            the base attributes if :obj:`attributes` contains existing keys.
+        :param int timestamp: the timestamp of the span event. Will be set to now() if timestamp is :obj:`None`.
+        :param bool escaped: sets to :obj:`False` for a handled exception and :obj:`True` for an unhandled exception.
         """
         current_span = self.current_span()
         if current_span is None:

--- a/releasenotes/notes/feat-add-dd-record-exception-033fd0436dfd2723.yaml
+++ b/releasenotes/notes/feat-add-dd-record-exception-033fd0436dfd2723.yaml
@@ -1,0 +1,30 @@
+---
+#instructions:
+#    The style guide below provides explanations, instructions, and templates to write your own release note.
+#    Once finished, all irrelevant sections (including this instruction section) should be removed,
+#    and the release note should be committed with the rest of the changes.
+#
+#    The main goal of a release note is to provide a brief overview of a change and provide actionable steps to the user.
+#    The release note should clearly communicate what the change is, why the change was made, and how a user can migrate their code.
+#
+#    The release note should also clearly distinguish between announcements and user instructions. Use:
+#    * Past tense for previous/existing behavior (ex: ``resulted, caused, failed``)
+#    * Third person present tense for the change itself (ex: ``adds, fixes, upgrades``)
+#    * Active present infinitive for user instructions (ex: ``set, use, add``)
+#
+#    Release notes should:
+#    * Use plain language
+#    * Be concise
+#    * Include actionable steps with the necessary code changes
+#    * Include relevant links (bug issues, upstream issues or release notes, documentation pages)
+#    * Use full sentences with sentence-casing and punctuation.
+#    * Before using Datadog specific acronyms/terminology, a release note must first introduce them with a definition.
+#
+#    Release notes should not:
+#    * Be vague. Example: ``fixes an issue in tracing``.
+#    * Use overly technical language
+#    * Use dynamic links (``stable/latest/1.x`` URLs). Instead, use static links (specific version, commit hash) whenever possible so that they don't break in the future.
+features:
+  - |
+    tracing: This introduces the record_exception tracer api. It allows to manually add an exception as a span event.
+    It also allows to tag a span with an error tuple of the recorded exception by setting the escaped parameter as true.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -519,6 +519,19 @@ class TracerTestCase(TestSpanContainer, BaseTestCase):
         root_span = self.get_root_span()
         root_span.assert_structure(root, children)
 
+    def assert_span_event_count(self, count):
+        "Assert the r"
+        root_span = self.get_root_span()
+        assert len(root_span._events) == count, "Span count {0} != {1}".format(len(root_span._events), count)
+
+    def assert_span_event_attributes(self, event_idx, attrs):
+        span_event_attrs = self.get_root_span()._events[event_idx].attributes
+        for name, value in attrs.items():
+            assert name in span_event_attrs, "{0!r} does not have property {1!r}".format(span_event_attrs, name)
+            assert span_event_attrs[name] == value, "{0!r} property {1}: {2!r} != {3!r}".format(
+                span_event_attrs, name, span_event_attrs[name], value
+            )
+
     @contextlib.contextmanager
     def override_global_tracer(self, tracer=None):
         original = ddtrace.tracer


### PR DESCRIPTION
Some users of Error Tracking product asked for the possibility to manually report an exception to ET. It was possible but only using Otel API. It seems that the users did not find it and it is easy to implement.

This PR implements the record_exception in dd api according to the Otel [specifications](https://opentelemetry.io/docs/specs/otel/trace/exceptions/). 

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
