### PR TITLE
chore(configuration): use `get_config` to access telemetry and logging configurations

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -22,7 +22,9 @@ from ._logger import configure_ddtrace_logger
 # configure ddtrace logger before other modules log
 configure_ddtrace_logger()  # noqa: E402
 
-from .settings import _global_config as config
+from .settings._config import Config as _Config
+
+config = _Config()
 
 
 # Enable telemetry writer and excepthook as early as possible to ensure we capture any exceptions from initialization

--- a/ddtrace/_logger.py
+++ b/ddtrace/_logger.py
@@ -1,8 +1,9 @@
 import logging
-import os
+from os import path
 from typing import Optional
 
 from ddtrace.internal.utils.formats import asbool
+from ddtrace.settings._core import get_config
 
 
 DD_LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] {}- %(message)s".format(
@@ -37,7 +38,7 @@ def configure_ddtrace_logger():
 
     """
     ddtrace_logger = logging.getLogger("ddtrace")
-    if asbool(os.environ.get("DD_TRACE_LOG_STREAM_HANDLER", "true")):
+    if get_config("DD_TRACE_LOG_STREAM_HANDLER", True, asbool):
         ddtrace_logger.addHandler(logging.StreamHandler())
 
     _configure_ddtrace_debug_logger(ddtrace_logger)
@@ -45,13 +46,13 @@ def configure_ddtrace_logger():
 
 
 def _configure_ddtrace_debug_logger(logger):
-    if asbool(os.environ.get("DD_TRACE_DEBUG", "false")):
+    if get_config("DD_TRACE_DEBUG", False, asbool):
         logger.setLevel(logging.DEBUG)
         logger.debug("debug mode has been enabled for the ddtrace logger")
 
 
 def _configure_ddtrace_file_logger(logger):
-    log_file_level = os.environ.get("DD_TRACE_LOG_FILE_LEVEL", "DEBUG").upper()
+    log_file_level = get_config("DD_TRACE_LOG_FILE_LEVEL", "DEBUG").upper()
     try:
         file_log_level_value = getattr(logging, log_file_level)
     except AttributeError:
@@ -59,21 +60,21 @@ def _configure_ddtrace_file_logger(logger):
             "DD_TRACE_LOG_FILE_LEVEL is invalid. Log level must be CRITICAL/ERROR/WARNING/INFO/DEBUG.",
             log_file_level,
         )
-    max_file_bytes = int(os.environ.get("DD_TRACE_LOG_FILE_SIZE_BYTES", DEFAULT_FILE_SIZE_BYTES))
-    log_path = os.environ.get("DD_TRACE_LOG_FILE")
+    max_file_bytes = get_config("DD_TRACE_LOG_FILE_SIZE_BYTES", DEFAULT_FILE_SIZE_BYTES, int)
+    log_path = get_config("DD_TRACE_LOG_FILE")
     _add_file_handler(logger=logger, log_path=log_path, log_level=file_log_level_value, max_file_bytes=max_file_bytes)
 
 
 def _add_file_handler(
     logger: logging.Logger,
-    log_path: str,
+    log_path: Optional[str],
     log_level: int,
     handler_name: Optional[str] = None,
     max_file_bytes: int = DEFAULT_FILE_SIZE_BYTES,
 ):
     ddtrace_file_handler = None
     if log_path is not None:
-        log_path = os.path.abspath(log_path)
+        log_path = path.abspath(log_path)
         num_backup = 1
         from logging.handlers import RotatingFileHandler
 

--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING  # noqa:F401
 
 from wrapt.importer import when_imported
 
+from ddtrace import config
 from ddtrace.appsec import load_common_appsec_modules
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.settings.asm import config as asm_config
@@ -12,7 +13,6 @@ from ddtrace.settings.asm import config as asm_config
 from .internal import telemetry
 from .internal.logger import get_logger
 from .internal.utils import formats
-from .settings import _global_config as config
 
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/ddtrace/_trace/sampler.py
+++ b/ddtrace/_trace/sampler.py
@@ -22,7 +22,6 @@ from ..internal.logger import get_logger
 from ..internal.rate_limiter import RateLimiter
 from ..internal.sampling import _get_highest_precedence_rule_matching
 from ..internal.sampling import _set_sampling_tags
-from ..settings import _global_config as ddconfig
 from .sampling_rule import SamplingRule
 
 
@@ -239,16 +238,16 @@ class DatadogSampler(RateByServiceSampler):
         self.default_sample_rate = default_sample_rate
         effective_sample_rate = default_sample_rate
         if default_sample_rate is None:
-            if ddconfig._get_source("_trace_sample_rate") != "default":
-                effective_sample_rate = float(ddconfig._trace_sample_rate)
+            if config._get_source("_trace_sample_rate") != "default":
+                effective_sample_rate = float(config._trace_sample_rate)
 
         if rate_limit is None:
-            rate_limit = int(ddconfig._trace_rate_limit)
+            rate_limit = int(config._trace_rate_limit)
 
         self._rate_limit_always_on = rate_limit_always_on
 
         if rules is None:
-            env_sampling_rules = ddconfig._trace_sampling_rules
+            env_sampling_rules = config._trace_sampling_rules
             if env_sampling_rules:
                 rules = self._parse_rules_from_str(env_sampling_rules)
             else:

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -486,9 +486,9 @@ class Tracer(object):
             config._trace_compute_stats = False
             # Update the rate limiter to 1 trace per minute when tracing is disabled
             if isinstance(sampler, DatadogSampler):
-                sampler._rate_limit_always_on = True
-                sampler.limiter.rate_limit = 1
-                sampler.limiter.time_window = 60e9
+                sampler._rate_limit_always_on = True  # type: ignore[has-type]
+                sampler.limiter.rate_limit = 1  # type: ignore[has-type]
+                sampler.limiter.time_window = 60e9  # type: ignore[has-type]
             else:
                 if sampler is not None:
                     log.warning(

--- a/ddtrace/internal/remoteconfig/worker.py
+++ b/ddtrace/internal/remoteconfig/worker.py
@@ -1,6 +1,7 @@
 import os
 from typing import Set  # noqa:F401
 
+from ddtrace import config as ddconfig
 from ddtrace.internal import agent
 from ddtrace.internal import periodic
 from ddtrace.internal.logger import get_logger
@@ -11,7 +12,6 @@ from ddtrace.internal.remoteconfig.constants import REMOTE_CONFIG_AGENT_ENDPOINT
 from ddtrace.internal.remoteconfig.utils import get_poll_interval_seconds
 from ddtrace.internal.service import ServiceStatus
 from ddtrace.internal.utils.time import StopWatch
-from ddtrace.settings import _global_config as ddconfig
 
 
 log = get_logger(__name__)

--- a/ddtrace/internal/sampling.py
+++ b/ddtrace/internal/sampling.py
@@ -14,6 +14,7 @@ try:
 except ImportError:
     from typing_extensions import TypedDict
 
+from ddtrace import config
 from ddtrace._trace.sampling_rule import SamplingRule  # noqa:F401
 from ddtrace.constants import _SAMPLING_AGENT_DECISION
 from ddtrace.constants import _SAMPLING_RULE_DECISION
@@ -27,7 +28,6 @@ from ddtrace.internal.constants import _REJECT_PRIORITY_INDEX
 from ddtrace.internal.constants import SAMPLING_DECISION_TRACE_TAG_KEY
 from ddtrace.internal.glob_matching import GlobMatcher
 from ddtrace.internal.logger import get_logger
-from ddtrace.settings import _global_config as config
 
 from .rate_limiter import RateLimiter
 

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -65,7 +65,7 @@ class _TelemetryConfig:
     VERSION: str = _get_config("DD_VERSION", "", report_telemetry=False)
     AGENTLESS_MODE: bool = _get_config("DD_CIVISIBILITY_AGENTLESS_ENABLED", False, asbool, report_telemetry=False)
     DEBUG: bool = _get_config("DD_TRACE_DEBUG", False, asbool, report_telemetry=False)
-    HEARTBEAT_INTERVAL: int = _get_config("DD_TELEMETRY_HEARTBEAT_INTERVAL", 60, int, report_telemetry=False)
+    HEARTBEAT_INTERVAL: float = _get_config("DD_TELEMETRY_HEARTBEAT_INTERVAL", 60, float, report_telemetry=False)
     TELEMETRY_ENABLED: bool = _get_config("DD_INSTRUMENTATION_TELEMETRY_ENABLED", True, asbool, report_telemetry=False)
     DEPENDENCY_COLLECTION: bool = _get_config(
         "DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED", True, asbool, report_telemetry=False

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -18,6 +18,7 @@ from ddtrace.internal.logger import get_logger
 
 from ...internal import atexit
 from ...internal import forksafe
+from ...settings._config import _get_config
 from ...settings._inferred_base_service import detect_service
 from ..agent import get_connection
 from ..agent import get_trace_url
@@ -57,22 +58,26 @@ log = get_logger(__name__)
 
 
 class _TelemetryConfig:
-    API_KEY = os.environ.get("DD_API_KEY", None)
-    SITE = os.environ.get("DD_SITE", "datadoghq.com")
-    ENV = os.environ.get("DD_ENV", "")
-    SERVICE = os.environ.get("DD_SERVICE", _inferred_service or "unnamed-python-service")
-    VERSION = os.environ.get("DD_VERSION", "")
-    AGENTLESS_MODE = asbool(os.environ.get("DD_CIVISIBILITY_AGENTLESS_ENABLED", False))
-    HEARTBEAT_INTERVAL = float(os.environ.get("DD_TELEMETRY_HEARTBEAT_INTERVAL", "60"))
-    TELEMETRY_ENABLED = asbool(os.environ.get("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "true").lower())
-    DEPENDENCY_COLLECTION = asbool(os.environ.get("DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED", "true"))
-    INSTALL_ID = os.environ.get("DD_INSTRUMENTATION_INSTALL_ID", None)
-    INSTALL_TYPE = os.environ.get("DD_INSTRUMENTATION_INSTALL_TYPE", None)
-    INSTALL_TIME = os.environ.get("DD_INSTRUMENTATION_INSTALL_TIME", None)
-    FORCE_START = asbool(os.environ.get("_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED", "false"))
-    LOG_COLLECTION_ENABLED = TELEMETRY_ENABLED and os.getenv("DD_TELEMETRY_LOG_COLLECTION_ENABLED", "true").lower() in (
-        "true",
-        "1",
+    API_KEY: str = _get_config("DD_API_KEY", None, report_telemetry=False)
+    SITE: str = _get_config("DD_SITE", "datadoghq.com", report_telemetry=False)
+    ENV: str = _get_config("DD_ENV", "", report_telemetry=False)
+    SERVICE: str = _get_config("DD_SERVICE", _inferred_service or "unnamed-python-service", report_telemetry=False)
+    VERSION: str = _get_config("DD_VERSION", "", report_telemetry=False)
+    AGENTLESS_MODE: bool = _get_config("DD_CIVISIBILITY_AGENTLESS_ENABLED", False, asbool, report_telemetry=False)
+    DEBUG: bool = _get_config("DD_TRACE_DEBUG", False, asbool, report_telemetry=False)
+    HEARTBEAT_INTERVAL: int = _get_config("DD_TELEMETRY_HEARTBEAT_INTERVAL", 60, int, report_telemetry=False)
+    TELEMETRY_ENABLED: bool = _get_config("DD_INSTRUMENTATION_TELEMETRY_ENABLED", True, asbool, report_telemetry=False)
+    DEPENDENCY_COLLECTION: bool = _get_config(
+        "DD_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED", True, asbool, report_telemetry=False
+    )
+    INSTALL_ID: Optional[str] = _get_config("DD_INSTRUMENTATION_INSTALL_ID", None, report_telemetry=False)
+    INSTALL_TYPE: Optional[str] = _get_config("DD_INSTRUMENTATION_INSTALL_TYPE", None, report_telemetry=False)
+    INSTALL_TIME: Optional[str] = _get_config("DD_INSTRUMENTATION_INSTALL_TIME", None, report_telemetry=False)
+    FORCE_START: bool = _get_config(
+        "_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED", False, asbool, report_telemetry=False
+    )
+    LOG_COLLECTION_ENABLED: bool = TELEMETRY_ENABLED and _get_config(
+        "DD_TELEMETRY_LOG_COLLECTION_ENABLED", True, asbool, report_telemetry=False
     )
 
 
@@ -201,7 +206,7 @@ class TelemetryWriter(PeriodicService):
         self.started = False
 
         # Debug flag that enables payload debug mode.
-        self._debug = os.environ.get("DD_TELEMETRY_DEBUG", "false").lower() in ("true", "1")
+        self._debug = _TelemetryConfig.DEBUG
 
         self._enabled = _TelemetryConfig.TELEMETRY_ENABLED
 

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -13,8 +13,8 @@ from typing import Optional
 from typing import TextIO
 
 import ddtrace
+from ddtrace import config
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
-from ddtrace.settings import _global_config as config
 from ddtrace.settings.asm import config as asm_config
 from ddtrace.vendor.dogstatsd import DogStatsd
 

--- a/ddtrace/propagation/_database_monitoring.py
+++ b/ddtrace/propagation/_database_monitoring.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING  # noqa:F401
 from typing import Union  # noqa:F401
 
 import ddtrace
+from ddtrace import config as dd_config
 from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.peer_service import PeerServiceConfig
@@ -10,7 +11,6 @@ from ddtrace.vendor.sqlcommenter import generate_sql_comment as _generate_sql_co
 from ..internal import compat
 from ..internal.utils import get_argument_value
 from ..internal.utils import set_argument_value
-from ..settings import _global_config as dd_config
 from ..settings._database_monitoring import dbm_config
 
 

--- a/ddtrace/settings/__init__.py
+++ b/ddtrace/settings/__init__.py
@@ -5,9 +5,6 @@ from .http import HttpConfig
 from .integration import IntegrationConfig
 
 
-# Default global config
-_global_config = Config()
-
 __all__ = [
     "Config",
     "ConfigException",

--- a/ddtrace/settings/_config.py
+++ b/ddtrace/settings/_config.py
@@ -525,6 +525,8 @@ class Config(object):
         self.env = _get_config("DD_ENV", self.tags.get("env"))
         self.service = _get_config("DD_SERVICE", self.tags.get("service", None), otel_env="OTEL_SERVICE_NAME")
 
+        self._is_user_provided_service = self.service is not None
+
         self._inferred_base_service = detect_service(sys.argv)
 
         if self.service is None and in_gcp_function():

--- a/ddtrace/settings/_core.py
+++ b/ddtrace/settings/_core.py
@@ -35,7 +35,7 @@ def get_config(
     modifier: Optional[Callable[[Any], Any]] = None,
     otel_env: Optional[str] = None,
     report_telemetry=True,
-):
+) -> Any:
     if isinstance(envs, str):
         envs = [envs]
     val = None

--- a/ddtrace/settings/_core.py
+++ b/ddtrace/settings/_core.py
@@ -5,32 +5,12 @@ from typing import List  # noqa:F401
 from typing import Optional  # noqa:F401
 from typing import Union  # noqa:F401
 
-from envier.env import EnvVariable
-from envier.env import _normalized
-
 from ddtrace.internal.native import get_configuration_from_disk
-from ddtrace.internal.telemetry import telemetry_writer
 
-from ._otel_remapper import hiding_otel_config
 from ._otel_remapper import parse_otel_env
 
 
 FLEET_CONFIG, LOCAL_CONFIG = get_configuration_from_disk()
-
-
-def report_telemetry(env: Any) -> None:
-    for name, e in list(env.__class__.__dict__.items()):
-        if isinstance(e, EnvVariable) and not e.private:
-            env_name = env._full_prefix + _normalized(e.name)
-            env_val = e(env, env._full_prefix)
-            raw_val = env.source.get(env_name)
-            if env_name in env.source and env_val == e._cast(e.type, raw_val, env):
-                source = "env_var"
-            elif env_val == e.default:
-                source = "default"
-            else:
-                source = "unknown"
-            telemetry_writer.add_configuration(env_name, env_val, source)
 
 
 def get_config(
@@ -75,8 +55,6 @@ def get_config(
                 source = "env_var"
                 effective_env = otel_env
                 val = parsed_val
-    elif effective_env is not None and otel_env is not None and otel_env in os.environ:
-        hiding_otel_config(otel_env, effective_env)
     # Get configurations from local stable config
     if val is None:
         for env in envs:
@@ -95,10 +73,8 @@ def get_config(
         source = "default"
     # Report telemetry
     if report_telemetry:
-        if effective_env == otel_env:
-            # We only report the raw value for OpenTelemetry configurations, we should make this consistent
-            raw_val = os.environ.get(effective_env, "").lower()
-            telemetry_writer.add_configuration(effective_env, raw_val, source)
-        else:
-            telemetry_writer.add_configuration(effective_env, val, source)
+        from ddtrace.settings._telemetry import report_config_telemetry
+
+        report_config_telemetry(effective_env, val, source, otel_env)
+
     return val

--- a/ddtrace/settings/_otel_remapper.py
+++ b/ddtrace/settings/_otel_remapper.py
@@ -8,8 +8,6 @@ from typing import Tuple
 from ..constants import ENV_KEY
 from ..constants import VERSION_KEY
 from ..internal.logger import get_logger
-from ..internal.telemetry import telemetry_writer
-from ..internal.telemetry.constants import TELEMETRY_NAMESPACE
 
 
 log = get_logger(__name__)
@@ -134,23 +132,6 @@ ENV_VAR_MAPPINGS: Dict[str, Tuple[str, Callable[[str], Optional[str]]]] = {
 }
 
 
-def validate_otel_envs():
-    user_envs = {key.upper(): value for key, value in os.environ.items()}
-    for otel_env, _ in user_envs.items():
-        if (
-            otel_env not in ENV_VAR_MAPPINGS
-            and otel_env.startswith("OTEL_")
-            and otel_env not in ("OTEL_PYTHON_CONTEXT", "OTEL_TRACES_SAMPLER_ARG", "OTEL_LOGS_EXPORTER")
-        ):
-            _unsupported_otel_config(otel_env)
-        elif otel_env == "OTEL_LOGS_EXPORTER":
-            # check for invalid values
-            otel_value = os.environ.get(otel_env, "none").lower()
-            if otel_value != "none":
-                _invalid_otel_config(otel_env)
-            telemetry_writer.add_configuration(otel_env, otel_value, "env_var")
-
-
 def parse_otel_env(otel_env: str) -> Optional[str]:
     _, otel_config_validator = ENV_VAR_MAPPINGS[otel_env]
     raw_value = os.environ.get(otel_env, "")
@@ -159,45 +140,5 @@ def parse_otel_env(otel_env: str) -> Optional[str]:
         raw_value = raw_value.lower()
     mapped_value = otel_config_validator(raw_value)
     if mapped_value is None:
-        _invalid_otel_config(otel_env)
         return None
     return mapped_value
-
-
-def hiding_otel_config(otel_env, dd_env):
-    log.debug(
-        "Datadog configuration %s is already set. OpenTelemetry configuration will be ignored: %s=%s",
-        dd_env,
-        otel_env,
-        os.environ[otel_env],
-    )
-    telemetry_writer.add_count_metric(
-        TELEMETRY_NAMESPACE.TRACERS,
-        "otel.env.hiding",
-        1,
-        (("config_opentelemetry", otel_env.lower()), ("config_datadog", dd_env.lower())),
-    )
-
-
-def _invalid_otel_config(otel_env):
-    log.warning(
-        "Setting %s to %s is not supported by ddtrace, this configuration will be ignored.",
-        otel_env,
-        os.environ.get(otel_env, ""),
-    )
-    telemetry_writer.add_count_metric(
-        TELEMETRY_NAMESPACE.TRACERS,
-        "otel.env.invalid",
-        1,
-        (("config_opentelemetry", otel_env.lower()),),
-    )
-
-
-def _unsupported_otel_config(otel_env):
-    log.warning("OpenTelemetry configuration %s is not supported by Datadog.", otel_env)
-    telemetry_writer.add_count_metric(
-        TELEMETRY_NAMESPACE.TRACERS,
-        "otel.env.unsupported",
-        1,
-        (("config_opentelemetry", otel_env.lower()),),
-    )

--- a/ddtrace/settings/_telemetry.py
+++ b/ddtrace/settings/_telemetry.py
@@ -1,0 +1,98 @@
+import os
+from typing import Any  # noqa:F401
+
+from envier.env import EnvVariable
+from envier.env import _normalized
+
+from ..internal.logger import get_logger
+from ..internal.telemetry import telemetry_writer
+from ..internal.telemetry.constants import TELEMETRY_NAMESPACE
+from ._otel_remapper import ENV_VAR_MAPPINGS
+
+
+log = get_logger(__name__)
+
+
+def report_telemetry(env: Any) -> None:
+    for name, e in list(env.__class__.__dict__.items()):
+        if isinstance(e, EnvVariable) and not e.private:
+            env_name = env._full_prefix + _normalized(e.name)
+            env_val = e(env, env._full_prefix)
+            raw_val = env.source.get(env_name)
+            if env_name in env.source and env_val == e._cast(e.type, raw_val, env):
+                source = "env_var"
+            elif env_val == e.default:
+                source = "default"
+            else:
+                source = "unknown"
+            telemetry_writer.add_configuration(env_name, env_val, source)
+
+
+def validate_otel_envs():
+    user_envs = {key.upper(): value for key, value in os.environ.items()}
+    for otel_env, _ in user_envs.items():
+        if (
+            otel_env not in ENV_VAR_MAPPINGS
+            and otel_env.startswith("OTEL_")
+            and otel_env not in ("OTEL_PYTHON_CONTEXT", "OTEL_TRACES_SAMPLER_ARG", "OTEL_LOGS_EXPORTER")
+        ):
+            _unsupported_otel_config(otel_env)
+        elif otel_env == "OTEL_LOGS_EXPORTER":
+            # check for invalid values
+            otel_value = os.environ.get(otel_env, "none").lower()
+            if otel_value != "none":
+                _invalid_otel_config(otel_env)
+            telemetry_writer.add_configuration(otel_env, otel_value, "env_var")
+
+
+def _hiding_otel_config(otel_env, dd_env):
+    log.debug(
+        "Datadog configuration %s is already set. OpenTelemetry configuration will be ignored: %s=%s",
+        dd_env,
+        otel_env,
+        os.environ[otel_env],
+    )
+    telemetry_writer.add_count_metric(
+        TELEMETRY_NAMESPACE.TRACERS,
+        "otel.env.hiding",
+        1,
+        (("config_opentelemetry", otel_env.lower()), ("config_datadog", dd_env.lower())),
+    )
+
+
+def _invalid_otel_config(otel_env):
+    log.warning(
+        "Setting %s to %s is not supported by ddtrace, this configuration will be ignored.",
+        otel_env,
+        os.environ.get(otel_env, ""),
+    )
+    telemetry_writer.add_count_metric(
+        TELEMETRY_NAMESPACE.TRACERS,
+        "otel.env.invalid",
+        1,
+        (("config_opentelemetry", otel_env.lower()),),
+    )
+
+
+def _unsupported_otel_config(otel_env):
+    log.warning("OpenTelemetry configuration %s is not supported by Datadog.", otel_env)
+    telemetry_writer.add_count_metric(
+        TELEMETRY_NAMESPACE.TRACERS,
+        "otel.env.unsupported",
+        1,
+        (("config_opentelemetry", otel_env.lower()),),
+    )
+
+
+def report_config_telemetry(effective_env, val, source, otel_env):
+    if effective_env == otel_env:
+        # We only report the raw value for OpenTelemetry configurations, we should make this consistent
+        raw_val = os.environ.get(effective_env, "").lower()
+        telemetry_writer.add_configuration(effective_env, raw_val, source)
+    else:
+        if otel_env is not None and otel_env in os.environ:
+            if source in ("fleet_stable_config", "env_var"):
+                _hiding_otel_config(otel_env, effective_env)
+            else:
+                _invalid_otel_config(otel_env)
+        telemetry_writer.add_configuration(effective_env, val, source)

--- a/ddtrace/settings/asm.py
+++ b/ddtrace/settings/asm.py
@@ -19,7 +19,7 @@ from ddtrace.appsec._constants import TELEMETRY_INFORMATION_NAME
 from ddtrace.constants import APPSEC_ENV
 from ddtrace.internal import core
 from ddtrace.internal.serverless import in_aws_lambda
-from ddtrace.settings._core import report_telemetry as _report_telemetry
+from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 
 
 def _validate_non_negative_int(r: int) -> None:

--- a/ddtrace/settings/crashtracker.py
+++ b/ddtrace/settings/crashtracker.py
@@ -3,7 +3,7 @@ import typing as t
 from envier import En
 
 from ddtrace.internal.utils.formats import parse_tags_str
-from ddtrace.settings._core import report_telemetry as _report_telemetry
+from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 
 
 resolver_default = "full"

--- a/ddtrace/settings/dynamic_instrumentation.py
+++ b/ddtrace/settings/dynamic_instrumentation.py
@@ -3,11 +3,11 @@ import typing as t
 
 from envier import En
 
+from ddtrace import config as ddconfig
 from ddtrace.internal import gitmetadata
 from ddtrace.internal.agent import get_trace_url
 from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
 from ddtrace.internal.utils.config import get_application_name
-from ddtrace.settings import _global_config as ddconfig
 from ddtrace.settings._core import report_telemetry as _report_telemetry
 from ddtrace.version import get_version
 

--- a/ddtrace/settings/dynamic_instrumentation.py
+++ b/ddtrace/settings/dynamic_instrumentation.py
@@ -8,7 +8,7 @@ from ddtrace.internal import gitmetadata
 from ddtrace.internal.agent import get_trace_url
 from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
 from ddtrace.internal.utils.config import get_application_name
-from ddtrace.settings._core import report_telemetry as _report_telemetry
+from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 from ddtrace.version import get_version
 
 

--- a/ddtrace/settings/exception_replay.py
+++ b/ddtrace/settings/exception_replay.py
@@ -1,6 +1,6 @@
 from envier import En
 
-from ddtrace.settings._core import report_telemetry as _report_telemetry
+from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 
 
 class ExceptionReplayConfig(En):

--- a/ddtrace/settings/peer_service.py
+++ b/ddtrace/settings/peer_service.py
@@ -4,7 +4,7 @@ from ddtrace.ext import SpanKind
 from ddtrace.internal.schema import SCHEMA_VERSION
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import parse_tags_str
-from ddtrace.settings._core import report_telemetry as _report_telemetry
+from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 
 
 class PeerServiceConfig(object):

--- a/ddtrace/settings/profiling.py
+++ b/ddtrace/settings/profiling.py
@@ -13,7 +13,7 @@ from ddtrace.internal import compat
 from ddtrace.internal import gitmetadata
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import parse_tags_str
-from ddtrace.settings._core import report_telemetry as _report_telemetry
+from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 
 
 logger = get_logger(__name__)

--- a/ddtrace/settings/symbol_db.py
+++ b/ddtrace/settings/symbol_db.py
@@ -2,7 +2,7 @@ import re
 
 from envier import En
 
-from ddtrace.settings._core import report_telemetry as _report_telemetry
+from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 
 
 class SymbolDatabaseConfig(En):

--- a/tests/contrib/logging/test_tracer_logging.py
+++ b/tests/contrib/logging/test_tracer_logging.py
@@ -220,9 +220,9 @@ import ddtrace
 ddtrace_logger = logging.getLogger('ddtrace')
 assert ddtrace_logger.getEffectiveLevel() == logging.WARN
 assert len(ddtrace_logger.handlers) == 3
-assert isinstance(ddtrace_logger.handlers[1], logging.handlers.RotatingFileHandler)
-assert ddtrace_logger.handlers[1].maxBytes == 200000
-assert ddtrace_logger.handlers[1].backupCount == 1
+assert isinstance(ddtrace_logger.handlers[2], logging.handlers.RotatingFileHandler)
+assert ddtrace_logger.handlers[2].maxBytes == 200000
+assert ddtrace_logger.handlers[2].backupCount == 1
 
 ddtrace_logger.warning('warning log')
 """
