### PR TITLE
fix(bedrock): [MLOB-2181] fix bedrock token metrics

### DIFF
--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -642,7 +642,7 @@ def _on_botocore_bedrock_process_response(
     integration = ctx["bedrock_integration"]
     if metadata is not None:
         for k, v in metadata.items():
-            if k in ["usage.completion_tokens", "usage.prompt_tokens"]:
+            if k in ["usage.completion_tokens", "usage.prompt_tokens"] and v:
                 span.set_metric("bedrock.{}".format(k), int(v))
             else:
                 span.set_tag_str("bedrock.{}".format(k), str(v))

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -595,8 +595,8 @@ def _on_botocore_patched_bedrock_api_call_success(ctx, reqid, latency, input_tok
     span = ctx.span
     span.set_tag_str("bedrock.response.id", reqid)
     span.set_tag_str("bedrock.response.duration", latency)
-    span.set_metric("bedrock.usage.prompt_tokens", input_token_count)
-    span.set_metric("bedrock.usage.completion_tokens", output_token_count)
+    span.set_metric("bedrock.usage.prompt_tokens", int(input_token_count))
+    span.set_metric("bedrock.usage.completion_tokens", int(output_token_count))
 
 
 def _propagate_context(ctx, headers):
@@ -640,7 +640,9 @@ def _on_botocore_bedrock_process_response(
     integration = ctx["bedrock_integration"]
     if metadata is not None:
         for k, v in metadata.items():
-            span.set_tag_str("bedrock.{}".format(k), str(v))
+            if k in ["usage.completion_tokens", "usage.prompt_tokens"]:
+                v = int(v)
+            span.set_metric("bedrock.{}".format(k), v)
     if "embed" in model_name:
         span.set_metric("bedrock.response.embedding_length", len(formatted_response["text"][0]))
         span.finish()

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -595,8 +595,8 @@ def _on_botocore_patched_bedrock_api_call_success(ctx, reqid, latency, input_tok
     span = ctx.span
     span.set_tag_str("bedrock.response.id", reqid)
     span.set_tag_str("bedrock.response.duration", latency)
-    span.set_tag_str("bedrock.usage.prompt_tokens", input_token_count)
-    span.set_tag_str("bedrock.usage.completion_tokens", output_token_count)
+    span.set_metric("bedrock.usage.prompt_tokens", input_token_count)
+    span.set_metric("bedrock.usage.completion_tokens", output_token_count)
 
 
 def _propagate_context(ctx, headers):

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -596,9 +596,9 @@ def _on_botocore_patched_bedrock_api_call_success(ctx, reqid, latency, input_tok
     span.set_tag_str("bedrock.response.id", reqid)
     span.set_tag_str("bedrock.response.duration", latency)
     if input_token_count:
-        span.set_metric("bedrock.usage.prompt_tokens", int(input_token_count))
+        span.set_metric("bedrock.response.usage.prompt_tokens", int(input_token_count))
     if output_token_count:
-        span.set_metric("bedrock.usage.completion_tokens", int(output_token_count))
+        span.set_metric("bedrock.response.usage.completion_tokens", int(output_token_count))
 
 
 def _propagate_context(ctx, headers):
@@ -643,9 +643,9 @@ def _on_botocore_bedrock_process_response(
     if metadata is not None:
         for k, v in metadata.items():
             if k in ["usage.completion_tokens", "usage.prompt_tokens"] and v:
-                span.set_metric("bedrock.{}".format(k), int(v))
+                span.set_metric("bedrock.response{}".format(k), int(v))
             else:
-                span.set_tag_str("bedrock.{}".format(k), str(v))
+                span.set_tag_str("bedrock.response{}".format(k), str(v))
     if "embed" in model_name:
         span.set_metric("bedrock.response.embedding_length", len(formatted_response["text"][0]))
         span.finish()

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -121,19 +121,6 @@ def extract_message_from_part_google(part, role=None):
 def get_llmobs_metrics_tags(integration_name, span):
     usage = {}
 
-    # bedrock integration tags usage under meta instead of metrics
-    if integration_name == "bedrock":
-        input_tokens = int(span.get_tag("bedrock.usage.prompt_tokens") or 0)
-        output_tokens = int(span.get_tag("bedrock.usage.completion_tokens") or 0)
-        total_tokens = input_tokens + output_tokens
-        if input_tokens:
-            usage[INPUT_TOKENS_METRIC_KEY] = input_tokens
-        if output_tokens:
-            usage[OUTPUT_TOKENS_METRIC_KEY] = output_tokens
-        if total_tokens:
-            usage[TOTAL_TOKENS_METRIC_KEY] = total_tokens
-        return usage
-
     # check for both prompt / completion or input / output tokens
     input_tokens = span.get_metric("%s.response.usage.prompt_tokens" % integration_name) or span.get_metric(
         "%s.response.usage.input_tokens" % integration_name

--- a/tests/contrib/botocore/test_bedrock.py
+++ b/tests/contrib/botocore/test_bedrock.py
@@ -373,6 +373,7 @@ def test_span_finishes_after_generator_exit(bedrock_client, request_vcr, mock_tr
                 if i >= 6:
                     raise GeneratorExit
                 i += 1
+    breakpoint()
     span = mock_tracer.pop_traces()[0][0]
     assert span is not None
     assert span.name == "bedrock-runtime.command"

--- a/tests/contrib/botocore/test_bedrock.py
+++ b/tests/contrib/botocore/test_bedrock.py
@@ -373,7 +373,6 @@ def test_span_finishes_after_generator_exit(bedrock_client, request_vcr, mock_tr
                 if i >= 6:
                     raise GeneratorExit
                 i += 1
-    breakpoint()
     span = mock_tracer.pop_traces()[0][0]
     assert span is not None
     assert span.name == "bedrock-runtime.command"

--- a/tests/contrib/botocore/test_bedrock_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_llmobs.py
@@ -80,8 +80,8 @@ def mock_llmobs_span_writer():
 class TestLLMObsBedrock:
     @staticmethod
     def expected_llmobs_span_event(span, n_output, message=False):
-        prompt_tokens = int(span.get_tag("bedrock.usage.prompt_tokens"))
-        completion_tokens = int(span.get_tag("bedrock.usage.completion_tokens"))
+        prompt_tokens = int(span.get_metric("bedrock.usage.prompt_tokens"))
+        completion_tokens = int(span.get_metric("bedrock.usage.completion_tokens"))
         expected_parameters = {"temperature": float(span.get_tag("bedrock.request.temperature"))}
         if span.get_tag("bedrock.request.max_tokens"):
             expected_parameters["max_tokens"] = int(span.get_tag("bedrock.request.max_tokens"))

--- a/tests/contrib/botocore/test_bedrock_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_llmobs.py
@@ -80,8 +80,8 @@ def mock_llmobs_span_writer():
 class TestLLMObsBedrock:
     @staticmethod
     def expected_llmobs_span_event(span, n_output, message=False):
-        prompt_tokens = int(span.get_metric("bedrock.usage.prompt_tokens"))
-        completion_tokens = int(span.get_metric("bedrock.usage.completion_tokens"))
+        prompt_tokens = int(span.get_metric("bedrock.response.usage.prompt_tokens"))
+        completion_tokens = int(span.get_metric("bedrock.response.usage.completion_tokens"))
         expected_parameters = {"temperature": float(span.get_tag("bedrock.request.temperature"))}
         if span.get_tag("bedrock.request.max_tokens"):
             expected_parameters["max_tokens"] = int(span.get_tag("bedrock.request.max_tokens"))

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_ai21_invoke.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_ai21_invoke.json
@@ -30,8 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": "10",
-      "bedrock.usage.prompt_tokens": "10",
+      "bedrock.usage.completion_tokens": 10,
+      "bedrock.usage.prompt_tokens": 10,
       "process_id": 7458
     },
     "duration": 2112000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_ai21_invoke.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_ai21_invoke.json
@@ -30,8 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": 10,
-      "bedrock.usage.prompt_tokens": 10,
+      "bedrock.response.usage.completion_tokens": 10,
+      "bedrock.response.usage.prompt_tokens": 10,
       "process_id": 7458
     },
     "duration": 2112000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_ai21_invoke.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_ai21_invoke.json
@@ -23,8 +23,6 @@
       "bedrock.response.choices.0.text": "\\nA neural network is like a secret recipe that a computer uses to learn how to",
       "bedrock.response.duration": "319",
       "bedrock.response.id": "1de3312e-48d1-4d7f-8694-733c1c1ea20f",
-      "bedrock.usage.completion_tokens": "10",
-      "bedrock.usage.prompt_tokens": "10",
       "language": "python",
       "runtime-id": "3dd17f1c810946349e47a84acb56402a"
     },
@@ -32,6 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
+      "bedrock.usage.completion_tokens": "10",
+      "bedrock.usage.prompt_tokens": "10",
       "process_id": 7458
     },
     "duration": 2112000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_embedding.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_embedding.json
@@ -25,8 +25,7 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
       "bedrock.response.embedding_length": 1536,
-      "bedrock.usage.completion_tokens": "",
-      "bedrock.usage.prompt_tokens": "3",
+      "bedrock.usage.prompt_tokens": 3,
       "process_id": 60939
     },
     "duration": 6739000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_embedding.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_embedding.json
@@ -17,8 +17,6 @@
       "bedrock.request.prompt": "Hello World!",
       "bedrock.response.duration": "311",
       "bedrock.response.id": "1fd884e0-c9e8-44fa-b736-d31e2f607d54",
-      "bedrock.usage.completion_tokens": "",
-      "bedrock.usage.prompt_tokens": "3",
       "language": "python",
       "runtime-id": "a7bb6456241740dea419398d37aa13d2"
     },
@@ -27,6 +25,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
       "bedrock.response.embedding_length": 1536,
+      "bedrock.usage.completion_tokens": "",
+      "bedrock.usage.prompt_tokens": "3",
       "process_id": 60939
     },
     "duration": 6739000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_embedding.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_embedding.json
@@ -25,7 +25,7 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
       "bedrock.response.embedding_length": 1536,
-      "bedrock.usage.prompt_tokens": 3,
+      "bedrock.response.usage.prompt_tokens": 3,
       "process_id": 60939
     },
     "duration": 6739000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_invoke.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_invoke.json
@@ -23,8 +23,6 @@
       "bedrock.response.choices.0.text": "\\nDatadog is a monitoring and analytics platform that helps businesses track and optimize their digital infrastructure. It provi...",
       "bedrock.response.duration": "1835",
       "bedrock.response.id": "758fa023-a298-48d0-89e6-0208306cb76d",
-      "bedrock.usage.completion_tokens": "50",
-      "bedrock.usage.prompt_tokens": "18",
       "language": "python",
       "runtime-id": "13983704e2404c4a911b0cc558662a8f"
     },
