### PR TITLE
ci(cassandra): move cassandra suite from circleci to gitlab

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -452,22 +452,6 @@ jobs:
           snapshot: true
           docker_services: 'postgres'
 
-  cassandra:
-    <<: *contrib_job
-    docker:
-      - image: *ddtrace_dev_image
-        environment:
-          CASS_DRIVER_NO_EXTENSIONS: 1
-      - image: *cassandra_image
-        environment:
-          - MAX_HEAP_SIZE=512M
-          - HEAP_NEWSIZE=256M
-      - *testagent
-    steps:
-      - run_test:
-          wait: cassandra
-          pattern: 'cassandra'
-
   consul:
     <<: *contrib_job_small
     docker:

--- a/.gitlab/services.yml
+++ b/.gitlab/services.yml
@@ -91,3 +91,8 @@
       MYSQL_PASSWORD: test
       MYSQL_USER: test
       MYSQL_DATABASE: test
+  cassandra:
+    image: registry.ddbuild.io/images/mirror/library/cassandra:3.11.3
+    variables:
+      MAX_HEAP_SIZE: 512M
+      HEAP_NEWSIZE: 256M

--- a/.gitlab/services.yml
+++ b/.gitlab/services.yml
@@ -92,7 +92,8 @@
       MYSQL_USER: test
       MYSQL_DATABASE: test
   cassandra:
-    image: registry.ddbuild.io/images/mirror/library/cassandra:3.11.3
+    name: registry.ddbuild.io/images/mirror/library/cassandra:3.11.3
+    alias: cassandra
     variables:
       MAX_HEAP_SIZE: 512M
       HEAP_NEWSIZE: 256M

--- a/.gitlab/services.yml
+++ b/.gitlab/services.yml
@@ -92,7 +92,7 @@
       MYSQL_USER: test
       MYSQL_DATABASE: test
   cassandra:
-    name: registry.ddbuild.io/images/mirror/library/cassandra:3.11.3
+    name: registry.ddbuild.io/images/mirror/cassandra:3.11.3
     alias: cassandra
     variables:
       MAX_HEAP_SIZE: 512M

--- a/tests/contrib/suitespec.yml
+++ b/tests/contrib/suitespec.yml
@@ -427,6 +427,7 @@ suites:
       - tests/contrib/cassandra/*
     runner: riot
     snapshot: true
+    parallelism: 3
     services:
       - cassandra
   celery:

--- a/tests/contrib/suitespec.yml
+++ b/tests/contrib/suitespec.yml
@@ -426,6 +426,7 @@ suites:
       - '@cassandra'
       - tests/contrib/cassandra/*
     runner: riot
+    snapshot: true
     services:
       - cassandra
   celery:

--- a/tests/contrib/suitespec.yml
+++ b/tests/contrib/suitespec.yml
@@ -426,6 +426,8 @@ suites:
       - '@cassandra'
       - tests/contrib/cassandra/*
     runner: riot
+    services:
+      - cassandra
   celery:
     env:
       DD_DISABLE_ERROR_RESPONSES: true

--- a/tests/contrib/suitespec.yml
+++ b/tests/contrib/suitespec.yml
@@ -427,7 +427,7 @@ suites:
       - tests/contrib/cassandra/*
     runner: riot
     snapshot: true
-    parallelism: 3
+    parallelism: 2
     services:
       - cassandra
   celery:


### PR DESCRIPTION
This change moves the `cassandra` test suite to gitlab, because we're in the process of migrating off of circleci.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
