### PR TITLE
chore(envier): support multiple sources

### DIFF
--- a/ddtrace/internal/gitmetadata.py
+++ b/ddtrace/internal/gitmetadata.py
@@ -1,13 +1,12 @@
 import typing  # noqa:F401
 
-from envier import Env
-
 from ddtrace.ext.ci import _filter_sensitive_info
 from ddtrace.ext.git import COMMIT_SHA
 from ddtrace.ext.git import MAIN_PACKAGE
 from ddtrace.ext.git import REPOSITORY_URL
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import formats
+from ddtrace.settings._core import DDConfig as Env
 
 
 _GITMETADATA_TAGS = None  # type: typing.Optional[typing.Tuple[str, str, str]]

--- a/ddtrace/internal/gitmetadata.py
+++ b/ddtrace/internal/gitmetadata.py
@@ -6,7 +6,7 @@ from ddtrace.ext.git import MAIN_PACKAGE
 from ddtrace.ext.git import REPOSITORY_URL
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import formats
-from ddtrace.settings._core import DDConfig as Env
+from ddtrace.settings._core import DDConfig
 
 
 _GITMETADATA_TAGS = None  # type: typing.Optional[typing.Tuple[str, str, str]]
@@ -14,23 +14,23 @@ _GITMETADATA_TAGS = None  # type: typing.Optional[typing.Tuple[str, str, str]]
 log = get_logger(__name__)
 
 
-class GitMetadataConfig(Env):
+class GitMetadataConfig(DDConfig):
     __prefix__ = "dd"
 
     # DD_TRACE_GIT_METADATA_ENABLED
-    enabled = Env.var(bool, "trace_git_metadata_enabled", default=True)
+    enabled = DDConfig.var(bool, "trace_git_metadata_enabled", default=True)
 
     # DD_GIT_REPOSITORY_URL
-    repository_url = Env.var(str, "git_repository_url", default="")
+    repository_url = DDConfig.var(str, "git_repository_url", default="")
 
     # DD_GIT_COMMIT_SHA
-    commit_sha = Env.var(str, "git_commit_sha", default="")
+    commit_sha = DDConfig.var(str, "git_commit_sha", default="")
 
     # DD_MAIN_PACKAGE
-    main_package = Env.var(str, "main_package", default="")
+    main_package = DDConfig.var(str, "main_package", default="")
 
     # DD_TAGS
-    tags = Env.var(str, "tags", default="")
+    tags = DDConfig.var(str, "tags", default="")
 
 
 def _get_tags_from_env(config):

