### PR TITLE
chore(profiling): use unordered_map instead of map

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <map>
 #include <stddef.h>
 #include <stdint.h>
 #include <string_view>
+#include <unordered_map>
 
 // Forward decl of the return pointer
 namespace Datadog {

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
@@ -32,8 +32,8 @@ extern "C"
     bool ddup_is_initialized();
     void ddup_start();
     void ddup_set_runtime_id(std::string_view runtime_id);
-    void ddup_profile_set_endpoints(std::map<int64_t, std::string_view> span_ids_to_endpoints);
-    void ddup_profile_add_endpoint_counts(std::map<std::string_view, int64_t> trace_endpoints_to_counts);
+    void ddup_profile_set_endpoints(std::unordered_map<int64_t, std::string_view> span_ids_to_endpoints);
+    void ddup_profile_add_endpoint_counts(std::unordered_map<std::string_view, int64_t> trace_endpoints_to_counts);
     bool ddup_upload();
 
     // Proxy functions to the underlying sample

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <unistd.h>
+#include <unordered_map>
 
 // State
 bool is_ddup_initialized = false; // NOLINT (cppcoreguidelines-avoid-non-const-global-variables)

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
@@ -350,7 +350,7 @@ ddup_upload() // cppcheck-suppress unusedFunction
 
 void
 ddup_profile_set_endpoints(
-  std::map<int64_t, std::string_view> span_ids_to_endpoints) // cppcheck-suppress unusedFunction
+  std::unordered_map<int64_t, std::string_view> span_ids_to_endpoints) // cppcheck-suppress unusedFunction
 {
     ddog_prof_Profile& profile = Datadog::Sample::profile_borrow();
     for (const auto& [span_id, trace_endpoint] : span_ids_to_endpoints) {
@@ -367,7 +367,7 @@ ddup_profile_set_endpoints(
 }
 
 void
-ddup_profile_add_endpoint_counts(std::map<std::string_view, int64_t> trace_endpoints_to_counts)
+ddup_profile_add_endpoint_counts(std::unordered_map<std::string_view, int64_t> trace_endpoints_to_counts)
 {
     ddog_prof_Profile& profile = Datadog::Sample::profile_borrow();
     for (const auto& [trace_endpoint, count] : trace_endpoints_to_counts) {

--- a/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
+++ b/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
@@ -7,7 +7,6 @@ from typing import Optional
 from typing import Union
 
 from cpython.unicode cimport PyUnicode_AsUTF8AndSize
-from libcpp.map cimport map
 from libcpp.unordered_map cimport unordered_map
 from libcpp.utility cimport pair
 
@@ -57,8 +56,8 @@ cdef extern from "ddup_interface.hpp":
 
     void ddup_start()
     void ddup_set_runtime_id(string_view _id)
-    void ddup_profile_set_endpoints(map[int64_t, string_view] span_ids_to_endpoints)
-    void ddup_profile_add_endpoint_counts(map[string_view, int64_t] trace_endpoints_to_counts)
+    void ddup_profile_set_endpoints(unordered_map[int64_t, string_view] span_ids_to_endpoints)
+    void ddup_profile_add_endpoint_counts(unordered_map[string_view, int64_t] trace_endpoints_to_counts)
     bint ddup_upload() nogil
 
     Sample *ddup_start_sample()
@@ -167,7 +166,7 @@ cdef call_ddup_profile_set_endpoints(endpoint_to_span_ids):
     # a view into the original string. If the original string is GC'ed, the view
     # will point to garbage.
     endpoint_list = []
-    cdef map[int64_t, string_view] span_ids_to_endpoints = map[int64_t, string_view]()
+    cdef unordered_map[int64_t, string_view] span_ids_to_endpoints = unordered_map[int64_t, string_view]()
     cdef const char* utf8_data
     cdef Py_ssize_t utf8_size
     for endpoint, span_ids in endpoint_to_span_ids.items():
@@ -201,7 +200,7 @@ cdef call_ddup_profile_add_endpoint_counts(endpoint_counts):
     # a view into the original string. If the original string is GC'ed, the view
     # will point to garbage.
     endpoint_list = []
-    cdef map[string_view, int64_t] trace_endpoints_to_counts = map[string_view, int64_t]()
+    cdef unordered_map[string_view, int64_t] trace_endpoints_to_counts = unordered_map[string_view, int64_t]()
     cdef const char* utf8_data
     cdef Py_ssize_t utf8_size
     for endpoint, count in endpoint_counts.items():


### PR DESCRIPTION
To implement [endpoint profiling](https://docs.datadoghq.com/profiler/connect_traces_and_profiles/?code-lang=python#endpoint-profiling), we maintain two mappings

1. span ids to endpoint names
2. endpoint names to request counts

Both mappings don't need to be ordered, so switch over to `std::unordered_map` from `std::map` for better average time complexity. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
