### PR TITLE
chore: fix vertica patching

### DIFF
--- a/ddtrace/contrib/internal/vertica/patch.py
+++ b/ddtrace/contrib/internal/vertica/patch.py
@@ -2,7 +2,6 @@ import importlib
 
 import wrapt
 
-import ddtrace
 from ddtrace import config
 from ddtrace.constants import _ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.constants import _SPAN_MEASURED_KEY
@@ -190,7 +189,6 @@ def _install_init(patch_item, patch_class, patch_mod, config):
         # create and attach a pin with the defaults
         Pin(
             tags=config.get("tags", {}),
-            tracer=config.get("tracer", ddtrace.tracer),
             _config=config["patch"][patch_item],
         ).onto(instance)
         return r

--- a/tests/contrib/vertica/test_vertica.py
+++ b/tests/contrib/vertica/test_vertica.py
@@ -16,7 +16,6 @@ from tests.opentracer.utils import init_tracer
 from tests.utils import DummyTracer
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
-from tests.utils import flaky
 
 
 TEST_TABLE = "test_table"
@@ -58,25 +57,6 @@ class TestVerticaPatching(TracerTestCase):
     def tearDown(self):
         super(TestVerticaPatching, self).tearDown()
         unpatch()
-
-    @flaky(1742580778)
-    def test_patch_after_import(self):
-        """Patching _after_ the import will not work because we hook into
-        the module import system.
-
-        Vertica uses a local reference to `Cursor` which won't get patched
-        if we call `patch` after the module has already been imported.
-        """
-        import vertica_python
-
-        assert not isinstance(vertica_python.vertica.connection.Connection.cursor, wrapt.ObjectProxy)
-        assert not isinstance(vertica_python.vertica.cursor.Cursor.execute, wrapt.ObjectProxy)
-
-        patch()
-
-        conn = vertica_python.connect(**VERTICA_CONFIG)
-        cursor = conn.cursor()
-        assert not isinstance(cursor, wrapt.ObjectProxy)
 
     def test_patch_before_import(self):
         patch()


### PR DESCRIPTION
Fixes vertica patching. `tracer` was removed as an argument to `Pin` but was still being used, causing some vertica tests to fail

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
