### PR TITLE
chore(configuration): use get_config for distributed tracing configurations

### DIFF
--- a/ddtrace/contrib/internal/rq/patch.py
+++ b/ddtrace/contrib/internal/rq/patch.py
@@ -10,6 +10,7 @@ from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.trace import Pin
+from ....settings._config import _get_config
 
 from ....ext import SpanKind
 from ....ext import SpanTypes
@@ -19,7 +20,7 @@ from ... import trace_utils
 config._add(
     "rq",
     dict(
-        distributed_tracing_enabled=asbool(os.environ.get("DD_RQ_DISTRIBUTED_TRACING_ENABLED", True)),
+        distributed_tracing_enabled=_get_config("DD_RQ_DISTRIBUTED_TRACING_ENABLED", True, asbool),
         _default_service=schematize_service_name("rq"),
     ),
 )
@@ -27,7 +28,7 @@ config._add(
 config._add(
     "rq_worker",
     dict(
-        distributed_tracing_enabled=asbool(os.environ.get("DD_RQ_DISTRIBUTED_TRACING_ENABLED", True)),
+        distributed_tracing_enabled=_get_config("DD_RQ_DISTRIBUTED_TRACING_ENABLED", True, asbool),
         _default_service=schematize_service_name("rq-worker"),
     ),
 )

--- a/ddtrace/contrib/internal/rq/patch.py
+++ b/ddtrace/contrib/internal/rq/patch.py
@@ -1,5 +1,3 @@
-import os
-
 from ddtrace import config
 from ddtrace.constants import SPAN_KIND
 from ddtrace.internal import core


### PR DESCRIPTION
Update rq integration to use _get_config instead of os.environ. Backlog task APMAPI-1210. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
