### PR TITLE
ci(benchmarks): add default value for dd_appsec_enabled envvar

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -35,7 +35,7 @@ variables:
   variables:
     # Benchmark's env variables. Modify to tweak benchmark parameters.
     DD_TRACE_DEBUG: "false"
-    DD_RUNTIME_METRICS_ENABLED: "true"
+    DD_RUNTIME_METRICS_ENABLED: "false"
     DD_REMOTE_CONFIGURATION_ENABLED: "false"
     DD_INSTRUMENTATION_TELEMETRY_ENABLED: "false"
     DD_CRASHTRACKING_ENABLED: "false"


### PR DESCRIPTION
Macrobenchmarks fail after recent change in https://github.com/DataDog/benchmarking-platform/commit/a5e50cf0deb936c10a4a471c740e1db7317e1e3b#diff-cdac2d7a54e837329dcc1560f02c71ffbdb8e12d73db1774b6441d576bd67b18R26-R83, because dd-agent config ends up broken. This PR fixes the issue, so they work again.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
