### PR TITLE
chore: add DD_BUILD_EXT_INCLUDES and DD_BUILD_EXT_EXCLUDES to setup.py

### DIFF
--- a/docs/build_system.rst
+++ b/docs/build_system.rst
@@ -200,3 +200,29 @@ These environment variables modify aspects of the build process.
 
     version_added:
         v2.16.0:
+
+  DD_BUILD_EXT_INCLUDES:
+    type: String
+    default: ""
+
+    description: |
+        Comma separated list of ``fnmatch`` patterns for native extensions to build when installing the package from source.
+        Example: ``DD_BUILD_EXT_INCLUDES="ddtrace.internal.*" pip install -e .`` to only build native extensions found in ``ddtrace/internal/`` folder.
+
+        ``DD_BUILD_EXT_EXCLUDES`` takes precedence over ``DD_BUILD_EXT_INCLUDES``.
+
+    version_added:
+        v3.3.0:
+
+  DD_BUILD_EXT_EXCLUDES:
+    type: String
+    default: ""
+
+    description: |
+        Comma separated list of ``fnmatch`` patterns for native extensions to skip when installing the package from source.
+        Example: ``DD_BUILD_EXT_EXCLUDES="*._encoding" pip install -e .`` to build all native extensions except ``ddtrace.internal._encoding``.
+
+        ``DD_BUILD_EXT_EXCLUDES`` takes precedence over ``DD_BUILD_EXT_INCLUDES``.
+
+    version_added:
+        v3.3.0:

--- a/setup.py
+++ b/setup.py
@@ -728,9 +728,9 @@ setup(
                     sources=["ddtrace/profiling/collector/stack.pyx"],
                     language="c",
                     # cython generated code errors on build in toolchains that are strict about int->ptr conversion
-                    # OTOH, the MSVC toolchain is different.  In a perfect world we'd deduce the underlying toolchain and
-                    # emit the right flags, but as a compromise we assume Windows implies MSVC and everything else is on a
-                    # GNU-like toolchain
+                    # OTOH, the MSVC toolchain is different.  In a perfect world we'd deduce the underlying
+                    # toolchain and emit the right flags, but as a compromise we assume Windows implies MSVC and
+                    # everything else is on a GNU-like toolchain
                     extra_compile_args=extra_compile_args
                     + (["-Wno-int-conversion"] if CURRENT_OS != "Windows" else []),
                 ),

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import atexit
+import fnmatch
 import hashlib
 import os
 import platform
@@ -531,6 +532,28 @@ def check_rust_toolchain():
         raise EnvironmentError("Rust toolchain not found. Please install Rust from https://rustup.rs/")
 
 
+DD_BUILD_EXT_INCLUDES = [_.strip() for _ in os.getenv("DD_BUILD_EXT_INCLUDES", "").split(",") if _.strip()]
+DD_BUILD_EXT_EXCLUDES = [_.strip() for _ in os.getenv("DD_BUILD_EXT_EXCLUDES", "").split(",") if _.strip()]
+
+
+def filter_extensions(extensions):
+    # type: (list[Extension]) -> list[Extension]
+    if not DD_BUILD_EXT_INCLUDES and not DD_BUILD_EXT_EXCLUDES:
+        return extensions
+
+    filtered: list[Extension] = []
+    for ext in extensions:
+        if DD_BUILD_EXT_EXCLUDES and any(fnmatch.fnmatch(ext.name, pattern) for pattern in DD_BUILD_EXT_EXCLUDES):
+            print(f"INFO: Excluding extension {ext.name}")
+            continue
+        elif DD_BUILD_EXT_INCLUDES and not any(fnmatch.fnmatch(ext.name, pattern) for pattern in DD_BUILD_EXT_INCLUDES):
+            print(f"INFO: Excluding extension {ext.name}")
+            continue
+        print(f"INFO: Including extension {ext.name}")
+        filtered.append(ext)
+    return filtered
+
+
 # Before adding any extensions, check that system pre-requisites are satisfied
 try:
     check_rust_toolchain()
@@ -679,57 +702,60 @@ setup(
         "clean": CleanLibraries,
     },
     setup_requires=["setuptools_scm[toml]>=4", "cython", "cmake>=3.24.2,<3.28", "setuptools-rust"],
