### PR TITLE
chore(ci_visibility): fetch quarantine status from backend

### DIFF
--- a/ddtrace/internal/ci_visibility/_api_client.py
+++ b/ddtrace/internal/ci_visibility/_api_client.py
@@ -22,6 +22,7 @@ from ddtrace.internal.ci_visibility.constants import SETTING_ENDPOINT
 from ddtrace.internal.ci_visibility.constants import SKIPPABLE_ENDPOINT
 from ddtrace.internal.ci_visibility.constants import SUITE
 from ddtrace.internal.ci_visibility.constants import TEST
+from ddtrace.internal.ci_visibility.constants import TEST_MANAGEMENT_TESTS_ENDPOINT
 from ddtrace.internal.ci_visibility.constants import UNIQUE_TESTS_ENDPOINT
 from ddtrace.internal.ci_visibility.errors import CIVisibilityAuthenticationException
 from ddtrace.internal.ci_visibility.git_data import GitData
@@ -35,6 +36,8 @@ from ddtrace.internal.ci_visibility.telemetry.early_flake_detection import recor
 from ddtrace.internal.ci_visibility.telemetry.git import record_settings_response
 from ddtrace.internal.ci_visibility.telemetry.itr import SKIPPABLE_TESTS_TELEMETRY
 from ddtrace.internal.ci_visibility.telemetry.itr import record_skippable_count
+from ddtrace.internal.ci_visibility.telemetry.test_management import TEST_MANAGEMENT_TELEMETRY
+from ddtrace.internal.ci_visibility.telemetry.test_management import record_test_management_tests_count
 from ddtrace.internal.ci_visibility.utils import combine_url_path
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.test_visibility._internal_item_ids import InternalTestId
@@ -93,6 +96,11 @@ class EarlyFlakeDetectionSettings:
 class QuarantineSettings:
     enabled: bool = False
     skip_quarantined_tests: bool = False
+
+
+@dataclasses.dataclass(frozen=True)
+class TestProperties:
+    quarantined: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -546,6 +554,64 @@ class _TestVisibilityAPIClientBase(abc.ABC):
         record_early_flake_detection_tests_count(len(unique_test_ids))
 
         return unique_test_ids
+
+    def fetch_test_management_tests(self) -> t.Optional[t.Dict[InternalTestId, TestProperties]]:
+        metric_names = APIRequestMetricNames(
+            count=TEST_MANAGEMENT_TELEMETRY.REQUEST.value,
+            duration=TEST_MANAGEMENT_TELEMETRY.REQUEST_MS.value,
+            response_bytes=TEST_MANAGEMENT_TELEMETRY.RESPONSE_BYTES.value,
+            error=TEST_MANAGEMENT_TELEMETRY.REQUEST_ERRORS.value,
+        )
+
+        test_properties: t.Dict[InternalTestId, TestProperties] = {}
+        payload = {
+            "data": {
+                "id": str(uuid4()),
+                "type": "ci_app_libraries_tests_request",
+                "attributes": {
+                    "repository_url": self._git_data.repository_url,
+                },
+            }
+        }
+
+        try:
+            parsed_response = self._do_request_with_telemetry(
+                "POST", TEST_MANAGEMENT_TESTS_ENDPOINT, json.dumps(payload), metric_names
+            )
+        except Exception:  # noqa: E722
+            return None
+
+        if "errors" in parsed_response:
+            record_api_request_error(metric_names.error, ERROR_TYPES.UNKNOWN)
+            log.debug("Test Management tests response contained an error")
+            return None
+
+        try:
+            modules = parsed_response["data"]["attributes"]["modules"]
+        except KeyError:
+            record_api_request_error(metric_names.error, ERROR_TYPES.UNKNOWN)
+            return None
+
+        try:
+            for module_name, module_data in modules.items():
+                module_id = TestModuleId(module_name)
+                suites = module_data["suites"]
+                for suite_name, suite_data in suites.items():
+                    suite_id = TestSuiteId(module_id, suite_name)
+                    tests = suite_data["tests"]
+                    for test_name, test_data in tests.items():
+                        test_id = InternalTestId(suite_id, test_name)
+                        properties = test_data.get("properties", {})
+                        test_properties[test_id] = TestProperties(quarantined=properties.get("quarantined", False))
+
+        except Exception:  # noqa: E722
+            log.debug("Failed to parse Test Management tests data", exc_info=True)
+            record_api_request_error(metric_names.error, ERROR_TYPES.UNKNOWN)
+            return None
+
+        record_test_management_tests_count(len(test_properties))
+
+        return test_properties
 
 
 class AgentlessTestVisibilityAPIClient(_TestVisibilityAPIClientBase):

