### PR TITLE
fix parenting

### DIFF
--- a/ddtrace/llmobs/_context.py
+++ b/ddtrace/llmobs/_context.py
@@ -41,10 +41,11 @@ class LLMObsContextProvider(DefaultContextProvider):
         new_active: Optional[Span] = span
         while new_active and new_active.finished:
             new_active = new_active._parent
-            if new_active and not new_active.finished and new_active.span_type == SpanTypes.LLM:
-                break
-        self.activate(new_active)
-        return new_active
+        if new_active and not new_active.finished and new_active.span_type == SpanTypes.LLM:
+            self.activate(new_active)
+            return new_active
+        self.activate(None)
+        return None
 
     def activate(self, ctx: ContextTypeValue) -> None:
         """Makes the given context active in the current execution."""

--- a/releasenotes/notes/fix-llmobs-parenting-fa9b420d1c9c098e.yaml
+++ b/releasenotes/notes/fix-llmobs-parenting-fa9b420d1c9c098e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: This fix resolves an issue where mixed APM and LLM Observability tracing caused incorrect parent IDs for LLM Observability spans.


### PR DESCRIPTION
Fixes the parenting logic for llmobs when there is a root apm span.

Previously with this logic:
```
    while new_active and new_active.finished:
      new_active = new_active._parent
      if new_active and not new_active.finished and new_active.span_type == SpanTypes.LLM:
        break
```
We active a non-LLMObs span when we break out of the while loop by bumping into an unfinished non-LLMObs span.

We fix the logic to **first** find the nearest unfinished span. This span is either an LLM or APM span. We active and return the span if it's an LLM span, otherwise we set the currently active span to `None`.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
