### PR TITLE
ci(release): fix publish-lib-init-pinned-tags job dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,7 +119,9 @@ publish-lib-init-ghcr-tags:
   rules: null
   only:
     - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
-  needs: [release_pypi_prod]
+  needs:
+    - job: release_pypi_prod
+    - job: create-multiarch-lib-injection-image
 
 publish-lib-init-pinned-tags:
   stage: release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,18 +95,21 @@ promote-oci-to-prod:
     - job: release_pypi_prod
     - job: package-oci
       artifacts: true
+    - job: oci-internal-publish
 
 promote-oci-to-prod-beta:
   stage: release
   needs:
     - job: package-oci
       artifacts: true
+    - job: oci-internal-publish
 
 promote-oci-to-staging:
   stage: release
   needs:
     - job: package-oci
       artifacts: true
+    - job: oci-internal-publish
 
 publish-lib-init-ghcr-tags:
   stage: release
@@ -122,7 +125,7 @@ publish-lib-init-pinned-tags:
     - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
   needs:
     - job: release_pypi_prod
-    - job: oci-internal-publish
+    - job: generate-lib-init-pinned-tag-values
       artifacts: true
 
 onboarding_tests_installer:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,7 +90,8 @@ promote-oci-to-prod:
   stage: release
   rules: null
   only:
-    - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+    # TODO: Support publishing rc releases
+    - /^v[0-9]+\.[0-9]+\.[0-9]+$/
   needs:
     - job: release_pypi_prod
     - job: package-oci
@@ -118,7 +119,8 @@ publish-lib-init-ghcr-tags:
   stage: release
   rules: null
   only:
-    - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+    # TODO: Support publishing rc releases
+    - /^v[0-9]+\.[0-9]+\.[0-9]+$/
   needs:
     - job: release_pypi_prod
     - job: create-multiarch-lib-injection-image
@@ -127,7 +129,8 @@ publish-lib-init-pinned-tags:
   stage: release
   rules: null
   only:
-    - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+    # TODO: Support publishing rc releases
+    - /^v[0-9]+\.[0-9]+\.[0-9]+$/
   needs:
     - job: release_pypi_prod
     - job: create-multiarch-lib-injection-image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,6 +96,7 @@ promote-oci-to-prod:
     - job: package-oci
       artifacts: true
     - job: oci-internal-publish
+      artifacts: true
 
 promote-oci-to-prod-beta:
   stage: release
@@ -103,6 +104,7 @@ promote-oci-to-prod-beta:
     - job: package-oci
       artifacts: true
     - job: oci-internal-publish
+      artifacts: true
 
 promote-oci-to-staging:
   stage: release
@@ -110,6 +112,7 @@ promote-oci-to-staging:
     - job: package-oci
       artifacts: true
     - job: oci-internal-publish
+      artifacts: true
 
 publish-lib-init-ghcr-tags:
   stage: release
@@ -125,6 +128,7 @@ publish-lib-init-pinned-tags:
     - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
   needs:
     - job: release_pypi_prod
+    - job: create-multiarch-lib-injection-image
     - job: generate-lib-init-pinned-tag-values
       artifacts: true
 


### PR DESCRIPTION
## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
