### PR TITLE
fix(logging): remove unneeded forksafe unregister to avoid unneeded logging

### DIFF
--- a/ddtrace/internal/remoteconfig/worker.py
+++ b/ddtrace/internal/remoteconfig/worker.py
@@ -2,7 +2,6 @@ import os
 from typing import List  # noqa:F401
 
 from ddtrace.internal import agent
-from ddtrace.internal import atexit
 from ddtrace.internal import forksafe
 from ddtrace.internal import periodic
 from ddtrace.internal.logger import get_logger
@@ -131,8 +130,6 @@ class RemoteConfigPoller(periodic.PeriodicService):
 
         if self.status == ServiceStatus.STOPPED:
             return
-
-        atexit.unregister(self.disable)
 
         self.stop(join=join)
 

--- a/ddtrace/internal/remoteconfig/worker.py
+++ b/ddtrace/internal/remoteconfig/worker.py
@@ -132,7 +132,6 @@ class RemoteConfigPoller(periodic.PeriodicService):
         if self.status == ServiceStatus.STOPPED:
             return
 
-        forksafe.unregister(self.reset_at_fork)
         atexit.unregister(self.disable)
 
         self.stop(join=join)

--- a/releasenotes/notes/remove_unneeded_unregister-ad20120201768a7e.yaml
+++ b/releasenotes/notes/remove_unneeded_unregister-ad20120201768a7e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    logging: This fix resolves an an unneeded info log being logged on process exit
+    due to a forksafe hook being unregistered that was never registered to begin with.

--- a/releasenotes/notes/remove_unneeded_unregister-ad20120201768a7e.yaml
+++ b/releasenotes/notes/remove_unneeded_unregister-ad20120201768a7e.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    logging: This fix resolves an an unneeded info log being logged on process exit
+    logging: Resolves an an unneeded info log being logged on process exit
     due to a forksafe hook being unregistered that was never registered to begin with.


### PR DESCRIPTION
Removes unneeded forksafe unregister hook. The unregister is not needed, because we never actually registered the hook to begin with.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
