### PR TITLE
chore(ci_visibility): change CODEOWNERS for internal Test Optimization contribs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,6 +57,10 @@ ddtrace/contrib/pytest                                @DataDog/ci-app-libraries
 ddtrace/contrib/pytest_bdd                            @DataDog/ci-app-libraries
 ddtrace/contrib/pytest_benchmark                      @DataDog/ci-app-libraries
 ddtrace/contrib/unittest                              @DataDog/ci-app-libraries
+ddtrace/contrib/internal/pytest                       @DataDog/ci-app-libraries
+ddtrace/contrib/internal/pytest_bdd                   @DataDog/ci-app-libraries
+ddtrace/contrib/internal/pytest_benchmark             @DataDog/ci-app-libraries
+ddtrace/contrib/internal/unittest                     @DataDog/ci-app-libraries
 tests/contrib/asynctest                               @DataDog/ci-app-libraries
 tests/contrib/pytest                                  @DataDog/ci-app-libraries
 tests/contrib/pytest_bdd                              @DataDog/ci-app-libraries


### PR DESCRIPTION
A bunch of modules for CI Visibility a.k.a. Test Visibility a.k.a. Test Optimization contribs were moved to `contrib/internal`, but the CODEOWNERS were not changed accordingly. This PR changes that.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
