### PR TITLE
feat(llmobs): auto-annotate deepseek as span name and model provider through openai

### DIFF
--- a/ddtrace/llmobs/_integrations/openai.py
+++ b/ddtrace/llmobs/_integrations/openai.py
@@ -87,7 +87,7 @@ class OpenAIIntegration(BaseLLMIntegration):
 
     @staticmethod
     def _is_provider(span, provider):
-        """Check if the traced operation is an AzureOpenAI operation using the request's base URL."""
+        """Check if the traced operation is from the given provider."""
         base_url = span.get_tag("openai.base_url") or span.get_tag("openai.api_base")
         if not base_url or not isinstance(base_url, str):
             return False

--- a/ddtrace/llmobs/_integrations/openai.py
+++ b/ddtrace/llmobs/_integrations/openai.py
@@ -86,7 +86,7 @@ class OpenAIIntegration(BaseLLMIntegration):
         span.set_tag_str("openai.request.client", client)
 
     @staticmethod
-    def _is_provider(span, provider="openai"):
+    def _is_provider(span, provider):
         """Check if the traced operation is an AzureOpenAI operation using the request's base URL."""
         base_url = span.get_tag("openai.base_url") or span.get_tag("openai.api_base")
         if not base_url or not isinstance(base_url, str):

--- a/releasenotes/notes/deepseek-openai-39564ebad1b6f98d.yaml
+++ b/releasenotes/notes/deepseek-openai-39564ebad1b6f98d.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    LLM Observability: Properly labels ``Deepseek`` for the model provider and span name for LLM Observability spans for calls to Deepseek models using the OpenAI SDK.

--- a/tests/contrib/openai/cassettes/v1/deepseek_completion.yaml
+++ b/tests/contrib/openai/cassettes/v1/deepseek_completion.yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "system", "content": "You are a helpful assistant"},
+      {"role": "user", "content": "Hello"}], "model": "deepseek-chat"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '140'
+      content-type:
+      - application/json
+      host:
+      - api.deepseek.com
+      user-agent:
+      - OpenAI/Python 1.0.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.0.0
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.13
+    method: POST
+    uri: https://api.deepseek.com/chat/completions
+  response:
+    content: "{\n  \"id\": \"chatcmpl-9lnJM4Cu2pXlrjd8dkJsqO5xwHtBS\",\n  \"object\":
+      \"chat.completion\",\n  \"created\": 1721177996,\n  \"model\": \"deepseek-chat\",\n
+      \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+      \"assistant\",\n        \"content\": \"Hello! How can I assist you today?\"\n      },\n      \"logprobs\": null,\n      \"finish_reason\":
+      \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 20,\n    \"completion_tokens\":
+      96,\n    \"total_tokens\": 116\n  },\n  \"system_fingerprint\": null\n}\n"
+    headers:
+      CF-RAY:
+      - 90fe1a5a1b0b41a1-EWR
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '111'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 10 Feb 2025 18:18:40 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - HWWAFSESID=899f6b5fd0e0dc8327; path=/
+      - HWWAFSESTIME=1739211514942; path=/
+      - __cf_bm=0HVZHDAUJ7IqnvyRIHQssD121ThIRadgV0i1IEUbzfM-1739211520-1.0.1.1-nOBP3Sr4cS9kPm.dI4BqFE1JCG28_Ubddvad190eHnfyTJrZ725QdsDGrtJUrjJc8DgO9DFXSb1jToa0SwRHjA;
+        path=/; expires=Mon, 10-Feb-25 18:48:40 GMT; domain=.deepseek.com; HttpOnly;
+        Secure; SameSite=None
+      access-control-allow-credentials:
+      - 'true'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - origin, access-control-request-method, access-control-request-headers
+      x-content-type-options:
+      - nosniff
+      x-ds-trace-id:
+      - c33eab0fc6380551336de9df6cef08be
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1


### PR DESCRIPTION
Sets `deepseek` as the model provider and client for the span name if using the [Deepseek API as the base URL for the Python OpenAI SDK](https://api-docs.deepseek.com/).

Most LoC are from adding a new cassette.

**Note**: I tried a generic approach to recognizing providers from the base URL but found that maybe a generic regex wouldn't always catch it. Special casing Deepseek and we can return to modify it as needed down the line.

<img width="1050" alt="Screenshot 2025-02-11 at 1 27 24 PM" src="https://github.com/user-attachments/assets/c66df5f5-abc9-4921-8dd8-535be35a9c1c" />
<img width="270" alt="Screenshot 2025-02-11 at 1 27 52 PM" src="https://github.com/user-attachments/assets/84c31a24-d9f1-4115-94f3-707a48ed50d9" />

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
