### PR TITLE
chore(profiling): allow libdatadog to be built from sources

### DIFF
--- a/ddtrace/internal/datadog/profiling/build_standalone.sh
+++ b/ddtrace/internal/datadog/profiling/build_standalone.sh
@@ -106,6 +106,11 @@ cmake_args=(
   -DPython3_ROOT_DIR=$(python3 -c "import sysconfig; print(sysconfig.get_config_var('prefix'))")
 )
 
+# If the COMMIT_LIBDATADOG environment variable is set, then add it to the cmake args
+if [ -n "${COMMIT_LIBDATADOG:-}" ]; then
+  cmake_args+=(-DCOMMIT_LIBDATADOG=${COMMIT_LIBDATADOG})
+fi
+
 # Initial build targets; start out empty
 targets=()
 

--- a/ddtrace/internal/datadog/profiling/cmake/FindLibdatadog.cmake
+++ b/ddtrace/internal/datadog/profiling/cmake/FindLibdatadog.cmake
@@ -24,16 +24,14 @@ set(FETCHCONTENT_DOWNLOADS_DIR
 include_guard(GLOBAL)
 include(FetchContent)
 
-
-# Depending on whether a commit or version was specified, either download + build the repo or just grab a release tarball
+# Depending on whether a commit or version was specified, either download + build the repo or just grab a release
+# tarball
 if(COMMIT_LIBDATADOG)
-        FetchContent_Declare(
+    FetchContent_Declare(
         libdatadog
         GIT_REPOSITORY "https://github.com/DataDog/libdatadog.git"
         GIT_TAG "${COMMIT_LIBDATADOG}"
-        DOWNLOAD_DIR "${FETCHCONTENT_DOWNLOADS_DIR}"
-        SOURCE_DIR "${FETCHCONTENT_BASE_DIR}/libdatadog-src"
-    )
+        DOWNLOAD_DIR "${FETCHCONTENT_DOWNLOADS_DIR}" SOURCE_DIR "${FETCHCONTENT_BASE_DIR}/libdatadog-src")
 
     FetchContent_MakeAvailable(libdatadog)
 
@@ -48,10 +46,11 @@ if(COMMIT_LIBDATADOG)
     # Create the output folder
     file(MAKE_DIRECTORY "${LIBDD_OUTPUT_FOLDER}")
     execute_process(
-        COMMAND cargo run --bin release --features profiling,telemetry,data-pipeline,symbolizer,crashtracker,library-config --release -- --out ${LIBDD_OUTPUT_FOLDER}
+        COMMAND
+            cargo run --bin release --features profiling,telemetry,data-pipeline,symbolizer,crashtracker,library-config
+            --release -- --out ${LIBDD_OUTPUT_FOLDER}
         WORKING_DIRECTORY "${libdatadog_SOURCE_DIR}"
-        RESULT_VARIABLE CARGO_RESULT
-    )
+        RESULT_VARIABLE CARGO_RESULT)
     if(NOT CARGO_RESULT EQUAL 0)
         message(FATAL_ERROR "Failed to build libdatadog FFI")
     endif()
@@ -77,7 +76,8 @@ else()
             "4540ffb8ccb671550a39ba79226117086582c1eaf9714180a9e26bd6bb175860 libdatadog-aarch64-apple-darwin.tar.gz"
             "31bceab4f56873b03b3728760d30e3abc493d32ca8fdc9e1f2ec2147ef4d5424 libdatadog-aarch64-unknown-linux-gnu.tar.gz"
             "530348c4b02cc7096de2231476ec12db82e2cc6de12a87e5b28af47ea73d4e56 libdatadog-x86_64-alpine-linux-musl.tar.gz"
-            "5073ffc657bc4698f8bdd4935475734577bfb18c54dcbebc4f7d8c7595626e52 libdatadog-x86_64-unknown-linux-gnu.tar.gz")
+            "5073ffc657bc4698f8bdd4935475734577bfb18c54dcbebc4f7d8c7595626e52 libdatadog-x86_64-unknown-linux-gnu.tar.gz"
+        )
     endif()
 
     # Determine platform-specific tarball name in a way that conforms to the libdatadog naming scheme in Github releases
