### PR TITLE
fix(llmobs): serialize inputs and outputs to valid json [backport #12416 to 3.0]

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -844,7 +844,7 @@ class LLMObs(Service):
         Will be mapped to span's `meta.{input,output}.text` fields.
         """
         if input_text is not None:
-            span._set_ctx_item(INPUT_VALUE, str(input_text))
+            span._set_ctx_item(INPUT_VALUE, safe_json(input_text))
         if output_documents is None:
             return
         try:
@@ -862,9 +862,9 @@ class LLMObs(Service):
         Will be mapped to span's `meta.{input,output}.values` fields.
         """
         if input_value is not None:
-            span._set_ctx_item(INPUT_VALUE, str(input_value))
+            span._set_ctx_item(INPUT_VALUE, safe_json(input_value))
         if output_value is not None:
-            span._set_ctx_item(OUTPUT_VALUE, str(output_value))
+            span._set_ctx_item(OUTPUT_VALUE, safe_json(output_value))
 
     @staticmethod
     def _set_dict_attribute(span: Span, key, value: Dict[str, Any]) -> None:

--- a/releasenotes/notes/llmobs-workflow-io-ae4ab508e7fe336a.yaml
+++ b/releasenotes/notes/llmobs-workflow-io-ae4ab508e7fe336a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes non-LLM message inputs and outputs to be rendered as json rather than Python strings.

--- a/tests/llmobs/test_llmobs.py
+++ b/tests/llmobs/test_llmobs.py
@@ -264,3 +264,41 @@ def test_non_utf8_inputs_outputs(llmobs, llmobs_backend):
         events[0]["spans"][0]["meta"]["input"]["messages"][0]["content"]
         == "The first Super Bowl (aka First AFL–NFL World Championship Game), was played in 1967."
     )
+
+
+def test_structured_io_data(llmobs, llmobs_backend):
+    """Ensure that structured output data is correctly serialized."""
+    for m in [llmobs.workflow, llmobs.task, llmobs.llm]:
+        with m() as span:
+            llmobs.annotate(span, input_data={"data": "test1"}, output_data={"data": "test2"})
+        events = llmobs_backend.wait_for_num_events(num=1)
+        assert len(events) == 1
+        assert events[0]["spans"][0]["meta"]["input"]["value"] == '{"data": "test1"}'
+        assert events[0]["spans"][0]["meta"]["output"]["value"] == '{"data": "test2"}'
+
+
+def test_structured_prompt_data(llmobs, llmobs_backend):
+    with llmobs.llm() as span:
+        llmobs.annotate(span, prompt={"template": "test {{value}}"})
+    events = llmobs_backend.wait_for_num_events(num=1)
+    assert len(events) == 1
+    assert events[0]["spans"][0]["meta"]["input"] == {
+        "prompt": {
+            "template": "test {{value}}",
+            "_dd_context_variable_keys": ["context"],
+            "_dd_query_variable_keys": ["question"],
+        },
+    }
+
+
+def test_structured_io_data_unserializable(llmobs, llmobs_backend):
+    class CustomObj:
+        pass
+
+    for m in [llmobs.workflow, llmobs.task, llmobs.llm, llmobs.retrieval]:
+        with m() as span:
+            llmobs.annotate(span, input_data=CustomObj(), output_data=CustomObj())
+        events = llmobs_backend.wait_for_num_events(num=1)
+        assert len(events) == 1
+        assert "[Unserializable object:" in events[0]["spans"][0]["meta"]["input"]["value"]
+        assert "[Unserializable object:" in events[0]["spans"][0]["meta"]["output"]["value"]

--- a/tests/llmobs/test_llmobs_decorators.py
+++ b/tests/llmobs/test_llmobs_decorators.py
@@ -434,7 +434,7 @@ def test_automatic_annotation_non_llm_decorators(llmobs, llmobs_events):
         assert llmobs_events[-1] == _expected_llmobs_non_llm_span_event(
             span,
             decorator_name,
-            input_value=str({"prompt": "test_prompt", "arg_2": "arg_2", "kwarg_2": 12345}),
+            input_value='{"prompt": "test_prompt", "arg_2": "arg_2", "kwarg_2": 12345}',
             output_value="test_prompt",
             session_id="test_session_id",
         )
@@ -452,7 +452,7 @@ def test_automatic_annotation_retrieval_decorator(llmobs, llmobs_events):
     assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
         span,
         "retrieval",
