### PR TITLE
chore(llmobs): update bedrock testing to use mock span writer

### DIFF
--- a/tests/contrib/botocore/test_bedrock_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_llmobs.py
@@ -7,14 +7,25 @@ import pytest
 from ddtrace.contrib.internal.botocore.patch import patch
 from ddtrace.contrib.internal.botocore.patch import unpatch
 from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs import LLMObs as llmobs_service
+from ddtrace.llmobs._constants import AGENTLESS_BASE_URL
+from ddtrace.llmobs._writer import LLMObsSpanWriter
 from ddtrace.trace import Pin
 from tests.contrib.botocore.bedrock_utils import _MODELS
 from tests.contrib.botocore.bedrock_utils import _REQUEST_BODIES
 from tests.contrib.botocore.bedrock_utils import get_request_vcr
 from tests.llmobs._utils import _expected_llmobs_llm_span_event
 from tests.utils import DummyTracer
-from tests.utils import DummyWriter
 from tests.utils import override_global_config
+
+
+class TestLLMObsSpanWriter(LLMObsSpanWriter):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.events = []
+
+    def enqueue(self, event):
+        self.events.append(event)
 
 
 @pytest.fixture(scope="session")
@@ -74,6 +85,37 @@ def mock_llmobs_span_writer():
         patcher.stop()
 
 
+@pytest.fixture
+def llmobs_span_writer():
+    agentless_url = "{}.{}".format(AGENTLESS_BASE_URL, "datad0g.com")
+    yield TestLLMObsSpanWriter(is_agentless=True, agentless_url=agentless_url, interval=1.0, timeout=1.0)
+
+
+@pytest.fixture
+def mock_tracer(bedrock_client):
+    mock_tracer = DummyTracer()
+    pin = Pin.get_from(bedrock_client)
+    pin._override(bedrock_client, tracer=mock_tracer)
+    yield mock_tracer
+
+
+@pytest.fixture
+def bedrock_llmobs(tracer, mock_tracer, llmobs_span_writer):
+    llmobs_service.disable()
+    with override_global_config(
+        {"_dd_api_key": "<not-a-real-api_key>", "_llmobs_ml_app": "<ml-app-name>", "service": "tests.llmobs"}
+    ):
+        llmobs_service.enable(_tracer=mock_tracer, integrations_enabled=False)
+        llmobs_service._instance._llmobs_span_writer = llmobs_span_writer
+        yield llmobs_service
+    llmobs_service.disable()
+
+
+@pytest.fixture
+def llmobs_events(bedrock_llmobs, llmobs_span_writer):
+    return llmobs_span_writer.events
+
+
 @pytest.mark.parametrize(
     "ddtrace_global_config", [dict(_llmobs_enabled=True, _llmobs_sample_rate=1.0, _llmobs_ml_app="<ml-app-name>")]
 )
@@ -108,14 +150,7 @@ class TestLLMObsBedrock:
         )
 
     @classmethod
-    def _test_llmobs_invoke(cls, provider, bedrock_client, mock_llmobs_span_writer, cassette_name=None, n_output=1):
-        mock_tracer = DummyTracer(writer=DummyWriter(trace_flush_enabled=False))
-        pin = Pin.get_from(bedrock_client)
-        pin._override(bedrock_client, tracer=mock_tracer)
-        # Need to disable and re-enable LLMObs service to use the mock tracer
-        LLMObs.disable()
-        LLMObs.enable(_tracer=mock_tracer, integrations_enabled=False)  # only want botocore patched
-
+    def _test_llmobs_invoke(cls, provider, bedrock_client, mock_tracer, llmobs_events, cassette_name=None, n_output=1):
         if cassette_name is None:
             cassette_name = "%s_invoke.yaml" % provider
         body = _REQUEST_BODIES[provider]
@@ -140,23 +175,14 @@ class TestLLMObsBedrock:
             json.loads(response.get("body").read())
         span = mock_tracer.pop_traces()[0][0]
 
-        assert mock_llmobs_span_writer.enqueue.call_count == 1
-        mock_llmobs_span_writer.enqueue.assert_called_with(
-            cls.expected_llmobs_span_event(span, n_output, message="message" in provider)
-        )
+        assert len(llmobs_events) == 1
+        assert llmobs_events[0] == cls.expected_llmobs_span_event(span, n_output, message="message" in provider)
         LLMObs.disable()
 
     @classmethod
     def _test_llmobs_invoke_stream(
-        cls, provider, bedrock_client, mock_llmobs_span_writer, cassette_name=None, n_output=1
+        cls, provider, bedrock_client, mock_tracer, llmobs_events, cassette_name=None, n_output=1
     ):
