### PR TITLE
ci: circleci->gitlab for suites that use the mysql and postgres images

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -422,6 +422,22 @@ jobs:
           snapshot: true
           docker_services: "localstack"
 
+  cassandra:
+    <<: *contrib_job
+    docker:
+      - image: *ddtrace_dev_image
+        environment:
+          CASS_DRIVER_NO_EXTENSIONS: 1
+      - image: *cassandra_image
+        environment:
+          - MAX_HEAP_SIZE=512M
+          - HEAP_NEWSIZE=256M
+      - *testagent
+    steps:
+      - run_test:
+          wait: cassandra
+          pattern: 'cassandra'
+
   consul:
     <<: *contrib_job_small
     docker:

--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -5,16 +5,10 @@ ubuntu_base_image: &ubuntu_base_img ubuntu-2004:2023.04.2
 cimg_base_image: &cimg_base_image cimg/base:2022.08
 python310_image: &python310_image cimg/python:3.10.12
 ddtrace_dev_image: &ddtrace_dev_image ghcr.io/datadog/dd-trace-py/testrunner:47c7b5287da25643e46652e6d222a40a52f2382a@sha256:3a02dafeff9cd72966978816d1b39b54f5517af4049396923b95c8452f604269
-redis_image: &redis_image redis:4.0-alpine@sha256:3e99741f293147ff406657dda7644c2b88564b80a498cd00da8f905743449c9f
-memcached_image: &memcached_image memcached:1.5-alpine@sha256:48cb7207e3d34871893fa1628f3a4984375153e9942facf82e25935b0a633c8a
-cassandra_image: &cassandra_image cassandra:3.11.7@sha256:495e5752526f7e75d3ad85b6a6bbf3b79714321b17a44255a216c341e3baae11
 consul_image: &consul_image consul:1.6.0@sha256:daa6203532fc30d81bf6c5593f79a2c7c23f08e8fde82f1e4bd8069b48b57596
 moto_image: &moto_image datadog/docker-library:moto_1_0_1@sha256:58c15f03141073629f4ff2a78910b812205324579c76f8bcac87e8e89af2e673
-mysql_image: &mysql_image mysql:5.7@sha256:03b6dcedf5a2754da00e119e2cc6094ed3c884ad36b67bb25fe67be4b4f9bdb1
 mongo_image: &mongo_image mongo:3.6@sha256:19c11a8f1064fd2bb713ef1270f79a742a184cd57d9bb922efdd2a8eca514af8
 httpbin_image: &httpbin_image kennethreitz/httpbin@sha256:2c7abc4803080c22928265744410173b6fea3b898872c01c5fd0f0f9df4a59fb
-vertica_image: &vertica_image vertica/vertica-ce:latest
-rabbitmq_image: &rabbitmq_image rabbitmq:3.7-alpine
 testagent_image: &testagent_image ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.20.0
 
 parameters:
@@ -311,14 +305,6 @@ executors:
 httpbin_local: &httpbin_local
   image: *httpbin_image
   name: httpbin.org
-
-mysql_server: &mysql_server
-  image: *mysql_image
-  environment:
-    - MYSQL_ROOT_PASSWORD=admin
-    - MYSQL_PASSWORD=test
-    - MYSQL_USER=test
-    - MYSQL_DATABASE=test
 
 testagent: &testagent
   image: *testagent_image

--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -11,7 +11,6 @@ cassandra_image: &cassandra_image cassandra:3.11.7@sha256:495e5752526f7e75d3ad85
 consul_image: &consul_image consul:1.6.0@sha256:daa6203532fc30d81bf6c5593f79a2c7c23f08e8fde82f1e4bd8069b48b57596
 moto_image: &moto_image datadog/docker-library:moto_1_0_1@sha256:58c15f03141073629f4ff2a78910b812205324579c76f8bcac87e8e89af2e673
 mysql_image: &mysql_image mysql:5.7@sha256:03b6dcedf5a2754da00e119e2cc6094ed3c884ad36b67bb25fe67be4b4f9bdb1
-postgres_image: &postgres_image postgres:12-alpine@sha256:c6704f41eb84be53d5977cb821bf0e5e876064b55eafef1e260c2574de40ad9a
 mongo_image: &mongo_image mongo:3.6@sha256:19c11a8f1064fd2bb713ef1270f79a742a184cd57d9bb922efdd2a8eca514af8
 httpbin_image: &httpbin_image kennethreitz/httpbin@sha256:2c7abc4803080c22928265744410173b6fea3b898872c01c5fd0f0f9df4a59fb
 vertica_image: &vertica_image vertica/vertica-ce:latest
@@ -321,13 +320,6 @@ mysql_server: &mysql_server
     - MYSQL_USER=test
     - MYSQL_DATABASE=test
 
-postgres_server: &postgres_server
-  image: *postgres_image
-  environment:
-    - POSTGRES_PASSWORD=postgres
-    - POSTGRES_USER=postgres
-    - POSTGRES_DB=postgres
-
 testagent: &testagent
   image: *testagent_image
   environment:
@@ -444,30 +436,6 @@ jobs:
           snapshot: true
           docker_services: "localstack"
 
