### PR TITLE
test(httpx): update some stale skipped tests in the httpx suite

### DIFF
--- a/tests/contrib/httpx/test_httpx.py
+++ b/tests/contrib/httpx/test_httpx.py
@@ -292,7 +292,6 @@ def test_schematized_configure_global_service_name_env_v1():
     asyncio.run(test())
 
 
-@flaky(1735812000)
 @pytest.mark.subprocess()
 def test_schematized_unspecified_service_name_env_default():
     """
@@ -325,7 +324,6 @@ def test_schematized_unspecified_service_name_env_default():
     asyncio.run(test())
 
 
-@flaky(1735812000)
 @pytest.mark.subprocess(env=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
 def test_schematized_unspecified_service_name_env_v0():
     """

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_default.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_default.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "http.request",
-    "service": "tests.contrib.httpx",
+    "service": "ddtrace_subprocess_dir",
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,
@@ -10,7 +10,7 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "67b8ba7400000000",
       "component": "httpx",
       "http.method": "GET",
       "http.status_code": "200",
@@ -18,7 +18,7 @@
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
       "out.host": "localhost",
-      "runtime-id": "7c3530b5d697442eae42e163e446edf0",
+      "runtime-id": "9f321945191a47ac8e55f09c141ec62a",
       "span.kind": "client"
     },
     "metrics": {
@@ -26,8 +26,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 912
+      "process_id": 15757
     },
-    "duration": 2486000,
-    "start": 1683920781034007000
+    "duration": 1742375,
+    "start": 1740159604021186135
   }]]

--- a/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v0.json
+++ b/tests/snapshots/tests.contrib.httpx.test_httpx.test_schematized_unspecified_service_name_env_v0.json
@@ -1,7 +1,7 @@
 [[
   {
     "name": "http.request",
-    "service": "tests.contrib.httpx",
+    "service": "ddtrace_subprocess_dir",
     "resource": "http.request",
     "trace_id": 0,
     "span_id": 1,
@@ -10,7 +10,7 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "654a694400000000",
+      "_dd.p.tid": "67b8bab400000000",
       "component": "httpx",
       "http.method": "GET",
       "http.status_code": "200",
@@ -18,7 +18,7 @@
       "http.useragent": "python-httpx/x.xx.x",
       "language": "python",
       "out.host": "localhost",
-      "runtime-id": "6f9d8b39083d4c69b64e0c0adb09dd7e",
+      "runtime-id": "d089202423a84e278ca4ad55b1fc549a",
       "span.kind": "client"
     },
     "metrics": {
@@ -26,8 +26,8 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 919
+      "process_id": 16245
     },
-    "duration": 2441000,
-    "start": 1683920781812906000
+    "duration": 1891709,
+    "start": 1740159668391149845
   }]]


### PR DESCRIPTION
This change removes the @flaky markers from some httpx tests and updates expectations that had become stale.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
