### PR TITLE
feat(llmobs): llmobs-specific context manager

### DIFF
--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -595,6 +595,7 @@ def activate_distributed_headers(tracer, int_config=None, request_headers=None, 
         # We have parsed a trace id from headers, and we do not already
         # have a context with the same trace id active
         tracer.context_provider.activate(context)
+        core.dispatch("http.activate_distributed_headers", (request_headers, context))
 
 
 def _flatten(

--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -45,6 +45,8 @@ AGENTLESS_ENDPOINT = "api/v2/llmobs"
 DROPPED_IO_COLLECTION_ERROR = "dropped_io"
 DROPPED_VALUE_TEXT = "[This value has been dropped because this span's size exceeds the 1MB size limit.]"
 
+ROOT_PARENT_ID = "undefined"
+
 # Set for traces of evaluator integrations e.g. `runner.integration:ragas`.
 # Used to differentiate traces of Datadog-run operations vs user-application operations.
 RUNNER_IS_INTEGRATION_SPAN_TAG = "runner.integration"

--- a/ddtrace/llmobs/_context.py
+++ b/ddtrace/llmobs/_context.py
@@ -1,0 +1,59 @@
+import contextvars
+from typing import Optional
+from typing import Union
+
+from ddtrace._trace.context import Context
+from ddtrace._trace.provider import DefaultContextProvider
+from ddtrace._trace.span import Span
+from ddtrace.ext import SpanTypes
+
+
+ContextTypeValue = Optional[Union[Context, Span]]
+
+
+_DD_LLMOBS_CONTEXTVAR: contextvars.ContextVar[ContextTypeValue] = contextvars.ContextVar(
+    "datadog_llmobs_contextvar",
+    default=None,
+)
+
+
+class LLMObsContextProvider(DefaultContextProvider):
+    """Context provider that retrieves contexts from a context variable.
+    It is suitable for synchronous programming and for asynchronous executors
+    that support contextvars.
+    """
+
+    def __init__(self) -> None:
+        super(DefaultContextProvider, self).__init__()
+        _DD_LLMOBS_CONTEXTVAR.set(None)
+
+    def _has_active_context(self) -> bool:
+        """Returns whether there is an active context in the current execution."""
+        ctx = _DD_LLMOBS_CONTEXTVAR.get()
+        return ctx is not None
+
+    def _update_active(self, span: Span) -> Optional[Span]:
+        """Updates the active LLMObs span.
+        The active span is updated to be the span's closest unfinished LLMObs ancestor span.
+        """
+        if not span.finished:
+            return span
+        new_active: Optional[Span] = span
+        while new_active and new_active.finished:
+            new_active = new_active._parent
+            if new_active and not new_active.finished and new_active.span_type == SpanTypes.LLM:
+                break
+        self.activate(new_active)
+        return new_active
+
+    def activate(self, ctx: ContextTypeValue) -> None:
+        """Makes the given context active in the current execution."""
+        _DD_LLMOBS_CONTEXTVAR.set(ctx)
+        super(DefaultContextProvider, self).activate(ctx)
+
+    def active(self) -> ContextTypeValue:
+        """Returns the active span or context for the current execution."""
+        item = _DD_LLMOBS_CONTEXTVAR.get()
+        if isinstance(item, Span):
+            return self._update_active(item)
+        return item

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -4,18 +4,16 @@ from typing import List
 from typing import Optional
 
 from ddtrace.internal.logger import get_logger
+from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs._constants import INPUT_MESSAGES
 from ddtrace.llmobs._constants import METADATA
 from ddtrace.llmobs._constants import METRICS
 from ddtrace.llmobs._constants import MODEL_NAME
 from ddtrace.llmobs._constants import MODEL_PROVIDER
 from ddtrace.llmobs._constants import OUTPUT_MESSAGES
-from ddtrace.llmobs._constants import PARENT_ID_KEY
-from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
 from ddtrace.llmobs._constants import SPAN_KIND
 from ddtrace.llmobs._integrations import BaseLLMIntegration
 from ddtrace.llmobs._integrations.utils import get_llmobs_metrics_tags
-from ddtrace.llmobs._utils import _get_llmobs_parent_id
 from ddtrace.trace import Span
 
 
@@ -34,9 +32,7 @@ class BedrockIntegration(BaseLLMIntegration):
         operation: str = "",
     ) -> None:
         """Extract prompt/response tags from a completion and set them as temporary "_ml_obs.*" tags."""
-        if span.get_tag(PROPAGATED_PARENT_ID_KEY) is None:
-            parent_id = _get_llmobs_parent_id(span) or "undefined"
-            span._set_ctx_item(PARENT_ID_KEY, parent_id)
+        LLMObs._instance._activate_llmobs_span(span)
         parameters = {}
         if span.get_tag("bedrock.request.temperature"):
             parameters["temperature"] = float(span.get_tag("bedrock.request.temperature") or 0.0)

--- a/ddtrace/llmobs/_integrations/langgraph.py
+++ b/ddtrace/llmobs/_integrations/langgraph.py
@@ -8,12 +8,13 @@ from ddtrace.internal.utils import get_argument_value
 from ddtrace.llmobs._constants import INPUT_VALUE
 from ddtrace.llmobs._constants import NAME
 from ddtrace.llmobs._constants import OUTPUT_VALUE
+from ddtrace.llmobs._constants import PARENT_ID_KEY
+from ddtrace.llmobs._constants import ROOT_PARENT_ID
 from ddtrace.llmobs._constants import SPAN_KIND
 from ddtrace.llmobs._constants import SPAN_LINKS
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._integrations.utils import format_langchain_io
 from ddtrace.llmobs._utils import _get_attr
-from ddtrace.llmobs._utils import _get_llmobs_parent_id
 from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
 from ddtrace.trace import Span
 from ddtrace.trace import tracer
@@ -154,7 +155,7 @@ def _default_span_link(span: Span):
     the span is linked to its parent's input.
     """
     return {
-        "span_id": str(_get_llmobs_parent_id(span)) or "undefined",
+        "span_id": span._get_ctx_item(PARENT_ID_KEY) or ROOT_PARENT_ID,
         "trace_id": "{:x}".format(span.trace_id),
         "attributes": {"from": "input", "to": "input"},
     }

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -10,6 +10,9 @@ from typing import Union
 import ddtrace
 from ddtrace import config
 from ddtrace import patch
+from ddtrace._trace.context import Context
+from ddtrace._trace.span import Span
+from ddtrace._trace.tracer import Tracer
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
@@ -45,18 +48,18 @@ from ddtrace.llmobs._constants import OUTPUT_MESSAGES
 from ddtrace.llmobs._constants import OUTPUT_VALUE
 from ddtrace.llmobs._constants import PARENT_ID_KEY
 from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
+from ddtrace.llmobs._constants import ROOT_PARENT_ID
 from ddtrace.llmobs._constants import SESSION_ID
 from ddtrace.llmobs._constants import SPAN_KIND
 from ddtrace.llmobs._constants import SPAN_LINKS
 from ddtrace.llmobs._constants import SPAN_START_WHILE_DISABLED_WARNING
 from ddtrace.llmobs._constants import TAGS
+from ddtrace.llmobs._context import LLMObsContextProvider
 from ddtrace.llmobs._evaluators.runner import EvaluatorRunner
 from ddtrace.llmobs._utils import AnnotationContext
-from ddtrace.llmobs._utils import _get_llmobs_parent_id
 from ddtrace.llmobs._utils import _get_ml_app
 from ddtrace.llmobs._utils import _get_session_id
 from ddtrace.llmobs._utils import _get_span_name
-from ddtrace.llmobs._utils import _inject_llmobs_parent_id
 from ddtrace.llmobs._utils import _is_evaluation_span
 from ddtrace.llmobs._utils import safe_json
 from ddtrace.llmobs._utils import validate_prompt
@@ -66,8 +69,6 @@ from ddtrace.llmobs.utils import Documents
 from ddtrace.llmobs.utils import ExportedLLMObsSpan
 from ddtrace.llmobs.utils import Messages
 from ddtrace.propagation.http import HTTPPropagator
-from ddtrace.trace import Context
-from ddtrace.trace import Span
 
 
 log = get_logger(__name__)
@@ -90,6 +91,7 @@ class LLMObs(Service):
     def __init__(self, tracer=None):
         super(LLMObs, self).__init__()
         self.tracer = tracer or ddtrace.tracer
+        self._llmobs_context_provider = LLMObsContextProvider()
         self._llmobs_span_writer = LLMObsSpanWriter(
             is_agentless=config._llmobs_agentless_enabled,
             agentless_url="%s.%s" % (AGENTLESS_BASE_URL, config._dd_site),
@@ -183,7 +185,7 @@ class LLMObs(Service):
         ml_app = _get_ml_app(span)
 
         span._set_ctx_item(ML_APP, ml_app)
-        parent_id = str(_get_llmobs_parent_id(span) or "undefined")
+        parent_id = span._get_ctx_item(PARENT_ID_KEY) or ROOT_PARENT_ID
 
         llmobs_span_event = {
             "trace_id": "{:x}".format(span.trace_id),
@@ -195,6 +197,7 @@ class LLMObs(Service):
             "status": "error" if span.error else "ok",
             "meta": meta,
             "metrics": metrics,
+            "_dd": {"span_id": str(span.span_id), "trace_id": "{:x}".format(span.trace_id)},
         }
         session_id = _get_session_id(span)
         if session_id is not None:
@@ -283,6 +286,7 @@ class LLMObs(Service):
         core.reset_listeners("trace.span_start", self._on_span_start)
         core.reset_listeners("trace.span_finish", self._on_span_finish)
         core.reset_listeners("http.span_inject", self._inject_llmobs_context)
+        core.reset_listeners("http.activate_distributed_headers", self._activate_llmobs_distributed_context)
 
         forksafe.unregister(self._child_after_fork)
 
@@ -296,7 +300,7 @@ class LLMObs(Service):
         api_key: Optional[str] = None,
         env: Optional[str] = None,
         service: Optional[str] = None,
-        _tracer: Optional[ddtrace.trace.Tracer] = None,
+        _tracer: Optional[Tracer] = None,
     ) -> None:
         """
         Enable LLM Observability tracing.
@@ -364,7 +368,8 @@ class LLMObs(Service):
         # Register hooks for span events
         core.on("trace.span_start", cls._instance._on_span_start)
         core.on("trace.span_finish", cls._instance._on_span_finish)
-        core.on("http.span_inject", cls._instance._inject_llmobs_context)
+        core.on("http.span_inject", cls._inject_llmobs_context)
+        core.on("http.activate_distributed_headers", cls._activate_llmobs_distributed_context)
 
         atexit.register(cls.disable)
         telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.LLMOBS, True)
