### PR TITLE
fix(lib-injection): prevent partial copy failures from stopping application startup

### DIFF
--- a/releasenotes/notes/fix-bad-lib-injection-copy-4829375eda10a561.yaml
+++ b/releasenotes/notes/fix-bad-lib-injection-copy-4829375eda10a561.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    lib-injection: Address partial library copy failures causing failed application startups in k8s.


### PR DESCRIPTION
The fix is a revert of a change in shared build script: https://github.com/DataDog/libdatadog-build/pull/75

The copy script was changed to only try to copy the library files once. Meaning if the init container gets OOM Killed then we won't try to copy the files again (which will likely fail). However, this may leave the library in a partially copied state which will prevent the application from loading properly.

The change to the copy script has been reverted and now we are only `cp -r source dest` again.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
