### PR TITLE
ci: prevent segfaults in ci_visibility Python 3.8 tests

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -2755,6 +2755,8 @@ venv = Venv(
                 Venv(
                     pys=["3.8"],
                     pkgs={"greenlet": "==3.1.0"},
+                    # Prevent segfaults from zope.interface c optimizations
+                    env={"PURE_PYTHON": "1"},
                 ),
                 # Python 3.9-3.12
                 Venv(


### PR DESCRIPTION
This change prevents a segfault coming from `zope.interface` when running the `ci_visibility` test suite under Python 3.8

This issue was found during the PR #12243. It is unclear why that PR surfaces the issue, but the extracted segfault traceback is showing [zope.interface._compat._c_optimizations_available](https://github.com/zopefoundation/zope.interface/blob/6f56f2c36daecc6f4263bf24a696614c90d4a3ac/src/zope/interface/_compat.py#L50) as the trigger for the segfault.

The fix to work around this issue is to set the [PURE_PYTHON=1](https://github.com/zopefoundation/zope.interface/blob/6f56f2c36daecc6f4263bf24a696614c90d4a3ac/src/zope/interface/_compat.py#L39) environment variable which will tell `zope.interface` to not use this c extension at all.

[Example segfault from CI](https://gist.github.com/brettlangdon/4155f08bcb4d00901935c750c417b81b)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
