### PR TITLE
fix(internal): require bytecode>=0.15.1 for Python 3.12 to avoid known bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "bytecode>=0.16.0; python_version>='3.13.0'",
-    "bytecode>=0.15.0; python_version~='3.12.0'",
+    "bytecode>=0.15.1; python_version~='3.12.0'",
     "bytecode>=0.14.0; python_version~='3.11.0'",
     "bytecode>=0.13.0; python_version<'3.11'",
     "envier~=0.5",

--- a/releasenotes/notes/avoid-bad-bytecode-release-2c8cdb1fa0b20b77.yaml
+++ b/releasenotes/notes/avoid-bad-bytecode-release-2c8cdb1fa0b20b77.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    internal: Require ``bytecode>=0.15.1`` for Python 3.12 to avoid `known bug <https://github.com/MatthieuDartiailh/bytecode/issues/130>`_.


### PR DESCRIPTION
https://github.com/MatthieuDartiailh/bytecode/issues/130

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