@@ -490,23 +495,45 @@ class LLMObs(Service):
         """Returns a simple representation of a span to export its span and trace IDs.
         If no span is provided, the current active LLMObs-type span will be used.
         """
-        if span:
-            try:
-                if span.span_type != SpanTypes.LLM:
-                    log.warning("Span must be an LLMObs-generated span.")
-                    return None
-                return ExportedLLMObsSpan(span_id=str(span.span_id), trace_id="{:x}".format(span.trace_id))
-            except (TypeError, AttributeError):
-                log.warning("Failed to export span. Span must be a valid Span object.")
-                return None
-        span = cls._instance.tracer.current_span()
         if span is None:
-            log.warning("No span provided and no active LLMObs-generated span found.")
+            span = cls._instance._current_span()
+            if span is None:
+                log.warning("No span provided and no active LLMObs-generated span found.")
+                return None
+        try:
+            if span.span_type != SpanTypes.LLM:
+                log.warning("Span must be an LLMObs-generated span.")
+                return None
+            return ExportedLLMObsSpan(span_id=str(span.span_id), trace_id="{:x}".format(span.trace_id))
+        except (TypeError, AttributeError):
+            log.warning("Failed to export span. Span must be a valid Span object.")
             return None
-        if span.span_type != SpanTypes.LLM:
-            log.warning("Span must be an LLMObs-generated span.")
-            return None
-        return ExportedLLMObsSpan(span_id=str(span.span_id), trace_id="{:x}".format(span.trace_id))
+
+    def _current_span(self) -> Optional[Span]:
+        """Returns the currently active LLMObs-generated span.
+        Note that there may be an active span represented by a context object
+        (i.e. a distributed trace) which will not be returned by this method.
+        """
+        active = self._llmobs_context_provider.active()
+        return active if isinstance(active, Span) else None
+
+    def _current_trace_context(self) -> Optional[Context]:
+        """Returns the context for the current LLMObs trace."""
+        active = self._llmobs_context_provider.active()
+        if isinstance(active, Context):
+            return active
+        elif isinstance(active, Span):
+            return active.context
+        return None
+
+    def _activate_llmobs_span(self, span: Span) -> None:
+        """Propagate the llmobs parent span's ID as the new span's parent ID and activate the new span."""
+        llmobs_parent = self._llmobs_context_provider.active()
+        if llmobs_parent:
+            span._set_ctx_item(PARENT_ID_KEY, str(llmobs_parent.span_id))
+        else:
+            span._set_ctx_item(PARENT_ID_KEY, ROOT_PARENT_ID)
+        self._llmobs_context_provider.activate(span)
 
     def _start_span(
         self,
@@ -529,6 +556,7 @@ class LLMObs(Service):
         if name is None:
             name = operation_kind
         span = self.tracer.trace(name, resource=operation_kind, span_type=SpanTypes.LLM)
+        self._activate_llmobs_span(span)
         span._set_ctx_item(SPAN_KIND, operation_kind)
         if model_name is not None:
             span._set_ctx_item(MODEL_NAME, model_name)
@@ -540,12 +568,6 @@ class LLMObs(Service):
         if ml_app is None:
             ml_app = _get_ml_app(span)
         span._set_ctx_item(ML_APP, ml_app)
-        if span.get_tag(PROPAGATED_PARENT_ID_KEY) is None:
-            # For non-distributed traces or spans in the first service of a distributed trace,
-            # The LLMObs parent ID tag is not set at span start time. We need to manually set the parent ID tag now
-            # in these cases to avoid conflicting with the later propagated tags.
-            parent_id = _get_llmobs_parent_id(span) or "undefined"
-            span._set_ctx_item(PARENT_ID_KEY, str(parent_id))
         return span
 
     @classmethod
@@ -750,7 +772,7 @@ class LLMObs(Service):
                         such as `{prompt,completion,total}_tokens`.
         """
         if span is None:
-            span = cls._instance.tracer.current_span()
+            span = cls._instance._current_span()
             if span is None:
                 log.warning("No span provided and no active LLMObs-generated span found.")
                 return
@@ -1119,10 +1141,16 @@ class LLMObs(Service):
 
         cls._instance._llmobs_eval_metric_writer.enqueue(evaluation_metric)
 
-    def _inject_llmobs_context(self, span_context: Context, request_headers: Dict[str, str]) -> None:
-        if self.enabled is False:
+    @classmethod
+    def _inject_llmobs_context(cls, span_context: Context, request_headers: Dict[str, str]) -> None:
+        if cls.enabled is False:
             return
-        _inject_llmobs_parent_id(span_context)
+        active_context = cls._instance._current_trace_context()
+        if active_context is None:
+            parent_id = ROOT_PARENT_ID
+        else:
+            parent_id = str(active_context.span_id)
+        span_context._meta[PROPAGATED_PARENT_ID_KEY] = parent_id
 
     @classmethod
     def inject_distributed_headers(cls, request_headers: Dict[str, str], span: Optional[Span] = None) -> Dict[str, str]:
@@ -1141,8 +1169,30 @@ class LLMObs(Service):
         if span is None:
             log.warning("No span provided and no currently active span found.")
             return request_headers
+        if not isinstance(span, Span):
+            log.warning("span must be a valid Span object. Distributed context will not be injected.")
+            return request_headers
         HTTPPropagator.inject(span.context, request_headers)
         return request_headers
+
+    @classmethod
+    def _activate_llmobs_distributed_context(cls, request_headers: Dict[str, str], context: Context) -> None:
+        if cls.enabled is False:
+            return
+        if not context.trace_id or not context.span_id:
+            log.warning("Failed to extract trace/span ID from request headers.")
+            return
+        _parent_id = context._meta.get(PROPAGATED_PARENT_ID_KEY)
+        if _parent_id is None:
+            log.warning("Failed to extract LLMObs parent ID from request headers.")
+            return
+        try:
+            parent_id = int(_parent_id)
+        except ValueError:
+            log.warning("Failed to parse LLMObs parent ID from request headers.")
+            return
+        llmobs_context = Context(trace_id=context.trace_id, span_id=parent_id)
+        cls._instance._llmobs_context_provider.activate(llmobs_context)
 
     @classmethod
     def activate_distributed_headers(cls, request_headers: Dict[str, str]) -> None:
@@ -1158,12 +1208,8 @@ class LLMObs(Service):
             )
             return
         context = HTTPPropagator.extract(request_headers)
-        if context.trace_id is None or context.span_id is None:
-            log.warning("Failed to extract trace ID or span ID from request headers.")
-            return
-        if PROPAGATED_PARENT_ID_KEY not in context._meta:
-            log.warning("Failed to extract LLMObs parent ID from request headers.")
         cls._instance.tracer.context_provider.activate(context)
+        cls._instance._activate_llmobs_distributed_context(request_headers, context)
 
 
 # initialize the default llmobs instance

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -51,6 +51,7 @@ class LLMObsSpanEvent(TypedDict):
     meta: Dict[str, Any]
     metrics: Dict[str, Any]
     collection_errors: List[str]
+    _dd: Dict[str, str]
 
 
 class LLMObsEvaluationMetricEvent(TypedDict, total=False):

--- a/releasenotes/notes/feat-llmobs-context-e4adabcb6894e4d8.yaml
+++ b/releasenotes/notes/feat-llmobs-context-e4adabcb6894e4d8.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    LLM Observability: Introduces an improved automated context management system for LLM Observability-specific spans.
+    Also modifies ``LLMObs.export_span()``, ``LLMObs.inject_distributed_headers()``, ``LLMObs.annotate()`` to default to the current active LLM Observability-specific span if ``span`` is not provided.

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -181,6 +181,7 @@ def _llmobs_base_span_event(
         "meta": {"span.kind": span_kind},
         "metrics": {},
         "tags": _expected_llmobs_tags(span, tags=tags, error=error, session_id=session_id),
+        "_dd": {"span_id": str(span.span_id), "trace_id": "{:x}".format(span.trace_id)},
     }
     if session_id:
         span_event["session_id"] = session_id
@@ -568,6 +569,7 @@ def _expected_ragas_context_precision_spans(ragas_inputs=None):
             },
             "metrics": {},
             "tags": expected_ragas_trace_tags(),
+            "_dd": {"span_id": mock.ANY, "trace_id": mock.ANY},
         },
         {
             "trace_id": mock.ANY,
@@ -585,6 +587,7 @@ def _expected_ragas_context_precision_spans(ragas_inputs=None):
             },
             "metrics": {},
             "tags": expected_ragas_trace_tags(),
+            "_dd": {"span_id": mock.ANY, "trace_id": mock.ANY},
         },
     ]
 
@@ -612,6 +615,7 @@ def _expected_ragas_faithfulness_spans(ragas_inputs=None):
             },
             "metrics": {},
             "tags": expected_ragas_trace_tags(),
+            "_dd": {"span_id": mock.ANY, "trace_id": mock.ANY},
         },
         {
             "trace_id": mock.ANY,
@@ -629,6 +633,7 @@ def _expected_ragas_faithfulness_spans(ragas_inputs=None):
             },
             "metrics": {},
             "tags": expected_ragas_trace_tags(),
+            "_dd": {"span_id": mock.ANY, "trace_id": mock.ANY},
         },
         {
             "trace_id": mock.ANY,
@@ -646,6 +651,7 @@ def _expected_ragas_faithfulness_spans(ragas_inputs=None):
             },
             "metrics": {},
             "tags": expected_ragas_trace_tags(),
+            "_dd": {"span_id": mock.ANY, "trace_id": mock.ANY},
         },
         {
             "trace_id": mock.ANY,
@@ -658,6 +664,7 @@ def _expected_ragas_faithfulness_spans(ragas_inputs=None):
             "meta": {"span.kind": "task", "metadata": {}},
             "metrics": {},
             "tags": expected_ragas_trace_tags(),
+            "_dd": {"span_id": mock.ANY, "trace_id": mock.ANY},
         },
         {
             "trace_id": mock.ANY,
@@ -675,6 +682,7 @@ def _expected_ragas_faithfulness_spans(ragas_inputs=None):
             },
             "metrics": {},
             "tags": expected_ragas_trace_tags(),
+            "_dd": {"span_id": mock.ANY, "trace_id": mock.ANY},
         },
         {
             "trace_id": mock.ANY,
@@ -687,6 +695,7 @@ def _expected_ragas_faithfulness_spans(ragas_inputs=None):
             "meta": {"span.kind": "task", "metadata": {}},
             "metrics": {},
             "tags": expected_ragas_trace_tags(),
+            "_dd": {"span_id": mock.ANY, "trace_id": mock.ANY},
         },
         {
             "trace_id": mock.ANY,
@@ -703,6 +712,7 @@ def _expected_ragas_faithfulness_spans(ragas_inputs=None):
             },
             "metrics": {},
             "tags": expected_ragas_trace_tags(),
+            "_dd": {"span_id": mock.ANY, "trace_id": mock.ANY},
         },
     ]
 
@@ -727,6 +737,7 @@ def _expected_ragas_answer_relevancy_spans(ragas_inputs=None):
             },
             "metrics": {},
             "tags": expected_ragas_trace_tags(),
+            "_dd": {"span_id": mock.ANY, "trace_id": mock.ANY},
         },
         {
             "trace_id": mock.ANY,
@@ -744,6 +755,7 @@ def _expected_ragas_answer_relevancy_spans(ragas_inputs=None):
             },
             "metrics": {},
             "tags": expected_ragas_trace_tags(),
+            "_dd": {"span_id": mock.ANY, "trace_id": mock.ANY},
         },
         {
             "trace_id": mock.ANY,
@@ -761,5 +773,6 @@ def _expected_ragas_answer_relevancy_spans(ragas_inputs=None):
             },
             "metrics": {},
             "tags": expected_ragas_trace_tags(),
+            "_dd": {"span_id": mock.ANY, "trace_id": mock.ANY},
         },
     ]

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -1,211 +1,47 @@
 import json
 import os
 
-from ddtrace.ext import SpanTypes
+from ddtrace.llmobs._constants import PARENT_ID_KEY
 from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
-from ddtrace.llmobs._utils import _get_llmobs_parent_id
-from ddtrace.llmobs._utils import _inject_llmobs_parent_id
-from ddtrace.propagation.http import HTTPPropagator
-from tests.utils import DummyTracer
+from ddtrace.llmobs._constants import ROOT_PARENT_ID
 
 
-def test_inject_llmobs_parent_id_no_llmobs_span():
-    dummy_tracer = DummyTracer()
-    with dummy_tracer.trace("Non-LLMObs span"):
-        with dummy_tracer.trace("Non-LLMObs span") as child_span:
-            _inject_llmobs_parent_id(child_span.context)
-    assert child_span.context._meta.get(PROPAGATED_PARENT_ID_KEY) == "undefined"
+def test_inject_llmobs_parent_id_no_llmobs_span(llmobs):
+    with llmobs._instance.tracer.trace("Non-LLMObs span"):
+        with llmobs._instance.tracer.trace("Non-LLMObs span") as span:
+            llmobs._inject_llmobs_context(span.context, {})
+    assert span.context._meta.get(PROPAGATED_PARENT_ID_KEY) == ROOT_PARENT_ID
 
 
-def test_inject_llmobs_parent_id_simple():
-    dummy_tracer = DummyTracer()
-    with dummy_tracer.trace("LLMObs span", span_type=SpanTypes.LLM) as root_span:
-        _inject_llmobs_parent_id(root_span.context)
-    assert root_span.context._meta.get(PROPAGATED_PARENT_ID_KEY) == str(root_span.span_id)
+def test_inject_llmobs_parent_id_simple(llmobs):
+    with llmobs.workflow("LLMObs span") as span:
+        llmobs._inject_llmobs_context(span.context, {})
+    assert span.context._meta.get(PROPAGATED_PARENT_ID_KEY) == str(span.span_id)
 
 
-def test_inject_llmobs_parent_id_nested_llmobs_non_llmobs():
-    dummy_tracer = DummyTracer()
-    with dummy_tracer.trace("LLMObs span", span_type=SpanTypes.LLM) as root_span:
-        with dummy_tracer.trace("Non-LLMObs span") as child_span:
-            _inject_llmobs_parent_id(child_span.context)
-    assert child_span.context._meta.get(PROPAGATED_PARENT_ID_KEY) == str(root_span.span_id)
+def test_inject_llmobs_parent_id_nested_llmobs_non_llmobs(llmobs):
+    with llmobs.workflow("LLMObs span") as root_span:
+        with llmobs._instance.tracer.trace("Non-LLMObs span") as span:
+            llmobs._inject_llmobs_context(span.context, {})
+    assert span.context._meta.get(PROPAGATED_PARENT_ID_KEY) == str(root_span.span_id)
 
 
-def test_inject_llmobs_parent_id_non_llmobs_root_span():
-    dummy_tracer = DummyTracer()
-    with dummy_tracer.trace("Non-LLMObs span"):
-        with dummy_tracer.trace("LLMObs span", span_type=SpanTypes.LLM) as child_span:
-            _inject_llmobs_parent_id(child_span.context)
-    assert child_span.context._meta.get(PROPAGATED_PARENT_ID_KEY) == str(child_span.span_id)
+def test_inject_llmobs_parent_id_non_llmobs_root_span(llmobs):
+    with llmobs._instance.tracer.trace("Non-LLMObs span"):
+        with llmobs.workflow("LLMObs span") as span:
+            llmobs._inject_llmobs_context(span.context, {})
+    assert span.context._meta.get(PROPAGATED_PARENT_ID_KEY) == str(span.span_id)
 
 
-def test_inject_llmobs_parent_id_nested_llmobs_spans():
-    dummy_tracer = DummyTracer()
-    with dummy_tracer.trace("LLMObs span", span_type=SpanTypes.LLM):
-        with dummy_tracer.trace("LLMObs child span", span_type=SpanTypes.LLM):
-            with dummy_tracer.trace("Last LLMObs child span", span_type=SpanTypes.LLM) as last_llmobs_span:
-                _inject_llmobs_parent_id(last_llmobs_span.context)
+def test_inject_llmobs_parent_id_nested_llmobs_spans(llmobs):
+    with llmobs.workflow("LLMObs span"):
+        with llmobs.workflow("LLMObs child span"):
+            with llmobs.workflow("Last LLMObs child span") as last_llmobs_span:
+                llmobs._inject_llmobs_context(last_llmobs_span.context, {})
     assert last_llmobs_span.context._meta.get(PROPAGATED_PARENT_ID_KEY) == str(last_llmobs_span.span_id)
 
 
-def test_propagate_correct_llmobs_parent_id_simple(run_python_code_in_subprocess):
-    """Test that the correct LLMObs parent ID is propagated in the headers in a simple distributed scenario.
-    Service A (subprocess) has a root LLMObs span and a non-LLMObs child span.
-    Service B (outside subprocess) has a LLMObs span.
-    Service B's span should have the LLMObs parent ID from service A's root LLMObs span.
-    """
-    code = """
-import json
-import mock
-
-from ddtrace.internal.utils.http import Response
-from ddtrace.llmobs import LLMObs
-from ddtrace.propagation.http import HTTPPropagator
-
-with mock.patch(
-    "ddtrace.internal.writer.HTTPWriter._send_payload", return_value=Response(status=200, body="{}"),
-):
-    LLMObs.enable(ml_app="test-app", api_key="<not-a-real-key>", agentless_enabled=True)
-    with LLMObs.workflow("LLMObs span") as root_span:
-        with LLMObs._instance.tracer.trace("Non-LLMObs span") as child_span:
-            headers = {"_DD_LLMOBS_SPAN_ID": str(root_span.span_id)}
-            HTTPPropagator.inject(child_span.context, headers)
-
-print(json.dumps(headers))
-        """
-    env = os.environ.copy()
-    env["DD_TRACE_ENABLED"] = "0"
-    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=env)
-    assert status == 0, (stdout, stderr)
-    assert stderr == b"", (stdout, stderr)
-
-    headers = json.loads(stdout.decode())
-    context = HTTPPropagator.extract(headers)
-    dummy_tracer = DummyTracer()
-    dummy_tracer.context_provider.activate(context)
-    with dummy_tracer.trace("LLMObs span", span_type=SpanTypes.LLM) as span:
-        assert str(span.parent_id) == headers["x-datadog-parent-id"]
-        assert _get_llmobs_parent_id(span) == headers["_DD_LLMOBS_SPAN_ID"]
-
-
-def test_propagate_llmobs_parent_id_complex(run_python_code_in_subprocess):
-    """Test that the correct LLMObs parent ID is propagated in the headers in a more complex trace.
-    Service A (subprocess) has a root LLMObs span and a non-LLMObs child span.
-    Service B (outside subprocess) has a non-LLMObs local root span and a LLMObs child span.
-    Both of service B's spans should have the same LLMObs parent ID (Root LLMObs span from service A).
-    """
-    code = """
-import json
-import mock
-
-from ddtrace.internal.utils.http import Response
-from ddtrace.llmobs import LLMObs
-from ddtrace.propagation.http import HTTPPropagator
-
-with mock.patch(
-    "ddtrace.internal.writer.HTTPWriter._send_payload", return_value=Response(status=200, body="{}"),
-):
-    from ddtrace import auto  # simulate ddtrace-run startup to ensure env var configs also propagate
-    with LLMObs.workflow("LLMObs span") as root_span:
-        with LLMObs._instance.tracer.trace("Non-LLMObs span") as child_span:
-            headers = {"_DD_LLMOBS_SPAN_ID": str(root_span.span_id)}
-            HTTPPropagator.inject(child_span.context, headers)
-
-print(json.dumps(headers))
-        """
-    env = os.environ.copy()
-    env.update(
-        {
-            "DD_LLMOBS_ENABLED": "1",
-            "DD_TRACE_ENABLED": "0",
-            "DD_AGENTLESS_ENABLED": "1",
-            "DD_API_KEY": "<not-a-real-key>",
-            "DD_LLMOBS_ML_APP": "test-app",
-        }
-    )
-    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=env)
-    assert status == 0, (stdout, stderr)
-    assert stderr == b"", (stdout, stderr)
-
-    headers = json.loads(stdout.decode())
-    context = HTTPPropagator.extract(headers)
-    dummy_tracer = DummyTracer()
-    dummy_tracer.context_provider.activate(context)
-    with dummy_tracer.trace("Non-LLMObs span") as span:
-        with dummy_tracer.trace("LLMObs span", span_type=SpanTypes.LLM) as llm_span:
-            assert str(span.parent_id) == headers["x-datadog-parent-id"]
-            assert _get_llmobs_parent_id(span) == headers["_DD_LLMOBS_SPAN_ID"]
-            assert _get_llmobs_parent_id(llm_span) == headers["_DD_LLMOBS_SPAN_ID"]
-
-
-def test_no_llmobs_parent_id_propagated_if_no_llmobs_spans(run_python_code_in_subprocess):
-    """Test that the correct LLMObs parent ID ('undefined') is extracted from headers in a simple distributed scenario.
-    Service A (subprocess) has spans, but none are LLMObs spans.
-    Service B (outside subprocess) has a LLMObs span.
-    Service B's span should have no LLMObs parent ID as there are no LLMObs spans from service A.
-    """
-    code = """
-import json
-
-from ddtrace.llmobs import LLMObs
-from ddtrace.propagation.http import HTTPPropagator
-
-LLMObs.enable(ml_app="ml-app", agentless_enabled=True, api_key="<not-a-real-key>")
-with LLMObs._instance.tracer.trace("Non-LLMObs span") as root_span:
-    headers = {}
-    HTTPPropagator.inject(root_span.context, headers)
-
-print(json.dumps(headers))
-        """
-    env = os.environ.copy()
-    env["DD_TRACE_ENABLED"] = "0"
-    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=env)
-    assert status == 0, (stdout, stderr)
-    assert stderr == b"", (stdout, stderr)
-
-    headers = json.loads(stdout.decode())
-    context = HTTPPropagator.extract(headers)
-    dummy_tracer = DummyTracer()
-    dummy_tracer.context_provider.activate(context)
-    with dummy_tracer.trace("LLMObs span", span_type=SpanTypes.LLM) as span:
-        assert str(span.parent_id) == headers["x-datadog-parent-id"]
-        assert _get_llmobs_parent_id(span) == "undefined"
-
-
-def test_inject_distributed_headers_simple(llmobs):
-    dummy_tracer = DummyTracer()
-    with dummy_tracer.trace("LLMObs span", span_type=SpanTypes.LLM) as root_span:
-        request_headers = llmobs.inject_distributed_headers({}, span=root_span)
-    assert PROPAGATED_PARENT_ID_KEY in request_headers["x-datadog-tags"]
-
-
-def test_inject_distributed_headers_nested_llmobs_non_llmobs(llmobs):
-    dummy_tracer = DummyTracer()
-    with dummy_tracer.trace("LLMObs span", span_type=SpanTypes.LLM):
-        with dummy_tracer.trace("Non-LLMObs span") as child_span:
-            request_headers = llmobs.inject_distributed_headers({}, span=child_span)
-    assert PROPAGATED_PARENT_ID_KEY in request_headers["x-datadog-tags"]
-
-
-def test_inject_distributed_headers_non_llmobs_root_span(llmobs):
-    dummy_tracer = DummyTracer()
-    with dummy_tracer.trace("Non-LLMObs span"):
-        with dummy_tracer.trace("LLMObs span", span_type=SpanTypes.LLM) as child_span:
-            request_headers = llmobs.inject_distributed_headers({}, span=child_span)
-    assert PROPAGATED_PARENT_ID_KEY in request_headers["x-datadog-tags"]
-
-
-def test_inject_distributed_headers_nested_llmobs_spans(llmobs):
-    dummy_tracer = DummyTracer()
-    with dummy_tracer.trace("LLMObs span", span_type=SpanTypes.LLM):
-        with dummy_tracer.trace("LLMObs child span", span_type=SpanTypes.LLM):
-            with dummy_tracer.trace("Last LLMObs child span", span_type=SpanTypes.LLM) as last_llmobs_span:
-                request_headers = llmobs.inject_distributed_headers({}, span=last_llmobs_span)
-    assert PROPAGATED_PARENT_ID_KEY in request_headers["x-datadog-tags"]
-
-
-def test_activate_distributed_headers_propagate_correct_llmobs_parent_id_simple(run_python_code_in_subprocess, llmobs):
+def test_propagate_correct_llmobs_parent_id_simple(ddtrace_run_python_code_in_subprocess, llmobs):
     """Test that the correct LLMObs parent ID is propagated in the headers in a simple distributed scenario.
     Service A (subprocess) has a root LLMObs span and a non-LLMObs child span.
     Service B (outside subprocess) has a LLMObs span.
@@ -214,33 +50,30 @@ def test_activate_distributed_headers_propagate_correct_llmobs_parent_id_simple(
     code = """
 import json
 
-from ddtrace.trace import tracer
-from ddtrace.ext import SpanTypes
+from ddtrace import tracer
 from ddtrace.llmobs import LLMObs
-
-LLMObs.enable(ml_app="test-app", api_key="<not-a-real-key>")
+from ddtrace.propagation.http import HTTPPropagator
 
 with LLMObs.workflow("LLMObs span") as root_span:
-    with tracer.trace("Non-LLMObs span") as child_span:
+    with tracer.trace("Non-LLMObs span"):
         headers = {"_DD_LLMOBS_SPAN_ID": str(root_span.span_id)}
-        headers = LLMObs.inject_distributed_headers(headers, span=child_span)
+        LLMObs.inject_distributed_headers(headers)
 
 print(json.dumps(headers))
         """
     env = os.environ.copy()
-    env["DD_LLMOBS_ENABLED"] = "1"
-    env["DD_TRACE_ENABLED"] = "0"
-    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=env)
+    env.update({"DD_LLMOBS_ML_APP": "test-app", "DD_LLMOBS_ENABLED": "1", "DD_TRACE_ENABLED": "0"})
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=env)
     assert status == 0, (stdout, stderr)
 
     headers = json.loads(stdout.decode())
     llmobs.activate_distributed_headers(headers)
     with llmobs.workflow("LLMObs span") as span:
         assert str(span.parent_id) == headers["x-datadog-parent-id"]