-        mock_tracer = DummyTracer(writer=DummyWriter(trace_flush_enabled=False))
-        pin = Pin.get_from(bedrock_client)
-        pin._override(bedrock_client, tracer=mock_tracer)
-        # Need to disable and re-enable LLMObs service to use the mock tracer
-        LLMObs.disable()
-        LLMObs.enable(_tracer=mock_tracer, integrations_enabled=False)  # only want botocore patched
-
         if cassette_name is None:
             cassette_name = "%s_invoke_stream.yaml" % provider
         body = _REQUEST_BODIES[provider]
@@ -178,85 +204,81 @@ class TestLLMObsBedrock:
                 pass
         span = mock_tracer.pop_traces()[0][0]
 
-        assert mock_llmobs_span_writer.enqueue.call_count == 1
-        mock_llmobs_span_writer.enqueue.assert_called_with(
-            cls.expected_llmobs_span_event(span, n_output, message="message" in provider)
-        )
-        LLMObs.disable()
+        assert len(llmobs_events) == 1
+        assert llmobs_events[0] == cls.expected_llmobs_span_event(span, n_output, message="message" in provider)
 
-    def test_llmobs_ai21_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke("ai21", bedrock_client, mock_llmobs_span_writer)
+    def test_llmobs_ai21_invoke(self, ddtrace_global_config, bedrock_client, mock_tracer, llmobs_events):
+        self._test_llmobs_invoke("ai21", bedrock_client, mock_tracer, llmobs_events)
 
-    def test_llmobs_amazon_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke("amazon", bedrock_client, mock_llmobs_span_writer)
+    def test_llmobs_amazon_invoke(self, ddtrace_global_config, bedrock_client, mock_tracer, llmobs_events):
+        self._test_llmobs_invoke("amazon", bedrock_client, mock_tracer, llmobs_events)
 
-    def test_llmobs_anthropic_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke("anthropic", bedrock_client, mock_llmobs_span_writer)
+    def test_llmobs_anthropic_invoke(self, ddtrace_global_config, bedrock_client, mock_tracer, llmobs_events):
+        self._test_llmobs_invoke("anthropic", bedrock_client, mock_tracer, llmobs_events)
 
