### PR TITLE
ci: move `promote-oci-to-prod` job to release stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,17 +84,6 @@ requirements_json_test:
 package-oci:
   needs: [ download_dependency_wheels, download_ddtrace_artifacts ]
 
-# promote-oci-to-prod:
-#   stage: release
-#   rules: null
-#   only:
-#     # v2.10.0
-#     # v2.10.1
-#     # v2.10.0rc0
-#     # v2.10.0rc5
-#     - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
-#   needs: [ release_pypi_prod ]
-
 promote-oci-to-staging:
   stage: release
   rules: null
@@ -107,16 +96,16 @@ promote-oci-to-staging:
     - erikayasuda/move-oci-job
   needs: [ release_pypi_test ]
 
-promote-oci-to-prod:
-  stage: release
-  rules: null
-  only:
-    # v2.10.0
-    # v2.10.1
-    # v2.10.0rc0
-    # v2.10.0rc5
-    - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
-  needs: [ release_pypi_prod ]
+# promote-oci-to-prod:
+#   stage: release
+#   rules: null
+#   only:
+#     # v2.10.0
+#     # v2.10.1
+#     # v2.10.0rc0
+#     # v2.10.0rc5
+#     - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+#   needs: [ release_pypi_prod ]
 
 onboarding_tests_installer:
   parallel:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,6 +86,7 @@ package-oci:
 
 promote-oci-to-prod:
   stage: release
+  rules: null
   only:
     # v2.10.0
     # v2.10.1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,12 +14,12 @@ default:
   interruptible: true
 
 include:
+  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/one-pipeline.yml
   - local: ".gitlab/services.yml" # Include early so others can use the definitions
   - local: ".gitlab/package.yml"
   - local: ".gitlab/release.yml"
   - local: ".gitlab/testrunner.yml"
   - local: ".gitlab/benchmarks/serverless.yml"
-  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/one-pipeline.yml
 
 tests-gen:
   stage: tests
@@ -86,6 +86,12 @@ package-oci:
 
 promote-oci-to-prod:
   stage: release
+  only:
+    # v2.10.0
+    # v2.10.1
+    # v2.10.0rc0
+    # v2.10.0rc5
+    - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
   needs: [ release_pypi_prod ]
 
 onboarding_tests_installer:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,6 +84,10 @@ requirements_json_test:
 package-oci:
   needs: [ download_dependency_wheels, download_ddtrace_artifacts ]
 
+promote-oci-to-prod:
+  stage: release
+  needs: [ release_pypi_prod ]
+
 onboarding_tests_installer:
   parallel:
     matrix:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,28 +84,40 @@ requirements_json_test:
 package-oci:
   needs: [ download_dependency_wheels, download_ddtrace_artifacts ]
 
+promote-oci-to-prod:
+  stage: release
+  rules: null
+  only:
+    - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+  needs: [ release_pypi_prod ]
+
+promote-oci-to-prod-beta:
+  stage: release
+  rules: null
+  only:
+    - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+  needs: null
+
 promote-oci-to-staging:
   stage: release
   rules: null
   only:
-    # v2.10.0
-    # v2.10.1
-    # v2.10.0rc0
-    # v2.10.0rc5
     - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
-    - erikayasuda/move-oci-job
-  needs: [ release_pypi_test ]
+  needs: null
 
-# promote-oci-to-prod:
-#   stage: release
-#   rules: null
-#   only:
-#     # v2.10.0
-#     # v2.10.1
-#     # v2.10.0rc0
-#     # v2.10.0rc5
-#     - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
-#   needs: [ release_pypi_prod ]
+publish-lib-init-ghcr-tags:
+  stage: release
+  rules: null
+  only:
+    - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+  needs: [release_pypi_prod]
+
+publish-lib-init-pinned-tags:
+  stage: release
+  rules: null
+  only:
+    - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+  needs: [release_pypi_prod]
 
 onboarding_tests_installer:
   parallel:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,7 +86,7 @@ package-oci:
 
 promote-oci-to-prod:
   stage: release
