### PR TITLE
perf(serverless): create noop telemetry writer when telemetry disabled

### DIFF
--- a/ddtrace/internal/telemetry/__init__.py
+++ b/ddtrace/internal/telemetry/__init__.py
@@ -3,7 +3,6 @@ Instrumentation Telemetry API.
 This is normally started automatically when ``ddtrace`` is imported. It can be disabled by setting
 ``DD_INSTRUMENTATION_TELEMETRY_ENABLED`` variable to ``False``.
 """
-
 import os
 import typing as t
 
@@ -21,8 +20,15 @@ from ddtrace.settings._otel_remapper import parse_otel_env
 
 log = get_logger(__name__)
 
+if os.environ.get("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "true").lower() in ("true", "1"):
+    from .writer import TelemetryWriter
 
-telemetry_writer = TelemetryWriter()  # type: TelemetryWriter
+    telemetry_writer = TelemetryWriter()  # type: TelemetryWriter
+
+else:
+    from .noop_writer import NoOpTelemetryWriter
+
+    telemetry_writer = NoOpTelemetryWriter()
 
 __all__ = ["telemetry_writer"]
 

--- a/ddtrace/internal/telemetry/__init__.py
+++ b/ddtrace/internal/telemetry/__init__.py
@@ -3,6 +3,7 @@ Instrumentation Telemetry API.
 This is normally started automatically when ``ddtrace`` is imported. It can be disabled by setting
 ``DD_INSTRUMENTATION_TELEMETRY_ENABLED`` variable to ``False``.
 """
+
 import os
 import typing as t
 
