### PR TITLE
feat(symdb): enable by default

### DIFF
--- a/ddtrace/contrib/internal/aiohttp/middlewares.py
+++ b/ddtrace/contrib/internal/aiohttp/middlewares.py
@@ -2,6 +2,7 @@ from aiohttp import web
 from aiohttp.web_urldispatcher import SystemRoute
 
 from ddtrace import config
+from ddtrace.contrib.asyncio import context_provider
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import http
 from ddtrace.internal import core
@@ -59,9 +60,8 @@ async def trace_middleware(app, handler):
             request[REQUEST_CONFIG_KEY] = app[CONFIG_KEY]
             try:
                 response = await handler(request)
-                if not config.aiohttp["disable_stream_timing_for_mem_leak"]:
-                    if isinstance(response, web.StreamResponse):
-                        request.task.add_done_callback(lambda _: finish_request_span(request, response))
+                if isinstance(response, web.StreamResponse):
+                    request.task.add_done_callback(lambda _: finish_request_span(request, response))
                 return response
             except Exception:
                 req_span.set_traceback()

--- a/ddtrace/settings/symbol_db.py
+++ b/ddtrace/settings/symbol_db.py
@@ -11,7 +11,7 @@ class SymbolDatabaseConfig(En):
     enabled = En.v(
         bool,
         "upload_enabled",
-        default=False,
+        default=True,
         help_type="Boolean",
         help="Whether to upload source code symbols to the Datadog backend",
     )

--- a/releasenotes/notes/feat-symdb-enabled-by-default-25eebb43fc8c5a0d.yaml
+++ b/releasenotes/notes/feat-symdb-enabled-by-default-25eebb43fc8c5a0d.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Symbol Database is now enabled by default.

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -420,7 +420,7 @@ import ddtrace.settings.exception_replay
             "value": str(file),
         },
         {"name": "DD_SYMBOL_DATABASE_INCLUDES", "origin": "default", "value": "set()"},
-        {"name": "DD_SYMBOL_DATABASE_UPLOAD_ENABLED", "origin": "default", "value": False},
+        {"name": "DD_SYMBOL_DATABASE_UPLOAD_ENABLED", "origin": "default", "value": True},
         {"name": "DD_TAGS", "origin": "env_var", "value": "team:apm,component:web"},
         {"name": "DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED", "origin": "default", "value": True},
         {"name": "DD_TELEMETRY_HEARTBEAT_INTERVAL", "origin": "default", "value": 60},


### PR DESCRIPTION
We make Symbol Database enabled by default.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
