### PR TITLE
fix(llmobs): [MLOB-1915] tag streamed response for errored spans

### DIFF
--- a/ddtrace/contrib/internal/vertexai/_utils.py
+++ b/ddtrace/contrib/internal/vertexai/_utils.py
@@ -43,9 +43,8 @@ class TracedVertexAIStreamResponse(BaseTracedVertexAIStreamResponse):
         except Exception:
             self._dd_span.set_exc_info(*sys.exc_info())
             raise
-        else:
-            tag_stream_response(self._dd_span, self._chunks, self._dd_integration)
         finally:
+            tag_stream_response(self._dd_span, self._chunks, self._dd_integration)
             if self._dd_integration.is_pc_sampled_llmobs(self._dd_span):
                 self._kwargs["instance"] = self._model_instance
                 self._kwargs["history"] = self._history
@@ -74,9 +73,8 @@ class TracedAsyncVertexAIStreamResponse(BaseTracedVertexAIStreamResponse):
         except Exception:
             self._dd_span.set_exc_info(*sys.exc_info())
             raise
-        else:
-            tag_stream_response(self._dd_span, self._chunks, self._dd_integration)
         finally:
+            tag_stream_response(self._dd_span, self._chunks, self._dd_integration)
             if self._dd_integration.is_pc_sampled_llmobs(self._dd_span):
                 self._kwargs["instance"] = self._model_instance
                 self._kwargs["history"] = self._history

--- a/ddtrace/llmobs/_integrations/vertexai.py
+++ b/ddtrace/llmobs/_integrations/vertexai.py
@@ -54,7 +54,7 @@ class VertexAIIntegration(BaseLLMIntegration):
         input_messages = self._extract_input_message(input_contents, history, system_instruction)
 
         output_messages = [{"content": ""}]
-        if not span.error and response is not None:
+        if response is not None:
             output_messages = self._extract_output_message(response)
 
         span._set_ctx_items(


### PR DESCRIPTION
This PR modifies the streaming logic for Vertex AI and Gemini integrations to capture streamed responses even in the case that an exception is thrown midway through the stream. 

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
