### PR TITLE
chore(llmobs): remove integration logs and metrics functionality

### DIFF
--- a/ddtrace/contrib/internal/langchain/utils.py
+++ b/ddtrace/contrib/internal/langchain/utils.py
@@ -33,7 +33,6 @@ class TracedLangchainStreamResponse(BaseTracedLangChainStreamResponse):
             raise
         except Exception:
             self._dd_span.set_exc_info(*sys.exc_info())
-            self._dd_integration.metric(self._dd_span, "incr", "request.error", 1)
             self._dd_span.finish()
             raise
 
@@ -60,7 +59,6 @@ class TracedLangchainAsyncStreamResponse(BaseTracedLangChainStreamResponse):
             raise
         except Exception:
             self._dd_span.set_exc_info(*sys.exc_info())
-            self._dd_integration.metric(self._dd_span, "incr", "request.error", 1)
             self._dd_span.finish()
             raise
 
@@ -99,8 +97,6 @@ def shared_stream(
         # error with the method call itself
         span.set_exc_info(*sys.exc_info())
         span.finish()
-        integration.metric(span, "incr", "request.error", 1)
-        integration.metric(span, "dist", "request.duration", span.duration_ns)
         raise
 
 

--- a/ddtrace/llmobs/_integrations/base.py
+++ b/ddtrace/llmobs/_integrations/base.py
@@ -1,6 +1,5 @@
 import abc
 import os
-import time
 from typing import Any  # noqa:F401
 from typing import Dict  # noqa:F401
 from typing import List  # noqa:F401
@@ -11,15 +10,11 @@ from ddtrace._trace.sampler import RateSampler
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.contrib.internal.trace_utils import int_service
 from ddtrace.ext import SpanTypes
-from ddtrace.internal.agent import get_stats_url
-from ddtrace.internal.dogstatsd import get_dogstatsd_client
-from ddtrace.internal.hostname import get_hostname
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.llmobs._llmobs import LLMObs
-from ddtrace.llmobs._log_writer import V2LogWriter
 from ddtrace.settings import IntegrationConfig
 from ddtrace.trace import Pin
 from ddtrace.trace import Span
@@ -36,30 +31,10 @@ class BaseLLMIntegration:
         # use a different hostname. eg. tracer.configure(host="new-hostname")
         # Ideally the metrics client should live on the tracer or some other core
         # object that is strongly linked with configuration.
-        self._log_writer = None
-        self._statsd = None
         self.integration_config = integration_config
         self._span_pc_sampler = RateSampler(
             sample_rate=getattr(integration_config, "span_prompt_completion_sample_rate", 1.0)
         )
-
-        if self.metrics_enabled:
-            self._statsd = get_dogstatsd_client(get_stats_url(), namespace=self._integration_name)
-        if self.logs_enabled:
-            if not config._dd_api_key:
-                raise ValueError(
-                    f"DD_API_KEY is required for sending logs from the {self._integration_name} integration. "
-                    f"To use the {self._integration_name} integration without logs, "
-                    f"set `DD_{self._integration_name.upper()}_LOGS_ENABLED=false`."
-                )
-            self._log_writer = V2LogWriter(
-                site=config._dd_site,
-                api_key=config._dd_api_key,
-                interval=float(os.getenv("_DD_%s_LOG_WRITER_INTERVAL" % self._integration_name.upper(), "1.0")),
-                timeout=float(os.getenv("_DD_%s_LOG_WRITER_TIMEOUT" % self._integration_name.upper(), "2.0")),
-            )
-            self._log_pc_sampler = RateSampler(sample_rate=integration_config.log_prompt_completion_sample_rate)
-            self.start_log_writer()
         self._llmobs_pc_sampler = RateSampler(sample_rate=config._llmobs_sample_rate)
 
     @property
@@ -67,24 +42,6 @@ class BaseLLMIntegration:
         return asbool(os.getenv("_DD_LLMOBS_AUTO_SPAN_LINKING_ENABLED", "false")) or asbool(
             os.getenv("_DD_TRACE_LANGGRAPH_ENABLED", "false")
         )
-
-    @property
-    def metrics_enabled(self) -> bool:
-        """
-        Return whether submitting metrics is enabled for this integration. Agentless mode disables submitting metrics.
-        """
-        if config._llmobs_agentless_enabled:
-            return False
-        if hasattr(self.integration_config, "metrics_enabled"):
-            return asbool(self.integration_config.metrics_enabled)
-        return False
-
-    @property
-    def logs_enabled(self) -> bool:
-        """Return whether submitting logs is enabled for this integration."""
-        if hasattr(self.integration_config, "logs_enabled"):
-            return asbool(self.integration_config.logs_enabled)
-        return False
 
     @property
     def llmobs_enabled(self) -> bool:
@@ -96,23 +53,11 @@ class BaseLLMIntegration:
             return False
         return self._span_pc_sampler.sample(span)
 
-    def is_pc_sampled_log(self, span: Span) -> bool:
-        if not self.logs_enabled:
-            return False
-        if span.context.sampling_priority is not None and span.context.sampling_priority <= 0:
-            return False
-        return self._log_pc_sampler.sample(span)
-
     def is_pc_sampled_llmobs(self, span: Span) -> bool:
         # Sampling of llmobs payloads is independent of spans, but we're using a RateSampler for consistency.
         if not self.llmobs_enabled:
             return False
         return self._llmobs_pc_sampler.sample(span)
-
-    def start_log_writer(self) -> None:
-        if not self.logs_enabled or self._log_writer is None:
-            return
-        self._log_writer.start()
 
     @abc.abstractmethod
     def _set_base_span_tags(self, span: Span, **kwargs) -> None:
@@ -146,55 +91,6 @@ class BaseLLMIntegration:
                 ),
             )
         return span
