### PR TITLE
ci: move consul, mariadb, mongoengine suites to gitlab

### DIFF
--- a/.circleci/config.templ.yml
+++ b/.circleci/config.templ.yml
@@ -5,9 +5,7 @@ ubuntu_base_image: &ubuntu_base_img ubuntu-2004:2023.04.2
 cimg_base_image: &cimg_base_image cimg/base:2022.08
 python310_image: &python310_image cimg/python:3.10.12
 ddtrace_dev_image: &ddtrace_dev_image ghcr.io/datadog/dd-trace-py/testrunner:47c7b5287da25643e46652e6d222a40a52f2382a@sha256:3a02dafeff9cd72966978816d1b39b54f5517af4049396923b95c8452f604269
-consul_image: &consul_image consul:1.6.0@sha256:daa6203532fc30d81bf6c5593f79a2c7c23f08e8fde82f1e4bd8069b48b57596
 moto_image: &moto_image datadog/docker-library:moto_1_0_1@sha256:58c15f03141073629f4ff2a78910b812205324579c76f8bcac87e8e89af2e673
-mongo_image: &mongo_image mongo:3.6@sha256:19c11a8f1064fd2bb713ef1270f79a742a184cd57d9bb922efdd2a8eca514af8
 httpbin_image: &httpbin_image kennethreitz/httpbin@sha256:2c7abc4803080c22928265744410173b6fea3b898872c01c5fd0f0f9df4a59fb
 testagent_image: &testagent_image ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.20.0
 
@@ -421,33 +419,6 @@ jobs:
           pattern: 'botocore'
           snapshot: true
           docker_services: "localstack"
-
-  consul:
-    <<: *contrib_job_small
-    docker:
-      - image: *ddtrace_dev_image
-      - image: *consul_image
-      - *testagent
-    steps:
-      - run_test:
-          pattern: 'consul'
-
-  mariadb:
-    <<: *machine_executor
-    parallelism: 4
-    steps:
-      - run_test:
-          pattern: 'mariadb$'
-          snapshot: true
-          docker_services: "mariadb"
-
-  mongoengine:
-    <<: *machine_executor
-    steps:
-      - run_test:
-          pattern: 'mongoengine'
-          snapshot: true
-          docker_services: 'mongo'
 
   aiobotocore:
     <<: *contrib_job

--- a/.gitlab/services.yml
+++ b/.gitlab/services.yml
@@ -97,3 +97,14 @@
     variables:
       MAX_HEAP_SIZE: 512M
       HEAP_NEWSIZE: 256M
+  mariadb:
+    name: registry.ddbuild.io/images/mirror/mariadb:lts
+    alias: mariadb
+    variables:
+      MYSQL_ROOT_PASSWORD: example
+      MYSQL_DATABASE: test
+      MYSQL_USER: test
+      MYSQL_PASSWORD: test
+  consul:
+    name: registry.ddbuild.io/images/mirror/consul:1.6.0
+    alias: consul

--- a/tests/contrib/consul/test.py
+++ b/tests/contrib/consul/test.py
@@ -1,3 +1,5 @@
+import os
+
 import consul
 from wrapt import BoundFunctionWrapper
 
@@ -17,6 +19,8 @@ class TestConsulPatch(TracerTestCase):
 
     def setUp(self):
         super(TestConsulPatch, self).setUp()
