### PR TITLE
ci(benchmarks): enable the ddtrace_run benchmark scenario

### DIFF
--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -61,6 +61,7 @@ microbenchmarks:
         - "packages_update_imported_dependencies"
         - "telemetry_add_metric"
         - "startup"
+        - "ddtrace_run"
 
 benchmarks-pr-comment:
   image: $MICROBENCHMARKS_CI_IMAGE

--- a/benchmarks/startup/config.yaml
+++ b/benchmarks/startup/config.yaml
@@ -1,6 +1,5 @@
 baseline: &defaults
   env: {}
-  ddtrace_run: false
   import_ddtrace: false
   import_ddtrace_auto: false
   import_flask: false
@@ -10,17 +9,6 @@ baseline_flask:
   import_flask: true
 baseline_django:
   <<: *defaults
-  import_django: true
-ddtrace_run:
-  <<: *defaults
-  ddtrace_run: true
-ddtrace_run_flask:
-  <<: *defaults
-  ddtrace_run: true
-  import_flask: true
-ddtrace_run_django:
-  <<: *defaults
-  ddtrace_run: true
   import_django: true
 import_ddtrace:
   <<: *defaults
@@ -42,19 +30,5 @@ import_ddtrace_auto_flask:
   import_flask: true
 import_ddtrace_auto_django:
   <<: *defaults
-  import_ddtrace_auto: true
-  import_django: true
-ddtrace_run_import_ddtrace_auto:
-  <<: *defaults
-  ddtrace_run: true
-  import_ddtrace_auto: true
-ddtrace_run_import_ddtrace_auto_flask:
-  <<: *defaults
-  ddtrace_run: true
-  import_ddtrace_auto: true
-  import_flask: true
-ddtrace_run_import_ddtrace_auto_django:
-  <<: *defaults
-  ddtrace_run: true
   import_ddtrace_auto: true
   import_django: true

--- a/benchmarks/startup/scenario.py
+++ b/benchmarks/startup/scenario.py
@@ -6,7 +6,6 @@ import bm
 
 
 class Startup(bm.Scenario):
-    ddtrace_run: bool
     import_ddtrace: bool
     import_ddtrace_auto: bool
     import_flask: bool
@@ -35,8 +34,6 @@ class Startup(bm.Scenario):
             commands.append("import django.core.management")
 
         args = ["python", "-c"] + [";".join(commands)]
-        if self.ddtrace_run:
-            args = ["ddtrace-run"] + args
 
         def _(loops: int):
             for _ in range(loops):


### PR DESCRIPTION
The new `startup` benchmarks are a bit slow, so in an effort to try and cut down on the total number of scenarios we are remove the `ddtrace-run` variants of the `startup` scenario and instead enabling the `ddtrace_run` specific scenarios to sub-divide the benchmarks.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
