### PR TITLE
chore: use guess-next-dev instead of release-branch-semver [3.3]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ Homepage = "https://github.com/DataDog/dd-trace-py"
 "Source Code" = "https://github.com/DataDog/dd-trace-py/"
 
 [tool.setuptools_scm]
-version_scheme = "release-branch-semver"  # Must be "release-branch-semver" for now in main, see https://github.com/DataDog/dd-trace-py/issues/8801
+version_scheme = "guess-next-dev"  # Must be "release-branch-semver" for now in main, see https://github.com/DataDog/dd-trace-py/issues/8801
 write_to = "ddtrace/_version.py"
 
 [tool.cython-lint]


### PR DESCRIPTION
This PR updates the `version_schema` in the `../pyproject.toml` file for the 3.3 release branch from `release-branch-semver` to `guess-next-dev`. This is to ensure that system tests work as intended with backports to this release branch.

IMPORTANT: This PR needs to be merged before the first backport is created for 3.3.Otherwise, system tests will not work as expected.