### PR TITLE
chore(llmobs): rename init telemetry metric names

### DIFF
--- a/ddtrace/bootstrap/preload.py
+++ b/ddtrace/bootstrap/preload.py
@@ -84,7 +84,7 @@ if config._otel_enabled:
 if config._llmobs_enabled:
     from ddtrace.llmobs import LLMObs
 
-    LLMObs.enable()
+    LLMObs.enable(_auto=True)
 
 if asbool(os.getenv("DD_TRACE_ENABLED", default=True)):
     from ddtrace import patch_all

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -311,6 +311,7 @@ class LLMObs(Service):
         env: Optional[str] = None,
         service: Optional[str] = None,
         _tracer: Optional[Tracer] = None,
+        _auto: bool = False,
     ) -> None:
         """
         Enable LLM Observability tracing.
@@ -393,7 +394,7 @@ class LLMObs(Service):
 
             log.debug("%s enabled", cls.__name__)
         finally:
-            telemetry.record_llmobs_enabled(error, config._llmobs_agentless_enabled, config._dd_site, start_ns)
+            telemetry.record_llmobs_enabled(error, config._llmobs_agentless_enabled, config._dd_site, start_ns, _auto)
 
     @classmethod
     def _integration_is_enabled(cls, integration: str) -> bool:

--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -1,4 +1,5 @@
 import time
+from typing import Optional
 
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
@@ -11,16 +12,21 @@ from ddtrace.llmobs._constants import SPAN_KIND
 from ddtrace.trace import Span
 
 
-def record_llmobs_enabled(error, agentless_enabled, site, start_ns):
-    tags = [("agentless", agentless_enabled), ("site", site)]
+def record_llmobs_enabled(error: Optional[str], agentless_enabled: bool, site: str, start_ns: int, auto: bool):
+    tags = [
+        ("agentless", str(int(agentless_enabled))),
+        ("site", site),
+        ("auto", str(int(auto))),
+        ("error", "1" if error else "0"),
+    ]
     if error:
-        tags.extend([("error", "1"), ("error_type", error)])
+        tags.append(("error_type", error))
     init_time_ms = (time.time_ns() - start_ns) / 1e6
     telemetry_writer.add_distribution_metric(
-        namespace=TELEMETRY_NAMESPACE.MLOBS, name="llmobs.init_time", value=init_time_ms, tags=tuple(tags)
+        namespace=TELEMETRY_NAMESPACE.MLOBS, name="init_time", value=init_time_ms, tags=tuple(tags)
     )
     telemetry_writer.add_count_metric(
-        namespace=TELEMETRY_NAMESPACE.MLOBS, name="llmobs.enabled", value=1, tags=tuple(tags)
+        namespace=TELEMETRY_NAMESPACE.MLOBS, name="product_enabled", value=1, tags=tuple(tags)
     )
 
 
@@ -38,16 +44,16 @@ def record_span_created(span: Span):
     model_provider = span._get_ctx_item("model_provider")
 
     tags = [
-        ("autoinstrumented", str(autoinstrumented)),
-        ("has_session_id", str(has_session_id)),
-        ("is_root_span", str(is_root_span)),
+        ("autoinstrumented", str(int(autoinstrumented))),
+        ("has_session_id", str(int(has_session_id))),
+        ("is_root_span", str(int(is_root_span))),
         ("span_kind", span_kind or "N/A"),
         ("error", str(span.error)),
     ]
     if autoinstrumented:
         tags.append(("integration", integration))
     else:
-        tags.append(("decorator", str(decorator)))
+        tags.append(("decorator", str(int(decorator))))
     if model_provider:
         tags.append(("model_provider", model_provider))
     telemetry_writer.add_count_metric(


### PR DESCRIPTION
Renames recently merged telemetry metric names to match allowed list from `llmobs.init_time/enabled` to `init_time/product_enabled`.

Also fixes up some tag types to be guaranteed to be strings.
Also adds a new tag `auto` to `product_enabled/init_time` metrics to indicate if this is coming from manual `LLMObs.enable()` or via `ddtrace-run`.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
