### PR TITLE
chore(django): make middleware,db,cache,and template spans opt in (instead of opt out)

### DIFF
--- a/ddtrace/contrib/_django.py
+++ b/ddtrace/contrib/_django.py
@@ -91,7 +91,7 @@ Configuration
 
    Can also be enabled with the ``DD_DJANGO_INSTRUMENT_MIDDLEWARE`` environment variable.
 
-   Default: ``True``
+   Default: ``False``
 
 .. py:data:: ddtrace.config.django['instrument_templates']
 
@@ -99,7 +99,7 @@ Configuration
 
    Can also be enabled with the ``DD_DJANGO_INSTRUMENT_TEMPLATES`` environment variable.
 
-   Default: ``True``
+   Default: ``False``
 
 .. py:data:: ddtrace.config.django['instrument_databases']
 
@@ -107,7 +107,7 @@ Configuration
 
    Can also be enabled with the ``DD_DJANGO_INSTRUMENT_DATABASES`` environment variable.
 
-   Default: ``True``
+   Default: ``False``
 
 .. py:data:: ddtrace.config.django['instrument_caches']
 
@@ -115,7 +115,7 @@ Configuration
 
     Can also be enabled with the ``DD_DJANGO_INSTRUMENT_CACHES`` environment variable.
 
-   Default: ``True``
+   Default: ``False``
 
 .. py:data:: ddtrace.config.django.http['trace_query_string']
 

