### PR TITLE
ci(benchmarks): refactor telemetry_add_metric benchmark scenario

### DIFF
--- a/benchmarks/telemetry_add_metric/config.yaml
+++ b/benchmarks/telemetry_add_metric/config.yaml
@@ -1,24 +1,33 @@
-one-metric-one-run-batch-flush-true:
-  runs: 1
-  batches: 1
-  flush: true
-one-metric-one-run-batch-flush-false:
-  runs: 1
-  batches: 1
-  flush: False
-many-metrics-many-runs-batch-flush-true:
-  runs: 1000
-  batches: 10
-  flush: true
-many-metrics-many-runs-batch-flush-false:
-  runs: 1000
-  batches: 10
-  flush: False
-one-metric-many-runs-batch-flush-true:
-  runs: 1000
-  batches: 1
-  flush: true
-one-metric-many-runs-batch-flush-false:
-  runs: 1000
-  batches: 1
-  flush: False
+# The scenario expects specific names:
+#   - create-1-<type>-metric: {}
+#   - create-100-<type>-metrics: {}
+#   - increment-1-<type>-metric-100-times: {}
+#   - increment-100-<type>-metrics-100-times: {}
+#
+# The create/increment-<num> is assumed to be a static name, it is not parsed.
+# The "100-times" is assumed as a static name, it is not parsed.
+
+
+# Count metrics
+create-1-count-metric: {}
+create-100-count-metrics: {}
+increment-1-count-metric-100-times: {}
+increment-100-count-metrics-100-times: {}
+
+# Gauge metrics
+create-1-gauge-metric: {}
+create-100-gauge-metrics: {}
+increment-1-gauge-metric-100-times: {}
+increment-100-gauge-metrics-100-times: {}
+
+# Distribution metrics
+create-1-distribution-metric: {}
+create-100-distribution-metrics: {}
+increment-1-distribution-metric-100-times: {}
+increment-100-distribution-metrics-100-times: {}
+
+# Rate metrics
+create-1-rate-metric: {}
+create-100-rate-metrics: {}
+increment-1-rate-metric-100-times: {}
+increment-100-rate-metrics-100-times: {}

--- a/benchmarks/telemetry_add_metric/scenario.py
+++ b/benchmarks/telemetry_add_metric/scenario.py
@@ -56,8 +56,6 @@ class TelemetryAddMetric(Scenario):
     """
 
     def run(self):
-        metricnamespace = MetricNamespace()
-
         add_metric = None
         if "count-metric" in self.name:
             add_metric = add_count_metric
@@ -74,23 +72,27 @@ class TelemetryAddMetric(Scenario):
 
             def _(loops: int):
                 for _ in range(loops):
+                    metricnamespace = MetricNamespace()
                     add_metric(metricnamespace, "metric")
         elif "create-100-" in self.name:
 
             def _(loops: int):
                 for _ in range(loops):
+                    metricnamespace = MetricNamespace()
                     for i in range(100):
                         add_metric(metricnamespace, str(i))
         elif "increment-1-" in self.name:
 
             def _(loops: int):
                 for _ in range(loops):
+                    metricnamespace = MetricNamespace()
                     for _ in range(100):
                         add_metric(metricnamespace, "metric")
         elif "increment-100-" in self.name:
 
             def _(loops: int):
                 for _ in range(loops):
+                    metricnamespace = MetricNamespace()
                     for i in range(100):
                         for _ in range(100):
                             add_metric(metricnamespace, str(i))

--- a/benchmarks/telemetry_add_metric/scenario.py
+++ b/benchmarks/telemetry_add_metric/scenario.py
@@ -1,8 +1,53 @@
+import re
+
 from bm import Scenario
 
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.internal.telemetry.metrics import CountMetric
+from ddtrace.internal.telemetry.metrics import GaugeMetric
+from ddtrace.internal.telemetry.metrics import DistributionMetric
+from ddtrace.internal.telemetry.metrics import RateMetric
 from ddtrace.internal.telemetry.metrics_namespaces import MetricNamespace
+
+
+def add_count_metric(namespace: MetricNamespace, name: str):
+    namespace.add_metric(
+        CountMetric,
+        TELEMETRY_NAMESPACE.TRACERS,
+        name,
+        10,
+        tags=(("integration_name", "somevalue"),),
+    )
+
+
+def add_gauge_metric(namespace: MetricNamespace, name: str):
+    namespace.add_metric(
+        GaugeMetric,
+        TELEMETRY_NAMESPACE.TRACERS,
+        name,
+        10,
+        tags=(("integration_name", "somevalue"),),
+    )
+
+
+def add_distribution_metric(namespace: MetricNamespace, name: str):
+    namespace.add_metric(
+        DistributionMetric,
+        TELEMETRY_NAMESPACE.TRACERS,
+        name,
+        10,
+        tags=(("integration_name", "somevalue"),),
+    )
+
+
+def add_rate_metric(namespace: MetricNamespace, name: str):
+    namespace.add_metric(
+        RateMetric,
+        TELEMETRY_NAMESPACE.TRACERS,
+        name,
+        10,
+        tags=(("integration_name", "somevalue"),),
+    )
 
 
 class TelemetryAddMetric(Scenario):
@@ -10,27 +55,46 @@ class TelemetryAddMetric(Scenario):
     This scenario checks to see if there's an impact on sending metrics via instrumentation telemetry
     """
 
