### PR TITLE
chore(llmobs): [MLOB-1944] generalize helper for extracting token metrics

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -31,7 +31,6 @@ VERTEXAI_APM_SPAN_NAME = "vertexai.request"
 INPUT_TOKENS_METRIC_KEY = "input_tokens"
 OUTPUT_TOKENS_METRIC_KEY = "output_tokens"
 TOTAL_TOKENS_METRIC_KEY = "total_tokens"
-INTEGRATIONS_USING_INPUT_OUTPUT_TOKENS = {"anthropic"}
 
 EVP_PROXY_AGENT_BASE_PATH = "evp_proxy/v2"
 EVP_PROXY_AGENT_ENDPOINT = "{}/api/v2/llmobs".format(EVP_PROXY_AGENT_BASE_PATH)

--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -31,6 +31,7 @@ VERTEXAI_APM_SPAN_NAME = "vertexai.request"
 INPUT_TOKENS_METRIC_KEY = "input_tokens"
 OUTPUT_TOKENS_METRIC_KEY = "output_tokens"
 TOTAL_TOKENS_METRIC_KEY = "total_tokens"
+INTEGRATIONS_USING_INPUT_OUTPUT_TOKENS = {"anthropic"}
 
 EVP_PROXY_AGENT_BASE_PATH = "evp_proxy/v2"
 EVP_PROXY_AGENT_ENDPOINT = "{}/api/v2/llmobs".format(EVP_PROXY_AGENT_BASE_PATH)

--- a/ddtrace/llmobs/_integrations/anthropic.py
+++ b/ddtrace/llmobs/_integrations/anthropic.py
@@ -7,15 +7,12 @@ from typing import Optional
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._constants import INPUT_MESSAGES
-from ddtrace.llmobs._constants import INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import METADATA
 from ddtrace.llmobs._constants import METRICS
 from ddtrace.llmobs._constants import MODEL_NAME
 from ddtrace.llmobs._constants import MODEL_PROVIDER
 from ddtrace.llmobs._constants import OUTPUT_MESSAGES
-from ddtrace.llmobs._constants import OUTPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import SPAN_KIND
-from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._integrations.utils import get_llmobs_metrics_tags
 from ddtrace.llmobs._utils import _get_attr

--- a/ddtrace/llmobs/_integrations/anthropic.py
+++ b/ddtrace/llmobs/_integrations/anthropic.py
@@ -17,6 +17,7 @@ from ddtrace.llmobs._constants import OUTPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import SPAN_KIND
 from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
+from ddtrace.llmobs._integrations.utils import get_llmobs_metrics_tags
 from ddtrace.llmobs._utils import _get_attr
 from ddtrace.trace import Span
 
@@ -77,7 +78,7 @@ class AnthropicIntegration(BaseLLMIntegration):
                 INPUT_MESSAGES: input_messages,
                 METADATA: parameters,
                 OUTPUT_MESSAGES: output_messages,
-                METRICS: self._get_llmobs_metrics_tags(span),
+                METRICS: get_llmobs_metrics_tags("anthropic", span),
             }
         )
 
@@ -188,18 +189,3 @@ class AnthropicIntegration(BaseLLMIntegration):
             span.set_metric("anthropic.response.usage.output_tokens", output_tokens)
         if input_tokens is not None and output_tokens is not None:
             span.set_metric("anthropic.response.usage.total_tokens", input_tokens + output_tokens)
-
-    @staticmethod
-    def _get_llmobs_metrics_tags(span):
-        usage = {}
-        input_tokens = span.get_metric("anthropic.response.usage.input_tokens")
-        output_tokens = span.get_metric("anthropic.response.usage.output_tokens")
-        total_tokens = span.get_metric("anthropic.response.usage.total_tokens")
-
-        if input_tokens is not None:
-            usage[INPUT_TOKENS_METRIC_KEY] = input_tokens
-        if output_tokens is not None:
-            usage[OUTPUT_TOKENS_METRIC_KEY] = output_tokens
-        if total_tokens is not None:
-            usage[TOTAL_TOKENS_METRIC_KEY] = total_tokens
-        return usage

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -5,17 +5,14 @@ from typing import Optional
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._constants import INPUT_MESSAGES
-from ddtrace.llmobs._constants import INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import METADATA
 from ddtrace.llmobs._constants import METRICS
 from ddtrace.llmobs._constants import MODEL_NAME
 from ddtrace.llmobs._constants import MODEL_PROVIDER
 from ddtrace.llmobs._constants import OUTPUT_MESSAGES
