### PR TITLE
chore(iast): xss vulnerability for jinja2

### DIFF
--- a/ddtrace/appsec/_iast/taint_sinks/xss.py
+++ b/ddtrace/appsec/_iast/taint_sinks/xss.py
@@ -64,7 +64,15 @@ def patch():
     )
 
     _set_metric_iast_instrumented_sink(VULN_XSS)
-    _set_metric_iast_instrumented_sink(VULN_XSS)
+    # Even when starting the application with `ddtrace-run ddtrace-run`, `jinja2.FILTERS` is created before this patch
+    # function executes. Therefore, we update the in-memory object with the newly patched version.
+    try:
+        from jinja2.filters import FILTERS
+        from jinja2.filters import do_mark_safe
+
+        FILTERS["safe"] = do_mark_safe
+    except (ImportError, KeyError):
+        pass
 
 
 def unpatch():

--- a/tests/appsec/integrations/fastapi_tests/test_fastapi_appsec_iast.py
+++ b/tests/appsec/integrations/fastapi_tests/test_fastapi_appsec_iast.py
@@ -1003,10 +1003,6 @@ def test_fastapi_xss(fastapi_application, client, tracer, test_spans):
 
     with override_global_config(dict(_iast_enabled=True, _iast_request_sampling=100.0)):
         patch_iast({"xss": True})
-        from jinja2.filters import FILTERS
-        from jinja2.filters import do_mark_safe
-
-        FILTERS["safe"] = do_mark_safe
         _aux_appsec_prepare_tracer(tracer)
         resp = client.get(
             "/index.html?iast_queryparam=test1234",

--- a/tests/appsec/integrations/flask_tests/test_iast_flask.py
+++ b/tests/appsec/integrations/flask_tests/test_iast_flask.py
@@ -51,10 +51,6 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             patch_header_injection()
             patch_xss_injection()
             patch_json()
-            from jinja2.filters import FILTERS
-            from jinja2.filters import do_mark_safe
-
-            FILTERS["safe"] = do_mark_safe
             super(FlaskAppSecIASTEnabledTestCase, self).setUp()
             self.tracer._configure(api_version="v0.4", appsec_enabled=True, iast_enabled=True)
             oce.reconfigure()


### PR DESCRIPTION
Even when starting the application with `ddtrace-run ddtrace-run`, `jinja2.FILTERS` is created before this patch function executes. Therefore, we update the in-memory object with the newly patched version.
## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
