### PR TITLE
chore(tracer): start_span raising mypy type errors

### DIFF
--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -551,9 +551,9 @@ class Tracer(object):
         span_api: str = SPAN_API_DATADOG,
     ) -> Span:
         log.warning("Spans started after the tracer has been shut down will not be sent to the Datadog Agent.")
-        return self._start_span(name, child_of, service, resource, span_type, activate, span_api)
+        return self.start_span(name, child_of, service, resource, span_type, activate, span_api)
 
-    def _start_span(
+    def start_span(
         self,
         name: str,
         child_of: Optional[Union[Span, Context]] = None,
@@ -715,8 +715,6 @@ class Tracer(object):
         self._hooks.emit(self.__class__.start_span, span)
         dispatch("trace.span_start", (span,))
         return span
-
-    start_span = _start_span
 
     def _on_span_finish(self, span: Span) -> None:
         active = self.current_span()

--- a/ddtrace/contrib/internal/pytest/_plugin_v1.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v1.py
@@ -299,7 +299,7 @@ def _start_test_module_span(item):
         span_target_item = pytest_module_item
 
     test_session_span = _extract_span(item.session)
-    test_module_span = _CIVisibility._instance.tracer._start_span(
+    test_module_span = _CIVisibility._instance.tracer.start_span(
         "pytest.test_module",
         service=_CIVisibility._instance._service,
         span_type=SpanTypes.TEST,
@@ -354,7 +354,7 @@ def _start_test_suite_span(item, test_module_span, should_enable_coverage=False)
     if parent_span is None:
         parent_span = test_session_span
 
-    test_suite_span = _CIVisibility._instance.tracer._start_span(
+    test_suite_span = _CIVisibility._instance.tracer.start_span(
         "pytest.test_suite",
         service=_CIVisibility._instance._service,
         span_type=SpanTypes.TEST,
@@ -654,7 +654,7 @@ def pytest_runtest_protocol(item, nextitem):
         test_session_span.set_tag_str(test.ITR_TEST_SKIPPING_TESTS_SKIPPED, "true")
         test_session_span.set_tag_str(test.ITR_DD_CI_ITR_TESTS_SKIPPED, "true")
 
-    with _CIVisibility._instance.tracer._start_span(
+    with _CIVisibility._instance.tracer.start_span(
         ddtrace.config.pytest.operation_name,
         service=_CIVisibility._instance._service,
         resource=item.nodeid,

--- a/ddtrace/contrib/internal/unittest/patch.py
+++ b/ddtrace/contrib/internal/unittest/patch.py
@@ -674,7 +674,7 @@ def _start_test_module_span(instance) -> ddtrace.trace.Span:
     test_session_span = _extract_session_span()
     test_module_name = _extract_module_name_from_module(instance)
     resource_name = _generate_module_resource(test_module_name)
-    test_module_span = tracer._start_span(
+    test_module_span = tracer.start_span(
         MODULE_OPERATION_NAME,
         service=_CIVisibility._instance._service,
         span_type=SpanTypes.TEST,
@@ -718,7 +718,7 @@ def _start_test_suite_span(instance) -> ddtrace.trace.Span:
     test_module_span = _extract_module_span(test_module_path)
     test_suite_name = _extract_suite_name_from_test_method(instance)
     resource_name = _generate_suite_resource(test_suite_name)
-    test_suite_span = tracer._start_span(
+    test_suite_span = tracer.start_span(
         SUITE_OPERATION_NAME,
         service=_CIVisibility._instance._service,
         span_type=SpanTypes.TEST,
@@ -754,7 +754,7 @@ def _start_test_span(instance, test_suite_span: ddtrace.trace.Span) -> ddtrace.t
     test_method_object = _extract_test_method_object(instance)
     test_suite_name = _extract_suite_name_from_test_method(instance)
     resource_name = _generate_test_resource(test_suite_name, test_name)
-    span = tracer._start_span(
+    span = tracer.start_span(
         ddtrace.config.unittest.operation_name,
         service=_CIVisibility._instance._service,
         resource=resource_name,

--- a/ddtrace/internal/ci_visibility/api/_base.py
+++ b/ddtrace/internal/ci_visibility/api/_base.py
@@ -180,7 +180,7 @@ class TestVisibilityItemBase(abc.ABC):
         # Test items do not use a parent, and are instead their own trace's root span
         parent_span = self.get_parent_span() if isinstance(self, TestVisibilityParentItem) else None
 
-        self._span = self._tracer._start_span(
+        self._span = self._tracer.start_span(
             self._operation_name,
             resource=self._resource if self._resource else self._operation_name,
             child_of=parent_span,
@@ -376,7 +376,7 @@ class TestVisibilityItemBase(abc.ABC):
                 raise CIVisibilityDataError(error_msg)
             return
         self._telemetry_record_event_created()
-        self._start_span()
+        self.start_span()
 
     def is_started(self) -> bool:
         return self._span is not None

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -682,7 +682,7 @@ class LLMObs(Service):
             model_name = "custom"
         if model_provider is None:
             model_provider = "custom"
-        return cls._instance._start_span(
+        return cls._instance.start_span(
             "llm",
             name,
             model_name=model_name,
@@ -712,7 +712,7 @@ class LLMObs(Service):
         """
         if cls.enabled is False:
             log.warning(SPAN_START_WHILE_DISABLED_WARNING)
-        return cls._instance._start_span("tool", name=name, session_id=session_id, ml_app=ml_app, _decorator=_decorator)
+        return cls._instance.start_span("tool", name=name, session_id=session_id, ml_app=ml_app, _decorator=_decorator)
 
     @classmethod
     def task(
@@ -734,7 +734,7 @@ class LLMObs(Service):
         """
         if cls.enabled is False:
             log.warning(SPAN_START_WHILE_DISABLED_WARNING)
-        return cls._instance._start_span("task", name=name, session_id=session_id, ml_app=ml_app, _decorator=_decorator)
+        return cls._instance.start_span("task", name=name, session_id=session_id, ml_app=ml_app, _decorator=_decorator)
 
     @classmethod
     def agent(
@@ -756,7 +756,7 @@ class LLMObs(Service):
         """
         if cls.enabled is False:
             log.warning(SPAN_START_WHILE_DISABLED_WARNING)
-        return cls._instance._start_span(
+        return cls._instance.start_span(
             "agent", name=name, session_id=session_id, ml_app=ml_app, _decorator=_decorator
         )
 
@@ -780,7 +780,7 @@ class LLMObs(Service):
         """
         if cls.enabled is False:
             log.warning(SPAN_START_WHILE_DISABLED_WARNING)
-        return cls._instance._start_span(
+        return cls._instance.start_span(
             "workflow", name=name, session_id=session_id, ml_app=ml_app, _decorator=_decorator
         )
 
@@ -814,7 +814,7 @@ class LLMObs(Service):
             model_name = "custom"
         if model_provider is None:
             model_provider = "custom"
-        return cls._instance._start_span(
+        return cls._instance.start_span(
             "embedding",
             name,
             model_name=model_name,
@@ -844,7 +844,7 @@ class LLMObs(Service):
         """
         if cls.enabled is False:
             log.warning(SPAN_START_WHILE_DISABLED_WARNING)
-        return cls._instance._start_span(
+        return cls._instance.start_span(
             "retrieval", name=name, session_id=session_id, ml_app=ml_app, _decorator=_decorator
         )
 


### PR DESCRIPTION
(#12574) Resolve type error by replacing the start_span alias with an instance method that automatically passes self.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
