### PR TITLE
Revert "ci(flaky): mark `tests/internal/test_auto.py` with flaky for 30 days [backport 2.21]"

### DIFF
--- a/tests/internal/test_auto.py
+++ b/tests/internal/test_auto.py
@@ -2,8 +2,6 @@ import sys
 
 import pytest
 
-from tests.utils import flaky
-
 
 @pytest.mark.skipif(sys.version_info < (3, 12, 5), reason="Python < 3.12.5 eagerly loads the threading module")
 @pytest.mark.subprocess(
@@ -12,7 +10,6 @@ from tests.utils import flaky
         DD_REMOTE_CONFIGURATION_ENABLED="1",
     )
 )
-@flaky(until=1742014801, reason='assert "threading" not in sys.modules')
 def test_auto():
     import sys
 


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#12530