@@ -233,9 +233,9 @@ import logging
 ddtrace_logger = logging.getLogger('ddtrace')
 assert ddtrace_logger.getEffectiveLevel() == logging.WARN
 assert len(ddtrace_logger.handlers) == 3
-assert isinstance(ddtrace_logger.handlers[1], logging.handlers.RotatingFileHandler)
-assert ddtrace_logger.handlers[1].maxBytes == 200000
-assert ddtrace_logger.handlers[1].backupCount == 1
+assert isinstance(ddtrace_logger.handlers[2], logging.handlers.RotatingFileHandler)
+assert ddtrace_logger.handlers[2].maxBytes == 200000
+assert ddtrace_logger.handlers[2].backupCount == 1
 
 ddtrace_logger.warning('warning log')
 """
@@ -335,11 +335,11 @@ import ddtrace
 ddtrace_logger = logging.getLogger('ddtrace')
 assert ddtrace_logger.getEffectiveLevel() == logging.DEBUG
 assert len(ddtrace_logger.handlers) == 3
-assert isinstance(ddtrace_logger.handlers[1], logging.handlers.RotatingFileHandler)
-assert ddtrace_logger.handlers[1].maxBytes == 10
-assert ddtrace_logger.handlers[1].backupCount == 1
+assert isinstance(ddtrace_logger.handlers[2], logging.handlers.RotatingFileHandler)
+assert ddtrace_logger.handlers[2].maxBytes == 10
+assert ddtrace_logger.handlers[2].backupCount == 1
 if os.environ.get("DD_TRACE_LOG_FILE_LEVEL") is not None:
-    ddtrace_logger.handlers[1].level == getattr(logging, os.environ.get("DD_TRACE_LOG_FILE_LEVEL"))
+    ddtrace_logger.handlers[2].level == getattr(logging, os.environ.get("DD_TRACE_LOG_FILE_LEVEL"))
 
 ddtrace_logger = logging.getLogger('ddtrace')
 
@@ -349,6 +349,7 @@ for attempt in range(100):
 """
 
     out, err, status, pid = run_python_code_in_subprocess(code, env=env)
