### PR TITLE
chore(debugging): guard against race on emitting status

### DIFF
--- a/ddtrace/debugging/_probe/registry.py
+++ b/ddtrace/debugging/_probe/registry.py
@@ -116,7 +116,16 @@ class ProbeRegistry(dict):
     def set_emitting(self, probe: Probe) -> None:
         """Set the emitting flag for a probe."""
         with self._lock:
-            entry = cast(ProbeRegistryEntry, self[probe.probe_id])
+            try:
+                entry = cast(ProbeRegistryEntry, self[probe.probe_id])
+            except KeyError:
+                # The probe has likely been removed by remote  config but the
+                # instrumentation has raced that thread from another thread.
+                # Since we can't get an entry from the registry for it we don't
+                # log the emitting state.
+                logger.debug("Probe %s no longer registered emitted data", probe.probe_id)
+                return
+
             if not entry.emitting:
                 entry.set_emitting()
                 self.logger.emitting(probe)

--- a/ddtrace/debugging/_probe/registry.py
+++ b/ddtrace/debugging/_probe/registry.py
@@ -119,7 +119,7 @@ class ProbeRegistry(dict):
             try:
                 entry = cast(ProbeRegistryEntry, self[probe.probe_id])
             except KeyError:
-                # The probe has likely been removed by remote  config but the
+                # The probe has likely been removed by remote config but the
                 # instrumentation has raced that thread from another thread.
                 # Since we can't get an entry from the registry for it we don't
                 # log the emitting state.


### PR DESCRIPTION
We guard the probe registry against potential race conditions when setting the `EMITTING` status. This can happen if a probe that has been instrumented is being deleted, but the instrumentation is triggered in a user thread at around the same time the RC client relies the configuration payload. In this case we simply log the event and do nothing.

The better solution would be to lock the registry access, since the handling of the `EMITTING` status exposes the registry to concurrent access. However, we opted for not introducing a lock to avoid adding blocking in-line on user code.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
