### PR TITLE
ci: increase profile suite timeout to 30 minutes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -166,12 +166,14 @@ ddtrace/internal/remoteconfig       @DataDog/remote-config @DataDog/apm-core-pyt
 tests/internal/remoteconfig         @DataDog/remote-config @DataDog/apm-core-python
 
 # API SDK
+ddtrace/trace/                                    @DataDog/apm-sdk-api-python
 ddtrace/_trace/                                    @DataDog/apm-sdk-api-python
 ddtrace/opentelemetry/                             @DataDog/apm-sdk-api-python
 ddtrace/internal/opentelemetry                     @DataDog/apm-sdk-api-python
 ddtrace/opentracer/                                @DataDog/apm-sdk-api-python
 ddtrace/propagation/                               @DataDog/apm-sdk-api-python
 ddtrace/filters.py                                 @DataDog/apm-sdk-api-python
+ddtrace/provider.py                                @DataDog/apm-sdk-api-python
 ddtrace/pin.py                                     @DataDog/apm-sdk-api-python
 ddtrace/sampler.py                                 @DataDog/apm-sdk-api-python
 ddtrace/sampling_rule.py                           @DataDog/apm-sdk-api-python

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -96,6 +96,7 @@ benchmark-serverless:
   tags: ["arch:amd64"]
   when: on_success
   needs: [ "benchmark-serverless-trigger" ]
+  allow_failure: true
   script:
     - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/serverless-tools.git ./serverless-tools && cd ./serverless-tools
     - ./ci/check_trigger_status.sh

--- a/.gitlab/prepare-oci-package.sh
+++ b/.gitlab/prepare-oci-package.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -eo pipefail
 
