### PR TITLE
Revert "chore: ignore useless conversion lint warning from pyo3 (#12450)"

### DIFF
--- a/src/core/lib.rs
+++ b/src/core/lib.rs
@@ -1,5 +1,5 @@
-#[allow(clippy::useless_conversion)]
 mod ddsketch;
+
 use pyo3::prelude::*;
 
 #[pymodule]


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#12453