### PR TITLE
chore(llmobs): migrate to core api

### DIFF
--- a/ddtrace/contrib/internal/openai/_endpoint_hooks.py
+++ b/ddtrace/contrib/internal/openai/_endpoint_hooks.py
@@ -8,6 +8,7 @@ from ddtrace.contrib.internal.openai.utils import _is_generator
 from ddtrace.contrib.internal.openai.utils import _loop_handler
 from ddtrace.contrib.internal.openai.utils import _process_finished_stream
 from ddtrace.contrib.internal.openai.utils import _tag_tool_calls
+from ddtrace.internal import core
 from ddtrace.internal.utils.version import parse_version
 
 
@@ -248,7 +249,7 @@ class _ChatCompletionHook(_BaseCompletionHook):
             if kwargs.get("stream_options", {}).get("include_usage", None) is not None:
                 # Only perform token chunk auto-extraction if this option is not explicitly set
                 return
-            span._set_ctx_item("_dd.auto_extract_token_chunk", True)
+            core.set_item("_dd.auto_extract_token_chunk", True)
             stream_options = kwargs.get("stream_options", {})
             stream_options["include_usage"] = True
             kwargs["stream_options"] = stream_options

--- a/ddtrace/contrib/internal/openai/utils.py
+++ b/ddtrace/contrib/internal/openai/utils.py
@@ -8,6 +8,7 @@ from typing import List
 
 import wrapt
 
+from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._utils import _get_attr
 
@@ -87,7 +88,7 @@ class TracedOpenAIStream(BaseTracedOpenAIStream):
 
     def _extract_token_chunk(self, chunk):
         """Attempt to extract the token chunk (last chunk in the stream) from the streamed response."""
-        if not self._dd_span._get_ctx_item("_dd.auto_extract_token_chunk"):
+        if not core.get_item("_dd.auto_extract_token_chunk"):
             return
         choices = getattr(chunk, "choices")
         if not choices:
@@ -153,7 +154,7 @@ class TracedOpenAIAsyncStream(BaseTracedOpenAIStream):
 
     async def _extract_token_chunk(self, chunk):
         """Attempt to extract the token chunk (last chunk in the stream) from the streamed response."""
-        if not self._dd_span._get_ctx_item("_dd.auto_extract_token_chunk"):
+        if not core.get_item("_dd.auto_extract_token_chunk"):
             return
         choices = getattr(chunk, "choices")
         if not choices:

--- a/ddtrace/llmobs/_evaluators/ragas/answer_relevancy.py
+++ b/ddtrace/llmobs/_evaluators/ragas/answer_relevancy.py
@@ -3,6 +3,7 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
+from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._constants import EVALUATION_SPAN_METADATA
 from ddtrace.llmobs._constants import IS_EVALUATION_SPAN
@@ -85,7 +86,7 @@ class RagasAnswerRelevancyEvaluator(BaseRagasEvaluator):
         with self.llmobs_service.workflow(
             "dd-ragas.answer_relevancy", ml_app=_get_ml_app_for_ragas_trace(span_event)
         ) as ragas_ar_workflow:
-            ragas_ar_workflow._set_ctx_item(IS_EVALUATION_SPAN, True)
+            core.set_item(IS_EVALUATION_SPAN, True)
             try:
                 evaluation_metadata[EVALUATION_SPAN_METADATA] = self.llmobs_service.export_span(span=ragas_ar_workflow)
 

--- a/ddtrace/llmobs/_evaluators/ragas/context_precision.py
+++ b/ddtrace/llmobs/_evaluators/ragas/context_precision.py
@@ -3,6 +3,7 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
+from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._constants import EVALUATION_KIND_METADATA
 from ddtrace.llmobs._constants import EVALUATION_SPAN_METADATA
@@ -83,7 +84,7 @@ class RagasContextPrecisionEvaluator(BaseRagasEvaluator):
         with self.llmobs_service.workflow(
             "dd-ragas.context_precision", ml_app=_get_ml_app_for_ragas_trace(span_event)
         ) as ragas_cp_workflow:
-            ragas_cp_workflow._set_ctx_item(IS_EVALUATION_SPAN, True)
+            core.set_item(IS_EVALUATION_SPAN, True)
             try:
                 evaluation_metadata[EVALUATION_SPAN_METADATA] = self.llmobs_service.export_span(span=ragas_cp_workflow)
 

