### PR TITLE
chore(llmobs): fix root span tag for telemetry metrics

### DIFF
--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -80,7 +80,7 @@ def record_span_started():
 
 
 def record_span_created(span: Span):
-    is_root_span = span._get_ctx_item(PARENT_ID_KEY) != ROOT_PARENT_ID
+    is_root_span = span._get_ctx_item(PARENT_ID_KEY) == ROOT_PARENT_ID
     has_session_id = span._get_ctx_item(SESSION_ID) is not None
     integration = span._get_ctx_item(INTEGRATION)
     autoinstrumented = integration is not None
@@ -149,7 +149,7 @@ def record_llmobs_annotate(span: Optional[Span], error: Optional[str]):
     is_root_span = "0"
     if span and isinstance(span, Span):
         span_kind = span._get_ctx_item(SPAN_KIND) or "N/A"
-        is_root_span = str(int(span._get_ctx_item(PARENT_ID_KEY) != ROOT_PARENT_ID))
+        is_root_span = str(int(span._get_ctx_item(PARENT_ID_KEY) == ROOT_PARENT_ID))
     tags.extend([("span_kind", span_kind), ("is_root_span", is_root_span)])
     telemetry_writer.add_count_metric(
         namespace=TELEMETRY_NAMESPACE.MLOBS, name=LLMObsTelemetryMetrics.ANNOTATIONS, value=1, tags=tuple(tags)
@@ -172,7 +172,7 @@ def record_span_exported(span: Optional[Span], error: Optional[str]):
     is_root_span = "0"
     if span and isinstance(span, Span):
         span_kind = span._get_ctx_item(SPAN_KIND) or "N/A"
-        is_root_span = str(int(span._get_ctx_item(PARENT_ID_KEY) != ROOT_PARENT_ID))
+        is_root_span = str(int(span._get_ctx_item(PARENT_ID_KEY) == ROOT_PARENT_ID))
     tags.extend([("span_kind", span_kind), ("is_root_span", is_root_span)])
     telemetry_writer.add_count_metric(
         namespace=TELEMETRY_NAMESPACE.MLOBS, name=LLMObsTelemetryMetrics.SPANS_EXPORTED, value=1, tags=tuple(tags)


### PR DESCRIPTION
Fixes an incorrect boolean check for if a llmobs span is a root span for LLMObs telemetry metrics.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