+
     assert status == 0, err
 
     assert out == b""
@@ -362,12 +363,12 @@ import os
 ddtrace_logger = logging.getLogger('ddtrace')
 assert ddtrace_logger.getEffectiveLevel() == logging.DEBUG
 assert len(ddtrace_logger.handlers) == 3
-assert isinstance(ddtrace_logger.handlers[1], logging.handlers.RotatingFileHandler)
-assert ddtrace_logger.handlers[1].maxBytes == 10
-assert ddtrace_logger.handlers[1].backupCount == 1
+assert isinstance(ddtrace_logger.handlers[2], logging.handlers.RotatingFileHandler)
+assert ddtrace_logger.handlers[2].maxBytes == 10
+assert ddtrace_logger.handlers[2].backupCount == 1
 
 if os.environ.get("DD_TRACE_LOG_FILE_LEVEL") is not None:
-    ddtrace_logger.handlers[1].level == getattr(logging, os.environ.get("DD_TRACE_LOG_FILE_LEVEL"))
+    ddtrace_logger.handlers[2].level == getattr(logging, os.environ.get("DD_TRACE_LOG_FILE_LEVEL"))
 
 for attempt in range(100):
     ddtrace_logger.debug('ddtrace multiple debug log')

--- a/tests/opentelemetry/test_config.py
+++ b/tests/opentelemetry/test_config.py
@@ -313,14 +313,14 @@ def test_otel_resource_attributes_tags_warning():
     }, config.tags
 
 
