### PR TITLE
chore(llmobs): add span.finished telemetry metric

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -67,3 +67,5 @@ EVALUATION_SPAN_METADATA = "_dd.evaluation_span"
 
 SPAN_LINKS = "_ml_obs.span_links"
 NAME = "_ml_obs.name"
+DECORATOR = "_ml_obs.decorator"
+INTEGRATION = "_ml_obs.integration"

--- a/ddtrace/llmobs/_integrations/base.py
+++ b/ddtrace/llmobs/_integrations/base.py
@@ -12,6 +12,7 @@ from ddtrace.contrib.internal.trace_utils import int_service
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import asbool
+from ddtrace.llmobs._constants import INTEGRATION
 from ddtrace.llmobs._llmobs import LLMObs
 from ddtrace.settings import IntegrationConfig
 from ddtrace.trace import Pin
@@ -77,6 +78,8 @@ class BaseLLMIntegration:
         # Enable trace metrics for these spans so users can see per-service openai usage in APM.
         span.set_tag(_SPAN_MEASURED_KEY)
         self._set_base_span_tags(span, **kwargs)
+        if self.llmobs_enabled:
+            span._set_ctx_item(INTEGRATION, self._integration_name)
         return span
 
     def trunc(self, text: str) -> str:

--- a/ddtrace/llmobs/_integrations/base.py
+++ b/ddtrace/llmobs/_integrations/base.py
@@ -11,8 +11,6 @@ from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.contrib.internal.trace_utils import int_service
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.logger import get_logger
-from ddtrace.internal.telemetry import telemetry_writer
-from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.llmobs._llmobs import LLMObs
 from ddtrace.settings import IntegrationConfig
@@ -79,16 +77,6 @@ class BaseLLMIntegration:
         # Enable trace metrics for these spans so users can see per-service openai usage in APM.
         span.set_tag(_SPAN_MEASURED_KEY)
         self._set_base_span_tags(span, **kwargs)
-        if submit_to_llmobs and self.llmobs_enabled:
-            telemetry_writer.add_count_metric(
-                namespace=TELEMETRY_NAMESPACE.MLOBS,
-                name="span.start",
-                value=1,
-                tags=(
-                    ("integration", self._integration_name),
-                    ("autoinstrumented", "true"),
-                ),
-            )
         return span
 
     def trunc(self, text: str) -> str:

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -123,6 +123,7 @@ class LLMObs(Service):
     def _on_span_start(self, span):
         if self.enabled and span.span_type == SpanTypes.LLM:
             self._activate_llmobs_span(span)
+            telemetry.record_span_started()
             self._do_annotations(span)
 
     def _on_span_finish(self, span):

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -28,7 +28,6 @@ from ddtrace.internal.service import Service
 from ddtrace.internal.service import ServiceStatusError
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_APM_PRODUCT
-from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.internal.utils.formats import parse_tags_str
@@ -36,10 +35,12 @@ from ddtrace.llmobs import _constants as constants
 from ddtrace.llmobs import _telemetry as telemetry
 from ddtrace.llmobs._constants import AGENTLESS_BASE_URL
 from ddtrace.llmobs._constants import ANNOTATIONS_CONTEXT_ID
+from ddtrace.llmobs._constants import DECORATOR
 from ddtrace.llmobs._constants import INPUT_DOCUMENTS
 from ddtrace.llmobs._constants import INPUT_MESSAGES
 from ddtrace.llmobs._constants import INPUT_PROMPT
 from ddtrace.llmobs._constants import INPUT_VALUE
+from ddtrace.llmobs._constants import INTEGRATION
 from ddtrace.llmobs._constants import METADATA
 from ddtrace.llmobs._constants import METRICS
 from ddtrace.llmobs._constants import ML_APP
@@ -127,6 +128,7 @@ class LLMObs(Service):
     def _on_span_finish(self, span):
         if self.enabled and span.span_type == SpanTypes.LLM:
             self._submit_llmobs_span(span)
+            telemetry.record_span_created(span)
 
     def _submit_llmobs_span(self, span: Span) -> None:
         """Generate and submit an LLMObs span event to be sent to LLMObs."""
@@ -230,6 +232,8 @@ class LLMObs(Service):
             "language": "python",
             "error": span.error,
         }
+        if span._get_ctx_item(INTEGRATION):
+            tags["integration"] = span._get_ctx_item(INTEGRATION)
         err_type = span.get_tag(ERROR_TYPE)
         if err_type:
             tags["error_type"] = err_type
