### PR TITLE
refactor: make imports in ddtrace/__init__.py lazy

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -1,62 +1,47 @@
-import sys
-import os
-
-
-LOADED_MODULES = frozenset(sys.modules.keys())
-
-
-# Ensure we capture references to unpatched modules as early as possible
-import ddtrace.internal._unpatched  # noqa
-from ._logger import configure_ddtrace_logger
-
-# configure ddtrace logger before other modules log
-configure_ddtrace_logger()  # noqa: E402
-
-from .settings._config import config
-
-
-# Enable telemetry writer and excepthook as early as possible to ensure we capture any exceptions from initialization
-import ddtrace.internal.telemetry  # noqa: E402
-
-from ._monkey import patch  # noqa: E402
-from ._monkey import patch_all  # noqa: E402
-from .internal.compat import PYTHON_VERSION_INFO  # noqa: E402
-from .internal.utils.deprecations import DDTraceDeprecationWarning  # noqa: E402
-
-from ddtrace.vendor import debtcollector
-from .version import get_version  # noqa: E402
-
-
-# TODO(mabdinur): Remove this once we have a better way to start the mini agent
-from ddtrace.internal.serverless.mini_agent import maybe_start_serverless_mini_agent as _start_mini_agent
-
-_start_mini_agent()
-
-__version__ = get_version()
-
-# TODO: Deprecate accessing tracer from ddtrace.__init__ module in v4.0
-if os.environ.get("_DD_GLOBAL_TRACER_INIT", "true").lower() in ("1", "true"):
-    from ddtrace.trace import tracer  # noqa: F401
-
 __all__ = [
     "patch",
     "patch_all",
     "config",
-    "DDTraceDeprecationWarning",
 ]
 
 
-def check_supported_python_version():
-    if PYTHON_VERSION_INFO < (3, 8):
-        deprecation_message = (
-            "Support for ddtrace with Python version %d.%d is deprecated and will be removed in 3.0.0."
-        )
-        if PYTHON_VERSION_INFO < (3, 7):
-            deprecation_message = "Support for ddtrace with Python version %d.%d was removed in 2.0.0."
-        debtcollector.deprecate(
-            (deprecation_message % (PYTHON_VERSION_INFO[0], PYTHON_VERSION_INFO[1])),
-            category=DDTraceDeprecationWarning,
-        )
+def __getattr__(name):
+    IMPORTS = {
+        "patch": "ddtrace._monkey",
+        "patch_all": "ddtrace._monkey",
+    }
 
+    if name in IMPORTS:
+        import importlib
 
-check_supported_python_version()
+        attr = getattr(importlib.import_module(IMPORTS[name]), name)
+
+    elif name == "__version__":
+        from ddtrace.version import get_version
+
+        attr = get_version()
+
+    elif name == "config":
+        from ddtrace.settings._config import Config as _Config
+
+        attr = _Config()
+
+    elif name == "tracer":
+        from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+        from ddtrace.trace import tracer
+        import ddtrace.vendor.debtcollector as debtcollector
+
+        msg = (
+            "Accessing `ddtrace.tracer` is deprecated and will be removed in version 4. "
+            "Use `ddtrace.trace.tracer` instead."
+        )
+        debtcollector.deprecate(msg, category=DDTraceDeprecationWarning)
+
+        attr = tracer
+
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    globals()[name] = attr
+
+    return attr

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -255,8 +255,8 @@ class Tracer(object):
             )
         self._single_span_sampling_rules: List[SpanSamplingRule] = get_span_sampling_rules()
         self._writer: TraceWriter = writer
