### PR TITLE
chore(iast): refactor open/read wrapping

### DIFF
--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -45,14 +45,7 @@ def patch_common_modules():
 
     try_wrap_function_wrapper("builtins", "open", wrapped_open_CFDDB7ABBA9081B6)
     try_wrap_function_wrapper("urllib.request", "OpenerDirector.open", wrapped_open_ED4CF71136E15EBF)
-    try_wrap_function_wrapper("_io", "BytesIO.read", wrapped_read_F3E51D71B4EC16EF)
-    try_wrap_function_wrapper("_io", "StringIO.read", wrapped_read_F3E51D71B4EC16EF)
     core.on("asm.block.dbapi.execute", execute_4C9BAC8E228EB347)
-    if asm_config._iast_enabled:
-        from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
-        from ddtrace.appsec._iast.constants import VULN_PATH_TRAVERSAL
-
-        _set_metric_iast_instrumented_sink(VULN_PATH_TRAVERSAL)
     _is_patched = True
 
 
@@ -69,29 +62,6 @@ def unpatch_common_modules():
     _is_patched = False
 
 
-def wrapped_read_F3E51D71B4EC16EF(original_read_callable, instance, args, kwargs):
-    """
-    wrapper for _io.BytesIO and _io.StringIO read function
-    """
-    result = original_read_callable(*args, **kwargs)
-    if asm_config._iast_enabled and asm_config.is_iast_request_enabled:
-        from ddtrace.appsec._iast._taint_tracking import OriginType
-        from ddtrace.appsec._iast._taint_tracking import Source
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
-
-        ranges = get_tainted_ranges(instance)
-        if len(ranges) > 0:
-            source = ranges[0].source if ranges[0].source else Source(name="_io", value=result, origin=OriginType.EMPTY)
-            result = taint_pyobject(
-                pyobject=result,
-                source_name=source.name,
-                source_value=source.value,
-                source_origin=source.origin,
-            )
-    return result
-
-
 def _must_block(actions: Iterable[str]) -> bool:
     return any(action in (WAF_ACTIONS.BLOCK_ACTION, WAF_ACTIONS.REDIRECT_ACTION) for action in actions)
 
