### PR TITLE
feat(graphql): add exception tracking graphql span

### DIFF
--- a/ddtrace/contrib/internal/graphql/patch.py
+++ b/ddtrace/contrib/internal/graphql/patch.py
@@ -358,6 +358,7 @@ def _set_span_errors(errors: List[GraphQLError], span: Span) -> None:
             if extensions:
                 for key in extensions:
                     attributes[f"extensions.{key}"] = extensions[key]
+        span.record_exception(error, attributes)
         span._add_event(
             name="dd.graphql.query.error",
             attributes=attributes,

--- a/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_fail.json
+++ b/tests/snapshots/tests.contrib.graphql.test_graphql.test_graphql_fail.json
@@ -11,20 +11,20 @@
     "meta": {
       "_dd.base_service": "tests.contrib.graphql",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "679b976d00000000",
+      "_dd.p.tid": "67b8efd800000000",
       "component": "graphql",
       "graphql.source": "type Query { fail: String }",
       "language": "python",
-      "runtime-id": "596dfe80a9184851a69f62836436abe5"
+      "runtime-id": "e1211760823c451db22d722cabe26aa7"
     },
     "metrics": {
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 27630
+      "process_id": 34574
     },
-    "duration": 257000,
-    "start": 1738250093732371000
+    "duration": 310000,
+    "start": 1740173272332112000
   }],
 [
   {
@@ -39,24 +39,24 @@
     "meta": {
       "_dd.base_service": "tests.contrib.graphql",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "679b976d00000000",
+      "_dd.p.tid": "67b8efd800000000",
       "component": "graphql",
       "error.message": "'NoneType' object has no attribute 'name'\n\nGraphQL request:3:7\n2 |     query {\n3 |       fail\n  |       ^\n4 |     }",
-      "error.stack": "Traceback (most recent call last):\n  File \"/Users/quinna.halim/dd-trace-py/.riot/venv_py31013_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio0211_graphql-core~320_pytest-randomly/lib/python3.10/site-packages/graphql/execution/execute.py\", line 521, in execute_field\n    result = resolve_fn(source, info, **args)\n  File \"/Users/quinna.halim/dd-trace-py/ddtrace/contrib/internal/graphql/patch.py\", line 243, in _resolver_middleware\n    return next_middleware(root, info, **args)\n  File \"/Users/quinna.halim/dd-trace-py/tests/contrib/graphql/test_graphql.py\", line 104, in <lambda>\n    result = graphql_sync(test_schema, query, root_value=None, field_resolver=lambda _type, _field: resolvers[_type.name][_field.name])\ngraphql.error.graphql_error.GraphQLError: 'NoneType' object has no attribute 'name'\n\nGraphQL request:3:7\n2 |     query {\n3 |       fail\n  |       ^\n4 |     }\n",
+      "error.stack": "Traceback (most recent call last):\n  File \"/Users/quinna.halim/dd-trace-py/.riot/venv_py3127_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio0211_graphql-core~320_pytest-randomly/lib/python3.12/site-packages/graphql/execution/execute.py\", line 521, in execute_field\n    result = resolve_fn(source, info, **args)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/quinna.halim/dd-trace-py/ddtrace/contrib/internal/graphql/patch.py\", line 253, in _resolver_middleware\n    return next_middleware(root, info, **args)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/quinna.halim/dd-trace-py/tests/contrib/graphql/test_graphql.py\", line 104, in <lambda>\n    test_schema, query, root_value=None, field_resolver=lambda _type, _field: resolvers[_type.name][_field.name]\n                                                                                        ^^^^^^^^^^\ngraphql.error.graphql_error.GraphQLError: 'NoneType' object has no attribute 'name'\n\nGraphQL request:3:7\n2 |     query {\n3 |       fail\n  |       ^\n4 |     }\n",
       "error.type": "graphql.error.graphql_error.GraphQLError",
-      "events": "[{\"name\": \"dd.graphql.query.error\", \"time_unix_nano\": 1738250093735707000, \"attributes\": {\"message\": \"'NoneType' object has no attribute 'name'\", \"type\": \"graphql.error.graphql_error.GraphQLError\", \"locations\": \"3:7\", \"stacktrace\": \"Traceback (most recent call last):\\n  File \\\"/Users/quinna.halim/dd-trace-py/.riot/venv_py31013_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio0211_graphql-core~320_pytest-randomly/lib/python3.10/site-packages/graphql/execution/execute.py\\\", line 521, in execute_field\\n    result = resolve_fn(source, info, **args)\\n  File \\\"/Users/quinna.halim/dd-trace-py/ddtrace/contrib/internal/graphql/patch.py\\\", line 243, in _resolver_middleware\\n    return next_middleware(root, info, **args)\\n  File \\\"/Users/quinna.halim/dd-trace-py/tests/contrib/graphql/test_graphql.py\\\", line 104, in <lambda>\\n    result = graphql_sync(test_schema, query, root_value=None, field_resolver=lambda _type, _field: resolvers[_type.name][_field.name])\\ngraphql.error.graphql_error.GraphQLError: 'NoneType' object has no attribute 'name'\\n\\nGraphQL request:3:7\\n2 |     query {\\n3 |       fail\\n  |       ^\\n4 |     }\\n\", \"path\": \"fail\"}}]",
+      "events": "[{\"name\": \"recorded exception\", \"time_unix_nano\": 1740173272337612000, \"attributes\": {\"exception.type\": \"graphql.error.graphql_error.GraphQLError\", \"exception.message\": \"'NoneType' object has no attribute 'name'\\n\\nGraphQL request:3:7\\n2 |     query {\\n3 |       fail\\n  |       ^\\n4 |     }\", \"exception.escaped\": false, \"exception.stacktrace\": \"Traceback (most recent call last):\\n  File \\\"/Users/quinna.halim/dd-trace-py/.riot/venv_py3127_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio0211_graphql-core~320_pytest-randomly/lib/python3.12/site-packages/graphql/execution/execute.py\\\", line 521, in execute_field\\n    result = resolve_fn(source, info, **args)\\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/Users/quinna.halim/dd-trace-py/ddtrace/contrib/internal/graphql/patch.py\\\", line 253, in _resolver_middleware\\n    return next_middleware(root, info, **args)\\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/Users/quinna.halim/dd-trace-py/tests/contrib/graphql/test_graphql.py\\\", line 104, in <lambda>\\n    test_schema, query, root_value=None, field_resolver=lambda _type, _field: resolvers[_type.name][_field.name]\\n                                                                                        ^^^^^^^^^^\\ngraphql.error.graphql_error.GraphQLError: 'NoneType' object has no attribute 'name'\\n\\nGraphQL request:3:7\\n2 |     query {\\n3 |       fail\\n  |       ^\\n4 |     }\\n\", \"message\": \"'NoneType' object has no attribute 'name'\", \"type\": \"graphql.error.graphql_error.GraphQLError\", \"locations\": [\"3:7\"], \"stacktrace\": \"Traceback (most recent call last):\\n  File \\\"/Users/quinna.halim/dd-trace-py/.riot/venv_py3127_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio0211_graphql-core~320_pytest-randomly/lib/python3.12/site-packages/graphql/execution/execute.py\\\", line 521, in execute_field\\n    result = resolve_fn(source, info, **args)\\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/Users/quinna.halim/dd-trace-py/ddtrace/contrib/internal/graphql/patch.py\\\", line 253, in _resolver_middleware\\n    return next_middleware(root, info, **args)\\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/Users/quinna.halim/dd-trace-py/tests/contrib/graphql/test_graphql.py\\\", line 104, in <lambda>\\n    test_schema, query, root_value=None, field_resolver=lambda _type, _field: resolvers[_type.name][_field.name]\\n                                                                                        ^^^^^^^^^^\\ngraphql.error.graphql_error.GraphQLError: 'NoneType' object has no attribute 'name'\\n\\nGraphQL request:3:7\\n2 |     query {\\n3 |       fail\\n  |       ^\\n4 |     }\\n\", \"path\": \"fail\"}}, {\"name\": \"dd.graphql.query.error\", \"time_unix_nano\": 1740173272337761000, \"attributes\": {\"message\": \"'NoneType' object has no attribute 'name'\", \"type\": \"graphql.error.graphql_error.GraphQLError\", \"locations\": [\"3:7\"], \"stacktrace\": \"Traceback (most recent call last):\\n  File \\\"/Users/quinna.halim/dd-trace-py/.riot/venv_py3127_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio0211_graphql-core~320_pytest-randomly/lib/python3.12/site-packages/graphql/execution/execute.py\\\", line 521, in execute_field\\n    result = resolve_fn(source, info, **args)\\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/Users/quinna.halim/dd-trace-py/ddtrace/contrib/internal/graphql/patch.py\\\", line 253, in _resolver_middleware\\n    return next_middleware(root, info, **args)\\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/Users/quinna.halim/dd-trace-py/tests/contrib/graphql/test_graphql.py\\\", line 104, in <lambda>\\n    test_schema, query, root_value=None, field_resolver=lambda _type, _field: resolvers[_type.name][_field.name]\\n                                                                                        ^^^^^^^^^^\\ngraphql.error.graphql_error.GraphQLError: 'NoneType' object has no attribute 'name'\\n\\nGraphQL request:3:7\\n2 |     query {\\n3 |       fail\\n  |       ^\\n4 |     }\\n\", \"path\": \"fail\"}}]",
       "language": "python",
-      "runtime-id": "596dfe80a9184851a69f62836436abe5"
+      "runtime-id": "e1211760823c451db22d722cabe26aa7"
     },
     "metrics": {
       "_dd.measured": 1,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 27630
+      "process_id": 34574
     },
-    "duration": 1681000,
-    "start": 1738250093734027000
+    "duration": 3302000,
+    "start": 1740173272334461000
   },
      {
        "name": "graphql.parse",
@@ -72,8 +72,8 @@
          "component": "graphql",
          "graphql.source": "query { fail }"
        },
-       "duration": 128000,
-       "start": 1738250093734164000
+       "duration": 123000,
+       "start": 1740173272334675000
      },
      {
        "name": "graphql.validate",
@@ -89,8 +89,8 @@
          "component": "graphql",
          "graphql.source": "query { fail }"
        },
