### PR TITLE
chore: fix incorrect test name issue in flaky test script

### DIFF
--- a/scripts/report_skipped_flaky.py
+++ b/scripts/report_skipped_flaky.py
@@ -8,7 +8,7 @@ from codeowners import CodeOwners
 
 
 FLAKY_PATTERN = re.compile(r'^\s*@flaky\(\s*(?:until=)?(\d+),?\s*(?:reason=\s*"(.*?)")?\s*\)?', re.IGNORECASE)
-TEST_FUNCTION_PATTERN = re.compile(r"^\s*def\s+(test_\w+)\s*\(", re.IGNORECASE)
+TEST_FUNCTION_PATTERN = re.compile(r"^\s*(?:async\s+)?def\s+(test_\w+)\s*\(", re.IGNORECASE)
 
 TEST_DIR = "tests"
 EXCLUDE_DIR = "tests/contrib/pytest"
@@ -56,6 +56,7 @@ def extract_flaky_tests(file_path):
                 timestamp, reason = int(flaky_match.group(1)), flaky_match.group(2)
                 flaky_tests.append((test_name, file_path, timestamp, reason))
                 flaky_match = None  # Reset for the next test function
+                test_name = None
 
     except (UnicodeDecodeError, IOError):
         print(f"Skipping file due to encoding issue: {file_path}")


### PR DESCRIPTION
Fixes a small bug in the flaky test script that would show the wrong test name for some entries. Count is still accurate.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
