### PR TITLE
fix(benchmarks): Remove flakiness from IAST benchmarks

### DIFF
--- a/benchmarks/appsec_iast_aspects/config.yaml
+++ b/benchmarks/appsec_iast_aspects/config.yaml
@@ -1,7 +1,6 @@
 add_aspect: &add_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_add_aspect"
 
@@ -10,9 +9,8 @@ add_noaspect:
   function_name: "add_noaspect"
 
 add_inplace_aspect: &add_inplace_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_add_inplace_aspect"
 
@@ -21,9 +19,8 @@ add_inplace_noaspect:
   function_name: "add_inplace_noaspect"
 
 bytearray_aspect: &bytearray_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_bytearray_aspect"
 
@@ -32,9 +29,8 @@ bytearray_noaspect:
   function_name: "bytearray_noaspect"
 
 bytearray_extend_aspect: &bytearray_extend_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_bytearray_extend_aspect"
 
@@ -43,9 +39,8 @@ bytearray_extend_noaspect:
   function_name: "bytearray_extend_noaspect"
 
 bytes_aspect: &bytes_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_bytes_aspect"
 
@@ -54,9 +49,8 @@ bytes_noaspect:
   function_name: "bytes_noaspect"
 
 bytesio_aspect: &bytesio_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_bytesio_aspect"
 
@@ -65,9 +59,8 @@ bytesio_noaspect:
   function_name: "bytesio_noaspect"
 
 capitalize_aspect: &capitalize_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_capitalize_aspect"
 
@@ -76,9 +69,8 @@ capitalize_noaspect:
   function_name: "capitalize_noaspect"
 
 casefold_aspect: &casefold_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_casefold_aspect"
 
@@ -87,9 +79,8 @@ casefold_noaspect:
   function_name: "casefold_noaspect"
 
 decode_aspect: &decode_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_decode_aspect"
 
@@ -98,9 +89,8 @@ decode_noaspect:
   function_name: "decode_noaspect"
 
 encode_aspect: &encode_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_encode_aspect"
 
@@ -109,9 +99,8 @@ encode_noaspect:
   function_name: "encode_noaspect"
 
 format_aspect: &format_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_format_aspect"
 
@@ -120,9 +109,8 @@ format_noaspect:
   function_name: "format_noaspect"
 
 format_map_aspect: &format_map_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_format_map_aspect"
 
@@ -131,9 +119,8 @@ format_map_noaspect:
   function_name: "format_map_noaspect"
 
 index_aspect: &index_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_index_aspect"
 
@@ -142,9 +129,8 @@ index_noaspect:
   function_name: "index_noaspect"
 
 join_aspect: &join_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_join_aspect"
 
@@ -153,9 +139,8 @@ join_noaspect:
   function_name: "join_noaspect"
 
 lower_aspect: &lower_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_lower_aspect"
 
@@ -164,9 +149,8 @@ lower_noaspect:
   function_name: "lower_noaspect"
 
 ljust_aspect: &ljust_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_ljust_aspect"
 
@@ -175,9 +159,8 @@ ljust_noaspect:
   function_name: "ljust_noaspect"
 
 modulo_aspect: &modulo_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_modulo_aspect"
 
@@ -198,9 +181,8 @@ modulo_noaspect:
   function_name: "modulo_noaspect"
 
 ospathbasename_aspect: &ospathbasename_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_ospathbasename_aspect"
 
@@ -209,9 +191,8 @@ ospathbasename_noaspect:
   function_name: "ospathbasename_noaspect"
 
 ospathdirname_aspect: &ospathdirname_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_ospathdirname_aspect"
 
@@ -220,9 +201,8 @@ ospathdirname_noaspect:
   function_name: "ospathdirname_noaspect"
 
 ospathjoin_aspect: &ospathjoin_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_ospathjoin_aspect"
 
@@ -231,9 +211,8 @@ ospathjoin_noaspect:
   function_name: "ospathjoin_noaspect"
 
 ospathnormcase_aspect: &ospathnormcase_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_ospathnormcase_aspect"
 
@@ -242,9 +221,8 @@ ospathnormcase_noaspect:
   function_name: "ospathnormcase_noaspect"
 
 ospathsplit_aspect: &ospathsplit_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_ospathsplit_aspect"
 
@@ -253,9 +231,8 @@ ospathsplit_noaspect:
   function_name: "ospathsplit_noaspect"
 
 ospathsplitdrive_aspect: &ospathsplitdrive_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_ospathsplitdrive_aspect"
 
@@ -264,9 +241,8 @@ ospathsplitdrive_noaspect:
   function_name: "ospathsplitdrive_noaspect"
 
 ospathsplitext_aspect: &ospathsplitext_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_ospathsplitext_aspect"
 