-       "duration": 493000,
-       "start": 1738250093734336000
+       "duration": 658000,
+       "start": 1740173272334840000
      },
      {
        "name": "graphql.execute",
@@ -105,17 +105,17 @@
          "_dd.base_service": "tests.contrib.graphql",
          "component": "graphql",
          "error.message": "'NoneType' object has no attribute 'name'\n\nGraphQL request:3:7\n2 |     query {\n3 |       fail\n  |       ^\n4 |     }",
-         "error.stack": "Traceback (most recent call last):\n  File \"/Users/quinna.halim/dd-trace-py/.riot/venv_py31013_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio0211_graphql-core~320_pytest-randomly/lib/python3.10/site-packages/graphql/execution/execute.py\", line 521, in execute_field\n    result = resolve_fn(source, info, **args)\n  File \"/Users/quinna.halim/dd-trace-py/ddtrace/contrib/internal/graphql/patch.py\", line 243, in _resolver_middleware\n    return next_middleware(root, info, **args)\n  File \"/Users/quinna.halim/dd-trace-py/tests/contrib/graphql/test_graphql.py\", line 104, in <lambda>\n    result = graphql_sync(test_schema, query, root_value=None, field_resolver=lambda _type, _field: resolvers[_type.name][_field.name])\ngraphql.error.graphql_error.GraphQLError: 'NoneType' object has no attribute 'name'\n\nGraphQL request:3:7\n2 |     query {\n3 |       fail\n  |       ^\n4 |     }\n",
+         "error.stack": "Traceback (most recent call last):\n  File \"/Users/quinna.halim/dd-trace-py/.riot/venv_py3127_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio0211_graphql-core~320_pytest-randomly/lib/python3.12/site-packages/graphql/execution/execute.py\", line 521, in execute_field\n    result = resolve_fn(source, info, **args)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/quinna.halim/dd-trace-py/ddtrace/contrib/internal/graphql/patch.py\", line 253, in _resolver_middleware\n    return next_middleware(root, info, **args)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/quinna.halim/dd-trace-py/tests/contrib/graphql/test_graphql.py\", line 104, in <lambda>\n    test_schema, query, root_value=None, field_resolver=lambda _type, _field: resolvers[_type.name][_field.name]\n                                                                                        ^^^^^^^^^^\ngraphql.error.graphql_error.GraphQLError: 'NoneType' object has no attribute 'name'\n\nGraphQL request:3:7\n2 |     query {\n3 |       fail\n  |       ^\n4 |     }\n",
          "error.type": "graphql.error.graphql_error.GraphQLError",
-         "events": "[{\"name\": \"dd.graphql.query.error\", \"time_unix_nano\": 1738250093735623000, \"attributes\": {\"message\": \"'NoneType' object has no attribute 'name'\", \"type\": \"graphql.error.graphql_error.GraphQLError\", \"locations\": \"3:7\", \"stacktrace\": \"Traceback (most recent call last):\\n  File \\\"/Users/quinna.halim/dd-trace-py/.riot/venv_py31013_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio0211_graphql-core~320_pytest-randomly/lib/python3.10/site-packages/graphql/execution/execute.py\\\", line 521, in execute_field\\n    result = resolve_fn(source, info, **args)\\n  File \\\"/Users/quinna.halim/dd-trace-py/ddtrace/contrib/internal/graphql/patch.py\\\", line 243, in _resolver_middleware\\n    return next_middleware(root, info, **args)\\n  File \\\"/Users/quinna.halim/dd-trace-py/tests/contrib/graphql/test_graphql.py\\\", line 104, in <lambda>\\n    result = graphql_sync(test_schema, query, root_value=None, field_resolver=lambda _type, _field: resolvers[_type.name][_field.name])\\ngraphql.error.graphql_error.GraphQLError: 'NoneType' object has no attribute 'name'\\n\\nGraphQL request:3:7\\n2 |     query {\\n3 |       fail\\n  |       ^\\n4 |     }\\n\", \"path\": \"fail\"}}]",
+         "events": "[{\"name\": \"recorded exception\", \"time_unix_nano\": 1740173272337250000, \"attributes\": {\"exception.type\": \"graphql.error.graphql_error.GraphQLError\", \"exception.message\": \"'NoneType' object has no attribute 'name'\\n\\nGraphQL request:3:7\\n2 |     query {\\n3 |       fail\\n  |       ^\\n4 |     }\", \"exception.escaped\": false, \"exception.stacktrace\": \"Traceback (most recent call last):\\n  File \\\"/Users/quinna.halim/dd-trace-py/.riot/venv_py3127_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio0211_graphql-core~320_pytest-randomly/lib/python3.12/site-packages/graphql/execution/execute.py\\\", line 521, in execute_field\\n    result = resolve_fn(source, info, **args)\\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/Users/quinna.halim/dd-trace-py/ddtrace/contrib/internal/graphql/patch.py\\\", line 253, in _resolver_middleware\\n    return next_middleware(root, info, **args)\\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/Users/quinna.halim/dd-trace-py/tests/contrib/graphql/test_graphql.py\\\", line 104, in <lambda>\\n    test_schema, query, root_value=None, field_resolver=lambda _type, _field: resolvers[_type.name][_field.name]\\n                                                                                        ^^^^^^^^^^\\ngraphql.error.graphql_error.GraphQLError: 'NoneType' object has no attribute 'name'\\n\\nGraphQL request:3:7\\n2 |     query {\\n3 |       fail\\n  |       ^\\n4 |     }\\n\", \"message\": \"'NoneType' object has no attribute 'name'\", \"type\": \"graphql.error.graphql_error.GraphQLError\", \"locations\": [\"3:7\"], \"stacktrace\": \"Traceback (most recent call last):\\n  File \\\"/Users/quinna.halim/dd-trace-py/.riot/venv_py3127_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio0211_graphql-core~320_pytest-randomly/lib/python3.12/site-packages/graphql/execution/execute.py\\\", line 521, in execute_field\\n    result = resolve_fn(source, info, **args)\\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/Users/quinna.halim/dd-trace-py/ddtrace/contrib/internal/graphql/patch.py\\\", line 253, in _resolver_middleware\\n    return next_middleware(root, info, **args)\\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/Users/quinna.halim/dd-trace-py/tests/contrib/graphql/test_graphql.py\\\", line 104, in <lambda>\\n    test_schema, query, root_value=None, field_resolver=lambda _type, _field: resolvers[_type.name][_field.name]\\n                                                                                        ^^^^^^^^^^\\ngraphql.error.graphql_error.GraphQLError: 'NoneType' object has no attribute 'name'\\n\\nGraphQL request:3:7\\n2 |     query {\\n3 |       fail\\n  |       ^\\n4 |     }\\n\", \"path\": \"fail\"}}, {\"name\": \"dd.graphql.query.error\", \"time_unix_nano\": 1740173272337430000, \"attributes\": {\"message\": \"'NoneType' object has no attribute 'name'\", \"type\": \"graphql.error.graphql_error.GraphQLError\", \"locations\": [\"3:7\"], \"stacktrace\": \"Traceback (most recent call last):\\n  File \\\"/Users/quinna.halim/dd-trace-py/.riot/venv_py3127_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio0211_graphql-core~320_pytest-randomly/lib/python3.12/site-packages/graphql/execution/execute.py\\\", line 521, in execute_field\\n    result = resolve_fn(source, info, **args)\\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/Users/quinna.halim/dd-trace-py/ddtrace/contrib/internal/graphql/patch.py\\\", line 253, in _resolver_middleware\\n    return next_middleware(root, info, **args)\\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/Users/quinna.halim/dd-trace-py/tests/contrib/graphql/test_graphql.py\\\", line 104, in <lambda>\\n    test_schema, query, root_value=None, field_resolver=lambda _type, _field: resolvers[_type.name][_field.name]\\n                                                                                        ^^^^^^^^^^\\ngraphql.error.graphql_error.GraphQLError: 'NoneType' object has no attribute 'name'\\n\\nGraphQL request:3:7\\n2 |     query {\\n3 |       fail\\n  |       ^\\n4 |     }\\n\", \"path\": \"fail\"}}]",
          "graphql.operation.type": "query",
          "graphql.source": "query { fail }"
        },
        "metrics": {
          "_dd.measured": 1
        },
