### PR TITLE
[MLOB-2266] add base_url to llmobs spans in open ai integration

### DIFF
--- a/ddtrace/contrib/internal/anthropic/patch.py
+++ b/ddtrace/contrib/internal/anthropic/patch.py
@@ -90,6 +90,8 @@ def traced_chat_model_generate(anthropic, pin, func, instance, args, kwargs):
                         str(_get_attr(block, "type", "text")),
                     )
             span.set_tag_str("anthropic.request.messages.%d.role" % message_idx, str(message.get("role", "")))
+        if instance._client.base_url:
+            span.set_tag_str("anthropic.base_url", str(instance._client.base_url))
         tag_params_on_span(span, kwargs, integration)
 
         chat_completions = func(*args, **kwargs)

--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -1,6 +1,7 @@
 SPAN_KIND = "_ml_obs.meta.span.kind"
 SESSION_ID = "_ml_obs.session_id"
 METADATA = "_ml_obs.meta.metadata"
+BASE_URL = "_ml_obs.base_url"
 METRICS = "_ml_obs.metrics"
 ML_APP = "_ml_obs.meta.ml_app"
 PROPAGATED_PARENT_ID_KEY = "_dd.p.llmobs_parent_id"

--- a/ddtrace/llmobs/_integrations/anthropic.py
+++ b/ddtrace/llmobs/_integrations/anthropic.py
@@ -6,6 +6,7 @@ from typing import List
 from typing import Optional
 
 from ddtrace.internal.logger import get_logger
+from ddtrace.llmobs._constants import BASE_URL
 from ddtrace.llmobs._constants import INPUT_MESSAGES
 from ddtrace.llmobs._constants import METADATA
 from ddtrace.llmobs._constants import METRICS
@@ -76,6 +77,7 @@ class AnthropicIntegration(BaseLLMIntegration):
                 METADATA: parameters,
                 OUTPUT_MESSAGES: output_messages,
                 METRICS: get_llmobs_metrics_tags("anthropic", span),
+                BASE_URL: span.get_tag("anthropic.base_url"),
             }
         )
 

--- a/ddtrace/llmobs/_integrations/openai.py
+++ b/ddtrace/llmobs/_integrations/openai.py
@@ -7,6 +7,7 @@ from typing import Tuple
 
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.utils.version import parse_version
+from ddtrace.llmobs._constants import BASE_URL
 from ddtrace.llmobs._constants import INPUT_DOCUMENTS
 from ddtrace.llmobs._constants import INPUT_MESSAGES
 from ddtrace.llmobs._constants import INPUT_TOKENS_METRIC_KEY
@@ -113,6 +114,7 @@ class OpenAIIntegration(BaseLLMIntegration):
         """Sets meta tags and metrics for span events to be sent to LLMObs."""
         span_kind = "embedding" if operation == "embedding" else "llm"
         model_name = span.get_tag("openai.response.model") or span.get_tag("openai.request.model")
+        base_url = span.get_tag("openai.base_url")
 
         model_provider = "openai"
         if self._is_provider(span, "azure"):
@@ -128,7 +130,7 @@ class OpenAIIntegration(BaseLLMIntegration):
             self._llmobs_set_meta_tags_from_embedding(span, kwargs, response)
         metrics = self._extract_llmobs_metrics_tags(span, response)
         span._set_ctx_items(
-            {SPAN_KIND: span_kind, MODEL_NAME: model_name or "", MODEL_PROVIDER: model_provider, METRICS: metrics}
+            {SPAN_KIND: span_kind, MODEL_NAME: model_name or "", MODEL_PROVIDER: model_provider, METRICS: metrics, BASE_URL: base_url}
         )
 
     @staticmethod

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -35,6 +35,7 @@ from ddtrace.internal.utils.formats import parse_tags_str
 from ddtrace.llmobs import _constants as constants
 from ddtrace.llmobs._constants import AGENTLESS_BASE_URL
 from ddtrace.llmobs._constants import ANNOTATIONS_CONTEXT_ID
+from ddtrace.llmobs._constants import BASE_URL
 from ddtrace.llmobs._constants import INPUT_DOCUMENTS
 from ddtrace.llmobs._constants import INPUT_MESSAGES
 from ddtrace.llmobs._constants import INPUT_PROMPT
@@ -227,6 +228,7 @@ class LLMObs(Service):
             "ddtrace.version": ddtrace.__version__,
             "language": "python",
             "error": span.error,
+            "base_url": span._get_ctx_item(BASE_URL),
         }
         err_type = span.get_tag(ERROR_TYPE)
         if err_type:


### PR DESCRIPTION
This PR modifies existing integrations for Open AI, Anthropic, [TODO] in order to capture the `base_url` parameter that is used to route requests made to these providers through a proxy like the one provided by LiteLLM. 

A follow-up to this PR will be creating a standalone integration for the LiteLLM Python SDK which will be helpful for identifying when a request is being routed through LiteLLM. This will allow us to attach the `ml-proxy:litellm` tag to these requests.

### Manual Testing (TODO: add code snippets and screenshots for testing out each integration)

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
