### PR TITLE
feat(llmobs): support multithreading context propagation

### DIFF
--- a/ddtrace/contrib/internal/futures/threading.py
+++ b/ddtrace/contrib/internal/futures/threading.py
@@ -1,6 +1,8 @@
 from typing import Optional
+from typing import Tuple
 
 import ddtrace
+from ddtrace.internal import core
 from ddtrace.trace import Context
 
 
@@ -12,6 +14,7 @@ def _wrap_submit(func, args, kwargs):
     """
     # DEV: Be sure to propagate a Context and not a Span since we are crossing thread boundaries
     current_ctx: Optional[Context] = ddtrace.tracer.current_trace_context()
+    llmobs_ctx: Optional[Context] = core.dispatch_with_results("threading.submit", ()).llmobs_ctx.value
 
     # The target function can be provided as a kwarg argument "fn" or the first positional argument
     self = args[0]
@@ -20,10 +23,10 @@ def _wrap_submit(func, args, kwargs):
         fn_args = args[1:]
     else:
         fn, fn_args = args[1], args[2:]
-    return func(self, _wrap_execution, current_ctx, fn, fn_args, kwargs)
+    return func(self, _wrap_execution, (current_ctx, llmobs_ctx), fn, fn_args, kwargs)
 
 
-def _wrap_execution(ctx: Optional[Context], fn, args, kwargs):
+def _wrap_execution(ctx: Tuple[Optional[Context], Optional[Context]], fn, args, kwargs):
     """
     Intermediate target function that is executed in a new thread;
     it receives the original function with arguments and keyword
@@ -31,6 +34,8 @@ def _wrap_execution(ctx: Optional[Context], fn, args, kwargs):
     provider sets the Active context in a thread local storage
     variable because it's outside the asynchronous loop.
     """
-    if ctx is not None:
-        ddtrace.tracer.context_provider.activate(ctx)
+    if ctx[0] is not None:
+        ddtrace.tracer.context_provider.activate(ctx[0])
+    if ctx[1] is not None:
+        core.dispatch("threading.execution", (ctx[1],))
     return fn(*args, **kwargs)

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -290,6 +290,8 @@ class LLMObs(Service):
         core.reset_listeners("trace.span_finish", self._on_span_finish)
         core.reset_listeners("http.span_inject", self._inject_llmobs_context)
         core.reset_listeners("http.activate_distributed_headers", self._activate_llmobs_distributed_context)
+        core.reset_listeners("threading.submit", self._current_trace_context)
+        core.reset_listeners("threading.execution", self._llmobs_context_provider.activate)
 
         forksafe.unregister(self._child_after_fork)
 
@@ -373,6 +375,8 @@ class LLMObs(Service):
         core.on("trace.span_finish", cls._instance._on_span_finish)
         core.on("http.span_inject", cls._inject_llmobs_context)
         core.on("http.activate_distributed_headers", cls._activate_llmobs_distributed_context)
+        core.on("threading.submit", cls._instance._current_trace_context, "llmobs_ctx")
+        core.on("threading.execution", cls._instance._llmobs_context_provider.activate)
 
         atexit.register(cls.disable)
         telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.LLMOBS, True)

--- a/releasenotes/notes/feat-llmobs-multithreading-783f29a684256b86.yaml
+++ b/releasenotes/notes/feat-llmobs-multithreading-783f29a684256b86.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    LLM Observability: Introduces automatic distributed tracing support for LLM Observability traces involving the ``concurrent.futures.thread`` module.

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -1,6 +1,8 @@
 import json
 import os
 
+from ddtrace.contrib.internal.futures.patch import patch as patch_futures
+from ddtrace.contrib.internal.futures.patch import unpatch as unpatch_futures
 from ddtrace.llmobs._constants import PARENT_ID_KEY
 from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
@@ -267,3 +269,53 @@ print(json.dumps(headers))
     with llmobs.task("LLMObs span") as span:
         assert str(span.parent_id) == headers["x-datadog-parent-id"]
         assert span._get_ctx_item(PARENT_ID_KEY) == ROOT_PARENT_ID
+
+
+def test_threading_submit_propagation(llmobs, llmobs_events):
+    patch_futures()
+    import concurrent.futures
+
+    def fn():
+        with llmobs.task("executor.thread"):
+            return 42
+
+    with llmobs.workflow("main.thread"):
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            future = executor.submit(fn)
+            result = future.result()
+            assert result == 42
+    assert len(llmobs_events) == 2
+    main_thread_span, executor_thread_span = None, None
+    for span in llmobs_events:
+        if span["name"] == "main.thread":
+            main_thread_span = span
+        else:
+            executor_thread_span = span
+    assert main_thread_span["parent_id"] == ROOT_PARENT_ID
+    assert executor_thread_span["parent_id"] == main_thread_span["span_id"]
+    unpatch_futures()
+
+
+def test_threading_map_propagation(llmobs, llmobs_events):
+    patch_futures()
+    import concurrent.futures
+
+    def fn(value):
+        with llmobs.task("executor.thread"):
+            return value
+
+    with llmobs.workflow("main.thread"):
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            _ = executor.map(fn, (1, 2))
+    assert len(llmobs_events) == 3
+    main_thread_span = None
+    executor_thread_spans = []
+    for span in llmobs_events:
+        if span["name"] == "main.thread":
+            main_thread_span = span
+        else:
+            executor_thread_spans.append(span)
+    assert main_thread_span["parent_id"] == ROOT_PARENT_ID
+    assert executor_thread_spans[0]["parent_id"] == main_thread_span["span_id"]
+    assert executor_thread_spans[1]["parent_id"] == main_thread_span["span_id"]
+    unpatch_futures()


### PR DESCRIPTION
This PR adds support for propagating llmobs contexts across multithreaded applications.

Prior to #10138 we were using the Context object to propagate distributed tracing parent IDs. This didn't work in multithreaded applications because the context object's _meta field was not thread safe (See #10138 for more details). Since we now have our own context manager/provider, we can simply propagate this across contexts/threads by adding support in the futures concurrent threading integration.

I used signal handling here to avoid any unnecessary import/load/startup of LLMObs code if LLMObs is not enabled.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
