### PR TITLE
chore(ci): remove flaky decorator from mariadb test

### DIFF
--- a/tests/contrib/aiomysql/test_aiomysql.py
+++ b/tests/contrib/aiomysql/test_aiomysql.py
@@ -13,6 +13,7 @@ from tests.contrib import shared_tests_async as shared_tests
 from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.asyncio.utils import mark_asyncio
 from tests.contrib.config import MYSQL_CONFIG
+from tests.utils import flaky
 
 
 AIOMYSQL_CONFIG = dict(MYSQL_CONFIG)
@@ -61,6 +62,7 @@ async def test_queries(snapshot_conn):
 
 @pytest.mark.asyncio
 @pytest.mark.snapshot
+@flaky(1741838400, reason="Did not receive expected traces: 'pytest.test','pytest.test'")
 async def test_pin_override(patched_conn, tracer):
     Pin._override(patched_conn, service="db")
     cursor = await patched_conn.cursor()

--- a/tests/contrib/aiomysql/test_aiomysql.py
+++ b/tests/contrib/aiomysql/test_aiomysql.py
@@ -13,7 +13,6 @@ from tests.contrib import shared_tests_async as shared_tests
 from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.asyncio.utils import mark_asyncio
 from tests.contrib.config import MYSQL_CONFIG
-from tests.utils import flaky
 
 
 AIOMYSQL_CONFIG = dict(MYSQL_CONFIG)
@@ -62,7 +61,6 @@ async def test_queries(snapshot_conn):
 
 @pytest.mark.asyncio
 @pytest.mark.snapshot
-@flaky(1741838400, reason="Did not receive expected traces: 'pytest.test','pytest.test'")
 async def test_pin_override(patched_conn, tracer):
     Pin._override(patched_conn, service="db")
     cursor = await patched_conn.cursor()

--- a/tests/contrib/mariadb/test_mariadb.py
+++ b/tests/contrib/mariadb/test_mariadb.py
@@ -11,7 +11,6 @@ from tests.contrib.config import MARIADB_CONFIG
 from tests.utils import DummyTracer
 from tests.utils import assert_dict_issuperset
 from tests.utils import assert_is_measured
-from tests.utils import flaky
 from tests.utils import override_config
 from tests.utils import snapshot
 
@@ -211,7 +210,6 @@ def test_simple_query_snapshot(tracer):
 
 
 @snapshot(include_tracer=True, variants=SNAPSHOT_VARIANTS, ignores=["meta.error.stack"])
-@flaky(1741838400, reason="Did not receive expected traces: 'mariadb.query'")
 def test_simple_malformed_query_snapshot(tracer):
     with get_connection(tracer) as connection:
         cursor = connection.cursor()


### PR DESCRIPTION
## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