-
-    @classmethod
-    @abc.abstractmethod
-    def _logs_tags(cls, span: Span) -> str:
-        """Generate ddtags from the corresponding span."""
-        pass
-
-    def log(self, span: Span, level: str, msg: str, attrs: Dict[str, Any]) -> None:
-        if not self.logs_enabled or self._log_writer is None:
-            return
-        tags = self._logs_tags(span)
-        log = {
-            "timestamp": time.time() * 1000,
-            "message": msg,
-            "hostname": get_hostname(),
-            "ddsource": self._integration_name,
-            "service": span.service or "",
-            "status": level,
-            "ddtags": tags,
-        }
-        if span is not None:
-            # FIXME: this is a temporary workaround until we figure out why 128 bit trace IDs are stored as decimals.
-            # log["dd.trace_id"] = str(span.trace_id)
-            log["dd.trace_id"] = "{:x}".format(span.trace_id)
-            log["dd.span_id"] = str(span.span_id)
-        log.update(attrs)
-        self._log_writer.enqueue(log)  # type: ignore[arg-type]
-
-    @classmethod
-    @abc.abstractmethod
-    def _metrics_tags(cls, span: Span) -> List[str]:
-        """Generate a list of metrics tags from a given span."""
-        return []
-
-    def metric(self, span: Span, kind: str, name: str, val: Any, tags: Optional[List[str]] = None) -> None:
-        """Set a metric using the context from the given span."""
-        if not self.metrics_enabled or self._statsd is None:
-            return
-        metric_tags = self._metrics_tags(span)
-        if tags:
-            metric_tags += tags
-        if kind == "dist":
-            self._statsd.distribution(name, val, tags=metric_tags)
-        elif kind == "incr":
-            self._statsd.increment(name, val, tags=metric_tags)
-        elif kind == "gauge":
-            self._statsd.gauge(name, val, tags=metric_tags)
-        else:
-            raise ValueError("Unexpected metric type %r" % kind)
 
     def trunc(self, text: str) -> str:
         """Truncate the given text.

--- a/tests/llmobs/test_llmobs_integrations.py
+++ b/tests/llmobs/test_llmobs_integrations.py
@@ -8,10 +8,8 @@ from tests.utils import DummyTracer
 @pytest.fixture(scope="function")
 def mock_integration_config(ddtrace_global_config):
     mock_config = mock.Mock()
-    mock_config.metrics_enabled = True
     mock_config.span_char_limit = 10
     mock_config.span_prompt_completion_sample_rate = 1.0
-    mock_config.log_prompt_completion_sample_rate = 1.0
     yield mock_config
 
 
@@ -38,40 +36,6 @@ def test_integration_truncate(mock_integration_config):
     assert integration.trunc("123") == "123"
 
 
-def test_integration_metrics_enabled(mock_integration_config, ddtrace_global_config, monkeypatch):
-    """Metrics should only ever be submitted if not in agentless mode, and if metrics env var is set to true."""
-    monkeypatch.setenv("DD_BASELLM_METRICS_ENABLED", "1")
-    integration = BaseLLMIntegration(mock_integration_config)
-    assert integration.metrics_enabled is True
-
-    monkeypatch.setenv("DD_BASELLM_METRICS_ENABLED", "1")
-    ddtrace_global_config._llmobs_agentless_enabled = True
-    integration = BaseLLMIntegration(mock_integration_config)
-    assert integration.metrics_enabled is False
-
-    monkeypatch.setenv("DD_BASELLM_METRICS_ENABLED", "0")
-    mock_integration_config.metrics_enabled = False
-    ddtrace_global_config._llmobs_agentless_enabled = True
-    integration = BaseLLMIntegration(mock_integration_config)
-    assert integration.metrics_enabled is False
-
-    monkeypatch.setenv("DD_BASELLM_METRICS_ENABLED", "0")
-    mock_integration_config.metrics_enabled = False
-    ddtrace_global_config._llmobs_agentless_enabled = False
-    integration = BaseLLMIntegration(mock_integration_config)
-    assert integration.metrics_enabled is False
-
-
-def test_integration_logs_enabled(mock_integration_config):
-    mock_integration_config.logs_enabled = False
-    integration = BaseLLMIntegration(mock_integration_config)
-    assert integration.logs_enabled is False
-
-    mock_integration_config.logs_enabled = True
-    integration = BaseLLMIntegration(mock_integration_config)
-    assert integration.logs_enabled is True
-
-
 @mock.patch("ddtrace.llmobs._integrations.base.LLMObs")
 def test_integration_llmobs_enabled(mock_llmobs, mock_integration_config):
     mock_llmobs.enabled = True
@@ -95,21 +59,6 @@ def test_pc_span_sampling(mock_integration_config, mock_pin):
         assert integration.is_pc_sampled_span(mock_span) is False
 
 
-def test_pc_span_sampling_log(mock_integration_config, mock_pin):
-    mock_integration_config.logs_enabled = True
-    integration = BaseLLMIntegration(mock_integration_config)
-    integration.pin = mock_pin
-    with mock_pin.tracer.trace("Dummy span") as mock_span:
-        assert integration.is_pc_sampled_log(mock_span) is True
-
-    mock_integration_config.log_prompt_completion_sample_rate = 0.0
-    mock_integration_config.logs_enabled = False
-    integration = BaseLLMIntegration(mock_integration_config)
-    integration.pin = mock_pin
-    with mock_pin.tracer.trace("Dummy span") as mock_span:
-        assert integration.is_pc_sampled_log(mock_span) is False
-
-
 @mock.patch("ddtrace.llmobs._integrations.base.LLMObs")
 def test_pc_span_sampling_llmobs(mock_llmobs, mock_integration_config, mock_pin):
     mock_llmobs.enabled = True
@@ -122,60 +71,6 @@ def test_pc_span_sampling_llmobs(mock_llmobs, mock_integration_config, mock_pin)
     integration.pin = mock_pin
     with mock_pin.tracer.trace("Dummy span") as mock_span:
         assert integration.is_pc_sampled_llmobs(mock_span) is False
-
-
-@mock.patch("ddtrace.llmobs._integrations.base.V2LogWriter")
-def test_log_writer_started(mock_log_writer, mock_integration_config):
-    mock_integration_config.logs_enabled = True
-    _ = BaseLLMIntegration(mock_integration_config)
-    mock_log_writer().start.assert_called_once()
-
-    mock_log_writer.reset_mock()
-    mock_integration_config.logs_enabled = False
-    _ = BaseLLMIntegration(mock_integration_config)
-    mock_log_writer().start.assert_not_called()
-
-
-@mock.patch("ddtrace.llmobs._integrations.base.V2LogWriter")
-def test_log_enqueues_log_writer(mock_log_writer, mock_integration_config):
-    span = DummyTracer().trace("Dummy span", service="dummy_service")
-    mock_integration_config.logs_enabled = True
-    integration = BaseLLMIntegration(mock_integration_config)
-    integration.log(span, "level", "message", {"DummyKey": "DummyValue"})
-    mock_log_writer().enqueue.assert_called_once_with(
-        {
-            "timestamp": mock.ANY,
-            "message": "message",
-            "hostname": mock.ANY,
-            "ddsource": "baseLLM",
-            "service": "dummy_service",
-            "status": "level",
-            "ddtags": mock.ANY,
-            "dd.span_id": str(span.span_id),
-            "dd.trace_id": "{:x}".format(span.trace_id),
-            "DummyKey": "DummyValue",
-        }
-    )
-
-
-def test_metric_calls_statsd_client(mock_integration_config, monkeypatch):
-    monkeypatch.setenv("DD_BASELLM_METRICS_ENABLED", "1")
-    span = DummyTracer().trace("Dummy span", service="dummy_service")
-    integration = BaseLLMIntegration(mock_integration_config)
-    mock_statsd = mock.Mock()
-    integration._statsd = mock_statsd
-
-    integration.metric(span, "dist", "name", 1, tags=["tag:value"])
-    mock_statsd.distribution.assert_called_once_with("name", 1, tags=["tag:value"])
-
-    integration.metric(span, "incr", "name", 2, tags=["tag:value"])
-    mock_statsd.increment.assert_called_once_with("name", 2, tags=["tag:value"])
-
-    integration.metric(span, "gauge", "name", 3, tags=["tag:value"])
-    mock_statsd.gauge.assert_called_once_with("name", 3, tags=["tag:value"])
-
-    with pytest.raises(ValueError):
-        integration.metric(span, "metric_type_does_not_exist", "name", 3, tags=["tag:value"])
 
 
 def test_integration_trace(mock_integration_config, mock_pin):


### PR DESCRIPTION
As of #12211 and #12220, we dropped support for legacy integration metrics and logs from openai and langchain integrations. This PR removes functional support for this in the BaseLLMIntegration class.

Note that we forgot to drop emitting integration metrics for streamed openai/langchain responses. Since #12211 and #12220 officially dropped support with a release note already for the ddtrace 3.0 release, I do not think this warrants a release note.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