-        assert _get_llmobs_parent_id(span) == headers["_DD_LLMOBS_SPAN_ID"]
+        assert span._get_ctx_item(PARENT_ID_KEY) == headers["_DD_LLMOBS_SPAN_ID"]
 
 
-def test_activate_distributed_headers_propagate_llmobs_parent_id_complex(run_python_code_in_subprocess, llmobs):
+def test_propagate_llmobs_parent_id_complex(ddtrace_run_python_code_in_subprocess, llmobs):
     """Test that the correct LLMObs parent ID is propagated in the headers in a more complex trace.
     Service A (subprocess) has a root LLMObs span and a non-LLMObs child span.
     Service B (outside subprocess) has a non-LLMObs local root span and a LLMObs child span.
@@ -249,36 +82,32 @@ def test_activate_distributed_headers_propagate_llmobs_parent_id_complex(run_pyt
     code = """
 import json
 
-from ddtrace.trace import tracer
-from ddtrace.ext import SpanTypes
+from ddtrace import tracer
 from ddtrace.llmobs import LLMObs
-
-LLMObs.enable(ml_app="test-app", api_key="<not-a-real-key>")
+from ddtrace.propagation.http import HTTPPropagator
 
 with LLMObs.workflow("LLMObs span") as root_span:
-    with tracer.trace("Non-LLMObs span") as child_span:
+    with tracer.trace("Non-LLMObs span"):
         headers = {"_DD_LLMOBS_SPAN_ID": str(root_span.span_id)}