@@ -32,6 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
+      "bedrock.usage.completion_tokens": "50",
+      "bedrock.usage.prompt_tokens": "18",
       "process_id": 14088
     },
     "duration": 2147082000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_invoke.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_invoke.json
@@ -30,8 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": 50,
-      "bedrock.usage.prompt_tokens": 18,
+      "bedrock.response.usage.completion_tokens": 50,
+      "bedrock.response.usage.prompt_tokens": 18,
       "process_id": 14088
     },
     "duration": 2147082000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_invoke.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_invoke.json
@@ -30,8 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": "50",
-      "bedrock.usage.prompt_tokens": "18",
+      "bedrock.usage.completion_tokens": 50,
+      "bedrock.usage.prompt_tokens": 18,
       "process_id": 14088
     },
     "duration": 2147082000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_invoke_stream.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_invoke_stream.json
@@ -23,8 +23,6 @@
       "bedrock.response.choices.0.text": "\\nDatadog is a monitoring and analytics platform that helps businesses track and optimize their digital infrastructure. It provi...",
       "bedrock.response.duration": "1804",
       "bedrock.response.id": "a4b0a846-cd84-41b5-a567-1bf5e341c30c",
-      "bedrock.usage.completion_tokens": "51",
-      "bedrock.usage.prompt_tokens": "18",
       "language": "python",
       "runtime-id": "13983704e2404c4a911b0cc558662a8f"
     },