-  needs: [ release_pypi_prod ]
+  needs: [ ]
 
 onboarding_tests_installer:
   parallel:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,6 +84,29 @@ requirements_json_test:
 package-oci:
   needs: [ download_dependency_wheels, download_ddtrace_artifacts ]
 
+# promote-oci-to-prod:
+#   stage: release
+#   rules: null
+#   only:
+#     # v2.10.0
+#     # v2.10.1
+#     # v2.10.0rc0
+#     # v2.10.0rc5
+#     - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+#   needs: [ release_pypi_prod ]
+
+promote-oci-to-staging:
+  stage: release
+  rules: null
+  only:
+    # v2.10.0
+    # v2.10.1
+    # v2.10.0rc0
+    # v2.10.0rc5
+    - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+    - erikayasuda/move-oci-job
+  needs: [ release_pypi_test ]
+
 promote-oci-to-prod:
   stage: release
   rules: null

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,12 +14,12 @@ default:
   interruptible: true
 
 include:
-  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/one-pipeline.yml
   - local: ".gitlab/services.yml" # Include early so others can use the definitions
   - local: ".gitlab/package.yml"
   - local: ".gitlab/release.yml"
   - local: ".gitlab/testrunner.yml"
   - local: ".gitlab/benchmarks/serverless.yml"
+  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/one-pipeline.yml
 
 tests-gen:
   stage: tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,7 +86,7 @@ package-oci:
 
 promote-oci-to-prod:
   stage: release
-  needs: [ ]
+  needs: [ release_pypi_prod ]
 
 onboarding_tests_installer:
   parallel:

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -9,6 +9,7 @@ variables:
     # v2.10.0rc0
     # v2.10.0rc5
     - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+    - erikayasuda/move-oci-job
 
 .release_pypi:
   extends: .release_base
@@ -34,14 +35,14 @@ variables:
       - pywheels/*.tar.gz
 
 # Can be used to validate uploading of artifacts
-# release_pypi_test:
-#   extends: .release_pypi
-#   dependencies: [ "download_ddtrace_artifacts" ]
-#   variables:
-#     PYPI_REPOSITORY: testpypi
-
-release_pypi_prod:
+release_pypi_test:
   extends: .release_pypi
   dependencies: [ "download_ddtrace_artifacts" ]
   variables:
-    PYPI_REPOSITORY: pypi
+    PYPI_REPOSITORY: testpypi
+
+# release_pypi_prod:
+#   extends: .release_pypi
+#   dependencies: [ "download_ddtrace_artifacts" ]
+#   variables:
+#     PYPI_REPOSITORY: pypi

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -34,14 +34,14 @@ variables:
       - pywheels/*.tar.gz
 
 # Can be used to validate uploading of artifacts
-release_pypi_test:
-  extends: .release_pypi
-  dependencies: [ "download_ddtrace_artifacts" ]
-  variables:
-    PYPI_REPOSITORY: testpypi
-
-# release_pypi_prod:
+# release_pypi_test:
 #   extends: .release_pypi
 #   dependencies: [ "download_ddtrace_artifacts" ]
 #   variables:
-#     PYPI_REPOSITORY: pypi
+#     PYPI_REPOSITORY: testpypi
+
+release_pypi_prod:
+  extends: .release_pypi
+  dependencies: [ "download_ddtrace_artifacts" ]
+  variables:
+    PYPI_REPOSITORY: pypi

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -9,7 +9,6 @@ variables:
     # v2.10.0rc0
     # v2.10.0rc5
     - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
-    - erikayasuda/move-oci-job
 
 .release_pypi:
   extends: .release_base


### PR DESCRIPTION
We want to ensure that no artifacts are published anywhere until the very end of the release pipeline. This was true for our PyPI pubilshing, but not for OCI images. This change will make the OCI publish job dependent on no jobs, but part of the release stage to ensure this.

This was tested on [this commit](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/pipelines/57265203) (temporarily added this feature branch as a valid trigger for release stage), and it successfully blocked the OCI job when the PyPI publish job failed.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
