### PR TITLE
ci: fix docs build

### DIFF
--- a/scripts/docs/build.sh
+++ b/scripts/docs/build.sh
@@ -2,7 +2,7 @@
 set -eux
 
 # DEV: unless it's built with editable, following sphinx-build fails
-if [ -z ${CIRCLECI+x} ]; then
+if [ -z ${GITLAB_HOST} ]; then
   CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) CARGO_BUILD_JOBS=$(nproc) pip install -v -e .
 fi
 

--- a/scripts/docs/build.sh
+++ b/scripts/docs/build.sh
@@ -2,9 +2,7 @@
 set -eux
 
 # DEV: unless it's built with editable, following sphinx-build fails
-if [ -z ${CI+x} ]; then
-  CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) CARGO_BUILD_JOBS=$(nproc) pip install -v -e .
-fi
+CMAKE_BUILD_PARALLEL_LEVEL=12 CARGO_BUILD_JOBS=12 pip install -v -e .
 
 if [[ "$(uname)" == "Darwin" ]]; then
   export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib

--- a/scripts/docs/build.sh
+++ b/scripts/docs/build.sh
@@ -2,7 +2,7 @@
 set -eux
 
 # DEV: unless it's built with editable, following sphinx-build fails
-if [ -z ${CI} ]; then
+if [ -z ${CI+x} ]; then
   CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) CARGO_BUILD_JOBS=$(nproc) pip install -v -e .
 fi
 

--- a/scripts/docs/build.sh
+++ b/scripts/docs/build.sh
@@ -2,7 +2,7 @@
 set -eux
 
 # DEV: unless it's built with editable, following sphinx-build fails
-if [ -z ${GITLAB_HOST} ]; then
+if [ -z ${CI} ]; then
   CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) CARGO_BUILD_JOBS=$(nproc) pip install -v -e .
 fi
 

--- a/scripts/gen_gitlab_config.py
+++ b/scripts/gen_gitlab_config.py
@@ -124,7 +124,7 @@ def gen_build_docs() -> None:
     from needs_testrun import pr_matches_patterns
 
     if pr_matches_patterns(
-        {"docker*", "docs/*", "ddtrace/*", "scripts/docs", "releasenotes/*", "benchmarks/README.rst"}
+        {"docker*", "docs/*", "ddtrace/*", "scripts/docs/*", "releasenotes/*", "benchmarks/README.rst"}
     ):
         with TESTS_GEN.open("a") as f:
             print("build_docs:", file=f)


### PR DESCRIPTION
This change fixes a failing `build_docs` job by unconditionally building the library in editable mode. It also adds some more files to the list that can trigger `build_docs` when changed on a PR.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
