### PR TITLE
unset config._inferred_base_service if it equals config.service

### DIFF
--- a/ddtrace/settings/_config.py
+++ b/ddtrace/settings/_config.py
@@ -536,6 +536,11 @@ class Config(object):
         if self.service is None and DEFAULT_SPAN_SERVICE_NAME:
             self.service = _get_config("DD_SERVICE", DEFAULT_SPAN_SERVICE_NAME)
 
+        # If the service equals inferred base service, leave inferred base service unset. Otherwise we 
+        # will get side effects.
+        if self.service == self._inferred_base_service:
+            self._inferred_base_service = None
+
         self._extra_services = set()
         self._extra_services_queue = None if in_aws_lambda() or not self._remote_config_enabled else File_Queue()
         self.version = _get_config("DD_VERSION", self.tags.get("version"))

--- a/ddtrace/settings/_config.py
+++ b/ddtrace/settings/_config.py
@@ -536,7 +536,7 @@ class Config(object):
         if self.service is None and DEFAULT_SPAN_SERVICE_NAME:
             self.service = _get_config("DD_SERVICE", DEFAULT_SPAN_SERVICE_NAME)
 
-        # If the service equals inferred base service, leave inferred base service unset. Otherwise we 
+        # If the service equals inferred base service, leave inferred base service unset. Otherwise we
         # will get side effects.
         if self.service == self._inferred_base_service:
             self._inferred_base_service = None


### PR DESCRIPTION
# Motivation

We added `inferred_base_service` as a way to detect traced application service names via file structure and the initial app startup commands as a way to get a logical service name when DD_SERVICE is unset. However, there may be a small edge case where if both are equal, when calling `config._get_service(default)` with a default, we will return the default, because the assumption was that if both `config.inferred_base_service` and `config.service` are equal, then `config.inferred_base_service` was the actual source of the service name. As a way to not break customers that relied on a default for service name, so when service equalled inferred base service, we returned the default.

This change unsets inferred base service if service is equal during config initialization. 


## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
