### PR TITLE
fix(encoding): fix encoding errors when the span started a very long time ago

### DIFF
--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -377,6 +377,22 @@ def test_msgpack_span_property_variations(encoding, span):
     assert decode(refencoder.encode_traces([trace])) == decode(encoder.encode()[0])
 
 
+@allencodings
+def test_long_span_start(encoding):
+    refencoder = REF_MSGPACK_ENCODERS[encoding]()
+    encoder = MSGPACK_ENCODERS[encoding](1 << 10, 1 << 10)
+
+    # Start a span a very long time ago
+    span = Span(None)
+    span.start = -62135596700
+    span.finish()
+
+    trace = [span]
+    encoder.put(trace)
+    # TODO: Right now this fails with Python int too large to convert to C long
+    assert decode(refencoder.encode_traces([trace])) == decode(encoder.encode()[0])
+
+
 class SubString(str):
     pass
 


### PR DESCRIPTION
Possible cause behind https://github.com/DataDog/dd-trace-py/issues/12240. If the span started a very long time ago, the encoding fails with:

> >   raise RuntimeError("failed to pack span: {!r}. Exception: {}".format(span, e))
E   RuntimeError: failed to pack span: <Span(id=2850960614187153438,trace_id=137823137092894037702114325005943826011,parent_id=None,name=None)>. Exception: Python int too large to convert to C long

TODO: Find a good way to check the min/max without causing issues.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