-@pytest.mark.subprocess(env={"OTEL_SDK_DISABLED": "false"})
+@pytest.mark.subprocess(env={"OTEL_SDK_DISABLED": "false", "DD_TRACE_OTEL_ENABLED": None})
 def test_otel_sdk_disabled_configuration():
     from ddtrace import config
 
     assert config._otel_enabled is True
 
 
-@pytest.mark.subprocess(env={"OTEL_SDK_DISABLED": "true", "DD_TRACE_OTEL_ENABLED": ""})
+@pytest.mark.subprocess(env={"OTEL_SDK_DISABLED": "true", "DD_TRACE_OTEL_ENABLED": None})
 def test_otel_sdk_disabled_configuration_true():
     from ddtrace import config
 

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -9,13 +9,13 @@ import httpretty
 import mock
 import pytest
 
+from ddtrace import config
 import ddtrace.internal.telemetry
 from ddtrace.internal.telemetry.constants import TELEMETRY_APM_PRODUCT
 from ddtrace.internal.telemetry.data import get_application
 from ddtrace.internal.telemetry.data import get_host_info
 from ddtrace.internal.telemetry.writer import get_runtime_id
 from ddtrace.internal.utils.version import _pep440_to_semver
-from ddtrace.settings import _global_config as config
 from ddtrace.settings._config import DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP_DEFAULT
 from tests.conftest import DEFAULT_DDTRACE_SUBPROCESS_TEST_SERVICE_NAME
 from tests.utils import override_global_config
