### PR TITLE
fix(asm): decouple appsec and iast [backport 2.21]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -115,6 +115,8 @@ ddtrace/contrib/flask_login/        @DataDog/asm-python
 ddtrace/contrib/webbrowser          @DataDog/asm-python
 ddtrace/contrib/urllib              @DataDog/asm-python
 ddtrace/internal/_exceptions.py     @DataDog/asm-python
+ddtrace/internal/appsec/            @DataDog/asm-python
+ddtrace/internal/iast/              @DataDog/asm-python
 tests/appsec/                       @DataDog/asm-python
 tests/contrib/dbapi/test_dbapi_appsec.py    @DataDog/asm-python
 tests/contrib/subprocess            @DataDog/asm-python

--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -7,8 +7,8 @@ from wrapt.importer import when_imported
 
 from ddtrace.appsec import load_common_appsec_modules
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
+from ddtrace.settings.asm import config as asm_config
 
-from .appsec._iast._utils import _is_iast_enabled
 from .internal import telemetry
 from .internal.logger import get_logger
 from .internal.utils import formats
@@ -240,7 +240,7 @@ def patch_all(**patch_modules):
     modules.update(patch_modules)
 
     patch(raise_errors=False, **modules)
-    if _is_iast_enabled():
+    if asm_config._iast_enabled:
         from ddtrace.appsec._iast._patch_modules import patch_iast
         from ddtrace.appsec.iast import enable_iast_propagation
 

--- a/ddtrace/appsec/__init__.py
+++ b/ddtrace/appsec/__init__.py
@@ -1,5 +1,6 @@
+# this module must not load any other unsafe appsec module directly
+
 from ddtrace.internal import core
-from ddtrace.settings.asm import config as asm_config
 
 
 _APPSEC_TO_BE_LOADED = True
@@ -28,7 +29,9 @@ def load_iast():
 
 def load_common_appsec_modules():
     """Lazily load the common module patches."""
-    if (asm_config._ep_enabled and asm_config._asm_enabled) or asm_config._iast_enabled:
+    from ddtrace.settings.asm import config as asm_config
+
+    if asm_config._load_modules:
         from ddtrace.appsec._common_module_patches import patch_common_modules
 
         patch_common_modules()

--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -15,10 +15,6 @@ from urllib import parse
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import EXPLOIT_PREVENTION
 from ddtrace.appsec._constants import SPAN_DATA_NAMES
-from ddtrace.appsec._iast._iast_request_context import is_iast_request_enabled
-from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
-from ddtrace.appsec._iast._utils import _is_iast_enabled
 from ddtrace.appsec._utils import add_context_log
 from ddtrace.appsec._utils import get_triggers
 from ddtrace.internal import core
@@ -27,6 +23,16 @@ from ddtrace.internal.constants import REQUEST_PATH_PARAMS
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
 from ddtrace.trace import Span
+
+
+if asm_config._iast_enabled:
+    from ddtrace.appsec._iast._iast_request_context import is_iast_request_enabled
+    from ddtrace.appsec._iast._taint_tracking import OriginType
+    from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+else:
+
+    def is_iast_request_enabled() -> bool:
+        return False
 
 
 if TYPE_CHECKING:
@@ -493,7 +499,7 @@ def _on_wrapped_view(kwargs):
 
     # If IAST is enabled, taint the Flask function kwargs (path parameters)
 
-    if _is_iast_enabled() and kwargs:
+    if asm_config._iast_enabled and kwargs:
         if not is_iast_request_enabled():
             return return_value
 

--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -1,3 +1,5 @@
+# this module must not load any other unsafe appsec module directly
+
 import os
 from re import Match
 import sys

--- a/ddtrace/appsec/_ddwaf/ddwaf_types.py
+++ b/ddtrace/appsec/_ddwaf/ddwaf_types.py
@@ -22,9 +22,12 @@ log = get_logger(__name__)
 
 if system() == "Linux":
     try:
+        asm_config._bypass_instrumentation_for_waf = True
         ctypes.CDLL(ctypes.util.find_library("rt"), mode=ctypes.RTLD_GLOBAL)
     except Exception:  # nosec
         pass
+    finally:
+        asm_config._bypass_instrumentation_for_waf = False
 
 ARCHI = machine().lower()
 

--- a/ddtrace/appsec/_iast/__init__.py
+++ b/ddtrace/appsec/_iast/__init__.py
@@ -38,7 +38,6 @@ from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.settings.asm import config as asm_config
 
 from ._overhead_control_engine import OverheadControl
-from ._utils import _is_iast_enabled
 
 
 log = get_logger(__name__)
@@ -54,7 +53,7 @@ def ddtrace_iast_flask_patch():
     and must be before the `app.run()` call. It also requires `DD_IAST_ENABLED` to be
     activated.
     """
-    if not _is_iast_enabled():
+    if not asm_config._iast_enabled:
         return
 
     from ._ast.ast_patching import astpatch_module

--- a/ddtrace/appsec/_iast/_loader.py
+++ b/ddtrace/appsec/_iast/_loader.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 
 from ddtrace.internal.logger import get_logger
+from ddtrace.settings.asm import config as asm_config
 
 from ._ast.ast_patching import astpatch_module
-from ._utils import _is_iast_enabled
 
 
 log = get_logger(__name__)
 
-IS_IAST_ENABLED = _is_iast_enabled()
+IS_IAST_ENABLED = asm_config._iast_enabled
 
 
 def _exec_iast_patched_module(module_watchdog, module):

--- a/ddtrace/appsec/_iast/_pytest_plugin.py
+++ b/ddtrace/appsec/_iast/_pytest_plugin.py
@@ -4,9 +4,9 @@ import json
 from typing import List
 
 from ddtrace.appsec._constants import IAST
-from ddtrace.appsec._iast._utils import _is_iast_enabled
 from ddtrace.appsec._iast.reporter import Vulnerability
 from ddtrace.internal.logger import get_logger
+from ddtrace.settings.asm import config as asm_config
 
 
 log = get_logger(__name__)
@@ -20,7 +20,7 @@ class VulnerabilityFoundInTest(Vulnerability):
 try:
     import pytest
 
-    @pytest.fixture(autouse=_is_iast_enabled())
+    @pytest.fixture(autouse=asm_config._iast_enabled)
     def ddtrace_iast(request, ddspan):
         """
         Extract the vulnerabilities discovered in tests.
@@ -72,7 +72,7 @@ def extract_code_snippet(filepath, line_number, context=3):
 
 
 def print_iast_report(terminalreporter):
-    if not _is_iast_enabled():
+    if not asm_config._iast_enabled:
         return
 
     if not vuln_data:

--- a/ddtrace/appsec/_iast/_utils.py
+++ b/ddtrace/appsec/_iast/_utils.py
@@ -1,27 +1,6 @@
-from functools import lru_cache
-import sys
 from typing import List
 
-from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
-
-
-@lru_cache(maxsize=1)
-def _is_python_version_supported() -> bool:
-    # IAST supports Python versions 3.6 to 3.13
-    return (3, 6, 0) <= sys.version_info < (3, 14, 0)
-
-
-def _is_iast_enabled():
-    if not asm_config._iast_enabled:
-        return False
-
-    if not _is_python_version_supported():
-        log = get_logger(__name__)
-        log.info("IAST is not compatible with the current Python version")
-        return False
-
-    return True
 
 
 def _get_source_index(sources: List, source) -> int:

--- a/ddtrace/appsec/_iast/taint_sinks/insecure_cookie.py
+++ b/ddtrace/appsec/_iast/taint_sinks/insecure_cookie.py
@@ -1,8 +1,9 @@
 from typing import Dict
 from typing import Optional
 
+from ddtrace.settings.asm import config as asm_config
+
 from ..._constants import IAST_SPAN_TAGS
-from .. import _is_iast_enabled
 from .. import oce
 from .._iast_request_context import is_iast_request_enabled
 from .._metrics import _set_metric_iast_executed_sink
@@ -36,7 +37,7 @@ class NoSameSite(VulnerabilityBase):
 def asm_check_cookies(cookies: Optional[Dict[str, str]]) -> None:
     if not cookies:
         return
-    if _is_iast_enabled() and is_iast_request_enabled():
+    if asm_config._iast_enabled and is_iast_request_enabled():
         try:
             for cookie_key, cookie_value in cookies.items():
                 lvalue = cookie_value.lower().replace(" ", "")

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -4,6 +4,7 @@ import json
 from json.decoder import JSONDecodeError
 import os
 import os.path
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import List
@@ -11,6 +12,11 @@ from typing import Optional
 from typing import Set
 from typing import Tuple
 from typing import Union
+
+
+if TYPE_CHECKING:
+    import ddtrace.appsec._ddwaf as ddwaf
+
 import weakref
 
 from ddtrace._trace.processor import SpanProcessor
@@ -167,14 +173,17 @@ class AppSecSpanProcessor(SpanProcessor):
     def delayed_init(self) -> None:
         try:
             if self._rules is not None and not hasattr(self, "_ddwaf"):
-                self._ddwaf = ddwaf.DDWaf(
+                from ddtrace.appsec._ddwaf import DDWaf  # noqa: E402
+                import ddtrace.appsec._metrics as metrics  # noqa: E402
+
+                self.metrics = metrics
+                self._ddwaf = DDWaf(
                     self._rules, self.obfuscation_parameter_key_regexp, self.obfuscation_parameter_value_regexp
                 )
-            _set_waf_init_metric(self._ddwaf.info)
+                self.metrics._set_waf_init_metric(self._ddwaf.info)
         except Exception:
             # Partial of DDAS-0005-00
             log.warning("[DDAS-0005-00] WAF initialization failed")
-            raise
         self._update_required()
 
     def _update_required(self):
@@ -193,7 +202,7 @@ class AppSecSpanProcessor(SpanProcessor):
         if asm_config._asm_static_rule_file is not None:
             return result
         result = self._ddwaf.update_rules(new_rules)
-        _set_waf_updates_metric(self._ddwaf.info)
+        self.metrics._set_waf_updates_metric(self._ddwaf.info)
         self._update_required()
         return result
 
@@ -241,7 +250,7 @@ class AppSecSpanProcessor(SpanProcessor):
             return self._waf_action(span._local_root or span, ctx, custom_data, **kwargs)
 
         _asm_request_context.set_waf_callback(waf_callable)
-        _asm_request_context.add_context_callback(_set_waf_request_metrics)
+        _asm_request_context.add_context_callback(self.metrics._set_waf_request_metrics)
         if headers is not None:
             _asm_request_context.set_waf_address(SPAN_DATA_NAMES.REQUEST_HEADERS_NO_COOKIES, headers)
             _asm_request_context.set_waf_address(
@@ -436,10 +445,3 @@ class AppSecSpanProcessor(SpanProcessor):
                     del self._span_to_waf_ctx[s]
                 except Exception:  # nosec B110
                     pass
-
-
-# load waf at the end only to avoid possible circular imports with gevent
-import ddtrace.appsec._ddwaf as ddwaf  # noqa: E402
-from ddtrace.appsec._metrics import _set_waf_init_metric  # noqa: E402
-from ddtrace.appsec._metrics import _set_waf_request_metrics  # noqa: E402
-from ddtrace.appsec._metrics import _set_waf_updates_metric  # noqa: E402

--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -7,7 +7,6 @@ from typing import Optional
 
 from ddtrace.appsec._capabilities import _asm_feature_is_required
 from ddtrace.appsec._constants import PRODUCTS
-from ddtrace.internal import forksafe
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.remoteconfig._connectors import PublisherSubscriberConnector
 from ddtrace.internal.remoteconfig._publishers import RemoteConfigPublisherMergeDicts
@@ -72,7 +71,6 @@ def enable_appsec_rc(test_tracer: Optional[Tracer] = None) -> None:
 
         load_common_appsec_modules()
 
-    forksafe.register(_forksafe_appsec_rc)
     telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, True)
 
 

--- a/ddtrace/appsec/_utils.py
+++ b/ddtrace/appsec/_utils.py
@@ -1,3 +1,5 @@
+# this module must not load any other unsafe appsec module directly
+
 import logging
 import sys
 from typing import Any
@@ -5,6 +7,7 @@ import uuid
 
 from ddtrace.appsec._constants import API_SECURITY
 from ddtrace.appsec._constants import APPSEC
+from ddtrace.appsec._constants import SPAN_DATA_NAMES
 from ddtrace.internal._unpatched import unpatched_json_loads
 from ddtrace.internal.compat import to_unicode
 from ddtrace.internal.logger import get_logger
@@ -21,7 +24,6 @@ def parse_response_body(raw_body):
     import xmltodict
 
     from ddtrace.appsec import _asm_request_context
-    from ddtrace.appsec._constants import SPAN_DATA_NAMES
     from ddtrace.contrib.internal.trace_utils import _get_header_value_case_insensitive
 
     if not raw_body:

--- a/ddtrace/bootstrap/preload.py
+++ b/ddtrace/bootstrap/preload.py
@@ -6,7 +6,6 @@ Add all monkey-patching that needs to run by default here
 import os  # noqa:I001
 
 from ddtrace import config  # noqa:F401
-from ddtrace.appsec._iast._utils import _is_iast_enabled
 from ddtrace.settings.profiling import config as profiling_config  # noqa:F401
 from ddtrace.internal.logger import get_logger  # noqa:F401
 from ddtrace.internal.module import ModuleWatchdog  # noqa:F401
@@ -15,7 +14,6 @@ from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker  # noqa:F401
 from ddtrace.internal.tracemethods import _install_trace_methods  # noqa:F401
 from ddtrace.internal.utils.formats import asbool  # noqa:F401
 from ddtrace.internal.utils.formats import parse_tags_str  # noqa:F401
-from ddtrace.settings.asm import config as asm_config  # noqa:F401
 from ddtrace.settings.crashtracker import config as crashtracker_config
 from ddtrace.trace import tracer
 
@@ -71,21 +69,6 @@ if profiling_config.enabled:
 
 if config._runtime_metrics_enabled:
     RuntimeWorker.enable()
-
-if _is_iast_enabled():
-    """
-    This is the entry point for the IAST instrumentation. `enable_iast_propagation` is called on patch_all function
-    too but patch_all depends of DD_TRACE_ENABLED environment variable. This is the reason why we need to call it
-    here and it's not a duplicate call due to `enable_iast_propagation` has a global variable to avoid multiple calls.
-    """
-    from ddtrace.appsec._iast import enable_iast_propagation
-
-    enable_iast_propagation()
-
-if asm_config._asm_enabled or config._remote_config_enabled:
-    from ddtrace.appsec._remoteconfiguration import enable_appsec_rc
-
-    enable_appsec_rc()
 
 if config._otel_enabled:
 

--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -4,15 +4,14 @@ Generic dbapi tracing code.
 import wrapt
 
 from ddtrace import config
-from ddtrace.appsec._iast._utils import _is_iast_enabled
+from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import ArgumentError
 from ddtrace.internal.utils import get_argument_value
+from ddtrace.settings.asm import config as asm_config
 
-from ...appsec._constants import IAST_SPAN_TAGS
-from ...appsec._iast._metrics import increment_iast_span_metric
 from ...constants import _ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import _SPAN_MEASURED_KEY
 from ...constants import SPAN_KIND
@@ -103,9 +102,10 @@ class TracedCursor(wrapt.ObjectProxy):
             # set span.kind to the type of request being performed
             s.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-            if _is_iast_enabled():
+            if asm_config._iast_enabled:
                 try:
                     from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
+                    from ddtrace.appsec._iast._metrics import increment_iast_span_metric
                     from ddtrace.appsec._iast._taint_utils import check_tainted_dbapi_args
                     from ddtrace.appsec._iast.taint_sinks.sql_injection import SqlInjection
 

--- a/ddtrace/contrib/dbapi_async/__init__.py
+++ b/ddtrace/contrib/dbapi_async/__init__.py
@@ -1,13 +1,12 @@
 from ddtrace import config
-from ddtrace.appsec._iast._utils import _is_iast_enabled
+from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import ArgumentError
 from ddtrace.internal.utils import get_argument_value
+from ddtrace.settings.asm import config as asm_config
 
-from ...appsec._constants import IAST_SPAN_TAGS
-from ...appsec._iast._metrics import increment_iast_span_metric
 from ...constants import _ANALYTICS_SAMPLE_RATE_KEY
 from ...constants import _SPAN_MEASURED_KEY
 from ...constants import SPAN_KIND
@@ -78,8 +77,9 @@ class TracedAsyncCursor(TracedCursor):
             # set span.kind to the type of request being performed
             s.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-            if _is_iast_enabled():
+            if asm_config._iast_enabled:
                 from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
+                from ddtrace.appsec._iast._metrics import increment_iast_span_metric
                 from ddtrace.appsec._iast._taint_utils import check_tainted_dbapi_args
                 from ddtrace.appsec._iast.taint_sinks.sql_injection import SqlInjection
 

--- a/ddtrace/contrib/internal/fastapi/patch.py
+++ b/ddtrace/contrib/internal/fastapi/patch.py
@@ -6,7 +6,6 @@ from wrapt import ObjectProxy
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
-from ddtrace.appsec._iast._utils import _is_iast_enabled
 from ddtrace.contrib.internal.asgi.middleware import TraceMiddleware
 from ddtrace.contrib.internal.starlette.patch import _trace_background_tasks
 from ddtrace.contrib.internal.starlette.patch import traced_handler
@@ -14,6 +13,7 @@ from ddtrace.contrib.internal.starlette.patch import traced_route_init
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.wrappers import unwrap as _u
+from ddtrace.settings.asm import config as asm_config
 from ddtrace.trace import Pin
 
 
@@ -86,7 +86,7 @@ def patch():
     if not isinstance(fastapi.routing.Mount.handle, ObjectProxy):
         _w("starlette.routing", "Mount.handle", traced_handler)
 
-    if _is_iast_enabled():
+    if asm_config._iast_enabled:
         from ddtrace.appsec._iast._handlers import _on_iast_fastapi_patch
 
         _on_iast_fastapi_patch()

--- a/ddtrace/contrib/internal/httplib/patch.py
+++ b/ddtrace/contrib/internal/httplib/patch.py
@@ -5,7 +5,6 @@ import sys
 import wrapt
 
 from ddtrace import config
-from ddtrace.appsec._common_module_patches import wrapped_request_D8CB81E472AF98A2 as _wrap_request_asm
 from ddtrace.constants import _ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
@@ -77,12 +76,14 @@ def _wrap_getresponse(func, instance, args, kwargs):
 
 
 def _call_asm_wrap(func, instance, *args, **kwargs):
+    from ddtrace.appsec._common_module_patches import wrapped_request_D8CB81E472AF98A2 as _wrap_request_asm
+
     _wrap_request_asm(func, instance, args, kwargs)
 
 
 def _wrap_request(func, instance, args, kwargs):
     # Use any attached tracer if available, otherwise use the global tracer
-    if asm_config._iast_enabled or asm_config._asm_enabled:
+    if asm_config._iast_enabled or (asm_config._asm_enabled and asm_config._ep_enabled):
         func_to_call = functools.partial(_call_asm_wrap, func, instance)
     else:
         func_to_call = func

--- a/ddtrace/contrib/internal/langchain/patch.py
+++ b/ddtrace/contrib/internal/langchain/patch.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     langchain_pinecone = None
 
-from ddtrace.appsec._iast import _is_iast_enabled
+from ddtrace.settings.asm import config as asm_config
 
 
 try:
@@ -677,7 +677,7 @@ def traced_chain_call(langchain, pin, func, instance, args, kwargs):
         if integration.is_pc_sampled_span(span):
             for k, v in final_outputs.items():
                 span.set_tag_str("langchain.response.outputs.%s" % k, integration.trunc(str(v)))
-        if _is_iast_enabled():
+        if asm_config._iast_enabled:
             taint_outputs(instance, inputs, final_outputs)
     except Exception:
         span.set_exc_info(*sys.exc_info())
@@ -1345,7 +1345,7 @@ def patch():
     if PATCH_LANGCHAIN_V0 or langchain_community:
         _patch_embeddings_and_vectorstores()
 
-    if _is_iast_enabled():
+    if asm_config._iast_enabled:
         from ddtrace.appsec._iast._metrics import _set_iast_error_metric
 
         def wrap_output_parser(module, parser):

--- a/ddtrace/contrib/internal/mysql/patch.py
+++ b/ddtrace/contrib/internal/mysql/patch.py
@@ -4,8 +4,6 @@ import mysql.connector
 import wrapt
 
 from ddtrace import config
-from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
-from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.contrib.dbapi import TracedConnection
 from ddtrace.contrib.internal.trace_utils import _convert_to_string
 from ddtrace.ext import db
@@ -51,6 +49,9 @@ def patch():
         mysql.connector.Connect = mysql.connector.connect
 
     if asm_config._iast_enabled:
+        from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
+        from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
+
         _set_metric_iast_instrumented_sink(VULN_SQL_INJECTION)
     mysql.connector._datadog_patch = True
 

--- a/ddtrace/contrib/internal/mysqldb/patch.py
+++ b/ddtrace/contrib/internal/mysqldb/patch.py
@@ -4,8 +4,6 @@ import MySQLdb
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
-from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
-from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib.dbapi import TracedConnection
@@ -67,6 +65,9 @@ def patch():
         _w("MySQLdb", "connect", _connect)
 
     if asm_config._iast_enabled:
+        from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
+        from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
+
         _set_metric_iast_instrumented_sink(VULN_SQL_INJECTION)
 
 

--- a/ddtrace/contrib/internal/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v2.py
@@ -59,6 +59,7 @@ from ddtrace.internal.test_visibility.api import InternalTestModule
 from ddtrace.internal.test_visibility.api import InternalTestSession
 from ddtrace.internal.test_visibility.api import InternalTestSuite
 from ddtrace.internal.test_visibility.coverage_lines import CoverageLines
+from ddtrace.settings.asm import config as asm_config
 from ddtrace.vendor.debtcollector import deprecate
 
 
@@ -574,9 +575,10 @@ def _pytest_terminal_summary_post_yield(terminalreporter, failed_reports_initial
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     """Report flaky or failed tests"""
     try:
-        from ddtrace.appsec._iast._pytest_plugin import print_iast_report
+        if asm_config._iast_enabled:
+            from ddtrace.appsec._iast._pytest_plugin import print_iast_report
 
-        print_iast_report(terminalreporter)
+            print_iast_report(terminalreporter)
     except Exception:  # noqa: E722
         log.debug("Encountered error during code security summary", exc_info=True)
 

--- a/ddtrace/contrib/internal/pytest/plugin.py
+++ b/ddtrace/contrib/internal/pytest/plugin.py
@@ -17,11 +17,14 @@ from typing import Dict  # noqa:F401
 import pytest
 
 from ddtrace import config
-from ddtrace.appsec._iast._pytest_plugin import ddtrace_iast  # noqa:F401
-from ddtrace.appsec._iast._utils import _is_iast_enabled
 from ddtrace.contrib.internal.pytest._utils import _USE_PLUGIN_V2
 from ddtrace.contrib.internal.pytest._utils import _extract_span
 from ddtrace.contrib.internal.pytest._utils import _pytest_version_supports_itr
+from ddtrace.settings.asm import config as asm_config
+
+
+if asm_config._iast_enabled:
+    from ddtrace.appsec._iast._pytest_plugin import ddtrace_iast  # noqa:F401
 
 
 # pytest default settings
@@ -93,7 +96,7 @@ def pytest_addoption(parser):
     parser.addini("no-ddtrace", DDTRACE_HELP_MSG, type="bool")
     parser.addini("ddtrace-patch-all", PATCH_ALL_HELP_MSG, type="bool")
     parser.addini("ddtrace-include-class-name", DDTRACE_INCLUDE_CLASS_HELP_MSG, type="bool")
-    if _is_iast_enabled():
+    if asm_config._iast_enabled:
         from ddtrace.appsec._iast import _iast_pytest_activation
 
         _iast_pytest_activation()

--- a/ddtrace/contrib/internal/requests/patch.py
+++ b/ddtrace/contrib/internal/requests/patch.py
@@ -4,9 +4,6 @@ import requests
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
-from ddtrace.appsec._common_module_patches import wrapped_request_D8CB81E472AF98A2 as _wrap_request
-from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
-from ddtrace.appsec._iast.constants import VULN_SSRF
 from ddtrace.contrib.internal.trace_utils import unwrap as _u
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.formats import asbool
@@ -41,10 +38,16 @@ def patch():
 
     _w("requests", "Session.send", _wrap_send)
     # IAST needs to wrap this function because `Session.send` is too late
-    _w("requests", "Session.request", _wrap_request)
+    if asm_config._load_modules:
+        from ddtrace.appsec._common_module_patches import wrapped_request_D8CB81E472AF98A2 as _wrap_request
+
+        _w("requests", "Session.request", _wrap_request)
     Pin(_config=config.requests).onto(requests.Session)
 
     if asm_config._iast_enabled:
+        from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
+        from ddtrace.appsec._iast.constants import VULN_SSRF
+
         _set_metric_iast_instrumented_sink(VULN_SSRF)
 
 
@@ -54,5 +57,13 @@ def unpatch():
         return
     requests.__datadog_patch = False
 
-    _u(requests.Session, "request")
-    _u(requests.Session, "send")
+    try:
+        _u(requests.Session, "request")
+    except AttributeError:
+        # It was not patched
+        pass
+    try:
+        _u(requests.Session, "send")
+    except AttributeError:
+        # It was not patched
+        pass

--- a/ddtrace/contrib/internal/sqlalchemy/patch.py
+++ b/ddtrace/contrib/internal/sqlalchemy/patch.py
@@ -1,8 +1,6 @@
 import sqlalchemy
 from wrapt import wrap_function_wrapper as _w
 
-from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
-from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.contrib.internal.trace_utils import unwrap
 from ddtrace.settings.asm import config as asm_config
 
@@ -24,6 +22,9 @@ def patch():
     _w("sqlalchemy.engine", "create_engine", _wrap_create_engine)
 
     if asm_config._iast_enabled:
+        from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
+        from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
+
         _set_metric_iast_instrumented_sink(VULN_SQL_INJECTION)
 
 

--- a/ddtrace/contrib/internal/sqlite3/patch.py
+++ b/ddtrace/contrib/internal/sqlite3/patch.py
@@ -6,8 +6,6 @@ import sys
 import wrapt
 
 from ddtrace import config
-from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
-from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.contrib.dbapi import FetchTracedCursor
 from ddtrace.contrib.dbapi import TracedConnection
 from ddtrace.contrib.dbapi import TracedCursor
@@ -48,6 +46,9 @@ def patch():
     sqlite3.dbapi2.connect = wrapped
 
     if asm_config._iast_enabled:
+        from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
+        from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
+
         _set_metric_iast_instrumented_sink(VULN_SQL_INJECTION)
 
 

--- a/ddtrace/contrib/internal/starlette/patch.py
+++ b/ddtrace/contrib/internal/starlette/patch.py
@@ -13,7 +13,6 @@ from wrapt import ObjectProxy
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
-from ddtrace.appsec._iast import _is_iast_enabled
 from ddtrace.contrib import trace_utils
 from ddtrace.contrib.asgi import TraceMiddleware
 from ddtrace.contrib.internal.trace_utils import with_traced_module
@@ -26,6 +25,7 @@ from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils import get_blocked
 from ddtrace.internal.utils import set_argument_value
 from ddtrace.internal.utils.wrappers import unwrap as _u
+from ddtrace.settings.asm import config as asm_config
 from ddtrace.trace import Pin
 from ddtrace.trace import Span  # noqa:F401
 from ddtrace.vendor.packaging.version import parse as parse_version
@@ -168,7 +168,7 @@ def traced_handler(wrapped, instance, args, kwargs):
             break
 
     if request_spans:
-        if _is_iast_enabled():
+        if asm_config._iast_enabled:
             from ddtrace.appsec._iast._patch import _iast_instrument_starlette_scope
 
             _iast_instrument_starlette_scope(scope)

--- a/ddtrace/contrib/internal/subprocess/patch.py
+++ b/ddtrace/contrib/internal/subprocess/patch.py
@@ -58,7 +58,7 @@ def del_lst_callback(name: str):
 
 
 def patch() -> List[str]:
-    if not (asm_config._asm_enabled or asm_config._iast_enabled):
+    if not asm_config._load_modules:
         return []
     patched: List[str] = []
 
@@ -66,7 +66,7 @@ def patch() -> List[str]:
     import subprocess  # nosec
 
     should_patch_system = not trace_utils.iswrapped(os.system)
-    should_patch_fork = not trace_utils.iswrapped(os.fork)
+    should_patch_fork = (not trace_utils.iswrapped(os.fork)) if hasattr(os, "fork") else False
     spawnvef = getattr(os, "_spawnvef", None)
     should_patch_spawnvef = spawnvef is not None and not trace_utils.iswrapped(spawnvef)
 
@@ -316,10 +316,11 @@ def unpatch() -> None:
     import os  # nosec
     import subprocess  # nosec
 
-    trace_utils.unwrap(os, "system")
-    trace_utils.unwrap(os, "_spawnvef")
-    trace_utils.unwrap(subprocess.Popen, "__init__")
-    trace_utils.unwrap(subprocess.Popen, "wait")
+    for obj, attr in [(os, "system"), (os, "_spawnvef"), (subprocess.Popen, "__init__"), (subprocess.Popen, "wait")]:
+        try:
+            trace_utils.unwrap(obj, attr)
+        except AttributeError:
+            pass
 
     SubprocessCmdLine._clear_cache()
 
@@ -327,6 +328,9 @@ def unpatch() -> None:
 @trace_utils.with_traced_module
 def _traced_ossystem(module, pin, wrapped, instance, args, kwargs):
     try:
+        if asm_config._bypass_instrumentation_for_waf or not (asm_config._asm_enabled or asm_config._iast_enabled):
+            return wrapped(*args, **kwargs)
+
         if isinstance(args[0], str):
             for callback in _STR_CALLBACKS.values():
                 callback(args[0])
@@ -349,6 +353,8 @@ def _traced_ossystem(module, pin, wrapped, instance, args, kwargs):
 
 @trace_utils.with_traced_module
 def _traced_fork(module, pin, wrapped, instance, args, kwargs):
+    if not (asm_config._asm_enabled or asm_config._iast_enabled):
+        return wrapped(*args, **kwargs)
     try:
         with pin.tracer.trace(COMMANDS.SPAN_NAME, resource="fork", span_type=SpanTypes.SYSTEM) as span:
             span.set_tag(COMMANDS.EXEC, ["os.fork"])
@@ -364,6 +370,8 @@ def _traced_fork(module, pin, wrapped, instance, args, kwargs):
 
 @trace_utils.with_traced_module
 def _traced_osspawn(module, pin, wrapped, instance, args, kwargs):
+    if not (asm_config._asm_enabled or asm_config._iast_enabled):
+        return wrapped(*args, **kwargs)
     try:
         mode, file, func_args, _, _ = args
         if isinstance(func_args, (list, tuple, str)):
@@ -393,6 +401,9 @@ def _traced_osspawn(module, pin, wrapped, instance, args, kwargs):
 @trace_utils.with_traced_module
 def _traced_subprocess_init(module, pin, wrapped, instance, args, kwargs):
     try:
+        if asm_config._bypass_instrumentation_for_waf or not (asm_config._asm_enabled or asm_config._iast_enabled):
+            return wrapped(*args, **kwargs)
+
         cmd_args = args[0] if len(args) else kwargs["args"]
         if isinstance(cmd_args, (list, tuple, str)):
             if kwargs.get("shell", False):
@@ -425,6 +436,9 @@ def _traced_subprocess_init(module, pin, wrapped, instance, args, kwargs):
 @trace_utils.with_traced_module
 def _traced_subprocess_wait(module, pin, wrapped, instance, args, kwargs):
     try:
+        if asm_config._bypass_instrumentation_for_waf or not (asm_config._asm_enabled or asm_config._iast_enabled):
+            return wrapped(*args, **kwargs)
+
         binary = core.get_item("subprocess_popen_binary")
 
         with pin.tracer.trace(COMMANDS.SPAN_NAME, resource=binary, span_type=SpanTypes.SYSTEM) as span:

--- a/ddtrace/contrib/internal/urllib/patch.py
+++ b/ddtrace/contrib/internal/urllib/patch.py
@@ -2,9 +2,6 @@ import urllib.request
 
 from wrapt import wrap_function_wrapper as _w
 
-from ddtrace.appsec._common_module_patches import wrapped_request_D8CB81E472AF98A2 as _wrap_open
-from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
-from ddtrace.appsec._iast.constants import VULN_SSRF
 from ddtrace.contrib.internal.trace_utils import unwrap as _u
 from ddtrace.settings.asm import config as asm_config
 
@@ -20,8 +17,15 @@ def patch():
         return
     urllib.request.__datadog_patch = True
 
-    _w("urllib.request", "urlopen", _wrap_open)
+    if asm_config._load_modules:
+        from ddtrace.appsec._common_module_patches import wrapped_request_D8CB81E472AF98A2 as _wrap_open
+
+        _w("urllib.request", "urlopen", _wrap_open)
+
     if asm_config._iast_enabled:
+        from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
+        from ddtrace.appsec._iast.constants import VULN_SSRF
+
         _set_metric_iast_instrumented_sink(VULN_SSRF)
 
 

--- a/ddtrace/contrib/internal/urllib3/patch.py
+++ b/ddtrace/contrib/internal/urllib3/patch.py
@@ -4,9 +4,6 @@ import urllib3
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
-from ddtrace.appsec._common_module_patches import wrapped_request_D8CB81E472AF98A2 as _wrap_request
-from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
-from ddtrace.appsec._iast.constants import VULN_SSRF
 from ddtrace.constants import _ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
@@ -54,14 +51,20 @@ def patch():
     urllib3.__datadog_patch = True
 
     _w("urllib3", "connectionpool.HTTPConnectionPool.urlopen", _wrap_urlopen)
-    if hasattr(urllib3, "_request_methods"):
-        _w("urllib3._request_methods", "RequestMethods.request", _wrap_request)
-    else:
-        # Old version before https://github.com/urllib3/urllib3/pull/2398
-        _w("urllib3.request", "RequestMethods.request", _wrap_request)
+    if asm_config._load_modules:
+        from ddtrace.appsec._common_module_patches import wrapped_request_D8CB81E472AF98A2 as _wrap_request
+
+        if hasattr(urllib3, "_request_methods"):
+            _w("urllib3._request_methods", "RequestMethods.request", _wrap_request)
+        else:
+            # Old version before https://github.com/urllib3/urllib3/pull/2398
+            _w("urllib3.request", "RequestMethods.request", _wrap_request)
     Pin().onto(urllib3.connectionpool.HTTPConnectionPool)
 
     if asm_config._iast_enabled:
+        from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
+        from ddtrace.appsec._iast.constants import VULN_SSRF
+
         _set_metric_iast_instrumented_sink(VULN_SSRF)
 
 

--- a/ddtrace/contrib/internal/webbrowser/patch.py
+++ b/ddtrace/contrib/internal/webbrowser/patch.py
@@ -2,9 +2,6 @@ import webbrowser
 
 from wrapt import wrap_function_wrapper as _w
 
-from ddtrace.appsec._common_module_patches import wrapped_request_D8CB81E472AF98A2 as _wrap_open
-from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
-from ddtrace.appsec._iast.constants import VULN_SSRF
 from ddtrace.contrib.internal.trace_utils import unwrap as _u
 from ddtrace.settings.asm import config as asm_config
 
@@ -20,9 +17,15 @@ def patch():
         return
     webbrowser.__datadog_patch = True
 
-    _w("webbrowser", "open", _wrap_open)
+    if asm_config._load_modules:
+        from ddtrace.appsec._common_module_patches import wrapped_request_D8CB81E472AF98A2 as _wrap_open
+
+        _w("webbrowser", "open", _wrap_open)
 
     if asm_config._iast_enabled:
+        from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
+        from ddtrace.appsec._iast.constants import VULN_SSRF
+
         _set_metric_iast_instrumented_sink(VULN_SSRF)
 
 

--- a/ddtrace/internal/appsec/product.py
+++ b/ddtrace/internal/appsec/product.py
@@ -1,0 +1,30 @@
+from ddtrace.settings.asm import config as asm_config
+
+
+requires = ["remote-configuration"]
+
+
+def post_preload():
+    pass
+
+
+def start():
+    if asm_config._asm_rc_enabled:
+        from ddtrace.appsec._remoteconfiguration import enable_appsec_rc
+
+        enable_appsec_rc()
+
+
+def restart(join=False):
+    if asm_config._asm_rc_enabled:
+        from ddtrace.appsec._remoteconfiguration import _forksafe_appsec_rc
+
+        _forksafe_appsec_rc()
+
+
+def stop(join=False):
+    pass
+
+
+def at_exit(join=False):
+    pass

--- a/ddtrace/internal/iast/product.py
+++ b/ddtrace/internal/iast/product.py
@@ -1,0 +1,29 @@
+"""
+This is the entry point for the IAST instrumentation. `enable_iast_propagation` is called on patch_all function
+too but patch_all depends of DD_TRACE_ENABLED environment variable. This is the reason why we need to call it
+here and it's not a duplicate call due to `enable_iast_propagation` has a global variable to avoid multiple calls.
+"""
+from ddtrace.settings.asm import config as asm_config
+
+
+def post_preload():
+    pass
+
+
+def start():
+    if asm_config._iast_enabled:
+        from ddtrace.appsec._iast import enable_iast_propagation
+
+        enable_iast_propagation()
+
+
+def restart(join=False):
+    pass
+
+
+def stop(join=False):
+    pass
+
+
+def at_exit(join=False):
+    pass

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -578,9 +578,7 @@ class AgentWriter(HTTPWriter):
         try:
             # appsec remote config should be enabled/started after the global tracer and configs
             # are initialized
-            if os.getenv("AWS_LAMBDA_FUNCTION_NAME") is None and (
-                asm_config._asm_enabled or config._remote_config_enabled
-            ):
+            if asm_config._asm_rc_enabled:
                 from ddtrace.appsec._remoteconfiguration import enable_appsec_rc
 
                 enable_appsec_rc()

--- a/ddtrace/settings/asm.py
+++ b/ddtrace/settings/asm.py
@@ -2,6 +2,7 @@ import os
 import os.path
 from platform import machine
 from platform import system
+import sys
 from typing import List
 from typing import Optional
 
@@ -16,6 +17,7 @@ from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._constants import LOGIN_EVENTS_MODE
 from ddtrace.appsec._constants import TELEMETRY_INFORMATION_NAME
 from ddtrace.constants import APPSEC_ENV
+from ddtrace.internal.serverless import in_aws_lambda
 from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.settings._core import report_telemetry as _report_telemetry
 from ddtrace.vendor.debtcollector import deprecate
@@ -245,19 +247,30 @@ class ASMConfig(Env):
         default=r"^[+-]?((0b[01]+)|(0x[0-9A-Fa-f]+)|(\d+\.?\d*(?:[Ee][+-]?\d+)?|\.\d+(?:[Ee][+-]"
         + r"?\d+)?)|(X\'[0-9A-Fa-f]+\')|(B\'[01]+\'))$",
     )
+    _bypass_instrumentation_for_waf = False
+
+    # IAST supported on python 3.6 to 3.13 and never on windows
+    _iast_supported: bool = ((3, 6, 0) <= sys.version_info < (3, 14, 0)) and not (
+        sys.platform.startswith("win") or sys.platform.startswith("cygwin")
+    )
 
     def __init__(self):
         super().__init__()
-        # Is one click available?
-        self._eval_asm_can_be_enabled()
-        # Only for deprecation phase
-        if self._automatic_login_events_mode and APPSEC.AUTO_USER_INSTRUMENTATION_MODE not in os.environ:
-            self._auto_user_instrumentation_local_mode = self._automatic_login_events_mode
-        if not self._asm_libddwaf_available:
+        if not self._iast_supported:
+            self._iast_enabled = False
+        if not self._asm_libddwaf_available or in_aws_lambda():
             self._asm_enabled = False
             self._asm_can_be_enabled = False
             self._iast_enabled = False
             self._api_security_enabled = False
+            self._ep_enabled = False
+            self._auto_user_instrumentation_enabled = False
+            self._auto_user_instrumentation_local_mode = LOGIN_EVENTS_MODE.DISABLED
+            self._load_modules = False
+            self._asm_rc_enabled = False
+        else:
+            # Is one click available?
+            self._eval_asm_can_be_enabled()
 
     def reset(self):
         """For testing purposes, reset the configuration to its default values given current environment variables."""
@@ -265,6 +278,10 @@ class ASMConfig(Env):
 
     def _eval_asm_can_be_enabled(self):
         self._asm_can_be_enabled = APPSEC_ENV not in os.environ and tracer_config._remote_config_enabled
+        self._load_modules: bool = bool(
+            self._iast_enabled or (self._ep_enabled and (self._asm_enabled or self._asm_can_be_enabled))
+        )
+        self._asm_rc_enabled = (self._asm_enabled and tracer_config._remote_config_enabled) or self._asm_can_be_enabled
 
     @property
     def _api_security_feature_active(self) -> bool:

--- a/hatch.toml
+++ b/hatch.toml
@@ -374,7 +374,7 @@ dependencies = [
 test = [
     "uname -a",
     "pip freeze",
-    "DD_TRACE_AGENT_URL=\"http://testagent:9126\" DD_CIVISIBILITY_ITR_ENABLED=0 DD_IAST_REQUEST_SAMPLING=100 DD_IAST_DEDUPLICATION_ENABLED=false python -m pytest -vvv {args:tests/appsec/integrations/flask_tests/}",
+    "DD_TRACE_AGENT_URL=\"http://testagent:9126\" DD_CIVISIBILITY_ITR_ENABLED=0 DD_IAST_ENABLED=true DD_IAST_REQUEST_SAMPLING=100 DD_IAST_DEDUPLICATION_ENABLED=false python -m pytest -vvv {args:tests/appsec/integrations/flask_tests/}",
 ]
 
 [[envs.appsec_integrations_flask.matrix]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,8 @@ ddtrace = "ddtrace.contrib.internal.pytest.plugin"
 "exception-replay" = "ddtrace.debugging._products.exception_replay"
 "remote-configuration" = "ddtrace.internal.remoteconfig.product"
 "symbol-database" = "ddtrace.internal.symbol_db.product"
+"appsec" = "ddtrace.internal.appsec.product"
+"iast" = "ddtrace.internal.iast.product"
 
 [project.urls]
 "Bug Tracker" = "https://github.com/DataDog/dd-trace-py/issues"

--- a/releasenotes/notes/ensure_no_appsec_loading-8ce46c58d6ecf81f.yaml
+++ b/releasenotes/notes/ensure_no_appsec_loading-8ce46c58d6ecf81f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    ASM: This ensures that no module from ASM are loaded when ASM is disabled or unavailable.
+    SCA: This ensures that no module from IAST are loaded when IAST is disabled or unavailable.

--- a/releasenotes/notes/fix-iast-avoid-native-import-6cef954e3c98c9e8.yaml
+++ b/releasenotes/notes/fix-iast-avoid-native-import-6cef954e3c98c9e8.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Runtime Code Analysis (IAST): Avoid imports of IAST native module when IAST is not enabled.

--- a/releasenotes/notes/no_IAST_unguarded_loading_in_common_module_patches-123cf6d3f8844823.yaml
+++ b/releasenotes/notes/no_IAST_unguarded_loading_in_common_module_patches-123cf6d3f8844823.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    ASM: This fix resolves an issue where IAST modules could be loaded, even if disabled, 
+         which could create an ImportError exception on Windows.

--- a/tests/appsec/iast/fixtures/integration/main_configure.py
+++ b/tests/appsec/iast/fixtures/integration/main_configure.py
@@ -4,8 +4,8 @@ import logging
 import os
 import sys
 
-from ddtrace.appsec._iast._utils import _is_iast_enabled
 from ddtrace.ext import SpanTypes
+from ddtrace.settings.asm import config as asm_config
 from ddtrace.trace import tracer
 
 
@@ -29,11 +29,11 @@ if __name__ == "__main__":
     main()
     if not iast_enabled:
         # Disabled by env var but then enabled with ``tracer.configure``
-        assert _is_iast_enabled()
+        assert asm_config._iast_enabled
         assert "ddtrace.appsec._iast.processor" in sys.modules
     else:
         # Enabled by env var but then disabled with ``tracer.configure``
-        assert not _is_iast_enabled()
+        assert not asm_config._iast_enabled
         # Module was loaded before
         assert "ddtrace.appsec._iast.processor" in sys.modules
         # But processor is not used by the tracer

--- a/tests/appsec/integrations/django_tests/test_django_appsec_iast.py
+++ b/tests/appsec/integrations/django_tests/test_django_appsec_iast.py
@@ -6,12 +6,12 @@ import pytest
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast import oce
 from ddtrace.appsec._iast._patch_modules import patch_iast
-from ddtrace.appsec._iast._utils import _is_python_version_supported as python_supported_by_iast
 from ddtrace.appsec._iast.constants import VULN_CMDI
 from ddtrace.appsec._iast.constants import VULN_HEADER_INJECTION
 from ddtrace.appsec._iast.constants import VULN_INSECURE_COOKIE
 from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.internal.compat import urlencode
+from ddtrace.settings.asm import config as asm_config
 from tests.appsec.iast.iast_utils import get_line_and_hash
 from tests.utils import override_env
 from tests.utils import override_global_config
@@ -80,7 +80,7 @@ def _aux_appsec_get_root_span_with_exception(
         return False
 
 
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_weak_hash(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
         oce.reconfigure()
@@ -93,7 +93,7 @@ def test_django_weak_hash(client, test_spans, tracer):
         assert vulnerability["evidence"]["value"] == "md5"
 
 
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_tainted_user_agent_iast_enabled(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
@@ -134,7 +134,7 @@ def test_django_tainted_user_agent_iast_enabled(client, test_spans, tracer):
         50.0,
     ],
 )
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_view_with_exception(client, test_spans, tracer, payload, content_type, deduplication, sampling):
     with override_global_config(
         dict(_iast_enabled=True, _deduplication_enabled=deduplication, _iast_request_sampling=sampling)
@@ -150,7 +150,7 @@ def test_django_view_with_exception(client, test_spans, tracer, payload, content
         assert response is False
 
 
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_tainted_user_agent_iast_disabled(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=False, _iast_deduplication_enabled=False)):
         oce.reconfigure()
@@ -172,7 +172,7 @@ def test_django_tainted_user_agent_iast_disabled(client, test_spans, tracer):
 
 
 @pytest.mark.django_db()
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_tainted_user_agent_iast_enabled_sqli_http_request_parameter(client, test_spans, tracer):
     with override_global_config(
         dict(_iast_enabled=True, _iast_deduplication_enabled=False, _iast_request_sampling=100.0)
@@ -221,8 +221,8 @@ def test_django_tainted_user_agent_iast_enabled_sqli_http_request_parameter(clie
 
 
 @pytest.mark.django_db()
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
-def test_django_tainted_user_agent_iast_enabled_sqli_http_request_parameter_name_get(client, test_spans, tracer):
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_sqli_http_request_parameter_name_get(client, test_spans, tracer):
     with override_global_config(
         dict(_iast_enabled=True, _iast_deduplication_enabled=False, _iast_request_sampling=100.0)
     ):
@@ -272,8 +272,8 @@ def test_django_tainted_user_agent_iast_enabled_sqli_http_request_parameter_name
 
 
 @pytest.mark.django_db()
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
-def test_django_tainted_user_agent_iast_enabled_sqli_http_request_parameter_name_post(client, test_spans, tracer):
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_sqli_http_request_parameter_name_post(client, test_spans, tracer):
     with override_global_config(
         dict(_iast_enabled=True, _iast_deduplication_enabled=False, _iast_request_sampling=100.0)
     ):
@@ -324,8 +324,8 @@ def test_django_tainted_user_agent_iast_enabled_sqli_http_request_parameter_name
 
 
 @pytest.mark.django_db()
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
-def test_django_tainted_user_agent_iast_enabled_sqli_http_request_header_value(client, test_spans, tracer):
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_sqli_http_request_header_value(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
@@ -362,8 +362,8 @@ def test_django_tainted_user_agent_iast_enabled_sqli_http_request_header_value(c
 
 
 @pytest.mark.django_db()
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
-def test_django_tainted_user_agent_iast_disabled_sqli_http_request_header_value(client, test_spans, tracer):
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_iast_disabled_sqli_http_request_header_value(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
@@ -382,8 +382,8 @@ def test_django_tainted_user_agent_iast_disabled_sqli_http_request_header_value(
 
 
 @pytest.mark.django_db()
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
-def test_django_tainted_user_agent_iast_enabled_sqli_http_request_header_name(client, test_spans, tracer):
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_sqli_http_request_header_name(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
@@ -420,8 +420,8 @@ def test_django_tainted_user_agent_iast_enabled_sqli_http_request_header_name(cl
 
 
 @pytest.mark.django_db()
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
-def test_django_tainted_user_agent_iast_disabled_sqli_http_request_header_name(client, test_spans, tracer):
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_iast_disabled_sqli_http_request_header_name(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
@@ -440,8 +440,8 @@ def test_django_tainted_user_agent_iast_disabled_sqli_http_request_header_name(c
 
 
 @pytest.mark.django_db()
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
-def test_django_iast_enabled_full_sqli_http_path_parameter(client, test_spans, tracer):
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_sqli_http_path_parameter(client, test_spans, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
         test_spans,
@@ -475,8 +475,8 @@ def test_django_iast_enabled_full_sqli_http_path_parameter(client, test_spans, t
 
 
 @pytest.mark.django_db()
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
-def test_django_iast_disabled_full_sqli_http_path_parameter(client, test_spans, tracer):
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_iast_disabled_sqli_http_path_parameter(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
@@ -493,8 +493,8 @@ def test_django_iast_disabled_full_sqli_http_path_parameter(client, test_spans, 
 
 
 @pytest.mark.django_db()
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
-def test_django_tainted_user_agent_iast_enabled_sqli_http_cookies_name(client, test_spans, tracer):
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_sqli_http_cookies_name(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
@@ -533,8 +533,8 @@ def test_django_tainted_user_agent_iast_enabled_sqli_http_cookies_name(client, t
 
 
 @pytest.mark.django_db()
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
-def test_django_tainted_iast_disabled_sqli_http_cookies_name(client, test_spans, tracer):
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_iast_disabled_sqli_http_cookies_name(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
@@ -551,8 +551,8 @@ def test_django_tainted_iast_disabled_sqli_http_cookies_name(client, test_spans,
 
 
 @pytest.mark.django_db()
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
-def test_django_tainted_user_agent_iast_enabled_sqli_http_cookies_value(client, test_spans, tracer):
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_sqli_http_cookies_value(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
@@ -593,8 +593,8 @@ def test_django_tainted_user_agent_iast_enabled_sqli_http_cookies_value(client, 
 
 
 @pytest.mark.django_db()
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
-def test_django_tainted_iast_disabled_sqli_http_cookies_value(client, test_spans, tracer):
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_iast_disabled_sqli_http_cookies_value(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
@@ -618,8 +618,8 @@ def test_django_tainted_iast_disabled_sqli_http_cookies_value(client, test_spans
     ],
 )
 @pytest.mark.django_db()
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
-def test_django_tainted_user_agent_iast_enabled_sqli_http_body(client, test_spans, tracer, payload, content_type):
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_sqli_http_body(client, test_spans, tracer, payload, content_type):
     with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
@@ -675,7 +675,7 @@ def test_django_tainted_user_agent_iast_enabled_sqli_http_body(client, test_span
     ],
 )
 @pytest.mark.django_db()
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_tainted_http_body_empty(client, test_spans, tracer, payload, content_type, deduplication, sampling):
     with override_global_config(
         dict(_iast_enabled=True, _deduplication_enabled=deduplication, _iast_request_sampling=sampling)
@@ -695,8 +695,8 @@ def test_django_tainted_http_body_empty(client, test_spans, tracer, payload, con
 
 
 @pytest.mark.django_db()
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
-def test_django_tainted_iast_disabled_sqli_http_body(client, test_spans, tracer):
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_iast_disabled_sqli_http_body(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
@@ -713,8 +713,8 @@ def test_django_tainted_iast_disabled_sqli_http_body(client, test_spans, tracer)
         assert response.content == b"master"
 
 
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
-def test_querydict_django_with_iast(client, test_spans, tracer):
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_querydict(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=True)):
         root_span, response = _aux_appsec_get_root_span(
             client,
@@ -731,7 +731,7 @@ def test_querydict_django_with_iast(client, test_spans, tracer):
         )
 
 
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_command_injection(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
         oce.reconfigure()
@@ -764,7 +764,7 @@ def test_django_command_injection(client, test_spans, tracer):
         assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
 
 
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_header_injection(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
         oce.reconfigure()
@@ -792,7 +792,7 @@ def test_django_header_injection(client, test_spans, tracer):
         assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
 
 
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_insecure_cookie(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
         oce.reconfigure()
@@ -817,7 +817,7 @@ def test_django_insecure_cookie(client, test_spans, tracer):
         assert vulnerability["hash"]
 
 
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_insecure_cookie_secure(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
         oce.reconfigure()
@@ -833,7 +833,7 @@ def test_django_insecure_cookie_secure(client, test_spans, tracer):
         assert root_span.get_tag(IAST.JSON) is None
 
 
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_insecure_cookie_empty_cookie(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
         oce.reconfigure()
@@ -849,7 +849,7 @@ def test_django_insecure_cookie_empty_cookie(client, test_spans, tracer):
         assert root_span.get_tag(IAST.JSON) is None
 
 
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_insecure_cookie_2_insecure_1_secure(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
         oce.reconfigure()
@@ -867,7 +867,7 @@ def test_django_insecure_cookie_2_insecure_1_secure(client, test_spans, tracer):
         assert len(loaded["vulnerabilities"]) == 2
 
 
-@pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_insecure_cookie_special_characters(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
         oce.reconfigure()

--- a/tests/appsec/integrations/flask_tests/mini.py
+++ b/tests/appsec/integrations/flask_tests/mini.py
@@ -1,0 +1,36 @@
+import ddtrace.auto  # noqa: F401
+
+
+"""do not move this import"""
+
+import os  # noqa: E402
+import sys  # noqa: E402
+
+from flask import Flask  # noqa: E402
+import requests  # noqa: E402 F401
+
+from ddtrace.settings.asm import config as asm_config  # noqa: E402
+from ddtrace.version import get_version  # noqa: E402
+
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def hello_world():
+    res = []
+    for m in sys.modules:
+        if m.startswith("ddtrace.appsec"):
+            res.append(m)
+    return {
+        "appsec": list(sorted(res)),
+        "asm_config": {
+            k: getattr(asm_config, k) for k in dir(asm_config) if isinstance(getattr(asm_config, k), (int, bool, float))
+        },
+        "aws": "AWS_LAMBDA_FUNCTION_NAME" in os.environ,
+        "version": get_version(),
+    }
+
+
+if __name__ == "__main__":
+    app.run(debug=True, port=8475)

--- a/tests/appsec/integrations/flask_tests/test_appsec_loading_modules.py
+++ b/tests/appsec/integrations/flask_tests/test_appsec_loading_modules.py
@@ -1,0 +1,84 @@
+import json
+import os
+import pathlib
+import subprocess
+import time
+from urllib.error import HTTPError
+from urllib.error import URLError
+from urllib.request import urlopen
+
+import pytest
+
+
+MODULES_ALWAYS_LOADED = ["ddtrace.appsec", "ddtrace.appsec._capabilities", "ddtrace.appsec._constants"]
+MODULE_ASM_ONLY = ["ddtrace.appsec._processor", "ddtrace.appsec._ddwaf"]
+MODULE_IAST_ONLY = [
+    "ddtrace.appsec._iast",
+    "ddtrace.appsec._iast._taint_tracking._native",
+    "ddtrace.appsec._iast._stacktrace",
+]
+
+
+@pytest.mark.parametrize("appsec_enabled", ["true", "false"])
+@pytest.mark.parametrize("iast_enabled", ["true", None])
+@pytest.mark.parametrize("aws_lambda", ["any", None])
+def test_loading(appsec_enabled, iast_enabled, aws_lambda):
+    flask_app = pathlib.Path(__file__).parent / "mini.py"
+    env = os.environ.copy()
+    if appsec_enabled:
+        env["DD_APPSEC_ENABLED"] = appsec_enabled
+    else:
+        env.pop("DD_APPSEC_ENABLED", None)
+    if iast_enabled:
+        env["DD_IAST_ENABLED"] = iast_enabled
+    else:
+        env.pop("DD_IAST_ENABLED", None)
+    if aws_lambda:
+        env["AWS_LAMBDA_FUNCTION_NAME"] = aws_lambda
+    else:
+        env.pop("AWS_LAMBDA_FUNCTION_NAME", None)
+
+    process = subprocess.Popen(
+        ["python", str(flask_app)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    for i in range(16):
+        time.sleep(1)
+        try:
+            with urlopen("http://localhost:8475") as response:
+                assert response.status == 200
+                payload = response.read().decode()
+                data = json.loads(payload)
+                assert "appsec" in data
+                # appsec is always enabled
+                for m in MODULES_ALWAYS_LOADED:
+                    assert m in data["appsec"], f"{m} not in {data['appsec']}"
+                for m in MODULE_ASM_ONLY:
+                    if appsec_enabled == "true" and not aws_lambda:
+                        assert m in data["appsec"], f"{m} not in {data['appsec']}"
+                    else:
+                        assert m not in data["appsec"], f"{m} in {data['appsec']}"
+                for m in MODULE_IAST_ONLY:
+                    if iast_enabled and not aws_lambda:
+                        assert m in data["appsec"], f"{m} not in {data['appsec']}"
+                    else:
+                        assert m not in data["appsec"], f"{m} in {data['appsec']}"
+            process.terminate()
+            process.wait()
+            break
+        except HTTPError as e:
+            process.terminate()
+            process.wait()
+            raise AssertionError(e.read().decode())
+        except URLError:
+            continue
+        except AssertionError:
+            process.terminate()
+            process.wait()
+            raise
+    else:
+        process.terminate()
+        process.wait()
+        raise AssertionError("Server did not start")

--- a/tests/appsec/integrations/flask_tests/test_iast_flask_telemetry.py
+++ b/tests/appsec/integrations/flask_tests/test_iast_flask_telemetry.py
@@ -1,6 +1,7 @@
 from ddtrace.appsec._iast._handlers import _on_flask_patch
 from ddtrace.appsec._iast.constants import VULN_PATH_TRAVERSAL
 from tests.appsec.appsec_utils import flask_server
+from tests.utils import flaky
 from tests.utils import override_global_config
 
 
@@ -15,6 +16,7 @@ def test_iast_span_metrics():
         assert response.content == b"OK"
 
 
+@flaky(1735812000)
 def test_flask_instrumented_metrics(telemetry_writer):
     from ddtrace.appsec._iast._taint_tracking import OriginType
     from ddtrace.appsec._iast._taint_tracking import origin_to_str
@@ -25,7 +27,7 @@ def test_flask_instrumented_metrics(telemetry_writer):
     metrics_result = telemetry_writer._namespace._metrics_data
     metrics_source_tags_result = [metric._tags[0][1] for metric in metrics_result["generate-metrics"]["iast"].values()]
 
-    assert len(metrics_source_tags_result) == 8
+    assert len(metrics_source_tags_result) == 11
     assert VULN_PATH_TRAVERSAL in metrics_source_tags_result
     assert origin_to_str(OriginType.HEADER_NAME) in metrics_source_tags_result
     assert origin_to_str(OriginType.HEADER) in metrics_source_tags_result
@@ -34,6 +36,9 @@ def test_flask_instrumented_metrics(telemetry_writer):
     assert origin_to_str(OriginType.PATH_PARAMETER) in metrics_source_tags_result
     assert origin_to_str(OriginType.QUERY) in metrics_source_tags_result
     assert origin_to_str(OriginType.BODY) in metrics_source_tags_result
+    assert origin_to_str(OriginType.COOKIE) in metrics_source_tags_result
+    assert origin_to_str(OriginType.COOKIE_NAME) in metrics_source_tags_result
+    assert origin_to_str(OriginType.PARAMETER_NAME) in metrics_source_tags_result
 
 
 def test_flask_instrumented_metrics_iast_disabled(telemetry_writer):

--- a/tests/contrib/dbapi/test_dbapi_appsec.py
+++ b/tests/contrib/dbapi/test_dbapi_appsec.py
@@ -2,9 +2,9 @@ import mock
 import pytest
 
 from ddtrace.appsec._iast import oce
-from ddtrace.appsec._iast._utils import _is_python_version_supported
 from ddtrace.contrib.dbapi import TracedCursor
 from ddtrace.settings import Config
+from ddtrace.settings.asm import config as asm_config
 from ddtrace.settings.integration import IntegrationConfig
 from ddtrace.trace import Pin
 from tests.appsec.iast.conftest import _end_iast_context_and_oce
@@ -33,7 +33,7 @@ class TestTracedCursor(TracerTestCase):
         ):
             _end_iast_context_and_oce()
 
-    @pytest.mark.skipif(not _is_python_version_supported(), reason="IAST compatible versions")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="IAST compatible versions")
     def test_tainted_query(self):
         from ddtrace.appsec._iast._taint_tracking import OriginType
         from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
@@ -56,7 +56,7 @@ class TestTracedCursor(TracerTestCase):
 
             mock_sql_injection_report.assert_called_once_with(evidence_value=query, dialect="sqlite")
 
-    @pytest.mark.skipif(not _is_python_version_supported(), reason="IAST compatible versions")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="IAST compatible versions")
     def test_tainted_query_args(self):
         from ddtrace.appsec._iast._taint_tracking import OriginType
         from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
@@ -79,7 +79,7 @@ class TestTracedCursor(TracerTestCase):
 
             mock_sql_injection_report.assert_not_called()
 
-    @pytest.mark.skipif(not _is_python_version_supported(), reason="IAST compatible versions")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="IAST compatible versions")
     def test_untainted_query(self):
         with mock.patch(
             "ddtrace.appsec._iast.taint_sinks.sql_injection.SqlInjection.report"
@@ -94,7 +94,7 @@ class TestTracedCursor(TracerTestCase):
 
             mock_sql_injection_report.assert_not_called()
 
-    @pytest.mark.skipif(not _is_python_version_supported(), reason="IAST compatible versions")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="IAST compatible versions")
     def test_untainted_query_and_args(self):
         with mock.patch(
             "ddtrace.appsec._iast.taint_sinks.sql_injection.SqlInjection.report"
@@ -110,7 +110,7 @@ class TestTracedCursor(TracerTestCase):
 
             mock_sql_injection_report.assert_not_called()
 
-    @pytest.mark.skipif(not _is_python_version_supported(), reason="IAST compatible versions")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="IAST compatible versions")
     def test_tainted_query_iast_disabled(self):
         from ddtrace.appsec._iast._taint_tracking import OriginType
         from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject

--- a/tests/contrib/flask/test_flask_appsec_iast.py
+++ b/tests/contrib/flask/test_flask_appsec_iast.py
@@ -9,7 +9,6 @@ from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast import oce
 from ddtrace.appsec._iast._iast_request_context import _iast_start_request
 from ddtrace.appsec._iast._patches.json_tainting import patch as patch_json
-from ddtrace.appsec._iast._utils import _is_python_version_supported as python_supported_by_iast
 from ddtrace.appsec._iast.constants import VULN_HEADER_INJECTION
 from ddtrace.appsec._iast.constants import VULN_INSECURE_COOKIE
 from ddtrace.appsec._iast.constants import VULN_NO_HTTPONLY_COOKIE
@@ -17,8 +16,10 @@ from ddtrace.appsec._iast.constants import VULN_NO_SAMESITE_COOKIE
 from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.appsec._iast.taint_sinks.header_injection import patch as patch_header_injection
 from ddtrace.contrib.internal.sqlite3.patch import patch as patch_sqlite_sqli
+from ddtrace.settings.asm import config as asm_config
 from tests.appsec.iast.iast_utils import get_line_and_hash
 from tests.contrib.flask import BaseFlaskTestCase
+from tests.utils import flaky
 from tests.utils import override_env
 from tests.utils import override_global_config
 
@@ -51,7 +52,8 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             self.tracer._configure(api_version="v0.4", appsec_enabled=True, iast_enabled=True)
             oce.reconfigure()
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @flaky(1735812000)
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_full_sqli_iast_http_request_path_parameter(self):
         @self.app.route("/sqli/<string:param_str>/", methods=["GET", "POST"])
         def sqli_1(param_str):
@@ -103,7 +105,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             assert vulnerability["location"]["path"] == TEST_FILE_PATH
             assert vulnerability["hash"] == hash_value
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_full_sqli_iast_enabled_http_request_header_getitem(self):
         @self.app.route("/sqli/<string:param_str>/", methods=["GET", "POST"])
         def sqli_2(param_str):
@@ -159,7 +161,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             assert vulnerability["location"]["path"] == TEST_FILE_PATH
             assert vulnerability["hash"] == hash_value
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_full_sqli_iast_enabled_http_request_header_name_keys(self):
         @self.app.route("/sqli/<string:param_str>/", methods=["GET", "POST"])
         def sqli_3(param_str):
@@ -213,7 +215,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             assert vulnerability["location"]["path"] == TEST_FILE_PATH
             assert vulnerability["hash"] == hash_value
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_full_sqli_iast_enabled_http_request_header_values(self):
         @self.app.route("/sqli/<string:param_str>/", methods=["GET", "POST"])
         def sqli_4(param_str):
@@ -317,7 +319,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             root_span = self.pop_spans()[0]
             assert root_span.get_metric(IAST.ENABLED) == 1.0
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_simple_iast_path_header_and_querystring_tainted_request_sampling_0(self):
         @self.app.route("/sqli/<string:param_str>/", methods=["GET", "POST"])
         def sqli_6(param_str):
@@ -349,7 +351,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
 
             assert root_span.get_metric(IAST.ENABLED) == 0.0
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_full_sqli_iast_enabled_http_request_cookies_value(self):
         @self.app.route("/sqli/cookies/", methods=["GET", "POST"])
         def sqli_7():
@@ -415,7 +417,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             assert vulnerability["location"]["path"] == TEST_FILE_PATH
             assert vulnerability["hash"] == hash_value
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_full_sqli_iast_enabled_http_request_cookies_name(self):
         @self.app.route("/sqli/cookies/", methods=["GET", "POST"])
         def sqli_8():
@@ -479,7 +481,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
 
             assert {VULN_SQL_INJECTION} == vulnerabilities
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_full_sqli_iast_http_request_parameter(self):
         @self.app.route("/sqli/parameter/", methods=["GET"])
         def sqli_9():
@@ -528,7 +530,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             assert vulnerability["location"]["path"] == TEST_FILE_PATH
             assert vulnerability["hash"] == hash_value
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_full_sqli_iast_http_request_parameter_name_post(self):
         @self.app.route("/sqli/", methods=["POST"])
         def sqli_13():
@@ -586,7 +588,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             assert vulnerability["location"]["path"] == TEST_FILE_PATH
             assert vulnerability["hash"] == hash_value
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_full_sqli_iast_http_request_parameter_name_get(self):
         @self.app.route("/sqli/", methods=["GET"])
         def sqli_14():
@@ -644,7 +646,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             assert vulnerability["location"]["path"] == TEST_FILE_PATH
             assert vulnerability["hash"] == hash_value
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_request_body(self):
         @self.app.route("/sqli/body/", methods=("POST",))
         def sqli_10():
@@ -710,7 +712,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             assert vulnerability["location"]["path"] == TEST_FILE_PATH
             assert vulnerability["hash"] == hash_value
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_request_body_complex_3_lvls(self):
         @self.app.route("/sqli/body/", methods=("POST",))
         def sqli_11():
@@ -775,7 +777,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             assert vulnerability["location"]["path"] == TEST_FILE_PATH
             assert vulnerability["hash"] == hash_value
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_request_body_complex_3_lvls_and_list(self):
         @self.app.route("/sqli/body/", methods=("POST",))
         def sqli_11():
@@ -840,7 +842,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             assert vulnerability["location"]["path"] == TEST_FILE_PATH
             assert vulnerability["hash"] == hash_value
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_request_body_complex_3_lvls_list_dict(self):
         @self.app.route("/sqli/body/", methods=("POST",))
         def sqli_11():
@@ -907,7 +909,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             assert vulnerability["location"]["path"] == TEST_FILE_PATH
             assert vulnerability["hash"] == hash_value
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_request_body_complex_json_all_types_of_values(self):
         @self.app.route("/sqli/body/", methods=("POST",))
         def sqli_11():
@@ -1045,7 +1047,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             assert vulnerability["location"]["path"] == TEST_FILE_PATH
             assert vulnerability["hash"] == hash_value
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_request_body_iast_and_appsec(self):
         """Verify IAST, Appsec and API security work correctly running at the same time"""
 
@@ -1098,7 +1100,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             list_metrics_logs = list(self._telemetry_writer._logs)
             assert len(list_metrics_logs) == 0
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_full_sqli_iast_enabled_http_request_header_values_scrubbed(self):
         @self.app.route("/sqli/<string:param_str>/", methods=["GET", "POST"])
         def sqli_12(param_str):
@@ -1152,7 +1154,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             assert vulnerability["location"]["path"] == TEST_FILE_PATH
             assert vulnerability["hash"] == hash_value
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_header_injection(self):
         @self.app.route("/header_injection/", methods=["GET", "POST"])
         def header_injection():
@@ -1192,7 +1194,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             }
             # TODO: vulnerability path is flaky, it points to "tests/contrib/flask/__init__.py"
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_header_injection_exlusions_location(self):
         @self.app.route("/header_injection/", methods=["GET", "POST"])
         def header_injection():
@@ -1221,7 +1223,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
 
             assert root_span.get_tag(IAST.JSON) is None
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_header_injection_exlusions_access_control(self):
         @self.app.route("/header_injection/", methods=["GET", "POST"])
         def header_injection():
@@ -1250,7 +1252,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
 
             assert root_span.get_tag(IAST.JSON) is None
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_insecure_cookie(self):
         @self.app.route("/insecure_cookie/", methods=["GET", "POST"])
         def insecure_cookie():
@@ -1288,7 +1290,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             assert vulnerability["location"]["spanId"]
             assert vulnerability["hash"]
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_insecure_cookie_empty(self):
         @self.app.route("/insecure_cookie_empty/", methods=["GET", "POST"])
         def insecure_cookie_empty():
@@ -1318,7 +1320,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             loaded = root_span.get_tag(IAST.JSON)
             assert loaded is None
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_no_http_only_cookie(self):
         @self.app.route("/no_http_only_cookie/", methods=["GET", "POST"])
         def no_http_only_cookie():
@@ -1356,7 +1358,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             assert vulnerability["location"]["spanId"]
             assert vulnerability["hash"]
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_no_http_only_cookie_empty(self):
         @self.app.route("/no_http_only_cookie_empty/", methods=["GET", "POST"])
         def no_http_only_cookie_empty():
@@ -1387,7 +1389,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             loaded = root_span.get_tag(IAST.JSON)
             assert loaded is None
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_no_samesite_cookie(self):
         @self.app.route("/no_samesite_cookie/", methods=["GET", "POST"])
         def no_samesite_cookie():
@@ -1425,7 +1427,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             assert vulnerability["location"]["spanId"]
             assert vulnerability["hash"]
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_no_samesite_cookie_empty(self):
         @self.app.route("/no_samesite_cookie_empty/", methods=["GET", "POST"])
         def no_samesite_cookie_empty():
@@ -1453,7 +1455,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             loaded = root_span.get_tag(IAST.JSON)
             assert loaded is None
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_cookie_secure(self):
         @self.app.route("/cookie_secure/", methods=["GET", "POST"])
         def cookie_secure():
@@ -1500,7 +1502,7 @@ class FlaskAppSecIASTDisabledTestCase(BaseFlaskTestCase):
             super(FlaskAppSecIASTDisabledTestCase, self).setUp()
             self.tracer._configure(api_version="v0.4")
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_full_sqli_iast_disabled_http_request_cookies_name(self):
         @self.app.route("/sqli/cookies/", methods=["GET", "POST"])
         def test_sqli():
@@ -1518,20 +1520,21 @@ class FlaskAppSecIASTDisabledTestCase(BaseFlaskTestCase):
 
             return "OK", 200
 
-        if tuple(map(int, werkzeug_version.split("."))) >= (2, 3):
-            self.client.set_cookie(domain="localhost", key="sqlite_master", value="sqlite_master3")
-        else:
-            self.client.set_cookie(server_name="localhost", key="sqlite_master", value="sqlite_master3")
+        with override_global_config(dict(_iast_enabled=False)):
+            if tuple(map(int, werkzeug_version.split("."))) >= (2, 3):
+                self.client.set_cookie(domain="localhost", key="sqlite_master", value="sqlite_master3")
+            else:
+                self.client.set_cookie(server_name="localhost", key="sqlite_master", value="sqlite_master3")
 
-        resp = self.client.post("/sqli/cookies/")
-        assert resp.status_code == 200
+            resp = self.client.post("/sqli/cookies/")
+            assert resp.status_code == 200
 
-        root_span = self.pop_spans()[0]
-        assert root_span.get_metric(IAST.ENABLED) is None
+            root_span = self.pop_spans()[0]
+            assert root_span.get_metric(IAST.ENABLED) is None
 
-        assert root_span.get_tag(IAST.JSON) is None
+            assert root_span.get_tag(IAST.JSON) is None
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_full_sqli_iast_disabled_http_request_header_getitem(self):
         @self.app.route("/sqli/<string:param_str>/", methods=["GET", "POST"])
         def test_sqli(param_str):
@@ -1563,7 +1566,7 @@ class FlaskAppSecIASTDisabledTestCase(BaseFlaskTestCase):
 
             assert root_span.get_tag(IAST.JSON) is None
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_full_sqli_iast_disabled_http_request_header_name_keys(self):
         @self.app.route("/sqli/<string:param_str>/", methods=["GET", "POST"])
         def test_sqli(param_str):
@@ -1595,7 +1598,7 @@ class FlaskAppSecIASTDisabledTestCase(BaseFlaskTestCase):
 
             assert root_span.get_tag(IAST.JSON) is None
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_full_sqli_iast_disabled_http_request_header_values(self):
         @self.app.route("/sqli/<string:param_str>/", methods=["GET", "POST"])
         def test_sqli(param_str):
@@ -1627,7 +1630,7 @@ class FlaskAppSecIASTDisabledTestCase(BaseFlaskTestCase):
 
             assert root_span.get_tag(IAST.JSON) is None
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_simple_iast_path_header_and_querystring_not_tainted_if_iast_disabled(self):
         @self.app.route("/sqli/<string:param_str>/", methods=["GET", "POST"])
         def test_sqli(param_str):
@@ -1653,7 +1656,7 @@ class FlaskAppSecIASTDisabledTestCase(BaseFlaskTestCase):
                 # not all flask versions have r.text
                 assert resp.text == "select%20from%20table"
 
-    @pytest.mark.skipif(not python_supported_by_iast(), reason="Python version not supported by IAST")
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
     def test_flask_full_sqli_iast_disabled_http_request_cookies_value(self):
         @self.app.route("/sqli/cookies/", methods=["GET", "POST"])
         def test_sqli():

--- a/tests/contrib/subprocess/test_subprocess.py
+++ b/tests/contrib/subprocess/test_subprocess.py
@@ -253,7 +253,7 @@ def test_unpatch(tracer):
         assert span.get_tag(COMMANDS.SHELL) == "dir -l /"
 
     unpatch()
-    with override_global_config(dict(_asm_enabled=True)):
+    with override_global_config(dict(_ep_enabled=False)):
         Pin.get_from(os).clone(tracer=tracer).onto(os)
         with tracer.trace("os.system_unpatch"):
             ret = os.system("dir -l /")
@@ -273,7 +273,7 @@ def test_unpatch(tracer):
 
 
 def test_ossystem_noappsec(tracer):
-    with override_global_config(dict(_asm_enabled=False)):
+    with override_global_config(dict(_ep_enabled=False)):
         patch()
         assert not hasattr(os.system, "__wrapped__")
         assert not hasattr(os._spawnvef, "__wrapped__")

--- a/tests/contrib/subprocess/test_subprocess_patch.py
+++ b/tests/contrib/subprocess/test_subprocess_patch.py
@@ -19,6 +19,8 @@ class TestSubprocessPatch(PatchTestCase.Base):
 
     def __init__(self, *args, **kwargs):
         asm_config._asm_enabled = True
+        asm_config._ep_enabled = True
+        asm_config._load_modules = True
         super(TestSubprocessPatch, self).__init__(*args, **kwargs)
 
     def assert_module_patched(self, subprocess):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -170,7 +170,7 @@ def override_global_config(values):
     ddtrace.config._subscriptions = []
     # Grab the current values of all keys
     originals = dict((key, getattr(ddtrace.config, key)) for key in global_config_keys)
-    asm_originals = dict((key, getattr(ddtrace.settings.asm.config, key)) for key in asm_config_keys)
+    asm_originals = dict((key, getattr(asm_config, key)) for key in asm_config_keys)
 
     # Override from the passed in keys
     for key, value in values.items():
@@ -179,9 +179,9 @@ def override_global_config(values):
     # rebuild asm config from env vars and global config
     for key, value in values.items():
         if key in asm_config_keys:
-            setattr(ddtrace.settings.asm.config, key, value)
+            setattr(asm_config, key, value)
     # If ddtrace.settings.asm.config has changed, check _asm_can_be_enabled again
-    ddtrace.settings.asm.config._eval_asm_can_be_enabled()
+    asm_config._eval_asm_can_be_enabled()
     try:
         core.dispatch("test.config.override")
         yield
@@ -190,9 +190,9 @@ def override_global_config(values):
         for key, value in originals.items():
             setattr(ddtrace.config, key, value)
 
-        ddtrace.settings.asm.config.reset()
+        asm_config.reset()
         for key, value in asm_originals.items():
-            setattr(ddtrace.settings.asm.config, key, value)
+            setattr(asm_config, key, value)
 
         ddtrace.config._reset()
         ddtrace.config._subscriptions = subscriptions


### PR DESCRIPTION
fix(asm): decouple appsec [backport 2.21] (#12319)

Backport https://github.com/DataDog/dd-trace-py/pull/12212 to  2.21

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer checklist
- [x] Reviewer has checked that all the criteria below are met
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

---------

Co-authored-by: Christophe Papazian <114495376+christophe-papazian@users.noreply.github.com>