-        headers = LLMObs.inject_distributed_headers(headers, span=child_span)
+        LLMObs.inject_distributed_headers(headers)
 
 print(json.dumps(headers))
         """
     env = os.environ.copy()
-    env["DD_LLMOBS_ENABLED"] = "1"
-    env["DD_TRACE_ENABLED"] = "0"
-    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=env)
+    env.update({"DD_LLMOBS_ML_APP": "test-app", "DD_LLMOBS_ENABLED": "1", "DD_TRACE_ENABLED": "0"})
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=env)
     assert status == 0, (stdout, stderr)
 
     headers = json.loads(stdout.decode())
     llmobs.activate_distributed_headers(headers)
-    dummy_tracer = DummyTracer()
-    with dummy_tracer.trace("Non-LLMObs span") as span:
+    with llmobs._instance.tracer.trace("Non-LLMObs span") as span:
         with llmobs.llm(model_name="llm_model", name="LLMObs span") as llm_span:
             assert str(span.parent_id) == headers["x-datadog-parent-id"]
-            assert _get_llmobs_parent_id(span) == headers["_DD_LLMOBS_SPAN_ID"]
-            assert _get_llmobs_parent_id(llm_span) == headers["_DD_LLMOBS_SPAN_ID"]
+            assert span._get_ctx_item(PARENT_ID_KEY) is None
+            assert llm_span._get_ctx_item(PARENT_ID_KEY) == headers["_DD_LLMOBS_SPAN_ID"]
 
 
-def test_activate_distributed_headers_does_not_propagate_if_no_llmobs_spans(run_python_code_in_subprocess, llmobs):
+def test_no_llmobs_parent_id_propagated_if_no_llmobs_spans(ddtrace_run_python_code_in_subprocess, llmobs):
     """Test that the correct LLMObs parent ID (None) is extracted from the headers in a simple distributed scenario.
     Service A (subprocess) has spans, but none are LLMObs spans.
     Service B (outside subprocess) has a LLMObs span.