-        self._partial_flush_enabled = config._partial_flush_enabled
-        self._partial_flush_min_spans = config._partial_flush_min_spans
+        self._partial_flush_enabled: bool = config._partial_flush_enabled
+        self._partial_flush_min_spans: int = config._partial_flush_min_spans
         # Direct link to the appsec processor
         self._endpoint_call_counter_span_processor = EndpointCallCounterProcessor()
         self._span_processors, self._appsec_processor, self._deferred_processors = _default_span_processors_factory(

--- a/ddtrace/bootstrap/cloning.py
+++ b/ddtrace/bootstrap/cloning.py
@@ -1,0 +1,96 @@
+# Support for gevent via module cloning
+
+import os
+import sys
+
+
+LOADED_MODULES = frozenset(sys.modules.keys())
+
+
+# Ensure we capture references to unpatched modules as early as possible
+import ddtrace.internal._unpatched  # noqa
+
+
+if "gevent" in sys.modules or "gevent.monkey" in sys.modules:
+    import gevent.monkey  # noqa:F401
+
+    if gevent.monkey.is_module_patched("threading"):
+        import warnings
+
+        warnings.warn(  # noqa: B028
+            "Loading ddtrace after gevent.monkey.patch_all() is not supported and is "
+            "likely to break the application. Use ddtrace-run to fix this, or "
+            "import ddtrace.auto before calling gevent.monkey.patch_all().",
+            RuntimeWarning,
+        )
+
+
+def cleanup_loaded_modules():
+    import logging
+
+    from ddtrace.internal.module import ModuleWatchdog  # noqa:F401
+    from ddtrace.internal.module import is_module_installed
+    from ddtrace.internal.utils.formats import asbool  # noqa:F401
+
+    def drop(module_name: str) -> None:
+        del sys.modules[module_name]
+
+    MODULES_REQUIRING_CLEANUP = ("gevent",)
+    do_cleanup = os.getenv("DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE", default="auto").lower()
+    if do_cleanup == "auto":
+        do_cleanup = any(is_module_installed(m) for m in MODULES_REQUIRING_CLEANUP)
+
+    if not asbool(do_cleanup):
+        return
+
+    # Unload all the modules that we have imported, except for the ddtrace one.
+    # NB: this means that every `import threading` anywhere in `ddtrace/` code
+    # uses a copy of that module that is distinct from the copy that user code
+    # gets when it does `import threading`. The same applies to every module
+    # not in `KEEP_MODULES`.
+    KEEP_MODULES = frozenset(
+        [
+            "atexit",
+            "copyreg",  # pickling issues for tracebacks with gevent
+            "ddtrace",
+            "concurrent",
+            "typing",
+            "re",  # referenced by the typing module
+            "sre_constants",  # imported by re at runtime
+            "logging",
+            "attr",
+            "google",
+            "google.protobuf",  # the upb backend in >= 4.21 does not like being unloaded
+            "wrapt",
+        ]
+    )
+    for m in list(_ for _ in sys.modules if _ not in LOADED_MODULES):
+        if any(m == _ or m.startswith(_ + ".") for _ in KEEP_MODULES):
+            continue
+
+        drop(m)
+
+    # TODO: The better strategy is to identify the core modules in LOADED_MODULES
+    # that should not be unloaded, and then unload as much as possible.
+    UNLOAD_MODULES = frozenset(
+        [
+            # imported in Python >= 3.10 and patched by gevent
+            "time",
+            # we cannot unload the whole concurrent hierarchy, but this
+            # submodule makes use of threading so it is critical to unload when
+            # gevent is used.
+            "concurrent.futures",
+        ]
+    )
+    for u in UNLOAD_MODULES:
+        for m in list(sys.modules):
+            if m == u or m.startswith(u + "."):
+                drop(m)
+
+    # Because we are not unloading it, the logging module requires a reference
+    # to the newly imported threading module to allow it to retrieve the correct
+    # thread object information, like the thread name. We register a post-import
+    # hook on the threading module to perform this update.
+    @ModuleWatchdog.after_module_imported("threading")
+    def _(threading):
+        logging.threading = threading

--- a/ddtrace/contrib/internal/pytest/_plugin_v1.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v1.py
@@ -22,7 +22,6 @@ from _pytest.nodes import get_fslocation_from_item
 import pytest
 
 import ddtrace
-from ddtrace import DDTraceDeprecationWarning
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib.internal.coverage.data import _coverage_data
 from ddtrace.contrib.internal.coverage.patch import patch as patch_coverage
@@ -69,6 +68,7 @@ from ddtrace.internal.ci_visibility.utils import take_over_logger_stream_handler
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.coverage.code import ModuleCodeCollector
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.inspection import undecorated
 from ddtrace.vendor.debtcollector import deprecate

--- a/ddtrace/contrib/internal/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v2.py
@@ -5,7 +5,6 @@ import typing as t
 
 import pytest
 
-from ddtrace import DDTraceDeprecationWarning
 from ddtrace import config as dd_config
 from ddtrace._monkey import patch
 from ddtrace.contrib.internal.coverage.constants import PCT_COVERED_KEY
@@ -64,6 +63,7 @@ from ddtrace.internal.test_visibility.api import InternalTestModule
 from ddtrace.internal.test_visibility.api import InternalTestSession
 from ddtrace.internal.test_visibility.api import InternalTestSuite
 from ddtrace.internal.test_visibility.coverage_lines import CoverageLines
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.settings.asm import config as asm_config
 from ddtrace.vendor.debtcollector import deprecate

--- a/ddtrace/contrib/internal/pytest_bdd/plugin.py
+++ b/ddtrace/contrib/internal/pytest_bdd/plugin.py
@@ -1,7 +1,7 @@
-from ddtrace import DDTraceDeprecationWarning
 from ddtrace import config
 from ddtrace.contrib.internal.pytest._utils import _USE_PLUGIN_V2
 from ddtrace.contrib.internal.pytest.plugin import is_enabled as is_ddtrace_enabled
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.vendor.debtcollector import deprecate
 
 

--- a/ddtrace/contrib/internal/pytest_benchmark/plugin.py
+++ b/ddtrace/contrib/internal/pytest_benchmark/plugin.py
@@ -1,6 +1,6 @@
-from ddtrace import DDTraceDeprecationWarning
 from ddtrace.contrib.internal.pytest._utils import _USE_PLUGIN_V2
 from ddtrace.contrib.internal.pytest.plugin import is_enabled as is_ddtrace_enabled
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.vendor.debtcollector import deprecate
 
 

--- a/ddtrace/debugging/_debugger.py
+++ b/ddtrace/debugging/_debugger.py
@@ -21,7 +21,6 @@ from typing import Type
 from typing import TypeVar
 from typing import cast
 
-import ddtrace
 from ddtrace import config as ddconfig
 from ddtrace.debugging._config import di_config
 from ddtrace.debugging._function.discovery import FunctionDiscovery
@@ -55,6 +54,7 @@ from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
 from ddtrace.internal.service import Service
 from ddtrace.internal.wrapping.context import WrappingContext
 from ddtrace.trace import Tracer
+from ddtrace.trace import tracer as global_tracer
 
 
 log = get_logger(__name__)
@@ -319,7 +319,7 @@ class Debugger(Service):
     def __init__(self, tracer: Optional[Tracer] = None) -> None:
         super().__init__()
 
-        self._tracer = tracer or ddtrace.tracer
+        self._tracer = tracer or global_tracer
         service_name = di_config.service_name
 
         self._status_logger = status_logger = self.__logger__(service_name)

--- a/ddtrace/debugging/_signal/tracing.py
+++ b/ddtrace/debugging/_signal/tracing.py
@@ -19,6 +19,7 @@ from ddtrace.debugging._signal.utils import serialize
 from ddtrace.internal.compat import ExcInfoType
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.safety import _isinstance
+import ddtrace.trace
 from ddtrace.trace import Span
 
 
@@ -42,7 +43,7 @@ class DynamicSpan(Signal):
     def enter(self, scope: t.Mapping[str, t.Any]) -> None:
         probe = t.cast(SpanFunctionProbe, self.probe)
 
-        self._span_cm = ddtrace.tracer.trace(
+        self._span_cm = ddtrace.trace.tracer.trace(
             SPAN_NAME,
             service=None,  # Currently unused
             resource=probe.func_qname,

--- a/ddtrace/internal/debug.py
+++ b/ddtrace/internal/debug.py
@@ -10,6 +10,7 @@ from typing import Dict  # noqa:F401
 from typing import Union  # noqa:F401
 
 import ddtrace
+import ddtrace._monkey
 from ddtrace.internal.packages import get_distributions
 from ddtrace.internal.utils.cache import callonce
 from ddtrace.internal.writer import AgentWriter

--- a/ddtrace/profiling/scheduler.py
+++ b/ddtrace/profiling/scheduler.py
@@ -8,13 +8,13 @@ from typing import List
 from typing import Optional
 from typing import Sequence  # noqa F401
 
-import ddtrace
 from ddtrace.internal import periodic
 from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.profiling import _traceback
 from ddtrace.profiling import exporter
 from ddtrace.settings.profiling import config
 from ddtrace.trace import Tracer
+from ddtrace.trace import tracer
 
 from .exporter import Exporter
 from .recorder import EventsType
@@ -32,7 +32,7 @@ class Scheduler(periodic.PeriodicService):
         recorder: Optional[Recorder] = None,
         exporters: Optional[List[Exporter]] = None,
         before_flush: Optional[Callable] = None,
-        tracer: Optional[Tracer] = ddtrace.tracer,
+        tracer: Optional[Tracer] = tracer,
         interval: float = config.upload_interval,
     ):
         super(Scheduler, self).__init__(interval=interval)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,7 @@ exclude = [
     ".eggs",
     "*.egg",
     "build",
-    "ddtrace/__init__.py",
+    "ddtrace/bootstrap/sitecustomize.py",
     "ddtrace/vendor/*",
     "ddtrace/appsec/_iast/_taint_tracking/_vendor/*",
     "ddtrace/profiling/exporter/pprof_*pb2.py",

--- a/tests/debugging/origin/test_span.py
+++ b/tests/debugging/origin/test_span.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 import typing as t
 
-import ddtrace
 from ddtrace.debugging._origin.span import SpanCodeOriginProcessor
 from ddtrace.debugging._session import Session
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
+import ddtrace.trace
 from tests.debugging.mocking import MockLogsIntakeUploaderV1
 from tests.utils import TracerTestCase
 
@@ -21,13 +21,13 @@ class MockSpanCodeOriginProcessor(SpanCodeOriginProcessor):
 class SpanProbeTestCase(TracerTestCase):
     def setUp(self):
         super(SpanProbeTestCase, self).setUp()
-        self.backup_tracer = ddtrace.tracer
-        ddtrace.tracer = self.tracer
+        self.backup_tracer = ddtrace.trace.tracer
+        ddtrace.trace.tracer = self.tracer
 
         MockSpanCodeOriginProcessor.enable()
 
     def tearDown(self):
-        ddtrace.tracer = self.backup_tracer
+        ddtrace.trace.tracer = self.backup_tracer
         super(SpanProbeTestCase, self).tearDown()
 
         MockSpanCodeOriginProcessor.disable()

--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -8,7 +8,6 @@ import mock
 from mock.mock import call
 import pytest
 
-import ddtrace
 from ddtrace.constants import _ORIGIN_KEY
 from ddtrace.debugging._debugger import DebuggerWrappingContext
 from ddtrace.debugging._probe.model import DDExpression
@@ -28,6 +27,7 @@ from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
 from ddtrace.internal.service import ServiceStatus
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.internal.utils.inspection import linenos
+import ddtrace.trace
 from tests.debugging.mocking import debugger
 from tests.debugging.utils import compile_template
 from tests.debugging.utils import create_log_function_probe
@@ -913,11 +913,11 @@ def test_debugger_log_line_probe_generate_messages(stuff):
 class SpanProbeTestCase(TracerTestCase):
     def setUp(self):
         super(SpanProbeTestCase, self).setUp()
-        self.backup_tracer = ddtrace.tracer
-        ddtrace.tracer = self.tracer
+        self.backup_tracer = ddtrace.trace.tracer
+        ddtrace.trace.tracer = self.tracer
 
     def tearDown(self):
-        ddtrace.tracer = self.backup_tracer
+        ddtrace.trace.tracer = self.backup_tracer
         super(SpanProbeTestCase, self).tearDown()
 
     def test_debugger_span_probe(self):

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -1903,5 +1903,5 @@ def test_multiple_tracer_instances():
     with mock.patch("ddtrace._trace.tracer.log") as log:
         ddtrace.trace.Tracer()
     log.error.assert_called_once_with(
-        "Multiple Tracer instances can not be initialized. Use ``ddtrace.trace.tracer`` instead."
+        "Initializing multiple Tracer instances is not supported. Use ``ddtrace.trace.tracer`` instead.",
     )

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -1897,11 +1897,11 @@ def test_detect_agent_config_with_lambda_extension():
 def test_multiple_tracer_instances():
     import mock
 
-    import ddtrace
+    import ddtrace.trace
 
     assert ddtrace.trace.tracer is not None
     with mock.patch("ddtrace._trace.tracer.log") as log:
         ddtrace.trace.Tracer()
     log.error.assert_called_once_with(
-        "Initializing multiple Tracer instances is not supported. Use ``ddtrace.trace.tracer`` instead.",
+        "Multiple Tracer instances can not be initialized. Use ``ddtrace.trace.tracer`` instead."
     )


### PR DESCRIPTION
We refactor the content of the `ddtrace/__init__.py` source to be as lazy as possible to reduce the side effects for when the library is simply imported, but not bootstrapped. We move most of the operations that make more sense only on the bootstrap path to the sitecustomize instead.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