@@ -275,9 +251,8 @@ ospathsplitext_noaspect:
   function_name: "ospathsplitext_noaspect"
 
 re_expand_aspect: &re_expand_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_re_expand_aspect"
 
@@ -286,9 +261,8 @@ re_expand_noaspect:
   function_name: "re_expand_noaspect"
 
 re_findall_aspect: &re_findall_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_re_findall_aspect"
 
@@ -297,9 +271,8 @@ re_findall_noaspect:
   function_name: "re_findall_noaspect"
 
 re_finditer_aspect: &re_finditer_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_re_finditer_aspect"
 
@@ -308,9 +281,8 @@ re_finditer_noaspect:
   function_name: "re_finditer_noaspect"
 
 re_fullmatch_aspect: &re_fullmatch_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_re_fullmatch_aspect"
 
@@ -319,9 +291,8 @@ re_fullmatch_noaspect:
   function_name: "re_fullmatch_noaspect"
 
 re_group_aspect: &re_group_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_re_group_aspect"
 
@@ -330,9 +301,8 @@ re_group_noaspect:
   function_name: "re_group_noaspect"
 
 re_groups_aspect: &re_groups_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_re_groups_aspect"
 
@@ -341,9 +311,8 @@ re_groups_noaspect:
   function_name: "re_groups_noaspect"
 
 re_match_aspect: &re_match_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_re_match_aspect"
 
@@ -352,9 +321,8 @@ re_match_noaspect:
   function_name: "re_match_noaspect"
 
 re_search_aspect: &re_search_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_re_search_aspect"
 
@@ -363,9 +331,8 @@ re_search_noaspect:
   function_name: "re_search_noaspect"
 
 re_sub_aspect: &re_sub_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_re_sub_aspect"
 
@@ -374,9 +341,8 @@ re_sub_noaspect:
   function_name: "re_sub_noaspect"
 
 re_subn_aspect: &re_subn_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_re_subn_aspect"
 
@@ -385,9 +351,8 @@ re_subn_noaspect:
   function_name: "re_subn_noaspect"
 
 replace_aspect: &replace_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_replace_aspect"
 
@@ -396,9 +361,8 @@ replace_noaspect:
   function_name: "replace_noaspect"
 
 repr_aspect: &repr_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_repr_aspect"
 
@@ -407,9 +371,8 @@ repr_noaspect:
   function_name: "repr_noaspect"
 
 rsplit_aspect: &rsplit_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_rsplit_aspect"
 
@@ -418,9 +381,8 @@ rsplit_noaspect:
   function_name: "rsplit_noaspect"
 
 slice_aspect: &slice_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_slice_aspect"
 
@@ -429,9 +391,8 @@ slice_noaspect:
   function_name: "slice_noaspect"
 
 split_aspect: &split_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_split_aspect"
 
@@ -440,9 +401,8 @@ split_noaspect:
   function_name: "split_noaspect"
 
 splitlines_aspect: &splitlines_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_splitlines_aspect"
 
@@ -451,9 +411,8 @@ splitlines_noaspect:
   function_name: "splitlines_noaspect"
 
 stringio_aspect: &stringio_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_stringio_aspect"
 
@@ -462,9 +421,8 @@ stringio_noaspect:
   function_name: "stringio_noaspect"
 
 swapcase_aspect: &swapcase_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_swapcase_aspect"
 
@@ -473,9 +431,8 @@ swapcase_noaspect:
   function_name: "swapcase_noaspect"
 
 title_aspect: &title_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_title_aspect"
 
@@ -484,9 +441,8 @@ title_noaspect:
   function_name: "title_noaspect"
 
 translate_aspect: &translate_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_translate_aspect"
 
@@ -495,9 +451,8 @@ translate_noaspect:
   function_name: "translate_noaspect"
 
 upper_aspect: &upper_aspect
-  processes: 10
   loops: 5
-  values: 100
+  values: 50
   warmups: 1
   function_name: "iast_upper_aspect"
 

--- a/benchmarks/appsec_iast_aspects/config.yaml
+++ b/benchmarks/appsec_iast_aspects/config.yaml
@@ -1,6 +1,6 @@
 add_aspect: &add_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_add_aspect"
 
@@ -9,8 +9,8 @@ add_noaspect:
   function_name: "add_noaspect"
 
 add_inplace_aspect: &add_inplace_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_add_inplace_aspect"
 
@@ -19,8 +19,8 @@ add_inplace_noaspect:
   function_name: "add_inplace_noaspect"
 
 bytearray_aspect: &bytearray_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_bytearray_aspect"
 
@@ -29,8 +29,8 @@ bytearray_noaspect:
   function_name: "bytearray_noaspect"
 
 bytearray_extend_aspect: &bytearray_extend_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_bytearray_extend_aspect"
 
