### PR TITLE
chore(ci): remove flaky decorator from aiomysql

### DIFF
--- a/tests/contrib/aiomysql/test_aiomysql.py
+++ b/tests/contrib/aiomysql/test_aiomysql.py
@@ -13,7 +13,6 @@ from tests.contrib import shared_tests_async as shared_tests
 from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.asyncio.utils import mark_asyncio
 from tests.contrib.config import MYSQL_CONFIG
-from tests.utils import flaky
 
 
 AIOMYSQL_CONFIG = dict(MYSQL_CONFIG)
@@ -62,7 +61,6 @@ async def test_queries(snapshot_conn):
 
 @pytest.mark.asyncio
 @pytest.mark.snapshot
-@flaky(1741838400, reason="Did not receive expected traces: 'pytest.test','pytest.test'")
 async def test_pin_override(patched_conn, tracer):
     Pin._override(patched_conn, service="db")
     cursor = await patched_conn.cursor()

--- a/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_pin_override.json
+++ b/tests/snapshots/tests.contrib.aiomysql.test_aiomysql.test_pin_override.json
@@ -1,0 +1,37 @@
+[[
+  {
+    "name": "mysql.query",
+    "service": "db",
+    "resource": "SELECT 1",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.contrib.aiomysql",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "67c7601300000000",
+      "component": "aiomysql",
+      "db.name": "test",
+      "db.system": "mysql",
+      "db.user": "test",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "226fd93508814a0f92525d53356be0e4",
+      "server.address": "127.0.0.1",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "db.row_count": 1,
+      "db.rownumber": 0,
+      "network.destination.port": 3306,
+      "process_id": 8506
+    },
+    "duration": 6168000,
+    "start": 1741119507559040000
+  }]]


### PR DESCRIPTION
## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
