### PR TITLE
chore(langchain): drop legacy integration metrics and logs

### DIFF
--- a/ddtrace/contrib/_langchain.py
+++ b/ddtrace/contrib/_langchain.py
@@ -1,9 +1,8 @@
 """
-The LangChain integration instruments the LangChain Python library to emit metrics,
-traces, and logs (logs are disabled by default) for requests made to the LLMs,
+The LangChain integration instruments the LangChain Python library to emit traces for requests made to the LLMs,
 chat models, embeddings, chains, and vector store interfaces.
 
-All metrics, logs, and traces submitted from the LangChain integration are tagged by:
+All traces submitted from the LangChain integration are tagged by:
 
 - ``service``, ``env``, ``version``: see the `Unified Service Tagging docs <https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging>`_.
 - ``langchain.request.provider``: LLM provider used in the request.
@@ -26,58 +25,6 @@ is no longer a required dependency of ``langchain>=0.2.0``. This means that this
 - Total cost metrics for OpenAI requests
 
 
-Metrics
-~~~~~~~
-
-The following metrics are collected by default by the LangChain integration.
-
-.. important::
-    If the Agent is configured to use a non-default Statsd hostname or port, use ``DD_DOGSTATSD_URL`` to configure
-    ``ddtrace`` to use it.
-
-
-.. py:data:: langchain.request.duration
-
-   The duration of the LangChain request in seconds.
-
-   Type: ``distribution``
-
-
-.. py:data:: langchain.request.error
-
-   The number of errors from requests made with LangChain.
-
-   Type: ``count``
-
-
-.. py:data:: langchain.tokens.prompt
-
-   The number of tokens used in the prompt of a LangChain request.
-
-   Type: ``distribution``
-
-
-.. py:data:: langchain.tokens.completion
-
-   The number of tokens used in the completion of a LangChain response.
-
-   Type: ``distribution``
-
-
-.. py:data:: langchain.tokens.total
-
-   The total number of tokens used in the prompt and completion of a LangChain request/response.
-
-   Type: ``distribution``
-
-
-.. py:data:: langchain.tokens.total_cost
-
-   The estimated cost in USD based on token usage.
-
-   Type: ``count``
-
-
 (beta) Prompt and Completion Sampling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -88,18 +35,6 @@ The following data is collected in span tags with a default sampling rate of ``1
 - Embedding inputs for the ``Embeddings`` interface.
 - Prompt inputs, chain inputs, and outputs for the ``Chain`` interface.
 - Query inputs and document outputs for the ``VectorStore`` interface.
-
-Prompt and message inputs and completions can also be emitted as log data.
-Logs are **not** emitted by default. When logs are enabled they are sampled at ``0.1``.
-
-Read the **Global Configuration** section for information about enabling logs and configuring sampling
-rates.
-
-.. important::
-
-    To submit logs, you must set the ``DD_API_KEY`` environment variable.
-
-    Set ``DD_SITE`` to send logs to a Datadog site such as ``datadoghq.eu``. The default is ``datadoghq.com``.
 
 
 Enabling
@@ -143,32 +78,6 @@ Global Configuration
    Default: ``DD_SERVICE``
 
 
-.. py:data:: ddtrace.config.langchain["logs_enabled"]
-
-   Enable collection of prompts and completions as logs. You can adjust the rate of prompts and completions collected
-   using the sample rate configuration described below.
-
-   Alternatively, you can set this option with the ``DD_LANGCHAIN_LOGS_ENABLED`` environment
-   variable.
-
-   Note that you must set the ``DD_API_KEY`` environment variable to enable sending logs.
-
-   Default: ``False``
-
-
-.. py:data:: ddtrace.config.langchain["metrics_enabled"]
-
-   Enable collection of LangChain metrics.
-
-   If the Datadog Agent is configured to use a non-default Statsd hostname
-   or port, use ``DD_DOGSTATSD_URL`` to configure ``ddtrace`` to use it.
-
-   Alternatively, you can set this option with the ``DD_LANGCHAIN_METRICS_ENABLED`` environment
-   variable.
-
-   Default: ``True``
-
-
 .. py:data:: (beta) ddtrace.config.langchain["span_char_limit"]
 
    Configure the maximum number of characters for the following data within span tags:
@@ -194,15 +103,5 @@ Global Configuration
    variable.
 
    Default: ``1.0``
-
-
-.. py:data:: (beta) ddtrace.config.langchain["log_prompt_completion_sample_rate"]
-
-   Configure the sample rate for the collection of prompts and completions as logs.
-
-   Alternatively, you can set this option with the ``DD_LANGCHAIN_LOG_PROMPT_COMPLETION_SAMPLE_RATE`` environment
-   variable.
-
-   Default: ``0.1``
 
 """  # noqa: E501

