### PR TITLE
chore(asm): add collection mode tag for set_user sdk

### DIFF
--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -315,9 +315,9 @@ def block_request_if_user_blocked(tracer: Tracer, userid: str) -> None:
     if span:
         root_span = span._local_root or span
         root_span.set_tag_str(APPSEC.AUTO_LOGIN_EVENTS_COLLECTION_MODE, LOGIN_EVENTS_MODE.SDK)
+        root_span.set_tag_str(user.ID, str(userid))
+        root_span.set_tag_str(APPSEC.USER_LOGIN_USERID, str(userid))
     if should_block_user(tracer, userid):
-        if root_span:
-            root_span.set_tag_str(user.ID, str(userid))
         _asm_request_context.block_request()
 
 

--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -303,7 +303,7 @@ def block_request_if_user_blocked(tracer: Tracer, userid: str) -> None:
     Check if the specified User ID should be blocked and if positive
     block the current request using `block_request`.
 
-    This should be only called with set_user from the sdk API
+    This should only be called with set_user from the sdk API
 
     :param tracer: tracer instance to use
     :param userid: the ID of the user as registered by `set_user`
@@ -313,10 +313,11 @@ def block_request_if_user_blocked(tracer: Tracer, userid: str) -> None:
         return
     span = tracer.current_root_span()
     if span:
-        span.set_tag_str(APPSEC.AUTO_LOGIN_EVENTS_COLLECTION_MODE, LOGIN_EVENTS_MODE.SDK)
+        root_span = span._local_root or span
+        root_span.set_tag_str(APPSEC.AUTO_LOGIN_EVENTS_COLLECTION_MODE, LOGIN_EVENTS_MODE.SDK)
     if should_block_user(tracer, userid):
-        if span:
-            span.set_tag_str(user.ID, str(userid))
+        if root_span:
+            root_span.set_tag_str(user.ID, str(userid))
         _asm_request_context.block_request()
 
 

--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -303,15 +303,18 @@ def block_request_if_user_blocked(tracer: Tracer, userid: str) -> None:
     Check if the specified User ID should be blocked and if positive
     block the current request using `block_request`.
 
+    This should be only called with set_user from the sdk API
+
     :param tracer: tracer instance to use
     :param userid: the ID of the user as registered by `set_user`
     """
     if not asm_config._asm_enabled:
         log.warning("should_block_user call requires ASM to be enabled")
         return
-
+    span = tracer.current_root_span()
+    if span:
+        span.set_tag_str(APPSEC.AUTO_LOGIN_EVENTS_COLLECTION_MODE, LOGIN_EVENTS_MODE.SDK)
     if should_block_user(tracer, userid):
-        span = tracer.current_root_span()
         if span:
             span.set_tag_str(user.ID, str(userid))
         _asm_request_context.block_request()

--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -316,7 +316,6 @@ def block_request_if_user_blocked(tracer: Tracer, userid: str) -> None:
         root_span = span._local_root or span
         root_span.set_tag_str(APPSEC.AUTO_LOGIN_EVENTS_COLLECTION_MODE, LOGIN_EVENTS_MODE.SDK)
         root_span.set_tag_str(user.ID, str(userid))
-        root_span.set_tag_str(APPSEC.USER_LOGIN_USERID, str(userid))
     if should_block_user(tracer, userid):
         _asm_request_context.block_request()
 

--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -298,7 +298,7 @@ def block_request() -> None:
     _asm_request_context.block_request()
 
 
-def block_request_if_user_blocked(tracer: Tracer, userid: str, mode: str) -> None:
+def block_request_if_user_blocked(tracer: Tracer, userid: str, mode: str = "sdk") -> None:
     """
     Check if the specified User ID should be blocked and if positive
     block the current request using `block_request`.
@@ -307,6 +307,7 @@ def block_request_if_user_blocked(tracer: Tracer, userid: str, mode: str) -> Non
 
     :param tracer: tracer instance to use
     :param userid: the ID of the user as registered by `set_user`
+    :param mode: the mode of the login event ("sdk" by default, "auto" to simulate auto instrumentation)
     """
     if not asm_config._asm_enabled:
         log.warning("should_block_user call requires ASM to be enabled")

--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -644,6 +644,7 @@ def set_user(
     propagate=False,  # type bool
     span=None,  # type: Optional[Span]
     may_block=True,  # type: bool
+    mode="sdk",  # type: str
 ):
     # type: (...) -> None
     """Set user tags.