-from ddtrace.llmobs._constants import OUTPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import PARENT_ID_KEY
 from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
 from ddtrace.llmobs._constants import SPAN_KIND
-from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
 from ddtrace.llmobs._integrations import BaseLLMIntegration
 from ddtrace.llmobs._integrations.utils import get_llmobs_metrics_tags
 from ddtrace.llmobs._utils import _get_llmobs_parent_id

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -17,6 +17,7 @@ from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
 from ddtrace.llmobs._constants import SPAN_KIND
 from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
 from ddtrace.llmobs._integrations import BaseLLMIntegration
+from ddtrace.llmobs._integrations.utils import get_llmobs_metrics_tags
 from ddtrace.llmobs._utils import _get_llmobs_parent_id
 from ddtrace.trace import Span
 
@@ -57,21 +58,10 @@ class BedrockIntegration(BaseLLMIntegration):
                 MODEL_PROVIDER: span.get_tag("bedrock.request.model_provider") or "",
                 INPUT_MESSAGES: input_messages,
                 METADATA: parameters,
-                METRICS: self._llmobs_metrics(span, response),
+                METRICS: get_llmobs_metrics_tags("bedrock", span),
                 OUTPUT_MESSAGES: output_messages,
             }
         )
-
-    @staticmethod
-    def _llmobs_metrics(span: Span, response: Optional[Dict[str, Any]]) -> Dict[str, Any]:
-        metrics = {}
-        if response and response.get("text"):
-            prompt_tokens = int(span.get_tag("bedrock.usage.prompt_tokens") or 0)
-            completion_tokens = int(span.get_tag("bedrock.usage.completion_tokens") or 0)
-            metrics[INPUT_TOKENS_METRIC_KEY] = prompt_tokens
-            metrics[OUTPUT_TOKENS_METRIC_KEY] = completion_tokens
-            metrics[TOTAL_TOKENS_METRIC_KEY] = prompt_tokens + completion_tokens
-        return metrics
 
     @staticmethod
     def _extract_input_message(prompt):

--- a/ddtrace/llmobs/_integrations/gemini.py
+++ b/ddtrace/llmobs/_integrations/gemini.py
@@ -14,7 +14,7 @@ from ddtrace.llmobs._constants import OUTPUT_MESSAGES
 from ddtrace.llmobs._constants import SPAN_KIND
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._integrations.utils import extract_message_from_part_google
-from ddtrace.llmobs._integrations.utils import get_llmobs_metrics_tags_google
+from ddtrace.llmobs._integrations.utils import get_llmobs_metrics_tags
 from ddtrace.llmobs._integrations.utils import get_system_instructions_from_google_model
 from ddtrace.llmobs._integrations.utils import llmobs_get_metadata_google
 from ddtrace.llmobs._utils import _get_attr
@@ -59,7 +59,7 @@ class GeminiIntegration(BaseLLMIntegration):
                 METADATA: metadata,
                 INPUT_MESSAGES: input_messages,
                 OUTPUT_MESSAGES: output_messages,
-                METRICS: get_llmobs_metrics_tags_google("google_generativeai", span),
+                METRICS: get_llmobs_metrics_tags("google_generativeai", span),
             }
         )
 

--- a/ddtrace/llmobs/_integrations/openai.py
+++ b/ddtrace/llmobs/_integrations/openai.py
@@ -21,6 +21,7 @@ from ddtrace.llmobs._constants import OUTPUT_VALUE
 from ddtrace.llmobs._constants import SPAN_KIND
 from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
