### PR TITLE
ci: fix vendor test suite with removed DDLogger class

### DIFF
--- a/ddtrace/commands/ddtrace_run.py
+++ b/ddtrace/commands/ddtrace_run.py
@@ -20,7 +20,7 @@ def _find_executable(args: typing.Optional[argparse.Namespace]) -> typing.Option
 
 
 # Do not use `ddtrace.internal.logger.get_logger` here
-# DEV: It isn't really necessary to use `DDLogger` here so we want to
+# DEV: It isn't really necessary to use our filtered logger here so we want to
 #        defer importing `ddtrace` until we actually need it.
 #      As well, no actual rate limiting would apply here since we only
 #        have a few logged lines

--- a/ddtrace/contrib/internal/aws_lambda/patch.py
+++ b/ddtrace/contrib/internal/aws_lambda/patch.py
@@ -20,7 +20,7 @@ def get_version():
 
 
 class DDLambdaLogger:
-    """Uses `DDLogger` to log only on cold start invocations."""
+    """Uses `Logger` to log only on cold start invocations."""
 
     def __init__(self):
         self.logger = get_logger(__name__)

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -128,7 +128,7 @@ on writing documentation for Integrations.
 Logging
 -------
 
-Use ``ddtrace.internal.logger.get_logger(__name__)`` to initialize/retrieve a ``DDLogger`` object you can use
+Use ``ddtrace.internal.logger.get_logger(__name__)`` to initialize/retrieve a ``Logger`` object you can use
 to emit well-formatted log messages from your code.
 
 Keep the following in mind when writing logging code:

--- a/tests/suitespec.yml
+++ b/tests/suitespec.yml
@@ -256,6 +256,7 @@ suites:
     runner: riot
   vendor:
     paths:
+      - '@core'
       - '@vendor'
       - tests/vendor/*
     runner: riot

--- a/tests/vendor/test_dogstatsd.py
+++ b/tests/vendor/test_dogstatsd.py
@@ -1,7 +1,7 @@
-from ddtrace.internal.logger import DDLogger
+from ddtrace.internal.logger import log_filter
 from ddtrace.vendor.dogstatsd.base import log
 
 
 def test_dogstatsd_logger():
     """Ensure dogstatsd logger is initialized as a rate limited logger"""
-    assert isinstance(log, DDLogger)
+    assert log_filter in log.filters


### PR DESCRIPTION
PR #12243 with a failing test because of a reference that was missing.

The `vendor` test suite did not run because there wasn't a linked dependency between that test suite and the core logging files that were modified. This meant the tests only ran on the `main` branch.

This PR removes the remaining references to `DDLogger` and updates `suitespec.yml` to explicitly define the relationship.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
