### PR TITLE
chore(configuration): use get_config to parse all envars used in ddtrace.config

### DIFF
--- a/ddtrace/settings/_config.py
+++ b/ddtrace/settings/_config.py
@@ -37,7 +37,7 @@ from ..internal.utils.formats import asbool
 from ..internal.utils.formats import parse_tags_str
 from ._core import get_config as _get_config
 from ._inferred_base_service import detect_service
-from ._otel_remapper import otel_remapping as _otel_remapping
+from ._otel_remapper import validate_otel_envs
 from .endpoint_config import fetch_config_from_endpoint
 from .http import HttpConfig
 from .integration import IntegrationConfig
@@ -194,10 +194,10 @@ _JSONType = Union[None, int, float, str, bool, List["_JSONType"], Dict[str, "_JS
 class _ConfigItem:
     """Configuration item that tracks the value of a setting, and where it came from."""
 
-    def __init__(self, default, envs):
-        # type: (Union[_JSONType, Callable[[], _JSONType]], List[Tuple[str, Callable[[str], Any]]]) -> None
+    def __init__(self, default, envs, modifier, otel_env=None):
+        # type: (Union[_JSONType, Callable[[], _JSONType]], List[str], Callable[[str], Any], Optional[str]) -> None
         # _ConfigItem._name is only used in __repr__ and instrumentation telemetry
-        self._name = envs[0][0]
+        self._name = envs[0]
         self._env_value: _JSONType = None
         self._code_value: _JSONType = None
         self._rc_value: _JSONType = None
@@ -206,11 +206,10 @@ class _ConfigItem:
         else:
             self._default_value = default
         self._envs = envs
-        for env_var, parser in envs:
-            if env_var in os.environ:
-                self._env_value = parser(os.environ[env_var])
-                break
-        telemetry_writer.add_configuration(self._name, self.value(), self.source())
+
+        val = _get_config(envs, self._default_value, modifier, otel_env)
+        if val is not self._default_value:
+            self._env_value = val
 
     def set_value_source(self, value: Any, source: _ConfigSource) -> None:
         if source == "code":
@@ -266,43 +265,56 @@ def _default_config() -> Dict[str, _ConfigItem]:
         "_trace_sample_rate": _ConfigItem(
             default=1.0,
             # trace_sample_rate is placeholder, this code will be removed up after v3.0
-            envs=[("trace_sample_rate", float)],
+            envs=["trace_sample_rate"],
+            modifier=float,
         ),
         "_trace_sampling_rules": _ConfigItem(
             default=lambda: "",
-            envs=[("DD_TRACE_SAMPLING_RULES", str)],
+            envs=["DD_TRACE_SAMPLING_RULES"],
+            otel_env="OTEL_TRACES_SAMPLER",
+            modifier=str,
         ),
         "_logs_injection": _ConfigItem(
             default=False,
-            envs=[("DD_LOGS_INJECTION", asbool)],
+            envs=["DD_LOGS_INJECTION"],
+            modifier=asbool,
         ),
         "_trace_http_header_tags": _ConfigItem(
             default=lambda: {},
-            envs=[("DD_TRACE_HEADER_TAGS", parse_tags_str)],
+            envs=["DD_TRACE_HEADER_TAGS"],
+            modifier=parse_tags_str,
         ),
         "tags": _ConfigItem(
             default=lambda: {},
-            envs=[("DD_TAGS", _parse_global_tags)],
+            envs=["DD_TAGS"],
+            otel_env="OTEL_RESOURCE_ATTRIBUTES",
+            modifier=_parse_global_tags,
         ),
         "_tracing_enabled": _ConfigItem(
             default=True,
-            envs=[("DD_TRACE_ENABLED", asbool)],
+            envs=["DD_TRACE_ENABLED"],
+            otel_env="OTEL_TRACES_EXPORTER",
+            modifier=asbool,
         ),
         "_profiling_enabled": _ConfigItem(
             default=False,
-            envs=[("DD_PROFILING_ENABLED", asbool)],
+            envs=["DD_PROFILING_ENABLED"],
+            modifier=asbool,
         ),
         "_asm_enabled": _ConfigItem(
             default=False,
-            envs=[("DD_APPSEC_ENABLED", asbool)],
+            envs=["DD_APPSEC_ENABLED"],
+            modifier=asbool,
         ),
         "_sca_enabled": _ConfigItem(
             default=None,
-            envs=[("DD_APPSEC_SCA_ENABLED", asbool)],
+            envs=["DD_APPSEC_SCA_ENABLED"],
+            modifier=asbool,
         ),
         "_dsm_enabled": _ConfigItem(
             default=False,
-            envs=[("DD_DATA_STREAMS_ENABLED", asbool)],
+            envs=["DD_DATA_STREAMS_ENABLED"],
+            modifier=asbool,
         ),
     }
 
@@ -346,8 +358,8 @@ class Config(object):
             return False
 
     def __init__(self):
-        # Must map Otel configurations to Datadog configurations before creating the config object.
-        _otel_remapping()
+        # Must validate Otel configurations before creating the config object.
+        validate_otel_envs()
         # Must come before _integration_configs due to __setattr__
         self._from_endpoint = ENDPOINT_FETCHED_CONFIG
         self._config = _default_config()
@@ -355,18 +367,17 @@ class Config(object):
         # Use a dict as underlying storing mechanism for integration configs
         self._integration_configs = {}
 
-        self._debug_mode = _get_config("DD_TRACE_DEBUG", False, asbool)
+        self._debug_mode = _get_config("DD_TRACE_DEBUG", False, asbool, "OTEL_LOG_LEVEL")
         self._startup_logs_enabled = _get_config("DD_TRACE_STARTUP_LOGS", False, asbool)
 
-        rate_limit = os.getenv("DD_TRACE_RATE_LIMIT")
-        if rate_limit is not None and self._trace_sampling_rules in ("", "[]"):
+        self._trace_rate_limit = _get_config("DD_TRACE_RATE_LIMIT", DEFAULT_SAMPLING_RATE_LIMIT, int)
+        if self._trace_rate_limit != DEFAULT_SAMPLING_RATE_LIMIT and self._trace_sampling_rules in ("", "[]"):
             log.warning(
                 "DD_TRACE_RATE_LIMIT is set to %s and DD_TRACE_SAMPLING_RULES is not set. "
                 "Tracer rate limiting is only applied to spans that match tracer sampling rules. "
                 "All other spans will be rate limited by the Datadog Agent via DD_APM_MAX_TPS.",
-                rate_limit,
+                self._trace_rate_limit,
             )
-        self._trace_rate_limit = _get_config("DD_TRACE_RATE_LIMIT", DEFAULT_SAMPLING_RATE_LIMIT, int)
         self._partial_flush_enabled = _get_config("DD_TRACE_PARTIAL_FLUSH_ENABLED", True, asbool)
         self._partial_flush_min_spans = _get_config("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", 300, int)
 
@@ -411,7 +422,7 @@ class Config(object):
         self._propagation_http_baggage_enabled = _get_config("DD_TRACE_PROPAGATION_HTTP_BAGGAGE_ENABLED", False, asbool)
 
         self.env = _get_config("DD_ENV", self.tags.get("env"))
-        self.service = _get_config("DD_SERVICE", self.tags.get("service", None))
+        self.service = _get_config("DD_SERVICE", self.tags.get("service", None), otel_env="OTEL_SERVICE_NAME")
 
         self._inferred_base_service = detect_service(sys.argv)
 
@@ -447,7 +458,9 @@ class Config(object):
         self._telemetry_heartbeat_interval = _get_config("DD_TELEMETRY_HEARTBEAT_INTERVAL", 60, float)
         self._telemetry_dependency_collection = _get_config("DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED", True, asbool)
 
-        self._runtime_metrics_enabled = _get_config("DD_RUNTIME_METRICS_ENABLED", False, asbool)
+        self._runtime_metrics_enabled = _get_config(
+            "DD_RUNTIME_METRICS_ENABLED", False, asbool, "OTEL_METRICS_EXPORTER"
+        )
 
         self._128_bit_trace_id_enabled = _get_config("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", True, asbool)
 
@@ -466,7 +479,9 @@ class Config(object):
         if self._propagation_behavior_extract != _PROPAGATION_BEHAVIOR_IGNORE:
             self._propagation_style_extract = _parse_propagation_styles(
                 _get_config(
-                    ["DD_TRACE_PROPAGATION_STYLE_EXTRACT", "DD_TRACE_PROPAGATION_STYLE"], _PROPAGATION_STYLE_DEFAULT
+                    ["DD_TRACE_PROPAGATION_STYLE_EXTRACT", "DD_TRACE_PROPAGATION_STYLE"],
+                    _PROPAGATION_STYLE_DEFAULT,
+                    otel_env="OTEL_PROPAGATORS",
                 )
             )
         else:
@@ -476,7 +491,11 @@ class Config(object):
             )
             self._propagation_style_extract = [_PROPAGATION_STYLE_NONE]
         self._propagation_style_inject = _parse_propagation_styles(
-            _get_config(["DD_TRACE_PROPAGATION_STYLE_INJECT", "DD_TRACE_PROPAGATION_STYLE"], _PROPAGATION_STYLE_DEFAULT)
+            _get_config(
+                ["DD_TRACE_PROPAGATION_STYLE_INJECT", "DD_TRACE_PROPAGATION_STYLE"],
+                _PROPAGATION_STYLE_DEFAULT,
+                otel_env="OTEL_PROPAGATORS",
+            )
         )
 
         self._propagation_extract_first = _get_config("DD_TRACE_PROPAGATION_EXTRACT_FIRST", False, asbool)
