### PR TITLE
fix(span): handle errors on spans when a custom exception overrides __str__ (#12307) [backport 2.21]

### DIFF
--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -545,9 +545,17 @@ class Span(object):
 
         # readable version of type (e.g. exceptions.ZeroDivisionError)
         exc_type_str = "%s.%s" % (exc_type.__module__, exc_type.__name__)
-
-        self._meta[ERROR_MSG] = str(exc_val)
         self._meta[ERROR_TYPE] = exc_type_str
+
+        try:
+            self._meta[ERROR_MSG] = str(exc_val)
+        except Exception:
+            # An exception can occur if a custom Exception overrides __str__
+            # If this happens str(exc_val) won't work, so best we can do is print the class name
+            # Otherwise, don't try to set an error message
+            if exc_val and hasattr(exc_val, "__class__"):
+                self._meta[ERROR_MSG] = exc_val.__class__.__name__
+
         self._meta[ERROR_STACK] = tb
 
         core.dispatch("span.exception", (self, exc_type, exc_val, exc_tb))

--- a/releasenotes/notes/fix-custom-error-spans-with-__str__-override-a05726045f8751d6.yaml
+++ b/releasenotes/notes/fix-custom-error-spans-with-__str__-override-a05726045f8751d6.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    span: Fix issue where spans weren't being handled correctly and were not being sent when using a custom Exception class that raises an exception in `__str__`.

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -828,6 +828,25 @@ def test_manual_context_usage():
     assert span1.context.sampling_priority == 1
 
 
+def test_set_exc_info_with_str_override():
+    span = Span("span")
+
+    class CustomException(Exception):
+        def __str__(self):
+            raise Exception("A custom exception")
+
+    try:
+        raise CustomException()
+    except Exception:
+        type_, value_, traceback_ = sys.exc_info()
+        span.set_exc_info(type_, value_, traceback_)
+
+    span.finish()
+    assert span.get_tag(ERROR_MSG) == "CustomException"
+    assert span.get_tag(ERROR_STACK) is not None
+    assert span.get_tag(ERROR_TYPE) == "tests.tracer.test_span.CustomException"
+
+
 def test_set_exc_info_with_systemexit():
     def get_exception_span():
         span = Span("span1")


### PR DESCRIPTION
Backport of #12307 to 2.21


Today when a custom exception overrides `__str__` by raising an exception, the tracer cannot apply an error message on it because `str(exc_val)` doesn't work (it raises the exception again). As a result the span doesn't close correctly because it's an exception, not a string and thus the span can't get sent.

If this condition occurs, this PR sets the error message to the class name of the custom exception so the spans can still get sent and there's a clue to what the exception was.

The current logic is this:

https://github.com/DataDog/dd-trace-py/blob/6b5f13c2701d55a695afcd4a73db8af2d251b55d/ddtrace/_trace/span.py#L523

When we run the current logic against a custom exception that overrides `__str__`, we can see from the [failed
job](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/805643750) that `str(exc_val)` leads to an error:
```
_____________________ test_set_exc_info_with_str_override ______________________
    def test_set_exc_info_with_str_override():
        span = Span("span")

        class CustomException(Exception):
            def __str__(self):
                raise Exception("A custom exception")

        try:
>           raise CustomException()
E           tests.tracer.test_span.test_set_exc_info_with_str_override.<locals>.CustomException: <exception str() failed>
tests/tracer/test_span.py:839: CustomException
During handling of the above exception, another exception occurred:
    def test_set_exc_info_with_str_override():
        span = Span("span")

        class CustomException(Exception):
            def __str__(self):
                raise Exception("A custom exception")

        try:
            raise CustomException()
        except Exception:
            type_, value_, traceback_ = sys.exc_info()
>           span.set_exc_info(type_, value_, traceback_)
tests/tracer/test_span.py:842:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
ddtrace/_trace/span.py:523: in set_exc_info
    self._meta[ERROR_MSG] = str(exc_val)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
self = CustomException()
    def __str__(self):
>       raise Exception("A custom exception")
E       Exception: A custom exception
tests/tracer/test_span.py:836: Exception
```

The fix is to try to catch this exception if `str(exc_val)` and just add the class name as a placeholder for the error message since there isn't an easy way to turn the exception into a string (since it just keeps raising the exception). This way, spans can at least be closed and sent.

Thanks to @wiggzz for demonstrating the issue in
https://github.com/wiggzz/dd-trace-debug!

This is for APMS-14834 .

(cherry picked from commit bada1cd7974515cc63a033b9d2e7361dedaef998)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