@@ -609,16 +613,8 @@ class LLMObs(Service):
         model_name: Optional[str] = None,
         model_provider: Optional[str] = None,
         ml_app: Optional[str] = None,
+        _decorator: bool = False,
     ) -> Span:
-        telemetry_writer.add_count_metric(
-            namespace=TELEMETRY_NAMESPACE.MLOBS,
-            name="span.start",
-            value=1,
-            tags=(
-                ("autoinstrumented", "false"),
-                ("kind", operation_kind),
-            ),
-        )
         if name is None:
             name = operation_kind
         span = self.tracer.trace(name, resource=operation_kind, span_type=SpanTypes.LLM)
@@ -632,7 +628,7 @@ class LLMObs(Service):
             span._set_ctx_item(SESSION_ID, session_id)
         if ml_app is None:
             ml_app = _get_ml_app(span)
-        span._set_ctx_item(ML_APP, ml_app)
+        span._set_ctx_items({DECORATOR: _decorator, SPAN_KIND: operation_kind, ML_APP: ml_app})
         return span
 
     @classmethod
@@ -643,6 +639,7 @@ class LLMObs(Service):
         model_provider: Optional[str] = None,
         session_id: Optional[str] = None,
         ml_app: Optional[str] = None,
+        _decorator: bool = False,
     ) -> Span:
         """
         Trace an invocation call to an LLM where inputs and outputs are represented as text.
@@ -664,11 +661,23 @@ class LLMObs(Service):
         if model_provider is None:
             model_provider = "custom"
         return cls._instance._start_span(
-            "llm", name, model_name=model_name, model_provider=model_provider, session_id=session_id, ml_app=ml_app
+            "llm",
+            name,
+            model_name=model_name,
+            model_provider=model_provider,
+            session_id=session_id,
+            ml_app=ml_app,
+            _decorator=_decorator,
         )
 
     @classmethod
-    def tool(cls, name: Optional[str] = None, session_id: Optional[str] = None, ml_app: Optional[str] = None) -> Span:
+    def tool(
+        cls,
+        name: Optional[str] = None,
+        session_id: Optional[str] = None,
+        ml_app: Optional[str] = None,
+        _decorator: bool = False,
+    ) -> Span:
         """
         Trace a call to an external interface or API.
 
@@ -681,10 +690,16 @@ class LLMObs(Service):
         """
         if cls.enabled is False:
             log.warning(SPAN_START_WHILE_DISABLED_WARNING)
-        return cls._instance._start_span("tool", name=name, session_id=session_id, ml_app=ml_app)
+        return cls._instance._start_span("tool", name=name, session_id=session_id, ml_app=ml_app, _decorator=_decorator)
 
     @classmethod
-    def task(cls, name: Optional[str] = None, session_id: Optional[str] = None, ml_app: Optional[str] = None) -> Span:
+    def task(
+        cls,
+        name: Optional[str] = None,
+        session_id: Optional[str] = None,
+        ml_app: Optional[str] = None,
+        _decorator: bool = False,
+    ) -> Span:
         """
         Trace a standalone non-LLM operation which does not involve an external request.
 
@@ -697,10 +712,16 @@ class LLMObs(Service):
         """
         if cls.enabled is False:
             log.warning(SPAN_START_WHILE_DISABLED_WARNING)
-        return cls._instance._start_span("task", name=name, session_id=session_id, ml_app=ml_app)
+        return cls._instance._start_span("task", name=name, session_id=session_id, ml_app=ml_app, _decorator=_decorator)
 
     @classmethod
-    def agent(cls, name: Optional[str] = None, session_id: Optional[str] = None, ml_app: Optional[str] = None) -> Span:
+    def agent(
+        cls,
+        name: Optional[str] = None,
+        session_id: Optional[str] = None,
+        ml_app: Optional[str] = None,
+        _decorator: bool = False,
+    ) -> Span:
         """
         Trace a dynamic workflow in which an embedded language model (agent) decides what sequence of actions to take.
 
@@ -713,11 +734,17 @@ class LLMObs(Service):
         """
         if cls.enabled is False:
             log.warning(SPAN_START_WHILE_DISABLED_WARNING)
-        return cls._instance._start_span("agent", name=name, session_id=session_id, ml_app=ml_app)
+        return cls._instance._start_span(
+            "agent", name=name, session_id=session_id, ml_app=ml_app, _decorator=_decorator
+        )
 
     @classmethod
     def workflow(
-        cls, name: Optional[str] = None, session_id: Optional[str] = None, ml_app: Optional[str] = None
+        cls,
+        name: Optional[str] = None,
+        session_id: Optional[str] = None,
+        ml_app: Optional[str] = None,
+        _decorator: bool = False,
     ) -> Span:
         """
         Trace a predefined or static sequence of operations.
