### PR TITLE
chore(ci): extend timestamp on flaky test decorator for grpc

### DIFF
--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -24,7 +24,6 @@ import pytest
 from ddtrace._trace._span_pointer import _SpanPointer
 from ddtrace._trace._span_pointer import _SpanPointerDirection
 from ddtrace._trace.utils_botocore import span_tags
-from tests.utils import flaky
 from tests.utils import get_128_bit_trace_id_from_headers
 
 
@@ -4077,7 +4076,7 @@ class BotocoreTest(TracerTestCase):
 
     @pytest.mark.snapshot(ignores=snapshot_ignores)
     @mock_s3
-    @flaky(1741838400, reason="span mismatch on 'service': got 'dd-trace-py' which does not match expected 'aws.sqs'")
+    # @flaky(1741838400, reason="span mismatch on 'service': got 'dd-trace-py' which does not match expected 'aws.sqs'")
     def test_aws_payload_tagging_s3_invalid_config(self):
         with self.override_config(
             "botocore",

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -24,6 +24,7 @@ import pytest
 from ddtrace._trace._span_pointer import _SpanPointer
 from ddtrace._trace._span_pointer import _SpanPointerDirection
 from ddtrace._trace.utils_botocore import span_tags
+from tests.utils import flaky
 from tests.utils import get_128_bit_trace_id_from_headers
 
 
@@ -4076,7 +4077,7 @@ class BotocoreTest(TracerTestCase):
 
     @pytest.mark.snapshot(ignores=snapshot_ignores)
     @mock_s3
-    # @flaky(1741838400, reason="span mismatch on 'service': got 'dd-trace-py' which does not match expected 'aws.sqs'")
+    @flaky(1741838400, reason="span mismatch on 'service': got 'dd-trace-py' which does not match expected 'aws.sqs'")
     def test_aws_payload_tagging_s3_invalid_config(self):
         with self.override_config(
             "botocore",

--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -16,7 +16,6 @@ from ddtrace.contrib.internal.grpc.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.trace import Pin
 from tests.utils import TracerTestCase
-from tests.utils import flaky
 from tests.utils import snapshot
 
 from .common import _GRPC_PORT
@@ -669,7 +668,7 @@ class _UnaryUnaryRpcHandler(grpc.GenericRpcHandler):
 
 
 @snapshot(ignores=["meta.network.destination.port"], wait_for_num_traces=2)
-@flaky(until=1767220930, reason="GitLab CI does not support ipv6 at this time")
+# @flaky(until=1738272799, reason="GitLab CI does not support ipv6 at this time")
 def test_method_service(patch_grpc):
     def handler(request, context):
         return b""

--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -16,6 +16,7 @@ from ddtrace.contrib.internal.grpc.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.trace import Pin
 from tests.utils import TracerTestCase
+from tests.utils import flaky
 from tests.utils import snapshot
 
 from .common import _GRPC_PORT
@@ -668,7 +669,7 @@ class _UnaryUnaryRpcHandler(grpc.GenericRpcHandler):
 
 
 @snapshot(ignores=["meta.network.destination.port"], wait_for_num_traces=2)
-# @flaky(until=1738272799, reason="GitLab CI does not support ipv6 at this time")
+@flaky(until=1738272799, reason="GitLab CI does not support ipv6 at this time")
 def test_method_service(patch_grpc):
     def handler(request, context):
         return b""

--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -669,7 +669,7 @@ class _UnaryUnaryRpcHandler(grpc.GenericRpcHandler):
 
 
 @snapshot(ignores=["meta.network.destination.port"], wait_for_num_traces=2)
-@flaky(until=1738272799, reason="GitLab CI does not support ipv6 at this time")
+@flaky(until=1767220930, reason="GitLab CI does not support ipv6 at this time")
 def test_method_service(patch_grpc):
     def handler(request, context):
         return b""


### PR DESCRIPTION
Extend flaky expiration date for flaky grpc test until `1767220930` (12/31/25)

notes:
If gitlab does not support `ipv6`, and we do not when this will change, long-term we should either
1) change to use a different protocol that is supported
2) remove the test entirely


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