@@ -134,9 +134,7 @@ else()
         libdatadog
         URL "https://github.com/DataDog/libdatadog/releases/download/${TAG_LIBDATADOG}/${DD_TARBALL}"
         URL_HASH SHA256=${DD_HASH}
-        DOWNLOAD_DIR "${FETCHCONTENT_DOWNLOADS_DIR}"
-        SOURCE_DIR "${FETCHCONTENT_BASE_DIR}/libdatadog-src"
-    )
+        DOWNLOAD_DIR "${FETCHCONTENT_DOWNLOADS_DIR}" SOURCE_DIR "${FETCHCONTENT_BASE_DIR}/libdatadog-src")
 
     # Set up paths.  This depends on how the libdatadog is acquired.
     get_filename_component(Datadog_ROOT "${libdatadog_SOURCE_DIR}" ABSOLUTE)

--- a/ddtrace/internal/datadog/profiling/cmake/FindLibdatadog.cmake
+++ b/ddtrace/internal/datadog/profiling/cmake/FindLibdatadog.cmake
@@ -24,8 +24,8 @@ set(FETCHCONTENT_DOWNLOADS_DIR
 include_guard(GLOBAL)
 include(FetchContent)
 
-# Depending on whether a commit or version was specified, either download + build the repo or just grab a release
-# tarball
+# Depending on whether a commit or version was specified
+#either download + build the repo or just grab a release tarball
 if(COMMIT_LIBDATADOG)
     FetchContent_Declare(
         libdatadog
@@ -37,14 +37,12 @@ if(COMMIT_LIBDATADOG)
 
     # Manage the output folder
     set(LIBDD_OUTPUT_FOLDER "${CMAKE_CURRENT_BINARY_DIR}/libdatadog-output")
-
-    # Clear the output folder if it exists
     if(EXISTS "${LIBDD_OUTPUT_FOLDER}")
         file(REMOVE_RECURSE "${LIBDD_OUTPUT_FOLDER}")
     endif()
-
-    # Create the output folder
     file(MAKE_DIRECTORY "${LIBDD_OUTPUT_FOLDER}")
+
+    # Run the build
     execute_process(
         COMMAND
             cargo run --bin release --features profiling,telemetry,data-pipeline,symbolizer,crashtracker,library-config
@@ -55,15 +53,10 @@ if(COMMIT_LIBDATADOG)
         message(FATAL_ERROR "Failed to build libdatadog FFI")
     endif()
 
-    # Set up paths.  This depends on how the libdatadog is acquired.
+    # Set up paths for the end user
     set(Datadog_DIR "${LIBDD_OUTPUT_FOLDER}/cmake")
     set(Datadog_LIBRARY "${LIBDD_OUTPUT_FOLDER}/lib/libdatadog_profiling${CMAKE_STATIC_LIBRARY_SUFFIX}")
     set(Datadog_INCLUDE_DIR "${LIBDD_OUTPUT_FOLDER}/include")
-
-    # Let's print these paths to the user so they can see where the library was built
-    message(STATUS "libdatadog library: ${Datadog_LIBRARY}")
-    message(STATUS "libdatadog include: ${Datadog_INCLUDE_DIR}")
-    message(STATUS "libdatadog cmake: ${Datadog_DIR}")
 
     if(NOT EXISTS ${Datadog_LIBRARY} OR NOT EXISTS ${Datadog_INCLUDE_DIR})
         message(FATAL_ERROR "Built libdatadog but couldn't find library or include files in ${LIBDD_OUTPUT_FOLDER}")

--- a/ddtrace/internal/datadog/profiling/cmake/FindLibdatadog.cmake
+++ b/ddtrace/internal/datadog/profiling/cmake/FindLibdatadog.cmake
@@ -2,98 +2,147 @@
 if(TARGET Datadog::Profiling)
     return()
 endif()
+if(NOT DEFINED TAG_LIBDATADOG)
+    set(TAG_LIBDATADOG
+        "v15.0.0"
+        CACHE STRING "libdatadog github tag")
+endif()
+if(NOT DEFINED COMMIT_LIBDATADOG)
+    # Default is empty because we want to default to using a pinned release
+    set(COMMIT_LIBDATADOG
+        ""
+        CACHE STRING "libdatadog git commit hash")
+endif()
 
-# Set the FetchContent paths early
+# Set up FetchContent
 set(FETCHCONTENT_BASE_DIR
     "${CMAKE_CURRENT_BINARY_DIR}/_deps"
     CACHE PATH "FetchContent base directory")
 set(FETCHCONTENT_DOWNLOADS_DIR
     "${FETCHCONTENT_BASE_DIR}/downloads"
     CACHE PATH "FetchContent downloads directory")
-
 include_guard(GLOBAL)
 include(FetchContent)
 
-# Set version if not already set
-if(NOT DEFINED TAG_LIBDATADOG)
-    set(TAG_LIBDATADOG
-        "v15.0.0"
-        CACHE STRING "libdatadog github tag")
-endif()
 
-if(NOT DEFINED DD_CHECKSUMS)
-    set(DD_CHECKSUMS
-        "d5b969b293e5a9e5e36404a553bbafdd55ff6af0b089698bd989a878534df0c7 libdatadog-aarch64-alpine-linux-musl.tar.gz"
-        "4540ffb8ccb671550a39ba79226117086582c1eaf9714180a9e26bd6bb175860 libdatadog-aarch64-apple-darwin.tar.gz"
-        "31bceab4f56873b03b3728760d30e3abc493d32ca8fdc9e1f2ec2147ef4d5424 libdatadog-aarch64-unknown-linux-gnu.tar.gz"
-        "530348c4b02cc7096de2231476ec12db82e2cc6de12a87e5b28af47ea73d4e56 libdatadog-x86_64-alpine-linux-musl.tar.gz"
-        "5073ffc657bc4698f8bdd4935475734577bfb18c54dcbebc4f7d8c7595626e52 libdatadog-x86_64-unknown-linux-gnu.tar.gz")
-endif()
+# Depending on whether a commit or version was specified, either download + build the repo or just grab a release tarball
+if(COMMIT_LIBDATADOG)
+        FetchContent_Declare(
+        libdatadog
+        GIT_REPOSITORY "https://github.com/DataDog/libdatadog.git"
+        GIT_TAG "${COMMIT_LIBDATADOG}"
+        DOWNLOAD_DIR "${FETCHCONTENT_DOWNLOADS_DIR}"
+        SOURCE_DIR "${FETCHCONTENT_BASE_DIR}/libdatadog-src"
+    )
 
-# Determine platform-specific tarball name in a way that conforms to the libdatadog naming scheme in Github releases
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
-    set(DD_ARCH "aarch64")
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
-    set(DD_ARCH "x86_64")
-else()
-    message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
-endif()
+    FetchContent_MakeAvailable(libdatadog)
 
-if(APPLE)
-    set(DD_PLATFORM "apple-darwin")
-elseif(UNIX)
+    # Manage the output folder
+    set(LIBDD_OUTPUT_FOLDER "${CMAKE_CURRENT_BINARY_DIR}/libdatadog-output")
+
+    # Clear the output folder if it exists
+    if(EXISTS "${LIBDD_OUTPUT_FOLDER}")
+        file(REMOVE_RECURSE "${LIBDD_OUTPUT_FOLDER}")
+    endif()
+
+    # Create the output folder
+    file(MAKE_DIRECTORY "${LIBDD_OUTPUT_FOLDER}")
     execute_process(
-        COMMAND ldd --version
-        OUTPUT_VARIABLE LDD_OUTPUT
-        ERROR_VARIABLE LDD_OUTPUT
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(LDD_OUTPUT MATCHES "musl")
-        set(DD_PLATFORM "alpine-linux-musl")
-    else()
-        set(DD_PLATFORM "unknown-linux-gnu")
+        COMMAND cargo run --bin release --features profiling,telemetry,data-pipeline,symbolizer,crashtracker,library-config --release -- --out ${LIBDD_OUTPUT_FOLDER}
+        WORKING_DIRECTORY "${libdatadog_SOURCE_DIR}"
+        RESULT_VARIABLE CARGO_RESULT
+    )
+    if(NOT CARGO_RESULT EQUAL 0)
+        message(FATAL_ERROR "Failed to build libdatadog FFI")
     endif()
+
+    # Set up paths.  This depends on how the libdatadog is acquired.
+    set(Datadog_DIR "${LIBDD_OUTPUT_FOLDER}/cmake")
+    set(Datadog_LIBRARY "${LIBDD_OUTPUT_FOLDER}/lib/libdatadog_profiling${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    set(Datadog_INCLUDE_DIR "${LIBDD_OUTPUT_FOLDER}/include")
+
+    # Let's print these paths to the user so they can see where the library was built
+    message(STATUS "libdatadog library: ${Datadog_LIBRARY}")
+    message(STATUS "libdatadog include: ${Datadog_INCLUDE_DIR}")
+    message(STATUS "libdatadog cmake: ${Datadog_DIR}")
+
+    if(NOT EXISTS ${Datadog_LIBRARY} OR NOT EXISTS ${Datadog_INCLUDE_DIR})
+        message(FATAL_ERROR "Built libdatadog but couldn't find library or include files in ${LIBDD_OUTPUT_FOLDER}")
+    endif()
+
 else()
-    message(FATAL_ERROR "Unsupported operating system")
-endif()
-
-set(DD_TARBALL "libdatadog-${DD_ARCH}-${DD_PLATFORM}.tar.gz")
-
-# Make sure we can get the checksum for the tarball
-foreach(ENTRY IN LISTS DD_CHECKSUMS)
-    if(ENTRY MATCHES "^([a-fA-F0-9]+) ${DD_TARBALL}$")
-        set(DD_HASH "${CMAKE_MATCH_1}")
-        break()
+    if(NOT DEFINED DD_CHECKSUMS)
+        set(DD_CHECKSUMS
+            "d5b969b293e5a9e5e36404a553bbafdd55ff6af0b089698bd989a878534df0c7 libdatadog-aarch64-alpine-linux-musl.tar.gz"
+            "4540ffb8ccb671550a39ba79226117086582c1eaf9714180a9e26bd6bb175860 libdatadog-aarch64-apple-darwin.tar.gz"
+            "31bceab4f56873b03b3728760d30e3abc493d32ca8fdc9e1f2ec2147ef4d5424 libdatadog-aarch64-unknown-linux-gnu.tar.gz"
+            "530348c4b02cc7096de2231476ec12db82e2cc6de12a87e5b28af47ea73d4e56 libdatadog-x86_64-alpine-linux-musl.tar.gz"
+            "5073ffc657bc4698f8bdd4935475734577bfb18c54dcbebc4f7d8c7595626e52 libdatadog-x86_64-unknown-linux-gnu.tar.gz")
     endif()
-endforeach()
 
-if(NOT DEFINED DD_HASH)
-    message(FATAL_ERROR "Could not find checksum for ${DD_TARBALL}")
-endif()
-
-# Clean up any existing downloads if they exist
-set(TARBALL_PATH "${FETCHCONTENT_DOWNLOADS_DIR}/${DD_TARBALL}")
-if(EXISTS "${TARBALL_PATH}")
-    file(SHA256 "${TARBALL_PATH}" EXISTING_HASH)
-    if(NOT EXISTING_HASH STREQUAL DD_HASH)
-        file(REMOVE "${TARBALL_PATH}")
-        # Also remove the subbuild directory to force a fresh download
-        file(REMOVE_RECURSE "${CMAKE_CURRENT_BINARY_DIR}/_deps/libdatadog-subbuild")
+    # Determine platform-specific tarball name in a way that conforms to the libdatadog naming scheme in Github releases
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+        set(DD_ARCH "aarch64")
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
+        set(DD_ARCH "x86_64")
+    else()
+        message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
     endif()
+
+    if(APPLE)
+        set(DD_PLATFORM "apple-darwin")
+    elseif(UNIX)
+        execute_process(
+            COMMAND ldd --version
+            OUTPUT_VARIABLE LDD_OUTPUT
+            ERROR_VARIABLE LDD_OUTPUT
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+        if(LDD_OUTPUT MATCHES "musl")
+            set(DD_PLATFORM "alpine-linux-musl")
+        else()
+            set(DD_PLATFORM "unknown-linux-gnu")
+        endif()
+    else()
+        message(FATAL_ERROR "Unsupported operating system")
+    endif()
+
+    set(DD_TARBALL "libdatadog-${DD_ARCH}-${DD_PLATFORM}.tar.gz")
+
+    # Make sure we can get the checksum for the tarball
+    foreach(ENTRY IN LISTS DD_CHECKSUMS)
+        if(ENTRY MATCHES "^([a-fA-F0-9]+) ${DD_TARBALL}$")
+            set(DD_HASH "${CMAKE_MATCH_1}")
+            break()
+        endif()
+    endforeach()
+
+    if(NOT DEFINED DD_HASH)
+        message(FATAL_ERROR "Could not find checksum for ${DD_TARBALL}")
+    endif()
+
+    # Clean up any existing downloads if they exist
+    set(TARBALL_PATH "${FETCHCONTENT_DOWNLOADS_DIR}/${DD_TARBALL}")
+    if(EXISTS "${TARBALL_PATH}")
+        file(SHA256 "${TARBALL_PATH}" EXISTING_HASH)
+        if(NOT EXISTING_HASH STREQUAL DD_HASH)
+            file(REMOVE "${TARBALL_PATH}")
+            # Also remove the subbuild directory to force a fresh download
+            file(REMOVE_RECURSE "${CMAKE_CURRENT_BINARY_DIR}/_deps/libdatadog-subbuild")
+        endif()
+    endif()
+    FetchContent_Declare(
+        libdatadog
+        URL "https://github.com/DataDog/libdatadog/releases/download/${TAG_LIBDATADOG}/${DD_TARBALL}"
+        URL_HASH SHA256=${DD_HASH}
+        DOWNLOAD_DIR "${FETCHCONTENT_DOWNLOADS_DIR}"
+        SOURCE_DIR "${FETCHCONTENT_BASE_DIR}/libdatadog-src"
+    )
+
+    # Set up paths.  This depends on how the libdatadog is acquired.
+    get_filename_component(Datadog_ROOT "${libdatadog_SOURCE_DIR}" ABSOLUTE)
+    set(Datadog_DIR "${Datadog_ROOT}/cmake")
+    FetchContent_MakeAvailable(libdatadog)
 endif()
-
-# Use FetchContent to download and extract the library
-FetchContent_Declare(
-    libdatadog
-    URL "https://github.com/DataDog/libdatadog/releases/download/${TAG_LIBDATADOG}/${DD_TARBALL}"
-    URL_HASH SHA256=${DD_HASH}
-    DOWNLOAD_DIR "${FETCHCONTENT_DOWNLOADS_DIR}" SOURCE_DIR "${FETCHCONTENT_BASE_DIR}/libdatadog-src")
-
-# Make the content available
-FetchContent_MakeAvailable(libdatadog)
-
-# Set up paths
-get_filename_component(Datadog_ROOT "${libdatadog_SOURCE_DIR}" ABSOLUTE)
-set(Datadog_DIR "${Datadog_ROOT}/cmake")
 
 # Configure library preferences (static over shared)
 set(CMAKE_FIND_LIBRARY_SUFFIXES_BACKUP ${CMAKE_FIND_LIBRARY_SUFFIXES})

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ CRASHTRACKER_DIR = HERE / "ddtrace" / "internal" / "datadog" / "profiling" / "cr
 STACK_V2_DIR = HERE / "ddtrace" / "internal" / "datadog" / "profiling" / "stack_v2"
 
 BUILD_PROFILING_NATIVE_TESTS = os.getenv("DD_PROFILING_NATIVE_TESTS", "0").lower() in ("1", "yes", "on", "true")
+PROFILING_LIBDATADOG_COMMIT = os.getenv("DD_PROFILING_LIBDATADOG_COMMIT", "")
 
 CURRENT_OS = platform.system()
 
@@ -358,6 +359,9 @@ class CMakeBuild(build_ext):
 
         if BUILD_PROFILING_NATIVE_TESTS:
             cmake_args += ["-DBUILD_TESTING=ON"]
+
+        if PROFILING_LIBDATADOG_COMMIT:
+            cmake_args += ["-DCOMMIT_LIBDATADOG={}".format(PROFILING_LIBDATADOG_COMMIT)]
 
         # If it's been enabled, also propagate sccache to the CMake build.  We have to manually set the default CC/CXX
         # compilers here, because otherwise the way we wrap sccache will conflict with the CMake wrappers


### PR DESCRIPTION
This should make some of the development workflows more straightforward, although please note that this is experimental.  You'll probably have to completely trash the build directory between major updates.

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