@@ -32,6 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
+      "bedrock.usage.completion_tokens": "51",
+      "bedrock.usage.prompt_tokens": "18",
       "process_id": 14088
     },
     "duration": 2185710000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_invoke_stream.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_invoke_stream.json
@@ -30,8 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": "51",
-      "bedrock.usage.prompt_tokens": "18",
+      "bedrock.usage.completion_tokens": 51,
+      "bedrock.usage.prompt_tokens": 18,
       "process_id": 14088
     },
     "duration": 2185710000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_invoke_stream.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_amazon_invoke_stream.json
@@ -30,8 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": 51,
-      "bedrock.usage.prompt_tokens": 18,
+      "bedrock.response.usage.completion_tokens": 51,
+      "bedrock.response.usage.prompt_tokens": 18,
       "process_id": 14088
     },
     "duration": 2185710000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_invoke.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_invoke.json
@@ -31,8 +31,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": "32",
-      "bedrock.usage.prompt_tokens": "23",
+      "bedrock.usage.completion_tokens": 32,
+      "bedrock.usage.prompt_tokens": 23,
       "process_id": 7272
     },
     "duration": 2434000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_invoke.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_invoke.json
@@ -24,8 +24,6 @@
       "bedrock.response.choices.0.text": " I'm an AI assistant created by Anthropic to be helpful, harmless, and honest. I don't compare myself to other systems.",
       "bedrock.response.duration": "556",
       "bedrock.response.id": "47ef2ae8-23da-4600-8cda-cbbf4df7bbb6",