--- a/ddtrace/internal/ci_visibility/constants.py
+++ b/ddtrace/internal/ci_visibility/constants.py
@@ -48,7 +48,7 @@ GIT_API_BASE_PATH = "/api/v2/git"
 SETTING_ENDPOINT = "/api/v2/libraries/tests/services/setting"
 SKIPPABLE_ENDPOINT = "/api/v2/ci/tests/skippable"
 UNIQUE_TESTS_ENDPOINT = "/api/v2/ci/libraries/tests"
-DETAILED_TESTS_ENDPOINT = "/api/v2/ci/libraries/tests/detailed"
+TEST_MANAGEMENT_TESTS_ENDPOINT = "/api/v2/test/libraries/test-management/tests"
 
 # Intelligent Test Runner constants
 ITR_UNSKIPPABLE_REASON = "datadog_itr_unskippable"

--- a/ddtrace/internal/ci_visibility/telemetry/test_management.py
+++ b/ddtrace/internal/ci_visibility/telemetry/test_management.py
@@ -1,0 +1,25 @@
+from enum import Enum
+
+from ddtrace.internal.logger import get_logger
+from ddtrace.internal.telemetry import telemetry_writer
+from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
+
+
+log = get_logger(__name__)
+
+
+class TEST_MANAGEMENT_TELEMETRY(str, Enum):
+    REQUEST = "test_management.request"
+    REQUEST_MS = "test_management.request_ms"
+    REQUEST_ERRORS = "test_management.request_errors"
+    RESPONSE_BYTES = "test_management.response_bytes"
+    RESPONSE_TESTS = "test_management.response_tests"
+
+
+def record_test_management_tests_count(test_management_count: int):
+    log.debug("Recording Test Management tests count telemetry: %s", test_management_count)
+    telemetry_writer.add_distribution_metric(
+        TELEMETRY_NAMESPACE.CIVISIBILITY,
+        TEST_MANAGEMENT_TELEMETRY.RESPONSE_TESTS.value,
+        test_management_count,
+    )

--- a/ddtrace/internal/test_visibility/_internal_item_ids.py
+++ b/ddtrace/internal/test_visibility/_internal_item_ids.py
@@ -1,8 +1,6 @@
-import dataclasses
-
 from ddtrace.ext.test_visibility import api as ext_api
 
 
-@dataclasses.dataclass(frozen=True)
-class InternalTestId(ext_api.TestId):
-    pass
+# TODO(vitor-de-araujo): InternalTestId exists for historical reasons; it used to consist of TestId + EFD retry number.
+# The retry number is not part of the test id anymore, so these types can be unified, and in the future removed.
+InternalTestId = ext_api.TestId

--- a/tests/ci_visibility/api_client/_util.py
+++ b/tests/ci_visibility/api_client/_util.py
@@ -105,23 +105,6 @@ def _get_tests_api_response(tests_body: t.Optional[t.Dict] = None):
     return Response(200, json.dumps(response))
 
 
