### PR TITLE
add check for span start time

### DIFF
--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -129,8 +129,6 @@ class Span(object):
         "_links",
         "_events",
         "__weakref__",
-        "min_span_start",
-        "max_span_start",
     ]
 
     def __init__(
@@ -195,8 +193,7 @@ class Span(object):
         self._meta_struct: Dict[str, Dict[str, Any]] = {}
 
         self.start_ns: int = time_ns() if start is None else int(start * 1e9)
-        self.min_span_start: int = 946684800  # 1-1-2000
-        self.max_span_start: int = 32503679999  # 12-31-2999
+
         self.duration_ns: Optional[int] = None
 
         if trace_id is not None:
@@ -254,12 +251,7 @@ class Span(object):
 
     @start.setter
     def start(self, value: Union[int, float]) -> None:
-        if int(value * 1e9) < self.min_span_start:  # todo: log output?
-            self.start_ns = self.min_span_start
-        elif int(value * 1e9) > self.max_span_start:
-            self.start_ns = self.max_span_start
-        else:
-            self.start_ns = int(value * 1e9)
+        self.start_ns = int(value * 1e9)
 
     @property
     def resource(self) -> str:

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -129,8 +129,8 @@ class Span(object):
         "_links",
         "_events",
         "__weakref__",
-        "min_start",
-        "max_start",
+        "min_span_start",
+        "max_span_start",
     ]
 
     def __init__(
@@ -195,8 +195,8 @@ class Span(object):
         self._meta_struct: Dict[str, Dict[str, Any]] = {}
 
         self.start_ns: int = time_ns() if start is None else int(start * 1e9)
-        self.min_start: int = 946684800 # 1-1-2000
-        self.max_start: int = 32503679999 # 12-31-2999
+        self.min_span_start: int = 946684800 # 1-1-2000
+        self.max_span_start: int = 32503679999 # 12-31-2999
         self.duration_ns: Optional[int] = None
 
         if trace_id is not None:
@@ -254,11 +254,11 @@ class Span(object):
 
     @start.setter
     def start(self, value: Union[int, float]) -> None:
-        breakpoint()
-        if int(value * 1e9) < self.min_start: # todo: log output?
-            self.start_ns = self.min_start
-        elif int(value * 1e9) > self.max_start:
-            self.start_ns = self.max_start
+        # breakpoint()
+        if int(value * 1e9) < self.min_span_start: # todo: log output?
+            self.start_ns = self.min_span_start
+        elif int(value * 1e9) > self.max_span_start:
+            self.start_ns = self.max_span_start
         else:
             self.start_ns = int(value * 1e9)
 

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -195,8 +195,8 @@ class Span(object):
         self._meta_struct: Dict[str, Dict[str, Any]] = {}
 
         self.start_ns: int = time_ns() if start is None else int(start * 1e9)
-        self.min_span_start: int = 946684800 # 1-1-2000
-        self.max_span_start: int = 32503679999 # 12-31-2999
+        self.min_span_start: int = 946684800  # 1-1-2000
+        self.max_span_start: int = 32503679999  # 12-31-2999
         self.duration_ns: Optional[int] = None
 
         if trace_id is not None:
@@ -254,8 +254,7 @@ class Span(object):
 
     @start.setter
     def start(self, value: Union[int, float]) -> None:
-        # breakpoint()
-        if int(value * 1e9) < self.min_span_start: # todo: log output?
+        if int(value * 1e9) < self.min_span_start:  # todo: log output?
             self.start_ns = self.min_span_start
         elif int(value * 1e9) > self.max_span_start:
             self.start_ns = self.max_span_start

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -129,6 +129,8 @@ class Span(object):
         "_links",
         "_events",
         "__weakref__",
+        "min_start",
+        "max_start",
     ]
 
     def __init__(
@@ -193,6 +195,8 @@ class Span(object):
         self._meta_struct: Dict[str, Dict[str, Any]] = {}
 
         self.start_ns: int = time_ns() if start is None else int(start * 1e9)
+        self.min_start: int = 946684800 # 1-1-2000
+        self.max_start: int = 32503679999 # 12-31-2999
         self.duration_ns: Optional[int] = None
 
         if trace_id is not None:
@@ -250,7 +254,13 @@ class Span(object):
 
     @start.setter
     def start(self, value: Union[int, float]) -> None:
-        self.start_ns = int(value * 1e9)
+        breakpoint()
+        if int(value * 1e9) < self.min_start: # todo: log output?
+            self.start_ns = self.min_start
+        elif int(value * 1e9) > self.max_start:
+            self.start_ns = self.max_start
+        else:
+            self.start_ns = int(value * 1e9)
 
     @property
     def resource(self) -> str:

--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -741,10 +741,10 @@ cdef class MsgpackEncoderV04(MsgpackEncoderBase):
             ret = pack_bytes(&self.pk, <char *> b"start", 5)
             if ret != 0:
                 return ret
-            
+
             if (span.start_ns < MIN_START_NS):
                 span.start_ns = MIN_START_NS
-            
+
             ret = pack_number(&self.pk, span.start_ns)
             if ret != 0:
                 return ret
@@ -895,7 +895,7 @@ cdef class MsgpackEncoderV05(MsgpackEncoderBase):
         _ = span.start_ns
         if (span.start_ns < MIN_START_NS):
             span.start_ns = MIN_START_NS
-        
+
         ret = msgpack_pack_int64(&self.pk, _ if _ is not None else 0)
         if ret != 0:
             return ret

--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -24,9 +24,9 @@ from .constants import SPAN_LINKS_KEY
 from .constants import SPAN_EVENTS_KEY
 from .constants import MAX_UINT_64BITS
 
-
 DEF MSGPACK_ARRAY_LENGTH_PREFIX_SIZE = 5
 DEF MSGPACK_STRING_TABLE_LENGTH_PREFIX_SIZE = 6
+cdef int MIN_START_NS = 946684800
 
 
 cdef extern from "Python.h":
@@ -741,6 +741,10 @@ cdef class MsgpackEncoderV04(MsgpackEncoderBase):
             ret = pack_bytes(&self.pk, <char *> b"start", 5)
             if ret != 0:
                 return ret
+            
+            if (span.start_ns < MIN_START_NS) {
+                span.start_ns = MIN_START_NS
+            }
             ret = pack_number(&self.pk, span.start_ns)
             if ret != 0:
                 return ret
@@ -889,6 +893,9 @@ cdef class MsgpackEncoderV05(MsgpackEncoderBase):
             return ret
 
         _ = span.start_ns
+        if (span.start_ns < MIN_START_NS) {
+            span.start_ns = MIN_START_NS
+        }
         ret = msgpack_pack_int64(&self.pk, _ if _ is not None else 0)
         if ret != 0:
             return ret

--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -742,9 +742,9 @@ cdef class MsgpackEncoderV04(MsgpackEncoderBase):
             if ret != 0:
                 return ret
             
-            if (span.start_ns < MIN_START_NS) {
+            if (span.start_ns < MIN_START_NS):
                 span.start_ns = MIN_START_NS
-            }
+            
             ret = pack_number(&self.pk, span.start_ns)
             if ret != 0:
                 return ret
@@ -893,9 +893,9 @@ cdef class MsgpackEncoderV05(MsgpackEncoderBase):
             return ret
 
         _ = span.start_ns
-        if (span.start_ns < MIN_START_NS) {
+        if (span.start_ns < MIN_START_NS):
             span.start_ns = MIN_START_NS
-        }
+        
         ret = msgpack_pack_int64(&self.pk, _ if _ is not None else 0)
         if ret != 0:
             return ret

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -388,6 +388,7 @@ def test_long_span_start(encoding):
     span.finish()
 
     trace = [span]
+    breakpoint()
     encoder.put(trace)
     # TODO: Right now this fails with Python int too large to convert to C long
     assert decode(refencoder.encode_traces([trace])) == decode(encoder.encode()[0])

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -377,6 +377,22 @@ def test_msgpack_span_property_variations(encoding, span):
     assert decode(refencoder.encode_traces([trace])) == decode(encoder.encode()[0])
 
 
+@allencodings
+def test_long_span_start(encoding):
+    refencoder = REF_MSGPACK_ENCODERS[encoding]()
+    encoder = MSGPACK_ENCODERS[encoding](1 << 10, 1 << 10)
+
+    # Start a span a very long time ago
+    span = Span(None)
+    span.start = -62135596700
+    span.finish()
+
+    trace = [span]
+    encoder.put(trace)
+    # TODO: Right now this fails with Python int too large to convert to C long
+    assert decode(refencoder.encode_traces([trace])) == decode(encoder.encode()[0])
+
+
 class SubString(str):
     pass
 

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -388,7 +388,6 @@ def test_long_span_start(encoding):
     span.finish()
 
     trace = [span]
-    breakpoint()
     encoder.put(trace)
     # TODO: Right now this fails with Python int too large to convert to C long
     assert decode(refencoder.encode_traces([trace])) == decode(encoder.encode()[0])


### PR DESCRIPTION
if span start time is very small, it will throw an issue in the encoder.
Check that the span start_ns > min_span_start and re-set it if it is.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