-      "bedrock.usage.completion_tokens": "32",
-      "bedrock.usage.prompt_tokens": "23",
       "language": "python",
       "runtime-id": "75edb3ee6bee404fa05694de91dd42a3"
     },
@@ -33,6 +31,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
+      "bedrock.usage.completion_tokens": "32",
+      "bedrock.usage.prompt_tokens": "23",
       "process_id": 7272
     },
     "duration": 2434000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_invoke.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_invoke.json
@@ -31,8 +31,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": 32,
-      "bedrock.usage.prompt_tokens": 23,
+      "bedrock.response.usage.completion_tokens": 32,
+      "bedrock.response.usage.prompt_tokens": 23,
       "process_id": 7272
     },
     "duration": 2434000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_invoke_stream.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_invoke_stream.json
@@ -31,8 +31,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": 4,
-      "bedrock.usage.prompt_tokens": 25,
+      "bedrock.response.usage.completion_tokens": 4,
+      "bedrock.response.usage.prompt_tokens": 25,
       "process_id": 13707
     },
     "duration": 624710000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_invoke_stream.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_invoke_stream.json
@@ -31,8 +31,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": "4",
-      "bedrock.usage.prompt_tokens": "25",
+      "bedrock.usage.completion_tokens": 4,
+      "bedrock.usage.prompt_tokens": 25,
       "process_id": 13707
     },
     "duration": 624710000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_invoke_stream.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_invoke_stream.json
@@ -24,8 +24,6 @@
       "bedrock.response.choices.0.text": "",
       "bedrock.response.duration": "266",
       "bedrock.response.id": "710b14d5-164f-460d-bfc6-d3b31e794691",
-      "bedrock.usage.completion_tokens": "4",
-      "bedrock.usage.prompt_tokens": "25",
       "language": "python",
       "runtime-id": "5e8e1855ea8f4eefaa631b5691eb5e62"
     },
@@ -33,6 +31,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
+      "bedrock.usage.completion_tokens": "4",
+      "bedrock.usage.prompt_tokens": "25",
       "process_id": 13707
     },
     "duration": 624710000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_message_invoke.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_message_invoke.json
@@ -31,8 +31,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": 22,
-      "bedrock.usage.prompt_tokens": 21,
+      "bedrock.response.usage.completion_tokens": 22,
+      "bedrock.response.usage.prompt_tokens": 21,
       "process_id": 40705
     },
     "duration": 2160000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_message_invoke.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_message_invoke.json
@@ -24,8 +24,6 @@
       "bedrock.response.choices.0.text": "{'type': 'text', 'text': 'Hobbits embark on epic quest to destroy powerful ring, battling dark forces.'}",
       "bedrock.response.duration": "886",
       "bedrock.response.id": "cfb79f63-67cf-45b5-8a3c-9f5bf02064f5",
-      "bedrock.usage.completion_tokens": "22",
-      "bedrock.usage.prompt_tokens": "21",
       "language": "python",
       "runtime-id": "d2a21cfa56b94b50bae2ca63f83c50f9"
     },
@@ -33,6 +31,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
+      "bedrock.usage.completion_tokens": "22",
+      "bedrock.usage.prompt_tokens": "21",
       "process_id": 40705
     },
     "duration": 2160000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_message_invoke.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_message_invoke.json
@@ -31,8 +31,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": "22",
-      "bedrock.usage.prompt_tokens": "21",
+      "bedrock.usage.completion_tokens": 22,
+      "bedrock.usage.prompt_tokens": 21,
       "process_id": 40705
     },
     "duration": 2160000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_message_invoke_stream.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_message_invoke_stream.json