@@ -287,10 +116,140 @@ def test_activate_distributed_headers_does_not_propagate_if_no_llmobs_spans(run_
     code = """
 import json
 
-from ddtrace.trace import tracer
+from ddtrace import tracer
+from ddtrace.llmobs import LLMObs
+from ddtrace.propagation.http import HTTPPropagator
+
+with tracer.trace("Non-LLMObs span") as span:
+    headers = {}
+    LLMObs.inject_distributed_headers(headers)
+    HTTPPropagator.inject(span.context, headers)
+
+print(json.dumps(headers))
+        """
+    env = os.environ.copy()
+    env.update({"DD_LLMOBS_ML_APP": "test-app", "DD_LLMOBS_ENABLED": "1", "DD_TRACE_ENABLED": "0"})
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=env)
+    assert status == 0, (stdout, stderr)
+
+    headers = json.loads(stdout.decode())
+    llmobs.activate_distributed_headers(headers)
+    with llmobs.workflow("LLMObs span") as span:
+        assert str(span.parent_id) == headers.get("x-datadog-parent-id")
+        assert span._get_ctx_item(PARENT_ID_KEY) == ROOT_PARENT_ID
+
+
+def test_inject_distributed_headers_simple(llmobs):
+    with llmobs.workflow("LLMObs span") as root_span:
+        request_headers = llmobs.inject_distributed_headers({}, span=root_span)
+    assert "llmobs_parent_id:{}".format(root_span.span_id) in request_headers.get("tracestate")
+
+
+def test_inject_distributed_headers_nested_llmobs_non_llmobs(llmobs):
+    with llmobs.workflow("LLMObs span") as root_span:
+        with llmobs._instance.tracer.trace("Non-LLMObs span") as child_span:
+            request_headers = llmobs.inject_distributed_headers({}, span=child_span)
+    assert "llmobs_parent_id:{}".format(root_span.span_id) in request_headers.get("tracestate")
+
+
+def test_inject_distributed_headers_non_llmobs_root_span(llmobs):
+    with llmobs._instance.tracer.trace("Non-LLMObs span"):
+        with llmobs.workflow("LLMObs span") as child_span:
+            request_headers = llmobs.inject_distributed_headers({}, span=child_span)
+    assert "llmobs_parent_id:{}".format(child_span.span_id) in request_headers.get("tracestate")
+
+
+def test_inject_distributed_headers_nested_llmobs_spans(llmobs):
+    with llmobs.workflow("LLMObs span"):
+        with llmobs.workflow("LLMObs child span"):
+            with llmobs.workflow("LLMObs grandchild span") as last_llmobs_span:
+                request_headers = llmobs.inject_distributed_headers({}, span=last_llmobs_span)
+    assert "llmobs_parent_id:{}".format(last_llmobs_span.span_id) in request_headers.get("tracestate")
+
+
+def test_activate_distributed_headers_propagate_correct_llmobs_parent_id_simple(
+    ddtrace_run_python_code_in_subprocess, llmobs
+):
+    """Test that the correct LLMObs parent ID is propagated in the headers in a simple distributed scenario.
+    Service A (subprocess) has a root LLMObs span and a non-LLMObs child span.
+    Service B (outside subprocess) has a LLMObs span.
+    Service B's span should have the LLMObs parent ID from service A's root LLMObs span.
+    """
+    code = """
+import json
+
+from ddtrace import tracer
 from ddtrace.llmobs import LLMObs
 
-LLMObs.enable(ml_app="test-app", api_key="<not-a-real-key>")
+LLMObs.enable(ml_app="test-app", site="datad0g.com", api_key="dummy-key", agentless_enabled=True)
+
+with LLMObs.workflow("LLMObs span") as root_span:
+    with tracer.trace("Non-LLMObs span") as child_span:
+        headers = {"_DD_LLMOBS_SPAN_ID": str(root_span.span_id)}
+        headers = LLMObs.inject_distributed_headers(headers, span=child_span)
+
+print(json.dumps(headers))
+        """
+    env = os.environ.copy()
+    env.update({"DD_TRACE_ENABLED": "0"})
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=env)
+    assert status == 0, (stdout, stderr)
+
+    headers = json.loads(stdout.decode())
+    llmobs.activate_distributed_headers(headers)
+    with llmobs.workflow("LLMObs span") as span:
+        assert str(span.parent_id) == headers["x-datadog-parent-id"]
+        assert span._get_ctx_item(PARENT_ID_KEY) == headers["_DD_LLMOBS_SPAN_ID"]
+
+
+def test_activate_distributed_headers_propagate_llmobs_parent_id_complex(ddtrace_run_python_code_in_subprocess, llmobs):
+    """Test that the correct LLMObs parent ID is propagated in the headers in a more complex trace.
+    Service A (subprocess) has a root LLMObs span and a non-LLMObs child span.
+    Service B (outside subprocess) has a non-LLMObs local root span and a LLMObs child span.
+    Service B's LLMObs span should have the  LLMObs parent ID (Root LLMObs span from service A).
+    """
+    code = """
+import json
+
+from ddtrace import tracer
+from ddtrace.llmobs import LLMObs
+
+LLMObs.enable(ml_app="test-app", site="datad0g.com", api_key="dummy-key", agentless_enabled=True)
+
+with LLMObs.workflow("LLMObs span") as root_span:
+    with tracer.trace("Non-LLMObs span") as child_span:
+        headers = {"_DD_LLMOBS_SPAN_ID": str(root_span.span_id)}
+        headers = LLMObs.inject_distributed_headers(headers)
+
+print(json.dumps(headers))
+        """
+    env = os.environ.copy()
+    env.update({"DD_TRACE_ENABLED": "0"})
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=env)
+    assert status == 0, (stdout, stderr)
+
+    headers = json.loads(stdout.decode())
+    llmobs.activate_distributed_headers(headers)
+    with llmobs._instance.tracer.trace("Non-LLMObs span") as span:
+        with llmobs.llm(model_name="llm_model", name="LLMObs span") as llm_span:
+            assert str(span.parent_id) == headers["x-datadog-parent-id"]
+            assert span._get_ctx_item(PARENT_ID_KEY) is None
+            assert llm_span._get_ctx_item(PARENT_ID_KEY) == headers["_DD_LLMOBS_SPAN_ID"]
+
+
+def test_activate_distributed_headers_does_not_propagate_if_no_llmobs_spans(
+    ddtrace_run_python_code_in_subprocess, llmobs
+):
+    """Test that the correct LLMObs parent ID (None) is extracted from the headers in a simple distributed scenario.
+    Service A (subprocess) has spans, but none are LLMObs spans.
+    Service B (outside subprocess) has a LLMObs span.
+    Service B's span should have no LLMObs parent ID as there are no LLMObs spans from service A.
+    """
+    code = """
+import json
+
+from ddtrace import tracer
+from ddtrace.llmobs import LLMObs
 
 with tracer.trace("Non-LLMObs span") as root_span:
     headers = {}
@@ -299,13 +258,12 @@ with tracer.trace("Non-LLMObs span") as root_span:
 print(json.dumps(headers))
         """
     env = os.environ.copy()
