### PR TITLE
ci: disable VPA for child jobs of benchmarks (#12717) [backport 3.2]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,12 +48,19 @@ microbenchmarks:
   trigger:
     include: .gitlab/benchmarks/microbenchmarks.yml
     strategy: depend
+  variables:
+    PARENT_PIPELINE_ID: $CI_PIPELINE_ID
+    # Disable VPA for benchmarks
+    KUBERNETES_POD_ANNOTATIONS_1: vpa.datadoghq.com/updateMode=Off
 
 macrobenchmarks:
   stage: benchmarks
   needs: [ ]
   trigger:
     include: .gitlab/benchmarks/macrobenchmarks.yml
+  variables:
+    # Disable VPA for benchmarks
+    KUBERNETES_POD_ANNOTATIONS_1: vpa.datadoghq.com/updateMode=Off
   allow_failure: true
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,6 @@ microbenchmarks:
     include: .gitlab/benchmarks/microbenchmarks.yml
     strategy: depend
   variables:
-    PARENT_PIPELINE_ID: $CI_PIPELINE_ID
     # Disable VPA for benchmarks
     KUBERNETES_POD_ANNOTATIONS_1: vpa.datadoghq.com/updateMode=Off
 


### PR DESCRIPTION
backport #12717 to `3.2`

<details open><summary>

</summary>

Benchmark jobs were shifted out of the benchmark stage causing them to be affected by the VPA as the feature flag.

</details>

<details open><summary>

</summary>

Instead of relying on the stages to disable the flag, we can add the disable annotation variable on the trigger job so that it's inherited by the child jobs

</details>

<details><summary>

</summary>
</details>

- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

- [x] Reviewer has checked that all the criteria below are met
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

(cherry picked from commit caefec1844cdb0c4ed15727af8f1a742711bf0e2)