@@ -31,8 +31,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": 22,
-      "bedrock.usage.prompt_tokens": 21,
+      "bedrock.response.usage.completion_tokens": 22,
+      "bedrock.response.usage.prompt_tokens": 21,
       "process_id": 40896
     },
     "duration": 2950000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_message_invoke_stream.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_message_invoke_stream.json
@@ -31,8 +31,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": "22",
-      "bedrock.usage.prompt_tokens": "21",
+      "bedrock.usage.completion_tokens": 22,
+      "bedrock.usage.prompt_tokens": 21,
       "process_id": 40896
     },
     "duration": 2950000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_message_invoke_stream.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_anthropic_message_invoke_stream.json
@@ -24,8 +24,6 @@
       "bedrock.response.choices.0.text": "Hobbits embark on epic quest to destroy powerful ring, battling dark forces.",
       "bedrock.response.duration": "2033",
       "bedrock.response.id": "1708c260-6ca9-46ce-8799-1ce6c03cae0d",
-      "bedrock.usage.completion_tokens": "22",
-      "bedrock.usage.prompt_tokens": "21",
       "language": "python",
       "runtime-id": "7cf2c8f7bcae407886c63c657123594f"
     },
@@ -33,6 +31,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
+      "bedrock.usage.completion_tokens": "22",
+      "bedrock.usage.prompt_tokens": "21",
       "process_id": 40896
     },
     "duration": 2950000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_embedding.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_embedding.json
@@ -27,7 +27,7 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
       "bedrock.response.embedding_length": 1024,
-      "bedrock.usage.prompt_tokens": 7,
+      "bedrock.response.usage.prompt_tokens": 7,
       "process_id": 61336
     },
     "duration": 630192000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_embedding.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_embedding.json
@@ -19,8 +19,6 @@
       "bedrock.request.truncate": "",
       "bedrock.response.duration": "271",
       "bedrock.response.id": "0e9cb5ab-1fef-46eb-8e2c-773f0f60f39d",
-      "bedrock.usage.completion_tokens": "",
-      "bedrock.usage.prompt_tokens": "7",
       "language": "python",
       "runtime-id": "c02c555fdac14227bee7b37a0c304534"
     },
@@ -29,6 +27,8 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
       "bedrock.response.embedding_length": 1024,
+      "bedrock.usage.completion_tokens": "",
+      "bedrock.usage.prompt_tokens": "7",
       "process_id": 61336
     },
     "duration": 630192000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_embedding.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_embedding.json
@@ -27,8 +27,7 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
       "bedrock.response.embedding_length": 1024,
-      "bedrock.usage.completion_tokens": "",
-      "bedrock.usage.prompt_tokens": "7",
+      "bedrock.usage.prompt_tokens": 7,
       "process_id": 61336
     },
     "duration": 630192000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_multi_output.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_multi_output.json
@@ -37,8 +37,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": "20",
-      "bedrock.usage.prompt_tokens": "40",
+      "bedrock.usage.completion_tokens": 20,
+      "bedrock.usage.prompt_tokens": 40,
       "process_id": 3568
     },
     "duration": 810213000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_multi_output.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_multi_output.json
@@ -30,8 +30,6 @@
       "bedrock.response.choices.1.text": " Sure! A Long Short-Term Memory (L",
       "bedrock.response.duration": "346",
       "bedrock.response.id": "c158207e-8168-4e9f-927c-971b9e2d9d38",
-      "bedrock.usage.completion_tokens": "20",
-      "bedrock.usage.prompt_tokens": "40",
       "language": "python",
       "runtime-id": "88ca69f6cc694697b1289399e130da4e"
     },
@@ -39,6 +37,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
+      "bedrock.usage.completion_tokens": "20",
+      "bedrock.usage.prompt_tokens": "40",
       "process_id": 3568
     },
     "duration": 810213000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_multi_output.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_multi_output.json
@@ -37,8 +37,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": 20,
-      "bedrock.usage.prompt_tokens": 40,
+      "bedrock.response.usage.completion_tokens": 20,
+      "bedrock.response.usage.prompt_tokens": 40,
       "process_id": 3568
     },
     "duration": 810213000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_single_output.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_single_output.json
@@ -27,8 +27,6 @@
       "bedrock.response.choices.0.text": " A Large Language Model (LLM) chain refers",
       "bedrock.response.duration": "277",
       "bedrock.response.id": "909434da-e64a-4ccd-8c11-c97793dc3746",
