### PR TITLE
chore(iast): revert #12508

### DIFF
--- a/ddtrace/appsec/_iast/processor.py
+++ b/ddtrace/appsec/_iast/processor.py
@@ -22,10 +22,8 @@ class AppSecIastSpanProcessor(SpanProcessor):
     def on_span_start(self, span: Span):
         if span.span_type != SpanTypes.WEB:
             return
-        _iast_start_request(span)
-        from .taint_sinks.stacktrace_leak import check_and_report_stacktrace_leak
 
-        check_and_report_stacktrace_leak()
+        _iast_start_request(span)
 
     def on_span_finish(self, span: Span):
         """Report reported vulnerabilities.

--- a/tests/appsec/integrations/flask_tests/test_iast_flask_testagent.py
+++ b/tests/appsec/integrations/flask_tests/test_iast_flask_testagent.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from ddtrace.appsec._iast.constants import VULN_STACKTRACE_LEAK
 from tests.appsec.appsec_utils import flask_server
 from tests.appsec.integrations.flask_tests.test_flask_remoteconfig import _get_agent_client
@@ -32,6 +34,7 @@ def _get_span(token):
     return json.loads(resp.read())
 
 
+@pytest.mark.skip(reason="Stacktrace error in debug mode doesn't work outside the request APPSEC-56862")
 def test_iast_stacktrace_error():
     token = "test_iast_stacktrace_error"
     _ = start_trace(token)
@@ -45,7 +48,7 @@ def test_iast_stacktrace_error():
             b"<title>ValueError: Check my stacktrace!" in response.content
         ), f"Exception doesn't found in CONTENT: {response.content}"
 
-        flask_client.get("/", headers={"X-Datadog-Test-Session-Token": token})
+        # flask_client.get("/", headers={"X-Datadog-Test-Session-Token": token})
 
     response_tracer = _get_span(token)
     spans_with_iast = []


### PR DESCRIPTION
partialy revert commit d23def992bf99c5fbfda65d6973c0f7339bd33a1 from #12508

We added a workaround but we decided to revert because it would be confuse if we send the stacktrace in the next span. The solution is to change the trace start/finish to ensure the debug_application is inside the trace spans. We need to check with APM

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