+from ddtrace.llmobs._integrations.utils import get_llmobs_metrics_tags
 from ddtrace.llmobs._utils import _get_attr
 from ddtrace.llmobs.utils import Document
 from ddtrace.trace import Pin
@@ -275,12 +276,4 @@ class OpenAIIntegration(BaseLLMIntegration):
                 OUTPUT_TOKENS_METRIC_KEY: completion_tokens,
                 TOTAL_TOKENS_METRIC_KEY: prompt_tokens + completion_tokens,
             }
-        prompt_tokens = span.get_metric("openai.response.usage.prompt_tokens")
-        completion_tokens = span.get_metric("openai.response.usage.completion_tokens")
-        if prompt_tokens is None or completion_tokens is None:
-            return {}
-        return {
-            INPUT_TOKENS_METRIC_KEY: prompt_tokens,
-            OUTPUT_TOKENS_METRIC_KEY: completion_tokens,
-            TOTAL_TOKENS_METRIC_KEY: prompt_tokens + completion_tokens,
-        }
+        return get_llmobs_metrics_tags("openai", span)

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -118,21 +118,6 @@ def extract_message_from_part_google(part, role=None):
         message["content"] = "[tool result: {}]".format(function_response_dict.get("response", ""))
     return message
 
-
-def get_llmobs_metrics_tags_google(integration_name, span):
-    usage = {}
-    input_tokens = span.get_metric("%s.response.usage.prompt_tokens" % integration_name)
-    output_tokens = span.get_metric("%s.response.usage.completion_tokens" % integration_name)
-    total_tokens = span.get_metric("%s.response.usage.total_tokens" % integration_name)
-
-    if input_tokens is not None:
-        usage[INPUT_TOKENS_METRIC_KEY] = input_tokens
-    if output_tokens is not None:
-        usage[OUTPUT_TOKENS_METRIC_KEY] = output_tokens
-    if total_tokens is not None:
-        usage[TOTAL_TOKENS_METRIC_KEY] = total_tokens
-    return usage
-
 def get_llmobs_metrics_tags(integration_name, span):
     usage = {}
 

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -118,6 +118,7 @@ def extract_message_from_part_google(part, role=None):
         message["content"] = "[tool result: {}]".format(function_response_dict.get("response", ""))
     return message
 
+
 def get_llmobs_metrics_tags(integration_name, span):
     usage = {}
 
@@ -129,7 +130,7 @@ def get_llmobs_metrics_tags(integration_name, span):
         usage[OUTPUT_TOKENS_METRIC_KEY] = output_tokens
         usage[TOTAL_TOKENS_METRIC_KEY] = input_tokens + output_tokens
         return usage
-    
+
     prompt_tokens_name = "prompt_tokens"
     completion_tokens_name = "completion_tokens"
     if integration_name in INTEGRATIONS_USING_INPUT_OUTPUT_TOKENS:

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -131,8 +131,12 @@ def get_llmobs_metrics_tags(integration_name, span):
         return usage
 
     # check for both prompt / completion or input / output tokens
-    input_tokens = span.get_metric("%s.response.usage.prompt_tokens" % integration_name) or span.get_metric("%s.response.usage.input_tokens" % integration_name)
-    output_tokens = span.get_metric("%s.response.usage.completion_tokens" % integration_name) or span.get_metric("%s.response.usage.output_tokens" % integration_name)
+    input_tokens = span.get_metric("%s.response.usage.prompt_tokens" % integration_name) or span.get_metric(
+        "%s.response.usage.input_tokens" % integration_name
+    )
+    output_tokens = span.get_metric("%s.response.usage.completion_tokens" % integration_name) or span.get_metric(
+        "%s.response.usage.output_tokens" % integration_name
+    )
     total_tokens = span.get_metric("%s.response.usage.total_tokens" % integration_name)
 
     if input_tokens is not None:

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -4,7 +4,6 @@ from typing import Union
 from ddtrace.llmobs._constants import INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import OUTPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
-from ddtrace.llmobs._constants import INTEGRATIONS_USING_INPUT_OUTPUT_TOKENS
 from ddtrace.llmobs._utils import _get_attr
 
 