-    env["DD_LLMOBS_ENABLED"] = "1"
-    env["DD_TRACE_ENABLED"] = "0"
-    stdout, stderr, status, _ = run_python_code_in_subprocess(code=code, env=env)
+    env.update({"DD_LLMOBS_ML_APP": "test-app", "DD_LLMOBS_ENABLED": "1", "DD_TRACE_ENABLED": "0"})
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=env)
     assert status == 0, (stdout, stderr)
 
     headers = json.loads(stdout.decode())
     llmobs.activate_distributed_headers(headers)
     with llmobs.task("LLMObs span") as span:
         assert str(span.parent_id) == headers["x-datadog-parent-id"]
-        assert _get_llmobs_parent_id(span) == "undefined"
+        assert span._get_ctx_item(PARENT_ID_KEY) == ROOT_PARENT_ID


### PR DESCRIPTION
[MLOB-1342] This is a manual copy of #10767 to 3.x-staging due to merge conflicts between 3.x-staging and main.

## Summary
Public facing changes:
- Any LLMObs method (`export_span(), annotate()`) that allow an optional span argument will now default to finding the current active LLMObs span rather than the current active APM span.
- ~Adds multithreading (futures.multithreading) support for LLMObs. Previously multithreaded apps would result in broken traces.~ UPDATE: will be moving multithreading support to a separate PR.

