### PR TITLE
fix(lib-injection): remove ddtrace stuff from path before adding to it [APMS-15139]

### DIFF
--- a/lib-injection/sources/sitecustomize.py
+++ b/lib-injection/sources/sitecustomize.py
@@ -388,11 +388,13 @@ def _inject():
                 import ddtrace.bootstrap.sitecustomize
 
                 # Modify the PYTHONPATH for any subprocesses that might be spawned:
+                #   - Remove any preexisting entries related to ddtrace to ensure initial state is clean
                 #   - Remove the PYTHONPATH entry used to bootstrap this installation as it's no longer necessary
                 #     now that the package is installed.
                 #   - Add the custom site-packages directory to PYTHONPATH to ensure the ddtrace package can be loaded
                 #   - Add the ddtrace bootstrap dir to the PYTHONPATH to achieve the same effect as ddtrace-run.
                 python_path = os.getenv("PYTHONPATH", "").split(os.pathsep)
+                python_path = [entry for entry in python_path if "ddtrace" not in entry]
                 if SCRIPT_DIR in python_path:
                     python_path.remove(SCRIPT_DIR)
                 python_path.insert(-1, site_pkgs_path)


### PR DESCRIPTION
This change addresses an issue in which Poetry running an app under a version of Python different from the one used to install Poetry causes library injection to fail. The approach is to ensure that the pythonpath doesn't contain anything related to ddtrace before adding new ddtrace-related entries to it.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
