### PR TITLE
ci(release): fix publish-lib-init-pinned-tags job dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,11 +93,15 @@ promote-oci-to-prod:
     - job: release_pypi_prod
     - job: package-oci
       artifacts: true
+    - job: oci-internal-publish
+      artifacts: true
 
 promote-oci-to-prod-beta:
   stage: release
   needs:
     - job: package-oci
+      artifacts: true
+    - job: oci-internal-publish
       artifacts: true
 
 promote-oci-to-staging:
@@ -105,13 +109,17 @@ promote-oci-to-staging:
   needs:
     - job: package-oci
       artifacts: true
+    - job: oci-internal-publish
+      artifacts: true
 
 publish-lib-init-ghcr-tags:
   stage: release
   rules: null
   only:
     - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
-  needs: [release_pypi_prod]
+  needs:
+    - job: release_pypi_prod
+    - job: create-multiarch-lib-injection-image
 
 publish-lib-init-pinned-tags:
   stage: release
@@ -120,7 +128,8 @@ publish-lib-init-pinned-tags:
     - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
   needs:
     - job: release_pypi_prod
-    - job: oci-internal-publish
+    - job: create-multiarch-lib-injection-image
+    - job: generate-lib-init-pinned-tag-values
       artifacts: true
 
 onboarding_tests_installer:
@@ -163,4 +172,3 @@ deploy_to_di_backend:manual:
     UPSTREAM_COMMIT_AUTHOR: $CI_COMMIT_AUTHOR
     UPSTREAM_TAG: $CI_COMMIT_TAG
     UPSTREAM_PACKAGE_JOB: build
-


### PR DESCRIPTION
## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
