### PR TITLE
chore(llmobs): remove reliance on span tags for bedrock llm integration

### DIFF
--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -692,12 +692,6 @@ def _on_botocore_patched_bedrock_api_call_success(ctx, reqid, latency, input_tok
         span.set_metric("bedrock.response.usage.prompt_tokens", int(input_token_count))
     if output_token_count:
         span.set_metric("bedrock.response.usage.completion_tokens", int(output_token_count))
-    usage = {}
-    if input_token_count:
-        usage["input_tokens"] = int(input_token_count)
-    if output_token_count:
-        usage["output_tokens"] = int(output_token_count)
-    ctx.set_item("llmobs.usage", usage)
 
 
 def _propagate_context(ctx, headers):
@@ -740,18 +734,11 @@ def _on_botocore_bedrock_process_response(
             span.set_tag_str("bedrock.response.choices.{}.id".format(i), str(body["generations"][i]["id"]))
     integration = ctx["bedrock_integration"]
     if metadata is not None:
-        usage = {}  # catch usage for streamed response case
         for k, v in metadata.items():
             if k in ["usage.completion_tokens", "usage.prompt_tokens"] and v:
                 span.set_metric("bedrock.response.{}".format(k), int(v))
-                if k == "usage.completion_tokens":
-                    usage["output_tokens"] = int(v)
-                if k == "usage.prompt_tokens":
-                    usage["input_tokens"] = int(v)
             else:
                 span.set_tag_str("bedrock.{}".format(k), str(v))
-        if usage:
-            ctx.set_item("llmobs.usage", usage)
     if "embed" in model_name:
         span.set_metric("bedrock.response.embedding_length", len(formatted_response["text"][0]))
         span.finish()

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -752,8 +752,7 @@ def _on_botocore_bedrock_process_response(
         span.set_tag_str(
             "bedrock.response.choices.{}.finish_reason".format(i), str(formatted_response["finish_reason"][i])
         )
-    ctx.set_item("llmobs.response", formatted_response)
-    integration.llmobs_set_tags(span, args=[ctx], kwargs={})
+    integration.llmobs_set_tags(span, args=[ctx], kwargs={}, response=formatted_response)
     span.finish()
 
 

--- a/ddtrace/contrib/internal/botocore/services/bedrock.py
+++ b/ddtrace/contrib/internal/botocore/services/bedrock.py
@@ -301,11 +301,8 @@ def handle_bedrock_request(ctx: core.ExecutionContext) -> None:
     """Perform request param extraction and tagging."""
     request_params = _extract_request_params(ctx["params"], ctx["model_provider"])
     core.dispatch("botocore.patched_bedrock_api_call.started", [ctx, request_params])
-    prompt = None
-    for k, v in request_params.items():
-        if k == "prompt" and ctx["bedrock_integration"].is_pc_sampled_llmobs(ctx.span):
-            prompt = v
-    ctx.set_item("prompt", prompt)
+    if ctx["bedrock_integration"].is_pc_sampled_llmobs(ctx.span):
+        ctx.set_item("llmobs.request_params", request_params)
 
 
 def handle_bedrock_response(

--- a/ddtrace/contrib/internal/botocore/services/bedrock.py
+++ b/ddtrace/contrib/internal/botocore/services/bedrock.py
@@ -321,7 +321,7 @@ def handle_bedrock_request(ctx: core.ExecutionContext) -> None:
     """Perform request param extraction and tagging."""
     request_params = _extract_request_params(ctx["params"], ctx["model_provider"])
     core.dispatch("botocore.patched_bedrock_api_call.started", [ctx, request_params])
-    if ctx["bedrock_integration"].is_pc_sampled_llmobs(ctx.span):
+    if ctx["bedrock_integration"].llmobs_enabled:
         ctx.set_item("llmobs.request_params", request_params)
 
 

--- a/ddtrace/contrib/internal/botocore/services/bedrock.py
+++ b/ddtrace/contrib/internal/botocore/services/bedrock.py
@@ -113,6 +113,19 @@ class TracedBotocoreStreamingBody(wrapt.ObjectProxy):
             )
 
 
+def _set_llmobs_usage_from_invoke(ctx: core.ExecutionContext, input_tokens, output_tokens) -> None:
+    """
+    Sets LLM usage metrics in the context for LLM Observability.
+    """
+    llmobs_usage = {}
+    if input_tokens:
+        llmobs_usage["input_tokens"] = int(input_tokens)
+    if output_tokens:
+        llmobs_usage["output_tokens"] = int(output_tokens)
+    if llmobs_usage:
+        ctx.set_item("llmobs.usage", llmobs_usage)
+
+
 def _extract_request_params(params: Dict[str, Any], provider: str) -> Dict[str, Any]:
     """
     Extracts request parameters including prompt, temperature, top_p, max_tokens, and stop_sequences.
@@ -281,6 +294,9 @@ def _extract_streamed_response(ctx: core.ExecutionContext, streamed_body: List[D
 def _extract_streamed_response_metadata(
     ctx: core.ExecutionContext, streamed_body: List[Dict[str, Any]]
 ) -> Dict[str, Any]:
+    """
+    Returns token usage metadata from streamed response, sets it in the context for LLMObs, and returns it.
+    """
     provider = ctx["model_provider"]
     metadata = {}
     if provider == _AI21:
@@ -290,10 +306,14 @@ def _extract_streamed_response_metadata(
     elif provider == _STABILITY:
         # TODO: figure out extraction for image-based models
         pass
+
+    input_tokens = metadata.get("inputTokenCount", None)
+    output_tokens = metadata.get("outputTokenCount", None)
+    _set_llmobs_usage_from_invoke(ctx, input_tokens, output_tokens)
     return {
         "response.duration": metadata.get("invocationLatency", None),
-        "usage.prompt_tokens": metadata.get("inputTokenCount", None),
-        "usage.completion_tokens": metadata.get("outputTokenCount", None),
+        "usage.prompt_tokens": input_tokens,
+        "usage.completion_tokens": output_tokens,
     }
 
 
@@ -312,14 +332,18 @@ def handle_bedrock_response(
     metadata = result["ResponseMetadata"]
     http_headers = metadata["HTTPHeaders"]
 
+    input_tokens = http_headers.get("x-amzn-bedrock-input-token-count", "")
+    output_tokens = http_headers.get("x-amzn-bedrock-output-token-count", "")
+    _set_llmobs_usage_from_invoke(ctx, input_tokens, output_tokens)
+
     core.dispatch(
         "botocore.patched_bedrock_api_call.success",
         [
             ctx,
             str(metadata.get("RequestId", "")),
             str(http_headers.get("x-amzn-bedrock-invocation-latency", "")),
-            str(http_headers.get("x-amzn-bedrock-input-token-count", "")),
-            str(http_headers.get("x-amzn-bedrock-output-token-count", "")),
+            str(input_tokens),
+            str(output_tokens),
         ],
     )
 

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -35,7 +35,6 @@ class BedrockIntegration(BaseLLMIntegration):
             "resource": str
             "model_name": str,
             "model_provider": str,
-            "llmobs.response": Optional[dict],
             "llmobs.request_params": {"prompt": str | list[dict],
                                 "temperature": Optional[float],
                                 "max_tokens": Optional[int]},
@@ -75,8 +74,8 @@ class BedrockIntegration(BaseLLMIntegration):
         input_messages = self._extract_input_message(prompt)
 
         output_messages = [{"content": ""}]
-        if not span.error and ctx.get_item("llmobs.response"):
-            output_messages = self._extract_output_message(ctx["llmobs.response"])
+        if not span.error and response is not None:
+            output_messages = self._extract_output_message(response)
 
         span._set_ctx_items(
             {

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -20,6 +20,8 @@ log = get_logger(__name__)
 
 
 class BedrockIntegration(BaseLLMIntegration):
+    _integration_name = "bedrock"
+
     def _llmobs_set_tags(
         self,
         span: Span,

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -13,7 +13,6 @@ from ddtrace.llmobs._constants import MODEL_PROVIDER
 from ddtrace.llmobs._constants import OUTPUT_MESSAGES
 from ddtrace.llmobs._constants import SPAN_KIND
 from ddtrace.llmobs._integrations import BaseLLMIntegration
-from ddtrace.llmobs._integrations.utils import get_llmobs_metrics_tags
 from ddtrace.trace import Span
 
 
@@ -21,8 +20,6 @@ log = get_logger(__name__)
 
 
 class BedrockIntegration(BaseLLMIntegration):
-    _integration_name = "bedrock"
-
     def _llmobs_set_tags(
         self,
         span: Span,
@@ -31,27 +28,62 @@ class BedrockIntegration(BaseLLMIntegration):
         response: Optional[Any] = None,
         operation: str = "",
     ) -> None:
-        """Extract prompt/response tags from a completion and set them as temporary "_ml_obs.*" tags."""
+        """Extract prompt/response attributes from an execution context.
+        {
+            "resource": str
+            "model_name": str,
+            "model_provider": str,
+            "llmobs.response": Optional[dict],
+            "llmobs.request_params": {"prompt": str | list[dict],
+                                "temperature": Optional[float],
+                                "max_tokens": Optional[int]},
+            "llmobs.usage": Optional[dict],
+        }
+        """
         LLMObs._instance._activate_llmobs_span(span)
-        parameters = {}
-        if span.get_tag("bedrock.request.temperature"):
-            parameters["temperature"] = float(span.get_tag("bedrock.request.temperature") or 0.0)
-        if span.get_tag("bedrock.request.max_tokens"):
-            parameters["max_tokens"] = int(span.get_tag("bedrock.request.max_tokens") or 0)
+        metadata = {}
+        usage_metrics = {}
+        ctx = args[0]
 
-        prompt = kwargs.get("prompt", "")
+        request_params = ctx.get_item("llmobs.request_params") or {}
+
+        if ctx.get_item("llmobs.usage"):
+            usage_metrics = ctx["llmobs.usage"]
+
+        # Translate raw usage metrics returned from bedrock to the standardized metrics format.
+        if "inputTokens" in usage_metrics:
+            usage_metrics["input_tokens"] = usage_metrics.pop("inputTokens")
+        if "outputTokens" in usage_metrics:
+            usage_metrics["output_tokens"] = usage_metrics.pop("outputTokens")
+        if "totalTokens" in usage_metrics:
+            usage_metrics["total_tokens"] = usage_metrics.pop("totalTokens")
+
+        if "total_tokens" not in usage_metrics and (
+            "input_tokens" in usage_metrics or "output_tokens" in usage_metrics
+        ):
+            usage_metrics["total_tokens"] = usage_metrics.get("input_tokens", 0) + usage_metrics.get("output_tokens", 0)
+
+        if "temperature" in request_params and request_params.get("temperature") != "":
+            metadata["temperature"] = float(request_params.get("temperature") or 0.0)
+        if "max_tokens" in request_params and request_params.get("max_tokens") != "":
+            metadata["max_tokens"] = int(request_params.get("max_tokens") or 0)
+
+        prompt = request_params.get("prompt", "")
+
         input_messages = self._extract_input_message(prompt)
+
         output_messages = [{"content": ""}]
-        if not span.error and response is not None:
-            output_messages = self._extract_output_message(response)
+        if not span.error and ctx.get_item("llmobs.response"):
+            output_messages = self._extract_output_message(ctx["llmobs.response"])
+
         span._set_ctx_items(
             {
                 SPAN_KIND: "llm",
-                MODEL_NAME: span.get_tag("bedrock.request.model") or "",
-                MODEL_PROVIDER: span.get_tag("bedrock.request.model_provider") or "",
+                MODEL_NAME: ctx.get_item("model_name") or "",
+                MODEL_PROVIDER: ctx.get_item("model_provider") or "",
                 INPUT_MESSAGES: input_messages,
-                METADATA: parameters,
-                METRICS: get_llmobs_metrics_tags("bedrock", span),
+                METADATA: metadata,
+                METRICS: usage_metrics,
                 OUTPUT_MESSAGES: output_messages,
             }
         )


### PR DESCRIPTION
Remove reliance on setting/getting span tags for bedrock LLM Obs integration and instead use `ExecutionContext` to store all LLM Obs related attributes.

Previously, `_llmobs_set_tags` relied on extracting out the following data:
- `prompt` in Execution context (which was passed in as the `prompt` kwarg to _llmobs_set_tags)
- Various tags set on the span that will be parsed out

We refactor it so that all the information is stored in the execution context under the following fields:
- `request_params` - contains `prompt` and inference parameters like max_tokens
- `usage` - contains token usage data
- `stop_reason` - (only for converse)
- `model_provider`, `model_name`

And then directly pass in the execution context to `llmobs_set_tags`. This way, we decouple the parsing logic for LLM Obs from the APM bedrock integration.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
