### PR TITLE
chore(llmobs): better span linking logic for langchain integration

### DIFF
--- a/ddtrace/llmobs/_integrations/langchain.py
+++ b/ddtrace/llmobs/_integrations/langchain.py
@@ -104,9 +104,6 @@ def _is_chain_instance(instance):
 class LangChainIntegration(BaseLLMIntegration):
     _integration_name = "langchain"
 
-    _spans: Dict[int, Span] = {}
-    """Maps instance ids to spans."""
-
     _instances: WeakKeyDictionary = WeakKeyDictionary()
     """Maps span to instances."""
 
@@ -117,7 +114,16 @@ class LangChainIntegration(BaseLLMIntegration):
         instance = _extract_instance(instance)
 
         self._instances[span] = instance
-        self._spans[id(instance)] = span
+
+        parent_span = _get_nearest_llmobs_ancestor(span)
+        parent_instance = self._instances.get(parent_span) if parent_span else None
+
+        if parent_instance is None or not _is_chain_instance(parent_instance):
+            return
+
+        spans: Dict[int, Span] = getattr(parent_instance, "_spans", {})
+        spans[id(instance)] = span
+        setattr(parent_instance, "_spans", spans)
 
     def _llmobs_set_tags(
         self,
@@ -187,7 +193,6 @@ class LangChainIntegration(BaseLLMIntegration):
 
         parent_span = _get_nearest_llmobs_ancestor(span)
         if parent_span is None:
-            self._clear_instance_recordings(instance, parent_span)
             return
 
         invoker_spans, from_output = self._get_invoker_spans(instance, parent_span)
@@ -195,7 +200,7 @@ class LangChainIntegration(BaseLLMIntegration):
         self._set_input_links(span, invoker_spans, from_output)
         self._set_output_links(span, parent_span, invoker_spans, from_output)
 
-        self._clear_instance_recordings(instance, parent_span)
+        self._clear_instance_recordings(instance)
 
     def _get_invoker_spans(self, instance, parent_span: Span) -> Tuple[List[Span], bool]:
         """
@@ -218,11 +223,13 @@ class LangChainIntegration(BaseLLMIntegration):
         curr_step = flatmap_chain_steps[0]
         prev_traced_step_idx = -1
 
+        chain_spans = getattr(parent_langchain_instance, "_spans", {})
+
         while id(curr_step) != id(instance) and not (
             isinstance(curr_step, list) and any(id(sub_step) == id(instance) for sub_step in curr_step)
         ):
-            if id(curr_step) in self._spans or (
-                isinstance(curr_step, list) and any(id(sub_step) in self._spans for sub_step in curr_step)
+            if id(curr_step) in chain_spans or (
+                isinstance(curr_step, list) and any(id(sub_step) in chain_spans for sub_step in curr_step)
             ):
                 prev_traced_step_idx = curr_idx
             curr_idx += 1
@@ -238,12 +245,12 @@ class LangChainIntegration(BaseLLMIntegration):
         if isinstance(invoker_steps, list):
             invoker_spans = []
             for step in invoker_steps:
-                span = self._spans.get(id(step))
+                span = chain_spans.get(id(step))
                 if span:
                     invoker_spans.append(span)
             return invoker_spans, True
 
-        return [self._spans[id(invoker_steps)]], True
+        return [chain_spans[id(invoker_steps)]], True
 
     def _set_input_links(self, span: Span, invoker_spans: List[Span], from_output: bool):
         """Sets the input links for the given span (to: input)"""
@@ -320,7 +327,7 @@ class LangChainIntegration(BaseLLMIntegration):
         if links:
             span._set_ctx_item(SPAN_LINKS, existing_links + links)
 
-    def _clear_instance_recordings(self, instance: Any, parent_span: Optional[Span]) -> None:
+    def _clear_instance_recordings(self, instance: Any) -> None:
         """
         Deletes the references of steps in a chain from the instance id to span mapping.
 
@@ -330,29 +337,10 @@ class LangChainIntegration(BaseLLMIntegration):
         We attempt to remove the current instance as well if it has no parent or its parent instance is not a chain.
         """
         if not _is_chain_instance(instance):
-            self._safe_delete_instance_recording(instance)
             return
 
-        steps = getattr(instance, "steps", [])
-        flatmap_chain_steps = _flattened_chain_steps(steps, nested=False)
-
-        for step in flatmap_chain_steps:
-            self._safe_delete_instance_recording(step)
-
-        if parent_span is None:
-            self._safe_delete_instance_recording(instance)
-            return
-
-        parent_instance = self._instances.get(parent_span)
-        if parent_instance is None or not _is_chain_instance(parent_instance):
-            self._safe_delete_instance_recording(instance)
-
-    def _safe_delete_instance_recording(self, instance):
-        instance_id = id(instance)
-        if instance_id in self._spans:
-            del self._spans[instance_id]
-        else:
-            log.debug("Unable to delete langchain instance from internal mapping")
+        if hasattr(instance, "_spans"):
+            delattr(instance, "_spans")
 
     def _llmobs_set_metadata(self, span: Span, model_provider: Optional[str] = None) -> None:
         if not model_provider:

--- a/ddtrace/llmobs/_integrations/langchain.py
+++ b/ddtrace/llmobs/_integrations/langchain.py
@@ -121,9 +121,9 @@ class LangChainIntegration(BaseLLMIntegration):
         if parent_instance is None or not _is_chain_instance(parent_instance):
             return
 
-        spans: Dict[int, Span] = getattr(parent_instance, "_spans", {})
+        spans: Dict[int, Span] = getattr(parent_instance, "_datadog_spans", {})
         spans[id(instance)] = span
-        setattr(parent_instance, "_spans", spans)
+        setattr(parent_instance, "_datadog_spans", spans)
 
     def _llmobs_set_tags(
         self,
@@ -223,7 +223,7 @@ class LangChainIntegration(BaseLLMIntegration):
         curr_step = flatmap_chain_steps[0]
         prev_traced_step_idx = -1
 
-        chain_spans = getattr(parent_langchain_instance, "_spans", {})
+        chain_spans = getattr(parent_langchain_instance, "_datadog_spans", {})
 
         while id(curr_step) != id(instance) and not (
             isinstance(curr_step, list) and any(id(sub_step) == id(instance) for sub_step in curr_step)
@@ -339,8 +339,8 @@ class LangChainIntegration(BaseLLMIntegration):
         if not _is_chain_instance(instance):
             return
 
-        if hasattr(instance, "_spans"):
-            delattr(instance, "_spans")
+        if hasattr(instance, "_datadog_spans"):
+            delattr(instance, "_datadog_spans")
 
     def _llmobs_set_metadata(self, span: Span, model_provider: Optional[str] = None) -> None:
         if not model_provider:


### PR DESCRIPTION
refines the beta span linking logic for llmobs langchain spans to reduce memory

removes the `_spans` mapping of instance IDs to spans. instead, since we really only used this for steps in chains, and the same runnable (e.g. chat model) could be used in different chains, we want to do this mapping by chain instance.

when "recording" an instance we trace, we always do the span --> instance mapping. however, now the instance --> span mapping is only done as a temporary property on chains, as steps outside of chains will be defaulted to their parent span for linkage. this also makes cleanup easier, as we can delete the property and let GC take care of getting rid of the mapping that's unreferenced.

[MLOB-2245]

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)


[MLOB-2245]: https://datadoghq.atlassian.net/browse/MLOB-2245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