### PR TITLE
test(httpx): fix expired httpx flaky as of Feb 2024

### DIFF
--- a/tests/contrib/httpx/test_httpx.py
+++ b/tests/contrib/httpx/test_httpx.py
@@ -325,7 +325,6 @@ def test_schematized_unspecified_service_name_env_default():
     asyncio.run(test())
 
 
-@flaky(1735812000)
 @pytest.mark.subprocess(env=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
 def test_schematized_unspecified_service_name_env_v0():
     """

--- a/tests/contrib/httpx/test_httpx.py
+++ b/tests/contrib/httpx/test_httpx.py
@@ -292,7 +292,6 @@ def test_schematized_configure_global_service_name_env_v1():
     asyncio.run(test())
 
 
-@flaky(1735812000)
 @pytest.mark.subprocess()
 def test_schematized_unspecified_service_name_env_default():
     """

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_default.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_default.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "http.request",
-    "service": "tests.contrib.httpx",
+    "service": "ddtrace_subprocess_dir",
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v0.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "http.request",
-    "service": "tests.contrib.httpx",
+    "service": "ddtrace_subprocess_dir",
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,


### PR DESCRIPTION
Two of these httpx tests (**test_schematized_unspecified_service_name_env_default** and **test_schematized_unspecified_service_name_env_v0**) have expired timestamps. This PR attempts to fix that.

While doing this, it looks like the newer changes to httpx has changed the expectation of what service name gets used as the default, so the reviewer is needed also to check that this is expected.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
