### PR TITLE
chore(langgraph): update tracer.current_span with llmobs context manager check

### DIFF
--- a/ddtrace/llmobs/_integrations/langgraph.py
+++ b/ddtrace/llmobs/_integrations/langgraph.py
@@ -3,8 +3,8 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-from ddtrace.ext import SpanTypes
 from ddtrace.internal.utils import get_argument_value
+from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs._constants import INPUT_VALUE
 from ddtrace.llmobs._constants import NAME
 from ddtrace.llmobs._constants import OUTPUT_VALUE
@@ -17,7 +17,6 @@ from ddtrace.llmobs._integrations.utils import format_langchain_io
 from ddtrace.llmobs._utils import _get_attr
 from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
 from ddtrace.trace import Span
-from ddtrace.trace import tracer
 
 
 class LangGraphIntegration(BaseLLMIntegration):
@@ -67,9 +66,9 @@ class LangGraphIntegration(BaseLLMIntegration):
         if not self.llmobs_enabled:
             return
         graph_span = (
-            tracer.current_span()
+            LLMObs._instance._current_span()
         )  # we're running between nodes, so the current span should be the pregel graph
-        if graph_span is None or graph_span.span_type != SpanTypes.LLM:
+        if graph_span is None:
             return
 
         if not more_tasks:


### PR DESCRIPTION
changes a `tracer.current_span()` call to `LLMObs._instance._current_span()` to ensure we are dealing with the current LLMObs span.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
