### PR TITLE
ci: add specific code owners for tests/internal/test_serverless.py

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -188,3 +188,6 @@ tests/opentelemetry/                               @DataDog/apm-sdk-api-python
 tests/tracer/                                      @DataDog/apm-sdk-api-python
 # Override because order matters
 tests/tracer/test_ci.py                            @DataDog/ci-app-libraries
+
+# Serverless
+tests/internal/test_serverless.py   @DataDog/apm-core-python @DataDog/apm-serverless


### PR DESCRIPTION
The new team https://github.com/orgs/DataDog/teams/apm-serverless would like to take on ownership of this testing file.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