@@ -39,8 +39,8 @@ bytearray_extend_noaspect:
   function_name: "bytearray_extend_noaspect"
 
 bytes_aspect: &bytes_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_bytes_aspect"
 
@@ -49,8 +49,8 @@ bytes_noaspect:
   function_name: "bytes_noaspect"
 
 bytesio_aspect: &bytesio_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_bytesio_aspect"
 
@@ -59,8 +59,8 @@ bytesio_noaspect:
   function_name: "bytesio_noaspect"
 
 capitalize_aspect: &capitalize_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_capitalize_aspect"
 
@@ -69,8 +69,8 @@ capitalize_noaspect:
   function_name: "capitalize_noaspect"
 
 casefold_aspect: &casefold_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_casefold_aspect"
 
@@ -79,8 +79,8 @@ casefold_noaspect:
   function_name: "casefold_noaspect"
 
 decode_aspect: &decode_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_decode_aspect"
 
@@ -89,8 +89,8 @@ decode_noaspect:
   function_name: "decode_noaspect"
 
 encode_aspect: &encode_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_encode_aspect"
 
@@ -99,8 +99,8 @@ encode_noaspect:
   function_name: "encode_noaspect"
 
 format_aspect: &format_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_format_aspect"
 
@@ -109,8 +109,8 @@ format_noaspect:
   function_name: "format_noaspect"
 
 format_map_aspect: &format_map_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_format_map_aspect"
 
@@ -119,8 +119,8 @@ format_map_noaspect:
   function_name: "format_map_noaspect"
 
 index_aspect: &index_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_index_aspect"
 
@@ -129,8 +129,8 @@ index_noaspect:
   function_name: "index_noaspect"
 
 join_aspect: &join_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_join_aspect"
 
@@ -139,8 +139,8 @@ join_noaspect:
   function_name: "join_noaspect"
 
 lower_aspect: &lower_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_lower_aspect"
 
@@ -149,8 +149,8 @@ lower_noaspect:
   function_name: "lower_noaspect"
 
 ljust_aspect: &ljust_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_ljust_aspect"
 
@@ -159,8 +159,8 @@ ljust_noaspect:
   function_name: "ljust_noaspect"
 
 modulo_aspect: &modulo_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_modulo_aspect"
 
@@ -181,8 +181,8 @@ modulo_noaspect:
   function_name: "modulo_noaspect"
 
 ospathbasename_aspect: &ospathbasename_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_ospathbasename_aspect"
 
@@ -191,8 +191,8 @@ ospathbasename_noaspect:
   function_name: "ospathbasename_noaspect"
 
 ospathdirname_aspect: &ospathdirname_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_ospathdirname_aspect"
 
@@ -201,8 +201,8 @@ ospathdirname_noaspect:
   function_name: "ospathdirname_noaspect"
 
 ospathjoin_aspect: &ospathjoin_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_ospathjoin_aspect"
 
@@ -211,8 +211,8 @@ ospathjoin_noaspect:
   function_name: "ospathjoin_noaspect"
 
 ospathnormcase_aspect: &ospathnormcase_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_ospathnormcase_aspect"
 
@@ -221,8 +221,8 @@ ospathnormcase_noaspect:
   function_name: "ospathnormcase_noaspect"
 
 ospathsplit_aspect: &ospathsplit_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_ospathsplit_aspect"
 
@@ -231,8 +231,8 @@ ospathsplit_noaspect:
   function_name: "ospathsplit_noaspect"
 
 ospathsplitdrive_aspect: &ospathsplitdrive_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_ospathsplitdrive_aspect"
 
@@ -241,8 +241,8 @@ ospathsplitdrive_noaspect:
   function_name: "ospathsplitdrive_noaspect"
 
 ospathsplitext_aspect: &ospathsplitext_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_ospathsplitext_aspect"
 
@@ -251,8 +251,8 @@ ospathsplitext_noaspect:
   function_name: "ospathsplitext_noaspect"
 
 re_expand_aspect: &re_expand_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_re_expand_aspect"
 
@@ -261,8 +261,8 @@ re_expand_noaspect:
   function_name: "re_expand_noaspect"
 
 re_findall_aspect: &re_findall_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_re_findall_aspect"
 
@@ -271,8 +271,8 @@ re_findall_noaspect:
   function_name: "re_findall_noaspect"
 
 re_finditer_aspect: &re_finditer_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_re_finditer_aspect"
 
@@ -281,8 +281,8 @@ re_finditer_noaspect:
   function_name: "re_finditer_noaspect"
 
 re_fullmatch_aspect: &re_fullmatch_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_re_fullmatch_aspect"
 
@@ -291,8 +291,8 @@ re_fullmatch_noaspect:
   function_name: "re_fullmatch_noaspect"
 
 re_group_aspect: &re_group_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_re_group_aspect"
 