-    runs: int
-    flush: bool
-    batches: int
-
     def run(self):
-        def _(loops):
-            for _ in range(loops):
-                # Start the test when MetricNamespace is created
-                metricnamespace = MetricNamespace()
-                for i in range(self.runs):
-                    for j in range(self.batches):
-                        metricnamespace.add_metric(
-                            CountMetric,
-                            TELEMETRY_NAMESPACE.TRACERS,
-                            str(j),
-                            10,
-                            tags=(("integration_name", "somevalue"),),
-                        )
+        metricnamespace = MetricNamespace()
 
-                # Make flush optional
-                if self.flush:
-                    metricnamespace.flush()
+        add_metric = None
+        if "count-metric" in self.name:
+            add_metric = add_count_metric
+        elif "gauge-metric" in self.name:
+            add_metric = add_gauge_metric
+        elif "distribution-metric" in self.name:
+            add_metric = add_distribution_metric
+        elif "rate-metric" in self.name:
+            add_metric = add_rate_metric
+        else:
+            raise ValueError(f"Unknown scenario: {self.name}")
+
+        if "create-1-" in self.name:
+
+            def _(loops: int):
+                for _ in range(loops):
+                    add_metric(metricnamespace, "metric")
+        elif "create-100-" in self.name:
+
+            def _(loops: int):
+                for _ in range(loops):
+                    for i in range(100):
+                        add_metric(metricnamespace, str(i))
+        elif "increment-1-" in self.name:
+
+            def _(loops: int):
+                for _ in range(loops):
+                    for _ in range(100):
+                        add_metric(metricnamespace, "metric")
+        elif "increment-100-" in self.name:
+
+            def _(loops: int):
+                for _ in range(loops):
+                    for i in range(100):
+                        for _ in range(100):
+                            add_metric(metricnamespace, str(i))
+        else:
+            raise ValueError(f"Unknown scenario: {self.name}")
 
         yield _

--- a/benchmarks/telemetry_add_metric/scenario.py
+++ b/benchmarks/telemetry_add_metric/scenario.py
@@ -1,11 +1,9 @@
-import re
-
 from bm import Scenario
 
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.internal.telemetry.metrics import CountMetric
-from ddtrace.internal.telemetry.metrics import GaugeMetric
 from ddtrace.internal.telemetry.metrics import DistributionMetric
+from ddtrace.internal.telemetry.metrics import GaugeMetric
 from ddtrace.internal.telemetry.metrics import RateMetric
 from ddtrace.internal.telemetry.metrics_namespaces import MetricNamespace
 
@@ -74,6 +72,7 @@ class TelemetryAddMetric(Scenario):
                 for _ in range(loops):
                     metricnamespace = MetricNamespace()
                     add_metric(metricnamespace, "metric")
+
         elif "create-100-" in self.name:
 
             def _(loops: int):
@@ -81,6 +80,7 @@ class TelemetryAddMetric(Scenario):
                     metricnamespace = MetricNamespace()
                     for i in range(100):
                         add_metric(metricnamespace, str(i))
+
         elif "increment-1-" in self.name:
 
             def _(loops: int):
@@ -88,6 +88,7 @@ class TelemetryAddMetric(Scenario):
                     metricnamespace = MetricNamespace()
                     for _ in range(100):
                         add_metric(metricnamespace, "metric")
+
         elif "increment-100-" in self.name:
 
             def _(loops: int):
@@ -96,6 +97,7 @@ class TelemetryAddMetric(Scenario):
                     for i in range(100):
                         for _ in range(100):
                             add_metric(metricnamespace, str(i))
+
         else:
             raise ValueError(f"Unknown scenario: {self.name}")
 


### PR DESCRIPTION
@wantsui and I were noticing the previous scenario was showing a much higher overhead than what we were getting locally. This may have just been how we wrote the benchmark and were extrapolating data from it.

This PR changes the benchmarking approach for telemetry metrics.

We now have the following scenarios for all metric types:

- Creating 1 unique metric
  - Test to create a single metric in an empty `MetricNamespace`
- Creating 100 unique metrics
  - Test to create a 100 unique metrics in an empty `MetricNamespace` 
- Increment 1 unique metric 100 times
  - Test to add metrics 100 times for 1 unique metric
- Incrementing 100 unique metrics 100 times
  - Test to add metrics 100 times for each of 100 unique metrics

Tests exist for Count, Gauge, Rate, and Distribution metrics.


We have to create a new `MetricNamespace` for each loop to ensure we are doing what the tests says, e.g. "create one new metric that doesn't already exist", since the cost to increment an existing metric may be different from setting a new one.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
