### PR TITLE
fix(profiling): fix crash in heap profiler due to unsigned integer wraparound

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_tb.h
+++ b/ddtrace/profiling/collector/_memalloc_tb.h
@@ -63,7 +63,7 @@ traceback_to_tuple(traceback_t* tb);
 
 /* The maximum number of events we can store in `traceback_array_t.count` */
 #define TRACEBACK_ARRAY_MAX_COUNT UINT16_MAX
-#define TRACEBACK_ARRAY_COUNT_TYPE uint16_t
+#define TRACEBACK_ARRAY_COUNT_TYPE size_t
 
 DO_ARRAY(traceback_t*, traceback, TRACEBACK_ARRAY_COUNT_TYPE, traceback_free)
 

--- a/ddtrace/profiling/collector/_utils.h
+++ b/ddtrace/profiling/collector/_utils.h
@@ -2,6 +2,7 @@
 #define _DDTRACE_UTILS_H
 
 #include <Python.h>
+#include <assert.h>
 #include <stdlib.h>
 
 static inline uint64_t
@@ -71,6 +72,10 @@ random_range(uint64_t max)
                                                                                                                        \
     static inline void pfx##_array_grow(pfx##_array_t* arr, size_type newlen)                                          \
     {                                                                                                                  \
+        if (newlen > arr->size) {                                                                                      \
+            size_type t = p_alloc_nr(arr->size);                                                                       \
+            assert(t >= arr->size);                                                                                    \
+        }                                                                                                              \
         p_grow(arr->tab, newlen, &arr->size);                                                                          \
     }                                                                                                                  \
     static inline void pfx##_array_splice(                                                                             \

--- a/releasenotes/notes/fix-memalloc-traceback-array-index-wraparound-f12e4da5a7de32f2.yaml
+++ b/releasenotes/notes/fix-memalloc-traceback-array-index-wraparound-f12e4da5a7de32f2.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    profiling: Fixes a crash in memory allocation profiler when tracking a large
+    number of live allocations, caused by unsigned integer wraparound which lead
+    to invalid memory access


### PR DESCRIPTION
The traceback array type used by the heap profiler is instantiated from
a preprocessor macro in `ddtrace/profiling/collector/_utils.h`. The macro
takes an index/count type, which for the traceback array was a `uint16_t`.
If the heap profiler's traceback array gets large, meaning we're
tracking a lot of allocations, then computing the new size of the array
when growing it can easily overflow the size type. This can lead us to
allocate a smaller array rather than a larger one, and yet the count of
elements stays the same. So we can write out of bounds, free NULL
pointers, etc, when we access elements outside the bounds of the actual
array.

Change the size type to a `size_t` for that array. The other arrays
instantiated from that macro already use 64-bit unsigned integers, which
are at least as big as `size_t` on our supported platforms. Really we
could do away with the size type parameter and just always use `size_t`.
But the next step for this code is probably to move it to C++ or Rust,
where we can use an existing dynamic array type, rather than to muck
with that set of macros.

This change also adds an assert when growing the array that the new size
doesn't wrap around. I originally found the bug by running this program:

```python
from ddtrace.profiling.collector import _memalloc

_memalloc.start(128, 10000, 8)

count = 100_000
thing_size = 32

junk = []
for i in range(count):
    b1 = bytearray(thing_size)
    b2 = bytearray(2*thing_size)
    b3 = bytearray(3*thing_size)
    b4 = bytearray(4*thing_size)
    t = (b1, b2, b3, b4)
    junk.append(t)

_memalloc.stop()

del junk
```

Prior to this fix, it crashes when growing the array, as described.
After the fix, it runs to completion without crashing. However, it takes
~50 seconds to run on my macbook due to the O(N) lookup when untracking
an element, which leads to O(N^2) cost to untrack all the allocations at
the end of the program. So, reviewers can manually run this to confirm
the fix but I'm hesistant to add a 50 second program to our already slow
CI.

PROF-11349

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