--- a/ddtrace/contrib/internal/langchain/patch.py
+++ b/ddtrace/contrib/internal/langchain/patch.py
@@ -56,7 +56,6 @@ from ddtrace.contrib.internal.trace_utils import wrap
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import ArgumentError
 from ddtrace.internal.utils import get_argument_value
-from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import deep_getattr
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._integrations import LangChainIntegration
@@ -76,10 +75,7 @@ def get_version():
 config._add(
     "langchain",
     {
-        "logs_enabled": asbool(os.getenv("DD_LANGCHAIN_LOGS_ENABLED", False)),
-        "metrics_enabled": asbool(os.getenv("DD_LANGCHAIN_METRICS_ENABLED", True)),
         "span_prompt_completion_sample_rate": float(os.getenv("DD_LANGCHAIN_SPAN_PROMPT_COMPLETION_SAMPLE_RATE", 1.0)),
-        "log_prompt_completion_sample_rate": float(os.getenv("DD_LANGCHAIN_LOG_PROMPT_COMPLETION_SAMPLE_RATE", 0.1)),
         "span_char_limit": int(os.getenv("DD_LANGCHAIN_SPAN_CHAR_LIMIT", 128)),
     },
 )
@@ -221,7 +217,6 @@ def traced_llm_generate(langchain, pin, func, instance, args, kwargs):
         completions = func(*args, **kwargs)
         if _is_openai_llm_instance(instance):
             _tag_openai_token_usage(span, completions.llm_output)
-            integration.record_usage(span, completions.llm_output)
 
         for idx, completion in enumerate(completions.generations):
             if integration.is_pc_sampled_span(span):
@@ -237,28 +232,10 @@ def traced_llm_generate(langchain, pin, func, instance, args, kwargs):
                 )
     except Exception:
         span.set_exc_info(*sys.exc_info())
-        integration.metric(span, "incr", "request.error", 1)
         raise
     finally:
         integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=completions, operation="llm")
         span.finish()
-        integration.metric(span, "dist", "request.duration", span.duration_ns)
-        if integration.is_pc_sampled_log(span):
-            if completions is None:
-                log_completions = []
-            else:
-                log_completions = [
-                    [{"text": completion.text} for completion in completions] for completions in completions.generations
-                ]
-            integration.log(
-                span,
-                "info" if span.error == 0 else "error",
-                "sampled %s.%s" % (instance.__module__, instance.__class__.__name__),
-                attrs={
-                    "prompts": prompts,
-                    "choices": log_completions,
-                },
-            )
     return completions
 
 
@@ -292,7 +269,6 @@ async def traced_llm_agenerate(langchain, pin, func, instance, args, kwargs):
         completions = await func(*args, **kwargs)
         if _is_openai_llm_instance(instance):
             _tag_openai_token_usage(span, completions.llm_output)
-            integration.record_usage(span, completions.llm_output)
 
         for idx, completion in enumerate(completions.generations):
             if integration.is_pc_sampled_span(span):
@@ -308,28 +284,10 @@ async def traced_llm_agenerate(langchain, pin, func, instance, args, kwargs):
                 )
     except Exception:
         span.set_exc_info(*sys.exc_info())
-        integration.metric(span, "incr", "request.error", 1)
         raise
     finally:
         integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=completions, operation="llm")
         span.finish()