@@ -527,7 +546,7 @@ class Config(object):
         self._test_visibility_early_flake_detection_enabled = _get_config(
             "DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED", True, asbool
         )
-        self._otel_enabled = _get_config("DD_TRACE_OTEL_ENABLED", False, asbool)
+        self._otel_enabled = _get_config("DD_TRACE_OTEL_ENABLED", False, asbool, "OTEL_SDK_DISABLED")
         if self._otel_enabled:
             # Replaces the default otel api runtime context with DDRuntimeContext
             # https://github.com/open-telemetry/opentelemetry-python/blob/v1.16.0/opentelemetry-api/src/opentelemetry/context/__init__.py#L53

--- a/ddtrace/settings/_core.py
+++ b/ddtrace/settings/_core.py
@@ -10,6 +10,9 @@ from envier.env import _normalized
 
 from ddtrace.internal.telemetry import telemetry_writer
 
+from ._otel_remapper import parse_otel_env
+from ._otel_remapper import should_parse_otel_env
+
 
 def report_telemetry(env: Any) -> None:
     for name, e in list(env.__class__.__dict__.items()):
@@ -30,21 +33,35 @@ def get_config(
     envs: Union[str, List[str]],
     default: Any = None,
     modifier: Optional[Callable[[Any], Any]] = None,
+    otel_env: Optional[str] = None,
     report_telemetry=True,
 ):
     if isinstance(envs, str):
         envs = [envs]
