### PR TITLE
ci(release): ensure promote-oci-* jobs have necessary artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,15 +91,22 @@ promote-oci-to-prod:
   rules: null
   only:
     - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
-  needs: [ release_pypi_prod ]
+  needs:
+    - job: release_pypi_prod
+    - job: package-oci
+      artifacts: true
 
 promote-oci-to-prod-beta:
   stage: release
-  needs: null
+  needs:
+    - job: package-oci
+      artifacts: true
 
 promote-oci-to-staging:
   stage: release
-  needs: null
+  needs:
+    - job: package-oci
+      artifacts: true
 
 publish-lib-init-ghcr-tags:
   stage: release


### PR DESCRIPTION
v3.2.0 release failed to publish the OCI images because it did not properly inherit the artifacts from the `package-oci` job.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