+        if "CONSUL_HTTP_ADDR" in os.environ:
+            del os.environ["CONSUL_HTTP_ADDR"]
         patch()
         c = consul.Consul(
             host=CONSUL_CONFIG["host"],

--- a/tests/contrib/consul/test.py
+++ b/tests/contrib/consul/test.py
@@ -19,8 +19,10 @@ class TestConsulPatch(TracerTestCase):
 
     def setUp(self):
         super(TestConsulPatch, self).setUp()
-        if "CONSUL_HTTP_ADDR" in os.environ:
-            del os.environ["CONSUL_HTTP_ADDR"]
+        print("EMMETT AAA")
+        for name, value in os.environ.items():
+            if "consul" in name.lower():
+                print("{0}: {1}".format(name, value))
         patch()
         c = consul.Consul(
             host=CONSUL_CONFIG["host"],

--- a/tests/contrib/consul/test.py
+++ b/tests/contrib/consul/test.py
@@ -14,17 +14,16 @@ from tests.utils import assert_is_measured
 from ..config import CONSUL_CONFIG
 
 
+CONSUL_HTTP_ADDR = f"{CONSUL_CONFIG['host']}:{CONSUL_CONFIG['port']}"
+
+
 class TestConsulPatch(TracerTestCase):
     TEST_SERVICE = "test-consul"
 
     def setUp(self):
-        super(TestConsulPatch, self).setUp()
-        print("EMMETT AAA")
-        for name, value in os.environ.items():
-            if "consul" in name.lower():
-                print("{0}: {1}".format(name, value))
         if "CONSUL_HTTP_ADDR" in os.environ:
             del os.environ["CONSUL_HTTP_ADDR"]
+        super(TestConsulPatch, self).setUp()
         patch()
         c = consul.Consul(
             host=CONSUL_CONFIG["host"],
@@ -184,7 +183,7 @@ class TestSchematization(TracerTestCase):
         unpatch()
         super(TestSchematization, self).tearDown()
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc"))
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", CONSUL_HTTP_ADDR=CONSUL_HTTP_ADDR))
     def test_schematize_service_name_default(self):
         key = "test/put/consul"
         value = "test_value"
@@ -197,7 +196,9 @@ class TestSchematization(TracerTestCase):
 
         assert span.service == "consul"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0", CONSUL_HTTP_ADDR=CONSUL_HTTP_ADDR)
+    )
     def test_schematize_service_name_v0(self):
         key = "test/put/consul"
         value = "test_value"
@@ -210,7 +211,9 @@ class TestSchematization(TracerTestCase):
 
         assert span.service == "consul"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_SERVICE="mysvc", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1", CONSUL_HTTP_ADDR=CONSUL_HTTP_ADDR)
+    )
     def test_schematize_service_name_v1(self):
         key = "test/put/consul"
         value = "test_value"
@@ -223,7 +226,7 @@ class TestSchematization(TracerTestCase):
 
         assert span.service == "mysvc"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict())
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(CONSUL_HTTP_ADDR=CONSUL_HTTP_ADDR))
     def test_schematize_unspecified_service_name_default(self):
         key = "test/put/consul"
         value = "test_value"
@@ -236,7 +239,9 @@ class TestSchematization(TracerTestCase):
 
         assert span.service == "consul"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0", CONSUL_HTTP_ADDR=CONSUL_HTTP_ADDR)
+    )
     def test_schematize_unspecified_service_name_v0(self):
         key = "test/put/consul"
         value = "test_value"
@@ -249,7 +254,9 @@ class TestSchematization(TracerTestCase):
 
         assert span.service == "consul"
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1", CONSUL_HTTP_ADDR=CONSUL_HTTP_ADDR)
+    )
     def test_schematize_unspecified_service_name_v1(self):
         key = "test/put/consul"
         value = "test_value"
@@ -262,7 +269,9 @@ class TestSchematization(TracerTestCase):
 
         assert span.service == DEFAULT_SPAN_SERVICE_NAME
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0", CONSUL_HTTP_ADDR=CONSUL_HTTP_ADDR)
+    )
     def test_schematize_operation_name_v0(self):
         key = "test/put/consul"
         value = "test_value"
@@ -275,7 +284,9 @@ class TestSchematization(TracerTestCase):
 
         assert span.name == consulx.CMD
 
-    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"))
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1", CONSUL_HTTP_ADDR=CONSUL_HTTP_ADDR)
+    )
     def test_schematize_operation_name_v1(self):
         key = "test/put/consul"
         value = "test_value"

--- a/tests/contrib/consul/test.py
+++ b/tests/contrib/consul/test.py
@@ -23,6 +23,8 @@ class TestConsulPatch(TracerTestCase):
         for name, value in os.environ.items():
             if "consul" in name.lower():
                 print("{0}: {1}".format(name, value))
+        if "CONSUL_HTTP_ADDR" in os.environ:
+            del os.environ["CONSUL_HTTP_ADDR"]
         patch()
         c = consul.Consul(
             host=CONSUL_CONFIG["host"],

--- a/tests/contrib/suitespec.yml
+++ b/tests/contrib/suitespec.yml
@@ -482,6 +482,9 @@ suites:
       - '@consul'
       - tests/contrib/consul/*
     runner: riot
+    snapshot: true
+    services:
+      - consul
   datastreams:
     paths:
       - '@bootstrap'
@@ -826,6 +829,9 @@ suites:
       - tests/contrib/mariadb/*
       - tests/snapshots/tests.contrib.mariadb.*
     runner: riot
+    services:
+      - mariadb
+    snapshot: true
   molten:
     paths:
       - '@bootstrap'
@@ -845,6 +851,9 @@ suites:
       - '@mongo'
       - tests/contrib/mongoengine/*
     runner: riot
+    snapshot: true
+    services:
+      - mongo
   mysqlpython:
     paths:
       - '@bootstrap'


### PR DESCRIPTION
This change moves to gitlab the mongoengine, mariadb, and consul test suites as part an the ongoing migration away from circleci.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
