### PR TITLE
chore(llmobs): consolidate json dumping into writer enqueue time

### DIFF
--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -7,6 +7,7 @@ from typing import Optional
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.llmobs._constants import DECORATOR
+from ddtrace.llmobs._constants import DROPPED_IO_COLLECTION_ERROR
 from ddtrace.llmobs._constants import INTEGRATION
 from ddtrace.llmobs._constants import PARENT_ID_KEY
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
@@ -113,8 +114,9 @@ def record_span_event_raw_size(event: LLMObsSpanEvent, raw_event_size: int):
     )
 
 
-def record_span_event_size(event: LLMObsSpanEvent, event_size: int, truncated: bool):
+def record_span_event_size(event: LLMObsSpanEvent, event_size: int):
     tags = _get_tags_from_span_event(event)
+    truncated = DROPPED_IO_COLLECTION_ERROR in event.get("collection_errors", [])
     tags.append(("truncated", str(int(truncated))))
     telemetry_writer.add_distribution_metric(
         namespace=TELEMETRY_NAMESPACE.MLOBS, name=LLMObsTelemetryMetrics.SPAN_SIZE, value=event_size, tags=tuple(tags)


### PR DESCRIPTION
Although we've mostly consolidated when we perform JSON encoding we still have an unfortunate pattern of JSON dumping the same span event multiple times before actually submitting:

1. Once at writer.enqueue() time to check if we need to truncate said event
2. Once at writer.encoder.put() time to keep track of the buffer size increase
3. Lastly at writer.encoder.encode() time to actually encode the entire payload to flush


This is definitely not great, considering json encoding is a non-trivial overhead. One easy solution is to encode it once at 1) and just use the size of the encoded event instead of having to encode multiple times at 2) and 3).

The drawbacks are that now we are performing JSON encoding at writer enqueue time, which is not how the writer/encoder architecture was designed for, and we are stitching together the payload at encoder.encode() time as a string, which could potentially lead to ingestion/type errors.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