-    def test_llmobs_anthropic_message(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke("anthropic_message", bedrock_client, mock_llmobs_span_writer)
+    def test_llmobs_anthropic_message(self, ddtrace_global_config, bedrock_client, mock_tracer, llmobs_events):
+        self._test_llmobs_invoke("anthropic_message", bedrock_client, mock_tracer, llmobs_events)
 
-    def test_llmobs_cohere_single_output_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
+    def test_llmobs_cohere_single_output_invoke(
+        self, ddtrace_global_config, bedrock_client, mock_tracer, llmobs_events
+    ):
         self._test_llmobs_invoke(
-            "cohere", bedrock_client, mock_llmobs_span_writer, cassette_name="cohere_invoke_single_output.yaml"
+            "cohere", bedrock_client, mock_tracer, llmobs_events, cassette_name="cohere_invoke_single_output.yaml"
         )
 
-    def test_llmobs_cohere_multi_output_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
+    def test_llmobs_cohere_multi_output_invoke(self, ddtrace_global_config, bedrock_client, mock_tracer, llmobs_events):
         self._test_llmobs_invoke(
             "cohere",
             bedrock_client,
-            mock_llmobs_span_writer,
+            mock_tracer,
+            llmobs_events,
             cassette_name="cohere_invoke_multi_output.yaml",
             n_output=2,
         )
 
-    def test_llmobs_meta_invoke(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke("meta", bedrock_client, mock_llmobs_span_writer)
+    def test_llmobs_meta_invoke(self, ddtrace_global_config, bedrock_client, mock_tracer, llmobs_events):
+        self._test_llmobs_invoke("meta", bedrock_client, mock_tracer, llmobs_events)
 
-    def test_llmobs_amazon_invoke_stream(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke_stream("amazon", bedrock_client, mock_llmobs_span_writer)
+    def test_llmobs_amazon_invoke_stream(self, ddtrace_global_config, bedrock_client, mock_tracer, llmobs_events):
+        self._test_llmobs_invoke_stream("amazon", bedrock_client, mock_tracer, llmobs_events)
 
-    def test_llmobs_anthropic_invoke_stream(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke_stream("anthropic", bedrock_client, mock_llmobs_span_writer)
+    def test_llmobs_anthropic_invoke_stream(self, ddtrace_global_config, bedrock_client, mock_tracer, llmobs_events):
+        self._test_llmobs_invoke_stream("anthropic", bedrock_client, mock_tracer, llmobs_events)
 
     def test_llmobs_anthropic_message_invoke_stream(
-        self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer
+        self, ddtrace_global_config, bedrock_client, mock_tracer, llmobs_events
     ):
-        self._test_llmobs_invoke_stream("anthropic_message", bedrock_client, mock_llmobs_span_writer)
+        self._test_llmobs_invoke_stream("anthropic_message", bedrock_client, mock_tracer, llmobs_events)
 
     def test_llmobs_cohere_single_output_invoke_stream(
-        self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer
+        self, ddtrace_global_config, bedrock_client, mock_tracer, llmobs_events
     ):
         self._test_llmobs_invoke_stream(
             "cohere",
             bedrock_client,
-            mock_llmobs_span_writer,
+            mock_tracer,
+            llmobs_events,
             cassette_name="cohere_invoke_stream_single_output.yaml",
         )
 
     def test_llmobs_cohere_multi_output_invoke_stream(
-        self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer
+        self, ddtrace_global_config, bedrock_client, mock_tracer, llmobs_events
     ):
         self._test_llmobs_invoke_stream(
             "cohere",
             bedrock_client,
-            mock_llmobs_span_writer,
+            mock_tracer,
+            llmobs_events,
             cassette_name="cohere_invoke_stream_multi_output.yaml",
             n_output=2,
         )
 
-    def test_llmobs_meta_invoke_stream(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer):
-        self._test_llmobs_invoke_stream("meta", bedrock_client, mock_llmobs_span_writer)
+    def test_llmobs_meta_invoke_stream(self, ddtrace_global_config, bedrock_client, mock_tracer, llmobs_events):
+        self._test_llmobs_invoke_stream("meta", bedrock_client, mock_tracer, llmobs_events)
 
-    def test_llmobs_error(self, ddtrace_global_config, bedrock_client, mock_llmobs_span_writer, request_vcr):
+    def test_llmobs_error(self, ddtrace_global_config, bedrock_client, mock_tracer, llmobs_events, request_vcr):
         import botocore
 
-        mock_tracer = DummyTracer(writer=DummyWriter(trace_flush_enabled=False))
-        pin = Pin.get_from(bedrock_client)
-        pin._override(bedrock_client, tracer=mock_tracer)
-        # Need to disable and re-enable LLMObs service to use the mock tracer
-        LLMObs.disable()
-        LLMObs.enable(_tracer=mock_tracer, integrations_enabled=False)  # only want botocore patched
         with pytest.raises(botocore.exceptions.ClientError):
             with request_vcr.use_cassette("meta_invoke_error.yaml"):
                 body, model = json.dumps(_REQUEST_BODIES["meta"]), _MODELS["meta"]
@@ -264,27 +286,19 @@ class TestLLMObsBedrock:
                 json.loads(response.get("body").read())
         span = mock_tracer.pop_traces()[0][0]
 
-        expected_llmobs_writer_calls = [
-            mock.call.start(),
-            mock.call.enqueue(
-                _expected_llmobs_llm_span_event(
-                    span,
-                    model_name=span.get_tag("bedrock.request.model"),
-                    model_provider=span.get_tag("bedrock.request.model_provider"),
-                    input_messages=[{"content": mock.ANY}],
-                    metadata={
-                        "temperature": float(span.get_tag("bedrock.request.temperature")),
-                        "max_tokens": int(span.get_tag("bedrock.request.max_tokens")),
-                    },
-                    output_messages=[{"content": ""}],
-                    error=span.get_tag("error.type"),
-                    error_message=span.get_tag("error.message"),
-                    error_stack=span.get_tag("error.stack"),
-                    tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>"},
-                )
-            ),
-        ]
-
-        assert mock_llmobs_span_writer.enqueue.call_count == 1
-        mock_llmobs_span_writer.assert_has_calls(expected_llmobs_writer_calls)
-        LLMObs.disable()
+        assert len(llmobs_events) == 1
+        assert llmobs_events[0] == _expected_llmobs_llm_span_event(
+            span,
+            model_name=span.get_tag("bedrock.request.model"),
+            model_provider=span.get_tag("bedrock.request.model_provider"),
+            input_messages=[{"content": mock.ANY}],
+            metadata={
+                "temperature": float(span.get_tag("bedrock.request.temperature")),
+                "max_tokens": int(span.get_tag("bedrock.request.max_tokens")),
+            },
+            output_messages=[{"content": ""}],
+            error=span.get_tag("error.type"),
+            error_message=span.get_tag("error.message"),
+            error_stack=span.get_tag("error.stack"),
+            tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>"},
+        )


### PR DESCRIPTION
Update the bedrock testing to use a `TestLLMObsSpanWriter` class, similar to what we have in [llmobs](https://github.com/DataDog/dd-trace-py/blob/8923ae8c92869a1b5cd74f5f903a3329502d3da7/tests/llmobs/conftest.py#L200)

Also, create a `bedrock_llmobs` fixture to avoid some of the repeated code to enable/disable llmobs with a mock tracer

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
