### PR TITLE
docs: removes sampling docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,12 +26,6 @@ Tracing
     :members:
     :undoc-members:
 
-.. autoclass:: ddtrace._trace.sampler.DatadogSampler
-    :members:
-
-.. autoclass:: ddtrace._trace.sampler.SamplingRule
-    :members:
-
 .. autoclass:: ddtrace.propagation.http.HTTPPropagator
     :members:
 


### PR DESCRIPTION
Users should only use `DD_TRACE_SAMPLING_RULES` to configure the DatadogSampler. They do not need to know the inner working of the Datadog Sampler. Making these docs internal to avoid confusion. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
