### PR TITLE
ci(iast): update hatch iast envs configuration [backport 3.1]

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -303,11 +303,17 @@ dependencies = [
     "mysqlclient==2.1.1",
 ]
 
+[envs.appsec_iast_default.env-vars]
+_DD_IAST_PATCH_MODULES = "benchmarks.,tests.appsec."
+DD_IAST_REQUEST_SAMPLING = "100"
+DD_IAST_DEDUPLICATION_ENABLED = "false"
+
+
 [envs.appsec_iast_default.scripts]
 test = [
     "uname -a",
     "pip freeze",
-    "DD_IAST_REQUEST_SAMPLING=100 DD_IAST_DEDUPLICATION_ENABLED=false python -m pytest {args:tests/appsec/iast/}",
+    "python -m pytest {args:tests/appsec/iast/}",
 ]
 
 [[envs.appsec_iast_default.matrix]]
@@ -329,6 +335,11 @@ dependencies = [
     "pytest-memray"
 ]
 
+[envs.appsec_iast_memcheck.env-vars]
+_DD_IAST_PATCH_MODULES = "benchmarks.,tests.appsec."
+DD_IAST_REQUEST_SAMPLING = "100"
+DD_IAST_DEDUPLICATION_ENABLED = "false"
+
 [envs.appsec_iast_memcheck.scripts]
 test = [
     "uname -a",
@@ -348,6 +359,11 @@ dependencies = [
     "pybind11",
     "clang"
 ]
+
+[envs.appsec_iast_native.env-vars]
+_DD_IAST_PATCH_MODULES = "benchmarks.,tests.appsec."
+DD_IAST_REQUEST_SAMPLING = "100"
+DD_IAST_DEDUPLICATION_ENABLED = "false"
 
 [envs.appsec_iast_native.scripts]
 test = [
@@ -373,15 +389,54 @@ dependencies = [
     "virtualenv-clone"
 ]
 
+[envs.appsec_iast_packages.env-vars]
+_DD_IAST_PATCH_MODULES = "benchmarks.,tests.appsec."
+DD_IAST_REQUEST_SAMPLING = "100"
+DD_IAST_DEDUPLICATION_ENABLED = "false"
+
 [envs.appsec_iast_packages.scripts]
 test = [
     "uname -a",
     "pip freeze",
-    "DD_CIVISIBILITY_ITR_ENABLED=0 DD_IAST_REQUEST_SAMPLING=100 DD_IAST_DEDUPLICATION_ENABLED=false python -m pytest tests/appsec/iast_packages",
+    "python -m pytest tests/appsec/iast_packages",
 ]
 
 [[envs.appsec_iast_packages.matrix]]
 python = ["3.9", "3.10", "3.11", "3.12"]
+
+## ASM iast_tdd_propagation
+
+[envs.iast_tdd_propagation]
+template = "iast_tdd_propagation"
+dependencies = [
+    "pytest",
+    "pytest-cov",
+    "requests",
+    "hypothesis",
+    "flask",
+    "pycryptodome",
+    "sqlalchemy~=2.0.23",
+    "pony",
+    "aiosqlite",
+    "tortoise-orm",
+    "peewee",
+    "aiosqlite",
+]
+
+[envs.iast_tdd_propagation.env-vars]
+_DD_IAST_PATCH_MODULES = "benchmarks.,tests.appsec."
+DD_IAST_REQUEST_SAMPLING = "100"
+DD_IAST_DEDUPLICATION_ENABLED = "false"
+
+[envs.iast_tdd_propagation.scripts]
+test = [
+    "uname -a",
+    "pip freeze",
+    "python -m pytest tests/appsec/iast_tdd_propagation",
+]
+
+[[envs.iast_tdd_propagation.matrix]]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 ## ASM appsec_integrations_django
 
@@ -398,11 +453,18 @@ dependencies = [
     "Django{matrix:django}",
 ]
 
+[envs.appsec_integrations_django.env-vars]
+DD_TRACE_AGENT_URL = "http://testagent:9126"
+_DD_IAST_PATCH_MODULES = "benchmarks.,tests.appsec."
+DD_IAST_REQUEST_SAMPLING = "100"
+DD_IAST_DEDUPLICATION_ENABLED = "false"
+
+
 [envs.appsec_integrations_django.scripts]
 test = [
     "uname -a",
     "pip freeze",
-    "DD_TRACE_AGENT_URL=\"http://testagent:9126\" DD_CIVISIBILITY_ITR_ENABLED=0 DD_IAST_REQUEST_SAMPLING=100 DD_IAST_DEDUPLICATION_ENABLED=false python -m pytest -vvv {args:tests/appsec/integrations/django_tests/}",
+    "python -m pytest -vvv {args:tests/appsec/integrations/django_tests/}",
 ]
 
 [[envs.appsec_integrations_django.matrix]]
@@ -430,11 +492,17 @@ dependencies = [
     "flask{matrix:flask}",
 ]
 
+[envs.appsec_integrations_flask.env-vars]
+DD_TRACE_AGENT_URL = "http://testagent:9126"
+_DD_IAST_PATCH_MODULES = "benchmarks.,tests.appsec."
+DD_IAST_REQUEST_SAMPLING = "100"
+DD_IAST_DEDUPLICATION_ENABLED = "false"
+
 [envs.appsec_integrations_flask.scripts]
 test = [
     "uname -a",
     "pip freeze",
-    "DD_TRACE_AGENT_URL=\"http://testagent:9126\" DD_CIVISIBILITY_ITR_ENABLED=0 DD_IAST_ENABLED=true DD_IAST_REQUEST_SAMPLING=100 DD_IAST_DEDUPLICATION_ENABLED=false python -m pytest -vvv {args:tests/appsec/integrations/flask_tests/}",
+    "python -m pytest -vvv {args:tests/appsec/integrations/flask_tests/}",
 ]
 
 [[envs.appsec_integrations_flask.matrix]]
@@ -482,13 +550,16 @@ dependencies = [
 ]
 
 [envs.appsec_integrations_fastapi.env-vars]
-CMAKE_BUILD_PARALLEL_LEVEL = "12"
+DD_TRACE_AGENT_URL = "http://testagent:9126"
+_DD_IAST_PATCH_MODULES = "benchmarks.,tests.appsec."
+DD_IAST_REQUEST_SAMPLING = "100"
+DD_IAST_DEDUPLICATION_ENABLED = "false"
 
 [envs.appsec_integrations_fastapi.scripts]
 test = [
     "uname -a",
     "pip freeze",
-    "DD_TRACE_AGENT_URL=\"http://testagent:9126\" DD_CIVISIBILITY_ITR_ENABLED=0 DD_IAST_REQUEST_SAMPLING=100 DD_IAST_DEDUPLICATION_ENABLED=false python -m pytest -vvv {args:tests/appsec/integrations/fastapi_tests/}",
+    "python -m pytest -vvv {args:tests/appsec/integrations/fastapi_tests/}",
 ]
 
 
@@ -506,7 +577,6 @@ fastapi = ["==0.94.1"]
 [[envs.appsec_integrations_fastapi.matrix]]
 python = ["3.8", "3.10", "3.13"]
 fastapi = ["~=0.114.2"]
-
 
 ## ASM FastAPI
 
@@ -569,7 +639,8 @@ dependencies = [
 CMAKE_BUILD_PARALLEL_LEVEL = "12"
 CARGO_BUILD_JOBS = "12"
 DD_IAST_ENABLED = "true"
-_DD_IAST_PATCH_MODULES = "scripts.iast"
+_DD_IAST_PATCH_MODULES = "benchmarks.,tests.appsec.,scripts.iast."
+DD_FAST_BUILD = "0"
 
 [envs.iast_aggregated_leak_testing.scripts]
 test = [
@@ -581,8 +652,6 @@ test = [
 
 [[envs.iast_aggregated_leak_testing.matrix]]
 python = ["3.10", "3.11", "3.12"]
-
-
 
 ## pytorch profiling test
 


### PR DESCRIPTION
Backport 170e126a05adf37c7a6d3139a62ca8c695296a3c from #12740 to 3.2.

Removed environment variables from Python commands in `envs.[scenario].scripts` and moved them to `[envs.[scenario].env-vars]`. This improves command readability. Additionally, the internal variable `_DD_IAST_PATCH_MODULES` has been included to prevent potential conflicts observed in other refactors, such as #12639.

This PR is a cherry-pick of one of the commits of this PR https://github.com/DataDog/dd-trace-py/pull/12639
## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