-    ext_modules=ext_modules
+    ext_modules=filter_extensions(ext_modules)
     + cythonize(
-        [
-            Cython.Distutils.Extension(
-                "ddtrace.internal._rand",
-                sources=["ddtrace/internal/_rand.pyx"],
-                language="c",
-            ),
-            Cython.Distutils.Extension(
-                "ddtrace.internal._tagset",
-                sources=["ddtrace/internal/_tagset.pyx"],
-                language="c",
-            ),
-            Extension(
-                "ddtrace.internal._encoding",
-                ["ddtrace/internal/_encoding.pyx"],
-                include_dirs=["."],
-                libraries=encoding_libraries,
-                define_macros=encoding_macros,
-            ),
-            Cython.Distutils.Extension(
-                "ddtrace.profiling.collector.stack",
-                sources=["ddtrace/profiling/collector/stack.pyx"],
-                language="c",
-                # cython generated code errors on build in toolchains that are strict about int->ptr conversion
-                # OTOH, the MSVC toolchain is different.  In a perfect world we'd deduce the underlying toolchain and
-                # emit the right flags, but as a compromise we assume Windows implies MSVC and everything else is on a
-                # GNU-like toolchain
-                extra_compile_args=extra_compile_args + (["-Wno-int-conversion"] if CURRENT_OS != "Windows" else []),
-            ),
-            Cython.Distutils.Extension(
-                "ddtrace.profiling.collector._traceback",
-                sources=["ddtrace/profiling/collector/_traceback.pyx"],
-                language="c",
-            ),
-            Cython.Distutils.Extension(
-                "ddtrace.profiling._threading",
-                sources=["ddtrace/profiling/_threading.pyx"],
-                language="c",
-            ),
-            Cython.Distutils.Extension(
-                "ddtrace.profiling.collector._task",
-                sources=["ddtrace/profiling/collector/_task.pyx"],
-                language="c",
-            ),
-            Cython.Distutils.Extension(
-                "ddtrace.profiling.exporter.pprof",
-                sources=["ddtrace/profiling/exporter/pprof.pyx"],
-                language="c",
-            ),
-        ],
+        filter_extensions(
+            [
+                Cython.Distutils.Extension(
+                    "ddtrace.internal._rand",
+                    sources=["ddtrace/internal/_rand.pyx"],
+                    language="c",
+                ),
+                Cython.Distutils.Extension(
+                    "ddtrace.internal._tagset",
+                    sources=["ddtrace/internal/_tagset.pyx"],
+                    language="c",
+                ),
+                Extension(
+                    "ddtrace.internal._encoding",
+                    ["ddtrace/internal/_encoding.pyx"],
+                    include_dirs=["."],
+                    libraries=encoding_libraries,
+                    define_macros=encoding_macros,
+                ),
+                Cython.Distutils.Extension(
+                    "ddtrace.profiling.collector.stack",
+                    sources=["ddtrace/profiling/collector/stack.pyx"],
+                    language="c",
+                    # cython generated code errors on build in toolchains that are strict about int->ptr conversion
+                    # OTOH, the MSVC toolchain is different.  In a perfect world we'd deduce the underlying toolchain and
+                    # emit the right flags, but as a compromise we assume Windows implies MSVC and everything else is on a
+                    # GNU-like toolchain
+                    extra_compile_args=extra_compile_args
+                    + (["-Wno-int-conversion"] if CURRENT_OS != "Windows" else []),
+                ),
+                Cython.Distutils.Extension(
+                    "ddtrace.profiling.collector._traceback",
+                    sources=["ddtrace/profiling/collector/_traceback.pyx"],
+                    language="c",
+                ),
+                Cython.Distutils.Extension(
+                    "ddtrace.profiling._threading",
+                    sources=["ddtrace/profiling/_threading.pyx"],
+                    language="c",
+                ),
+                Cython.Distutils.Extension(
+                    "ddtrace.profiling.collector._task",
+                    sources=["ddtrace/profiling/collector/_task.pyx"],
+                    language="c",
+                ),
+                Cython.Distutils.Extension(
+                    "ddtrace.profiling.exporter.pprof",
+                    sources=["ddtrace/profiling/exporter/pprof.pyx"],
+                    language="c",
+                ),
+            ]
+        ),
         compile_time_env={
             "PY_MAJOR_VERSION": sys.version_info.major,
             "PY_MINOR_VERSION": sys.version_info.minor,
@@ -740,14 +766,16 @@ setup(
         annotate=os.getenv("_DD_CYTHON_ANNOTATE") == "1",
         compiler_directives={"language_level": "3"},
     )
-    + get_exts_for("psutil"),
-    rust_extensions=[
-        RustExtension(
-            "ddtrace.internal.native._native",
-            path="src/native/Cargo.toml",
-            py_limited_api="auto",
-            binding=Binding.PyO3,
-            debug=os.getenv("_DD_RUSTC_DEBUG") == "1",
-        ),
-    ],
+    + filter_extensions(get_exts_for("psutil")),
+    rust_extensions=filter_extensions(
+        [
+            RustExtension(
+                "ddtrace.internal.native._native",
+                path="src/native/Cargo.toml",
+                py_limited_api="auto",
+                binding=Binding.PyO3,
+                debug=os.getenv("_DD_RUSTC_DEBUG") == "1",
+            ),
+        ]
+    ),
 )


### PR DESCRIPTION
This change adds two env variables to `setup.py`:

- `DD_BUILD_EXT_INCLUDES`
  - comma separated list of `fnmatch` patterns to match native extensions to build
- `DD_BUILD_EXT_EXCLUDES`
  - comma separated list of `fnmatch` patterns to match native extensions to _not_ build

`DD_BUILD_EXT_EXCLUDES` takes precedence over `DD_BUILD_EXT_INCLUDES`.


Example usage:

```shell
$ DD_BUILD_EXT_INCLUDES="ddtrace.internal.*" DD_BUILD_EXT_EXCLUDES="*._encoding" pip install --verbose -e .
  INFO: Excluding extension ddtrace.profiling.collector._memalloc
  INFO: Including extension ddtrace.internal._threads
  INFO: Excluding extension ddtrace.appsec._iast._stacktrace
  INFO: Excluding extension ddtrace.appsec._iast._taint_tracking._native
  INFO: Including extension ddtrace.internal.datadog.profiling.ddup._ddup
  INFO: Including extension ddtrace.internal.datadog.profiling.crashtracker._crashtracker
  INFO: Including extension ddtrace.internal._rand
  INFO: Including extension ddtrace.internal._tagset
  INFO: Excluding extension ddtrace.internal._encoding
  INFO: Excluding extension ddtrace.profiling.collector.stack
  INFO: Excluding extension ddtrace.profiling.collector._traceback
  INFO: Excluding extension ddtrace.profiling._threading
  INFO: Excluding extension ddtrace.profiling.collector._task
  INFO: Excluding extension ddtrace.profiling.exporter.pprof
  INFO: Excluding extension ddtrace.vendor.psutil._psutil_osx
  INFO: Excluding extension ddtrace.vendor.psutil._psutil_posix
  INFO: Including extension ddtrace.internal.native._native
```

The above will only build extensions that start with `ddtrace.internal.*` except for any extensions which end with `*._encoding` (`ddtrace.internal._encoding`).

These two new env variables are meant to be used for local development when iterating on a specific native extension. With the correct filter you can be sure that only the required extension is built, drastically improving iteration speed for building locally.


```shell
$ time DD_USE_SCCACHE=0 DD_FAST_BUILD=0 pip install -e .
  103.56s user 19.57s system 92% cpu 2:12.54 total

$ time DD_USE_SCCACHE=1 DD_FAST_BUILD=1 pip install -e .
  17.29s user 7.04s system 67% cpu 36.290 total

$ time DD_USE_SCCACHE=0 DD_FAST_BUILD=0 DD_BUILD_EXT_INCLUDES="ddtrace.internal.*" DD_BUILD_EXT_EXCLUDES="*._encoding" pip install -e .
  15.33s user 5.95s system 82% cpu 25.793 total

$ time DD_USE_SCCACHE=1 DD_FAST_BUILD=1 DD_BUILD_EXT_INCLUDES="ddtrace.internal.*" DD_BUILD_EXT_EXCLUDES="*._encoding" pip install -e .
  10.35s user 5.35s system 65% cpu 24.033 total

$ time DD_USE_SCCACHE=1 DD_FAST_BUILD=1 DD_BUILD_EXT_INCLUDES="ddtrace.internal._encoding" pip install -e .
  5.65s user 2.46s system 75% cpu 10.803 total
```

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