@@ -440,6 +440,10 @@ import ddtrace.settings.exception_replay
         {"name": "DD_TRACE_HTTP_CLIENT_TAG_QUERY_STRING", "origin": "default", "value": "true"},
         {"name": "DD_TRACE_HTTP_SERVER_ERROR_STATUSES", "origin": "default", "value": "500-599"},
         {"name": "DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED", "origin": "default", "value": False},
+        {"name": "DD_TRACE_LOG_FILE", "origin": "default", "value": None},
+        {"name": "DD_TRACE_LOG_FILE_LEVEL", "origin": "default", "value": "DEBUG"},
+        {"name": "DD_TRACE_LOG_FILE_SIZE_BYTES", "origin": "default", "value": 15728640},
+        {"name": "DD_TRACE_LOG_STREAM_HANDLER", "origin": "default", "value": True},
         {"name": "DD_TRACE_METHODS", "origin": "default", "value": None},
         {"name": "DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP", "origin": "env_var", "value": ".*"},
         {"name": "DD_TRACE_OTEL_ENABLED", "origin": "env_var", "value": True},


### PR DESCRIPTION
## Description

- Uses `ddtrace.settings._core.get_config` to set configurations in the telemtry writer. This allows telemetry to be configured via stable configuration and otel environment variables. Currently the telemetry writer is only uses configures in Datadog environment variables.
- Uses `ddtrace.settings._core.get_config` to set configurations in ddtrace loggers. This will allow us to configure loggers remotely and enable debug mode. 

## Motivation

Ensures `ddtrace.settings._core.get_config` can be used without initializing the global config object. This will allow us to replace most instance of `os.environ` with an function that:
- collects instrumentation telemetry about configurations
- supports loading configurations from files (via stable/static apm config)
- Respects the precedence of ddtrace configurations (fleet stable config -> datadog env -> otel env -> local stable config -> default)


Follow up: https://github.com/DataDog/dd-trace-py/pull/12347/files

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
