### PR TITLE
fix(profiling): make reentrancy guard actually thread-local

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_reentrant.c
+++ b/ddtrace/profiling/collector/_memalloc_reentrant.c
@@ -1,3 +1,3 @@
 #include "_memalloc_reentrant.h"
 
-bool _MEMALLOC_ON_THREAD = false;
+MEMALLOC_TLS bool _MEMALLOC_ON_THREAD = false;

--- a/releasenotes/notes/memalloc-reentrancy-tls-fix-e706dec1d92fbe24.yaml
+++ b/releasenotes/notes/memalloc-reentrancy-tls-fix-e706dec1d92fbe24.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    profiling: The memory profiler has a guard to avoid re-entering its code if
+    there are allocations during sampling. This guard was meant to be
+    thread-local, but was not correctly declared as such. This doesn't
+    immediately cause problems because the profiler uses try-locks to protect
+    access to its data structures, and re-entering the code will fail to acquire
+    the locks.  But this bug could be a source of deadlocks or data corruption
+    if the code changes substantially in the future. This fix makes the guard
+    thread-local as originally intended.


### PR DESCRIPTION
The memory profiler has a guard to avoid re-entering its code if there
are allocations during sampling. This guard was meant to be
thread-local, but was not correctly declared as such. This doesn't
immediately cause problems because the profiler uses try-locks to
protect access to its data structures, and re-entering the code will
fail to acquire the locks. But this bug could be a source of deadlocks
or data corruption if the code changes substantially in the future. This
fix makes the guard thread-local as originally intended.  Also document
a little more the thread-local access model we specify here, since it
might not be obvious what it's for or why we need to explicitly declare
it.

Note: this might increase the overhead of the memory profiler. global-dynamic
TLS access (the kind we should be/might implicitly end up using here) can
involve a few function calls for every access to the variable, and we access
the reentrancy guard for every allocation, whether or not we sample the
allocation.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
