### PR TITLE
ci(tracer): avoids shutting down the global tracer in the main process

### DIFF
--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -47,7 +47,6 @@ from tests.contrib.fastapi.conftest import fastapi_application  # noqa:F401
 from tests.contrib.fastapi.conftest import test_spans as fastapi_test_spans  # noqa:F401
 from tests.contrib.fastapi.conftest import tracer  # noqa:F401
 
-from ..utils import flaky
 from ..utils import override_env
 from ..utils import override_global_config
 
@@ -837,7 +836,6 @@ def test_extract_128bit_trace_ids_tracecontext():
                 assert child_span.trace_id == trace_id
 
 
-@flaky(1735812000, reason="FIXME: Failing due to the global tracer being used in all tests")
 def test_last_dd_span_id():
     non_dd_remote_context = HTTPPropagator.extract(
         {

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -676,7 +676,9 @@ def test_tracer_shutdown_timeout():
     mock_stop.assert_called_once_with(2)
 
 
-@pytest.mark.subprocess
+@pytest.mark.subprocess(
+    err=b"Spans started after the tracer has been shut down will not be sent to the Datadog Agent.\n",
+)
 def test_tracer_shutdown():
     import mock
 
@@ -690,26 +692,6 @@ def test_tracer_shutdown():
             pass
 
     mock_write.assert_not_called()
-
-@pytest.mark.subprocess
-def test_tracer_shutdown_warning():
-    import logging
-
-    import mock
-
-    from ddtrace.trace import tracer as t
-
-    t.shutdown()
-
-    with mock.patch.object(logging.Logger, "warning") as mock_logger:
-        with t.trace("something"):
-            pass
-
-    mock_logger.assert_has_calls(
-        [
-            mock.call("Spans started after the tracer has been shut down will not be sent to the Datadog Agent."),
-        ]
-    )
 
 
 @pytest.mark.skip(reason="Fails to Pickle RateLimiter in the Tracer")

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -676,6 +676,7 @@ def test_tracer_shutdown_timeout():
     mock_stop.assert_called_once_with(2)
 
 
+@pytest.mark.subprocess
 def test_tracer_shutdown():
     import mock
 
@@ -690,7 +691,7 @@ def test_tracer_shutdown():
 
     mock_write.assert_not_called()
 
-
+@pytest.mark.subprocess
 def test_tracer_shutdown_warning():
     import logging
 


### PR DESCRIPTION
When the tracer is shutdown span aggregators are removed. If this is done outside of a subprocess it will impact the state of the tracer in future test runs. This PR ensures the tracer shutdown tests are only run in a subprocess. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
