### PR TITLE
chore(ci_visibility): support attempt-to-fix v2 API

### DIFF
--- a/ddtrace/contrib/internal/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v2.py
@@ -269,7 +269,7 @@ def pytest_sessionstart(session: pytest.Session) -> None:
             test_impact_analysis="1" if _pytest_version_supports_itr() else None,
             test_management_quarantine="1",
             test_management_disable="1",
-            test_management_attempt_to_fix="1" if _pytest_version_supports_attempt_to_fix() else None,
+            test_management_attempt_to_fix="2" if _pytest_version_supports_attempt_to_fix() else None,
         )
 
         InternalTestSession.discover(

--- a/ddtrace/internal/ci_visibility/_api_client.py
+++ b/ddtrace/internal/ci_visibility/_api_client.py
@@ -587,6 +587,7 @@ class _TestVisibilityAPIClientBase(abc.ABC):
                 "type": "ci_app_libraries_tests_request",
                 "attributes": {
                     "repository_url": self._git_data.repository_url,
+                    "commit_message": self._git_data.commit_message,
                 },
             }
         }

--- a/ddtrace/internal/ci_visibility/git_data.py
+++ b/ddtrace/internal/ci_visibility/git_data.py
@@ -9,11 +9,13 @@ class GitData:
     repository_url: t.Optional[str]
     branch: t.Optional[str]
     commit_sha: t.Optional[str]
+    commit_message: t.Optional[str]
 
 
 def get_git_data_from_tags(tags: t.Dict[str, t.Any]) -> GitData:
     return GitData(
-        tags.get(ci.git.REPOSITORY_URL),
-        tags.get(ci.git.BRANCH),
-        tags.get(ci.git.COMMIT_SHA),
+        repository_url=tags.get(ci.git.REPOSITORY_URL),
+        branch=tags.get(ci.git.BRANCH),
+        commit_sha=tags.get(ci.git.COMMIT_SHA),
+        commit_message=tags.get(ci.git.COMMIT_MESSAGE),
     )

--- a/tests/ci_visibility/api_client/_util.py
+++ b/tests/ci_visibility/api_client/_util.py
@@ -159,7 +159,7 @@ class TestTestVisibilityAPIClientBase:
             # no-dd-sa:python-best-practices/no-silent-exception
             pass
 
-    default_git_data = GitData("my_repo_url", "some_branch", "mycommitshaaaaaaalalala")
+    default_git_data = GitData("my_repo_url", "some_branch", "mycommitshaaaaaaalalala", "some message")
 
     default_configurations = {
         "os.architecture": "arm64",

--- a/tests/ci_visibility/api_client/test_ci_visibility_api_client.py
+++ b/tests/ci_visibility/api_client/test_ci_visibility_api_client.py
@@ -117,9 +117,9 @@ class TestTestVisibilityAPIClient(TestTestVisibilityAPIClientBase):
     ]
 
     git_data_parameters = [
-        GitData("my_repo_url", "some_branch", "mycommitshaaaaaaalalala"),
-        GitData(None, "shalessbranch", None),
-        GitData("git@gitbob.com:myorg/myrepo.git", "shalessbranch", None),
+        GitData("my_repo_url", "some_branch", "mycommitshaaaaaaalalala", "some message"),
+        GitData(None, "shalessbranch", None, None),
+        GitData("git@gitbob.com:myorg/myrepo.git", "shalessbranch", None, None),
         None,
     ]
 
@@ -356,7 +356,7 @@ class TestTestVisibilityAPIClient(TestTestVisibilityAPIClientBase):
         if "dd_env" not in _expected_config:
             _expected_config["dd_env"] = "none"
 
-        git_data = GitData("git@github.com:TestDog/dd-test-py.git", "notmainbranch", "mytestcommitsha1234")
+        git_data = GitData("git@github.com:TestDog/dd-test-py.git", "notmainbranch", "mytestcommitsha1234", "message")
         with _ci_override_env(_env_vars, full_clear=True), _patch_env_for_testing():
             try:
                 expected_client = AgentlessTestVisibilityAPIClient(
@@ -415,7 +415,7 @@ class TestTestVisibilityAPIClient(TestTestVisibilityAPIClientBase):
         if "dd_service" not in _expected_config:
             _expected_config["dd_service"] = "dd-test-py"
 
-        git_data = GitData("git@github.com:TestDog/dd-test-py.git", "notmainbranch", "mytestcommitsha1234")
+        git_data = GitData("git@github.com:TestDog/dd-test-py.git", "notmainbranch", "mytestcommitsha1234", "message")
         with _ci_override_env(_env_vars, full_clear=True), _patch_env_for_testing(), mock.patch(
             "ddtrace.internal.ci_visibility.recorder.CIVisibility._agent_evp_proxy_is_available", return_value=True
         ), mock.patch("ddtrace.internal.agent.get_trace_url", return_value="http://shouldntbeused:6218"), mock.patch(
@@ -516,7 +516,7 @@ class TestTestVisibilityAPIClient(TestTestVisibilityAPIClientBase):
             "runtime.version": "1.2.3",
         }
 
-        git_data = GitData("git@github.com:TestDog/dd-test-py.git", "notmainbranch", "mytestcommitsha1234")
+        git_data = GitData("git@github.com:TestDog/dd-test-py.git", "notmainbranch", "mytestcommitsha1234", "message")
         with _ci_override_env(full_clear=True), _patch_env_for_testing(), mock.patch(
             "ddtrace.internal.ci_visibility.recorder.CIVisibility._agent_evp_proxy_is_available", return_value=True
         ), mock.patch("ddtrace.internal.agent.info", return_value=agent_info_response), mock.patch(

--- a/tests/ci_visibility/api_client/test_ci_visibility_api_client.py
+++ b/tests/ci_visibility/api_client/test_ci_visibility_api_client.py
@@ -43,6 +43,7 @@ def _patch_env_for_testing():
             "git.repository_url": "git@github.com:TestDog/dd-test-py.git",
             "git.commit.sha": "mytestcommitsha1234",
             "git.branch": "notmainbranch",
+            "git.commit.message": "message",
         },
     ), mock.patch(
         "ddtrace.internal.ci_visibility.recorder.CIVisibility._check_enabled_features",
@@ -117,7 +118,7 @@ class TestTestVisibilityAPIClient(TestTestVisibilityAPIClientBase):
     ]
 
     git_data_parameters = [
-        GitData("my_repo_url", "some_branch", "mycommitshaaaaaaalalala", "some message"),
+        GitData("my_repo_url", "some_branch", "mycommitshaaaaaaalalala", "message"),
         GitData(None, "shalessbranch", None, None),
         GitData("git@gitbob.com:myorg/myrepo.git", "shalessbranch", None, None),
         None,


### PR DESCRIPTION
For attempt-to-fix v2, we have to send the commit message as an argument to the test management endpoint.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