-       "duration": 761000,
-       "start": 1738250093734863000
+       "duration": 1881000,
+       "start": 1740173272335551000
      },
         {
           "name": "graphql.resolve",
@@ -130,9 +130,9 @@
             "_dd.base_service": "tests.contrib.graphql",
             "component": "graphql",
             "error.message": "'NoneType' object has no attribute 'name'",
-            "error.stack": "Traceback (most recent call last):\n  File \"/Users/quinna.halim/dd-trace-py/ddtrace/contrib/internal/graphql/patch.py\", line 243, in _resolver_middleware\n    return next_middleware(root, info, **args)\n  File \"/Users/quinna.halim/dd-trace-py/tests/contrib/graphql/test_graphql.py\", line 104, in <lambda>\n    result = graphql_sync(test_schema, query, root_value=None, field_resolver=lambda _type, _field: resolvers[_type.name][_field.name])\nAttributeError: 'NoneType' object has no attribute 'name'\n",
+            "error.stack": "Traceback (most recent call last):\n  File \"/Users/quinna.halim/dd-trace-py/ddtrace/contrib/internal/graphql/patch.py\", line 253, in _resolver_middleware\n    return next_middleware(root, info, **args)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/quinna.halim/dd-trace-py/tests/contrib/graphql/test_graphql.py\", line 104, in <lambda>\n    test_schema, query, root_value=None, field_resolver=lambda _type, _field: resolvers[_type.name][_field.name]\n                                                                                        ^^^^^^^^^^\nAttributeError: 'NoneType' object has no attribute 'name'\n",
             "error.type": "builtins.AttributeError"
           },
-          "duration": 424000,
-          "start": 1738250093734961000
+          "duration": 680000,
+          "start": 1740173272335685000
         }]]


### PR DESCRIPTION
Add exception tracking on graphql span event with the following attributes:
- exception.type
- exception.message
- exception.escaped
- exception.stacktrace

{\"exception.type\": \"graphql.error.graphql_error.GraphQLError\", \"exception.message\": \"'NoneType' object has no attribute 'name'\\n\\nGraphQL request:3:7\\n2 |     query {\\n3 |       fail\\n  |       ^\\n4 |     }\", \"exception.escaped\": false, \"exception.stacktrace\": <formatted stacktrace>}

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