@@ -100,15 +70,6 @@ def wrapped_open_CFDDB7ABBA9081B6(original_open_callable, instance, args, kwargs
     """
     wrapper for open file function
     """
-    if asm_config._iast_enabled and asm_config.is_iast_request_enabled:
-        try:
-            from ddtrace.appsec._iast.taint_sinks.path_traversal import check_and_report_path_traversal
-
-            check_and_report_path_traversal(*args, **kwargs)
-        except ImportError:
-            # open is used during module initialization
-            # and shouldn't be changed at that time
-            return original_open_callable(*args, **kwargs)
     if (
         asm_config._asm_enabled
         and asm_config._ep_enabled

--- a/ddtrace/appsec/_iast/_ast/visitor.py
+++ b/ddtrace/appsec/_iast/_ast/visitor.py
@@ -15,6 +15,7 @@ from typing import Tuple  # noqa:F401
 from ..._constants import IAST
 from .._metrics import _set_metric_iast_instrumented_propagation
 from ..constants import DEFAULT_PATH_TRAVERSAL_FUNCTIONS
+from ..constants import DEFAULT_SOURCE_IO_FUNCTIONS
 from ..constants import DEFAULT_WEAK_RANDOMNESS_FUNCTIONS
 
 
@@ -29,6 +30,7 @@ CODE_TYPE_DD = "datadog"
 CODE_TYPE_SITE_PACKAGES = "site_packages"
 CODE_TYPE_STDLIB = "stdlib"
 TAINT_SINK_FUNCTION_REPLACEMENT = _PREFIX + "taint_sinks.ast_function"
+SOURCES_FUNCTION_REPLACEMENT = _PREFIX + "sources.ast_function"
 
 
 def _mark_avoid_convert_recursively(node):
@@ -132,14 +134,6 @@ _ASPECTS_SPEC: Dict[Text, Any] = {
     "taint_sinks": {
         "weak_randomness": DEFAULT_WEAK_RANDOMNESS_FUNCTIONS,
         "path_traversal": DEFAULT_PATH_TRAVERSAL_FUNCTIONS,
-        "other": {
-            "load",
-            "run",
-            "path",
-            "exit",
-            "sleep",
-            "socket",
-        },
         # These explicitly WON'T be replaced by taint_sink_function:
         "disabled": {
             "__new__",
@@ -149,6 +143,7 @@ _ASPECTS_SPEC: Dict[Text, Any] = {
             "super",
         },
     },
+    "sources": {"io": DEFAULT_SOURCE_IO_FUNCTIONS, "disabled": {}},
 }
 
 
@@ -168,9 +163,11 @@ class AstVisitor(ast.NodeTransformer):
         self._sinkpoints_spec = {
             "definitions_module": "ddtrace.appsec._iast.taint_sinks",
             "alias_module": _PREFIX + "taint_sinks",
-            "functions": {},
         }
-        self._sinkpoints_functions = self._sinkpoints_spec["functions"]
+        self._source_spec = {
+            "definitions_module": "ddtrace.appsec._iast.sources",
+            "alias_module": _PREFIX + "sources",
+        }
 
         self._aspect_index = _ASPECTS_SPEC["slices"]["index"]
         self._aspect_slice = _ASPECTS_SPEC["slices"]["slice"]
@@ -182,11 +179,14 @@ class AstVisitor(ast.NodeTransformer):
         self._aspect_build_string = _ASPECTS_SPEC["operators"]["BUILD_STRING"]
 
         # Sink points
-        self._taint_sink_replace_any = self._merge_taint_sinks(
-            _ASPECTS_SPEC["taint_sinks"]["other"],
+        self._taint_sink_replace_any = self._merge_dicts(
             _ASPECTS_SPEC["taint_sinks"]["weak_randomness"],
             *[functions for module, functions in _ASPECTS_SPEC["taint_sinks"]["path_traversal"].items()],
         )
+        self._source_replace_any = self._merge_dicts(
+            *[functions for module, functions in _ASPECTS_SPEC["sources"]["io"].items()],
+        )
+
         self._taint_sink_replace_disabled = _ASPECTS_SPEC["taint_sinks"]["disabled"]
 
         self.update_location(filename, module_name)
@@ -219,7 +219,7 @@ class AstVisitor(ast.NodeTransformer):
             self.codetype = CODE_TYPE_STDLIB
 
     @staticmethod
-    def _merge_taint_sinks(*args_functions: Set[str]) -> Set[str]:
+    def _merge_dicts(*args_functions: Set[str]) -> Set[str]:
         merged_set = set()
 
         for functions in args_functions:
@@ -283,6 +283,11 @@ class AstVisitor(ast.NodeTransformer):
             return False
 
         return function_name in self._taint_sink_replace_any
+
+    def _should_replace_with_source(self, call_node: ast.Call, is_function: bool) -> bool:
+        function_name = self._get_function_name(call_node, is_function)
+
+        return function_name in self._source_replace_any
 
     def _add_original_function_as_arg(self, call_node: ast.Call, is_function: bool) -> Any:
         """
@@ -452,6 +457,21 @@ class AstVisitor(ast.NodeTransformer):
             ],
         )
         module_node.body.insert(insert_position, replacements_import)
+
+        definitions_module = self._source_spec["definitions_module"]
+        replacements_import = self._node(
+            ast.Import,
+            module_node,
+            names=[
+                ast.alias(
+                    lineno=1,
+                    col_offset=0,
+                    name=definitions_module,
+                    asname=self._source_spec["alias_module"],
+                )
+            ],
+        )
+        module_node.body.insert(insert_position, replacements_import)
         # Must be called here instead of the start so the line offset is already
         # processed
         self.generic_visit(module_node)
@@ -519,11 +539,7 @@ class AstVisitor(ast.NodeTransformer):
                 # Substitute function call
                 call_node.func = self._attr_node(call_node, aspect)
                 self.ast_modified = call_modified = True
-            else:
-                sink_point = self._sinkpoints_functions.get(func_name_node)
-                if sink_point:
-                    call_node.func = self._attr_node(call_node, sink_point)
-                    self.ast_modified = call_modified = True
+
         # Call [attr] -> Attribute [value]-> Attribute [value]-> Attribute
         # a.b.c.method()
         # replaced_method(a.b.c)
@@ -593,6 +609,14 @@ class AstVisitor(ast.NodeTransformer):
                     # Create a new Name node for the replacement and set it as node.func
                     call_node.func = self._attr_node(call_node, aspect)
                     self.ast_modified = call_modified = True
+                else:
+                    aspect = self._should_replace_with_source(call_node, False)
+                    if aspect:
+                        # Send 0 as flag_added_args value
+                        call_node.args.insert(0, self._int_constant(call_node, 0))
+                        call_node.args = self._add_original_function_as_arg(call_node, False)
+                        call_node.func = self._attr_node(call_node, SOURCES_FUNCTION_REPLACEMENT)
+                        self.ast_modified = call_modified = True
 
         if self.codetype == CODE_TYPE_FIRST_PARTY:
             # Function replacement case

--- a/ddtrace/appsec/_iast/constants.py
+++ b/ddtrace/appsec/_iast/constants.py
@@ -65,6 +65,7 @@ DEFAULT_WEAK_RANDOMNESS_FUNCTIONS = {
 
 DEFAULT_PATH_TRAVERSAL_FUNCTIONS = {
     "_io": {"open"},
+    "io": {"open"},
     "glob": {"glob"},
     "os": {
         "mkdir",

--- a/ddtrace/appsec/_iast/constants.py
+++ b/ddtrace/appsec/_iast/constants.py
@@ -64,6 +64,7 @@ DEFAULT_WEAK_RANDOMNESS_FUNCTIONS = {
 }
 
 DEFAULT_PATH_TRAVERSAL_FUNCTIONS = {
+    "_io": {"open"},
     "glob": {"glob"},
     "os": {
         "mkdir",
@@ -97,3 +98,7 @@ DBAPI_MYSQLDB = "mysqldb"
 DBAPI_PYMYSQL = "pymysql"
 DBAPI_MARIADB = "mariadb"
 DBAPI_INTEGRATIONS = (DBAPI_SQLITE, DBAPI_PSYCOPG, DBAPI_MYSQL, DBAPI_MYSQLDB, DBAPI_MARIADB, DBAPI_PYMYSQL)
+
+DEFAULT_SOURCE_IO_FUNCTIONS = {
+    "_io": {"read"},
+}

--- a/ddtrace/appsec/_iast/sources/__init__.py
+++ b/ddtrace/appsec/_iast/sources/__init__.py
@@ -1,0 +1,6 @@
+from .ast_taint import ast_function
+
+
+__all__ = [
+    "ast_function",
+]

--- a/ddtrace/appsec/_iast/sources/ast_taint.py
+++ b/ddtrace/appsec/_iast/sources/ast_taint.py
@@ -1,12 +1,15 @@
 from typing import Any
 from typing import Callable
 
+from ddtrace.appsec._iast._taint_tracking import OriginType
+from ddtrace.appsec._iast._taint_tracking import Source
+from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.settings.asm import config as asm_config
 
 from ..constants import DEFAULT_SOURCE_IO_FUNCTIONS
 
 
-# TODO: we also need a native version of this function!
 def ast_function(
     func: Callable,
     flag_added_args: Any,
@@ -16,7 +19,6 @@ def ast_function(
     instance = getattr(func, "__self__", None)
     func_name = getattr(func, "__name__", None)
     cls_name = ""
-
     if instance is not None and func_name:
         try:
             cls_name = instance.__class__.__name__
@@ -34,11 +36,6 @@ def ast_function(
         and func_name in DEFAULT_SOURCE_IO_FUNCTIONS[module_name]
     ):
         if asm_config._iast_enabled and asm_config.is_iast_request_enabled:
-            from ddtrace.appsec._iast._taint_tracking import OriginType
-            from ddtrace.appsec._iast._taint_tracking import Source
-            from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
-            from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
-
             ranges = get_tainted_ranges(instance)
             if len(ranges) > 0:
                 source = (

--- a/ddtrace/appsec/_iast/sources/ast_taint.py
+++ b/ddtrace/appsec/_iast/sources/ast_taint.py
@@ -1,0 +1,53 @@
+from typing import Any
+from typing import Callable
+
+from ddtrace.settings.asm import config as asm_config
+
+from ..constants import DEFAULT_SOURCE_IO_FUNCTIONS
+
+
+# TODO: we also need a native version of this function!
+def ast_function(
+    func: Callable,
+    flag_added_args: Any,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    instance = getattr(func, "__self__", None)
+    func_name = getattr(func, "__name__", None)
+    cls_name = ""
+
+    if instance is not None and func_name:
+        try:
+            cls_name = instance.__class__.__name__
+        except AttributeError:
+            pass
+
+    if flag_added_args > 0:
+        args = args[flag_added_args:]
+
+    module_name = instance.__class__.__module__
+    result = func(*args, **kwargs)
+    if (
+        module_name == "_io"
+        and cls_name in ("BytesIO", "StringIO")
+        and func_name in DEFAULT_SOURCE_IO_FUNCTIONS[module_name]
+    ):
+        if asm_config._iast_enabled and asm_config.is_iast_request_enabled:
+            from ddtrace.appsec._iast._taint_tracking import OriginType
+            from ddtrace.appsec._iast._taint_tracking import Source
+            from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+            from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+
+            ranges = get_tainted_ranges(instance)
+            if len(ranges) > 0:
+                source = (
+                    ranges[0].source if ranges[0].source else Source(name="_io", value=result, origin=OriginType.EMPTY)
+                )
+                result = taint_pyobject(
+                    pyobject=result,
+                    source_name=source.name,
+                    source_value=source.value,
+                    source_origin=source.origin,
+                )
+    return result

--- a/ddtrace/appsec/_iast/taint_sinks/ast_taint.py
+++ b/ddtrace/appsec/_iast/taint_sinks/ast_taint.py
@@ -1,6 +1,8 @@
 from typing import Any
 from typing import Callable
 
+from ddtrace.settings.asm import config as asm_config
+
 from ..._constants import IAST_SPAN_TAGS
 from .._metrics import _set_metric_iast_executed_sink
 from .._metrics import increment_iast_span_metric
@@ -34,10 +36,11 @@ def ast_function(
         and cls_name == "Random"
         and func_name in DEFAULT_WEAK_RANDOMNESS_FUNCTIONS
     ):
-        # Weak, run the analyzer
-        increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, WeakRandomness.vulnerability_type)
-        _set_metric_iast_executed_sink(WeakRandomness.vulnerability_type)
-        WeakRandomness.report(evidence_value=cls_name + "." + func_name)
+        if asm_config._iast_enabled and asm_config.is_iast_request_enabled:
+            # Weak, run the analyzer
+            increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, WeakRandomness.vulnerability_type)
+            _set_metric_iast_executed_sink(WeakRandomness.vulnerability_type)
+            WeakRandomness.report(evidence_value=cls_name + "." + func_name)
     elif hasattr(func, "__module__") and DEFAULT_PATH_TRAVERSAL_FUNCTIONS.get(func.__module__):
         if func_name in DEFAULT_PATH_TRAVERSAL_FUNCTIONS[func.__module__]:
             check_and_report_path_traversal(*args, **kwargs)

--- a/ddtrace/appsec/_iast/taint_sinks/path_traversal.py
+++ b/ddtrace/appsec/_iast/taint_sinks/path_traversal.py
@@ -3,6 +3,7 @@ from typing import Any
 from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.appsec._iast import oce
 from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
+from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
 from ddtrace.appsec._iast._metrics import increment_iast_span_metric
 from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast.constants import VULN_PATH_TRAVERSAL
@@ -20,7 +21,15 @@ class PathTraversal(VulnerabilityBase):
     vulnerability_type = VULN_PATH_TRAVERSAL
 
 
+IS_REPORTED_INTRUMENTED_SINK = False
+
+
 def check_and_report_path_traversal(*args: Any, **kwargs: Any) -> None:
+    global IS_REPORTED_INTRUMENTED_SINK
+    if not IS_REPORTED_INTRUMENTED_SINK:
+        _set_metric_iast_instrumented_sink(VULN_PATH_TRAVERSAL)
+        IS_REPORTED_INTRUMENTED_SINK = True
+
     if asm_config.is_iast_request_enabled and PathTraversal.has_quota():
         filename_arg = args[0] if args else kwargs.get("file", None)
         if is_pyobject_tainted(filename_arg):

--- a/ddtrace/appsec/_iast/taint_sinks/path_traversal.py
+++ b/ddtrace/appsec/_iast/taint_sinks/path_traversal.py
@@ -21,10 +21,9 @@ class PathTraversal(VulnerabilityBase):
 
 
 def check_and_report_path_traversal(*args: Any, **kwargs: Any) -> None:
-    if asm_config._iast_enabled:
-        if asm_config.is_iast_request_enabled:
-            filename_arg = args[0] if args else kwargs.get("file", None)
-            if is_pyobject_tainted(filename_arg):
-                PathTraversal.report(evidence_value=filename_arg)
-        increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, PathTraversal.vulnerability_type)
-        _set_metric_iast_executed_sink(PathTraversal.vulnerability_type)
+    if asm_config.is_iast_request_enabled and PathTraversal.has_quota():
+        filename_arg = args[0] if args else kwargs.get("file", None)
+        if is_pyobject_tainted(filename_arg):
+            PathTraversal.report(evidence_value=filename_arg)
+    increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, PathTraversal.vulnerability_type)
+    _set_metric_iast_executed_sink(PathTraversal.vulnerability_type)

--- a/ddtrace/appsec/_iast/taint_sinks/path_traversal.py
+++ b/ddtrace/appsec/_iast/taint_sinks/path_traversal.py
@@ -21,18 +21,10 @@ class PathTraversal(VulnerabilityBase):
 
 
 def check_and_report_path_traversal(*args: Any, **kwargs: Any) -> None:
-    if asm_config.is_iast_request_enabled and PathTraversal.has_quota():
-        try:
-            increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, PathTraversal.vulnerability_type)
-            _set_metric_iast_executed_sink(PathTraversal.vulnerability_type)
+    if asm_config._iast_enabled:
+        if asm_config.is_iast_request_enabled:
             filename_arg = args[0] if args else kwargs.get("file", None)
             if is_pyobject_tainted(filename_arg):
                 PathTraversal.report(evidence_value=filename_arg)
-        except Exception:  # nosec
-            # FIXME: see below
-            # log.debug("Unexpected exception while reporting vulnerability", exc_info=True)
-            pass
-    # FIXME: this is commented out because logs can execute _open which can runs the check_and_report_path_traversal
-    # entering an infinite loop
-    # else:
-    #     log.debug("IAST: no vulnerability quota to analyze more sink points")
+        increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, PathTraversal.vulnerability_type)
+        _set_metric_iast_executed_sink(PathTraversal.vulnerability_type)

--- a/hatch.toml
+++ b/hatch.toml
@@ -306,7 +306,7 @@ DD_IAST_DEDUPLICATION_ENABLED = "false"
 test = [
     "uname -a",
     "pip freeze",
-    "python -m pytest {args:tests/appsec/iast/}",
+    "python -m pytest --no-ddtrace {args:tests/appsec/iast/}",
 ]
 
 [[envs.appsec_iast_default.matrix]]

--- a/tests/appsec/iast/_ast/test_ast_patching.py
+++ b/tests/appsec/iast/_ast/test_ast_patching.py
@@ -77,6 +77,7 @@ def test_astpatch_module_changed(module_name):
     assert ("", None) != (module_path, new_ast)
     new_code = astunparse.unparse(new_ast)
     assert new_code.startswith(
+        f"\nimport ddtrace.appsec._iast.sources as {_PREFIX}sources"
         f"\nimport ddtrace.appsec._iast.taint_sinks as {_PREFIX}taint_sinks"
         f"\nimport ddtrace.appsec._iast._taint_tracking.aspects as {_PREFIX}aspects"
     )
@@ -94,6 +95,7 @@ def test_astpatch_module_changed_add_operator(module_name):
     assert ("", None) != (module_path, new_ast)
     new_code = astunparse.unparse(new_ast)
     assert new_code.startswith(
+        f"\nimport ddtrace.appsec._iast.sources as {_PREFIX}sources"
         f"\nimport ddtrace.appsec._iast.taint_sinks as {_PREFIX}taint_sinks"
         f"\nimport ddtrace.appsec._iast._taint_tracking.aspects as {_PREFIX}aspects"
     )
@@ -111,6 +113,7 @@ def test_astpatch_module_changed_add_inplace_operator(module_name):
     assert ("", None) != (module_path, new_ast)
     new_code = astunparse.unparse(new_ast)
     assert new_code.startswith(
+        f"\nimport ddtrace.appsec._iast.sources as {_PREFIX}sources"
         f"\nimport ddtrace.appsec._iast.taint_sinks as {_PREFIX}taint_sinks"
         f"\nimport ddtrace.appsec._iast._taint_tracking.aspects as {_PREFIX}aspects"
     )
@@ -135,6 +138,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+import ddtrace.appsec._iast.sources as {_PREFIX}sources
 import ddtrace.appsec._iast.taint_sinks as {_PREFIX}taint_sinks
 import ddtrace.appsec._iast._taint_tracking.aspects as {_PREFIX}aspects
 import html"""
@@ -228,6 +232,7 @@ def test_astpatch_stringio_module_changed(module_name):
     assert ("", None) != (module_path, new_ast)
     new_code = astunparse.unparse(new_ast)
     assert new_code.startswith(
+        f"\nimport ddtrace.appsec._iast.sources as {_PREFIX}sources"
         f"\nimport ddtrace.appsec._iast.taint_sinks as {_PREFIX}taint_sinks"
         f"\nimport ddtrace.appsec._iast._taint_tracking.aspects as {_PREFIX}aspects"
     )
@@ -246,6 +251,7 @@ def test_astpatch_bytesio_module_changed(module_name):
     assert ("", None) != (module_path, new_ast)
     new_code = astunparse.unparse(new_ast)
     assert new_code.startswith(
+        f"\nimport ddtrace.appsec._iast.sources as {_PREFIX}sources"
         f"\nimport ddtrace.appsec._iast.taint_sinks as {_PREFIX}taint_sinks"
         f"\nimport ddtrace.appsec._iast._taint_tracking.aspects as {_PREFIX}aspects"
     )

--- a/tests/appsec/iast/fixtures/taint_sinks/path_traversal.py
+++ b/tests/appsec/iast/fixtures/taint_sinks/path_traversal.py
@@ -26,11 +26,15 @@ def pt_open(origin_string):
 
 
 def path__io_open(origin_string):
-    pt_open(origin_string)
+    # label path__io_open
+    m = open(origin_string)
+    return m.read()
 
 
 def path_io_open(origin_string):
-    pt_open(origin_string)
+    # label path_io_open
+    m = open(origin_string)
+    return m.read()
 
 
 def path_os_remove(origin_string):

--- a/tests/appsec/iast/fixtures/taint_sinks/path_traversal.py
+++ b/tests/appsec/iast/fixtures/taint_sinks/path_traversal.py
@@ -25,6 +25,14 @@ def pt_open(origin_string):
     return m.read()
 
 
+def path__io_open(origin_string):
+    pt_open(origin_string)
+
+
+def path_io_open(origin_string):
+    pt_open(origin_string)
+
+
 def path_os_remove(origin_string):
     try:
         # label path_os_remove

--- a/tests/appsec/iast/taint_sinks/test_command_injection.py
+++ b/tests/appsec/iast/taint_sinks/test_command_injection.py
@@ -12,6 +12,8 @@ from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect
 from ddtrace.appsec._iast.constants import VULN_CMDI
 from ddtrace.appsec._iast.taint_sinks.command_injection import patch
+from tests.appsec.iast.conftest import _end_iast_context_and_oce
+from tests.appsec.iast.conftest import _start_iast_context_and_oce
 from tests.appsec.iast.iast_utils import get_line_and_hash
 from tests.appsec.iast.taint_sinks.conftest import _get_iast_data
 
@@ -212,26 +214,29 @@ def test_string_cmdi(iast_context_defaults):
     assert len(list(data["vulnerabilities"])) == 1
 
 
-@pytest.mark.parametrize("num_vuln_expected", [1, 0, 0])
-def test_cmdi_deduplication(num_vuln_expected, iast_context_deduplication_enabled):
+def test_cmdi_deduplication(iast_context_deduplication_enabled):
     patch()
-    _BAD_DIR = "forbidden_dir/"
-    _BAD_DIR = taint_pyobject(
-        pyobject=_BAD_DIR,
-        source_name="test_ossystem",
-        source_value=_BAD_DIR,
-        source_origin=OriginType.PARAMETER,
-    )
-    assert is_pyobject_tainted(_BAD_DIR)
-    for _ in range(0, 5):
-        # label test_ossystem
-        os.system(add_aspect("dir -l ", _BAD_DIR))
+    _end_iast_context_and_oce()
+    for num_vuln_expected in [1, 0, 0]:
+        _start_iast_context_and_oce()
+        _BAD_DIR = "forbidden_dir/"
+        _BAD_DIR = taint_pyobject(
+            pyobject=_BAD_DIR,
+            source_name="test_ossystem",
+            source_value=_BAD_DIR,
+            source_origin=OriginType.PARAMETER,
+        )
+        assert is_pyobject_tainted(_BAD_DIR)
+        for _ in range(0, 5):
+            # label test_ossystem
+            os.system(add_aspect("dir -l ", _BAD_DIR))
 
-    span_report = get_iast_reporter()
+        span_report = get_iast_reporter()
 
-    if num_vuln_expected == 0:
-        assert span_report is None
-    else:
-        assert span_report
-        data = span_report.build_and_scrub_value_parts()
-        assert len(data["vulnerabilities"]) == num_vuln_expected
+        if num_vuln_expected == 0:
+            assert span_report is None
+        else:
+            assert span_report
+            data = span_report.build_and_scrub_value_parts()
+            assert len(data["vulnerabilities"]) == num_vuln_expected
+        _end_iast_context_and_oce()

--- a/tests/appsec/iast/test_telemetry.py
+++ b/tests/appsec/iast/test_telemetry.py
@@ -1,7 +1,5 @@
 import pytest
 
-from ddtrace.appsec._common_module_patches import patch_common_modules
-from ddtrace.appsec._common_module_patches import unpatch_common_modules
 from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.appsec._constants import TELEMETRY_DEBUG_VERBOSITY
 from ddtrace.appsec._constants import TELEMETRY_INFORMATION_NAME
@@ -18,7 +16,6 @@ from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast.constants import VULN_CMDI
 from ddtrace.appsec._iast.constants import VULN_CODE_INJECTION
 from ddtrace.appsec._iast.constants import VULN_HEADER_INJECTION
-from ddtrace.appsec._iast.constants import VULN_PATH_TRAVERSAL
 from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.appsec._iast.taint_sinks.code_injection import patch as code_injection_patch
 from ddtrace.appsec._iast.taint_sinks.code_injection import unpatch as code_injection_unpatch
@@ -103,15 +100,6 @@ def test_metric_instrumented_cmdi(no_request_sampling, telemetry_writer):
         cmdi_patch()
 
     _assert_instrumented_sink(telemetry_writer, VULN_CMDI)
-
-
-def test_metric_instrumented_path_traversal(no_request_sampling, telemetry_writer):
-    # We need to unpatch first because ddtrace.appsec._iast._patch_modules loads at runtime this patch function
-    unpatch_common_modules()
-    with override_global_config(dict(_iast_enabled=True, _iast_telemetry_report_lvl=TELEMETRY_INFORMATION_NAME)):
-        patch_common_modules()
-
-    _assert_instrumented_sink(telemetry_writer, VULN_PATH_TRAVERSAL)
 
 
 def test_metric_instrumented_header_injection(no_request_sampling, telemetry_writer):

--- a/tests/appsec/integrations/flask_tests/test_iast_flask_patching.py
+++ b/tests/appsec/integrations/flask_tests/test_iast_flask_patching.py
@@ -68,14 +68,8 @@ def test_flask_iast_ast_patching_re(style, endpoint, function):
 @pytest.mark.parametrize(
     "function",
     [
-        "bytesio",
-        "stringio",
         "bytesio-read",
         "stringio-read",
-        "bytesio-untainted",
-        "stringio-untainted",
-        "bytesio-read-untainted",
-        "stringio-read-untainted",
     ],
 )
 def test_flask_iast_ast_patching_io(style, function, endpoint="io"):


### PR DESCRIPTION
In this PR, we're migrating the way we propagate the `open` and `read` functions. Until now, we were using `wrapt`, but it's too invasive since these functions are used in many core operations. That's why we've migrated it to AST, ensuring that only the functions actually used in the application get replaced.  

To achieve this, we've added a new import in the AST visitor. In addition to aspects and sink points, we now define "sources" as well.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
