### PR TITLE
fix(asm): make sure iast is not loaded by exploit prevention if disabled [backport 2.19]

### DIFF
--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -1,5 +1,4 @@
-# This module must not import other modules inconditionnaly that
-# require iast, ddwaf or any native optional module.
+# This module must not import other modules unconditionally that require iast
 
 import ctypes
 import os
@@ -14,14 +13,20 @@ from wrapt import resolve_path
 import ddtrace
 from ddtrace.appsec._asm_request_context import get_blocked
 from ddtrace.appsec._constants import WAF_ACTIONS
-from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
-from ddtrace.appsec._iast.constants import VULN_PATH_TRAVERSAL
 from ddtrace.internal import core
 from ddtrace.internal._exceptions import BlockingException
 from ddtrace.internal._unpatched import _gc as gc
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.settings.asm import config as asm_config
+
+
+if asm_config._iast_enabled:
+    from ddtrace.appsec._iast._iast_request_context import is_iast_request_enabled
+else:
+
+    def is_iast_request_enabled() -> bool:
+        return False
 
 
 log = get_logger(__name__)
@@ -34,6 +39,16 @@ def patch_common_modules():
     global _is_patched
     if _is_patched:
         return
+    # for testing purposes, we need to update is_iast_request_enabled
+    if asm_config._iast_enabled:
+        global is_iast_request_enabled
+        from ddtrace.appsec._iast._iast_request_context import is_iast_request_enabled
+    else:
+        global is_iast_request_enabled
+
+        def is_iast_request_enabled() -> bool:
+            return False
+
     try_wrap_function_wrapper("builtins", "open", wrapped_open_CFDDB7ABBA9081B6)
     try_wrap_function_wrapper("urllib.request", "OpenerDirector.open", wrapped_open_ED4CF71136E15EBF)
     try_wrap_function_wrapper("_io", "BytesIO.read", wrapped_read_F3E51D71B4EC16EF)
@@ -41,6 +56,9 @@ def patch_common_modules():
     try_wrap_function_wrapper("os", "system", wrapped_system_5542593D237084A7)
     core.on("asm.block.dbapi.execute", execute_4C9BAC8E228EB347)
     if asm_config._iast_enabled:
+        from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
+        from ddtrace.appsec._iast.constants import VULN_PATH_TRAVERSAL
+
         _set_metric_iast_instrumented_sink(VULN_PATH_TRAVERSAL)
     _is_patched = True
 

--- a/ddtrace/appsec/_iast/_iast_request_context.py
+++ b/ddtrace/appsec/_iast/_iast_request_context.py
@@ -113,7 +113,7 @@ def set_iast_request_enabled(request_enabled) -> None:
         log.debug("[IAST] Trying to set IAST reporter but no context is present")
 
 
-def is_iast_request_enabled():
+def is_iast_request_enabled() -> bool:
     env = _get_iast_context()
     if env:
         return env.request_enabled

--- a/ddtrace/appsec/_iast/_patch.py
+++ b/ddtrace/appsec/_iast/_patch.py
@@ -4,7 +4,6 @@ from typing import Text
 
 from wrapt import FunctionWrapper
 
-from ddtrace.appsec._common_module_patches import wrap_object
 from ddtrace.internal.logger import get_logger
 
 from ._taint_utils import taint_structure
@@ -35,6 +34,7 @@ def set_module_unpatched(module_str: Text, default_attr: Text = "_datadog_patch"
 
 
 def try_wrap_function_wrapper(module: Text, name: Text, wrapper: Callable):
+    from ddtrace.appsec._common_module_patches import wrap_object
     try:
         wrap_object(module, name, FunctionWrapper, (wrapper,))
     except (ImportError, AttributeError):

--- a/ddtrace/appsec/_iast/_patch.py
+++ b/ddtrace/appsec/_iast/_patch.py
@@ -35,6 +35,7 @@ def set_module_unpatched(module_str: Text, default_attr: Text = "_datadog_patch"
 
 def try_wrap_function_wrapper(module: Text, name: Text, wrapper: Callable):
     from ddtrace.appsec._common_module_patches import wrap_object
+
     try:
         wrap_object(module, name, FunctionWrapper, (wrapper,))
     except (ImportError, AttributeError):

--- a/releasenotes/notes/no_IAST_unguarded_loading_in_common_module_patches-123cf6d3f8844823.yaml
+++ b/releasenotes/notes/no_IAST_unguarded_loading_in_common_module_patches-123cf6d3f8844823.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    ASM: This fix resolves an issue where IAST modules could be loaded, even if disabled, 
+         which could create an ImportError exception on Windows.


### PR DESCRIPTION
backport https://github.com/DataDog/dd-trace-py/pull/12198 to 2.19

Make sure, if iast is disabled, that we don't load any iast modules in the common module mechanism used both by iast and exploit prevention.

APPSEC-56659

Co-authored-by: Ramy Elkest <4thkest@gmail.com>
(cherry picked from commit 362fa22be2f7f6b61b023adb2aa56949aa163210)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
