### PR TITLE
make graphql locations optional

### DIFF
--- a/ddtrace/contrib/internal/graphql/patch.py
+++ b/ddtrace/contrib/internal/graphql/patch.py
@@ -332,12 +332,13 @@ def _set_span_errors(errors: List[GraphQLError], span: Span) -> None:
     error_msgs = "\n".join([str(error) for error in errors])
     span.set_tag_str(ERROR_MSG, error_msgs)
     for error in errors:
-        locations = [f"{loc.formatted['line']}:{loc.formatted['column']}" for loc in error.locations]
         attributes = {
             "message": error.message,
             "type": span.get_tag("error.type"),
-            "locations": locations,
         }
+        if error.locations:
+            locations = [f"{loc.formatted['line']}:{loc.formatted['column']}" for loc in error.locations]
+            attributes["locations"] = locations
 
         if error.__traceback__:
             exc_type, exc_val, exc_tb = type(error), error, error.__traceback__


### PR DESCRIPTION
Only set span event attribute `locations` when `GraphQLError` locations is not None, as `GraphQLErrror` locations are optional

Fixes #12843

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