--- a/ddtrace/llmobs/_evaluators/ragas/faithfulness.py
+++ b/ddtrace/llmobs/_evaluators/ragas/faithfulness.py
@@ -5,6 +5,7 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
+from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._constants import EVALUATION_KIND_METADATA
 from ddtrace.llmobs._constants import EVALUATION_SPAN_METADATA
@@ -97,7 +98,7 @@ class RagasFaithfulnessEvaluator(BaseRagasEvaluator):
         with self.llmobs_service.workflow(
             "dd-ragas.faithfulness", ml_app=_get_ml_app_for_ragas_trace(span_event)
         ) as ragas_faithfulness_workflow:
-            ragas_faithfulness_workflow._set_ctx_item(IS_EVALUATION_SPAN, True)
+            core.set_item(IS_EVALUATION_SPAN, True)
             try:
                 evaluation_metadata[EVALUATION_SPAN_METADATA] = self.llmobs_service.export_span(
                     span=ragas_faithfulness_workflow

--- a/ddtrace/llmobs/_integrations/anthropic.py
+++ b/ddtrace/llmobs/_integrations/anthropic.py
@@ -5,6 +5,7 @@ from typing import Iterable
 from typing import List
 from typing import Optional
 
+from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._constants import INPUT_MESSAGES
 from ddtrace.llmobs._constants import METADATA
@@ -67,7 +68,7 @@ class AnthropicIntegration(BaseLLMIntegration):
         if not span.error and response is not None:
             output_messages = self._extract_output_message(response)
 
-        span._set_ctx_items(
+        core.set_items(
             {
                 SPAN_KIND: "llm",
                 MODEL_NAME: span.get_tag("anthropic.request.model") or "",

--- a/ddtrace/llmobs/_integrations/base.py
+++ b/ddtrace/llmobs/_integrations/base.py
@@ -11,6 +11,7 @@ from ddtrace._trace.sampler import RateSampler
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.contrib.internal.trace_utils import int_service
 from ddtrace.ext import SpanTypes
+from ddtrace.internal import core
 from ddtrace.internal.agent import get_stats_url
 from ddtrace.internal.dogstatsd import get_dogstatsd_client
 from ddtrace.internal.hostname import get_hostname
@@ -137,7 +138,7 @@ class BaseLLMIntegration:
                 # The LLMObs parent ID tag is not set at span start time. We need to manually set the parent ID tag now
                 # in these cases to avoid conflicting with the later propagated tags.
                 parent_id = _get_llmobs_parent_id(span) or "undefined"
-                span._set_ctx_item(PARENT_ID_KEY, str(parent_id))
+                core.set_item(PARENT_ID_KEY, str(parent_id))
         telemetry_writer.add_count_metric(
             namespace=TELEMETRY_NAMESPACE.MLOBS,
             name="span.start",

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -3,6 +3,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
+from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._constants import INPUT_MESSAGES
 from ddtrace.llmobs._constants import METADATA
@@ -36,7 +37,7 @@ class BedrockIntegration(BaseLLMIntegration):
         """Extract prompt/response tags from a completion and set them as temporary "_ml_obs.*" tags."""
         if span.get_tag(PROPAGATED_PARENT_ID_KEY) is None:
             parent_id = _get_llmobs_parent_id(span) or "undefined"
-            span._set_ctx_item(PARENT_ID_KEY, parent_id)
+            core.set_item(PARENT_ID_KEY, parent_id)
         parameters = {}
         if span.get_tag("bedrock.request.temperature"):
             parameters["temperature"] = float(span.get_tag("bedrock.request.temperature") or 0.0)
@@ -48,7 +49,7 @@ class BedrockIntegration(BaseLLMIntegration):
         output_messages = [{"content": ""}]
         if not span.error and response is not None:
             output_messages = self._extract_output_message(response)
-        span._set_ctx_items(
+        core.set_items(
             {
                 SPAN_KIND: "llm",
                 MODEL_NAME: span.get_tag("bedrock.request.model") or "",

--- a/ddtrace/llmobs/_integrations/gemini.py
+++ b/ddtrace/llmobs/_integrations/gemini.py
@@ -4,6 +4,7 @@ from typing import Iterable
 from typing import List
 from typing import Optional
 
+from ddtrace.internal import core
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.llmobs._constants import INPUT_MESSAGES
 from ddtrace.llmobs._constants import METADATA
@@ -51,7 +52,7 @@ class GeminiIntegration(BaseLLMIntegration):
         if not span.error and response is not None:
             output_messages = self._extract_output_message(response)
 
-        span._set_ctx_items(
+        core.set_items(
             {
                 SPAN_KIND: "llm",
                 MODEL_NAME: span.get_tag("google_generativeai.request.model") or "",

--- a/ddtrace/llmobs/_integrations/langgraph.py
+++ b/ddtrace/llmobs/_integrations/langgraph.py
@@ -4,6 +4,7 @@ from typing import List
 from typing import Optional
 
 from ddtrace.ext import SpanTypes
+from ddtrace.internal import core
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.llmobs._constants import INPUT_VALUE
 from ddtrace.llmobs._constants import NAME
@@ -45,9 +46,9 @@ class LangGraphIntegration(BaseLLMIntegration):
         invoked_node_span_links = invoked_node.get("span_links")
         if invoked_node_span_links is not None:
             span_links = invoked_node_span_links
-        current_span_links = span._get_ctx_item(SPAN_LINKS) or []
+        current_span_links = core.get_item(SPAN_LINKS) or []
 
-        span._set_ctx_items(
+        core.set_items(
             {
                 SPAN_KIND: "agent" if operation == "graph" else "task",
                 INPUT_VALUE: format_langchain_io(inputs),
@@ -90,10 +91,10 @@ class LangGraphIntegration(BaseLLMIntegration):
             {**self._graph_nodes_by_task_id[task_id]["span"], "attributes": {"from": "output", "to": "output"}}
             for task_id in finished_tasks.keys()
         ]
-        graph_span_span_links = graph_span._get_ctx_item(SPAN_LINKS) or []
-        graph_span._set_ctx_item(SPAN_LINKS, graph_span_span_links + output_span_links)
+        graph_span_span_links = core.get_item(SPAN_LINKS) or []
+        core.set_item(SPAN_LINKS, graph_span_span_links + output_span_links)
         if graph_caller_span is not None and not is_subgraph_node:
-            graph_caller_span_links = graph_caller_span._get_ctx_item(SPAN_LINKS) or []
+            graph_caller_span_links = core.get_item(SPAN_LINKS) or []
             span_links = [
                 {
                     "span_id": str(graph_span.span_id) or "undefined",
@@ -101,7 +102,7 @@ class LangGraphIntegration(BaseLLMIntegration):
                     "attributes": {"from": "output", "to": "output"},
                 }
             ]
-            graph_caller_span._set_ctx_item(SPAN_LINKS, graph_caller_span_links + span_links)
+            core.set_item(SPAN_LINKS, graph_caller_span_links + span_links)
         return
 
     def _link_task_to_parent(self, task_id, task, finished_task_names_to_ids):

--- a/ddtrace/llmobs/_integrations/vertexai.py
+++ b/ddtrace/llmobs/_integrations/vertexai.py
@@ -4,6 +4,7 @@ from typing import Iterable
 from typing import List
 from typing import Optional
 
+from ddtrace.internal import core
 from ddtrace.internal.utils import ArgumentError
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.llmobs._constants import INPUT_MESSAGES
@@ -57,7 +58,7 @@ class VertexAIIntegration(BaseLLMIntegration):
         if not span.error and response is not None:
             output_messages = self._extract_output_message(response)
 
-        span._set_ctx_items(
+        core.set_items(
             {
                 SPAN_KIND: "llm",
                 MODEL_NAME: span.get_tag("vertexai.request.model") or "",

--- a/ddtrace/llmobs/decorators.py
+++ b/ddtrace/llmobs/decorators.py
@@ -5,6 +5,7 @@ import sys
 from typing import Callable
 from typing import Optional
 
+from ddtrace.internal import core
 from ddtrace.internal.compat import iscoroutinefunction
 from ddtrace.internal.compat import isgeneratorfunction
 from ddtrace.internal.logger import get_logger
@@ -192,7 +193,7 @@ def _llmobs_decorator(operation_kind):
                             _automatic_io_annotation
                             and resp
                             and operation_kind != "retrieval"
-                            and span._get_ctx_item(OUTPUT_VALUE) is None
+                            and core.get_item(OUTPUT_VALUE) is None
                         ):
                             LLMObs.annotate(span=span, output_data=resp)
                         return resp
@@ -240,7 +241,7 @@ def _llmobs_decorator(operation_kind):
                             _automatic_io_annotation
                             and resp
                             and operation_kind != "retrieval"
-                            and span._get_ctx_item(OUTPUT_VALUE) is None
+                            and core.get_item(OUTPUT_VALUE) is None
                         ):
                             LLMObs.annotate(span=span, output_data=resp)
                         return resp

--- a/tests/llmobs/test_llmobs.py
+++ b/tests/llmobs/test_llmobs.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ddtrace.ext import SpanTypes
+from ddtrace.internal import core
 from ddtrace.llmobs import _constants as const
 from ddtrace.llmobs._utils import _get_llmobs_parent_id
 from ddtrace.llmobs._utils import _get_session_id
@@ -11,16 +12,16 @@ class TestMLApp:
     @pytest.mark.parametrize("llmobs_env", [{"DD_LLMOBS_ML_APP": "<not-a-real-app-name>"}])
     def test_tag_defaults_to_env_var(self, tracer, llmobs_env, llmobs_events):
         """Test that no ml_app defaults to the environment variable DD_LLMOBS_ML_APP."""
-        with tracer.trace("root_llm_span", span_type=SpanTypes.LLM) as llm_span:
-            llm_span._set_ctx_item(const.SPAN_KIND, "llm")
+        with tracer.trace("root_llm_span", span_type=SpanTypes.LLM):
+            core.set_item(const.SPAN_KIND, "llm")
         assert "ml_app:<not-a-real-app-name>" in llmobs_events[0]["tags"]
 
     @pytest.mark.parametrize("llmobs_env", [{"DD_LLMOBS_ML_APP": "<not-a-real-app-name>"}])
     def test_tag_overrides_env_var(self, tracer, llmobs_env, llmobs_events):
         """Test that when ml_app is set on the span, it overrides the environment variable DD_LLMOBS_ML_APP."""
-        with tracer.trace("root_llm_span", span_type=SpanTypes.LLM) as llm_span:
-            llm_span._set_ctx_item(const.SPAN_KIND, "llm")
-            llm_span._set_ctx_item(const.ML_APP, "test-ml-app")
+        with tracer.trace("root_llm_span", span_type=SpanTypes.LLM):
+            core.set_item(const.SPAN_KIND, "llm")
+            core.set_item(const.ML_APP, "test-ml-app")
         assert "ml_app:test-ml-app" in llmobs_events[0]["tags"]
 
     def test_propagates_ignore_non_llmobs_spans(self, tracer, llmobs_events):
@@ -28,14 +29,14 @@ class TestMLApp:
         Test that when ml_app is not set, we propagate from nearest LLMObs ancestor
         even if there are non-LLMObs spans in between.
         """
-        with tracer.trace("root_llm_span", span_type=SpanTypes.LLM) as llm_span:
-            llm_span._set_ctx_item(const.SPAN_KIND, "llm")
-            llm_span._set_ctx_item(const.ML_APP, "test-ml-app")
+        with tracer.trace("root_llm_span", span_type=SpanTypes.LLM):
+            core.set_item(const.SPAN_KIND, "llm")
+            core.set_item(const.ML_APP, "test-ml-app")
             with tracer.trace("child_span"):
-                with tracer.trace("llm_grandchild_span", span_type=SpanTypes.LLM) as grandchild_span:
-                    grandchild_span._set_ctx_item(const.SPAN_KIND, "llm")
-                    with tracer.trace("great_grandchild_span", span_type=SpanTypes.LLM) as great_grandchild_span:
-                        great_grandchild_span._set_ctx_item(const.SPAN_KIND, "llm")
+                with tracer.trace("llm_grandchild_span", span_type=SpanTypes.LLM):
+                    core.set_item(const.SPAN_KIND, "llm")
+                    with tracer.trace("great_grandchild_span", span_type=SpanTypes.LLM):
+                        core.set_item(const.SPAN_KIND, "llm")
         assert len(llmobs_events) == 3
         for llmobs_event in llmobs_events:
             assert "ml_app:test-ml-app" in llmobs_event["tags"]
@@ -62,8 +63,8 @@ class TestSessionId:
         Test that session_id is propagated from the nearest LLMObs span in the span's ancestor tree
         if no session_id is not set on the span itself.
         """
-        with tracer.trace("root_llm_span", span_type=SpanTypes.LLM) as root_span:
-            root_span._set_ctx_item(const.SESSION_ID, "test_session_id")
+        with tracer.trace("root_llm_span", span_type=SpanTypes.LLM):
+            core.set_item(const.SESSION_ID, "test_session_id")
             with tracer.trace("child_span"):
                 with tracer.trace("llm_span", span_type=SpanTypes.LLM) as llm_span:
                     pass
@@ -71,11 +72,11 @@ class TestSessionId:
 
     def test_if_set_manually(self, tracer):
         """Test that session_id is extracted from the span if it is already set manually."""
-        with tracer.trace("root_llm_span", span_type=SpanTypes.LLM) as root_span:
-            root_span._set_ctx_item(const.SESSION_ID, "test_session_id")
+        with tracer.trace("root_llm_span", span_type=SpanTypes.LLM):
+            core.set_item(const.SESSION_ID, "test_session_id")
             with tracer.trace("child_span"):
                 with tracer.trace("llm_span", span_type=SpanTypes.LLM) as llm_span:
-                    llm_span._set_ctx_item(const.SESSION_ID, "test_different_session_id")
+                    core.set_item(const.SESSION_ID, "test_different_session_id")
         assert _get_session_id(llm_span) == "test_different_session_id"
 
     def test_propagates_ignore_non_llmobs_spans(self, tracer, llmobs_events):
@@ -83,14 +84,14 @@ class TestSessionId:
         Test that when session_id is not set, we propagate from nearest LLMObs ancestor
         even if there are non-LLMObs spans in between.
         """
-        with tracer.trace("root_llm_span", span_type=SpanTypes.LLM) as llm_span:
-            llm_span._set_ctx_item(const.SPAN_KIND, "llm")
-            llm_span._set_ctx_item(const.SESSION_ID, "session-123")
+        with tracer.trace("root_llm_span", span_type=SpanTypes.LLM):
+            core.set_item(const.SPAN_KIND, "llm")
+            core.set_item(const.SESSION_ID, "session-123")
             with tracer.trace("child_span"):
-                with tracer.trace("llm_grandchild_span", span_type=SpanTypes.LLM) as grandchild_span:
-                    grandchild_span._set_ctx_item(const.SPAN_KIND, "llm")
-                    with tracer.trace("great_grandchild_span", span_type=SpanTypes.LLM) as great_grandchild_span:
-                        great_grandchild_span._set_ctx_item(const.SPAN_KIND, "llm")
+                with tracer.trace("llm_grandchild_span", span_type=SpanTypes.LLM):
+                    core.set_item(const.SPAN_KIND, "llm")
+                    with tracer.trace("great_grandchild_span", span_type=SpanTypes.LLM):
+                        core.set_item(const.SPAN_KIND, "llm")
 
         llm_event, grandchild_event, great_grandchild_event = llmobs_events
         assert llm_event["session_id"] == "session-123"
@@ -100,81 +101,81 @@ class TestSessionId:
 
 def test_input_value_is_set(tracer, llmobs_events):
     """Test that input value is set on the span event if they are present on the span."""
-    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM) as llm_span:
-        llm_span._set_ctx_item(const.SPAN_KIND, "llm")
-        llm_span._set_ctx_item(const.INPUT_VALUE, "value")
+    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM):
+        core.set_item(const.SPAN_KIND, "llm")
+        core.set_item(const.INPUT_VALUE, "value")
     assert llmobs_events[0]["meta"]["input"]["value"] == "value"
 
 
 def test_input_messages_are_set(tracer, llmobs_events):
     """Test that input messages are set on the span event if they are present on the span."""
-    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM) as llm_span:
-        llm_span._set_ctx_item(const.SPAN_KIND, "llm")
-        llm_span._set_ctx_item(const.INPUT_MESSAGES, [{"content": "message", "role": "user"}])
+    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM):
+        core.set_item(const.SPAN_KIND, "llm")
+        core.set_item(const.INPUT_MESSAGES, [{"content": "message", "role": "user"}])
     assert llmobs_events[0]["meta"]["input"]["messages"] == [{"content": "message", "role": "user"}]
 
 
 def test_output_messages_are_set(tracer, llmobs_events):
     """Test that output messages are set on the span event if they are present on the span."""
-    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM) as llm_span:
-        llm_span._set_ctx_item(const.SPAN_KIND, "llm")
-        llm_span._set_ctx_item(const.OUTPUT_MESSAGES, [{"content": "message", "role": "user"}])
+    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM):
+        core.set_item(const.SPAN_KIND, "llm")
+        core.set_item(const.OUTPUT_MESSAGES, [{"content": "message", "role": "user"}])
     assert llmobs_events[0]["meta"]["output"]["messages"] == [{"content": "message", "role": "user"}]
 
 
 def test_output_value_is_set(tracer, llmobs_events):
     """Test that output value is set on the span event if they are present on the span."""
-    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM) as llm_span:
-        llm_span._set_ctx_item(const.SPAN_KIND, "llm")
-        llm_span._set_ctx_item(const.OUTPUT_VALUE, "value")
+    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM):
+        core.set_item(const.SPAN_KIND, "llm")
+        core.set_item(const.OUTPUT_VALUE, "value")
     assert llmobs_events[0]["meta"]["output"]["value"] == "value"
 
 
 def test_prompt_is_set(tracer, llmobs_events):
     """Test that prompt is set on the span event if they are present on the span."""
-    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM) as llm_span:
-        llm_span._set_ctx_item(const.SPAN_KIND, "llm")
-        llm_span._set_ctx_item(const.INPUT_PROMPT, {"variables": {"var1": "var2"}})
+    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM):
+        core.set_item(const.SPAN_KIND, "llm")
+        core.set_item(const.INPUT_PROMPT, {"variables": {"var1": "var2"}})
     assert llmobs_events[0]["meta"]["input"]["prompt"] == {"variables": {"var1": "var2"}}
 
 
 def test_prompt_is_not_set_for_non_llm_spans(tracer, llmobs_events):
     """Test that prompt is NOT set on the span event if the span is not an LLM span."""
-    with tracer.trace("task_span", span_type=SpanTypes.LLM) as task_span:
-        task_span._set_ctx_item(const.SPAN_KIND, "task")
-        task_span._set_ctx_item(const.INPUT_VALUE, "ival")
-        task_span._set_ctx_item(const.INPUT_PROMPT, {"variables": {"var1": "var2"}})
+    with tracer.trace("task_span", span_type=SpanTypes.LLM):
+        core.set_item(const.SPAN_KIND, "task")
+        core.set_item(const.INPUT_VALUE, "ival")
+        core.set_item(const.INPUT_PROMPT, {"variables": {"var1": "var2"}})
     assert llmobs_events[0]["meta"]["input"].get("prompt") is None
 
 
 def test_metadata_is_set(tracer, llmobs_events):
     """Test that metadata is set on the span event if it is present on the span."""
-    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM) as llm_span:
-        llm_span._set_ctx_item(const.SPAN_KIND, "llm")
-        llm_span._set_ctx_item(const.METADATA, {"key": "value"})
+    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM):
+        core.set_item(const.SPAN_KIND, "llm")
+        core.set_item(const.METADATA, {"key": "value"})
     assert llmobs_events[0]["meta"]["metadata"] == {"key": "value"}
 
 
 def test_metrics_are_set(tracer, llmobs_events):
     """Test that metadata is set on the span event if it is present on the span."""
-    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM) as llm_span:
-        llm_span._set_ctx_item(const.SPAN_KIND, "llm")
-        llm_span._set_ctx_item(const.METRICS, {"tokens": 100})
+    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM):
+        core.set_item(const.SPAN_KIND, "llm")
+        core.set_item(const.METRICS, {"tokens": 100})
     assert llmobs_events[0]["metrics"] == {"tokens": 100}
 
 
 def test_langchain_span_name_is_set_to_class_name(tracer, llmobs_events):
     """Test span names for langchain auto-instrumented spans is set correctly."""
-    with tracer.trace(const.LANGCHAIN_APM_SPAN_NAME, resource="expected_name", span_type=SpanTypes.LLM) as llm_span:
-        llm_span._set_ctx_item(const.SPAN_KIND, "llm")
+    with tracer.trace(const.LANGCHAIN_APM_SPAN_NAME, resource="expected_name", span_type=SpanTypes.LLM):
+        core.set_item(const.SPAN_KIND, "llm")
     assert llmobs_events[0]["name"] == "expected_name"
 
 
 def test_error_is_set(tracer, llmobs_events):
     """Test that error is set on the span event if it is present on the span."""
     with pytest.raises(ValueError):
-        with tracer.trace("root_llm_span", span_type=SpanTypes.LLM) as llm_span:
-            llm_span._set_ctx_item(const.SPAN_KIND, "llm")
+        with tracer.trace("root_llm_span", span_type=SpanTypes.LLM):
+            core.set_item(const.SPAN_KIND, "llm")
             raise ValueError("error")
     span_event = llmobs_events[0]
     assert span_event["meta"]["error.message"] == "error"
@@ -184,9 +185,9 @@ def test_error_is_set(tracer, llmobs_events):
 
 def test_model_provider_defaults_to_custom(tracer, llmobs_events):
     """Test that model provider defaults to "custom" if not provided."""
-    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM) as llm_span:
-        llm_span._set_ctx_item(const.SPAN_KIND, "llm")
-        llm_span._set_ctx_item(const.MODEL_NAME, "model_name")
+    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM):
+        core.set_item(const.SPAN_KIND, "llm")
+        core.set_item(const.MODEL_NAME, "model_name")
     span_event = llmobs_events[0]
     assert span_event["meta"]["model_name"] == "model_name"
     assert span_event["meta"]["model_provider"] == "custom"
@@ -194,9 +195,9 @@ def test_model_provider_defaults_to_custom(tracer, llmobs_events):
 
 def test_model_not_set_if_not_llm_kind_span(tracer, llmobs_events):
     """Test that model name and provider not set if non-LLM span."""
-    with tracer.trace("root_workflow_span", span_type=SpanTypes.LLM) as span:
-        span._set_ctx_item(const.SPAN_KIND, "workflow")
-        span._set_ctx_item(const.MODEL_NAME, "model_name")
+    with tracer.trace("root_workflow_span", span_type=SpanTypes.LLM):
+        core.set_item(const.SPAN_KIND, "workflow")
+        core.set_item(const.MODEL_NAME, "model_name")
     span_event = llmobs_events[0]
     assert "model_name" not in span_event["meta"]
     assert "model_provider" not in span_event["meta"]
@@ -204,10 +205,10 @@ def test_model_not_set_if_not_llm_kind_span(tracer, llmobs_events):
 
 def test_model_and_provider_are_set(tracer, llmobs_events):
     """Test that model and provider are set on the span event if they are present on the LLM-kind span."""
-    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM) as llm_span:
-        llm_span._set_ctx_item(const.SPAN_KIND, "llm")
-        llm_span._set_ctx_item(const.MODEL_NAME, "model_name")
-        llm_span._set_ctx_item(const.MODEL_PROVIDER, "model_provider")
+    with tracer.trace("root_llm_span", span_type=SpanTypes.LLM):
+        core.set_item(const.SPAN_KIND, "llm")
+        core.set_item(const.MODEL_NAME, "model_name")
+        core.set_item(const.MODEL_PROVIDER, "model_provider")
     span_event = llmobs_events[0]
     assert span_event["meta"]["model_name"] == "model_name"
     assert span_event["meta"]["model_provider"] == "model_provider"
@@ -227,10 +228,10 @@ def test_malformed_span_logs_error_instead_of_raising(tracer, llmobs_events, moc
 def test_only_generate_span_events_from_llmobs_spans(tracer, llmobs_events):
     """Test that we only generate LLMObs span events for LLM span types."""
     with tracer.trace("root_llm_span", service="tests.llmobs", span_type=SpanTypes.LLM) as root_span:
-        root_span._set_ctx_item(const.SPAN_KIND, "llm")
+        core.set_item(const.SPAN_KIND, "llm")
         with tracer.trace("child_span"):
             with tracer.trace("llm_span", span_type=SpanTypes.LLM) as grandchild_span:
-                grandchild_span._set_ctx_item(const.SPAN_KIND, "llm")
+                core.set_item(const.SPAN_KIND, "llm")
     expected_grandchild_llmobs_span = _expected_llmobs_llm_span_event(grandchild_span, "llm")
     expected_grandchild_llmobs_span["parent_id"] = str(root_span.span_id)
 


### PR DESCRIPTION
Replaces usages of `Span._store` with `ddtrace.internal.core`.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