--- a/ddtrace/contrib/internal/django/patch.py
+++ b/ddtrace/contrib/internal/django/patch.py
@@ -65,10 +65,10 @@ config._add(
         database_service_name=os.getenv("DD_DJANGO_DATABASE_SERVICE_NAME", default=""),
         trace_fetch_methods=asbool(os.getenv("DD_DJANGO_TRACE_FETCH_METHODS", default=False)),
         distributed_tracing_enabled=True,
-        instrument_middleware=asbool(os.getenv("DD_DJANGO_INSTRUMENT_MIDDLEWARE", default=True)),
-        instrument_templates=asbool(os.getenv("DD_DJANGO_INSTRUMENT_TEMPLATES", default=True)),
-        instrument_databases=asbool(os.getenv("DD_DJANGO_INSTRUMENT_DATABASES", default=True)),
-        instrument_caches=asbool(os.getenv("DD_DJANGO_INSTRUMENT_CACHES", default=True)),
+        instrument_middleware=asbool(os.getenv("DD_DJANGO_INSTRUMENT_MIDDLEWARE", default=False)),
+        instrument_templates=asbool(os.getenv("DD_DJANGO_INSTRUMENT_TEMPLATES", default=False)),
+        instrument_databases=asbool(os.getenv("DD_DJANGO_INSTRUMENT_DATABASES", default=False)),
+        instrument_caches=asbool(os.getenv("DD_DJANGO_INSTRUMENT_CACHES", default=False)),
         analytics_enabled=None,  # None allows the value to be overridden by the global config
         analytics_sample_rate=None,
         trace_query_string=None,  # Default to global config

--- a/releasenotes/notes/make-django-spans-optin-13586d37aafa03a8.yaml
+++ b/releasenotes/notes/make-django-spans-optin-13586d37aafa03a8.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+    django: The following configurations are now disabled by default. To enable django middleware, 
+    templates, databases, and/or caches spans, set the following environment variables to `true`:
+     - DD_DJANGO_INSTRUMENT_MIDDLEWARE
+     - DD_DJANGO_INSTRUMENT_TEMPLATES
+     - DD_DJANGO_INSTRUMENT_DATABASES
+     - DD_DJANGO_INSTRUMENT_CACHES

--- a/riotfile.py
+++ b/riotfile.py
@@ -823,7 +823,7 @@ venv = Venv(
                 "DD_DJANGO_INSTRUMENT_TEMPLATES": "true",
                 "DD_DJANGO_INSTRUMENT_DATABASES": "true",
                 "DD_DJANGO_INSTRUMENT_CACHES": "true",
-            }
+            },
             venvs=[
                 Venv(
                     # djangorestframework dropped support for Django 2.x in 3.14
@@ -871,7 +871,7 @@ venv = Venv(
                 "DD_DJANGO_INSTRUMENT_TEMPLATES": "true",
                 "DD_DJANGO_INSTRUMENT_DATABASES": "true",
                 "DD_DJANGO_INSTRUMENT_CACHES": "true",
-            }
+            },
             venvs=[
                 Venv(
                     pys=select_pys(min_version="3.8", max_version="3.11"),

--- a/riotfile.py
+++ b/riotfile.py
@@ -742,6 +742,13 @@ venv = Venv(
             env={
                 "DD_CIVISIBILITY_ITR_ENABLED": "0",
                 "DD_IAST_REQUEST_SAMPLING": "100",  # Override default 30% to analyze all IAST requests
+                # With ddtrace>=3.0 django middleware, db, cache, and template instrumentation are opt-in
+                # Setting these environment variables to true in riot will allow us to roll out this change
+                # without updating very single test.
+                "DD_DJANGO_INSTRUMENT_MIDDLEWARE": "true",
+                "DD_DJANGO_INSTRUMENT_TEMPLATES": "true",
+                "DD_DJANGO_INSTRUMENT_DATABASES": "true",
+                "DD_DJANGO_INSTRUMENT_CACHES": "true",
             },
             venvs=[
                 Venv(
@@ -773,6 +780,17 @@ venv = Venv(
                 "pytest-randomly": latest,
                 "setuptools": latest,
             },
+            env={
+                "DD_CIVISIBILITY_ITR_ENABLED": "0",
+                "DD_IAST_REQUEST_SAMPLING": "100",  # Override default 30% to analyze all IAST requests
+                # With ddtrace>=3.0 django middleware, db, cache, and template instrumentation are opt-in
+                # Setting these environment variables to true in riot will allow us to roll out this change
+                # without updating very single test.
+                "DD_DJANGO_INSTRUMENT_MIDDLEWARE": "true",
+                "DD_DJANGO_INSTRUMENT_TEMPLATES": "true",
+                "DD_DJANGO_INSTRUMENT_DATABASES": "true",
+                "DD_DJANGO_INSTRUMENT_CACHES": "true",
+            },
             venvs=[
                 Venv(
                     pys=select_pys(min_version="3.8"),
@@ -797,6 +815,15 @@ venv = Venv(
                 "pytest-django[testing]": "==3.10.0",
                 "pytest-randomly": latest,
             },
+            # With ddtrace>=3.0 django middleware, db, cache, and template instrumentation are opt-in
+            # Setting these environment variables to true in riot will allow us to roll out this change
+            # without updating very single test.
+            env={
+                "DD_DJANGO_INSTRUMENT_MIDDLEWARE": "true",
+                "DD_DJANGO_INSTRUMENT_TEMPLATES": "true",
+                "DD_DJANGO_INSTRUMENT_DATABASES": "true",
+                "DD_DJANGO_INSTRUMENT_CACHES": "true",
+            }
             venvs=[
                 Venv(
                     # djangorestframework dropped support for Django 2.x in 3.14
@@ -836,6 +863,15 @@ venv = Venv(
                 "typing-extensions": latest,
                 "pytest-randomly": latest,
             },
+            # With ddtrace>=3.0 django middleware, db, cache, and template instrumentation are opt-in
+            # Setting these environment variables to true in riot will allow us to roll out this change
+            # without updating very single test.
+            env={
+                "DD_DJANGO_INSTRUMENT_MIDDLEWARE": "true",
+                "DD_DJANGO_INSTRUMENT_TEMPLATES": "true",
+                "DD_DJANGO_INSTRUMENT_DATABASES": "true",
+                "DD_DJANGO_INSTRUMENT_CACHES": "true",
+            }
             venvs=[
                 Venv(
                     pys=select_pys(min_version="3.8", max_version="3.11"),


### PR DESCRIPTION
The following configurations are now disabled by default. To enable django middleware, 
    templates, databases, and/or caches spans, set the following environment variables to `true`:
     - DD_DJANGO_INSTRUMENT_MIDDLEWARE
     - DD_DJANGO_INSTRUMENT_TEMPLATES
     - DD_DJANGO_INSTRUMENT_DATABASES
     - DD_DJANGO_INSTRUMENT_CACHES
  
This PR updates the riotfile to avoid rewriting/updating tests. This clean up work will be done in a future PR (after v3.0).

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
