### PR TITLE
fix(celery): list of broker urls

### DIFF
--- a/releasenotes/notes/celery-broker-url-list-8998b5629fd2693d.yaml
+++ b/releasenotes/notes/celery-broker-url-list-8998b5629fd2693d.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    celery: When multiple broker URLs are provided as a list, use the first broker URL from a list to avoid parsing errors.

--- a/tests/contrib/celery/test_tagging.py
+++ b/tests/contrib/celery/test_tagging.py
@@ -140,3 +140,46 @@ def assert_traces(tracer, task_name, task, port):
     assert run_span.get_tag("component") == "celery"
     assert run_span.get_tag("span.kind") == "consumer"
     assert socket.gethostname() in run_span.get_tag("celery.hostname")
+
+
+@pytest.fixture(autouse=False)
+def list_broker_celery_app(instrument_celery, dummy_tracer):
+    app = Celery("list_broker_celery", broker=BROKER_URL, backend=BACKEND_URL)
+    # Set the broker URL to a list where the first URL is used for parsing
+    app.conf.broker_url = [BROKER_URL, "memory://"]
+
+    @app.task(name="tests.contrib.celery.test_tagging.subtract")
+    def subtract(x, y):
+        return x - y
+
+    # Ensure the app is instrumented with the dummy tracer
+    Pin.get_from(app)
+    Pin._override(app, tracer=dummy_tracer)
+    patch()
+    yield app
+    unpatch()
+
+
+def test_list_broker_urls(list_broker_celery_app):
+    """
+    Test that when the broker URL is provided as a list,
+    the instrumentation correctly parses the first URL in the list.
+    """
+    tracer = Pin.get_from(list_broker_celery_app).tracer
+
+    with start_worker(
+        list_broker_celery_app,
+        pool="solo",
+        loglevel="info",
+        perform_ping_check=False,
+        shutdown_timeout=30,
+    ):
+        t = list_broker_celery_app.tasks["tests.contrib.celery.test_tagging.subtract"].delay(10, 3)
+        assert t.get(timeout=2) == 7
+
+        # Allow time for the publish span to be recorded
+        time.sleep(3)
+
+        # assert_traces is assumed to be a helper function that checks that the
+        # span has the expected values (e.g. target port is 6379 for BROKER_URL)
+        assert_traces(tracer, "subtract", t, 6379)

--- a/tests/contrib/celery/test_tagging.py
+++ b/tests/contrib/celery/test_tagging.py
@@ -78,7 +78,7 @@ def list_broker_celery_app(instrument_celery, dummy_tracer):
     # Override broker_url with a list of URLs.
     app.conf.broker_url = [BROKER_URL, "memory://"]
 
-    @app.task
+    @app.task(name="list_broker_celery.subtract")
     def subtract(x, y):
         return x - y
 

--- a/tests/contrib/celery/test_tagging.py
+++ b/tests/contrib/celery/test_tagging.py
@@ -71,6 +71,7 @@ def traced_amqp_celery_app(instrument_celery, dummy_tracer):
     Pin._override(amqp_celery_app, tracer=dummy_tracer)
     yield amqp_celery_app
 
+
 @pytest.fixture(autouse=False)
 def list_broker_celery_app(instrument_celery, dummy_tracer):
     app = Celery("list_broker_celery", broker=BROKER_URL, backend=BACKEND_URL)
@@ -84,6 +85,7 @@ def list_broker_celery_app(instrument_celery, dummy_tracer):
     Pin.get_from(app)
     Pin._override(app, tracer=dummy_tracer)
     yield app
+
 
 def test_redis_task(traced_redis_celery_app):
     tracer = Pin.get_from(traced_redis_celery_app).tracer
@@ -122,6 +124,7 @@ def test_amqp_task(instrument_celery, traced_amqp_celery_app):
 
         assert_traces(tracer, "add", t, 5672)
 
+
 def test_list_broker_urls(list_broker_celery_app):
     """
     Test that when the broker URL is provided as a list,
@@ -142,6 +145,7 @@ def test_list_broker_urls(list_broker_celery_app):
         time.sleep(3)
 
         assert_traces(tracer, "subtract", t, 6379)
+
 
 def assert_traces(tracer, task_name, task, port):
     traces = tracer.pop_traces()

--- a/tests/contrib/celery/test_tagging.py
+++ b/tests/contrib/celery/test_tagging.py
@@ -75,10 +75,9 @@ def traced_amqp_celery_app(instrument_celery, dummy_tracer):
 @pytest.fixture(autouse=False)
 def list_broker_celery_app(instrument_celery, dummy_tracer):
     app = Celery("list_broker_celery", broker=BROKER_URL, backend=BACKEND_URL)
-    # Override broker_url with a list of URLs.
     app.conf.broker_url = [BROKER_URL, "memory://"]
 
-    @app.task(name="list_broker_celery.subtract")
+    @app.task(name="tests.contrib.celery.test_tagging.subtract")
     def subtract(x, y):
         return x - y
 


### PR DESCRIPTION
Resolves issue: #12473 where multiple broker urls are in a list 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
