### PR TITLE
chore(packages): add support for Bazel runfiles

### DIFF
--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -145,6 +145,13 @@ def _root_module(path: Path) -> str:
         except IndexError:
             pass
 
+    # Bazel runfiles support: we assume that these paths look like
+    # /some/path.runfiles/.../site-packages/<root_module>/...
+    if any(p.suffix == ".runfiles" for p in path.parents):
+        for s in path.parents:
+            if s.parent.name == "site-packages":
+                return s.name
+
     msg = f"Could not find root module for path {path}"
     raise ValueError(msg)
 


### PR DESCRIPTION
We add some initial support for Bazel runfiles when trying to infer the root module from a path

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