-    val = default
-    source = "default"
-    effective_env = envs[0]
-    for env in envs:
-        if env in os.environ:
-            val = os.environ[env]
+    val = None
+    if otel_env and should_parse_otel_env(otel_env):
+        parsed_val = parse_otel_env(otel_env)
+        if parsed_val is not None:
+            val = parsed_val
             if modifier:
                 val = modifier(val)
-            source = "env_var"
-            effective_env = env
-            break
-    if report_telemetry:
-        telemetry_writer.add_configuration(effective_env, val, source)
+            if report_telemetry:
+                raw_value = os.environ.get(otel_env, "").lower()
+                telemetry_writer.add_configuration(otel_env, raw_value, "env_var")
+
+    if val is None:
+        for env in envs:
+            if env in os.environ:
+                val = os.environ[env]
+                if modifier:
+                    val = modifier(val)
+                if report_telemetry:
+                    telemetry_writer.add_configuration(env, val, "env_var")
+                break
+
+    if val is None:
+        val = default
+        if report_telemetry:
+            telemetry_writer.add_configuration(envs[0], val, "default")
+
     return val

--- a/ddtrace/settings/_otel_remapper.py
+++ b/ddtrace/settings/_otel_remapper.py
@@ -2,7 +2,6 @@ import os
 from typing import Callable
 from typing import Dict
 from typing import List
-from typing import Literal
 from typing import Optional
 from typing import Tuple
 
@@ -79,13 +78,6 @@ def _remap_metrics_exporter(otel_value: str) -> Optional[str]:
     return None
 
 
-def _validate_logs_exporter(otel_value: str) -> Literal["", None]:
-    """Logs warning when OTEL Logs exporter is configured. DDTRACE does not support this configuration."""
-    if otel_value == "none":
-        return ""
-    return None
-
-
 def _remap_otel_tags(otel_value: str) -> Optional[str]:
     """Remaps the otel tags to ddtrace tags"""
     dd_tags: List[str] = []