@@ -671,8 +672,8 @@ def set_user(
         if session_id:
             span.set_tag_str(user.SESSION_ID, session_id)
 
-        if may_block and asm_config._asm_enabled:
-            exc = core.dispatch_with_results("set_user_for_asm", [tracer, user_id]).block_user.exception
+        if (may_block or mode == "auto") and asm_config._asm_enabled:
+            exc = core.dispatch_with_results("set_user_for_asm", [tracer, user_id, mode]).block_user.exception
             if exc:
                 raise exc
 

--- a/tests/appsec/appsec/test_appsec_trace_utils.py
+++ b/tests/appsec/appsec/test_appsec_trace_utils.py
@@ -236,6 +236,7 @@ class EventsSDKTestCase(TracerTestCase):
             assert span.get_tag(user.SCOPE)
             assert span.get_tag(user.SESSION_ID)
             assert span.get_tag(APPSEC.AUTO_LOGIN_EVENTS_COLLECTION_MODE) == LOGIN_EVENTS_MODE.SDK
+            assert span.get_tag(APPSEC.USER_LOGIN_USERID) == str(self._BLOCKED_USER)
             assert is_blocked(span)
 
     def test_no_span_doesnt_raise(self):

--- a/tests/appsec/appsec/test_appsec_trace_utils.py
+++ b/tests/appsec/appsec/test_appsec_trace_utils.py
@@ -235,6 +235,7 @@ class EventsSDKTestCase(TracerTestCase):
             assert span.get_tag(user.ROLE)
             assert span.get_tag(user.SCOPE)
             assert span.get_tag(user.SESSION_ID)
+            assert span.get_tag(APPSEC.AUTO_LOGIN_EVENTS_COLLECTION_MODE) == LOGIN_EVENTS_MODE.SDK
             assert is_blocked(span)
 
     def test_no_span_doesnt_raise(self):

--- a/tests/appsec/appsec/test_appsec_trace_utils.py
+++ b/tests/appsec/appsec/test_appsec_trace_utils.py
@@ -236,7 +236,7 @@ class EventsSDKTestCase(TracerTestCase):
             assert span.get_tag(user.SCOPE)
             assert span.get_tag(user.SESSION_ID)
             assert span.get_tag(APPSEC.AUTO_LOGIN_EVENTS_COLLECTION_MODE) == LOGIN_EVENTS_MODE.SDK
-            assert span.get_tag(APPSEC.USER_LOGIN_USERID) == str(self._BLOCKED_USER)
+            assert span.get_tag("usr.id") == str(self._BLOCKED_USER)
             assert is_blocked(span)
 
     def test_no_span_doesnt_raise(self):

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env].json
@@ -10,7 +10,6 @@
     "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
-      "_dd.appsec.user.collection_mode": "sdk",
       "_dd.appsec.waf.version": "1.22.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_processexec_subprocesscommunicateshell[flask_appsec_good_rules_env].json
@@ -10,6 +10,7 @@
     "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
+      "_dd.appsec.user.collection_mode": "sdk",
       "_dd.appsec.waf.version": "1.22.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
@@ -11,6 +11,7 @@
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.user.collection_mode": "sdk",
+      "_dd.appsec.usr.id": "111111",
       "_dd.appsec.waf.version": "1.22.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -32,7 +33,8 @@
       "language": "python",
       "network.client.ip": "127.0.0.1",
       "runtime-id": "3415570b0bbf4266991e33812294dd45",