@@ -731,7 +758,9 @@ class LLMObs(Service):
         """
         if cls.enabled is False:
             log.warning(SPAN_START_WHILE_DISABLED_WARNING)
-        return cls._instance._start_span("workflow", name=name, session_id=session_id, ml_app=ml_app)
+        return cls._instance._start_span(
+            "workflow", name=name, session_id=session_id, ml_app=ml_app, _decorator=_decorator
+        )
 
     @classmethod
     def embedding(
@@ -741,6 +770,7 @@ class LLMObs(Service):
         model_provider: Optional[str] = None,
         session_id: Optional[str] = None,
         ml_app: Optional[str] = None,
+        _decorator: bool = False,
     ) -> Span:
         """
         Trace a call to an embedding model or function to create an embedding.
@@ -769,11 +799,16 @@ class LLMObs(Service):
             model_provider=model_provider,
             session_id=session_id,
             ml_app=ml_app,
+            _decorator=_decorator,
         )
 
     @classmethod
     def retrieval(
-        cls, name: Optional[str] = None, session_id: Optional[str] = None, ml_app: Optional[str] = None
+        cls,
+        name: Optional[str] = None,
+        session_id: Optional[str] = None,
+        ml_app: Optional[str] = None,
+        _decorator: bool = False,
     ) -> Span:
         """
         Trace a vector search operation involving a list of documents being returned from an external knowledge base.
@@ -787,7 +822,9 @@ class LLMObs(Service):
         """
         if cls.enabled is False:
             log.warning(SPAN_START_WHILE_DISABLED_WARNING)
-        return cls._instance._start_span("retrieval", name=name, session_id=session_id, ml_app=ml_app)
+        return cls._instance._start_span(
+            "retrieval", name=name, session_id=session_id, ml_app=ml_app, _decorator=_decorator
+        )
 
     @classmethod
     def annotate(

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -40,7 +40,6 @@ from ddtrace.llmobs._constants import INPUT_DOCUMENTS
 from ddtrace.llmobs._constants import INPUT_MESSAGES
 from ddtrace.llmobs._constants import INPUT_PROMPT
 from ddtrace.llmobs._constants import INPUT_VALUE
-from ddtrace.llmobs._constants import INTEGRATION
 from ddtrace.llmobs._constants import METADATA
 from ddtrace.llmobs._constants import METRICS
 from ddtrace.llmobs._constants import ML_APP
@@ -233,8 +232,6 @@ class LLMObs(Service):
             "language": "python",
             "error": span.error,
         }
-        if span._get_ctx_item(INTEGRATION):
-            tags["integration"] = span._get_ctx_item(INTEGRATION)
         err_type = span.get_tag(ERROR_TYPE)
         if err_type:
             tags["error_type"] = err_type

--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -1,6 +1,5 @@
 import time
 
-from ddtrace.constants import ERROR_TYPE
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.llmobs._constants import DECORATOR
@@ -37,14 +36,13 @@ def record_span_created(span: Span):
     decorator = span._get_ctx_item(DECORATOR) is True
     span_kind = span._get_ctx_item(SPAN_KIND)
     model_provider = span._get_ctx_item("model_provider")
-    status = "ok" if span.error == 0 else "error_{}".format(span.get_tag(ERROR_TYPE))
 
     tags = [
         ("autoinstrumented", str(autoinstrumented)),
         ("has_session_id", str(has_session_id)),
         ("is_root_span", str(is_root_span)),
         ("span_kind", span_kind or "N/A"),
-        ("status", status),
+        ("error", str(span.error)),
     ]
     if autoinstrumented:
         tags.append(("integration", integration))

--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -25,6 +25,10 @@ def record_llmobs_enabled(error, agentless_enabled, site, start_ns):
     )
 
 
+def record_span_started():
+    telemetry_writer.add_count_metric(namespace=TELEMETRY_NAMESPACE.MLOBS, name="span.start", value=1)
+
+
 def record_span_created(span: Span):
     is_root_span = span._get_ctx_item(PARENT_ID_KEY) != ROOT_PARENT_ID
     has_session_id = span._get_ctx_item(SESSION_ID) is not None
@@ -48,4 +52,4 @@ def record_span_created(span: Span):
         tags.append(("decorator", str(decorator)))
     if model_provider:
         tags.append(("model_provider", model_provider))
