### PR TITLE
ci(release): fix publish-lib-init-pinned-tags job dependencies [backport 3.2]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,10 +88,13 @@ promote-oci-to-prod:
   stage: release
   rules: null
   only:
-    - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+    # TODO: Support publishing rc releases
+    - /^v[0-9]+\.[0-9]+\.[0-9]+$/
   needs:
     - job: release_pypi_prod
     - job: package-oci
+      artifacts: true
+    - job: oci-internal-publish
       artifacts: true
 
 promote-oci-to-prod-beta:
@@ -99,28 +102,37 @@ promote-oci-to-prod-beta:
   needs:
     - job: package-oci
       artifacts: true
+    - job: oci-internal-publish
+      artifacts: true
 
 promote-oci-to-staging:
   stage: release
   needs:
     - job: package-oci
       artifacts: true
+    - job: oci-internal-publish
+      artifacts: true
 
 publish-lib-init-ghcr-tags:
   stage: release
   rules: null
   only:
-    - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
-  needs: [release_pypi_prod]
+    # TODO: Support publishing rc releases
+    - /^v[0-9]+\.[0-9]+\.[0-9]+$/
+  needs:
+    - job: release_pypi_prod
+    - job: create-multiarch-lib-injection-image
 
 publish-lib-init-pinned-tags:
   stage: release
   rules: null
   only:
-    - /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+    # TODO: Support publishing rc releases
+    - /^v[0-9]+\.[0-9]+\.[0-9]+$/
   needs:
     - job: release_pypi_prod
-    - job: oci-internal-publish
+    - job: create-multiarch-lib-injection-image
+    - job: generate-lib-init-pinned-tag-values
       artifacts: true
 
 onboarding_tests_installer:


### PR DESCRIPTION
Backport https://github.com/DataDog/dd-trace-py/commit/268284eb574296f24a71f3f21ee636d483551a92 from https://github.com/DataDog/dd-trace-py/pull/12670 to 3.1.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
