### PR TITLE
Revert "chore(ci): don't allow `main` or release branches to be interruptible"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,9 +44,6 @@ run-tests-trigger:
      - artifact: .gitlab/tests-gen.yml
        job: tests-gen
    strategy: depend
- rules:
-     - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+$/'
-       interruptible: false
 
 requirements_json_test:
   rules:
@@ -97,9 +94,7 @@ deploy_to_di_backend:manual:
 
 check_new_flaky_tests:
   stage: quality-gate
-  image: registry.ddbuild.io/images/mirror/dd-trace-py/testrunner:0a50e839f4b1600f02157518b8d016451b346578@sha256:5dae9bc7872f69b31b612690f0748c7ad71ab90ef28a754b2ae93d0ba505837b
-  # DEV: we have a larger pool of amd64 runners, prefer that over arm64
-  tags: [ "arch:amd64" ]
+  extends: .testrunner
   script:
     - export DD_SITE=datadoghq.com
     - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.${CI_PROJECT_NAME}.dd-api-key-qualitygate --with-decryption --query "Parameter.Value" --out text)

--- a/.gitlab/testrunner.yml
+++ b/.gitlab/testrunner.yml
@@ -7,6 +7,3 @@
     - ulimit -c unlimited
     - pyenv global 3.12 3.8 3.9 3.10 3.11 3.13
     - export _CI_DD_AGENT_URL=http://${HOST_IP}:8126/
-  rules:
-    - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+$/'
-      interruptible: false


### PR DESCRIPTION
- [x] Reverts DataDog/dd-trace-py#11517

This causes the tests to be entirely skipped unless it is the main or release branch.