Private changes:
- LLMObs has its own context provider which keeps track of the active LLM-type span (generated by both LLMObs._start_span() and LLM integrations)
- HTTPPropagation now adds LLMObs parent ID as a field on the request headers directly, rather than through the context object.
- Adds private helper method `LLMObs._instance.current_span()`, returns the current active LLMObs-generated (integration, SDK) span.
- Adds private helper method `LLMObs._instance._current_trace_context()`, returns current LLMObs context (which can represent both a span or a distributed span)
- Adds a new field to the LLMObs span event struct, `_dd` which is a str/str dictionary containing the span/trace IDs of the APM span to correlate with. Currently these are the same span/trace IDs as the LLMObs span/trace ID, but this unlocks future steps of using independent span/trace IDs.
 
## Previous behavior
LLMObs spans are based on APM spans, except LLMObs spans' parenting involves only other LLMObs spans. So with a potential trace structure containing a mixture of APM-specific and LLMObs spans, like:
```
Span A (LLMObs span) --> Span B (Apm-specific span) --> Span C (LLMObs span)
```
LLMObs only cares about the LLMObs spans, where span C's parent is the root span, even though in APM it would be span B. Combined with distributed tracing and multithreading, this makes it not so easy to determine that "correct" (read LLMObs) parenting tree for traces submitted to LLM Observability.

