### PR TITLE
refactor(di): make DI depend on Symbol DB

### DIFF
--- a/ddtrace/debugging/_debugger.py
+++ b/ddtrace/debugging/_debugger.py
@@ -43,6 +43,7 @@ from ddtrace.debugging._signal.model import Signal
 from ddtrace.debugging._signal.model import SignalState
 from ddtrace.debugging._uploader import LogsIntakeUploaderV1
 from ddtrace.debugging._uploader import UploaderProduct
+from ddtrace.internal import symbol_db
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.metrics import Metrics
 from ddtrace.internal.module import ModuleHookType
@@ -275,6 +276,8 @@ class Debugger(Service):
 
         di_config.enabled = True
 
+        symbol_db.register()
+
         cls.__watchdog__.install()
 
         if di_config.metrics:
@@ -308,7 +311,10 @@ class Debugger(Service):
         cls._instance.stop(join=join)
         cls._instance = None
 
+        symbol_db.unregister()
+
         cls.__watchdog__.uninstall()
+
         if di_config.metrics:
             metrics.disable()
 

--- a/ddtrace/debugging/_products/dynamic_instrumentation.py
+++ b/ddtrace/debugging/_products/dynamic_instrumentation.py
@@ -1,7 +1,10 @@
 from ddtrace.settings.dynamic_instrumentation import config
 
 
-requires = ["remote-configuration"]
+requires = [
+    "remote-configuration",
+    "symbol-database",
+]
 
 
 def post_preload():

--- a/ddtrace/internal/symbol_db/product.py
+++ b/ddtrace/internal/symbol_db/product.py
@@ -9,17 +9,15 @@ def post_preload():
 
 
 def start():
-    if config.enabled:
-        from ddtrace.internal import symbol_db
+    if config._force:
+        # Force the upload of symbols, ignoring RCM instructions.
+        from ddtrace.internal.symbol_db.symbols import SymbolDatabaseUploader
 
-        symbol_db.bootstrap()
+        SymbolDatabaseUploader.install()
 
 
 def restart(join=False):
-    if not config._force:
-        from ddtrace.internal import symbol_db
-
-        symbol_db.restart()
+    pass
 
 
 def stop(join=False):

--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -1239,3 +1239,14 @@ def test_debugger_exception_conditional_function_probe():
     return_capture = snapshot_data["captures"]["return"]
     assert return_capture["throwable"]["message"] == "'Hello', 'world!', 42"
     assert return_capture["throwable"]["type"] == "Exception"
+
+
+@pytest.mark.subprocess(
+    ddtrace_run=True, env=dict(DD_SYMBOL_DATABASE_UPLOAD_ENABLED="1", DD_DYNAMIC_INSTRUMENTATION_ENABLED="1")
+)
+def test_symbols_upload_enabled():
+    from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
+    from ddtrace.internal.symbol_db.symbols import SymbolDatabaseUploader
+
+    assert not SymbolDatabaseUploader.is_installed()
+    assert remoteconfig_poller.get_registered("LIVE_DEBUGGING_SYMBOL_DB") is not None

--- a/tests/internal/symbol_db/test_symbols.py
+++ b/tests/internal/symbol_db/test_symbols.py
@@ -202,7 +202,7 @@ def test_symbols_upload_enabled():
     from ddtrace.internal.symbol_db.symbols import SymbolDatabaseUploader
 
     assert not SymbolDatabaseUploader.is_installed()
-    assert remoteconfig_poller.get_registered("LIVE_DEBUGGING_SYMBOL_DB") is not None
+    assert remoteconfig_poller.get_registered("LIVE_DEBUGGING_SYMBOL_DB") is None
 
 
 @pytest.mark.subprocess(ddtrace_run=True, env=dict(DD_SYMBOL_DATABASE_INCLUDES="tests.submod.stuff"))


### PR DESCRIPTION
We add an explicit dependency on Symbol DB to DI. The current implementation of Symbol DB is relevant for just DI, so we make sure this is reflected in the implementation. The added benefit is that we can make some of the imports lazy and save startup time when DI is not enabled.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
