### PR TITLE
test(botocore): remove flaky decorator from botocore test

### DIFF
--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -4076,7 +4076,6 @@ class BotocoreTest(TracerTestCase):
 
     @pytest.mark.snapshot(ignores=snapshot_ignores)
     @mock_s3
-    # @flaky(1741838400, reason="span mismatch on 'service': got 'dd-trace-py' which does not match expected 'aws.sqs'")
     def test_aws_payload_tagging_s3_invalid_config(self):
         with self.override_config(
             "botocore",

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -24,7 +24,6 @@ import pytest
 from ddtrace._trace._span_pointer import _SpanPointer
 from ddtrace._trace._span_pointer import _SpanPointerDirection
 from ddtrace._trace.utils_botocore import span_tags
-from tests.utils import flaky
 from tests.utils import get_128_bit_trace_id_from_headers
 
 
@@ -4077,7 +4076,7 @@ class BotocoreTest(TracerTestCase):
 
     @pytest.mark.snapshot(ignores=snapshot_ignores)
     @mock_s3
-    @flaky(1741838400, reason="span mismatch on 'service': got 'dd-trace-py' which does not match expected 'aws.sqs'")
+    # @flaky(1741838400, reason="span mismatch on 'service': got 'dd-trace-py' which does not match expected 'aws.sqs'")
     def test_aws_payload_tagging_s3_invalid_config(self):
         with self.override_config(
             "botocore",


### PR DESCRIPTION
Remove an unnecessary `@flaky` decorator from the botocore test: `test_aws_payload_tagging_s3_invalid_config`

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