-      "bedrock.usage.completion_tokens": "10",
-      "bedrock.usage.prompt_tokens": "20",
       "language": "python",
       "runtime-id": "5fae717bb41e4e75bb78b4443e234992"
     },
@@ -36,6 +34,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
+      "bedrock.usage.completion_tokens": "10",
+      "bedrock.usage.prompt_tokens": "20",
       "process_id": 13549
     },
     "duration": 659370000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_single_output.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_single_output.json
@@ -34,8 +34,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": "10",
-      "bedrock.usage.prompt_tokens": "20",
+      "bedrock.usage.completion_tokens": 10,
+      "bedrock.usage.prompt_tokens": 20,
       "process_id": 13549
     },
     "duration": 659370000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_single_output.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_single_output.json
@@ -34,8 +34,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": 10,
-      "bedrock.usage.prompt_tokens": 20,
+      "bedrock.response.usage.completion_tokens": 10,
+      "bedrock.response.usage.prompt_tokens": 20,
       "process_id": 13549
     },
     "duration": 659370000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_stream_multi_output.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_stream_multi_output.json
@@ -35,8 +35,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": 20,
-      "bedrock.usage.prompt_tokens": 40,
+      "bedrock.response.usage.completion_tokens": 20,
+      "bedrock.response.usage.prompt_tokens": 40,
       "process_id": 21816
     },
     "duration": 980170000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_stream_multi_output.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_stream_multi_output.json
@@ -28,8 +28,6 @@
       "bedrock.response.choices.1.text": " A large language model (LLM) chain refers",
       "bedrock.response.duration": "597",
       "bedrock.response.id": "2501c28f-0a40-49ec-9b59-5d58313c05f3",
-      "bedrock.usage.completion_tokens": "20",
-      "bedrock.usage.prompt_tokens": "40",
       "language": "python",
       "runtime-id": "e2468c635ce44f8788acce3e9e569237"
     },
@@ -37,6 +35,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
+      "bedrock.usage.completion_tokens": "20",
+      "bedrock.usage.prompt_tokens": "40",
       "process_id": 21816
     },
     "duration": 980170000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_stream_multi_output.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_stream_multi_output.json
@@ -35,8 +35,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": "20",
-      "bedrock.usage.prompt_tokens": "40",
+      "bedrock.usage.completion_tokens": 20,
+      "bedrock.usage.prompt_tokens": 40,
       "process_id": 21816
     },
     "duration": 980170000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_stream_single_output.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_stream_single_output.json
@@ -33,8 +33,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": 10,
-      "bedrock.usage.prompt_tokens": 20,
+      "bedrock.response.usage.completion_tokens": 10,
+      "bedrock.response.usage.prompt_tokens": 20,
       "process_id": 21816
     },
     "duration": 630536000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_stream_single_output.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_stream_single_output.json
@@ -26,8 +26,6 @@
       "bedrock.response.choices.0.text": " I am very happy to assist you! A Long",
       "bedrock.response.duration": "347",
       "bedrock.response.id": "ff340d3e-475b-4774-92fa-56ee3d4702c8",
-      "bedrock.usage.completion_tokens": "10",
-      "bedrock.usage.prompt_tokens": "20",
       "language": "python",
       "runtime-id": "e2468c635ce44f8788acce3e9e569237"
     },
@@ -35,6 +33,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
+      "bedrock.usage.completion_tokens": "10",
+      "bedrock.usage.prompt_tokens": "20",
       "process_id": 21816
     },
     "duration": 630536000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_stream_single_output.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_cohere_invoke_stream_single_output.json
@@ -33,8 +33,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": "10",
-      "bedrock.usage.prompt_tokens": "20",
+      "bedrock.usage.completion_tokens": 10,
+      "bedrock.usage.prompt_tokens": 20,
       "process_id": 21816
     },
     "duration": 630536000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_invoke_model_using_aws_arn_model_id.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_invoke_model_using_aws_arn_model_id.json
@@ -30,8 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": 50,
-      "bedrock.usage.prompt_tokens": 18,
+      "bedrock.response.usage.completion_tokens": 50,
+      "bedrock.response.usage.prompt_tokens": 18,
       "process_id": 96028
     },
     "duration": 2318000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_invoke_model_using_aws_arn_model_id.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_invoke_model_using_aws_arn_model_id.json