@@ -301,8 +301,8 @@ re_group_noaspect:
   function_name: "re_group_noaspect"
 
 re_groups_aspect: &re_groups_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_re_groups_aspect"
 
@@ -311,8 +311,8 @@ re_groups_noaspect:
   function_name: "re_groups_noaspect"
 
 re_match_aspect: &re_match_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_re_match_aspect"
 
@@ -321,8 +321,8 @@ re_match_noaspect:
   function_name: "re_match_noaspect"
 
 re_search_aspect: &re_search_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_re_search_aspect"
 
@@ -331,8 +331,8 @@ re_search_noaspect:
   function_name: "re_search_noaspect"
 
 re_sub_aspect: &re_sub_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_re_sub_aspect"
 
@@ -341,8 +341,8 @@ re_sub_noaspect:
   function_name: "re_sub_noaspect"
 
 re_subn_aspect: &re_subn_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_re_subn_aspect"
 
@@ -351,8 +351,8 @@ re_subn_noaspect:
   function_name: "re_subn_noaspect"
 
 replace_aspect: &replace_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_replace_aspect"
 
@@ -361,8 +361,8 @@ replace_noaspect:
   function_name: "replace_noaspect"
 
 repr_aspect: &repr_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_repr_aspect"
 
@@ -371,8 +371,8 @@ repr_noaspect:
   function_name: "repr_noaspect"
 
 rsplit_aspect: &rsplit_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_rsplit_aspect"
 
@@ -381,8 +381,8 @@ rsplit_noaspect:
   function_name: "rsplit_noaspect"
 
 slice_aspect: &slice_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_slice_aspect"
 
@@ -391,8 +391,8 @@ slice_noaspect:
   function_name: "slice_noaspect"
 
 split_aspect: &split_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_split_aspect"
 
@@ -401,8 +401,8 @@ split_noaspect:
   function_name: "split_noaspect"
 
 splitlines_aspect: &splitlines_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_splitlines_aspect"
 
@@ -411,8 +411,8 @@ splitlines_noaspect:
   function_name: "splitlines_noaspect"
 
 stringio_aspect: &stringio_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_stringio_aspect"
 
@@ -421,8 +421,8 @@ stringio_noaspect:
   function_name: "stringio_noaspect"
 
 swapcase_aspect: &swapcase_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_swapcase_aspect"
 
@@ -431,8 +431,8 @@ swapcase_noaspect:
   function_name: "swapcase_noaspect"
 
 title_aspect: &title_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_title_aspect"
 
@@ -441,8 +441,8 @@ title_noaspect:
   function_name: "title_noaspect"
 
 translate_aspect: &translate_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_translate_aspect"
 
@@ -451,8 +451,8 @@ translate_noaspect:
   function_name: "translate_noaspect"
 
 upper_aspect: &upper_aspect
-  loops: 5
-  values: 50
+  loops: 50
+  values: 20
   warmups: 1
   function_name: "iast_upper_aspect"
 

--- a/benchmarks/appsec_iast_aspects/scenario.py
+++ b/benchmarks/appsec_iast_aspects/scenario.py
@@ -41,17 +41,18 @@ class IAST_Aspects(bm.Scenario):
         if self.iast_enabled:
             with override_env({"DD_IAST_ENABLED": "True"}):
                 _start_iast_context_and_oce()
+                
+                func = getattr(functions, self.function_name)
 
-        def _(loops):
-            for _ in range(loops):
-                if self.iast_enabled:
-                    with override_env({"DD_IAST_ENABLED": "True"}):
-                        getattr(functions, self.function_name)()
-
-                else:
-                    getattr(functions, self.function_name)()
-
-        yield _
-        if self.iast_enabled:
-            with override_env({"DD_IAST_ENABLED": "True"}):
+                def _(loops):
+                    for _ in range(loops):
+                        func()
+        
+                yield _
                 _end_iast_context_and_oce()
+        else:
+            def _(loops):
+                for _ in range(loops):
+                    func()
+    
+            yield _

--- a/benchmarks/appsec_iast_aspects/scenario.py
+++ b/benchmarks/appsec_iast_aspects/scenario.py
@@ -51,6 +51,8 @@ class IAST_Aspects(bm.Scenario):
                 yield _
                 _end_iast_context_and_oce()
         else:
+            func = getattr(functions, self.function_name)
+                
             def _(loops):
                 for _ in range(loops):
                     func()


### PR DESCRIPTION
Several changes were introduced in order to remove flakiness from IAST benchmarks runs:

1. Rebalance number of loops & iterations, so samples are more representative.
2. Move helper code outside of actual measurements, so it no longer skews results.
3. Reset number of spawned pyperf processes back to default 20 in order to get more representative sample for max RSS usage.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
