### PR TITLE
fix(profiling): wrap del with try/except

### DIFF
--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -185,8 +185,10 @@ class _ProfiledLock(wrapt.ObjectProxy):
             # _self_acquired_at is only set when the acquire was captured
             # if it's not set, we're not capturing the release
             start = self._self_acquired_at
-            del self._self_acquired_at
-
+            try:
+                del self._self_acquired_at
+            except AttributeError:
+                LOG.debug("Failed to delete _self_acquired_at")
         try:
             return inner_func(*args, **kwargs)
         finally:

--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -180,15 +180,22 @@ class _ProfiledLock(wrapt.ObjectProxy):
     def _release(self, inner_func, *args, **kwargs):
         # type (typing.Any, typing.Any) -> None
 
-        start = None
-        if hasattr(self, "_self_acquired_at"):
-            # _self_acquired_at is only set when the acquire was captured
-            # if it's not set, we're not capturing the release
-            start = self._self_acquired_at
-            try:
-                del self._self_acquired_at
-            except AttributeError:
-                LOG.debug("Failed to delete _self_acquired_at")
+        # The underlying threading.Lock class is implemented using C code, and
+        # it doesn't have the __dict__ attribute. So we can't do
+        # self.__dict__.pop("_self_acquired_at", None) to remove the attribute.
+        # Instead, we need to use the following workaround to retrieve and
+        # remove the attribute.
+        start = getattr(self, "_self_acquired_at", None)
+        try:
+            # Though it should generally be avoided to call release() from
+            # multiple threads, it is possible to do so. In that scenario, the
+            # following statement code will raise an AttributeError. This should
+            # not be propagated to the caller and to the users. The inner_func
+            # will raise an RuntimeError as the threads are trying to release()
+            # and unlocked lock, and the expected behavior is to propagate that.
+            del self._self_acquired_at
+        except AttributeError:
+            LOG.debug("Failed to delete _self_acquired_at")
         try:
             return inner_func(*args, **kwargs)
         finally:

--- a/releasenotes/notes/profiling-self-acquired-at-963cadba71ac62b8.yaml
+++ b/releasenotes/notes/profiling-self-acquired-at-963cadba71ac62b8.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: This fix resolves an issue where the Lock profiler would throw
+    an ``AttributeError: '_ProfiledThreadingLock' object has no attribute '_self_acquired_at'``.


### PR DESCRIPTION
```Python
        start = None
        if hasattr(self, "_self_acquired_at"):
            # _self_acquired_at is only set when the acquire was captured
            # if it's not set, we're not capturing the release
            start = self._self_acquired_at
            del self._self_acquired_at
```

Above code can raise an `AttributeError`, if there are multiple threads calling on `release()`. Though in such scenarios, except for the thread which actually held and released the lock, such threads would result in a `RuntimeError`, the current behavior makes customers blame our code instead of theirs. 

The following code, by @nsrip-dd, can be used to check whether the code raises an error or not

```Python
import threading
import sys

sys.setswitchinterval(0.0000001)

def unlock(l):
    try:
        l.release()
    except RuntimeError:
        pass
    except Exception as e:
        raise e

while True:
    l = threading.Lock()
    l.acquire()
    threads = [threading.Thread(target=unlock, args=[l,]) for _ in range(64)]
    for t in threads:
        t.start()
    for t in threads:
        t.join()
```



## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
