### PR TITLE
Replacing broken testing guidelines link in contributing.rst

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -114,7 +114,7 @@ Tests
 -----
 
 If your change touches Python code, it should probably include at least one test. See the
-`testing guidelines<https://github.com/DataDog/dd-trace-py/blob/1.x/docs/contributing-testing.rst>`_ for details.
+`testing guidelines<https://github.com/DataDog/dd-trace-py/tree/main/docs/contributing-testing.rst>`_ for details.
 
 Documentation
 -------------

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -114,7 +114,7 @@ Tests
 -----
 
 If your change touches Python code, it should probably include at least one test. See the
-:ref:`testing guidelines<testing_guidelines>` for details.
+`testing guidelines<https://github.com/DataDog/dd-trace-py/blob/1.x/docs/contributing-testing.rst>`_ for details.
 
 Documentation
 -------------

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -114,7 +114,7 @@ Tests
 -----
 
 If your change touches Python code, it should probably include at least one test. See the
-`testing guidelines<https://github.com/DataDog/dd-trace-py/tree/main/docs/contributing-testing.rst>`_ for details.
+`testing guidelines <https://github.com/DataDog/dd-trace-py/tree/main/docs/contributing-testing.rst>`_ for details.
 
 Documentation
 -------------


### PR DESCRIPTION
The section being referred to no longer exists therefore adding a link to the contributing testing docs for users to follow. 

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
