### PR TITLE
ci: fix flaky script report test names being off by one

### DIFF
--- a/scripts/report_skipped_flaky.py
+++ b/scripts/report_skipped_flaky.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import json
 import os
+import pdb
 import re
 import time
 
@@ -49,7 +50,7 @@ def extract_flaky_tests(file_path):
                 flaky_match = FLAKY_PATTERN.match(line)
 
             func_match = TEST_FUNCTION_PATTERN.match(line)
-            if func_match:
+            if flaky_match and func_match:
                 test_name = func_match.group(1)
 
             if flaky_match and test_name:

--- a/scripts/report_skipped_flaky.py
+++ b/scripts/report_skipped_flaky.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 import json
 import os
-import pdb
 import re
 import time
 


### PR DESCRIPTION
The test names associated with each `@flaky` decorator was still off by one in some cases. This should fix it.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