-        integration.metric(span, "dist", "request.duration", span.duration_ns)
-        if integration.is_pc_sampled_log(span):
-            if completions is None:
-                log_completions = []
-            else:
-                log_completions = [
-                    [{"text": completion.text} for completion in completions] for completions in completions.generations
-                ]
-            integration.log(
-                span,
-                "info" if span.error == 0 else "error",
-                "sampled %s.%s" % (instance.__module__, instance.__class__.__name__),
-                attrs={
-                    "prompts": prompts,
-                    "choices": log_completions,
-                },
-            )
     return completions
 
 
@@ -376,7 +334,6 @@ def traced_chat_model_generate(langchain, pin, func, instance, args, kwargs):
         chat_completions = func(*args, **kwargs)
         if _is_openai_chat_instance(instance):
             _tag_openai_token_usage(span, chat_completions.llm_output)
-            integration.record_usage(span, chat_completions.llm_output)
 
         for message_set_idx, message_set in enumerate(chat_completions.generations):
             for idx, chat_completion in enumerate(message_set):
@@ -417,45 +374,10 @@ def traced_chat_model_generate(langchain, pin, func, instance, args, kwargs):
                 )
     except Exception:
         span.set_exc_info(*sys.exc_info())
-        integration.metric(span, "incr", "request.error", 1)
         raise
     finally:
         integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=chat_completions, operation="chat")
         span.finish()
-        integration.metric(span, "dist", "request.duration", span.duration_ns)
-        if integration.is_pc_sampled_log(span):
-            if chat_completions is None:
-                log_chat_completions = []
-            else:
-                log_chat_completions = [
-                    [
-                        {"content": message.text, "message_type": message.message.__class__.__name__}
-                        for message in messages
-                    ]
-                    for messages in chat_completions.generations
-                ]
-            integration.log(
-                span,
-                "info" if span.error == 0 else "error",
-                "sampled %s.%s" % (instance.__module__, instance.__class__.__name__),
-                attrs={
-                    "messages": [
-                        [
-                            {
-                                "content": (
-                                    message.get("content", "")
-                                    if isinstance(message, dict)
-                                    else str(getattr(message, "content", ""))
-                                ),
-                                "message_type": message.__class__.__name__,
-                            }
-                            for message in messages
-                        ]
-                        for messages in chat_messages
-                    ],
-                    "choices": log_chat_completions,
-                },
-            )
     return chat_completions
 
 
@@ -502,7 +424,6 @@ async def traced_chat_model_agenerate(langchain, pin, func, instance, args, kwar
         chat_completions = await func(*args, **kwargs)
         if _is_openai_chat_instance(instance):
             _tag_openai_token_usage(span, chat_completions.llm_output)
-            integration.record_usage(span, chat_completions.llm_output)
 
         for message_set_idx, message_set in enumerate(chat_completions.generations):
             for idx, chat_completion in enumerate(message_set):
@@ -542,45 +463,10 @@ async def traced_chat_model_agenerate(langchain, pin, func, instance, args, kwar
                 )
     except Exception:
         span.set_exc_info(*sys.exc_info())
-        integration.metric(span, "incr", "request.error", 1)
         raise
     finally:
         integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=chat_completions, operation="chat")
         span.finish()
-        integration.metric(span, "dist", "request.duration", span.duration_ns)
-        if integration.is_pc_sampled_log(span):
-            if chat_completions is None:
-                log_chat_completions = []
-            else:
-                log_chat_completions = [
-                    [
-                        {"content": message.text, "message_type": message.message.__class__.__name__}
-                        for message in messages
-                    ]
-                    for messages in chat_completions.generations
-                ]
-            integration.log(
-                span,
-                "info" if span.error == 0 else "error",
-                "sampled %s.%s" % (instance.__module__, instance.__class__.__name__),
-                attrs={
-                    "messages": [
-                        [
-                            {
-                                "content": (
-                                    message.get("content", "")
-                                    if isinstance(message, dict)
-                                    else str(getattr(message, "content", ""))
-                                ),
-                                "message_type": message.__class__.__name__,
-                            }
-                            for message in messages
-                        ]
-                        for messages in chat_messages
-                    ],
-                    "choices": log_chat_completions,
-                },
-            )
     return chat_completions
 
 
