### PR TITLE
fix(lib-injection): bump max allowed runtime version for lib-injection

### DIFF
--- a/lib-injection/sources/sitecustomize.py
+++ b/lib-injection/sources/sitecustomize.py
@@ -36,7 +36,7 @@ SCRIPT_DIR = os.path.dirname(__file__)
 RUNTIMES_ALLOW_LIST = {
     "cpython": {
         "min": Version(version=(3, 8), constraint=""),
-        "max": Version(version=(3, 13), constraint=""),
+        "max": Version(version=(3, 14), constraint=""),
     }
 }
 

--- a/releasenotes/notes/ssi-constraint-runtime-1d31502a3848369b.yaml
+++ b/releasenotes/notes/ssi-constraint-runtime-1d31502a3848369b.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    single-step instrumentation: resolves an issue in which incorrect runtime version constraints prevented injection into
+    processes using Python 3.13.1+


### PR DESCRIPTION
Partially addresses #10932 (https://github.com/DataDog/dd-trace-py/issues/10932#issuecomment-2616189476) by increasing the maximum allowed runtime version for lib-injection to 3.14.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
