### PR TITLE
refactor(profiling): consolidate memalloc global state

### DIFF
--- a/ddtrace/profiling/collector/_memalloc.h
+++ b/ddtrace/profiling/collector/_memalloc.h
@@ -1,0 +1,82 @@
+#ifndef _DDTRACE_MEMALLOC_H
+#define _DDTRACE_MEMALLOC_H
+
+#include <stdint.h>
+
+#include <Python.h>
+
+#include "_memalloc_reentrant.h"
+#include "_memalloc_tb.h"
+#include "_utils.h"
+
+#define MEMALLOC_HEAP_PTR_ARRAY_COUNT_TYPE uint64_t
+#define MEMALLOC_HEAP_PTR_ARRAY_MAX_COUNT UINT64_MAX
+DO_ARRAY(void*, ptr, MEMALLOC_HEAP_PTR_ARRAY_COUNT_TYPE, DO_NOTHING)
+
+typedef struct
+{
+    /* Heap profiler sampling interval */
+    uint64_t sample_size;
+    /* Next heap sample target, in bytes allocated */
+    uint64_t current_sample_size;
+    /* Tracked allocations */
+    traceback_array_t allocs;
+    /* Bytes allocated since the last sample was collected */
+    uint64_t allocated_memory;
+    /* True if the heap tracker is frozen */
+    bool frozen;
+    /* Contains the ongoing heap allocation/deallocation while frozen */
+    struct
+    {
+        traceback_array_t allocs;
+        ptr_array_t frees;
+    } freezer;
+} heap_tracker_t;
+
+typedef struct
+{
+    /* List of traceback */
+    traceback_array_t allocs;
+    /* Total number of allocations */
+    uint64_t alloc_count;
+} alloc_tracker_t;
+
+typedef struct
+{
+    /* The original allocator we're wrapping */
+    PyMemAllocatorEx pymem_allocator_obj;
+    /* The domain we are tracking */
+    PyMemAllocatorDomain domain;
+    /* The maximum number of events for allocation tracking */
+    uint16_t max_events;
+    /* The maximum number of frames collected in stack traces */
+    uint16_t max_nframe;
+
+    /* active indicates we're initialized and actively tracking allocations */
+    bool active;
+    /* one_time_init indicates whether we've done initialization which should
+       only be performed once even if the profiler is started and stopped,
+       like installing fork handlers */
+    bool one_time_init;
+
+    /* This lock protects access to alloc_profile. The GIL is NOT sufficient
+       to protect our data structures from concurrent access. For one, the GIL is an
+       implementation detail and may go away in the future. Additionally, even if the
+       GIL is held on _entry_ to our C extension functions, making it safe to call
+       Python C API functions, the GIL can be released during Python C API calls if
+       we call back into interpreter code. This can happen if we allocate a Python
+       object (such as frame info), trigger garbage collection, and run arbitrary
+       destructors. When this happens, other threads can run python code, such as the
+       thread that aggregates and uploads the profile data and mutates the global
+       data structures. The GIL does not create critical sections for C extension
+       functions!
+     */
+    memlock_t alloc_lock;
+    alloc_tracker_t alloc_profile;
+
+    /* This lock protects heap_profile. See alloc_lock */
+    memlock_t heap_lock;
+    heap_tracker_t heap_profile;
+} memalloc_context_t;
+
+#endif

--- a/ddtrace/profiling/collector/_memalloc_heap.h
+++ b/ddtrace/profiling/collector/_memalloc_heap.h
@@ -7,26 +7,23 @@
 
 #include <Python.h>
 
+#include "_memalloc.h"
 #include "_utils.h"
 
 /* The maximum heap sample size is the maximum value we can store in a heap_tracker_t.allocated_memory */
 #define MAX_HEAP_SAMPLE_SIZE UINT32_MAX
 
 void
-memalloc_heap_tracker_init(uint32_t sample_size);
+memalloc_heap_tracker_init(memalloc_context_t* ctx, uint32_t sample_size);
 void
-memalloc_heap_tracker_deinit(void);
+memalloc_heap_tracker_deinit(memalloc_context_t* ctx);
 
 PyObject*
-memalloc_heap();
+memalloc_heap(memalloc_context_t* ctx);
 
 bool
-memalloc_heap_track(uint16_t max_nframe, void* ptr, size_t size, PyMemAllocatorDomain domain);
+memalloc_heap_track(memalloc_context_t* ctx, uint16_t max_nframe, void* ptr, size_t size, PyMemAllocatorDomain domain);
 void
-memalloc_heap_untrack(void* ptr);
-
-#define MEMALLOC_HEAP_PTR_ARRAY_COUNT_TYPE uint64_t
-#define MEMALLOC_HEAP_PTR_ARRAY_MAX_COUNT UINT64_MAX
-DO_ARRAY(void*, ptr, MEMALLOC_HEAP_PTR_ARRAY_COUNT_TYPE, DO_NOTHING)
+memalloc_heap_untrack(memalloc_context_t* ctx, void* ptr);
 
 #endif


### PR DESCRIPTION
The memory profiler has several bits of global state. There are the data
structures to hold sampled allocations for the allocation and heap
profilers. There are locks protecting those data structures. There is a
scratch buffer used for building tracebacks. We can't completely avoid
global state for the memory profiler since the allocators themselves are
"global". But right now this state is spread across several different
global objects accessed by different parts of the code. These objects
are inherently interdependent. Data structures depend on their locks,
and building profiles depens on all this state.

I'd like to consolidate this state and pass it around explicitly to the
places where it's needed. This is mainly motivated by transitioning to
C++ (or Rust). In C++, at least, managing lifetime and initialization
for global state is painful. We need the state we use to actually be
initialized by the time we use it, and it needs to stay alive until the
last time we need it. This is more painful when there are multiple
inter-dependent globals. It's easier if there is one object. We can
construct it in one go with "new", let RAII set everything up, and store
in a single global pointer. Then we can pass that pointer around
explicitly to the places where the profiler state is manipulated so
that, even if it's global, we can be more confident the state is
initialized & valid when we're looking at the code locally.

Admittedly the "passing things around explicitly" part is also a
stylistic preference. Really the main thing is to encapsulate access to
the shared profiler state so we can be more confident that it's managed
correctly.

This PR doesn't consolidate everything. We currently need to leave the
reentrancy guard as-is, since C structs can't have thread-local (or
static) members.

This PR also picks up a stray change that's not necessarily worth
submitting separately: the format strings for the memalloc_start error
messages were usign the wrong format specifiers. This was causing the
"v1" unit tests to fail on my macbook. We can use inttypes.h to get
portable format specifiers. I just did this to make sure the tests were
all green locally; doesn't feel worth burning a bunch of CI time just
for that by itself.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