@@ -104,9 +105,9 @@ def get_config(
     return val
 
 
-if get_config("DD_INSTRUMENTATION_TELEMETRY_ENABLED", True, asbool, report_telemetry=False):
+telemetry_enabled = get_config("DD_INSTRUMENTATION_TELEMETRY_ENABLED", True, asbool, report_telemetry=False)
+if telemetry_enabled:
     from .writer import TelemetryWriter
-
 else:
     from .noop_writer import NoOpTelemetryWriter as TelemetryWriter  # type: ignore[assignment]
 

--- a/ddtrace/internal/telemetry/__init__.py
+++ b/ddtrace/internal/telemetry/__init__.py
@@ -9,6 +9,7 @@ import typing as t
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.internal.telemetry.writer import TelemetryWriter
+from ddtrace.internal.utils.formats import asbool
 from ddtrace.settings._agent import config as agent_config
 from ddtrace.settings._core import FLEET_CONFIG
 from ddtrace.settings._core import FLEET_CONFIG_IDS
@@ -19,16 +20,6 @@ from ddtrace.settings._otel_remapper import parse_otel_env
 
 
 log = get_logger(__name__)
-
-if os.environ.get("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "true").lower() in ("true", "1"):
-    from .writer import TelemetryWriter
-
-    telemetry_writer = TelemetryWriter()  # type: TelemetryWriter
-
-else:
-    from .noop_writer import NoOpTelemetryWriter
-
-    telemetry_writer = NoOpTelemetryWriter()
 
 __all__ = ["telemetry_writer"]
 
@@ -112,6 +103,16 @@ def get_config(
         report_config_telemetry(effective_env, val, source, otel_env, config_id)
 
     return val
+
+if get_config("DD_INSTRUMENTATION_TELEMETRY_ENABLED", True, asbool, report_telemetry=False):
+    from .writer import TelemetryWriter
+
+    telemetry_writer = TelemetryWriter()  # type: TelemetryWriter
+
+else:
+    from .noop_writer import NoOpTelemetryWriter
+
+    telemetry_writer = NoOpTelemetryWriter()
 
 
 def report_configuration(config: DDConfig) -> None:

--- a/ddtrace/internal/telemetry/__init__.py
+++ b/ddtrace/internal/telemetry/__init__.py
@@ -8,7 +8,6 @@ import typing as t
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
-from ddtrace.internal.telemetry.writer import TelemetryWriter
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.settings._agent import config as agent_config
 from ddtrace.settings._core import FLEET_CONFIG
@@ -108,12 +107,10 @@ def get_config(
 if get_config("DD_INSTRUMENTATION_TELEMETRY_ENABLED", True, asbool, report_telemetry=False):
     from .writer import TelemetryWriter
 
-    telemetry_writer = TelemetryWriter()  # type: TelemetryWriter
-
 else:
-    from .noop_writer import NoOpTelemetryWriter
+    from .noop_writer import NoOpTelemetryWriter as TelemetryWriter  # type: ignore[assignment]
 
-    telemetry_writer = NoOpTelemetryWriter()
+telemetry_writer = TelemetryWriter()
 
 
 def report_configuration(config: DDConfig) -> None:

--- a/ddtrace/internal/telemetry/__init__.py
+++ b/ddtrace/internal/telemetry/__init__.py
@@ -104,6 +104,7 @@ def get_config(
 
     return val
 
+
 if get_config("DD_INSTRUMENTATION_TELEMETRY_ENABLED", True, asbool, report_telemetry=False):
     from .writer import TelemetryWriter
 

--- a/ddtrace/internal/telemetry/noop_writer.py
+++ b/ddtrace/internal/telemetry/noop_writer.py
@@ -1,5 +1,4 @@
 class NoOpTelemetryWriter(object):
-
     def __getattr__(self, name):
         return self.noop
 

--- a/ddtrace/internal/telemetry/noop_writer.py
+++ b/ddtrace/internal/telemetry/noop_writer.py
@@ -1,0 +1,7 @@
+class NoOpTelemetryWriter(object):
+
+    def __getattr__(self, name):
+        return self.noop
+
+    def noop(self, *args, **kwargs):
+        pass

--- a/ddtrace/settings/_config.py
+++ b/ddtrace/settings/_config.py
@@ -14,8 +14,6 @@ from typing import Union  # noqa:F401
 
 from ddtrace.internal.serverless import in_azure_function
 from ddtrace.internal.serverless import in_gcp_function
-from ddtrace.internal.telemetry import telemetry_enabled
-from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry import validate_otel_envs
 from ddtrace.internal.utils.cache import cachedmethod
 
@@ -530,7 +528,7 @@ class Config(object):
 
         self._health_metrics_enabled = _get_config("DD_TRACE_HEALTH_METRICS_ENABLED", False, asbool)
 
-        self._telemetry_enabled = telemetry_enabled
+        self._telemetry_enabled = _get_config("DD_INSTRUMENTATION_TELEMETRY_ENABLED", True, asbool)
         self._telemetry_heartbeat_interval = _get_config("DD_TELEMETRY_HEARTBEAT_INTERVAL", 60, float)
         self._telemetry_dependency_collection = _get_config("DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED", True, asbool)
 
@@ -778,6 +776,8 @@ class Config(object):
             item = self._config[key]
             item.set_value_source(value, origin)
             if self._telemetry_enabled:
+                from ddtrace.internal.telemetry import telemetry_writer
+
                 telemetry_writer.add_configuration(item._name, item.value(), item.source())
         self._notify_subscribers(item_names)
 

--- a/ddtrace/settings/_config.py
+++ b/ddtrace/settings/_config.py
@@ -14,6 +14,8 @@ from typing import Union  # noqa:F401
 
 from ddtrace.internal.serverless import in_azure_function
 from ddtrace.internal.serverless import in_gcp_function
+from ddtrace.internal.telemetry import telemetry_enabled
+from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry import validate_otel_envs
 from ddtrace.internal.utils.cache import cachedmethod
 
@@ -528,7 +530,7 @@ class Config(object):
 
         self._health_metrics_enabled = _get_config("DD_TRACE_HEALTH_METRICS_ENABLED", False, asbool)
 
-        self._telemetry_enabled = _get_config("DD_INSTRUMENTATION_TELEMETRY_ENABLED", True, asbool)
+        self._telemetry_enabled = telemetry_enabled
         self._telemetry_heartbeat_interval = _get_config("DD_TELEMETRY_HEARTBEAT_INTERVAL", 60, float)
         self._telemetry_dependency_collection = _get_config("DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED", True, asbool)
 
@@ -776,8 +778,6 @@ class Config(object):
             item = self._config[key]
             item.set_value_source(value, origin)
             if self._telemetry_enabled:
-                from ddtrace.internal.telemetry import telemetry_writer
-
                 telemetry_writer.add_configuration(item._name, item.value(), item.source())
         self._notify_subscribers(item_names)
 

--- a/tests/internal/test_serverless.py
+++ b/tests/internal/test_serverless.py
@@ -82,7 +82,7 @@ def test_not_azure_function_consumption_plan():
 standard_blocklist = [
     "ddtrace.appsec._api_security.api_manager",
     "ddtrace.appsec._iast._ast.ast_patching",
-    "ddtrace.internal.telemetry.telemetry_writer",
+    "ddtrace.internal.telemetry.writer",
     "email.mime.application",
     "email.mime.multipart",
     "logging.handlers",

--- a/tests/internal/test_serverless.py
+++ b/tests/internal/test_serverless.py
@@ -123,14 +123,6 @@ def test_slow_imports(package, blocklist, run_python_code_in_subprocess):
     # any of those modules are imported during the import of ddtrace.
     import os
 
-    os.environ.update(
-        {
-            "AWS_LAMBDA_FUNCTION_NAME": "foobar",
-            "DD_INSTRUMENTATION_TELEMETRY_ENABLED": "False",
-            "DD_API_SECURITY_ENABLED": "False",
-        }
-    )
-
     env = os.environ.copy()
     env.update(
         {


### PR DESCRIPTION
We explicitly disable telemetry when running the python tracer in aws lambda to save on its additional overhead. Despite this, we still import `ddtrace/internal/telemetry/writer.py`, which takes around 35ms to import.

This PR aims to avoid any import of `ddtrace/internal/telemetry/writer.py` when telemetry is disabled.

### Testing
I packaged `ddtrace`, before and after this commit, into an AWS Lambda function. Without using `datadog-lambda-python`, I simply timed the import of `ddtrace` and sent this value as a metric. Here are the results of this testing.

<img width="437" alt="Screenshot 2025-02-14 at 10 38 14 AM" src="https://github.com/user-attachments/assets/3222eb16-2638-4350-9265-389f1de7b21f" />

Interestingly, according to our cold start tracing, the import of `ddtrace/internal/telemetry/writer.py` is around 6.5% of the total time of a cold start invocation. Why then are we not seeing a cold start time reduction of 6.5%? I do not have definitive data on this, but I assume some of the dependencies of this file are being imported elsewhere in the tracer.

<img width="1121" alt="Screenshot 2025-02-14 at 10 40 12 AM" src="https://github.com/user-attachments/assets/6ac2a067-3221-4ec1-a2ff-d45b355914c8" />

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