@@ -23,8 +23,6 @@
       "bedrock.response.choices.0.text": "\\n\\nDatadog is a monitoring and analytics platform for IT operations, DevOps, and software development teams. It provides real-t...",
       "bedrock.response.duration": "2646",
       "bedrock.response.id": "b2d0fd44-c29a-4cd4-a97a-6901a48f6264",
-      "bedrock.usage.completion_tokens": "50",
-      "bedrock.usage.prompt_tokens": "18",
       "language": "python",
       "runtime-id": "cf8ef38d3504475ba71634071f15d00f"
     },
@@ -32,6 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
+      "bedrock.usage.completion_tokens": "50",
+      "bedrock.usage.prompt_tokens": "18",
       "process_id": 96028
     },
     "duration": 2318000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_invoke_model_using_aws_arn_model_id.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_invoke_model_using_aws_arn_model_id.json
@@ -30,8 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": "50",
-      "bedrock.usage.prompt_tokens": "18",
+      "bedrock.usage.completion_tokens": 50,
+      "bedrock.usage.prompt_tokens": 18,
       "process_id": 96028
     },
     "duration": 2318000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_meta_invoke.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_meta_invoke.json
@@ -29,8 +29,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": "60",
-      "bedrock.usage.prompt_tokens": "10",
+      "bedrock.usage.completion_tokens": 60,
+      "bedrock.usage.prompt_tokens": 10,
       "process_id": 10703
     },
     "duration": 2120703000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_meta_invoke.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_meta_invoke.json
@@ -29,8 +29,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": 60,
-      "bedrock.usage.prompt_tokens": 10,
+      "bedrock.response.usage.completion_tokens": 60,
+      "bedrock.response.usage.prompt_tokens": 10,
       "process_id": 10703
     },
     "duration": 2120703000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_meta_invoke.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_meta_invoke.json
@@ -22,8 +22,6 @@
       "bedrock.response.choices.0.text": "\\n\\n\"Lorem ipsum\" is a commonly used phrase in the graphic design and publishing industries. It refers to a piece of pretend tex...",
       "bedrock.response.duration": "1686",
       "bedrock.response.id": "491ad1a3-45d8-4d84-b92c-eb8e79cc79d3",
-      "bedrock.usage.completion_tokens": "60",
-      "bedrock.usage.prompt_tokens": "10",
       "language": "python",
       "runtime-id": "63a32fa9ed86471383f1355fba7356d8"
     },
@@ -31,6 +29,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
+      "bedrock.usage.completion_tokens": "60",
+      "bedrock.usage.prompt_tokens": "10",
       "process_id": 10703
     },
     "duration": 2120703000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_meta_invoke_stream.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_meta_invoke_stream.json
@@ -29,8 +29,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": 60,
-      "bedrock.usage.prompt_tokens": 10,
+      "bedrock.response.usage.completion_tokens": 60,
+      "bedrock.response.usage.prompt_tokens": 10,
       "process_id": 2664
     },
     "duration": 3795000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_meta_invoke_stream.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_meta_invoke_stream.json
@@ -29,8 +29,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": "60",
-      "bedrock.usage.prompt_tokens": "10",
+      "bedrock.usage.completion_tokens": 60,
+      "bedrock.usage.prompt_tokens": 10,
       "process_id": 2664
     },
     "duration": 3795000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_meta_invoke_stream.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_meta_invoke_stream.json
@@ -22,8 +22,6 @@
       "bedrock.response.choices.0.text": "\\n\\nThe phrase \"lorem ipsum\" is a commonly used dummy text in the graphic design and publishing industries. The text is derived ...",
       "bedrock.response.duration": "1686",
       "bedrock.response.id": "4dcc90b7-81b8-4983-b2d3-9989798b0db1",
-      "bedrock.usage.completion_tokens": "60",
-      "bedrock.usage.prompt_tokens": "10",
       "language": "python",
       "runtime-id": "60ce339e546c4812962fb496314b8dab"
     },
@@ -31,6 +29,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
+      "bedrock.usage.completion_tokens": "60",
+      "bedrock.usage.prompt_tokens": "10",
       "process_id": 2664
     },
     "duration": 3795000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_read_error.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_read_error.json
@@ -30,8 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": 60,
-      "bedrock.usage.prompt_tokens": 10,
+      "bedrock.response.usage.completion_tokens": 60,
+      "bedrock.response.usage.prompt_tokens": 10,
       "process_id": 42139
     },
     "duration": 2505000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_read_error.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_read_error.json
