### PR TITLE
refactor(dogstatsd): make imports lazy

### DIFF
--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -16,7 +16,6 @@ import ddtrace
 from ddtrace import config
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from ddtrace.settings.asm import config as asm_config
-from ddtrace.vendor.dogstatsd import DogStatsd
 
 from ...constants import _KEEP_SPANS_RATE_KEY
 from ...internal.utils.formats import parse_tags_str
@@ -44,6 +43,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Tuple  # noqa:F401
 
     from ddtrace.trace import Span  # noqa:F401
+    from ddtrace.vendor.dogstatsd import DogStatsd
 
     from .agent import ConnectionType  # noqa:F401
 
@@ -145,7 +145,7 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
         buffer_size: Optional[int] = None,
         max_payload_size: Optional[int] = None,
         timeout: Optional[float] = None,
-        dogstatsd: Optional[DogStatsd] = None,
+        dogstatsd: Optional["DogStatsd"] = None,
         sync_mode: bool = False,
         reuse_connections: Optional[bool] = None,
         headers: Optional[Dict[str, str]] = None,
@@ -438,7 +438,7 @@ class AgentWriter(HTTPWriter):
         buffer_size: Optional[int] = None,
         max_payload_size: Optional[int] = None,
         timeout: Optional[float] = None,
-        dogstatsd: Optional[DogStatsd] = None,
+        dogstatsd: Optional["DogStatsd"] = None,
         report_metrics: bool = True,
         sync_mode: bool = False,
         api_version: Optional[str] = None,

--- a/ddtrace/vendor/__init__.py
+++ b/ddtrace/vendor/__init__.py
@@ -93,12 +93,15 @@ Notes:
     Changed "-" to "_" as was causing errors when importing.
 """
 
-# Initialize `ddtrace.vendor.datadog.base.log` logger with our custom rate limited logger
-# DEV: This helps ensure if there are connection issues we do not spam their logs
-# DEV: Overwrite `base.log` instead of `get_logger('datadog.dogstatsd')` so we do
-#      not conflict with any non-vendored datadog.dogstatsd logger
-from ..internal.logger import get_logger
-from .dogstatsd import base
+from ddtrace.internal.module import ModuleWatchdog
 
 
-base.log = get_logger("ddtrace.vendor.dogstatsd")
+@ModuleWatchdog.after_module_imported("ddtrace.vendor.dogstatsd.base")
+def _(base):
+    # Initialize `ddtrace.vendor.datadog.base.log` logger with our custom rate limited logger
+    # DEV: This helps ensure if there are connection issues we do not spam their logs
+    # DEV: Overwrite `base.log` instead of `get_logger('datadog.dogstatsd')` so we do
+    #      not conflict with any non-vendored datadog.dogstatsd logger
+    from ddtrace.internal.logger import get_logger
+
+    base.log = get_logger("ddtrace.vendor.dogstatsd")


### PR DESCRIPTION
We make some of the dogstatsd imports lazy to prevent some of the vendored modules from being force-loaded even when not needed.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
