### PR TITLE
chore(telemetry): benchmark to track impact of metrics

### DIFF
--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -59,6 +59,7 @@ microbenchmarks:
         - "http_propagation_inject"
         - "rate_limiter"
         - "packages_update_imported_dependencies"
+        - "telemetry_add_metric"
 
 benchmarks-pr-comment:
   image: $MICROBENCHMARKS_CI_IMAGE

--- a/benchmarks/telemetry_add_metric/config.yaml
+++ b/benchmarks/telemetry_add_metric/config.yaml
@@ -1,0 +1,24 @@
+one-metric-one-run-batch-flush-true:
+  runs: 1
+  batches: 1
+  flush: true
+one-metric-one-run-batch-flush-false:
+  runs: 1
+  batches: 1
+  flush: False
+many-metrics-many-runs-batch-flush-true:
+  runs: 1000
+  batches: 10
+  flush: true
+many-metrics-many-runs-batch-flush-false:
+  runs: 1000
+  batches: 10
+  flush: False
+one-metric-many-runs-batch-flush-true:
+  runs: 1000
+  batches: 1
+  flush: true
+one-metric-many-runs-batch-flush-false:
+  runs: 1000
+  batches: 1
+  flush: False

--- a/benchmarks/telemetry_add_metric/scenario.py
+++ b/benchmarks/telemetry_add_metric/scenario.py
@@ -1,0 +1,36 @@
+from bm import Scenario
+
+from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
+from ddtrace.internal.telemetry.metrics import CountMetric
+from ddtrace.internal.telemetry.metrics_namespaces import MetricNamespace
+
+
+class TelemetryAddMetric(Scenario):
+    """
+    This scenario checks to see if there's an impact on sending metrics via instrumentation telemetry
+    """
+
+    runs: int
+    flush: bool
+    batches: int
+
+    def run(self):
+        def _(loops):
+            for _ in range(loops):
+                # Start the test when MetricNamespace is created
+                metricnamespace = MetricNamespace()
+                for i in range(self.runs):
+                    for j in range(self.batches):
+                        metricnamespace.add_metric(
+                            CountMetric,
+                            TELEMETRY_NAMESPACE.TRACERS,
+                            str(j),
+                            10,
+                            tags=(("integration_name", "somevalue"),),
+                        )
+
+                # Make flush optional
+                if self.flush:
+                    metricnamespace.flush()
+
+        yield _


### PR DESCRIPTION
Related to the efforts in https://github.com/DataDog/dd-trace-py/pull/12430. I separated the benchmarks in a separate PR since it doesn't need to be tied up with that PR.

The goal of this PR is to add the benchmark measuring the impact of creating instrumentation telemetry metrics.

Credits: @erikayasuda and @brettlangdon for pairing with me on this and checking out the results!

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