-    telemetry_writer.add_count_metric(namespace=TELEMETRY_NAMESPACE.MLOBS, name="span.created", value=1, tags=tuple(tags))
+    telemetry_writer.add_count_metric(namespace=TELEMETRY_NAMESPACE.MLOBS, name="span.finished", value=1, tags=tuple(tags))

--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -1,7 +1,15 @@
 import time
 
+from ddtrace.constants import ERROR_TYPE
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
+from ddtrace.llmobs._constants import DECORATOR
+from ddtrace.llmobs._constants import INTEGRATION
+from ddtrace.llmobs._constants import PARENT_ID_KEY
+from ddtrace.llmobs._constants import ROOT_PARENT_ID
+from ddtrace.llmobs._constants import SESSION_ID
+from ddtrace.llmobs._constants import SPAN_KIND
+from ddtrace.trace import Span
 
 
 def record_llmobs_enabled(error, agentless_enabled, site, start_ns):
@@ -15,3 +23,29 @@ def record_llmobs_enabled(error, agentless_enabled, site, start_ns):
     telemetry_writer.add_count_metric(
         namespace=TELEMETRY_NAMESPACE.MLOBS, name="llmobs.enabled", value=1, tags=tuple(tags)
     )
+
+
+def record_span_created(span: Span):
+    is_root_span = span._get_ctx_item(PARENT_ID_KEY) != ROOT_PARENT_ID
+    has_session_id = span._get_ctx_item(SESSION_ID) is not None
+    integration = span._get_ctx_item(INTEGRATION)
+    autoinstrumented = integration is not None
+    decorator = span._get_ctx_item(DECORATOR) is True
+    span_kind = span._get_ctx_item(SPAN_KIND)
+    model_provider = span._get_ctx_item("model_provider")
+    status = "ok" if span.error == 0 else "error_{}".format(span.get_tag(ERROR_TYPE))
+
+    tags = [
+        ("autoinstrumented", str(autoinstrumented)),
+        ("has_session_id", str(has_session_id)),
+        ("is_root_span", str(is_root_span)),
+        ("span_kind", span_kind or "N/A"),
+        ("status", status),
+    ]
+    if autoinstrumented:
+        tags.append(("integration", integration))
+    else:
+        tags.append(("decorator", str(decorator)))
+    if model_provider:
+        tags.append(("model_provider", model_provider))
+    telemetry_writer.add_count_metric(namespace=TELEMETRY_NAMESPACE.MLOBS, name="span.created", value=1, tags=tuple(tags))

--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -52,4 +52,6 @@ def record_span_created(span: Span):
         tags.append(("decorator", str(decorator)))
     if model_provider:
         tags.append(("model_provider", model_provider))
-    telemetry_writer.add_count_metric(namespace=TELEMETRY_NAMESPACE.MLOBS, name="span.finished", value=1, tags=tuple(tags))
+    telemetry_writer.add_count_metric(
+        namespace=TELEMETRY_NAMESPACE.MLOBS, name="span.finished", value=1, tags=tuple(tags)
+    )

--- a/ddtrace/llmobs/decorators.py
+++ b/ddtrace/llmobs/decorators.py
@@ -80,6 +80,7 @@ def _model_decorator(operation_kind):
                         name=span_name,
                         session_id=session_id,
                         ml_app=ml_app,
+                        _decorator=True,
                     )
                     return yield_from_async_gen(func, span, args, kwargs)
 
@@ -96,6 +97,7 @@ def _model_decorator(operation_kind):
                         name=span_name,
                         session_id=session_id,
                         ml_app=ml_app,
+                        _decorator=True,
                     ):
                         return await func(*args, **kwargs)
 
@@ -115,6 +117,7 @@ def _model_decorator(operation_kind):
                             name=span_name,
                             session_id=session_id,
                             ml_app=ml_app,
+                            _decorator=True,
                         )
                         try:
                             yield from func(*args, **kwargs)
@@ -139,6 +142,7 @@ def _model_decorator(operation_kind):
                         name=span_name,
                         session_id=session_id,
                         ml_app=ml_app,
+                        _decorator=True,
                     ) as span:
                         if config._llmobs_auto_span_linking_enabled:
                             for arg in args:
@@ -177,7 +181,7 @@ def _llmobs_decorator(operation_kind):
                         return func(*args, **kwargs)
                     _, span_name = _get_llmobs_span_options(name, None, func)
                     traced_operation = getattr(LLMObs, operation_kind, LLMObs.workflow)
