### PR TITLE
support pydantic for llmobs

### DIFF
--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -189,6 +189,8 @@ def safe_json(obj, ensure_ascii=True):
     if isinstance(obj, str):
         return obj
     try:
+        if hasattr(obj, "model_dump") and callable(obj.model_dump):
+            obj = obj.model_dump()
         return json.dumps(obj, ensure_ascii=ensure_ascii, skipkeys=True, default=_unserializable_default_repr)
     except Exception:
         log.error("Failed to serialize object to JSON.", exc_info=True)


### PR DESCRIPTION
Adding support for pydantic for usage with the llmops `@workflow` decorator.

A lot of langchain projects depend on pydantic for type safety, if a function has a pydantic input or output the datadog agent will generate noisy warning logs and less readable traces `[Unserializable object: ... `.

<img width="305" alt="image" src="https://github.com/user-attachments/assets/08c5eca5-82a8-47e7-92d6-026840b5adf3" />

pydantic it self supports json serialization.
This pr will check if the object has a callable [model_dump](https://docs.pydantic.dev/latest/concepts/serialization/) attribute and then call that to serialize the object.


There is a risk that a non pydantic object has implemented a callable `model_dump` attribute.
Ideally the serialization should be pluggable, but this would require a much more extensive refactor.


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