--- a/ddtrace/internal/native/__init__.py
+++ b/ddtrace/internal/native/__init__.py
@@ -8,7 +8,7 @@ from ._native import PyConfigurator
 
 def get_configuration_from_disk(
     debug_logs: bool = False,
-) -> Tuple[Dict[str, Dict[str, str]], Dict[str, Dict[str, str]]]:
+) -> Tuple[Dict[str, str], Dict[str, str]]:
     """
     Retrieves the tracer configuration from disk. Calls the PyConfigurator object
     to read the configuration from the disk using the libdatadog shared library
@@ -34,9 +34,9 @@ def get_configuration_from_disk(
             env = entry["name"]
             source = entry["source"]
             if source == "fleet_stable_config":
-                fleet_config[env] = entry
+                fleet_config[env] = entry["value"]
             elif source == "local_stable_config":
-                local_config[env] = entry
+                local_config[env] = entry["value"]
             else:
                 print(f"Unknown configuration source: {source}, for {env}")
     except Exception as e:

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -19,8 +19,6 @@ from typing import Set
 from typing import Tuple
 import uuid
 
-from envier import En
-
 import ddtrace
 from ddtrace.internal import agent
 from ddtrace.internal import gitmetadata
@@ -31,6 +29,7 @@ from ddtrace.internal.packages import is_distribution_available
 from ddtrace.internal.remoteconfig.constants import REMOTE_CONFIG_AGENT_ENDPOINT
 from ddtrace.internal.service import ServiceStatus
 from ddtrace.internal.utils.time import parse_isoformat
+from ddtrace.settings._core import DDConfig as En
 
 from ..utils.formats import parse_tags_str
 from ..utils.version import _pep440_to_semver

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -29,7 +29,7 @@ from ddtrace.internal.packages import is_distribution_available
 from ddtrace.internal.remoteconfig.constants import REMOTE_CONFIG_AGENT_ENDPOINT
 from ddtrace.internal.service import ServiceStatus
 from ddtrace.internal.utils.time import parse_isoformat
-from ddtrace.settings._core import DDConfig as En
+from ddtrace.settings._core import DDConfig
 
 from ..utils.formats import parse_tags_str
 from ..utils.version import _pep440_to_semver
@@ -52,13 +52,13 @@ def derive_skip_shutdown(c: "RemoteConfigClientConfig") -> bool:
     )
 
 
-class RemoteConfigClientConfig(En):
+class RemoteConfigClientConfig(DDConfig):
     __prefix__ = "_dd.remote_configuration"
 
-    log_payloads = En.v(bool, "log_payloads", default=False)
+    log_payloads = DDConfig.v(bool, "log_payloads", default=False)
 
-    _skip_shutdown = En.v(Optional[bool], "skip_shutdown", default=None)
-    skip_shutdown = En.d(bool, derive_skip_shutdown)
+    _skip_shutdown = DDConfig.v(Optional[bool], "skip_shutdown", default=None)
+    skip_shutdown = DDConfig.d(bool, derive_skip_shutdown)
 
 
 config = RemoteConfigClientConfig()

--- a/ddtrace/settings/_core.py
+++ b/ddtrace/settings/_core.py
@@ -30,7 +30,7 @@ class DDConfig(Env):
         self.local_source = LOCAL_CONFIG
         self.env_source = os.environ
         # Order of precedence: provided source < local stable config < environment variables < fleet stable config
-        full_source = ChainMap(self.fleet_source, self.env_source, self.local_source, source or {})  # type: ignore
+        full_source = ChainMap(self.fleet_source, self.env_source, self.local_source, source or {})
         super().__init__(source=full_source, parent=parent, dynamic=dynamic)
 
 

--- a/ddtrace/settings/_core.py
+++ b/ddtrace/settings/_core.py
@@ -1,9 +1,13 @@
+from collections import ChainMap
 import os
 from typing import Any  # noqa:F401
 from typing import Callable  # noqa:F401
+from typing import Dict  # noqa:F401
 from typing import List  # noqa:F401
 from typing import Optional  # noqa:F401
 from typing import Union  # noqa:F401
+
+from envier import Env
 
 from ddtrace.internal.native import get_configuration_from_disk
 
@@ -11,6 +15,22 @@ from ._otel_remapper import parse_otel_env
 
 
 FLEET_CONFIG, LOCAL_CONFIG = get_configuration_from_disk()
+
+
+class DDConfig(Env):
+    """Provides support for loading configurations from multiple sources."""
+
+    def __init__(
+        self,
+        source: Optional[Dict[str, str]] = None,
+        parent: Optional["Env"] = None,
+        dynamic: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self.fleet_source = FLEET_CONFIG
+        self.local_source = LOCAL_CONFIG
+        # Order of precedence: local stable config < environment variables < fleet stable config < provided source
+        source = ChainMap(source or {}, self.fleet_source, os.environ, self.local_source)  # type: ignore
+        super().__init__(source=source, parent=parent, dynamic=dynamic)
 
 
 def get_config(
@@ -37,7 +57,7 @@ def get_config(
         if env in FLEET_CONFIG:
             source = "fleet_stable_config"
             effective_env = env
-            val = FLEET_CONFIG[env]["value"]
+            val = FLEET_CONFIG[env]
             break
     # Get configurations from datadog env vars
     if val is None:
@@ -61,7 +81,7 @@ def get_config(
             if env in LOCAL_CONFIG:
                 source = "local_stable_config"
                 effective_env = env
-                val = LOCAL_CONFIG[env]["value"]
+                val = LOCAL_CONFIG[env]
                 break
     # Convert the raw value to expected format, if a modifier is provided
     if val is not None and modifier:

--- a/ddtrace/settings/_core.py
+++ b/ddtrace/settings/_core.py
@@ -28,9 +28,10 @@ class DDConfig(Env):
     ) -> None:
         self.fleet_source = FLEET_CONFIG
         self.local_source = LOCAL_CONFIG
-        # Order of precedence: local stable config < environment variables < fleet stable config < provided source
-        source = ChainMap(source or {}, self.fleet_source, os.environ, self.local_source)  # type: ignore
-        super().__init__(source=source, parent=parent, dynamic=dynamic)
+        self.env_source = os.environ
+        # Order of precedence: provided source < local stable config < environment variables < fleet stable config
+        full_source = ChainMap(self.fleet_source, self.env_source, self.local_source, source or {})  # type: ignore
+        super().__init__(source=full_source, parent=parent, dynamic=dynamic)
 
 
 def get_config(

--- a/ddtrace/settings/_database_monitoring.py
+++ b/ddtrace/settings/_database_monitoring.py
@@ -1,5 +1,6 @@
-from envier import En
 from envier import validators
+
+from ddtrace.settings._core import DDConfig as En
 
 
 class DatabaseMonitoringConfig(En):

--- a/ddtrace/settings/_database_monitoring.py
+++ b/ddtrace/settings/_database_monitoring.py
@@ -1,12 +1,12 @@
 from envier import validators
 
-from ddtrace.settings._core import DDConfig as En
+from ddtrace.settings._core import DDConfig
 
 
-class DatabaseMonitoringConfig(En):
+class DatabaseMonitoringConfig(DDConfig):
     __prefix__ = "dd_dbm"
 
-    propagation_mode = En.v(
+    propagation_mode = DDConfig.v(
         str,
         "propagation_mode",
         default="disabled",

--- a/ddtrace/settings/_telemetry.py
+++ b/ddtrace/settings/_telemetry.py
@@ -1,7 +1,7 @@
 import os
 from typing import Any  # noqa:F401
 
-from ddtrace.settings._core import DDConfig as Env
+from ddtrace.settings._core import DDConfig
 
 from ..internal.logger import get_logger
 from ..internal.telemetry import telemetry_writer
@@ -12,7 +12,7 @@ from ._otel_remapper import ENV_VAR_MAPPINGS
 log = get_logger(__name__)
 
 
-class Config(Env):
+class Config(DDConfig):
     """Env-based configuration sub-class for automatic telemetry reporting."""
 
     def __init__(self, *args, **kwargs):
@@ -31,11 +31,11 @@ class Config(Env):
             for p in name.split("."):
                 env_val = getattr(env_val, p)
 
-            if isinstance(self, Env) and env_name in self.fleet_source:
+            if env_name in self.fleet_source:
                 source = "fleet_stable_config"
-            elif env_name in os.environ:
+            elif env_name in self.env_source:
                 source = "env_var"
-            elif isinstance(self, Env) and env_name in self.local_source:
+            elif env_name in self.local_source:
                 source = "local_stable_config"
             elif env_name in self.source:
                 source = "code"
@@ -47,7 +47,7 @@ class Config(Env):
             telemetry_writer.add_configuration(env_name, env_val, source)
 
 
-def report_telemetry(env: Env) -> None:
+def report_telemetry(env: DDConfig) -> None:
     Config._report_telemetry(env)
 
 

--- a/ddtrace/settings/asm.py
+++ b/ddtrace/settings/asm.py
@@ -17,7 +17,7 @@ from ddtrace.appsec._constants import TELEMETRY_INFORMATION_NAME
 from ddtrace.constants import APPSEC_ENV
 from ddtrace.internal import core
 from ddtrace.internal.serverless import in_aws_lambda
-from ddtrace.settings._core import DDConfig as Env
+from ddtrace.settings._core import DDConfig
 from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 
 
@@ -59,37 +59,37 @@ def build_libddwaf_filename() -> str:
     return os.path.join(_DIRNAME, "appsec", "_ddwaf", "libddwaf", ARCHITECTURE, "lib", "libddwaf." + FILE_EXTENSION)
 
 
-class ASMConfig(Env):
-    _asm_enabled = Env.var(bool, APPSEC_ENV, default=False)
-    _asm_static_rule_file = Env.var(Optional[str], APPSEC.RULE_FILE, default=None)
+class ASMConfig(DDConfig):
+    _asm_enabled = DDConfig.var(bool, APPSEC_ENV, default=False)
+    _asm_static_rule_file = DDConfig.var(Optional[str], APPSEC.RULE_FILE, default=None)
     # prevent empty string
     if _asm_static_rule_file == "":
         _asm_static_rule_file = None
     _iast_enabled = tracer_config._from_endpoint.get(  # type: ignore
-        "iast_enabled", Env.var(bool, IAST.ENV, default=False)
+        "iast_enabled", DDConfig.var(bool, IAST.ENV, default=False)
     )
-    _iast_request_sampling = Env.var(float, IAST.ENV_REQUEST_SAMPLING, default=30.0)
-    _iast_debug = Env.var(bool, IAST.ENV_DEBUG, default=False, private=True)
-    _iast_propagation_debug = Env.var(bool, IAST.ENV_PROPAGATION_DEBUG, default=False, private=True)
-    _iast_telemetry_report_lvl = Env.var(str, IAST.ENV_TELEMETRY_REPORT_LVL, default=TELEMETRY_INFORMATION_NAME)
-    _apm_tracing_enabled = Env.var(bool, APPSEC.APM_TRACING_ENV, default=True)
+    _iast_request_sampling = DDConfig.var(float, IAST.ENV_REQUEST_SAMPLING, default=30.0)
+    _iast_debug = DDConfig.var(bool, IAST.ENV_DEBUG, default=False, private=True)
+    _iast_propagation_debug = DDConfig.var(bool, IAST.ENV_PROPAGATION_DEBUG, default=False, private=True)
+    _iast_telemetry_report_lvl = DDConfig.var(str, IAST.ENV_TELEMETRY_REPORT_LVL, default=TELEMETRY_INFORMATION_NAME)
+    _apm_tracing_enabled = DDConfig.var(bool, APPSEC.APM_TRACING_ENV, default=True)
     _use_metastruct_for_triggers = True
 
-    _auto_user_instrumentation_local_mode = Env.var(
+    _auto_user_instrumentation_local_mode = DDConfig.var(
         str,
         APPSEC.AUTO_USER_INSTRUMENTATION_MODE,
         default=LOGIN_EVENTS_MODE.IDENT,
         parser=_parse_options([LOGIN_EVENTS_MODE.DISABLED, LOGIN_EVENTS_MODE.IDENT, LOGIN_EVENTS_MODE.ANON]),
     )
     _auto_user_instrumentation_rc_mode: Optional[str] = None
-    _auto_user_instrumentation_enabled = Env.var(bool, APPSEC.AUTO_USER_INSTRUMENTATION_MODE_ENABLED, default=True)
+    _auto_user_instrumentation_enabled = DDConfig.var(bool, APPSEC.AUTO_USER_INSTRUMENTATION_MODE_ENABLED, default=True)
 
-    _user_model_login_field = Env.var(str, APPSEC.USER_MODEL_LOGIN_FIELD, default="")
-    _user_model_email_field = Env.var(str, APPSEC.USER_MODEL_EMAIL_FIELD, default="")
-    _user_model_name_field = Env.var(str, APPSEC.USER_MODEL_NAME_FIELD, default="")
-    _api_security_enabled = Env.var(bool, API_SECURITY.ENV_VAR_ENABLED, default=True)
-    _api_security_sample_delay = Env.var(float, API_SECURITY.SAMPLE_DELAY, default=30.0)
-    _api_security_parse_response_body = Env.var(bool, API_SECURITY.PARSE_RESPONSE_BODY, default=True)
+    _user_model_login_field = DDConfig.var(str, APPSEC.USER_MODEL_LOGIN_FIELD, default="")
+    _user_model_email_field = DDConfig.var(str, APPSEC.USER_MODEL_EMAIL_FIELD, default="")
+    _user_model_name_field = DDConfig.var(str, APPSEC.USER_MODEL_NAME_FIELD, default="")
+    _api_security_enabled = DDConfig.var(bool, API_SECURITY.ENV_VAR_ENABLED, default=True)
+    _api_security_sample_delay = DDConfig.var(float, API_SECURITY.SAMPLE_DELAY, default=30.0)
+    _api_security_parse_response_body = DDConfig.var(bool, API_SECURITY.PARSE_RESPONSE_BODY, default=True)
 
     # internal state of the API security Manager service.
     # updated in API Manager enable/disable
@@ -97,23 +97,23 @@ class ASMConfig(Env):
     _asm_libddwaf = build_libddwaf_filename()
     _asm_libddwaf_available = os.path.exists(_asm_libddwaf)
 
-    _waf_timeout = Env.var(
+    _waf_timeout = DDConfig.var(
         float,
         "DD_APPSEC_WAF_TIMEOUT",
         default=DEFAULT.WAF_TIMEOUT,
         help_type=float,
         help="Timeout in milliseconds for WAF computations",
     )
-    _asm_deduplication_enabled = Env.var(bool, "_DD_APPSEC_DEDUPLICATION_ENABLED", default=True)
-    _asm_obfuscation_parameter_key_regexp = Env.var(
+    _asm_deduplication_enabled = DDConfig.var(bool, "_DD_APPSEC_DEDUPLICATION_ENABLED", default=True)
+    _asm_obfuscation_parameter_key_regexp = DDConfig.var(
         str, APPSEC.OBFUSCATION_PARAMETER_KEY_REGEXP, default=DEFAULT.APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP
     )
-    _asm_obfuscation_parameter_value_regexp = Env.var(
+    _asm_obfuscation_parameter_value_regexp = DDConfig.var(
         str, APPSEC.OBFUSCATION_PARAMETER_VALUE_REGEXP, default=DEFAULT.APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP
     )
 
-    _iast_redaction_enabled = Env.var(bool, IAST.REDACTION_ENABLED, default=True)
-    _iast_redaction_name_pattern = Env.var(
+    _iast_redaction_enabled = DDConfig.var(bool, IAST.REDACTION_ENABLED, default=True)
+    _iast_redaction_name_pattern = DDConfig.var(
         str,
         IAST.REDACTION_NAME_PATTERN,
         default=r"(?i)^.*(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|"
@@ -121,50 +121,50 @@ class ASMConfig(Env):
         + r"consumer_?(?:id|key|secret)|"
         + r"sign(?:ed|ature)?|auth(?:entication|orization)?)",
     )
-    _iast_redaction_value_pattern = Env.var(
+    _iast_redaction_value_pattern = DDConfig.var(
         str,
         IAST.REDACTION_VALUE_PATTERN,
         default=r"(?i)bearer\s+[a-z0-9\._\-]+|token:[a-z0-9]{13}|password|gh[opsu]_[0-9a-zA-Z]{36}|"
         + r"ey[I-L][\w=-]+\.ey[I-L][\w=-]+(\.[\w.+\/=-]+)?|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY"
         + r"[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*[a-z0-9\/\.+]{100,}",
     )
-    _iast_max_concurrent_requests = Env.var(
+    _iast_max_concurrent_requests = DDConfig.var(
         int,
         IAST.DD_IAST_MAX_CONCURRENT_REQUESTS,
         default=2,
     )
-    _iast_max_vulnerabilities_per_requests = Env.var(
+    _iast_max_vulnerabilities_per_requests = DDConfig.var(
         int,
         IAST.DD_IAST_VULNERABILITIES_PER_REQUEST,
         default=2,
     )
-    _iast_lazy_taint = Env.var(bool, IAST.LAZY_TAINT, default=False)
-    _iast_deduplication_enabled = Env.var(bool, "DD_IAST_DEDUPLICATION_ENABLED", default=True)
+    _iast_lazy_taint = DDConfig.var(bool, IAST.LAZY_TAINT, default=False)
+    _iast_deduplication_enabled = DDConfig.var(bool, "DD_IAST_DEDUPLICATION_ENABLED", default=True)
 
     # default will be set to True once the feature is GA. For now it's always False
-    _ep_enabled = Env.var(bool, EXPLOIT_PREVENTION.EP_ENABLED, default=True)
-    _ep_stack_trace_enabled = Env.var(bool, EXPLOIT_PREVENTION.STACK_TRACE_ENABLED, default=True)
+    _ep_enabled = DDConfig.var(bool, EXPLOIT_PREVENTION.EP_ENABLED, default=True)
+    _ep_stack_trace_enabled = DDConfig.var(bool, EXPLOIT_PREVENTION.STACK_TRACE_ENABLED, default=True)
     # for max_stack_traces, 0 == unlimited
-    _ep_max_stack_traces = Env.var(
+    _ep_max_stack_traces = DDConfig.var(
         int, EXPLOIT_PREVENTION.MAX_STACK_TRACES, default=2, validator=_validate_non_negative_int
     )
     # for max_stack_trace_depth, 0 == unlimited
-    _ep_max_stack_trace_depth = Env.var(
+    _ep_max_stack_trace_depth = DDConfig.var(
         int, EXPLOIT_PREVENTION.MAX_STACK_TRACE_DEPTH, default=32, validator=_validate_non_negative_int
     )
 
     # percentage of stack trace reported on top, in case depth is larger than max_stack_trace_depth
-    _ep_stack_top_percent = Env.var(
+    _ep_stack_top_percent = DDConfig.var(
         float, EXPLOIT_PREVENTION.STACK_TOP_PERCENT, default=75.0, validator=_validate_percentage
     )
 
-    _iast_stack_trace_enabled = Env.var(bool, IAST.STACK_TRACE_ENABLED, default=True)
+    _iast_stack_trace_enabled = DDConfig.var(bool, IAST.STACK_TRACE_ENABLED, default=True)
 
     # Django ATO
-    _django_include_user_name = Env.var(bool, "DD_DJANGO_INCLUDE_USER_NAME", default=True)
-    _django_include_user_email = Env.var(bool, "DD_DJANGO_INCLUDE_USER_EMAIL", default=False)
-    _django_include_user_login = Env.var(bool, "DD_DJANGO_INCLUDE_USER_LOGIN", default=True)
-    _django_include_user_realname = Env.var(bool, "DD_DJANGO_INCLUDE_USER_REALNAME", default=False)
+    _django_include_user_name = DDConfig.var(bool, "DD_DJANGO_INCLUDE_USER_NAME", default=True)
+    _django_include_user_email = DDConfig.var(bool, "DD_DJANGO_INCLUDE_USER_EMAIL", default=False)
+    _django_include_user_login = DDConfig.var(bool, "DD_DJANGO_INCLUDE_USER_LOGIN", default=True)
+    _django_include_user_realname = DDConfig.var(bool, "DD_DJANGO_INCLUDE_USER_REALNAME", default=False)
 
     # for tests purposes
     _asm_config_keys = [
@@ -210,7 +210,7 @@ class ASMConfig(Env):
         "_django_include_user_login",
         "_django_include_user_realname",
     ]
-    _iast_redaction_numeral_pattern = Env.var(
+    _iast_redaction_numeral_pattern = DDConfig.var(
         str,
         IAST.REDACTION_VALUE_NUMERAL,
         default=r"^[+-]?((0b[01]+)|(0x[0-9A-Fa-f]+)|(\d+\.?\d*(?:[Ee][+-]?\d+)?|\.\d+(?:[Ee][+-]"

--- a/ddtrace/settings/asm.py
+++ b/ddtrace/settings/asm.py
@@ -6,8 +6,6 @@ import sys
 from typing import List
 from typing import Optional
 
-from envier import Env
-
 from ddtrace import config as tracer_config
 from ddtrace.appsec._constants import API_SECURITY
 from ddtrace.appsec._constants import APPSEC
@@ -19,6 +17,7 @@ from ddtrace.appsec._constants import TELEMETRY_INFORMATION_NAME
 from ddtrace.constants import APPSEC_ENV
 from ddtrace.internal import core
 from ddtrace.internal.serverless import in_aws_lambda
+from ddtrace.settings._core import DDConfig as Env
 from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 
 

--- a/ddtrace/settings/code_origin.py
+++ b/ddtrace/settings/code_origin.py
@@ -1,10 +1,10 @@
-from ddtrace.settings._core import DDConfig as En
+from ddtrace.settings._core import DDConfig
 
 
-class CodeOriginConfig(En):
+class CodeOriginConfig(DDConfig):
     __prefix__ = "dd.code_origin"
 
-    max_user_frames = En.v(
+    max_user_frames = DDConfig.v(
         int,
         "max_user_frames",
         default=8,
@@ -13,11 +13,11 @@ class CodeOriginConfig(En):
         private=True,
     )
 
-    class SpanCodeOriginConfig(En):
+    class SpanCodeOriginConfig(DDConfig):
         __prefix__ = "for_spans"
         __item__ = "span"
 
-        enabled = En.v(
+        enabled = DDConfig.v(
             bool,
             "enabled",
             default=False,

--- a/ddtrace/settings/code_origin.py
+++ b/ddtrace/settings/code_origin.py
@@ -1,4 +1,4 @@
-from envier import En
+from ddtrace.settings._core import DDConfig as En
 
 
 class CodeOriginConfig(En):

--- a/ddtrace/settings/crashtracker.py
+++ b/ddtrace/settings/crashtracker.py
@@ -1,8 +1,7 @@
 import typing as t
 
-from envier import En
-
 from ddtrace.internal.utils.formats import parse_tags_str
+from ddtrace.settings._core import DDConfig as En
 from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 
 

--- a/ddtrace/settings/crashtracker.py
+++ b/ddtrace/settings/crashtracker.py
@@ -1,7 +1,7 @@
 import typing as t
 
 from ddtrace.internal.utils.formats import parse_tags_str
-from ddtrace.settings._core import DDConfig as En
+from ddtrace.settings._core import DDConfig
 from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 
 
@@ -32,12 +32,12 @@ def _derive_crashtracking_enabled(config: "CrashtrackingConfig") -> bool:
     return bool(config._enabled)
 
 
-class CrashtrackingConfig(En):
+class CrashtrackingConfig(DDConfig):
     # Although the component is called crashtrack_er_, for consistency with other products/telemetry we use the term
     # crashtrack_ing_ as much as possible.  We'll gradually align on this.
     __prefix__ = "dd.crashtracking"
 
-    _enabled = En.v(
+    _enabled = DDConfig.v(
         bool,
         "enabled",
         default=True,
@@ -45,9 +45,9 @@ class CrashtrackingConfig(En):
         help="Enables crashtracking",
     )
 
-    enabled = En.d(bool, _derive_crashtracking_enabled)
+    enabled = DDConfig.d(bool, _derive_crashtracking_enabled)
 
-    debug_url = En.v(
+    debug_url = DDConfig.v(
         t.Optional[str],
         "debug_url",
         default=None,
@@ -56,7 +56,7 @@ class CrashtrackingConfig(En):
         "This is generally useful only for dd-trace-py development.",
     )
 
-    stdout_filename = En.v(
+    stdout_filename = DDConfig.v(
         t.Optional[str],
         "stdout_filename",
         default=None,
@@ -64,7 +64,7 @@ class CrashtrackingConfig(En):
         help="The destination filename for crashtracking stdout",
     )
 
-    stderr_filename = En.v(
+    stderr_filename = DDConfig.v(
         t.Optional[str],
         "stderr_filename",
         default=None,
@@ -72,7 +72,7 @@ class CrashtrackingConfig(En):
         help="The destination filename for crashtracking stderr",
     )
 
-    use_alt_stack = En.v(
+    use_alt_stack = DDConfig.v(
         bool,
         "use_alt_stack",
         default=True,
@@ -80,7 +80,7 @@ class CrashtrackingConfig(En):
         help="Whether to use an alternate stack for crashtracking.",
     )
 
-    create_alt_stack = En.v(
+    create_alt_stack = DDConfig.v(
         bool,
         "create_alt_stack",
         default=True,
@@ -90,7 +90,7 @@ class CrashtrackingConfig(En):
         "use_alt_stack to ensure that the altstack is large enough.",
     )
 
-    _stacktrace_resolver = En.v(
+    _stacktrace_resolver = DDConfig.v(
         t.Optional[str],
         "stacktrace_resolver",
         default=resolver_default,
@@ -98,9 +98,9 @@ class CrashtrackingConfig(En):
         help="How to collect native stack traces during a crash, if at all.  Accepted values are 'none', 'fast',"
         " 'safe', and 'full'.  The default value is '" + resolver_default + "'.",
     )
-    stacktrace_resolver = En.d(t.Optional[str], _derive_stacktrace_resolver)
+    stacktrace_resolver = DDConfig.d(t.Optional[str], _derive_stacktrace_resolver)
 
-    tags = En.v(
+    tags = DDConfig.v(
         dict,
         "tags",
         parser=parse_tags_str,
@@ -110,7 +110,7 @@ class CrashtrackingConfig(En):
         "This is generally useful only for dd-trace-py development.",
     )
 
-    wait_for_receiver = En.v(
+    wait_for_receiver = DDConfig.v(
         bool,
         "wait_for_receiver",
         default=True,

--- a/ddtrace/settings/dynamic_instrumentation.py
+++ b/ddtrace/settings/dynamic_instrumentation.py
@@ -1,13 +1,12 @@
 import re
 import typing as t
 
-from envier import En
-
 from ddtrace import config as ddconfig
 from ddtrace.internal import gitmetadata
 from ddtrace.internal.agent import get_trace_url
 from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
 from ddtrace.internal.utils.config import get_application_name
+from ddtrace.settings._core import DDConfig as En
 from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 from ddtrace.version import get_version
 

--- a/ddtrace/settings/dynamic_instrumentation.py
+++ b/ddtrace/settings/dynamic_instrumentation.py
@@ -6,7 +6,7 @@ from ddtrace.internal import gitmetadata
 from ddtrace.internal.agent import get_trace_url
 from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
 from ddtrace.internal.utils.config import get_application_name
-from ddtrace.settings._core import DDConfig as En
+from ddtrace.settings._core import DDConfig
 from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 from ddtrace.version import get_version
 
@@ -16,7 +16,7 @@ DEFAULT_GLOBAL_RATE_LIMIT = 100.0
 
 
 def _derive_tags(c):
-    # type: (En) -> str
+    # type: (DDConfig) -> str
     _tags = dict(env=ddconfig.env, version=ddconfig.version, debugger_version=get_version())
     _tags.update(ddconfig.tags)
 
@@ -44,18 +44,18 @@ def validate_type_patterns(types: t.Set[str]):
                 raise ValueError(f"Invalid redaction type pattern {typ}: {s} is not a valid identifier")
 
 
-class DynamicInstrumentationConfig(En):
+class DynamicInstrumentationConfig(DDConfig):
     __prefix__ = "dd.dynamic_instrumentation"
 
-    service_name = En.d(str, lambda _: ddconfig.service or get_application_name() or DEFAULT_SERVICE_NAME)
-    _intake_url = En.d(str, lambda _: get_trace_url())
-    max_probes = En.d(int, lambda _: DEFAULT_MAX_PROBES)
-    global_rate_limit = En.d(float, lambda _: DEFAULT_GLOBAL_RATE_LIMIT)
-    _tags_in_qs = En.d(bool, lambda _: True)
-    _intake_endpoint = En.d(str, lambda _: "/debugger/v1/input")
-    tags = En.d(str, _derive_tags)
+    service_name = DDConfig.d(str, lambda _: ddconfig.service or get_application_name() or DEFAULT_SERVICE_NAME)
+    _intake_url = DDConfig.d(str, lambda _: get_trace_url())
+    max_probes = DDConfig.d(int, lambda _: DEFAULT_MAX_PROBES)
+    global_rate_limit = DDConfig.d(float, lambda _: DEFAULT_GLOBAL_RATE_LIMIT)
+    _tags_in_qs = DDConfig.d(bool, lambda _: True)
+    _intake_endpoint = DDConfig.d(str, lambda _: "/debugger/v1/input")
+    tags = DDConfig.d(str, _derive_tags)
 
-    enabled = En.v(
+    enabled = DDConfig.v(
         bool,
         "enabled",
         default=False,
@@ -63,7 +63,7 @@ class DynamicInstrumentationConfig(En):
         help="Enable Dynamic Instrumentation",
     )
 
-    metrics = En.v(
+    metrics = DDConfig.v(
         bool,
         "metrics.enabled",
         default=True,
@@ -71,7 +71,7 @@ class DynamicInstrumentationConfig(En):
         help="Enable Dynamic Instrumentation diagnostic metrics",
     )
 
-    max_payload_size = En.v(
+    max_payload_size = DDConfig.v(
         int,
         "max_payload_size",
         default=1 << 20,  # 1 MB
@@ -79,7 +79,7 @@ class DynamicInstrumentationConfig(En):
         help="Maximum size in bytes of a single configuration payload that can be handled per request",
     )
 
-    upload_timeout = En.v(
+    upload_timeout = DDConfig.v(
         int,
         "upload.timeout",
         default=30,  # seconds
@@ -87,7 +87,7 @@ class DynamicInstrumentationConfig(En):
         help="Timeout in seconds for uploading Dynamic Instrumentation payloads",
     )
 
-    upload_flush_interval = En.v(
+    upload_flush_interval = DDConfig.v(
         float,
         "upload.flush_interval",
         default=1.0,  # seconds
@@ -95,7 +95,7 @@ class DynamicInstrumentationConfig(En):
         help="Interval in seconds for flushing the dynamic logs upload queue",
     )
 
-    diagnostics_interval = En.v(
+    diagnostics_interval = DDConfig.v(
         int,
         "diagnostics.interval",
         default=3600,  # 1 hour
@@ -103,7 +103,7 @@ class DynamicInstrumentationConfig(En):
         help="Interval in seconds for periodically emitting probe diagnostic messages",
     )
 
-    redacted_identifiers = En.v(
+    redacted_identifiers = DDConfig.v(
         set,
         "redacted_identifiers",
         map=normalize_ident,
@@ -112,7 +112,7 @@ class DynamicInstrumentationConfig(En):
         help="List of identifiers/object attributes/dict keys to redact from dynamic logs and snapshots",
     )
 
-    redacted_types = En.v(
+    redacted_types = DDConfig.v(
         set,
         "redacted_types",
         map=str.strip,
@@ -122,7 +122,7 @@ class DynamicInstrumentationConfig(En):
         help="List of object types to redact from dynamic logs and snapshots",
     )
 
-    redacted_types_re = En.d(
+    redacted_types_re = DDConfig.d(
         t.Optional[re.Pattern],
         lambda c: re.compile(f"^(?:{'|'.join((_.replace('.', '[.]').replace('*', '.*') for _ in c.redacted_types))})$")
         if c.redacted_types

--- a/ddtrace/settings/exception_replay.py
+++ b/ddtrace/settings/exception_replay.py
@@ -1,11 +1,11 @@
-from ddtrace.settings._core import DDConfig as En
+from ddtrace.settings._core import DDConfig
 from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 
 
-class ExceptionReplayConfig(En):
+class ExceptionReplayConfig(DDConfig):
     __prefix__ = "dd.exception"
 
-    enabled = En.v(
+    enabled = DDConfig.v(
         bool,
         "replay.enabled",
         default=False,
@@ -13,7 +13,7 @@ class ExceptionReplayConfig(En):
         help="Enable automatic capturing of exception debugging information",
         deprecations=[("debugging.enabled", None, "3.0")],
     )
-    max_frames = En.v(
+    max_frames = DDConfig.v(
         int,
         "replay.capture_max_frames",
         default=8,

--- a/ddtrace/settings/exception_replay.py
+++ b/ddtrace/settings/exception_replay.py
@@ -1,5 +1,4 @@
-from envier import En
-
+from ddtrace.settings._core import DDConfig as En
 from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 
 

--- a/ddtrace/settings/live_debugging.py
+++ b/ddtrace/settings/live_debugging.py
@@ -1,10 +1,10 @@
-from ddtrace.settings._core import DDConfig as En
+from ddtrace.settings._core import DDConfig
 
 
-class LiveDebuggerConfig(En):
+class LiveDebuggerConfig(DDConfig):
     __prefix__ = "dd.live_debugging"
 
-    enabled = En.v(
+    enabled = DDConfig.v(
         bool,
         "enabled",
         default=False,

--- a/ddtrace/settings/live_debugging.py
+++ b/ddtrace/settings/live_debugging.py
@@ -1,4 +1,4 @@
-from envier import En
+from ddtrace.settings._core import DDConfig as En
 
 
 class LiveDebuggerConfig(En):

--- a/ddtrace/settings/profiling.py
+++ b/ddtrace/settings/profiling.py
@@ -3,8 +3,6 @@ import math
 import os
 import typing as t
 
-from envier import En
-
 from ddtrace import config as core_config
 from ddtrace.ext.git import COMMIT_SHA
 from ddtrace.ext.git import MAIN_PACKAGE
@@ -13,6 +11,7 @@ from ddtrace.internal import compat
 from ddtrace.internal import gitmetadata
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import parse_tags_str
+from ddtrace.settings._core import DDConfig as En
 from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 
 

--- a/ddtrace/settings/profiling.py
+++ b/ddtrace/settings/profiling.py
@@ -11,7 +11,7 @@ from ddtrace.internal import compat
 from ddtrace.internal import gitmetadata
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import parse_tags_str
-from ddtrace.settings._core import DDConfig as En
+from ddtrace.settings._core import DDConfig
 from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 
 
@@ -168,12 +168,12 @@ def _enrich_tags(tags) -> t.Dict[str, str]:
     return tags
 
 
-class ProfilingConfig(En):
+class ProfilingConfig(DDConfig):
     __prefix__ = "dd.profiling"
 
     # Note that the parser here has a side-effect, since SSI has changed the once-truthy value of the envvar to
     # truthy + "auto", which has a special meaning.
-    enabled = En.v(
+    enabled = DDConfig.v(
         bool,
         "enabled",
         parser=_parse_profiling_enabled,
@@ -182,7 +182,7 @@ class ProfilingConfig(En):
         help="Enable Datadog profiling when using ``ddtrace-run``",
     )
 
-    agentless = En.v(
+    agentless = DDConfig.v(
         bool,
         "agentless",
         default=False,
@@ -190,7 +190,7 @@ class ProfilingConfig(En):
         help="",
     )
 
-    code_provenance = En.v(
+    code_provenance = DDConfig.v(
         bool,
         "enable_code_provenance",
         default=True,
@@ -198,7 +198,7 @@ class ProfilingConfig(En):
         help="Whether to enable code provenance",
     )
 
-    endpoint_collection = En.v(
+    endpoint_collection = DDConfig.v(
         bool,
         "endpoint_collection_enabled",
         default=True,
@@ -206,7 +206,7 @@ class ProfilingConfig(En):
         help="Whether to enable the endpoint data collection in profiles",
     )
 
-    output_pprof = En.v(
+    output_pprof = DDConfig.v(
         t.Optional[str],
         "output_pprof",
         default=None,
@@ -214,7 +214,7 @@ class ProfilingConfig(En):
         help="",
     )
 
-    max_events = En.v(
+    max_events = DDConfig.v(
         int,
         "max_events",
         default=16384,
@@ -222,7 +222,7 @@ class ProfilingConfig(En):
         help="",
     )
 
-    upload_interval = En.v(
+    upload_interval = DDConfig.v(
         float,
         "upload_interval",
         default=60.0,
@@ -230,7 +230,7 @@ class ProfilingConfig(En):
         help="The interval in seconds to wait before flushing out recorded events",
     )
 
-    capture_pct = En.v(
+    capture_pct = DDConfig.v(
         float,
         "capture_pct",
         default=1.0,
@@ -240,7 +240,7 @@ class ProfilingConfig(En):
         "greater than 0 lesser or equal to 100",
     )
 
-    max_frames = En.v(
+    max_frames = DDConfig.v(
         int,
         "max_frames",
         default=64,
@@ -248,7 +248,7 @@ class ProfilingConfig(En):
         help="The maximum number of frames to capture in stack execution tracing",
     )
 
-    ignore_profiler = En.v(
+    ignore_profiler = DDConfig.v(
         bool,
         "ignore_profiler",
         default=False,
@@ -256,7 +256,7 @@ class ProfilingConfig(En):
         help="**Deprecated**: whether to ignore the profiler in the generated data",
     )
 
-    max_time_usage_pct = En.v(
+    max_time_usage_pct = DDConfig.v(
         float,
         "max_time_usage_pct",
         default=1.0,
@@ -265,7 +265,7 @@ class ProfilingConfig(En):
         "statistics. Must be greater than 0 and lesser or equal to 100",
     )
 
-    api_timeout = En.v(
+    api_timeout = DDConfig.v(
         float,
         "api_timeout",
         default=10.0,
@@ -273,7 +273,7 @@ class ProfilingConfig(En):
         help="The timeout in seconds before dropping events if the HTTP API does not reply",
     )
 
-    timeline_enabled = En.v(
+    timeline_enabled = DDConfig.v(
         bool,
         "timeline_enabled",
         default=False,
@@ -282,7 +282,7 @@ class ProfilingConfig(En):
         "overhead to the profiler, but enables the use of the Timeline view in the UI.",
     )
 
-    tags = En.v(
+    tags = DDConfig.v(
         dict,
         "tags",
         parser=parse_tags_str,
@@ -291,7 +291,7 @@ class ProfilingConfig(En):
         help="The tags to apply to uploaded profile. Must be a list in the ``key1:value,key2:value2`` format",
     )
 
-    enable_asserts = En.v(
+    enable_asserts = DDConfig.v(
         bool,
         "enable_asserts",
         default=False,
@@ -299,7 +299,7 @@ class ProfilingConfig(En):
         help="Whether to enable debug assertions in the profiler code",
     )
 
-    _force_legacy_exporter = En.v(
+    _force_legacy_exporter = DDConfig.v(
         bool,
         "_force_legacy_exporter",
         default=False,
@@ -308,7 +308,7 @@ class ProfilingConfig(En):
         "not for general use and will be removed in the near future.",
     )
 
-    sample_pool_capacity = En.v(
+    sample_pool_capacity = DDConfig.v(
         int,
         "sample_pool_capacity",
         default=4,
@@ -319,10 +319,10 @@ class ProfilingConfig(En):
     )
 
 
-class ProfilingConfigStack(En):
+class ProfilingConfigStack(DDConfig):
     __item__ = __prefix__ = "stack"
 
-    enabled = En.v(
+    enabled = DDConfig.v(
         bool,
         "enabled",
         default=True,
@@ -330,7 +330,7 @@ class ProfilingConfigStack(En):
         help="Whether to enable the stack profiler",
     )
 
-    _v2_enabled = En.v(
+    _v2_enabled = DDConfig.v(
         bool,
         "v2_enabled",
         default=True,
@@ -339,13 +339,13 @@ class ProfilingConfigStack(En):
     )
 
     # V2 can't be enabled if stack collection is disabled or if pre-requisites are not met
-    v2_enabled = En.d(bool, lambda c: _check_for_stack_v2_available() and c._v2_enabled and c.enabled)
+    v2_enabled = DDConfig.d(bool, lambda c: _check_for_stack_v2_available() and c._v2_enabled and c.enabled)
 
 
-class ProfilingConfigLock(En):
+class ProfilingConfigLock(DDConfig):
     __item__ = __prefix__ = "lock"
 
-    enabled = En.v(
+    enabled = DDConfig.v(
         bool,
         "enabled",
         default=True,
@@ -353,7 +353,7 @@ class ProfilingConfigLock(En):
         help="Whether to enable the lock profiler",
     )
 
-    name_inspect_dir = En.v(
+    name_inspect_dir = DDConfig.v(
         bool,
         "name_inspect_dir",
         default=True,
@@ -363,10 +363,10 @@ class ProfilingConfigLock(En):
     )
 
 
-class ProfilingConfigMemory(En):
+class ProfilingConfigMemory(DDConfig):
     __item__ = __prefix__ = "memory"
 
-    enabled = En.v(
+    enabled = DDConfig.v(
         bool,
         "enabled",
         default=True,
@@ -374,7 +374,7 @@ class ProfilingConfigMemory(En):
         help="Whether to enable the memory profiler",
     )
 
-    events_buffer = En.v(
+    events_buffer = DDConfig.v(
         int,
         "events_buffer",
         default=16,
@@ -383,10 +383,10 @@ class ProfilingConfigMemory(En):
     )
 
 
-class ProfilingConfigHeap(En):
+class ProfilingConfigHeap(DDConfig):
     __item__ = __prefix__ = "heap"
 
-    enabled = En.v(
+    enabled = DDConfig.v(
         bool,
         "enabled",
         default=True,
@@ -394,20 +394,20 @@ class ProfilingConfigHeap(En):
         help="Whether to enable the heap memory profiler",
     )
 
-    _sample_size = En.v(
+    _sample_size = DDConfig.v(
         t.Optional[int],
         "sample_size",
         default=None,
         help_type="Integer",
         help="",
     )
-    sample_size = En.d(int, _derive_default_heap_sample_size)
+    sample_size = DDConfig.d(int, _derive_default_heap_sample_size)
 
 
-class ProfilingConfigPytorch(En):
+class ProfilingConfigPytorch(DDConfig):
     __item__ = __prefix__ = "pytorch"
 
-    enabled = En.v(
+    enabled = DDConfig.v(
         bool,
         "enabled",
         default=False,
@@ -415,7 +415,7 @@ class ProfilingConfigPytorch(En):
         help="Whether to enable the PyTorch profiler",
     )
 
-    events_limit = En.v(
+    events_limit = DDConfig.v(
         int,
         "events_limit",
         default=1_000_000,
@@ -424,10 +424,10 @@ class ProfilingConfigPytorch(En):
     )
 
 
-class ProfilingConfigExport(En):
+class ProfilingConfigExport(DDConfig):
     __item__ = __prefix__ = "export"
 
-    _libdd_enabled = En.v(
+    _libdd_enabled = DDConfig.v(
         bool,
         "libdd_enabled",
         default=False,

--- a/ddtrace/settings/symbol_db.py
+++ b/ddtrace/settings/symbol_db.py
@@ -1,7 +1,6 @@
 import re
 
-from envier import En
-
+from ddtrace.settings._core import DDConfig as En
 from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 
 

--- a/ddtrace/settings/symbol_db.py
+++ b/ddtrace/settings/symbol_db.py
@@ -1,13 +1,13 @@
 import re
 
-from ddtrace.settings._core import DDConfig as En
+from ddtrace.settings._core import DDConfig
 from ddtrace.settings._telemetry import report_telemetry as _report_telemetry
 
 
-class SymbolDatabaseConfig(En):
+class SymbolDatabaseConfig(DDConfig):
     __prefix__ = "dd.symbol_database"
 
-    enabled = En.v(
+    enabled = DDConfig.v(
         bool,
         "upload_enabled",
         default=True,
@@ -15,18 +15,20 @@ class SymbolDatabaseConfig(En):
         help="Whether to upload source code symbols to the Datadog backend",
     )
 
-    includes = En.v(
+    includes = DDConfig.v(
         set,
         "includes",
         default=set(),
         help_type="List",
         help="List of modules/packages to include in the symbol uploads",
     )
-    _includes_re = En.d(re.Pattern, lambda c: re.compile("(" + "|".join(f"^{p}$|^{p}[.]" for p in c.includes) + ")"))
+    _includes_re = DDConfig.d(
+        re.Pattern, lambda c: re.compile("(" + "|".join(f"^{p}$|^{p}[.]" for p in c.includes) + ")")
+    )
 
     # ---- Private settings ----
 
-    _force = En.v(
+    _force = DDConfig.v(
         bool,
         "force_upload",
         default=False,

--- a/ddtrace/settings/third_party.py
+++ b/ddtrace/settings/third_party.py
@@ -1,4 +1,4 @@
-from envier import En
+from ddtrace.settings._core import DDConfig as En
 
 
 class ThirdPartyDetectionConfig(En):

--- a/ddtrace/settings/third_party.py
+++ b/ddtrace/settings/third_party.py
@@ -1,17 +1,17 @@
-from ddtrace.settings._core import DDConfig as En
+from ddtrace.settings._core import DDConfig
 
 
-class ThirdPartyDetectionConfig(En):
+class ThirdPartyDetectionConfig(DDConfig):
     __prefix__ = "dd.third_party_detection"
 
-    excludes = En.v(
+    excludes = DDConfig.v(
         set,
         "excludes",
         help="List of packages that should not be treated as third-party",
         help_type="List",
         default=set(),
     )
-    includes = En.v(
+    includes = DDConfig.v(
         set,
         "includes",
         help="Additional packages to treat as third-party",

--- a/tests/debugging/exploration/_config.py
+++ b/tests/debugging/exploration/_config.py
@@ -4,9 +4,8 @@ import sys
 import typing as t
 from warnings import warn
 
-from envier import En
-
 from ddtrace.debugging._probe.model import CaptureLimits
+from ddtrace.settings._core import DDConfig
 
 
 def parse_venv(value: str) -> t.Optional[Path]:
@@ -19,29 +18,29 @@ def parse_venv(value: str) -> t.Optional[Path]:
         )
 
 
-class ExplorationConfig(En):
-    venv = En.v(
+class ExplorationConfig(DDConfig):
+    venv = DDConfig.v(
         t.Optional[Path],
         "virtual_env",
         parser=parse_venv,
         default=None,
     )
 
-    encode = En.v(
+    encode = DDConfig.v(
         bool,
         "dd.debugger.expl.encode",
         default=True,
         help="Whether to encode the snapshots",
     )
 
-    status_messages = En.v(
+    status_messages = DDConfig.v(
         bool,
         "dd.debugger.expl.status_messages",
         default=False,
         help="Whether to print exploration debugger status messages",
     )
 
-    include = En.v(
+    include = DDConfig.v(
         list,
         "dd.debugger.expl.include",
         parser=lambda v: [path.split(".") for path in v.split(",")],
@@ -49,33 +48,33 @@ class ExplorationConfig(En):
         help="List of module paths to include in the exploration",
     )
 
-    elusive = En.v(
+    elusive = DDConfig.v(
         bool,
         "dd.debugger.expl.elusive",
         default=False,
         help="Whether to include elusive modules in the exploration",
     )
 
-    conservative = En.v(
+    conservative = DDConfig.v(
         bool,
         "dd.debugger.expl.conservative",
         default=False,
         help="Use extremely low capture limits to reduce overhead",
     )
 
-    output_file = En.v(
+    output_file = DDConfig.v(
         t.Optional[Path],
         "dd.debugger.expl.output_file",
         default=None,
         help="Path to the output file. The standard output is used otherwise",
     )
 
-    output_stream = En.d(
+    output_stream = DDConfig.d(
         TextIOWrapper,
         lambda c: c.output_file.open("a") if c.output_file is not None else sys.__stdout__,
     )
 
-    limits = En.d(
+    limits = DDConfig.d(
         CaptureLimits,
         lambda c: CaptureLimits(
             max_level=0 if c.conservative else 1,
@@ -85,35 +84,35 @@ class ExplorationConfig(En):
         ),
     )
 
-    class ProfilerConfig(En):
+    class ProfilerConfig(DDConfig):
         __item__ = "profiler"
         __prefix__ = "dd.debugger.expl.profiler"
 
-        enabled = En.v(
+        enabled = DDConfig.v(
             bool,
             "enabled",
             default=True,
             help="Whether to enable the exploration deterministic profiler",
         )
-        delete_probes = En.v(
+        delete_probes = DDConfig.v(
             bool,
             "delete_function_probes",
             default=False,
             help="Whether to delete function probes after they are triggered",
         )
 
-    class CoverageConfig(En):
+    class CoverageConfig(DDConfig):
         __item__ = "coverage"
         __prefix__ = "dd.debugger.expl.coverage"
 
-        enabled = En.v(
+        enabled = DDConfig.v(
             bool,
             "enabled",
             default=True,
             help="Whether to enable the exploration line coverage",
         )
 
-        delete_probes = En.v(
+        delete_probes = DDConfig.v(
             bool,
             "delete_line_probes",
             default=False,

--- a/tests/debugging/mocking.py
+++ b/tests/debugging/mocking.py
@@ -8,8 +8,6 @@ from typing import Any
 from typing import Generator
 from typing import List
 
-from envier import En
-
 from ddtrace.debugging._config import di_config
 from ddtrace.debugging._debugger import Debugger
 from ddtrace.debugging._exception.replay import SpanExceptionHandler
@@ -19,6 +17,7 @@ from ddtrace.debugging._probe.remoteconfig import _filter_by_env_and_version
 from ddtrace.debugging._signal.collector import SignalCollector
 from ddtrace.debugging._signal.snapshot import Snapshot
 from ddtrace.debugging._uploader import LogsIntakeUploaderV1
+from ddtrace.settings._core import DDConfig
 from tests.debugging.probe.test_status import DummyProbeStatusLogger
 
 
@@ -175,7 +174,7 @@ class TestDebugger(Debugger):
 
 
 @contextmanager
-def _debugger(config_to_override: En, config_overrides: Any) -> Generator[TestDebugger, None, None]:
+def _debugger(config_to_override: DDConfig, config_overrides: Any) -> Generator[TestDebugger, None, None]:
     """Test with the debugger enabled."""
     atexit_register = atexit.register
     try:

--- a/tests/internal/bytecode_injection/framework_injection/_config.py
+++ b/tests/internal/bytecode_injection/framework_injection/_config.py
@@ -4,7 +4,7 @@ import sys
 import typing as t
 from warnings import warn
 
-from envier import En
+from ddtrace.settings._core import DDConfig
 
 
 def parse_venv(value: str) -> t.Optional[Path]:
@@ -17,22 +17,22 @@ def parse_venv(value: str) -> t.Optional[Path]:
         )
 
 
-class InjectionConfig(En):
-    venv = En.v(
+class InjectionConfig(DDConfig):
+    venv = DDConfig.v(
         t.Optional[Path],
         "virtual_env",
         parser=parse_venv,
         default=None,
     )
 
-    status_messages = En.v(
+    status_messages = DDConfig.v(
         bool,
         "dd.bytecode.injection.status_messages",
         default=False,
         help="Whether to print bytecode injecter status messages",
     )
 
-    include = En.v(
+    include = DDConfig.v(
         list,
         "dd.bytecode.injection.include",
         parser=lambda v: [path.split(".") for path in v.split(",")],
@@ -40,21 +40,21 @@ class InjectionConfig(En):
         help="List of module paths to include in the injection",
     )
 
-    elusive = En.v(
+    elusive = DDConfig.v(
         bool,
         "dd.bytecode.injection.elusive",
         default=False,
         help="Whether to include elusive modules in the injection",
     )
 
-    output_file = En.v(
+    output_file = DDConfig.v(
         t.Optional[Path],
         "dd.bytecode.injection.output_file",
         default=None,
         help="Path to the output file. The standard output is used otherwise",
     )
 
-    output_stream = En.d(
+    output_stream = DDConfig.d(
         TextIOWrapper,
         lambda c: c.output_file.open("a") if c.output_file is not None else sys.__stdout__,
     )


### PR DESCRIPTION
Currently `envier.Env` supports reading environment variables from one source (usually os.enviorn). This PR introduces `EnvDD` which will add support for loading environment variables from multiple sources. 

This will be used to load configurations from files and through the DatadogUI.

Note - This PR attempts to support multiple configuration sources without updating the envier library. This approach will be refactored when stable support configurations is GA 🤞.


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