-def _get_detailed_tests_api_response(modules: t.Dict):
-    response = {"data": {"id": "J0ucvcSApX8", "type": "ci_app_libraries_tests", "attributes": {"modules": []}}}
-
-    for module_id, suites in modules.items():
-        module = {"id": module_id, "suites": []}
-        response["data"]["attributes"]["modules"].append(module)
-
-        for suite_id, tests in suites.items():
-            suite = {"id": suite_id, "tests": []}
-            module["suites"].append(suite)
-
-            for test_id in tests:
-                suite["tests"].append({"id": test_id})
-
-    return Response(200, json.dumps(response))
-
-
 def _make_fqdn_internal_test_id(module_name: str, suite_name: str, test_name: str, parameters: t.Optional[str] = None):
     """An easy way to create a test id "from the bottom up"
 

--- a/tests/ci_visibility/api_client/test_ci_visibility_api_client_test_management_responses.py
+++ b/tests/ci_visibility/api_client/test_ci_visibility_api_client_test_management_responses.py
@@ -1,0 +1,106 @@
+from http.client import RemoteDisconnected
+import json
+import socket
+import textwrap
+from unittest import mock
+
+import pytest
+
+from ddtrace.internal.ci_visibility._api_client import TestProperties
+from ddtrace.internal.utils.http import Response
+from tests.ci_visibility.api_client._util import TestTestVisibilityAPIClientBase
+from tests.ci_visibility.api_client._util import _make_fqdn_internal_test_id
+
+
+class TestTestVisibilityAPIClientTestManagementResponses(TestTestVisibilityAPIClientBase):
+    """Tests that Test Management tests responses from the API client are parsed properly"""
+
+    def test_api_client_test_management_tests_parsed(self):
+        response_dict = {
+            "data": {
+                "id": "J0ucvcSApX8",
+                "type": "ci_app_libraries_tests",
+                "attributes": {
+                    "modules": {
+                        "module1": {
+                            "suites": {
+                                "suite1.py": {
+                                    "tests": {
+                                        "test1": {"properties": {"quarantined": True}},
+                                        "test2": {"properties": {"quarantined": False}},
+                                        "test3": {"properties": {}},
+                                        "test4": {},
+                                    }
+                                },
+                                "suite2.py": {
+                                    "tests": {
+                                        "test1": {"properties": {"quarantined": False}},
+                                        "test5": {"properties": {"quarantined": True}},
+                                    }
+                                },
+                            }
+                        },
+                        "module2": {
+                            "suites": {
+                                "suite1.py": {
+                                    "tests": {
+                                        "test1": {"properties": {"quarantined": False}},
+                                    }
+                                }
+                            }
+                        },
+                    }
+                },
+            }
+        }
+        mock_response = Response(200, json.dumps(response_dict))
+
+        expected_tests = {
+            _make_fqdn_internal_test_id("module1", "suite1.py", "test1"): TestProperties(quarantined=True),
+            _make_fqdn_internal_test_id("module1", "suite1.py", "test2"): TestProperties(quarantined=False),
+            _make_fqdn_internal_test_id("module1", "suite1.py", "test3"): TestProperties(quarantined=False),
+            _make_fqdn_internal_test_id("module1", "suite1.py", "test4"): TestProperties(quarantined=False),
+            _make_fqdn_internal_test_id("module1", "suite2.py", "test1"): TestProperties(quarantined=False),
+            _make_fqdn_internal_test_id("module1", "suite2.py", "test5"): TestProperties(quarantined=True),
+            _make_fqdn_internal_test_id("module2", "suite1.py", "test1"): TestProperties(quarantined=False),
+        }
+
+        client = self._get_test_client()
+        with mock.patch.object(client, "_do_request", return_value=mock_response):
+            assert client.fetch_test_management_tests() == expected_tests
+
+    @pytest.mark.parametrize(
+        "do_request_side_effect",
+        [
+            TimeoutError,
+            socket.timeout,
+            RemoteDisconnected,
+            Response(403),
+            Response(500),
+            Response(200, "this is not json"),
+            Response(200, '{"valid_json": "invalid_structure"}'),
+            Response(200, '{"errors": "there was an error"}'),
+            Response(
+                200,
+                textwrap.dedent(
+                    """
+                {
+                    "data": {
+                    "id": "J0ucvcSApX8",
+                    "type": "ci_app_libraries_tests",
+                    "attributes": {
+                        "potatoes_but_not_tests": {}
+                        }
+                    }
+                }
+            """
+                ),
+            ),
+        ],
+    )
+    def test_api_client_test_management_tests_errors(self, do_request_side_effect):
+        """Tests that the client correctly handles errors in the Test Management test API response"""
+        client = self._get_test_client()
+        with mock.patch.object(client, "_do_request", side_effect=[do_request_side_effect]):
+            settings = client.fetch_test_management_tests()
+            assert settings is None


### PR DESCRIPTION
Fetch quarantine status from the new Test Management endpoint, instead of relying on pytest marks.

This is https://github.com/DataDog/dd-trace-py/pull/12136, migrated to the 3.x main branch.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
