### PR TITLE
chore(er): fix exception ID tag

### DIFF
--- a/ddtrace/debugging/_exception/replay.py
+++ b/ddtrace/debugging/_exception/replay.py
@@ -43,7 +43,7 @@ CAPTURE_TRACE_TAG = "_dd.debug.error.trace_captured"
 
 # unique exception id
 EXCEPTION_HASH_TAG = "_dd.debug.error.exception_hash"
-EXCEPTION_ID_TAG = "_dd.debug.error.exception_capture_id"
+EXCEPTION_ID_TAG = "_dd.debug.error.exception_id"
 
 # link to matching snapshot for every frame in the traceback
 FRAME_SNAPSHOT_ID_TAG = "_dd.debug.error.%d.snapshot_id"


### PR DESCRIPTION
We fix the name of the exception ID tag in Exception Replay to align with the latest version of the PR.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