@@ -137,70 +129,83 @@ ENV_VAR_MAPPINGS: Dict[str, Tuple[str, Callable[[str], Optional[str]]]] = {
     "OTEL_TRACES_SAMPLER": ("DD_TRACE_SAMPLING_RULES", _remap_traces_sampler),
     "OTEL_TRACES_EXPORTER": ("DD_TRACE_ENABLED", _remap_traces_exporter),
     "OTEL_METRICS_EXPORTER": ("DD_RUNTIME_METRICS_ENABLED", _remap_metrics_exporter),
-    "OTEL_LOGS_EXPORTER": ("", _validate_logs_exporter),  # Does not set a DDTRACE environment variable.
     "OTEL_RESOURCE_ATTRIBUTES": ("DD_TAGS", _remap_otel_tags),
     "OTEL_SDK_DISABLED": ("DD_TRACE_OTEL_ENABLED", _remap_otel_sdk_config),
 }
 
 
-def otel_remapping():
-    """Checks for the existence of both OTEL and Datadog tracer environment variables and remaps them accordingly.
-    Datadog Environment variables take precedence over OTEL, but if there isn't a Datadog value present,
-    then OTEL values take their place.
-    """
+def validate_otel_envs():
     user_envs = {key.upper(): value for key, value in os.environ.items()}
+    for otel_env, _ in user_envs.items():
+        if (
+            otel_env not in ENV_VAR_MAPPINGS
+            and otel_env.startswith("OTEL_")
+            and otel_env not in ("OTEL_PYTHON_CONTEXT", "OTEL_TRACES_SAMPLER_ARG", "OTEL_LOGS_EXPORTER")
+        ):
+            _unsupported_otel_config(otel_env)
+        elif otel_env == "OTEL_LOGS_EXPORTER":
+            # check for invalid values
+            otel_value = os.environ.get(otel_env, "none").lower()
+            if otel_value != "none":
+                _invalid_otel_config(otel_env)
+            telemetry_writer.add_configuration(otel_env, otel_value, "env_var")
 
-    for otel_env, otel_value in user_envs.items():
-        if otel_env not in ENV_VAR_MAPPINGS:
-            if otel_env.startswith("OTEL_") and otel_env != "OTEL_PYTHON_CONTEXT":
-                log.warning("OpenTelemetry configuration %s is not supported by Datadog.", otel_env)
-                telemetry_writer.add_count_metric(
-                    TELEMETRY_NAMESPACE.TRACERS,
-                    "otel.env.unsupported",
-                    1,
-                    (("config_opentelemetry", otel_env.lower()),),
-                )
-            continue
 
-        dd_env, otel_config_validator = ENV_VAR_MAPPINGS[otel_env]
-        if dd_env in user_envs:
-            log.debug(
-                "Datadog configuration %s is already set. OpenTelemetry configuration will be ignored: %s=%s",
-                dd_env,
-                otel_env,
-                otel_value,
-            )
-            telemetry_writer.add_count_metric(
-                TELEMETRY_NAMESPACE.TRACERS,
-                "otel.env.hiding",
-                1,
-                (("config_opentelemetry", otel_env.lower()), ("config_datadog", dd_env.lower())),
-            )
-            continue
+def should_parse_otel_env(otel_env):
+    dd_env, _ = ENV_VAR_MAPPINGS[otel_env]
+    if otel_env in os.environ and dd_env in os.environ:
+        _hiding_otel_config(otel_env, dd_env)
+        return False
+    return otel_env in os.environ
 
-        if otel_env not in ("OTEL_RESOURCE_ATTRIBUTES", "OTEL_SERVICE_NAME"):
-            # Resource attributes and service name are case-insensitive
-            otel_value = otel_value.lower()
 
