### PR TITLE
fix(llmobs): fix max payload size limit

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -38,7 +38,7 @@ EVP_PROXY_AGENT_BASE_PATH = "evp_proxy/v2"
 EVP_PROXY_AGENT_ENDPOINT = "{}/api/v2/llmobs".format(EVP_PROXY_AGENT_BASE_PATH)
 EVP_SUBDOMAIN_HEADER_NAME = "X-Datadog-EVP-Subdomain"
 EVP_SUBDOMAIN_HEADER_VALUE = "llmobs-intake"
-EVP_PAYLOAD_SIZE_LIMIT = 5 << 20  # 5MB (actual limit is 5.1MB)
+EVP_PAYLOAD_SIZE_LIMIT = (1 << 20) - 1024  # 999KB (actual limit is 1MB)
 EVP_EVENT_SIZE_LIMIT = (1 << 20) - 1024  # 999KB (actual limit is 1MB)
 
 AGENTLESS_BASE_URL = "https://llmobs-intake"

--- a/releasenotes/notes/fix-truncation-d9ed5dccb7a8f5c6.yaml
+++ b/releasenotes/notes/fix-truncation-d9ed5dccb7a8f5c6.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    LLM Observability: This fix resolves an issue where an incorrect max payload size value caused spans to be dropped.
+    LLM Observability: This fix resolves an issue where an incorrect max payload size setting caused spans to be dropped.
 

--- a/releasenotes/notes/fix-truncation-d9ed5dccb7a8f5c6.yaml
+++ b/releasenotes/notes/fix-truncation-d9ed5dccb7a8f5c6.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    LLM Observability: This fix resolves an issue where an incorrect max payload size value caused spans to be dropped.
+

--- a/tests/llmobs/conftest.py
+++ b/tests/llmobs/conftest.py
@@ -71,8 +71,8 @@ def mock_http_writer_send_payload_response():
     with mock.patch(
         "ddtrace.internal.writer.HTTPWriter._send_payload",
         return_value=Response(status=200, body="{}"),
-    ) as mock_http_writer:
-        yield mock_http_writer
+    ):
+        yield
 
 
 @pytest.fixture

--- a/tests/llmobs/conftest.py
+++ b/tests/llmobs/conftest.py
@@ -71,8 +71,8 @@ def mock_http_writer_send_payload_response():
     with mock.patch(
         "ddtrace.internal.writer.HTTPWriter._send_payload",
         return_value=Response(status=200, body="{}"),
-    ):
-        yield
+    ) as mock_http_writer:
+        yield mock_http_writer
 
 
 @pytest.fixture

--- a/tests/llmobs/test_llmobs_span_agent_writer.py
+++ b/tests/llmobs/test_llmobs_span_agent_writer.py
@@ -36,10 +36,11 @@ def test_flush_queue_when_event_cause_queue_to_exceed_payload_limit(
     llmobs_span_writer = LLMObsSpanWriter(is_agentless=False, interval=1000, timeout=1)
     llmobs_span_writer.enqueue(_chat_completion_event())
     llmobs_span_writer.enqueue(_large_event())
+    llmobs_span_writer.enqueue(_large_event())
     mock_writer_logs.debug.assert_has_calls(
         [
             mock.call("flushing queue because queuing next event will exceed EVP payload limit"),
-            mock.call("encode %d LLMObs span events to be sent", 5),
+            mock.call("encode %d LLMObs span events to be sent", 2),
         ],
         any_order=True,
     )

--- a/tests/llmobs/test_llmobs_span_agent_writer.py
+++ b/tests/llmobs/test_llmobs_span_agent_writer.py
@@ -21,7 +21,7 @@ def test_writer_start(mock_writer_logs):
     mock_writer_logs.debug.assert_has_calls([mock.call("started %r to %r", "LLMObsSpanWriter", INTAKE_ENDPOINT)])
 
 
-def test_buffer_limit(mock_writer_logs, mock_http_writer_send_payload_response):
+def test_buffer_payload_limit(mock_writer_logs, mock_http_writer_send_payload_response):
     llmobs_span_writer = LLMObsSpanWriter(is_agentless=False, interval=1000, timeout=1)
     for _ in range(1001):
         llmobs_span_writer.enqueue({})
@@ -61,6 +61,18 @@ def test_truncating_oversized_events(mock_writer_logs, mock_http_writer_send_pay
             mock.call("dropping event input/output because its size (%d) exceeds the event size limit (1MB)", 1400441),
         ]
     )
+
+
+def test_payload_size_limit(mock_writer_logs, mock_http_writer_send_payload_response):
+    llmobs_span_writer = LLMObsSpanWriter(is_agentless=False, interval=1000, timeout=1)
+    llmobs_span_writer.enqueue(_chat_completion_event())
+    llmobs_span_writer.enqueue(_oversized_llm_event())
+    mock_writer_logs.debug.assert_has_calls(
+        [
+            mock.call("flushing queue because queuing next event will exceed EVP payload limit"),
+        ]
+    )
+    assert mock_http_writer_send_payload_response.call_count == 1
 
 
 def test_send_completion_event(mock_writer_logs, mock_http_writer_send_payload_response):

--- a/tests/llmobs/test_llmobs_span_agentless_writer.py
+++ b/tests/llmobs/test_llmobs_span_agentless_writer.py
@@ -40,16 +40,13 @@ def test_flush_queue_when_event_cause_queue_to_exceed_payload_limit(
 ):
     with override_global_config(dict(_dd_api_key="foobar.baz", _dd_site=DATADOG_SITE)):
         llmobs_span_writer = LLMObsSpanWriter(is_agentless=True, agentless_url=INTAKE_URL, interval=1000, timeout=1)
-        llmobs_span_writer.enqueue(_large_event())
-        llmobs_span_writer.enqueue(_large_event())
-        llmobs_span_writer.enqueue(_large_event())
-        llmobs_span_writer.enqueue(_large_event())
+        llmobs_span_writer.enqueue(_chat_completion_event())
         llmobs_span_writer.enqueue(_large_event())
         llmobs_span_writer.enqueue(_large_event())
         mock_writer_logs.debug.assert_has_calls(
             [
                 mock.call("flushing queue because queuing next event will exceed EVP payload limit"),
-                mock.call("encode %d LLMObs span events to be sent", 5),
+                mock.call("encode %d LLMObs span events to be sent", 2),
             ],
             any_order=True,
         )


### PR DESCRIPTION
For the time being, we have the wrong `EVP_PAYLOAD_SIZE_LIMIT` size limit set. Our backend can't distinguish between a list of spans being a _batch of events_ vs a _single event_, so it enforces the 1MB per-event limit on the entire list of spans.

This PR changes the max payload size to be the same value as per-event size limit.

### **before - 55 out of 1000 traces sent**

<img width="744" alt="image" src="https://github.com/user-attachments/assets/ae0a7fd4-e813-4d8c-b0dc-d44bea1f830e" />

### **with this pr - all 1000 show up**
1000 large spans show up no problem
<img width="924" alt="image" src="https://github.com/user-attachments/assets/12e964b4-496d-455a-896d-6729a9cc2a97" />


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
