### PR TITLE
chore(llmobs): add telemetry for dropped spans/evals

### DIFF
--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -1,4 +1,6 @@
 import time
+from typing import Any
+from typing import List
 from typing import Optional
 
 from ddtrace.internal.telemetry import telemetry_writer
@@ -20,6 +22,8 @@ class LLMObsTelemetryMetrics:
     SPAN_SIZE = "span.size"
     SPAN_STARTED = "span.start"
     SPAN_FINISHED = "span.finished"
+    DROPPED_SPAN_EVENTS = "dropped_span_events"
+    DROPPED_EVAL_EVENTS = "dropped_eval_events"
 
 
 def _find_integration_from_tags(tags):
@@ -106,4 +110,24 @@ def record_span_event_size(event: LLMObsSpanEvent, event_size: int, truncated: b
     tags.append(("truncated", str(int(truncated))))
     telemetry_writer.add_distribution_metric(
         namespace=TELEMETRY_NAMESPACE.MLOBS, name=LLMObsTelemetryMetrics.SPAN_SIZE, value=event_size, tags=tuple(tags)
+    )
+
+
+def record_dropped_span_payload(events: List[LLMObsSpanEvent], error: str):
+    tags = [("error", error)]
+    telemetry_writer.add_count_metric(
+        namespace=TELEMETRY_NAMESPACE.MLOBS,
+        name=LLMObsTelemetryMetrics.DROPPED_SPAN_EVENTS,
+        value=len(events),
+        tags=tuple(tags),
+    )
+
+
+def record_dropped_eval_payload(events: List[Any], error: str):
+    tags = [("error", error)]
+    telemetry_writer.add_count_metric(
+        namespace=TELEMETRY_NAMESPACE.MLOBS,
+        name=LLMObsTelemetryMetrics.DROPPED_EVAL_EVENTS,
+        value=len(events),
+        tags=tuple(tags),
     )

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -134,6 +134,7 @@ class BaseLLMObsWriter(PeriodicService):
             else:
                 logger.debug("sent %d LLMObs %s events to %s", len(events), self._event_type, self._url)
         except Exception:
+            telemetry.record_dropped_eval_payload(events, error="connection_error")
             logger.error(
                 "failed to send %d LLMObs %s events to %s", len(events), self._event_type, self._intake, exc_info=True
             )


### PR DESCRIPTION
[MLOB-2395]

This PR adds telemetry for dropped span/eval events to LLM Observability.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)


[MLOB-2394]: https://datadoghq.atlassian.net/browse/MLOB-2394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MLOB-2395]: https://datadoghq.atlassian.net/browse/MLOB-2395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