-        telemetry_writer.add_configuration(otel_env, otel_value, "env_var")
-        mapped_value = otel_config_validator(otel_value)
-        if mapped_value is None:
-            log.warning(
-                "Setting %s to %s is not supported by ddtrace, this configuration will be ignored.",
-                otel_env,
-                otel_value,
-            )
-            telemetry_writer.add_count_metric(
-                TELEMETRY_NAMESPACE.TRACERS,
-                "otel.env.invalid",
-                1,
-                (("config_opentelemetry", otel_env.lower()), ("config_datadog", dd_env.lower())),
-            )
-        elif mapped_value != "":
-            os.environ[dd_env] = mapped_value
-            log.debug(
-                "OpenTelemetry configuration %s has been remapped to ddtrace configuration %s=%s",
-                otel_env,
-                dd_env,
-                mapped_value,
-            )
+def parse_otel_env(otel_env: str) -> Optional[str]:
+    _, otel_config_validator = ENV_VAR_MAPPINGS[otel_env]
+    raw_value = os.environ.get(otel_env, "")
+    if otel_env not in ("OTEL_RESOURCE_ATTRIBUTES", "OTEL_SERVICE_NAME"):
+        # Resource attributes and service name are case-insensitive
+        raw_value = raw_value.lower()
+    mapped_value = otel_config_validator(raw_value)
+    if mapped_value is None:
+        _invalid_otel_config(otel_env)
+        return None
+    return mapped_value
+
+
+def _hiding_otel_config(otel_env, dd_env):
+    log.debug(
+        "Datadog configuration %s is already set. OpenTelemetry configuration will be ignored: %s=%s",
+        dd_env,
+        otel_env,
+        os.environ[otel_env],
+    )
+    telemetry_writer.add_count_metric(
+        TELEMETRY_NAMESPACE.TRACERS,
+        "otel.env.hiding",
+        1,
+        (("config_opentelemetry", otel_env.lower()), ("config_datadog", dd_env.lower())),
+    )
+
+
+def _invalid_otel_config(otel_env):
+    log.warning(
+        "Setting %s to %s is not supported by ddtrace, this configuration will be ignored.",
+        otel_env,
+        os.environ.get(otel_env, ""),
+    )
+    telemetry_writer.add_count_metric(
+        TELEMETRY_NAMESPACE.TRACERS,
+        "otel.env.invalid",
+        1,
+        (("config_opentelemetry", otel_env.lower()),),
+    )
+
+
+def _unsupported_otel_config(otel_env):
+    log.warning("OpenTelemetry configuration %s is not supported by Datadog.", otel_env)
+    telemetry_writer.add_count_metric(
+        TELEMETRY_NAMESPACE.TRACERS,
+        "otel.env.unsupported",
+        1,
+        (("config_opentelemetry", otel_env.lower()),),
+    )

--- a/tests/opentelemetry/test_config.py
+++ b/tests/opentelemetry/test_config.py
@@ -72,9 +72,8 @@ def test_dd_otel_mixed_env_configuration():
         "service.version=1.0,testtag1=random1,testtag2=random2,testtag3=random3,testtag4=random4",
         "OTEL_SDK_DISABLED": "False",
     },
-    err=b"Following style not supported by ddtrace: jaegar.\n"
-    b"Setting OTEL_TRACES_EXPORTER to otlp is not supported by ddtrace, "
-    b"this configuration will be ignored.\n",
+    err=b"Setting OTEL_LOGS_EXPORTER to warning is not supported by ddtrace, "
+    b"this configuration will be ignored.\nFollowing style not supported by ddtrace: jaegar.\n",
 )
 def test_dd_otel_missing_dd_env_configuration():
     from ddtrace import config
@@ -185,8 +184,7 @@ def test_otel_traces_sampler_configuration_alwaysoff():
         "OTEL_TRACES_SAMPLER": "traceidratio",
         "OTEL_TRACES_SAMPLER_ARG": "0.5",
     },
-    err=b"Trace sampler set from traceidratio to parentbased_traceidratio; only parent based sampling is supported.\n"
-    b"OpenTelemetry configuration OTEL_TRACES_SAMPLER_ARG is not supported by Datadog.\n",
+    err=b"Trace sampler set from traceidratio to parentbased_traceidratio; only parent based sampling is supported.\n",
 )
 def test_otel_traces_sampler_configuration_traceidratio():
     from ddtrace import config
@@ -230,7 +228,7 @@ def test_otel_metrics_exporter_configuration_unsupported_exporter():
 
 
 @pytest.mark.subprocess(
-    env={"otel_LOGS_EXPORTER": "console"},
+    env={"OTEL_LOGS_EXPORTER": "console"},
     err=b"Setting OTEL_LOGS_EXPORTER to console is not supported by ddtrace, this configuration will be ignored.\n",
 )
 def test_otel_logs_exporter_configuration_unsupported():

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -876,4 +876,4 @@ def test_otel_config_telemetry(test_agent_session, run_python_code_in_subprocess
 
     env_invalid_metrics = test_agent_session.get_metrics("otel.env.invalid")
     tags = [m["tags"] for m in env_invalid_metrics]
-    assert tags == [["config_opentelemetry:otel_logs_exporter", "config_datadog:"]]
+    assert tags == [["config_opentelemetry:otel_logs_exporter"]]


### PR DESCRIPTION
Removes all usages of `os.getenv` from `ddtrace.config`. Moving forward the `get_config(..)` helper will be used to parse all Datadog and OpenTelemetry environment variables. 

This will ensure instrumentation telemetry is collected in a consistent manner.


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