+if [ "$OS" != "linux" ]; then
+  echo "Only linux packages are supported. Exiting"
+  exit 0
+fi
+
 if [ -n "$CI_COMMIT_TAG" ] && [ -z "$PYTHON_PACKAGE_VERSION" ]; then
   PYTHON_PACKAGE_VERSION=${CI_COMMIT_TAG##v}
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Changelogs for versions not listed here can be found at https://github.com/DataD
 
 ---
 
+## 2.19.2
+### Bug Fixes
+
+- Tracing
+  - celery: Fixes an issue where `celery.apply` spans from Celery prerun got closed too soon leading to span tags being missing.
+  - openai: Fixes a patching issue where asynchronous moderation endpoint calls resulted in coroutine scheduling errors.
+  - openai: Ensures the OpenAI integration is compatible with Python versions 3.12 and 3.13.
+  - vertexai: Resolves an issue with `chat.send_message()` where the content keyword argument was not parsed correctly.
+- LLM Observability
+  - This fix resolves an issue where annotating a span with non latin-1 (but valid utf-8) input/output values resulted in encoding errors.
+- Lib-Injection
+  - Fixes incorrect telemetry data payload format.
+
+---
+
 ## 2.19.1
 ### Bug Fixes
 

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -109,11 +109,14 @@ def _get_parameters_for_new_span_directly_from_context(ctx: core.ExecutionContex
 def _start_span(ctx: core.ExecutionContext, call_trace: bool = True, **kwargs) -> "Span":
     span_kwargs = _get_parameters_for_new_span_directly_from_context(ctx)
     call_trace = ctx.get_item("call_trace", call_trace)
-    tracer = (ctx.get_item("middleware") or ctx["pin"]).tracer
+    tracer = ctx.get_item("tracer") or (ctx.get_item("middleware") or ctx["pin"]).tracer
     distributed_headers_config = ctx.get_item("distributed_headers_config")
     if distributed_headers_config:
         trace_utils.activate_distributed_headers(
-            tracer, int_config=distributed_headers_config, request_headers=ctx["distributed_headers"]
+            tracer,
+            int_config=distributed_headers_config,
+            request_headers=ctx["distributed_headers"],
+            override=ctx.get_item("distributed_headers_config_override"),
         )
     distributed_context = ctx.get_item("distributed_context")
     if distributed_context and not call_trace:
@@ -124,6 +127,42 @@ def _start_span(ctx: core.ExecutionContext, call_trace: bool = True, **kwargs) -
         span.set_tag_str(tk, tv)
     ctx.span = span
     return span
+
+
+def _set_web_frameworks_tags(ctx, span, int_config):
+    span.set_tag_str(COMPONENT, int_config.integration_name)
+    span.set_tag_str(SPAN_KIND, SpanKind.SERVER)
+    span.set_tag(_SPAN_MEASURED_KEY)
+
+    analytics_enabled = ctx.get_item("analytics_enabled")
+    analytics_sample_rate = ctx.get_item("analytics_sample_rate", True)
+
+    # Configure trace search sample rate
+    if (config._analytics_enabled and analytics_enabled is not False) or analytics_enabled is True:
+        span.set_tag(_ANALYTICS_SAMPLE_RATE_KEY, analytics_sample_rate)
+
+
+def _on_web_framework_start_request(ctx, int_config):
+    request_span = ctx.get_item("req_span")
+    _set_web_frameworks_tags(ctx, request_span, int_config)
+
+
+def _on_web_framework_finish_request(
+    span, int_config, method, url, status_code, query, req_headers, res_headers, route, finish
+):
+    trace_utils.set_http_meta(
+        span=span,
+        integration_config=int_config,
+        method=method,
+        url=url,
+        status_code=status_code,
+        query=query,
+        request_headers=req_headers,
+        response_headers=res_headers,
+        route=route,
+    )
+    if finish:
+        span.finish()
 
 
 def _on_traced_request_context_started_flask(ctx):
@@ -761,6 +800,10 @@ def listen():
     core.on("azure.functions.request_call_modifier", _on_azure_functions_request_span_modifier)
     core.on("azure.functions.start_response", _on_azure_functions_start_response)
 
+    # web frameworks general handlers
+    core.on("web.request.start", _on_web_framework_start_request)
+    core.on("web.request.finish", _on_web_framework_finish_request)
+
     core.on("test_visibility.enable", _on_test_visibility_enable)
     core.on("test_visibility.disable", _on_test_visibility_disable)
     core.on("test_visibility.is_enabled", _on_test_visibility_is_enabled, "is_enabled")
@@ -769,6 +812,14 @@ def listen():
     core.on("rq.queue.enqueue_job", _propagate_context)
 
     for context_name in (
+        # web frameworks
+        "aiohttp.request",
+        "bottle.request",
+        "cherrypy.request",
+        "falcon.request",
+        "molten.request",
+        "pyramid.request",
+        "sanic.request",
         "flask.call",
         "flask.jsonify",
         "flask.render_template",
@@ -779,6 +830,7 @@ def listen():
         "django.template.render",
         "django.process_exception",
         "django.func.wrapped",
+        # non web frameworks
         "botocore.instrumented_api_call",
         "botocore.instrumented_lib_function",
         "botocore.patched_kinesis_api_call",

--- a/ddtrace/appsec/_ddwaf/ddwaf_types.py
+++ b/ddtrace/appsec/_ddwaf/ddwaf_types.py
@@ -22,9 +22,12 @@ log = get_logger(__name__)
 
 if system() == "Linux":
     try:
+        asm_config._bypass_instrumentation_for_waf = True
         ctypes.CDLL(ctypes.util.find_library("rt"), mode=ctypes.RTLD_GLOBAL)
     except Exception:  # nosec
         pass
+    finally:
+        asm_config._bypass_instrumentation_for_waf = False
 
 ARCHI = machine().lower()
 

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -4,6 +4,7 @@ import json
 from json.decoder import JSONDecodeError
 import os
 import os.path
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import List
@@ -11,6 +12,11 @@ from typing import Optional
 from typing import Set
 from typing import Tuple
 from typing import Union
+
+
+if TYPE_CHECKING:
+    import ddtrace.appsec._ddwaf as ddwaf
+
 import weakref
 
 from ddtrace._trace.processor import SpanProcessor
@@ -167,14 +173,17 @@ class AppSecSpanProcessor(SpanProcessor):
     def delayed_init(self) -> None:
         try:
             if self._rules is not None and not hasattr(self, "_ddwaf"):
-                self._ddwaf = ddwaf.DDWaf(
+                from ddtrace.appsec._ddwaf import DDWaf  # noqa: E402
+                import ddtrace.appsec._metrics as metrics  # noqa: E402
+
+                self.metrics = metrics
+                self._ddwaf = DDWaf(
                     self._rules, self.obfuscation_parameter_key_regexp, self.obfuscation_parameter_value_regexp
                 )
-            _set_waf_init_metric(self._ddwaf.info)
+                self.metrics._set_waf_init_metric(self._ddwaf.info)
         except Exception:
             # Partial of DDAS-0005-00
             log.warning("[DDAS-0005-00] WAF initialization failed")
-            raise
         self._update_required()
 
     def _update_required(self):
@@ -193,7 +202,7 @@ class AppSecSpanProcessor(SpanProcessor):
         if asm_config._asm_static_rule_file is not None:
             return result
         result = self._ddwaf.update_rules(new_rules)
-        _set_waf_updates_metric(self._ddwaf.info)
+        self.metrics._set_waf_updates_metric(self._ddwaf.info)
         self._update_required()
         return result
 
@@ -241,7 +250,7 @@ class AppSecSpanProcessor(SpanProcessor):
             return self._waf_action(span._local_root or span, ctx, custom_data, **kwargs)
 
         _asm_request_context.set_waf_callback(waf_callable)
-        _asm_request_context.add_context_callback(_set_waf_request_metrics)
+        _asm_request_context.add_context_callback(self.metrics._set_waf_request_metrics)
         if headers is not None:
             _asm_request_context.set_waf_address(SPAN_DATA_NAMES.REQUEST_HEADERS_NO_COOKIES, headers)
             _asm_request_context.set_waf_address(
@@ -436,10 +445,3 @@ class AppSecSpanProcessor(SpanProcessor):
                     del self._span_to_waf_ctx[s]
                 except Exception:  # nosec B110
                     pass
-
-
-# load waf at the end only to avoid possible circular imports with gevent
-import ddtrace.appsec._ddwaf as ddwaf  # noqa: E402
-from ddtrace.appsec._metrics import _set_waf_init_metric  # noqa: E402
-from ddtrace.appsec._metrics import _set_waf_request_metrics  # noqa: E402
-from ddtrace.appsec._metrics import _set_waf_updates_metric  # noqa: E402

--- a/ddtrace/contrib/internal/aiohttp/middlewares.py
+++ b/ddtrace/contrib/internal/aiohttp/middlewares.py
@@ -2,15 +2,10 @@ from aiohttp import web
 from aiohttp.web_urldispatcher import SystemRoute
 
 from ddtrace import config
-from ddtrace.constants import _ANALYTICS_SAMPLE_RATE_KEY
-from ddtrace.constants import _SPAN_MEASURED_KEY
-from ddtrace.constants import SPAN_KIND
-from ddtrace.contrib import trace_utils
 from ddtrace.contrib.asyncio import context_provider
-from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import http
-from ddtrace.internal.constants import COMPONENT
+from ddtrace.internal import core
 from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 
@@ -35,47 +30,42 @@ async def trace_middleware(app, handler):
         # application configs
         tracer = app[CONFIG_KEY]["tracer"]
         service = app[CONFIG_KEY]["service"]
-        distributed_tracing = app[CONFIG_KEY]["distributed_tracing_enabled"]
-        # Create a new context based on the propagated information.
-        trace_utils.activate_distributed_headers(
-            tracer,
-            int_config=config.aiohttp,
-            request_headers=request.headers,
-            override=distributed_tracing,
-        )
-
-        # trace the handler
-        request_span = tracer.trace(
-            schematize_url_operation("aiohttp.request", protocol="http", direction=SpanDirection.INBOUND),
-            service=service,
-            span_type=SpanTypes.WEB,
-        )
-        request_span.set_tag(_SPAN_MEASURED_KEY)
-
-        request_span.set_tag_str(COMPONENT, config.aiohttp.integration_name)
-
-        # set span.kind tag equal to type of request
-        request_span.set_tag_str(SPAN_KIND, SpanKind.SERVER)
-
-        # Configure trace search sample rate
         # DEV: aiohttp is special case maintains separate configuration from config api
         analytics_enabled = app[CONFIG_KEY]["analytics_enabled"]
-        if (config._analytics_enabled and analytics_enabled is not False) or analytics_enabled is True:
-            request_span.set_tag(_ANALYTICS_SAMPLE_RATE_KEY, app[CONFIG_KEY].get("analytics_sample_rate", True))
+        # Create a new context based on the propagated information.
 
-        # attach the context and the root span to the request; the Context
-        # may be freely used by the application code
-        request[REQUEST_CONTEXT_KEY] = request_span.context
-        request[REQUEST_SPAN_KEY] = request_span
-        request[REQUEST_CONFIG_KEY] = app[CONFIG_KEY]
-        try:
-            response = await handler(request)
-            if isinstance(response, web.StreamResponse):
-                request.task.add_done_callback(lambda _: finish_request_span(request, response))
-            return response
-        except Exception:
-            request_span.set_traceback()
-            raise
+        with core.context_with_data(
+            "aiohttp.request",
+            span_name=schematize_url_operation("aiohttp.request", protocol="http", direction=SpanDirection.INBOUND),
+            span_type=SpanTypes.WEB,
+            service=service,
+            tags={},
+            tracer=tracer,
+            distributed_headers=request.headers,
+            distributed_headers_config=config.aiohttp,
+            distributed_headers_config_override=app[CONFIG_KEY]["distributed_tracing_enabled"],
+            headers_case_sensitive=True,
+            analytics_enabled=analytics_enabled,
+            analytics_sample_rate=app[CONFIG_KEY].get("analytics_sample_rate", True),
+        ) as ctx:
+            req_span = ctx.span
+
+            ctx.set_item("req_span", req_span)
+            core.dispatch("web.request.start", (ctx, config.aiohttp))
+
+            # attach the context and the root span to the request; the Context
+            # may be freely used by the application code
+            request[REQUEST_CONTEXT_KEY] = req_span.context
+            request[REQUEST_SPAN_KEY] = req_span
+            request[REQUEST_CONFIG_KEY] = app[CONFIG_KEY]
+            try:
+                response = await handler(request)
+                if isinstance(response, web.StreamResponse):
+                    request.task.add_done_callback(lambda _: finish_request_span(request, response))
+                return response
+            except Exception:
+                req_span.set_traceback()
+                raise
 
     return attach_context
 
@@ -122,18 +112,21 @@ def finish_request_span(request, response):
             # SystemRoute objects exist to throw HTTP errors and have no path
             route = aiohttp_route.resource.canonical
 
-    trace_utils.set_http_meta(
-        request_span,
-        config.aiohttp,
-        method=request.method,
-        url=str(request.url),  # DEV: request.url is a yarl's URL object
-        status_code=response.status,
-        request_headers=request.headers,
-        response_headers=response.headers,
-        route=route,
+    core.dispatch(
+        "web.request.finish",
+        (
+            request_span,
+            config.aiohttp,
+            request.method,
+            str(request.url),  # DEV: request.url is a yarl's URL object
+            response.status,
+            None,  # query arg = None
+            request.headers,
+            response.headers,
+            route,
+            True,
+        ),
     )
-
-    request_span.finish()
 
 
 async def on_prepare(request, response):

--- a/ddtrace/contrib/internal/bottle/trace.py
+++ b/ddtrace/contrib/internal/bottle/trace.py
@@ -5,13 +5,8 @@ from bottle import response
 
 import ddtrace
 from ddtrace import config
-from ddtrace.constants import _ANALYTICS_SAMPLE_RATE_KEY
-from ddtrace.constants import _SPAN_MEASURED_KEY
-from ddtrace.constants import SPAN_KIND
-from ddtrace.contrib import trace_utils
-from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
-from ddtrace.internal.constants import COMPONENT
+from ddtrace.internal import core
 from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.utils.formats import asbool
@@ -42,24 +37,21 @@ class TracePlugin(object):
 
             resource = "{} {}".format(request.method, route.rule)
 
-            trace_utils.activate_distributed_headers(
-                self.tracer, int_config=config.bottle, request_headers=request.headers
-            )
-
-            with self.tracer.trace(
-                schematize_url_operation("bottle.request", protocol="http", direction=SpanDirection.INBOUND),
+            with core.context_with_data(
+                "bottle.request",
+                span_name=schematize_url_operation("bottle.request", protocol="http", direction=SpanDirection.INBOUND),
+                span_type=SpanTypes.WEB,
                 service=self.service,
                 resource=resource,
-                span_type=SpanTypes.WEB,
-            ) as s:
-                s.set_tag_str(COMPONENT, config.bottle.integration_name)
-
-                # set span.kind to the type of request being performed
-                s.set_tag_str(SPAN_KIND, SpanKind.SERVER)
-
-                s.set_tag(_SPAN_MEASURED_KEY)
-                # set analytics sample rate with global config enabled
-                s.set_tag(_ANALYTICS_SAMPLE_RATE_KEY, config.bottle.get_analytics_sample_rate(use_global_config=True))
+                tags={},
+                tracer=self.tracer,
+                distributed_headers=request.headers,
+                distributed_headers_config=config.bottle,
+                headers_case_sensitive=True,
+                analytics_sample_rate=config.bottle.get_analytics_sample_rate(use_global_config=True),
+            ) as ctx, ctx.span as req_span:
+                ctx.set_item("req_span", req_span)
+                core.dispatch("web.request.start", (ctx, config.bottle))
 
                 code = None
                 result = None
@@ -91,16 +83,21 @@ class TracePlugin(object):
                     method = request.method
                     url = request.urlparts._replace(query="").geturl()
                     full_route = "/".join([request.script_name.rstrip("/"), route.rule.lstrip("/")])
-                    trace_utils.set_http_meta(
-                        s,
-                        config.bottle,
-                        method=method,
-                        url=url,
-                        status_code=response_code,
-                        query=request.query_string,
-                        request_headers=request.headers,
-                        response_headers=response.headers,
-                        route=full_route,
+
+                    core.dispatch(
+                        "web.request.finish",
+                        (
+                            req_span,
+                            config.bottle,
+                            method,
+                            url,
+                            response_code,
+                            request.query_string,
+                            request.headers,
+                            response.headers,
+                            full_route,
+                            False,
+                        ),
                     )
 
         return wrapped

--- a/ddtrace/contrib/internal/cherrypy/middleware.py
+++ b/ddtrace/contrib/internal/cherrypy/middleware.py
@@ -11,12 +11,10 @@ from ddtrace import config
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
-from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
-from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import compat
-from ddtrace.internal.constants import COMPONENT
+from ddtrace.internal import core
 from ddtrace.internal.schema import SpanDirection
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema import schematize_url_operation
@@ -77,20 +75,23 @@ class TraceTool(cherrypy.Tool):
         cherrypy.request.hooks.attach("after_error_response", self._after_error_response, priority=5)
 
     def _on_start_resource(self):
-        trace_utils.activate_distributed_headers(
-            self._tracer, int_config=config.cherrypy, request_headers=cherrypy.request.headers
-        )
-
-        cherrypy.request._datadog_span = self._tracer.trace(
-            SPAN_NAME,
-            service=trace_utils.int_service(None, config.cherrypy, default="cherrypy"),
+        with core.context_with_data(
+            "cherrypy.request",
+            span_name=SPAN_NAME,
             span_type=SpanTypes.WEB,
-        )
+            service=trace_utils.int_service(None, config.cherrypy, default="cherrypy"),
+            tags={},
+            tracer=self._tracer,
+            distributed_headers=cherrypy.request.headers,
+            distributed_headers_config=config.cherrypy,
+            headers_case_sensitive=True,
+        ) as ctx:
+            req_span = ctx.span
 
-        cherrypy.request._datadog_span.set_tag_str(COMPONENT, config.cherrypy.integration_name)
+            ctx.set_item("req_span", req_span)
+            core.dispatch("web.request.start", (ctx, config.cherrypy))
 
-        # set span.kind to the type of request being performed
-        cherrypy.request._datadog_span.set_tag_str(SPAN_KIND, SpanKind.SERVER)
+            cherrypy.request._datadog_span = req_span
 
     def _after_error_response(self):
         span = getattr(cherrypy.request, "_datadog_span", None)
@@ -135,17 +136,21 @@ class TraceTool(cherrypy.Tool):
         url = compat.to_unicode(cherrypy.request.base + cherrypy.request.path_info)
         status_code, _, _ = valid_status(cherrypy.response.status)
 
-        trace_utils.set_http_meta(
-            span,
-            config.cherrypy,
-            method=cherrypy.request.method,
-            url=url,
-            status_code=status_code,
-            request_headers=cherrypy.request.headers,
-            response_headers=cherrypy.response.headers,
+        core.dispatch(
+            "web.request.finish",
+            (
+                span,
+                config.cherrypy,
+                cherrypy.request.method,
+                url,
+                status_code,
+                None,
+                cherrypy.request.headers,
+                cherrypy.response.headers,
+                None,
+                True,
+            ),
         )
-
-        span.finish()
 
         # Clear our span just in case.
         cherrypy.request._datadog_span = None

--- a/ddtrace/contrib/internal/falcon/middleware.py
+++ b/ddtrace/contrib/internal/falcon/middleware.py
@@ -1,14 +1,8 @@
 import sys
 
 from ddtrace import config
-from ddtrace.constants import _ANALYTICS_SAMPLE_RATE_KEY
-from ddtrace.constants import _SPAN_MEASURED_KEY
-from ddtrace.constants import SPAN_KIND
-from ddtrace.contrib import trace_utils
-from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
-from ddtrace.ext import http as httpx
-from ddtrace.internal.constants import COMPONENT
+from ddtrace.internal import core
 from ddtrace.internal.schema import SpanDirection
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema import schematize_url_operation
@@ -27,26 +21,27 @@ class TraceMiddleware(object):
     def process_request(self, req, resp):
         # Falcon uppercases all header names.
         headers = dict((k.lower(), v) for k, v in req.headers.items())
-        trace_utils.activate_distributed_headers(self.tracer, int_config=config.falcon, request_headers=headers)
 
-        span = self.tracer.trace(
-            schematize_url_operation("falcon.request", protocol="http", direction=SpanDirection.INBOUND),
-            service=self.service,
+        with core.context_with_data(
+            "falcon.request",
+            span_name=schematize_url_operation("falcon.request", protocol="http", direction=SpanDirection.INBOUND),
             span_type=SpanTypes.WEB,
-        )
-        span.set_tag_str(COMPONENT, config.falcon.integration_name)
+            service=self.service,
+            tags={},
+            tracer=self.tracer,
+            distributed_headers=headers,
+            distributed_headers_config=config.falcon,
+            headers_case_sensitive=True,
+            analytics_sample_rate=config.falcon.get_analytics_sample_rate(use_global_config=True),
+        ) as ctx:
+            req_span = ctx.span
+            ctx.set_item("req_span", req_span)
+            core.dispatch("web.request.start", (ctx, config.falcon))
 
-        # set span.kind to the type of operation being performed
-        span.set_tag_str(SPAN_KIND, SpanKind.SERVER)
-
-        span.set_tag(_SPAN_MEASURED_KEY)
-
-        # set analytics sample rate with global config enabled
-        span.set_tag(_ANALYTICS_SAMPLE_RATE_KEY, config.falcon.get_analytics_sample_rate(use_global_config=True))
-
-        trace_utils.set_http_meta(
-            span, config.falcon, method=req.method, url=req.url, query=req.query_string, request_headers=req.headers
-        )
+            core.dispatch(
+                "web.request.finish",
+                (req_span, config.falcon, req.method, req.url, None, req.query_string, req.headers, None, None, False),
+            )
 
     def process_resource(self, req, resp, resource, params):
         span = self.tracer.current_span()
@@ -69,8 +64,7 @@ class TraceMiddleware(object):
         if resource is None:
             status = "404"
             span.resource = "%s 404" % req.method
-            span.set_tag(httpx.STATUS_CODE, status)
-            span.finish()
+            core.dispatch("web.request.finish", (span, config.falcon, None, None, status, None, None, None, None, True))
             return
 
         err_type = sys.exc_info()[0]
@@ -87,20 +81,13 @@ class TraceMiddleware(object):
 
         route = req.root_path or "" + req.uri_template
 
-        trace_utils.set_http_meta(
-            span,
-            config.falcon,
-            status_code=status,
-            response_headers=resp._headers,
-            route=route,
-        )
-
         # Emit span hook for this response
         # DEV: Emit before closing so they can overwrite `span.resource` if they want
         config.falcon.hooks.emit("request", span, req, resp)
 
-        # Close the span
-        span.finish()
+        core.dispatch(
+            "web.request.finish", (span, config.falcon, None, None, status, None, None, resp._headers, route, True)
+        )
 
 
 def _is_404(err_type):

--- a/ddtrace/contrib/internal/molten/patch.py
+++ b/ddtrace/contrib/internal/molten/patch.py
@@ -5,15 +5,11 @@ import wrapt
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
-from ddtrace.constants import _ANALYTICS_SAMPLE_RATE_KEY
-from ddtrace.constants import _SPAN_MEASURED_KEY
-from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
 from ddtrace.contrib.internal.trace_utils import unwrap as _u
-from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
+from ddtrace.internal import core
 from ddtrace.internal.compat import urlencode
-from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
@@ -89,25 +85,21 @@ def patch_app_call(wrapped, instance, args, kwargs):
     request = molten.http.Request.from_environ(environ)
     resource = func_name(wrapped)
 
-    # request.headers is type Iterable[Tuple[str, str]]
-    trace_utils.activate_distributed_headers(
-        pin.tracer, int_config=config.molten, request_headers=dict(request.headers)
-    )
-
-    with pin.tracer.trace(
-        schematize_url_operation("molten.request", protocol="http", direction=SpanDirection.INBOUND),
+    with core.context_with_data(
+        "molten.request",
+        span_name=schematize_url_operation("molten.request", protocol="http", direction=SpanDirection.INBOUND),
+        span_type=SpanTypes.WEB,
         service=trace_utils.int_service(pin, config.molten),
         resource=resource,
-        span_type=SpanTypes.WEB,
-    ) as span:
-        span.set_tag_str(COMPONENT, config.molten.integration_name)
-
-        # set span.kind tag equal to type of operation being performed
-        span.set_tag_str(SPAN_KIND, SpanKind.SERVER)
-
-        span.set_tag(_SPAN_MEASURED_KEY)
-        # set analytics sample rate with global config enabled
-        span.set_tag(_ANALYTICS_SAMPLE_RATE_KEY, config.molten.get_analytics_sample_rate(use_global_config=True))
+        tags={},
+        tracer=pin.tracer,
+        distributed_headers=dict(request.headers),  # request.headers is type Iterable[Tuple[str, str]]
+        distributed_headers_config=config.molten,
+        headers_case_sensitive=True,
+        analytics_sample_rate=config.molten.get_analytics_sample_rate(use_global_config=True),
+    ) as ctx, ctx.span as req_span:
+        ctx.set_item("req_span", req_span)
+        core.dispatch("web.request.start", (ctx, config.molten))
 
         @wrapt.function_wrapper
         def _w_start_response(wrapped, instance, args, kwargs):
@@ -125,11 +117,13 @@ def patch_app_call(wrapped, instance, args, kwargs):
             except ValueError:
                 pass
 
-            if not span.get_tag(MOLTEN_ROUTE):
+            if not req_span.get_tag(MOLTEN_ROUTE):
                 # if route never resolve, update root resource
-                span.resource = "{} {}".format(request.method, code)
+                req_span.resource = "{} {}".format(request.method, code)
 
-            trace_utils.set_http_meta(span, config.molten, status_code=code)
+            core.dispatch(
+                "web.request.finish", (req_span, config.molten, None, None, code, None, None, None, None, False)
+            )
 
             return wrapped(*args, **kwargs)
 
@@ -143,11 +137,13 @@ def patch_app_call(wrapped, instance, args, kwargs):
             request.path,
         )
         query = urlencode(dict(request.params))
-        trace_utils.set_http_meta(
-            span, config.molten, method=request.method, url=url, query=query, request_headers=request.headers
+
+        core.dispatch(
+            "web.request.finish",
+            (req_span, config.molten, request.method, url, None, query, request.headers, None, None, False),
         )
 
-        span.set_tag_str("molten.version", molten.__version__)
+        req_span.set_tag_str("molten.version", molten.__version__)
         return wrapped(environ, start_response, **kwargs)
 
 

--- a/ddtrace/contrib/internal/pyramid/trace.py
+++ b/ddtrace/contrib/internal/pyramid/trace.py
@@ -6,12 +6,8 @@ import wrapt
 # project
 import ddtrace
 from ddtrace import config
-from ddtrace.constants import _ANALYTICS_SAMPLE_RATE_KEY
-from ddtrace.constants import _SPAN_MEASURED_KEY
-from ddtrace.constants import SPAN_KIND
-from ddtrace.contrib import trace_utils
-from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
+from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.schema import schematize_service_name
@@ -67,29 +63,30 @@ def trace_tween_factory(handler, registry):
     service = settings.get(SETTINGS_SERVICE) or schematize_service_name("pyramid")
     tracer = settings.get(SETTINGS_TRACER) or ddtrace.tracer
     enabled = asbool(settings.get(SETTINGS_TRACE_ENABLED, tracer.enabled))
-    distributed_tracing = asbool(settings.get(SETTINGS_DISTRIBUTED_TRACING, True))
+
+    # ensure distributed tracing within pyramid settings matches config
+    config.pyramid.distributed_tracing_enabled = asbool(settings.get(SETTINGS_DISTRIBUTED_TRACING, True))
 
     if enabled:
         # make a request tracing function
         def trace_tween(request):
-            trace_utils.activate_distributed_headers(
-                tracer, int_config=config.pyramid, request_headers=request.headers, override=distributed_tracing
-            )
-
-            span_name = schematize_url_operation("pyramid.request", protocol="http", direction=SpanDirection.INBOUND)
-            with tracer.trace(span_name, service=service, resource="404", span_type=SpanTypes.WEB) as span:
-                span.set_tag_str(COMPONENT, config.pyramid.integration_name)
-
-                # set span.kind to the type of operation being performed
-                span.set_tag_str(SPAN_KIND, SpanKind.SERVER)
-
-                span.set_tag(_SPAN_MEASURED_KEY)
-                # Configure trace search sample rate
+            with core.context_with_data(
+                "pyramid.request",
+                span_name=schematize_url_operation("pyramid.request", protocol="http", direction=SpanDirection.INBOUND),
+                span_type=SpanTypes.WEB,
+                service=service,
+                resource="404",
+                tags={},
+                tracer=tracer,
+                distributed_headers=request.headers,
+                distributed_headers_config=config.pyramid,
+                headers_case_sensitive=True,
                 # DEV: pyramid is special case maintains separate configuration from config api
-                analytics_enabled = settings.get(SETTINGS_ANALYTICS_ENABLED)
-
-                if (config._analytics_enabled and analytics_enabled is not False) or analytics_enabled is True:
-                    span.set_tag(_ANALYTICS_SAMPLE_RATE_KEY, settings.get(SETTINGS_ANALYTICS_SAMPLE_RATE, True))
+                analytics_enabled=settings.get(SETTINGS_ANALYTICS_ENABLED),
+                analytics_sample_rate=settings.get(SETTINGS_ANALYTICS_SAMPLE_RATE, True),
+            ) as ctx, ctx.span as req_span:
+                ctx.set_item("req_span", req_span)
+                core.dispatch("web.request.start", (ctx, config.pyramid))
 
                 setattr(request, DD_TRACER, tracer)  # used to find the tracer in templates
                 response = None
@@ -110,8 +107,8 @@ def trace_tween_factory(handler, registry):
                 finally:
                     # set request tags
                     if request.matched_route:
-                        span.resource = "{} {}".format(request.method, request.matched_route.name)
-                        span.set_tag_str("pyramid.route.name", request.matched_route.name)
+                        req_span.resource = "{} {}".format(request.method, request.matched_route.name)
+                        req_span.set_tag_str("pyramid.route.name", request.matched_route.name)
                     # set response tags
                     if response:
                         status = response.status_code
@@ -119,17 +116,22 @@ def trace_tween_factory(handler, registry):
                     else:
                         response_headers = None
 
-                    trace_utils.set_http_meta(
-                        span,
-                        config.pyramid,
-                        method=request.method,
-                        url=request.path_url,
-                        status_code=status,
-                        query=request.query_string,
-                        request_headers=request.headers,
-                        response_headers=response_headers,
-                        route=request.matched_route.pattern if request.matched_route else None,
+                    core.dispatch(
+                        "web.request.finish",
+                        (
+                            req_span,
+                            config.pyramid,
+                            request.method,
+                            request.path_url,
+                            status,
+                            request.query_string,
+                            request.headers,
+                            response_headers,
+                            request.matched_route.pattern if request.matched_route else None,
+                            False,
+                        ),
                     )
+
                 return response
 
         return trace_tween

--- a/ddtrace/contrib/internal/sanic/patch.py
+++ b/ddtrace/contrib/internal/sanic/patch.py
@@ -4,14 +4,10 @@ import sanic
 import wrapt
 from wrapt import wrap_function_wrapper as _w
 
-import ddtrace
 from ddtrace import config
-from ddtrace.constants import _ANALYTICS_SAMPLE_RATE_KEY
-from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
-from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
-from ddtrace.internal.constants import COMPONENT
+from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema import schematize_url_operation
@@ -47,7 +43,10 @@ def update_span(span, response):
     #      and so use 500
     status_code = getattr(response, "status", 500)
     response_headers = getattr(response, "headers", None)
-    trace_utils.set_http_meta(span, config.sanic, status_code=status_code, response_headers=response_headers)
+
+    core.dispatch(
+        "web.request.finish", (span, config.sanic, None, None, status_code, None, None, response_headers, None, False)
+    )
 
 
 def _wrap_response_callback(span, callback):
@@ -200,31 +199,35 @@ def _create_sanic_request_span(request):
 
     headers = request.headers.copy()
 
-    trace_utils.activate_distributed_headers(ddtrace.tracer, int_config=config.sanic, request_headers=headers)
-
-    span = pin.tracer.trace(
-        schematize_url_operation("sanic.request", protocol="http", direction=SpanDirection.INBOUND),
+    with core.context_with_data(
+        "sanic.request",
+        span_name=schematize_url_operation("sanic.request", protocol="http", direction=SpanDirection.INBOUND),
+        span_type=SpanTypes.WEB,
         service=trace_utils.int_service(None, config.sanic),
         resource=resource,
-        span_type=SpanTypes.WEB,
-    )
-    span.set_tag_str(COMPONENT, config.sanic.integration_name)
+        tags={},
+        pin=pin,
+        distributed_headers=headers,
+        distributed_headers_config=config.sanic,
+        headers_case_sensitive=True,
+        analytics_sample_rate=config.sanic.get_analytics_sample_rate(use_global_config=True),
+    ) as ctx:
+        req_span = ctx.span
 
-    # set span.kind to the type of operation being performed
-    span.set_tag_str(SPAN_KIND, SpanKind.SERVER)
+        ctx.set_item("req_span", req_span)
+        core.dispatch("web.request.start", (ctx, config.sanic))
 
-    sample_rate = config.sanic.get_analytics_sample_rate(use_global_config=True)
-    if sample_rate is not None:
-        span.set_tag(_ANALYTICS_SAMPLE_RATE_KEY, sample_rate)
+        method = request.method
+        url = "{scheme}://{host}{path}".format(scheme=request.scheme, host=request.host, path=request.path)
+        query_string = request.query_string
+        if isinstance(query_string, bytes):
+            query_string = query_string.decode()
 
-    method = request.method
-    url = "{scheme}://{host}{path}".format(scheme=request.scheme, host=request.host, path=request.path)
-    query_string = request.query_string
-    if isinstance(query_string, bytes):
-        query_string = query_string.decode()
-    trace_utils.set_http_meta(span, config.sanic, method=method, url=url, query=query_string, request_headers=headers)
+        core.dispatch(
+            "web.request.finish", (req_span, config.sanic, method, url, None, query_string, headers, None, None, False)
+        )
 
-    return span
+        return req_span
 
 
 async def sanic_http_lifecycle_handle(request):

--- a/ddtrace/contrib/internal/subprocess/patch.py
+++ b/ddtrace/contrib/internal/subprocess/patch.py
@@ -327,6 +327,8 @@ def unpatch() -> None:
 @trace_utils.with_traced_module
 def _traced_ossystem(module, pin, wrapped, instance, args, kwargs):
     try:
+        if asm_config._bypass_instrumentation_for_waf:
+            return wrapped(*args, **kwargs)
         if isinstance(args[0], str):
             for callback in _STR_CALLBACKS.values():
                 callback(args[0])
@@ -393,6 +395,8 @@ def _traced_osspawn(module, pin, wrapped, instance, args, kwargs):
 @trace_utils.with_traced_module
 def _traced_subprocess_init(module, pin, wrapped, instance, args, kwargs):
     try:
+        if asm_config._bypass_instrumentation_for_waf:
+            return wrapped(*args, **kwargs)
         cmd_args = args[0] if len(args) else kwargs["args"]
         if isinstance(cmd_args, (list, tuple, str)):
             if kwargs.get("shell", False):
@@ -425,6 +429,8 @@ def _traced_subprocess_init(module, pin, wrapped, instance, args, kwargs):
 @trace_utils.with_traced_module
 def _traced_subprocess_wait(module, pin, wrapped, instance, args, kwargs):
     try:
+        if asm_config._bypass_instrumentation_for_waf:
+            return wrapped(*args, **kwargs)
         binary = core.get_item("subprocess_popen_binary")
 
         with pin.tracer.trace(COMMANDS.SPAN_NAME, resource=binary, span_type=SpanTypes.SYSTEM) as span:

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -285,6 +285,7 @@ class LLMObs(Service):
         # Remove listener hooks for span events
         core.reset_listeners("trace.span_start", self._on_span_start)
         core.reset_listeners("trace.span_finish", self._on_span_finish)
+        core.reset_listeners("http.span_inject", self._inject_llmobs_context)
 
         forksafe.unregister(self._child_after_fork)
 
@@ -369,6 +370,7 @@ class LLMObs(Service):
         # Register hooks for span events
         core.on("trace.span_start", cls._instance._on_span_start)
         core.on("trace.span_finish", cls._instance._on_span_finish)
+        core.on("http.span_inject", cls._instance._inject_llmobs_context)
 
         atexit.register(cls.disable)
         telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.LLMOBS, True)
@@ -1162,6 +1164,11 @@ class LLMObs(Service):
 
         cls._instance._llmobs_eval_metric_writer.enqueue(evaluation_metric)
 
+    def _inject_llmobs_context(self, span_context: Context, request_headers: Dict[str, str]) -> None:
+        if self.enabled is False:
+            return
+        _inject_llmobs_parent_id(span_context)
+
     @classmethod
     def inject_distributed_headers(cls, request_headers: Dict[str, str], span: Optional[Span] = None) -> Dict[str, str]:
         """Injects the span's distributed context into the given request headers."""
@@ -1179,7 +1186,6 @@ class LLMObs(Service):
         if span is None:
             log.warning("No span provided and no currently active span found.")
             return request_headers
-        _inject_llmobs_parent_id(span.context)
         HTTPPropagator.inject(span.context, request_headers)
         return request_headers
 

--- a/ddtrace/profiling/collector/_memalloc.c
+++ b/ddtrace/profiling/collector/_memalloc.c
@@ -394,20 +394,28 @@ iterevents_new(PyTypeObject* type, PyObject* Py_UNUSED(args), PyObject* Py_UNUSE
     }
 
     IterEventsState* iestate = (IterEventsState*)type->tp_alloc(type, 0);
-    if (!iestate)
+    if (!iestate) {
+        PyErr_SetString(PyExc_RuntimeError, "failed to allocate IterEventsState");
         return NULL;
+    }
 
     memalloc_assert_gil();
 
-    /* reset the current traceback list */
-    if (memlock_trylock(&g_memalloc_lock)) {
-        iestate->alloc_tracker = global_alloc_tracker;
-        global_alloc_tracker = alloc_tracker_new();
-        memlock_unlock(&g_memalloc_lock);
-    } else {
+    /* Reset the current traceback list. Do this outside lock so we can track it,
+     * and avoid reentrancy/deadlock problems, if we start tracking the raw
+     * allocator domain */
+    alloc_tracker_t* tracker = alloc_tracker_new();
+    if (!tracker) {
+        PyErr_SetString(PyExc_RuntimeError, "failed to allocate new allocation tracker");
         Py_TYPE(iestate)->tp_free(iestate);
         return NULL;
     }
+
+    memlock_lock(&g_memalloc_lock);
+    iestate->alloc_tracker = global_alloc_tracker;
+    global_alloc_tracker = tracker;
+    memlock_unlock(&g_memalloc_lock);
+
     iestate->seq_index = 0;
 
     PyObject* iter_and_count = PyTuple_New(3);

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -28,6 +28,7 @@ from ddtrace._trace.span import _get_64_highest_order_bits_as_hex
 from ddtrace._trace.span import _get_64_lowest_order_bits_as_int
 from ddtrace._trace.span import _MetaDictType
 from ddtrace.appsec._constants import APPSEC
+from ddtrace.internal.core import dispatch
 from ddtrace.settings.asm import config as asm_config
 
 from ..constants import AUTO_KEEP
@@ -1052,6 +1053,7 @@ class HTTPPropagator(object):
         :param dict headers: HTTP headers to extend with tracing attributes.
         :param Span non_active_span: Only to be used if injecting a non-active span.
         """
+        dispatch("http.span_inject", (span_context, headers))
         if not config._propagation_style_inject:
             return
         if non_active_span is not None and non_active_span.context is not span_context:
@@ -1088,11 +1090,6 @@ class HTTPPropagator(object):
         if config._propagation_http_baggage_enabled is True and span_context._baggage is not None:
             for key in span_context._baggage:
                 headers[_HTTP_BAGGAGE_PREFIX + key] = span_context._baggage[key]
-
-        if config._llmobs_enabled:
-            from ddtrace.llmobs._utils import _inject_llmobs_parent_id
-
-            _inject_llmobs_parent_id(span_context)
 
         if PROPAGATION_STYLE_DATADOG in config._propagation_style_inject:
             _DatadogMultiHeader._inject(span_context, headers)

--- a/ddtrace/provider.py
+++ b/ddtrace/provider.py
@@ -7,7 +7,8 @@ from ddtrace.vendor.debtcollector import deprecate
 
 
 deprecate(
-    "The context provider interface is deprecated.",
-    message="The trace context is an internal interface and will no longer be supported.",
+    "The context provider interface is deprecated",
+    message="Import BaseContextProvider from `ddtrace.trace` instead.",
     category=DDTraceDeprecationWarning,
+    removal_version="3.0.0",
 )

--- a/ddtrace/settings/asm.py
+++ b/ddtrace/settings/asm.py
@@ -245,6 +245,7 @@ class ASMConfig(Env):
         default=r"^[+-]?((0b[01]+)|(0x[0-9A-Fa-f]+)|(\d+\.?\d*(?:[Ee][+-]?\d+)?|\.\d+(?:[Ee][+-]"
         + r"?\d+)?)|(X\'[0-9A-Fa-f]+\')|(B\'[01]+\'))$",
     )
+    _bypass_instrumentation_for_waf = False
 
     def __init__(self):
         super().__init__()

--- a/ddtrace/trace/__init__.py
+++ b/ddtrace/trace/__init__.py
@@ -1,6 +1,7 @@
 from ddtrace._trace.context import Context
 from ddtrace._trace.filters import TraceFilter
 from ddtrace._trace.pin import Pin
+from ddtrace._trace.provider import BaseContextProvider
 from ddtrace._trace.span import Span
 from ddtrace._trace.tracer import Tracer
 
@@ -15,4 +16,5 @@ __all__ = [
     "Tracer",
     "Span",
     "tracer",
+    "BaseContextProvider",
 ]

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -221,7 +221,7 @@ context management.
 
 If there is a case where the default is insufficient then a custom context
 provider can be used. It must implement the
-:class:`ddtrace.provider.BaseContextProvider` interface and can be configured
+:class:`ddtrace.trace.BaseContextProvider` interface and can be configured
 with::
 
     tracer.configure(context_provider=MyContextProvider)

--- a/releasenotes/notes/feat-expose-base-context-provider-530ebec2225f6c8d.yaml
+++ b/releasenotes/notes/feat-expose-base-context-provider-530ebec2225f6c8d.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    tracing: Moves ``ddtrace.provider.BaseContextProvider`` to ``ddtrace.trace.BaseContextProvider``. 
+    The ``ddtrace.provider`` module is deprecated and will be removed in v3.0.0.

--- a/releasenotes/notes/fix-llmobs-enable-updates-config-45379a7a30e2e0e3.yaml
+++ b/releasenotes/notes/fix-llmobs-enable-updates-config-45379a7a30e2e0e3.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    LLM Observability: Resolves an issue where explicitly only using ``LLMObs.enable()`` to configure LLM Observability 
+    without environment variables would not automatically propagate distributed tracing headers.  

--- a/releasenotes/notes/profiling-memalloc-iter-events-null-780fd50bbebbf616.yaml
+++ b/releasenotes/notes/profiling-memalloc-iter-events-null-780fd50bbebbf616.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    profiling: fix SystemError from the memory profiler returning NULL when collecting events

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -60,7 +60,6 @@ def test_service_enable_proxy_default():
         assert llmobs_instance.tracer == dummy_tracer
         assert isinstance(llmobs_instance._llmobs_span_writer._clients[0], LLMObsProxiedEventClient)
         assert run_llmobs_trace_filter(dummy_tracer) is not None
-
         llmobs_service.disable()
 
 

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_child.json
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_child.json
@@ -22,6 +22,7 @@
       "span.kind": "server"
     },
     "metrics": {
+      "_dd.measured": 1,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_error.json
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_error.json
@@ -25,6 +25,7 @@
       "span.kind": "server"
     },
     "metrics": {
+      "_dd.measured": 1,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_fatal.json
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_fatal.json
@@ -25,6 +25,7 @@
       "span.kind": "server"
     },
     "metrics": {
+      "_dd.measured": 1,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,

--- a/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_success.json
+++ b/tests/snapshots/tests.contrib.cherrypy.test_middleware.test_success.json
@@ -22,6 +22,7 @@
       "span.kind": "server"
     },
     "metrics": {
+      "_dd.measured": 1,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http.json
@@ -23,6 +23,7 @@
       "span.kind": "server"
     },
     "metrics": {
+      "_dd.measured": 1,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
@@ -72,6 +73,7 @@
       "span.kind": "server"
     },
     "metrics": {
+      "_dd.measured": 1,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http_pre_21.9.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_multiple_requests_sanic_http_pre_21.9.json
@@ -22,6 +22,7 @@
       "span.kind": "server"
     },
     "metrics": {
+      "_dd.measured": 1,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
@@ -70,6 +71,7 @@
       "span.kind": "server"
     },
     "metrics": {
+      "_dd.measured": 1,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_sanic_errors.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_sanic_errors.json
@@ -22,6 +22,7 @@
       "span.kind": "server"
     },
     "metrics": {
+      "_dd.measured": 1,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
@@ -58,6 +59,7 @@
       "span.kind": "server"
     },
     "metrics": {
+      "_dd.measured": 1,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,

--- a/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_sanic_errors_pre_21.9.json
+++ b/tests/snapshots/tests.contrib.sanic.test_sanic_server.test_sanic_errors_pre_21.9.json
@@ -22,6 +22,7 @@
       "span.kind": "server"
     },
     "metrics": {
+      "_dd.measured": 1,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
@@ -54,6 +55,7 @@
       "span.kind": "server"
     },
     "metrics": {
+      "_dd.measured": 1,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,

--- a/tests/suitespec.yml
+++ b/tests/suitespec.yml
@@ -223,6 +223,7 @@ suites:
     pattern: profile$|profile-v2
     retry: 2
     runner: riot
+    timeout: 30m
   runtime:
     paths:
       - '@bootstrap'

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -4,7 +4,6 @@ import logging
 import os
 import pickle
 
-import mock
 import pytest
 
 import ddtrace
@@ -3385,29 +3384,6 @@ print(json.dumps(headers))
 
     result = json.loads(stdout.decode())
     assert result == expected_headers
-
-
-def test_llmobs_enabled_injects_llmobs_parent_id():
-    with override_global_config(dict(_llmobs_enabled=True)):
-        with mock.patch("ddtrace.llmobs._utils._inject_llmobs_parent_id") as mock_llmobs_inject:
-            context = Context(trace_id=1, span_id=2)
-            HTTPPropagator.inject(context, {})
-            mock_llmobs_inject.assert_called_once_with(context)
-
-
-def test_llmobs_disabled_does_not_inject_parent_id():
-    with override_global_config(dict(_llmobs_enabled=False)):
-        with mock.patch("ddtrace.llmobs._utils._inject_llmobs_parent_id") as mock_llmobs_inject:
-            context = Context(trace_id=1, span_id=2)
-            HTTPPropagator.inject(context, {})
-            mock_llmobs_inject.assert_not_called()
-
-
-def test_llmobs_parent_id_not_injected_by_default():
-    with mock.patch("ddtrace.llmobs._utils._inject_llmobs_parent_id") as mock_llmobs_inject:
-        context = Context(trace_id=1, span_id=2)
-        HTTPPropagator.inject(context, {})
-        mock_llmobs_inject.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
These jobs have been timing out frequently lately, see https://github.com/DataDog/dd-trace-py/pull/11888 for example

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