-                    span = traced_operation(name=span_name, session_id=session_id, ml_app=ml_app)
+                    span = traced_operation(name=span_name, session_id=session_id, ml_app=ml_app, _decorator=True)
                     func_signature = signature(func)
                     bound_args = func_signature.bind_partial(*args, **kwargs)
                     if _automatic_io_annotation and bound_args.arguments:
@@ -191,7 +195,9 @@ def _llmobs_decorator(operation_kind):
                         return await func(*args, **kwargs)
                     _, span_name = _get_llmobs_span_options(name, None, func)
                     traced_operation = getattr(LLMObs, operation_kind, LLMObs.workflow)
-                    with traced_operation(name=span_name, session_id=session_id, ml_app=ml_app) as span:
+                    with traced_operation(
+                        name=span_name, session_id=session_id, ml_app=ml_app, _decorator=True
+                    ) as span:
                         func_signature = signature(func)
                         bound_args = func_signature.bind_partial(*args, **kwargs)
                         if _automatic_io_annotation and bound_args.arguments:
@@ -216,7 +222,7 @@ def _llmobs_decorator(operation_kind):
                     else:
                         _, span_name = _get_llmobs_span_options(name, None, func)
                         traced_operation = getattr(LLMObs, operation_kind, LLMObs.workflow)
-                        span = traced_operation(name=span_name, session_id=session_id, ml_app=ml_app)
+                        span = traced_operation(name=span_name, session_id=session_id, ml_app=ml_app, _decorator=True)
                         func_signature = signature(func)
                         bound_args = func_signature.bind_partial(*args, **kwargs)
                         if _automatic_io_annotation and bound_args.arguments:
@@ -239,7 +245,9 @@ def _llmobs_decorator(operation_kind):
                         return func(*args, **kwargs)
                     _, span_name = _get_llmobs_span_options(name, None, func)
                     traced_operation = getattr(LLMObs, operation_kind, LLMObs.workflow)
-                    with traced_operation(name=span_name, session_id=session_id, ml_app=ml_app) as span:
+                    with traced_operation(
+                        name=span_name, session_id=session_id, ml_app=ml_app, _decorator=True
+                    ) as span:
                         if config._llmobs_auto_span_linking_enabled:
                             for arg in args:
                                 LLMObs._instance._record_object(span, arg, "input")

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -11,6 +11,7 @@ except ImportError:
 import ddtrace
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.utils.formats import format_trace_id
+from ddtrace.llmobs._constants import INTEGRATION
 from ddtrace.llmobs._utils import _get_span_name
 from ddtrace.llmobs._writer import LLMObsEvaluationMetricEvent
 from ddtrace.trace import Span
@@ -46,6 +47,8 @@ def _expected_llmobs_tags(span, error=None, tags=None, session_id=None):
         expected_tags.append("error_type:{}".format(error))
     else:
         expected_tags.append("error:0")
+    if span._get_ctx_item(INTEGRATION):
+        expected_tags.append("integration:{}".format(span._get_ctx_item(INTEGRATION)))
     if session_id:
         expected_tags.append("session_id:{}".format(session_id))
     if tags:

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -11,7 +11,6 @@ except ImportError:
 import ddtrace
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.utils.formats import format_trace_id
-from ddtrace.llmobs._constants import INTEGRATION
 from ddtrace.llmobs._utils import _get_span_name
 from ddtrace.llmobs._writer import LLMObsEvaluationMetricEvent
 from ddtrace.trace import Span
@@ -47,8 +46,6 @@ def _expected_llmobs_tags(span, error=None, tags=None, session_id=None):
         expected_tags.append("error_type:{}".format(error))
     else:
         expected_tags.append("error:0")
-    if span._get_ctx_item(INTEGRATION):
-        expected_tags.append("integration:{}".format(span._get_ctx_item(INTEGRATION)))
     if session_id:
         expected_tags.append("session_id:{}".format(session_id))
     if tags:


### PR DESCRIPTION
[MLOB-2216]
This PR adds a `span.created` telemetry metric, which includes the tags (`decorator`, `integration`, `is_root_span`, `has_session_id`, `model_provider`).

We added this in addition to  `span.start` because right before finishing was the only place we had access to all of the above tags. Otherwise `autoinstrumented` was the only feasible tag we were guaranteed to have at span start time. We kept `span.start` as a metric to be able to count unfinished spans.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)


[MLOB-2216]: https://datadoghq.atlassian.net/browse/MLOB-2216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