-  asyncpg:
-    <<: *machine_executor
-    steps:
-      - run_test:
-          pattern: 'asyncpg'
-          snapshot: true
-          docker_services: 'postgres'
-
-  cassandra:
-    <<: *contrib_job
-    docker:
-      - image: *ddtrace_dev_image
-        environment:
-          CASS_DRIVER_NO_EXTENSIONS: 1
-      - image: *cassandra_image
-        environment:
-          - MAX_HEAP_SIZE=512M
-          - HEAP_NEWSIZE=256M
-      - *testagent
-    steps:
-      - run_test:
-          wait: cassandra
-          pattern: 'cassandra'
-
   consul:
     <<: *contrib_job_small
     docker:
@@ -487,39 +455,6 @@ jobs:
           snapshot: true
           docker_services: "mariadb"
 
-  mysqlconnector:
-    <<: *contrib_job
-    docker:
-      - image: *ddtrace_dev_image
-      - *mysql_server
-      - *testagent
-    steps:
-      - run_test:
-          wait: mysql
-          pattern: 'mysql$'
-
-  mysqlpython:
-    <<: *contrib_job
-    docker:
-      - image: *ddtrace_dev_image
-      - *mysql_server
-      - *testagent
-    steps:
-      - run_test:
-          wait: mysql
-          pattern: 'mysqldb$'
-
-  pymysql:
-    <<: *contrib_job
-    docker:
-      - image: *ddtrace_dev_image
-      - *mysql_server
-      - *testagent
-    steps:
-      - run_test:
-          wait: mysql
-          pattern: 'pymysql$'
-
   mongoengine:
     <<: *machine_executor
     steps:
@@ -527,28 +462,6 @@ jobs:
           pattern: 'mongoengine'
           snapshot: true
           docker_services: 'mongo'
-
-  sqlalchemy:
-    <<: *contrib_job_small
-    docker:
-      - image: *ddtrace_dev_image
-      - *testagent
-      - *postgres_server
-      - *mysql_server
-    steps:
-      - run_test:
-          wait: postgres mysql
-          pattern: "sqlalchemy"
-
-  psycopg:
-    <<: *machine_executor
-    parallelism: 4
-    steps:
-      - run_test:
-          # We want psycopg and psycopg2 collected
-          pattern: "psycopg"
-          snapshot: true
-          docker_services: "postgres"
 
   aiobotocore:
     <<: *contrib_job
@@ -559,27 +472,6 @@ jobs:
     steps:
        - run_test:
           pattern: 'aiobotocore'
-
-  aiomysql:
-    <<: *machine_executor
-    steps:
-      - run_test:
-          docker_services: 'mysql'
-          wait: mysql
-          pattern: 'aiomysql'
-          snapshot: true
-
-  aiopg:
-    <<: *contrib_job_small
-    parallelism: 4
-    docker:
-      - image: *ddtrace_dev_image
-      - *postgres_server
-      - *testagent
-    steps:
-      - run_test:
-          wait: postgres
-          pattern: 'aiopg'
 
   build_docs:
     # build documentation and store as an artifact

--- a/tests/contrib/suitespec.yml
+++ b/tests/contrib/suitespec.yml
@@ -286,6 +286,9 @@ suites:
       - tests/snapshots/tests.{suite}.*
       - tests/contrib/shared_tests_async.py
     runner: riot
+    services:
+      - mysql
+    snapshot: true
   aiopg:
     paths:
       - '@bootstrap'
@@ -298,6 +301,9 @@ suites:
       - tests/contrib/aiopg/*
       - tests/contrib/shared_tests_async.py
     runner: riot
+    snapshot: true
+    services:
+      - postgres
   algoliasearch:
     paths:
       - '@bootstrap'
@@ -348,6 +354,8 @@ suites:
       - tests/contrib/shared_tests_async.py
     runner: riot
     snapshot: true
+    services:
+      - postgres
   asynctest:
     parallelism: 2
     paths:
@@ -833,6 +841,8 @@ suites:
     pattern: mysqldb$
     runner: riot
     skip: true
+    services:
+      - mysql
   opentelemetry:
     parallelism: 4
     paths:
@@ -876,6 +886,9 @@ suites:
       - tests/snapshots/tests.contrib.psycopg2.*
       - tests/contrib/shared_tests.py
     runner: riot
+    services:
+      - postgres
+    snapshot: true
   pylibmc:
     paths:
       - '@bootstrap'
@@ -924,6 +937,9 @@ suites:
       - tests/contrib/mysql/*
       - tests/contrib/shared_tests.py
     runner: riot
+    services:
+      - mysql
+    snapshot: true
   pynamodb:
     paths:
       - '@bootstrap'
@@ -1054,6 +1070,14 @@ suites:
       - '@dbapi'
       - tests/contrib/sqlalchemy/*
     runner: riot
+    services:
+      - postgres
+      - mysql
+    snapshot: true
+    services:
+      - postgres
+      - mysql
+    snapshot: true
   starlette:
     paths:
       - '@bootstrap'

--- a/tests/contrib/suitespec.yml
+++ b/tests/contrib/suitespec.yml
@@ -1074,10 +1074,6 @@ suites:
       - postgres
       - mysql
     snapshot: true
-    services:
-      - postgres
-      - mysql
-    snapshot: true
   starlette:
     paths:
       - '@bootstrap'


### PR DESCRIPTION
This change moves to gitlab all of the remaining test suites that communicate with the Postgres or Mysql images as part of the ongoing migration away from circleci.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