-      "span.kind": "server"
+      "span.kind": "server",
+      "usr.id": "111111"
     },
     "metrics": {
       "_dd.appsec.enabled": 1.0,

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
@@ -11,7 +11,6 @@
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.user.collection_mode": "sdk",
-      "_dd.appsec.usr.id": "111111",
       "_dd.appsec.waf.version": "1.22.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
@@ -10,7 +10,6 @@
     "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
-      "_dd.appsec.user.collection_mode": "sdk",
       "_dd.appsec.waf.version": "1.22.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env].json
@@ -10,6 +10,7 @@
     "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
+      "_dd.appsec.user.collection_mode": "sdk",
       "_dd.appsec.waf.version": "1.22.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
@@ -11,6 +11,7 @@
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.user.collection_mode": "sdk",
+      "_dd.appsec.usr.id": "111111",
       "_dd.appsec.waf.version": "1.22.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",
@@ -32,7 +33,8 @@
       "language": "python",
       "network.client.ip": "127.0.0.1",
       "runtime-id": "fb2ca5c86850486981c575def356a1bc",
-      "span.kind": "server"
+      "span.kind": "server",
+      "usr.id": "111111"
     },
     "metrics": {
       "_dd.appsec.enabled": 1.0,

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
@@ -11,7 +11,6 @@
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.user.collection_mode": "sdk",
-      "_dd.appsec.usr.id": "111111",
       "_dd.appsec.waf.version": "1.22.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_200_json[flask_appsec_good_rules_env]_220.json
@@ -10,6 +10,7 @@
     "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
+      "_dd.appsec.user.collection_mode": "sdk",
       "_dd.appsec.waf.version": "1.22.0",
       "_dd.base_service": "",
       "_dd.p.dm": "-0",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
@@ -12,6 +12,7 @@
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-002\",\n      \"name\": \"Block User Addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"security_response\",\n        \"type\": \"block_user\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"exact_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"usr.id\",\n            \"highlight\": [\n              \"123456\"\n            ],\n            \"key_path\": [],\n            \"value\": \"123456\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
       "_dd.appsec.user.collection_mode": "sdk",
+      "_dd.appsec.usr.id": "123456",
       "_dd.appsec.waf.version": "1.22.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
@@ -11,6 +11,7 @@
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-002\",\n      \"name\": \"Block User Addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"security_response\",\n        \"type\": \"block_user\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"exact_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"usr.id\",\n            \"highlight\": [\n              \"123456\"\n            ],\n            \"key_path\": [],\n            \"value\": \"123456\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
+      "_dd.appsec.user.collection_mode": "sdk",
       "_dd.appsec.waf.version": "1.22.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env].json
@@ -12,7 +12,6 @@
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-002\",\n      \"name\": \"Block User Addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"security_response\",\n        \"type\": \"block_user\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"exact_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"usr.id\",\n            \"highlight\": [\n              \"123456\"\n            ],\n            \"key_path\": [],\n            \"value\": \"123456\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
       "_dd.appsec.user.collection_mode": "sdk",
-      "_dd.appsec.usr.id": "123456",
       "_dd.appsec.waf.version": "1.22.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -12,6 +12,7 @@
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-002\",\n      \"name\": \"Block User Addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"security_response\",\n        \"type\": \"block_user\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"exact_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"usr.id\",\n            \"highlight\": [\n              \"123456\"\n            ],\n            \"key_path\": [],\n            \"value\": \"123456\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
       "_dd.appsec.user.collection_mode": "sdk",
+      "_dd.appsec.usr.id": "123456",
       "_dd.appsec.waf.version": "1.22.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -10,6 +10,7 @@
     "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
+      "_dd.appsec.user.collection_mode": "sdk",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-002\",\n      \"name\": \"Block User Addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"security_response\",\n        \"type\": \"block_user\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"exact_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"usr.id\",\n            \"highlight\": [\n              \"123456\"\n            ],\n            \"key_path\": [],\n            \"value\": \"123456\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
       "_dd.appsec.waf.version": "1.22.0",
       "_dd.base_service": "",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -10,8 +10,8 @@
     "error": 0,
     "meta": {
       "_dd.appsec.event_rules.version": "rules_good",
-      "_dd.appsec.user.collection_mode": "sdk",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-002\",\n      \"name\": \"Block User Addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"security_response\",\n        \"type\": \"block_user\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"exact_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"usr.id\",\n            \"highlight\": [\n              \"123456\"\n            ],\n            \"key_path\": [],\n            \"value\": \"123456\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
+      "_dd.appsec.user.collection_mode": "sdk",
       "_dd.appsec.waf.version": "1.22.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",

--- a/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
+++ b/tests/snapshots/tests.contrib.flask.test_appsec_flask_snapshot.test_flask_userblock_match_403_json[flask_appsec_good_rules_env]_220.json
@@ -12,7 +12,6 @@
       "_dd.appsec.event_rules.version": "rules_good",
       "_dd.appsec.json": "{\"triggers\":[\n  {\n    \"rule\": {\n      \"id\": \"blk-001-002\",\n      \"name\": \"Block User Addresses\",\n      \"on_match\": [\n        \"block\"\n      ],\n      \"tags\": {\n        \"category\": \"security_response\",\n        \"type\": \"block_user\"\n      }\n    },\n    \"rule_matches\": [\n      {\n        \"operator\": \"exact_match\",\n        \"operator_value\": \"\",\n        \"parameters\": [\n          {\n            \"address\": \"usr.id\",\n            \"highlight\": [\n              \"123456\"\n            ],\n            \"key_path\": [],\n            \"value\": \"123456\"\n          }\n        ]\n      }\n    ]\n  }\n]}",
       "_dd.appsec.user.collection_mode": "sdk",
-      "_dd.appsec.usr.id": "123456",
       "_dd.appsec.waf.version": "1.22.0",
       "_dd.base_service": "",
       "_dd.origin": "appsec",


### PR DESCRIPTION
- Improve ATO support by adding collection mode and usr.id tags to set_user sdk
- Add unit test for both tags
- Update snapshot tests
- It will be also tested by new ato system tests. (https://github.com/DataDog/system-tests/pull/4125)
- Add an optional parameter `mode` to set_user to simulate auto instrumentation

APPSEC-56786

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
