### PR TITLE
chore: do not return default service if config.service was user set and equals inferred service

### DIFF
--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -380,7 +380,7 @@ def int_service(pin, int_config, default=None):
     if (
         global_service
         and global_service != int_config.global_config._inferred_base_service
-        and not int_config.global_config._is_user_provided_service
+        # and not int_config.global_config._is_user_provided_service
     ):
         return cast(str, global_service)
 

--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -377,11 +377,7 @@ def int_service(pin, int_config, default=None):
     # defaults to _inferred_base_service when no DD_SERVICE is set. In this case, we want to not
     # use the inferred base service value, and instead use the integration default service. If we
     # didn't do this, we would have a massive breaking change from adding inferred_base_service.
-    if (
-        global_service
-        and global_service != int_config.global_config._inferred_base_service
-        # and not int_config.global_config._is_user_provided_service
-    ):
+    if global_service and global_service != int_config.global_config._inferred_base_service:
         return cast(str, global_service)
 
     if "_default_service" in int_config and int_config._default_service is not None:

--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -377,7 +377,11 @@ def int_service(pin, int_config, default=None):
     # defaults to _inferred_base_service when no DD_SERVICE is set. In this case, we want to not
     # use the inferred base service value, and instead use the integration default service. If we
     # didn't do this, we would have a massive breaking change from adding inferred_base_service.
-    if global_service and global_service != int_config.global_config._inferred_base_service:
+    if (
+        global_service
+        and global_service != int_config.global_config._inferred_base_service
+        and not int_config.global_config._is_user_provided_service
+    ):
         return cast(str, global_service)
 
     if "_default_service" in int_config and int_config._default_service is not None:

--- a/ddtrace/settings/_config.py
+++ b/ddtrace/settings/_config.py
@@ -774,7 +774,10 @@ class Config(object):
         # use the inferred base service value, and instead use the default if included. If we
         # didn't do this, we would have a massive breaking change from adding inferred_base_service,
         # which would be replacing any integration defaults since service is no longer None.
-        if self.service and self.service == self._inferred_base_service:
+        # We also check if the service was user provided since an edge case may be that
+        # DD_SERVICE == inferred base service, which would force the default to be returned
+        # even though we want config.service in this case.
+        if self.service and self.service == self._inferred_base_service and not self._is_user_provided_service:
             return default if default is not None else self.service
 
         # TODO: This method can be replaced with `config.service`.


### PR DESCRIPTION
## Motivation

Fixes small edge case for service naming, where if the user-provided service equals the inferred base service, the code returns default service name, even though the actual service name should be returned in this case. Adds a check to see if the service name was user provided.


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