@@ -131,13 +130,9 @@ def get_llmobs_metrics_tags(integration_name, span):
         usage[TOTAL_TOKENS_METRIC_KEY] = input_tokens + output_tokens
         return usage
 
-    prompt_tokens_name = "prompt_tokens"
-    completion_tokens_name = "completion_tokens"
-    if integration_name in INTEGRATIONS_USING_INPUT_OUTPUT_TOKENS:
-        prompt_tokens_name = "input_tokens"
-        completion_tokens_name = "output_tokens"
-    input_tokens = span.get_metric("%s.response.usage.%s" % (integration_name, prompt_tokens_name))
-    output_tokens = span.get_metric("%s.response.usage.%s" % (integration_name, completion_tokens_name))
+    # check for both prompt / completion or input / output tokens
+    input_tokens = span.get_metric("%s.response.usage.prompt_tokens" % integration_name) or span.get_metric("%s.response.usage.input_tokens" % integration_name)
+    output_tokens = span.get_metric("%s.response.usage.completion_tokens" % integration_name) or span.get_metric("%s.response.usage.output_tokens" % integration_name)
     total_tokens = span.get_metric("%s.response.usage.total_tokens" % integration_name)
 
     if input_tokens is not None:

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -125,9 +125,13 @@ def get_llmobs_metrics_tags(integration_name, span):
     if integration_name == "bedrock":
         input_tokens = int(span.get_tag("bedrock.usage.prompt_tokens") or 0)
         output_tokens = int(span.get_tag("bedrock.usage.completion_tokens") or 0)
-        usage[INPUT_TOKENS_METRIC_KEY] = input_tokens
-        usage[OUTPUT_TOKENS_METRIC_KEY] = output_tokens
-        usage[TOTAL_TOKENS_METRIC_KEY] = input_tokens + output_tokens
+        total_tokens = input_tokens + output_tokens
+        if input_tokens:
+            usage[INPUT_TOKENS_METRIC_KEY] = input_tokens
+        if output_tokens:
+            usage[OUTPUT_TOKENS_METRIC_KEY] = output_tokens
+        if total_tokens:
+            usage[TOTAL_TOKENS_METRIC_KEY] = total_tokens
         return usage
 
     # check for both prompt / completion or input / output tokens

--- a/ddtrace/llmobs/_integrations/vertexai.py
+++ b/ddtrace/llmobs/_integrations/vertexai.py
@@ -15,7 +15,7 @@ from ddtrace.llmobs._constants import OUTPUT_MESSAGES
 from ddtrace.llmobs._constants import SPAN_KIND
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._integrations.utils import extract_message_from_part_google
-from ddtrace.llmobs._integrations.utils import get_llmobs_metrics_tags_google
+from ddtrace.llmobs._integrations.utils import get_llmobs_metrics_tags
 from ddtrace.llmobs._integrations.utils import get_system_instructions_from_google_model
 from ddtrace.llmobs._integrations.utils import llmobs_get_metadata_google
 from ddtrace.llmobs._utils import _get_attr
@@ -65,7 +65,7 @@ class VertexAIIntegration(BaseLLMIntegration):
                 METADATA: metadata,
                 INPUT_MESSAGES: input_messages,
                 OUTPUT_MESSAGES: output_messages,
-                METRICS: get_llmobs_metrics_tags_google("vertexai", span),
+                METRICS: get_llmobs_metrics_tags("vertexai", span),
             }
         )
 


### PR DESCRIPTION
[applying https://github.com/DataDog/dd-trace-py/pull/12026 to 3.x-staging]

This PR generalizes the helper method used to extract token metrics from an APM span to be attached to an LLMObs span. Before, Anthropic, Bedrock, and Open AI had specific methods on each of their integration classes to accomplish this. Now, there is one get_llmobs_metrics_tags utils function adapted from the google-specific get_llmobs_metrics_tags_google function that gets reused across these integrations as well as Vertex AI and Gemini. The Langchain integration was excluded from this change since its logic for extracting token metrics varies significantly compared to the other integrations.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