@@ -20,8 +20,6 @@
       "bedrock.request.top_p": "1.0",
       "bedrock.response.duration": "1686",
       "bedrock.response.id": "491ad1a3-45d8-4d84-b92c-eb8e79cc79d3",
-      "bedrock.usage.completion_tokens": "60",
-      "bedrock.usage.prompt_tokens": "10",
       "error.message": "test",
       "error.stack": "Traceback (most recent call last):\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/ddtrace/contrib/botocore/services/bedrock.py\", line 37, in read\n    formatted_response = _extract_response(self._datadog_span, self._body[0])\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py3105_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_moto[all]_botocore_pytest-randomly_vcrpy/lib/python3.10/site-packages/mock/mock.py\", line 1178, in __call__\n    return _mock_self._mock_call(*args, **kwargs)\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py3105_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_moto[all]_botocore_pytest-randomly_vcrpy/lib/python3.10/site-packages/mock/mock.py\", line 1182, in _mock_call\n    return _mock_self._execute_mock_call(*args, **kwargs)\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py3105_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_moto[all]_botocore_pytest-randomly_vcrpy/lib/python3.10/site-packages/mock/mock.py\", line 1239, in _execute_mock_call\n    raise effect\nException: test\n",
       "error.type": "builtins.Exception",
@@ -32,6 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
+      "bedrock.usage.completion_tokens": "60",
+      "bedrock.usage.prompt_tokens": "10",
       "process_id": 42139
     },
     "duration": 2505000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_read_error.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_read_error.json
@@ -30,8 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": "60",
-      "bedrock.usage.prompt_tokens": "10",
+      "bedrock.usage.completion_tokens": 60,
+      "bedrock.usage.prompt_tokens": 10,
       "process_id": 42139
     },
     "duration": 2505000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_readlines_error.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_readlines_error.json
@@ -30,8 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": "60",
-      "bedrock.usage.prompt_tokens": "10",
+      "bedrock.usage.completion_tokens": 60,
+      "bedrock.usage.prompt_tokens": 10,
       "process_id": 42139
     },
     "duration": 3064000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_readlines_error.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_readlines_error.json
@@ -20,8 +20,6 @@
       "bedrock.request.top_p": "1.0",
       "bedrock.response.duration": "1686",
       "bedrock.response.id": "491ad1a3-45d8-4d84-b92c-eb8e79cc79d3",
-      "bedrock.usage.completion_tokens": "60",
-      "bedrock.usage.prompt_tokens": "10",
       "error.message": "test",
       "error.stack": "Traceback (most recent call last):\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/ddtrace/contrib/botocore/services/bedrock.py\", line 51, in readlines\n    formatted_response = _extract_response(self._datadog_span, self._body[0])\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py3105_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_moto[all]_botocore_pytest-randomly_vcrpy/lib/python3.10/site-packages/mock/mock.py\", line 1178, in __call__\n    return _mock_self._mock_call(*args, **kwargs)\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py3105_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_moto[all]_botocore_pytest-randomly_vcrpy/lib/python3.10/site-packages/mock/mock.py\", line 1182, in _mock_call\n    return _mock_self._execute_mock_call(*args, **kwargs)\n  File \"/Users/yun.kim/go/src/github.com/DataDog/dd-trace-py/.riot/venv_py3105_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_moto[all]_botocore_pytest-randomly_vcrpy/lib/python3.10/site-packages/mock/mock.py\", line 1239, in _execute_mock_call\n    raise effect\nException: test\n",
       "error.type": "builtins.Exception",
@@ -32,6 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
+      "bedrock.usage.completion_tokens": "60",
+      "bedrock.usage.prompt_tokens": "10",
       "process_id": 42139
     },
     "duration": 3064000,

--- a/tests/snapshots/tests.contrib.botocore.test_bedrock.test_readlines_error.json
+++ b/tests/snapshots/tests.contrib.botocore.test_bedrock.test_readlines_error.json
@@ -30,8 +30,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "bedrock.usage.completion_tokens": 60,
-      "bedrock.usage.prompt_tokens": 10,
+      "bedrock.response.usage.completion_tokens": 60,
+      "bedrock.response.usage.prompt_tokens": 10,
       "process_id": 42139
     },
     "duration": 3064000,


### PR DESCRIPTION
Moves token counts for APM spans generated from Bedrock to the metrics field instead of the meta field.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
