### PR TITLE
fix(asm): improve BlockingException catch for fastapi

### DIFF
--- a/ddtrace/contrib/internal/asgi/middleware.py
+++ b/ddtrace/contrib/internal/asgi/middleware.py
@@ -311,6 +311,11 @@ class TraceMiddleware:
             except BlockingException as e:
                 set_blocked(e.args[0])
                 return await _blocked_asgi_app(scope, receive, wrapped_blocked_send)
+            except Exception as exc:
+                (exc_type, exc_val, exc_tb) = sys.exc_info()
+                span.set_exc_info(exc_type, exc_val, exc_tb)
+                self.handle_exception_span(exc, span)
+                raise
             except BaseException as exception:
                 # managing python 3.11+ BaseExceptionGroup with compatible code for 3.10 and below
                 if exception.__class__.__name__ == "BaseExceptionGroup":
@@ -318,11 +323,6 @@ class TraceMiddleware:
                         if isinstance(exc, BlockingException):
                             set_blocked(exc.args[0])
                             return await _blocked_asgi_app(scope, receive, wrapped_blocked_send)
-                raise
-            except Exception as exc:
-                (exc_type, exc_val, exc_tb) = sys.exc_info()
-                span.set_exc_info(exc_type, exc_val, exc_tb)
-                self.handle_exception_span(exc, span)
                 raise
             finally:
                 core.dispatch("web.request.final_tags", (span,))

--- a/ddtrace/contrib/internal/asgi/middleware.py
+++ b/ddtrace/contrib/internal/asgi/middleware.py
@@ -311,6 +311,14 @@ class TraceMiddleware:
             except BlockingException as e:
                 set_blocked(e.args[0])
                 return await _blocked_asgi_app(scope, receive, wrapped_blocked_send)
+            except BaseException as exception:
+                # managing python 3.11+ BaseExceptionGroup with compatible code for 3.10 and below
+                if exception.__class__.__name__ == "BaseExceptionGroup":
+                    for exc in exception.exceptions:
+                        if isinstance(exc, BlockingException):
+                            set_blocked(exc.args[0])
+                            return await _blocked_asgi_app(scope, receive, wrapped_blocked_send)
+                raise
             except Exception as exc:
                 (exc_type, exc_val, exc_tb) = sys.exc_info()
                 span.set_exc_info(exc_type, exc_val, exc_tb)

--- a/releasenotes/notes/fix_blocking_on_fastapi_with_middleware-08ac58a6b112e29f.yaml
+++ b/releasenotes/notes/fix_blocking_on_fastapi_with_middleware-08ac58a6b112e29f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    ASM: This fix resolves an issue where blocking mechanism could partially fail with a 500 error on fastapi with python>=3.11 with a custom middleware.
+


### PR DESCRIPTION
Fastapi middleware use BaseExceptionGroup on python 3.11. With a custom middleware, this mechanism could encapsulate BlockingException raised by our blocking mechanism, preventing it to be properly caught to generate a proper blocking response.

This will be tested permanently by the `fastapi` weblog, as https://github.com/DataDog/system-tests/pull/4125 adds a custom middleware to simulate ATO automatic instrumentation.

Due to our mandatory compatibility with previous python version, we can't use syntaxic sugar to handle exception group.


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