-        input_value=str({"query": "test_query", "arg_2": "arg_2", "kwarg_2": 12345}),
+        input_value='{"query": "test_query", "arg_2": "arg_2", "kwarg_2": 12345}',
         session_id="test_session_id",
     )
 
@@ -823,7 +823,7 @@ def test_generator_exit_exception_sync(llmobs, llmobs_events):
     assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
         span,
         "workflow",
-        input_value=str({"alist": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}),
+        input_value='{"alist": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}',
         error=span.get_tag("error.type"),
         error_message=span.get_tag("error.message"),
         error_stack=span.get_tag("error.stack"),

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -435,13 +435,13 @@ def test_annotate_numeric_io(llmobs):
 def test_annotate_input_serializable_value(llmobs):
     with llmobs.task() as task_span:
         llmobs.annotate(span=task_span, input_data=["test_input"])
-        assert task_span._get_ctx_item(INPUT_VALUE) == str(["test_input"])
+        assert task_span._get_ctx_item(INPUT_VALUE) == '["test_input"]'
     with llmobs.tool() as tool_span:
         llmobs.annotate(span=tool_span, input_data={"test_input": "hello world"})
-        assert tool_span._get_ctx_item(INPUT_VALUE) == str({"test_input": "hello world"})
+        assert tool_span._get_ctx_item(INPUT_VALUE) == '{"test_input": "hello world"}'
     with llmobs.workflow() as workflow_span:
         llmobs.annotate(span=workflow_span, input_data=("asd", 123))
-        assert workflow_span._get_ctx_item(INPUT_VALUE) == str(("asd", 123))
+        assert workflow_span._get_ctx_item(INPUT_VALUE) == '["asd", 123]'
     with llmobs.agent() as agent_span:
         llmobs.annotate(span=agent_span, input_data="test_input")
         assert agent_span._get_ctx_item(INPUT_VALUE) == "test_input"
@@ -609,16 +609,16 @@ def test_annotate_output_string(llmobs):
 def test_annotate_output_serializable_value(llmobs):
     with llmobs.embedding(model_name="test_model") as embedding_span:
         llmobs.annotate(span=embedding_span, output_data=[[0, 1, 2, 3], [4, 5, 6, 7]])
-        assert embedding_span._get_ctx_item(OUTPUT_VALUE) == str([[0, 1, 2, 3], [4, 5, 6, 7]])
+        assert embedding_span._get_ctx_item(OUTPUT_VALUE) == "[[0, 1, 2, 3], [4, 5, 6, 7]]"
     with llmobs.task() as task_span:
         llmobs.annotate(span=task_span, output_data=["test_output"])
-        assert task_span._get_ctx_item(OUTPUT_VALUE) == str(["test_output"])
+        assert task_span._get_ctx_item(OUTPUT_VALUE) == '["test_output"]'
     with llmobs.tool() as tool_span:
         llmobs.annotate(span=tool_span, output_data={"test_output": "hello world"})
-        assert tool_span._get_ctx_item(OUTPUT_VALUE) == str({"test_output": "hello world"})
+        assert tool_span._get_ctx_item(OUTPUT_VALUE) == '{"test_output": "hello world"}'
     with llmobs.workflow() as workflow_span:
         llmobs.annotate(span=workflow_span, output_data=("asd", 123))
-        assert workflow_span._get_ctx_item(OUTPUT_VALUE) == str(("asd", 123))
+        assert workflow_span._get_ctx_item(OUTPUT_VALUE) == '["asd", 123]'
     with llmobs.agent() as agent_span:
         llmobs.annotate(span=agent_span, output_data="test_output")
         assert agent_span._get_ctx_item(OUTPUT_VALUE) == "test_output"


### PR DESCRIPTION
Backports #12416 to 3.0.

Prior to this change, inputs and outputs on workflow or task spans would just be stringified which would produce Python string representations of dicts and lists.

This change proposes changing this representation to valid json so we can render them in the UI.

Before:

<img width="1060" alt="image"
src="https://github.com/user-attachments/assets/578e80a1-1efc-4653-8f25-78a7597ae3e0" />

After:
<img width="1057" alt="image"
src="https://github.com/user-attachments/assets/c377b0c7-a133-4885-95dd-ef3369b83675" />

---------

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