### Problems with previous approach

Previously we worked around this by traversing the span's local parent tree and finding the next LLM-type span on both span start and finish for non-distributed cases, and for distributed cases we would attach the parent ID on the span context's meta field to be propagated in distributed request headers. However attaching things to the span context meta was not suitable long-term due to a couple factors:
1. Context objects are not thread-safe: in a multithreading case with n>1 child threads creating their own spans, the parent ID stored in the context object could be overwritten during thread execution, therefore incorrectly propagating parent IDs.
2. Context objects store trace-specific information, and are not designed for our use case where we skip spans here and there in the trace. This also leads to edge cases that were handled with [ugly workaround code](https://github.com/DataDog/dd-trace-py/blob/3bffd02a071db91a6fdc56ae12b496dc84ff8abf/ddtrace/llmobs/_llmobs.py#L312-L317):
<details>
  <summary><i>Example ugly workaround</i></summary>
  <b>Any meta fields set on the context object gets propagated as span tags on all subsequent spans in the trace on span start time, except for the spans in the first service of a trace which get propagated at span finish time. Fixing this resulted in overriding these span tags on span start and more checks on span finish.</b>
</details>

## Current approach
Instead of being dependent on a Context object that doesn't quite fit our use case and trying to make it fit our use case, we simply keep track of our own active LLMObs span/context:
- `LLMObsContextProvider` handles keeping track of the current active LLMObs span via `active()` and `activate()`
- Instead of traversing a span's local ancestor tree to solve for a span's llmobs parent ID, we just use `LLMObsContextProvider._activate_llmobs_span()` and set the llmobs parent ID as a tag at span start time.
(called by `LLMObs._start_span()` and `BaseLLMIntegration.trace(submit_to_llmobs=True)` and the bedrock integration).
- `LLMObs.inject_distributed_headers` now uses the LLMObsContextProvider to inject the active llmobs span's ID into span context and request headers
- `LLMObs.activate_distributed_headers()` now uses the LLMObsContextProvider to activate the extracted llmobs context to continue the trace in a distributed case.
- `trace_utils.activate_distributed_headers()` now includes automatic llmobs context activation if llmobs is enabled. I've used signal handling to avoid importing LLMObs entirely for non-LLMObs users (same for `HTTPPropagator.inject()`).

By keeping track of our own active LLMObs spans, spans submitted to LLM Observability have an independent set of span and parent IDs, even if the span and trace IDs are shared with APM spans for now. This is the first step to decoupling from tracer internals.

## Next steps
We can go further by generating LLMObs-specific span/trace IDs which are separate from APM. This will solve some edge cases with traces involving mixed APM/LLMObs spans.


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)


[MLOB-1342]: https://datadoghq.atlassian.net/browse/MLOB-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