### PR TITLE
test(django): update some stale skipped tests in the django suite

### DIFF
--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -1461,7 +1461,8 @@ def test_cached_template(client, test_spans):
 
     # check the first call for a non-cached view
     spans = list(test_spans.filter_spans(name="django.cache"))
-    assert len(spans) == 2
+    cache_span_count = len(spans)
+    assert cache_span_count >= 1
     # the cache miss
     assert spans[0].resource == "django.core.cache.backends.locmem.get"
     # store the result in the cache
@@ -1472,7 +1473,7 @@ def test_cached_template(client, test_spans):
     assert response.status_code == 200
     spans = list(test_spans.filter_spans(name="django.cache"))
     # Should have 1 more span
-    assert len(spans) == 3
+    assert len(spans) == cache_span_count + 1
 
     span_template_cache = spans[2]
     assert span_template_cache.service == "django"

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -39,7 +39,6 @@ from tests.conftest import DEFAULT_DDTRACE_SUBPROCESS_TEST_SERVICE_NAME
 from tests.opentracer.utils import init_tracer
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
 from tests.utils import assert_dict_issuperset
-from tests.utils import flaky
 from tests.utils import override_config
 from tests.utils import override_env
 from tests.utils import override_global_config

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -1454,7 +1454,6 @@ def test_cached_view(client, test_spans):
     assert span_header.get_tags() == expected_meta_header
 
 
-@flaky(1735812000)
 @pytest.mark.django_db
 def test_cached_template(client, test_spans):
     # make the first request so that the view is cached
@@ -1487,7 +1486,7 @@ def test_cached_template(client, test_spans):
         "component": "django",
         "django.cache.backend": "django.core.cache.backends.locmem.LocMemCache",
         "django.cache.key": "template.cache.users_list.d41d8cd98f00b204e9800998ecf8427e",
-        "_dd.base_service": "",
+        "_dd.base_service": "tests.contrib.django",
     }
 
     assert span_template_cache.get_tags() == expected_meta

--- a/tests/contrib/django/test_django_snapshots.py
+++ b/tests/contrib/django/test_django_snapshots.py
@@ -84,7 +84,6 @@ def daphne_client(django_asgi, additional_env=None):
         server_process.terminate()
 
 
-@flaky(1735812000)
 @pytest.mark.skipif(django.VERSION < (2, 0), reason="")
 @snapshot(variants={"": django.VERSION >= (2, 2)}, ignores=SNAPSHOT_IGNORES)
 def test_urlpatterns_include(client):
@@ -171,7 +170,6 @@ def psycopg2_patched(transactional_db):
     unpatch()
 
 
-@flaky(1735812000)
 @pytest.mark.django_db
 def test_psycopg2_query_default(client, snapshot_context, psycopg2_patched):
     """Execute a psycopg2 query on a Django database wrapper.
@@ -219,7 +217,6 @@ def psycopg3_patched(transactional_db):
         unpatch()
 
 
-@flaky(1735812000)
 @pytest.mark.django_db
 @pytest.mark.skipif(django.VERSION < (4, 2, 0), reason="Psycopg3 not supported in django<4.2")
 def test_psycopg3_query_default(client, snapshot_context, psycopg3_patched):

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg2_query_default.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg2_query_default.json
@@ -9,14 +9,18 @@
     "type": "sql",
     "error": 0,
     "meta": {
-      "_dd.base_service": "",
+      "_dd.base_service": "tests.contrib.django",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "67b8b65900000000",
       "component": "django-postgres",
+      "db.name": "test_postgres",
+      "db.user": "postgres",
       "django.db.alias": "postgres",
       "django.db.vendor": "postgresql",
       "language": "python",
-      "runtime-id": "5f1251d265904185ae371a48d5cfc7f4",
+      "out.host": "127.0.0.1",
+      "runtime-id": "09170f9453654e5f971905934ab65285",
+      "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
@@ -25,10 +29,11 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
       "db.row_count": 1,
-      "process_id": 19970
+      "network.destination.port": 5432,
+      "process_id": 14457
     },
-    "duration": 481458,
-    "start": 1692647371725790802
+    "duration": 857791,
+    "start": 1740158553293644760
   },
      {
        "name": "postgres.query",
@@ -40,8 +45,7 @@
        "type": "sql",
        "error": 0,
        "meta": {
-         "_dd.base_service": "",
-         "_dd.p.tid": "654a694400000000",
+         "_dd.base_service": "tests.contrib.django",
          "component": "psycopg",
          "db.application": "None",
          "db.name": "test_postgres",
@@ -57,6 +61,6 @@
          "db.row_count": 1,
          "network.destination.port": 5432
        },
-       "duration": 339625,
-       "start": 1692647371725901010
+       "duration": 654458,
+       "start": 1740158553293788510
      }]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg3_query_default.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_psycopg3_query_default.json
@@ -9,14 +9,18 @@
     "type": "sql",
     "error": 0,
     "meta": {
-      "_dd.base_service": "",
+      "_dd.base_service": "tests.contrib.django",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "67b8b47800000000",
       "component": "django-postgres",
+      "db.name": "test_postgres",
+      "db.user": "postgres",
       "django.db.alias": "postgres",
       "django.db.vendor": "postgresql",
       "language": "python",
-      "runtime-id": "1bf237bb7ea94061afe926a0962d6390",
+      "out.host": "127.0.0.1",
+      "runtime-id": "b7354874b34c40d5ac8383c4c75c18f8",
+      "server.address": "127.0.0.1",
       "span.kind": "client"
     },
     "metrics": {
@@ -25,10 +29,11 @@
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
       "db.row_count": 1,
-      "process_id": 34137
+      "network.destination.port": 5432,
+      "process_id": 6986
     },
-    "duration": 451667,
-    "start": 1692708845478561507
+    "duration": 648500,
+    "start": 1740158072979098718
   },
      {
        "name": "postgres.query",
@@ -40,8 +45,7 @@
        "type": "sql",
        "error": 0,
        "meta": {
-         "_dd.base_service": "",
-         "_dd.p.tid": "654a694400000000",
+         "_dd.base_service": "tests.contrib.django",
          "component": "psycopg",
          "db.application": "None",
          "db.name": "test_postgres",
@@ -57,6 +61,6 @@
          "db.row_count": 1,
          "network.destination.port": 5432
        },
-       "duration": 329250,
-       "start": 1692708845478650340
+       "duration": 504458,
+       "start": 1740158072979200635
      }]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_urlpatterns_include.json
@@ -9,9 +9,9 @@
     "type": "web",
     "error": 0,
     "meta": {
-      "_dd.base_service": "",
+      "_dd.base_service": "tests.contrib.django",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "67b8b4ab00000000",
       "component": "django",
       "django.request.class": "django.core.handlers.wsgi.WSGIRequest",
       "django.response.class": "django.http.response.HttpResponse",
@@ -22,7 +22,7 @@
       "http.status_code": "200",
       "http.url": "http://testserver/include/test/",
       "language": "python",
-      "runtime-id": "5f1251d265904185ae371a48d5cfc7f4",
+      "runtime-id": "a4f3f77e9eed4f408aeca90296519978",
       "span.kind": "server"
     },
     "metrics": {
@@ -30,10 +30,10 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 19970
+      "process_id": 7661
     },
-    "duration": 2585958,
-    "start": 1692647428167494300
+    "duration": 31772625,
+    "start": 1740158123232224047
   },
      {
        "name": "django.middleware",
@@ -45,12 +45,11 @@
        "type": "",
        "error": 0,
        "meta": {
-         "_dd.base_service": "",
-         "_dd.p.tid": "654a694400000000",
+         "_dd.base_service": "tests.contrib.django",
          "component": "django"
        },
-       "duration": 2026625,
-       "start": 1692647428167765675
+       "duration": 9416667,
+       "start": 1740158123253742630
      },
         {
           "name": "django.middleware",
@@ -62,12 +61,11 @@
           "type": "",
           "error": 0,
           "meta": {
-            "_dd.base_service": "",
-            "_dd.p.tid": "654a694400000000",
+            "_dd.base_service": "tests.contrib.django",
             "component": "django"
           },
-          "duration": 69459,
-          "start": 1692647428167897133
+          "duration": 766125,
+          "start": 1740158123253874963
         },
         {
           "name": "django.middleware",
@@ -79,12 +77,11 @@
           "type": "",
           "error": 0,
           "meta": {
-            "_dd.base_service": "",
-            "_dd.p.tid": "654a694400000000",
+            "_dd.base_service": "tests.contrib.django",
             "component": "django"
           },
-          "duration": 1739084,
-          "start": 1692647428167997883
+          "duration": 8210500,
+          "start": 1740158123254801547
         },
            {
              "name": "django.middleware",
@@ -96,12 +93,11 @@
              "type": "",
              "error": 0,
              "meta": {
-               "_dd.base_service": "",
-               "_dd.p.tid": "654a694400000000",
+               "_dd.base_service": "tests.contrib.django",
                "component": "django"
              },
-             "duration": 59417,
-             "start": 1692647428168031050
+             "duration": 1122125,
+             "start": 1740158123254902963
            },
            {
              "name": "django.middleware",
@@ -113,12 +109,11 @@
              "type": "",
              "error": 0,
              "meta": {
-               "_dd.base_service": "",
-               "_dd.p.tid": "654a694400000000",
+               "_dd.base_service": "tests.contrib.django",
                "component": "django"
              },
-             "duration": 1563167,
-             "start": 1692647428168121633
+             "duration": 6748292,
+             "start": 1740158123256135630
            },
               {
                 "name": "django.middleware",
@@ -130,12 +125,11 @@
                 "type": "",
                 "error": 0,
                 "meta": {
-                  "_dd.base_service": "",
-                  "_dd.p.tid": "654a694400000000",
+                  "_dd.base_service": "tests.contrib.django",
                   "component": "django"
                 },
-                "duration": 26042,
-                "start": 1692647428168151425
+                "duration": 38125,
+                "start": 1740158123256234172
               },
               {
                 "name": "django.middleware",
@@ -147,12 +141,11 @@
                 "type": "",
                 "error": 0,
                 "meta": {
-                  "_dd.base_service": "",
-                  "_dd.p.tid": "654a694400000000",
+                  "_dd.base_service": "tests.contrib.django",
                   "component": "django"
                 },
-                "duration": 1441875,
-                "start": 1692647428168197925
+                "duration": 6401834,
+                "start": 1740158123256360588
               },
                  {
                    "name": "django.middleware",
@@ -164,12 +157,11 @@
                    "type": "",
                    "error": 0,
                    "meta": {
-                     "_dd.base_service": "",
-                     "_dd.p.tid": "654a694400000000",
+                     "_dd.base_service": "tests.contrib.django",
                      "component": "django"
                    },
-                   "duration": 32500,
-                   "start": 1692647428168227967
+                   "duration": 36417,
+                   "start": 1740158123256469380
                  },
                  {
                    "name": "django.middleware",
@@ -181,12 +173,11 @@
                    "type": "",
                    "error": 0,
                    "meta": {
-                     "_dd.base_service": "",
-                     "_dd.p.tid": "654a694400000000",
+                     "_dd.base_service": "tests.contrib.django",
                      "component": "django"
                    },
-                   "duration": 1351333,
-                   "start": 1692647428168278300
+                   "duration": 6151875,
+                   "start": 1740158123256593880
                  },
                     {
                       "name": "django.middleware",
@@ -198,12 +189,11 @@
                       "type": "",
                       "error": 0,
                       "meta": {
-                        "_dd.base_service": "",
-                        "_dd.p.tid": "654a694400000000",
+                        "_dd.base_service": "tests.contrib.django",
                         "component": "django"
                       },
-                      "duration": 94458,
-                      "start": 1692647428168308050
+                      "duration": 3922750,
+                      "start": 1740158123256694338
                     },
                     {
                       "name": "django.middleware",
@@ -215,12 +205,11 @@
                       "type": "",
                       "error": 0,
                       "meta": {
-                        "_dd.base_service": "",
-                        "_dd.p.tid": "654a694400000000",
+                        "_dd.base_service": "tests.contrib.django",
                         "component": "django"
                       },
-                      "duration": 1155042,
-                      "start": 1692647428168423175
+                      "duration": 1858583,
+                      "start": 1740158123260753130
                     },
                        {
                          "name": "django.middleware",
@@ -232,12 +221,11 @@
                          "type": "",
                          "error": 0,
                          "meta": {
-                           "_dd.base_service": "",
-                           "_dd.p.tid": "654a694400000000",
+                           "_dd.base_service": "tests.contrib.django",
                            "component": "django"
                          },
-                         "duration": 1071458,
-                         "start": 1692647428168452467
+                         "duration": 1592541,
+                         "start": 1740158123260874047
                        },
                           {
                             "name": "django.middleware",
@@ -249,12 +237,11 @@
                             "type": "",
                             "error": 0,
                             "meta": {
-                              "_dd.base_service": "",
-                              "_dd.p.tid": "654a694400000000",
+                              "_dd.base_service": "tests.contrib.django",
                               "component": "django"
                             },
-                            "duration": 21208,
-                            "start": 1692647428168483217
+                            "duration": 28209,
+                            "start": 1740158123260984588
                           },
                           {
                             "name": "django.middleware",
@@ -266,12 +253,11 @@
                             "type": "",
                             "error": 0,
                             "meta": {
-                              "_dd.base_service": "",
-                              "_dd.p.tid": "654a694400000000",
+                              "_dd.base_service": "tests.contrib.django",
                               "component": "django"
                             },
-                            "duration": 942541,
-                            "start": 1692647428168521467
+                            "duration": 1176792,
+                            "start": 1740158123261124088
                           },
                              {
                                "name": "django.middleware",
@@ -283,12 +269,11 @@
                                "type": "",
                                "error": 0,
                                "meta": {
-                                 "_dd.base_service": "",
-                                 "_dd.p.tid": "654a694400000000",
+                                 "_dd.base_service": "tests.contrib.django",
                                  "component": "django"
                                },
-                               "duration": 902709,
-                               "start": 1692647428168550633
+                               "duration": 1052167,
+                               "start": 1740158123261232130
                              },
                                 {
                                   "name": "django.middleware",
@@ -300,12 +285,11 @@
                                   "type": "",
                                   "error": 0,
                                   "meta": {
-                                    "_dd.base_service": "",
-                                    "_dd.p.tid": "654a694400000000",
+                                    "_dd.base_service": "tests.contrib.django",
                                     "component": "django"
                                   },
-                                  "duration": 554959,
-                                  "start": 1692647428168886633
+                                  "duration": 921459,
+                                  "start": 1740158123261343088
                                 },
                                    {
                                      "name": "django.middleware",
@@ -317,12 +301,11 @@
                                      "type": "",
                                      "error": 0,
                                      "meta": {
-                                       "_dd.base_service": "",
-                                       "_dd.p.tid": "654a694400000000",
+                                       "_dd.base_service": "tests.contrib.django",
                                        "component": "django"
                                      },
-                                     "duration": 31542,
-                                     "start": 1692647428169226883
+                                     "duration": 39625,
+                                     "start": 1740158123261598797
                                    },
                                    {
                                      "name": "django.middleware",
@@ -334,12 +317,11 @@
                                      "type": "",
                                      "error": 0,
                                      "meta": {
-                                       "_dd.base_service": "",
-                                       "_dd.p.tid": "654a694400000000",
+                                       "_dd.base_service": "tests.contrib.django",
                                        "component": "django"
                                      },
-                                     "duration": 24250,
-                                     "start": 1692647428169277425
+                                     "duration": 25833,
+                                     "start": 1740158123261807505
                                    },
                                    {
                                      "name": "django.view",
@@ -351,12 +333,11 @@
                                      "type": "",
                                      "error": 0,
                                      "meta": {
-                                       "_dd.base_service": "",
-                                       "_dd.p.tid": "654a694400000000",
+                                       "_dd.base_service": "tests.contrib.django",
                                        "component": "django"
                                      },
-                                     "duration": 80833,
-                                     "start": 1692647428169332092
+                                     "duration": 89458,
+                                     "start": 1740158123262018297
                                    },
                           {
                             "name": "django.middleware",
@@ -368,12 +349,11 @@
                             "type": "",
                             "error": 0,
                             "meta": {
-                              "_dd.base_service": "",
-                              "_dd.p.tid": "654a694400000000",
+                              "_dd.base_service": "tests.contrib.django",
                               "component": "django"
                             },
-                            "duration": 31792,
-                            "start": 1692647428169481175
+                            "duration": 46791,
+                            "start": 1740158123262402297
                           },
                        {
                          "name": "django.middleware",
@@ -385,12 +365,11 @@
                          "type": "",
                          "error": 0,
                          "meta": {
-                           "_dd.base_service": "",
-                           "_dd.p.tid": "654a694400000000",
+                           "_dd.base_service": "tests.contrib.django",
                            "component": "django"
                          },
-                         "duration": 27667,
-                         "start": 1692647428169539925
+                         "duration": 34833,
+                         "start": 1740158123262558797
                        },
                     {
                       "name": "django.middleware",
@@ -402,12 +381,11 @@
                       "type": "",
                       "error": 0,
                       "meta": {
-                        "_dd.base_service": "",
-                        "_dd.p.tid": "654a694400000000",
+                        "_dd.base_service": "tests.contrib.django",
                         "component": "django"
                       },
-                      "duration": 25167,
-                      "start": 1692647428169593883
+                      "duration": 27917,
+                      "start": 1740158123262701338
                     },
               {
                 "name": "django.middleware",
@@ -419,12 +397,11 @@
                 "type": "",
                 "error": 0,
                 "meta": {
-                  "_dd.base_service": "",
-                  "_dd.p.tid": "654a694400000000",
+                  "_dd.base_service": "tests.contrib.django",
                   "component": "django"
                 },
-                "duration": 18583,
-                "start": 1692647428169655800
+                "duration": 23667,
+                "start": 1740158123262844005
               },
            {
              "name": "django.middleware",
@@ -436,12 +413,11 @@
              "type": "",
              "error": 0,
              "meta": {
-               "_dd.base_service": "",
-               "_dd.p.tid": "654a694400000000",
+               "_dd.base_service": "tests.contrib.django",
                "component": "django"
              },
-             "duration": 25833,
-             "start": 1692647428169700675
+             "duration": 32000,
+             "start": 1740158123262963463
            },
         {
           "name": "django.middleware",
@@ -453,10 +429,9 @@
           "type": "",
           "error": 0,
           "meta": {
-            "_dd.base_service": "",
-            "_dd.p.tid": "654a694400000000",
+            "_dd.base_service": "tests.contrib.django",
             "component": "django"
           },
-          "duration": 28875,
-          "start": 1692647428169753050
+          "duration": 42792,
+          "start": 1740158123263097130
         }]]


### PR DESCRIPTION
This change removes the `@flaky` markers from some django tests and updates expectations that had become stale.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