@@ -627,19 +513,10 @@ def traced_embedding(langchain, pin, func, instance, args, kwargs):
             span.set_metric("langchain.response.outputs.embedding_length", len(embeddings))
     except Exception:
         span.set_exc_info(*sys.exc_info())
-        integration.metric(span, "incr", "request.error", 1)
         raise
     finally:
         integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=embeddings, operation="embedding")
         span.finish()
-        integration.metric(span, "dist", "request.duration", span.duration_ns)
-        if integration.is_pc_sampled_log(span):
-            integration.log(
-                span,
-                "info" if span.error == 0 else "error",
-                "sampled %s.%s" % (instance.__module__, instance.__class__.__name__),
-                attrs={"inputs": [input_texts] if isinstance(input_texts, str) else input_texts},
-            )
     return embeddings
 
 
@@ -689,12 +566,10 @@ def traced_lcel_runnable_sequence(langchain, pin, func, instance, args, kwargs):
                 span.set_tag_str("langchain.response.outputs.%d" % idx, integration.trunc(str(output)))
     except Exception:
         span.set_exc_info(*sys.exc_info())
-        integration.metric(span, "incr", "request.error", 1)
         raise
     finally:
         integration.llmobs_set_tags(span, args=[], kwargs=inputs, response=final_output, operation="chain")
         span.finish()
-        integration.metric(span, "dist", "request.duration", span.duration_ns)
     return final_output
 
 
@@ -735,12 +610,10 @@ async def traced_lcel_runnable_sequence_async(langchain, pin, func, instance, ar
                 span.set_tag_str("langchain.response.outputs.%d" % idx, integration.trunc(str(output)))
     except Exception:
         span.set_exc_info(*sys.exc_info())
-        integration.metric(span, "incr", "request.error", 1)
         raise
     finally:
         integration.llmobs_set_tags(span, args=[], kwargs=inputs, response=final_output, operation="chain")
         span.finish()
-        integration.metric(span, "dist", "request.duration", span.duration_ns)
     return final_output
 
 
@@ -793,25 +666,10 @@ def traced_similarity_search(langchain, pin, func, instance, args, kwargs):
                 )
     except Exception:
         span.set_exc_info(*sys.exc_info())
-        integration.metric(span, "incr", "request.error", 1)
         raise
     finally:
         integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=documents, operation="retrieval")
         span.finish()
-        integration.metric(span, "dist", "request.duration", span.duration_ns)
-        if integration.is_pc_sampled_log(span):
-            integration.log(
-                span,
-                "info" if span.error == 0 else "error",
-                "sampled %s.%s" % (instance.__module__, instance.__class__.__name__),
-                attrs={
-                    "query": query,
-                    "k": k or "",
-                    "documents": [
-                        {"page_content": document.page_content, "metadata": document.metadata} for document in documents
-                    ],
-                },
-            )
     return documents
 
 

--- a/releasenotes/notes/langchain-drop-logs-metrics-a997e8059886b20a.yaml
+++ b/releasenotes/notes/langchain-drop-logs-metrics-a997e8059886b20a.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    langchain: Removes prompt-completion log sampling from the LangChain integration. To continue logging prompt completions,
+     enable LLM Observability.
+  - |
+    langchain: Removes integration metrics from the LangChain integration. To continue tracking operational metrics from the
+     OpenAI integration, enable LLM Observability or use trace metrics instead.


### PR DESCRIPTION
This PR removes integration metrics and logs from the langchain integration.

Prompt-completion logs were always experimental, rarely used, and unofficially deprecated since the release of LLM Observability. For any customers looking to continue getting visibility into their langchain call prompt/completions, we are now pushing to migrate over to use LLM Observability instead.

Operational Integration metrics can either be replaced with LLM Observability or APM trace metrics instead. The only caveat of using LLM Observability is for customers who may not want prompt/completion logging, and the only caveat of using APM trace metrics is that token metrics will not be included, primarily only operation metrics.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
