### PR TITLE
ci(benchmarks): fix failing microbenchmarks

### DIFF
--- a/benchmarks/bm/utils.py
+++ b/benchmarks/bm/utils.py
@@ -65,7 +65,7 @@ class _DropTraces(TraceFilter):
 
 
 def drop_traces(tracer):
-    tracer.configure(settings={"FILTERS": [_DropTraces()]})
+    tracer.configure(trace_processors=[_DropTraces()])
 
 
 def drop_telemetry_events():

--- a/benchmarks/rate_limiter/scenario.py
+++ b/benchmarks/rate_limiter/scenario.py
@@ -23,8 +23,8 @@ class RateLimiter(bm.Scenario):
             windows = [start + (i * self.time_window) for i in range(self.num_windows)]
             per_window = math.floor(loops / self.num_windows)
 
-            for window in windows:
+            for _ in windows:
                 for _ in range(per_window):
-                    rate_limiter.is_allowed(window)
+                    rate_limiter.is_allowed()
 
         yield _


### PR DESCRIPTION
https://github.com/DataDog/dd-trace-py/pull/12186 removed deprecated parameters from `tracer.configure(...)` and `rate_limiter.allowed(...)` but did not update the microbenchmarks. This PR address this issue.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
