### PR TITLE
ci: add `retry: 2` to the `.testrunner` definition so everything inherits it

### DIFF
--- a/.gitlab/testrunner.yml
+++ b/.gitlab/testrunner.yml
@@ -7,3 +7,4 @@
     - ulimit -c unlimited
     - pyenv global 3.12 3.8 3.9 3.10 3.11 3.13
     - export _CI_DD_AGENT_URL=http://${HOST_IP}:8126/
+  retry: 2

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -20,7 +20,6 @@ include:
   needs: []
   parallel: 4
   # DEV: This is the max retries that GitLab currently allows for
-  retry: 2
   before_script:
     - !reference [.testrunner, before_script]
     - pip install riot==0.20.1
@@ -81,7 +80,6 @@ build_base_venvs:
   services:
     - !reference [.services, ddagent]
   # DEV: This is the max retries that GitLab currently allows for
-  retry: 2
   before_script:
     - !reference [.testrunner, before_script]
     - pip install riot==0.20.1


### PR DESCRIPTION
We had this on the base riot and hatch definitions, but we should just have it on the .testrunner definition itself so everything gets it.


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
