### PR TITLE
fix(ci_visibility): count failed/skipped tests in JUnit XML when retries are enabled

### DIFF
--- a/ddtrace/contrib/internal/pytest/_atr_utils.py
+++ b/ddtrace/contrib/internal/pytest/_atr_utils.py
@@ -80,12 +80,14 @@ def atr_handle_retries(
         return
 
     atr_outcome = _atr_do_retries(item, outcomes)
+    longrepr = InternalTest.stash_get(test_id, "failure_longrepr") if atr_outcome == TestStatus.FAIL else None
 
     final_report = RetryTestReport(
         nodeid=item.nodeid,
         location=item.location,
         keywords=item.keywords,
         when="call",
+        longrepr=longrepr,
         outcome=final_outcomes[atr_outcome],
     )
     item.ihook.pytest_runtest_logreport(report=final_report)

--- a/ddtrace/contrib/internal/pytest/_atr_utils.py
+++ b/ddtrace/contrib/internal/pytest/_atr_utils.py
@@ -80,7 +80,7 @@ def atr_handle_retries(
         return
 
     atr_outcome = _atr_do_retries(item, outcomes)
-    longrepr = InternalTest.stash_get(test_id, "failure_longrepr") if atr_outcome == TestStatus.FAIL else None
+    longrepr = InternalTest.stash_get(test_id, "failure_longrepr")  # if atr_outcome == TestStatus.FAIL else None
 
     final_report = RetryTestReport(
         nodeid=item.nodeid,

--- a/ddtrace/contrib/internal/pytest/_atr_utils.py
+++ b/ddtrace/contrib/internal/pytest/_atr_utils.py
@@ -4,6 +4,7 @@ import _pytest
 import pytest
 
 from ddtrace.contrib.internal.pytest._retry_utils import RetryOutcomes
+from ddtrace.contrib.internal.pytest._retry_utils import RetryTestReport
 from ddtrace.contrib.internal.pytest._retry_utils import _get_outcome_from_retry
 from ddtrace.contrib.internal.pytest._retry_utils import _get_retry_attempt_string
 from ddtrace.contrib.internal.pytest._retry_utils import set_retry_num
@@ -80,12 +81,11 @@ def atr_handle_retries(
 
     atr_outcome = _atr_do_retries(item, outcomes)
 
-    final_report = pytest_TestReport(
+    final_report = RetryTestReport(
         nodeid=item.nodeid,
         location=item.location,
         keywords=item.keywords,
         when="call",
-        longrepr=None,
         outcome=final_outcomes[atr_outcome],
     )
     item.ihook.pytest_runtest_logreport(report=final_report)

--- a/ddtrace/contrib/internal/pytest/_atr_utils.py
+++ b/ddtrace/contrib/internal/pytest/_atr_utils.py
@@ -80,7 +80,7 @@ def atr_handle_retries(
         return
 
     atr_outcome = _atr_do_retries(item, outcomes)
-    longrepr = InternalTest.stash_get(test_id, "failure_longrepr")  # if atr_outcome == TestStatus.FAIL else None
+    longrepr = InternalTest.stash_get(test_id, "failure_longrepr")
 
     final_report = RetryTestReport(
         nodeid=item.nodeid,

--- a/ddtrace/contrib/internal/pytest/_attempt_to_fix.py
+++ b/ddtrace/contrib/internal/pytest/_attempt_to_fix.py
@@ -65,12 +65,14 @@ def attempt_to_fix_handle_retries(
         return
 
     retries_outcome = _do_retries(item, outcomes)
+    longrepr = InternalTest.stash_get(test_id, "failure_longrepr") if retries_outcome == TestStatus.FAIL else None
 
     final_report = RetryTestReport(
         nodeid=item.nodeid,
         location=item.location,
         keywords=item.keywords,
         when="call",
+        longrepr=longrepr,
         outcome=final_outcomes[retries_outcome],
         user_properties=item.user_properties,
     )

--- a/ddtrace/contrib/internal/pytest/_attempt_to_fix.py
+++ b/ddtrace/contrib/internal/pytest/_attempt_to_fix.py
@@ -65,7 +65,7 @@ def attempt_to_fix_handle_retries(
         return
 
     retries_outcome = _do_retries(item, outcomes)
-    longrepr = InternalTest.stash_get(test_id, "failure_longrepr") if retries_outcome == TestStatus.FAIL else None
+    longrepr = InternalTest.stash_get(test_id, "failure_longrepr")
 
     final_report = RetryTestReport(
         nodeid=item.nodeid,

--- a/ddtrace/contrib/internal/pytest/_attempt_to_fix.py
+++ b/ddtrace/contrib/internal/pytest/_attempt_to_fix.py
@@ -4,6 +4,7 @@ import _pytest
 import pytest
 
 from ddtrace.contrib.internal.pytest._retry_utils import RetryOutcomes
+from ddtrace.contrib.internal.pytest._retry_utils import RetryTestReport
 from ddtrace.contrib.internal.pytest._retry_utils import _get_outcome_from_retry
 from ddtrace.contrib.internal.pytest._retry_utils import _get_retry_attempt_string
 from ddtrace.contrib.internal.pytest._retry_utils import set_retry_num
@@ -65,12 +66,11 @@ def attempt_to_fix_handle_retries(
 
     retries_outcome = _do_retries(item, outcomes)
 
-    final_report = pytest_TestReport(
+    final_report = RetryTestReport(
         nodeid=item.nodeid,
         location=item.location,
         keywords=item.keywords,
         when="call",
-        longrepr=None,
         outcome=final_outcomes[retries_outcome],
         user_properties=item.user_properties,
     )

--- a/ddtrace/contrib/internal/pytest/_efd_utils.py
+++ b/ddtrace/contrib/internal/pytest/_efd_utils.py
@@ -37,7 +37,7 @@ _EFD_FLAKY_OUTCOME = "flaky"
 
 _FINAL_OUTCOMES: t.Dict[EFDTestStatus, str] = {
     EFDTestStatus.ALL_PASS: _EFD_RETRY_OUTCOMES.EFD_FINAL_PASSED,
-    EFDTestStatus.ALL_FAIL: _EFD_RETRY_OUTCOMES.EFD_FINAL_FAILED,
+    EFDTestStatus.ALL_FAIL: "failed", #_EFD_RETRY_OUTCOMES.EFD_FINAL_FAILED,
     EFDTestStatus.ALL_SKIP: _EFD_RETRY_OUTCOMES.EFD_FINAL_SKIPPED,
     EFDTestStatus.FLAKY: _EFD_RETRY_OUTCOMES.EFD_FINAL_FLAKY,
 }
@@ -90,8 +90,9 @@ def efd_handle_retries(
         nodeid=item.nodeid,
         location=item.location,
         keywords=item.keywords,
+        user_properties=item.user_properties + [("dd_retry_reason", "efd")],
         when="call",
-        longrepr=None,
+        longrepr="ꙮ",
         outcome=_FINAL_OUTCOMES[efd_outcome],
     )
     item.ihook.pytest_runtest_logreport(report=final_report)
@@ -305,6 +306,8 @@ def efd_pytest_terminal_summary_post_yield(terminalreporter: _pytest.terminal.Te
 
 
 def efd_get_teststatus(report: pytest_TestReport) -> _pytest_report_teststatus_return_type:
+    retry_reason = [value for (key, value) in report.user_properties if key == "dd_retry_reason"]
+
     if report.outcome == _EFD_RETRY_OUTCOMES.EFD_ATTEMPT_PASSED:
         return (
             _EFD_RETRY_OUTCOMES.EFD_ATTEMPT_PASSED,
@@ -325,7 +328,7 @@ def efd_get_teststatus(report: pytest_TestReport) -> _pytest_report_teststatus_r
         )
     if report.outcome == _EFD_RETRY_OUTCOMES.EFD_FINAL_PASSED:
         return (_EFD_RETRY_OUTCOMES.EFD_FINAL_PASSED, ".", ("EFD FINAL STATUS: PASSED", {"green": True}))
-    if report.outcome == _EFD_RETRY_OUTCOMES.EFD_FINAL_FAILED:
+    if report.outcome == "failed" and retry_reason == ["efd"] : #_EFD_RETRY_OUTCOMES.EFD_FINAL_FAILED:
         return (_EFD_RETRY_OUTCOMES.EFD_FINAL_FAILED, "F", ("EFD FINAL STATUS: FAILED", {"red": True}))
     if report.outcome == _EFD_RETRY_OUTCOMES.EFD_FINAL_SKIPPED:
         return (_EFD_RETRY_OUTCOMES.EFD_FINAL_SKIPPED, "S", ("EFD FINAL STATUS: SKIPPED", {"yellow": True}))

--- a/ddtrace/contrib/internal/pytest/_efd_utils.py
+++ b/ddtrace/contrib/internal/pytest/_efd_utils.py
@@ -86,7 +86,7 @@ def efd_handle_retries(
             InternalTest.mark_skip(test_id)
 
     efd_outcome = _efd_do_retries(item)
-    longrepr = InternalTest.stash_get(test_id, "failure_longrepr") if efd_outcome == EFDTestStatus.ALL_FAIL else None
+    longrepr = InternalTest.stash_get(test_id, "failure_longrepr")
 
     final_report = RetryTestReport(
         nodeid=item.nodeid,

--- a/ddtrace/contrib/internal/pytest/_efd_utils.py
+++ b/ddtrace/contrib/internal/pytest/_efd_utils.py
@@ -37,7 +37,7 @@ _EFD_FLAKY_OUTCOME = "flaky"
 
 _FINAL_OUTCOMES: t.Dict[EFDTestStatus, str] = {
     EFDTestStatus.ALL_PASS: _EFD_RETRY_OUTCOMES.EFD_FINAL_PASSED,
-    EFDTestStatus.ALL_FAIL: "failed", #_EFD_RETRY_OUTCOMES.EFD_FINAL_FAILED,
+    EFDTestStatus.ALL_FAIL: _EFD_RETRY_OUTCOMES.EFD_FINAL_FAILED,
     EFDTestStatus.ALL_SKIP: _EFD_RETRY_OUTCOMES.EFD_FINAL_SKIPPED,
     EFDTestStatus.FLAKY: _EFD_RETRY_OUTCOMES.EFD_FINAL_FLAKY,
 }
@@ -90,9 +90,8 @@ def efd_handle_retries(
         nodeid=item.nodeid,
         location=item.location,
         keywords=item.keywords,
-        user_properties=item.user_properties + [("dd_retry_reason", "efd")],
         when="call",
-        longrepr="ꙮ",
+        longrepr=None,
         outcome=_FINAL_OUTCOMES[efd_outcome],
     )
     item.ihook.pytest_runtest_logreport(report=final_report)
@@ -306,8 +305,6 @@ def efd_pytest_terminal_summary_post_yield(terminalreporter: _pytest.terminal.Te
 
 
 def efd_get_teststatus(report: pytest_TestReport) -> _pytest_report_teststatus_return_type:
-    retry_reason = [value for (key, value) in report.user_properties if key == "dd_retry_reason"]
-
     if report.outcome == _EFD_RETRY_OUTCOMES.EFD_ATTEMPT_PASSED:
         return (
             _EFD_RETRY_OUTCOMES.EFD_ATTEMPT_PASSED,
@@ -328,7 +325,7 @@ def efd_get_teststatus(report: pytest_TestReport) -> _pytest_report_teststatus_r
         )
     if report.outcome == _EFD_RETRY_OUTCOMES.EFD_FINAL_PASSED:
         return (_EFD_RETRY_OUTCOMES.EFD_FINAL_PASSED, ".", ("EFD FINAL STATUS: PASSED", {"green": True}))
-    if report.outcome == "failed" and retry_reason == ["efd"] : #_EFD_RETRY_OUTCOMES.EFD_FINAL_FAILED:
+    if report.outcome == _EFD_RETRY_OUTCOMES.EFD_FINAL_FAILED:
         return (_EFD_RETRY_OUTCOMES.EFD_FINAL_FAILED, "F", ("EFD FINAL STATUS: FAILED", {"red": True}))
     if report.outcome == _EFD_RETRY_OUTCOMES.EFD_FINAL_SKIPPED:
         return (_EFD_RETRY_OUTCOMES.EFD_FINAL_SKIPPED, "S", ("EFD FINAL STATUS: SKIPPED", {"yellow": True}))

--- a/ddtrace/contrib/internal/pytest/_efd_utils.py
+++ b/ddtrace/contrib/internal/pytest/_efd_utils.py
@@ -86,12 +86,14 @@ def efd_handle_retries(
             InternalTest.mark_skip(test_id)
 
     efd_outcome = _efd_do_retries(item)
+    longrepr = InternalTest.stash_get(test_id, "failure_longrepr") if efd_outcome == EFDTestStatus.ALL_FAIL else None
 
     final_report = RetryTestReport(
         nodeid=item.nodeid,
         location=item.location,
         keywords=item.keywords,
         when="call",
+        longrepr=longrepr,
         outcome=_FINAL_OUTCOMES[efd_outcome],
     )
     item.ihook.pytest_runtest_logreport(report=final_report)

--- a/ddtrace/contrib/internal/pytest/_efd_utils.py
+++ b/ddtrace/contrib/internal/pytest/_efd_utils.py
@@ -4,6 +4,7 @@ import _pytest
 import pytest
 
 from ddtrace.contrib.internal.pytest._retry_utils import RetryOutcomes
+from ddtrace.contrib.internal.pytest._retry_utils import RetryTestReport
 from ddtrace.contrib.internal.pytest._retry_utils import _get_outcome_from_retry
 from ddtrace.contrib.internal.pytest._retry_utils import _get_retry_attempt_string
 from ddtrace.contrib.internal.pytest._retry_utils import set_retry_num
@@ -86,12 +87,11 @@ def efd_handle_retries(
 
     efd_outcome = _efd_do_retries(item)
 
-    final_report = pytest_TestReport(
+    final_report = RetryTestReport(
         nodeid=item.nodeid,
         location=item.location,
         keywords=item.keywords,
         when="call",
-        longrepr=None,
         outcome=_FINAL_OUTCOMES[efd_outcome],
     )
     item.ihook.pytest_runtest_logreport(report=final_report)

--- a/ddtrace/contrib/internal/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v2.py
@@ -529,6 +529,9 @@ def _pytest_runtest_makereport(item: pytest.Item, call: pytest_CallInfo, outcome
         # (see <https://github.com/pytest-dev/pytest/blob/8.3.x/src/_pytest/main.py#L654>).
         original_result.outcome = OUTCOME_QUARANTINED
 
+    if original_result.failed and original_result.longrepr:
+        InternalTest.stash_set(test_id, "failure_longrepr", original_result.longrepr)
+
     # ATR and EFD retry tests only if their teardown succeeded to ensure the best chance the retry will succeed
     # NOTE: this mutates the original result's outcome
     if InternalTest.stash_get(test_id, "setup_failed") or InternalTest.stash_get(test_id, "teardown_failed"):

--- a/ddtrace/contrib/internal/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v2.py
@@ -529,7 +529,7 @@ def _pytest_runtest_makereport(item: pytest.Item, call: pytest_CallInfo, outcome
         # (see <https://github.com/pytest-dev/pytest/blob/8.3.x/src/_pytest/main.py#L654>).
         original_result.outcome = OUTCOME_QUARANTINED
 
-    if original_result.failed and original_result.longrepr:
+    if original_result.failed or original_result.skipped:
         InternalTest.stash_set(test_id, "failure_longrepr", original_result.longrepr)
 
     # ATR and EFD retry tests only if their teardown succeeded to ensure the best chance the retry will succeed

--- a/ddtrace/contrib/internal/pytest/_retry_utils.py
+++ b/ddtrace/contrib/internal/pytest/_retry_utils.py
@@ -140,18 +140,19 @@ class RetryTestReport(pytest_TestReport):
 
     @property
     def failed(self):
+        if self.longrepr is None:
+            return False
         return "final_failed" in self.outcome
 
     @property
     def passed(self):
         if self.longrepr is None:
-            # `longrepr` is initialized from the test's first attempt. If the first attempt was successful, `longrepr`
-            # is None, and the initial attempt was already reported as successful, so we don't count the final attempt
-            # as successful too.
             return False
 
         return "final_passed" in self.outcome or "final_flaky" in self.outcome
 
     @property
     def skipped(self):
+        if self.longrepr is None:
+            return False
         return "final_skipped" in self.outcome

--- a/ddtrace/contrib/internal/pytest/_retry_utils.py
+++ b/ddtrace/contrib/internal/pytest/_retry_utils.py
@@ -140,12 +140,18 @@ class RetryTestReport(pytest_TestReport):
 
     @property
     def failed(self):
-        return "final_failed" in self.outcome or super().failed
+        return "final_failed" in self.outcome
 
     @property
     def passed(self):
-        return "final_passed" in self.outcome or "final_flaky" in self.outcome or super().passed
+        if self.longrepr is None:
+            # `longrepr` is initialized from the test's first attempt. If the first attempt was successful, `longrepr`
+            # is None, and the initial attempt was already reported as successful, so we don't count the final attempt
+            # as successful too.
+            return False
+
+        return "final_passed" in self.outcome or "final_flaky" in self.outcome
 
     @property
     def skipped(self):
-        return "final_skipped" in self.outcome or super().skipped
+        return "final_skipped" in self.outcome

--- a/ddtrace/contrib/internal/pytest/_retry_utils.py
+++ b/ddtrace/contrib/internal/pytest/_retry_utils.py
@@ -135,17 +135,8 @@ class RetryTestReport(pytest_TestReport):
     """
     A RetryTestReport behaves just like a normal pytest TestReport, except that the the failed/passed/skipped
     properties are aware of retry final states (dd_efd_final_*, etc). This affects the test counts in JUnit XML output,
-    for instance. It also ensures that failed states have a longrepr attribute (again used by JUnit XML output).
+    for instance.
     """
-
-    def __init__(self, *args, **kwargs):
-        if "longrepr" not in kwargs:
-            if "final_failed" in kwargs.get("outcome", ""):
-                kwargs["longrepr"] = "All retries failed"
-            else:
-                kwargs["longrepr"] = None
-
-        super().__init__(*args, **kwargs)
 
     @property
     def failed(self):

--- a/ddtrace/contrib/internal/pytest/_retry_utils.py
+++ b/ddtrace/contrib/internal/pytest/_retry_utils.py
@@ -138,7 +138,7 @@ class RetryTestReport(pytest_TestReport):
     for instance.
 
     The object should be initialized with the `longrepr` of the _initial_ test attempt. A `longrepr` set to `None` means
-    the initial attempt either succeded (which means it was already counted by pytest) or was quarantined (which means
+    the initial attempt either succeeded (which means it was already counted by pytest) or was quarantined (which means
     we should not count it at all), so we don't need to count it here.
     """
 

--- a/ddtrace/contrib/internal/pytest/_retry_utils.py
+++ b/ddtrace/contrib/internal/pytest/_retry_utils.py
@@ -136,6 +136,10 @@ class RetryTestReport(pytest_TestReport):
     A RetryTestReport behaves just like a normal pytest TestReport, except that the the failed/passed/skipped
     properties are aware of retry final states (dd_efd_final_*, etc). This affects the test counts in JUnit XML output,
     for instance.
+
+    The object should be initialized with the `longrepr` of the _initial_ test attempt. A `longrepr` set to `None` means
+    the initial attempt either succeded (which means it was already counted by pytest) or was quarantined (which means
+    we should not count it at all), so we don't need to count it here.
     """
 
     @property
@@ -148,11 +152,8 @@ class RetryTestReport(pytest_TestReport):
     def passed(self):
         if self.longrepr is None:
             return False
-
         return "final_passed" in self.outcome or "final_flaky" in self.outcome
 
     @property
     def skipped(self):
-        if self.longrepr is None:
-            return False
         return "final_skipped" in self.outcome

--- a/ddtrace/contrib/internal/pytest/_retry_utils.py
+++ b/ddtrace/contrib/internal/pytest/_retry_utils.py
@@ -156,4 +156,6 @@ class RetryTestReport(pytest_TestReport):
 
     @property
     def skipped(self):
+        if self.longrepr is None:
+            return False
         return "final_skipped" in self.outcome

--- a/ddtrace/contrib/internal/pytest/_retry_utils.py
+++ b/ddtrace/contrib/internal/pytest/_retry_utils.py
@@ -139,8 +139,12 @@ class RetryTestReport(pytest_TestReport):
     """
 
     def __init__(self, *args, **kwargs):
-        if "longrepr" not in kwargs and "final_failed" in kwargs.get("outcome", ""):
-            kwargs["longrepr"] = "All retries failed"
+        if "longrepr" not in kwargs:
+            if "final_failed" in kwargs.get("outcome", ""):
+                kwargs["longrepr"] = "All retries failed"
+            else:
+                kwargs["longrepr"] = None
+
         super().__init__(*args, **kwargs)
 
     @property

--- a/releasenotes/notes/ci_visibility-fix-junit-xml-retry-count-65de6ad6b9bb35d2.yaml
+++ b/releasenotes/notes/ci_visibility-fix-junit-xml-retry-count-65de6ad6b9bb35d2.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    CI Visibility: This fix resolves an issue where JUnit XML output would not count tests retried by Early Flake
+    Detection, Auto Test Retries, and Attempt-to-Fix.

--- a/tests/contrib/pytest/test_pytest_atr.py
+++ b/tests/contrib/pytest/test_pytest_atr.py
@@ -187,7 +187,6 @@ class PytestATRTestCase(PytestTestCaseBase):
         self.testdir.makepyfile(test_skip=_TEST_SKIP_CONTENT)
 
         rec = self.inline_run("--ddtrace", "-v")
-        breakpoint()
         assert rec.ret == 1
         spans = self.pop_spans()
         session_span = _get_spans_from_list(spans, "session")[0]

--- a/tests/contrib/pytest/test_pytest_atr.py
+++ b/tests/contrib/pytest/test_pytest_atr.py
@@ -333,3 +333,5 @@ class PytestATRTestCase(PytestTestCaseBase):
         assert test_suite.attrib["failures"] == "4"
         assert test_suite.attrib["skipped"] == "4"
         assert test_suite.attrib["errors"] == "2"
+
+        breakpoint()

--- a/tests/contrib/pytest/test_pytest_atr.py
+++ b/tests/contrib/pytest/test_pytest_atr.py
@@ -6,8 +6,8 @@ are checked.
 - The same known tests are used to override fetching of known tests.
 - The session object is patched to never be a faulty session, by default.
 """
-from xml.etree import ElementTree
 from unittest import mock
+from xml.etree import ElementTree
 
 import pytest
 
@@ -320,13 +320,17 @@ class PytestATRTestCase(PytestTestCaseBase):
 
     def test_pytest_atr_junit_xml(self):
         """Tests that an EFD session properly does the correct number of retries and sets the correct tags"""
-        # self.testdir.makepyfile(test_pass=_TEST_PASS_CONTENT)
-        # self.testdir.makepyfile(test_fail=_TEST_FAIL_CONTENT)
-        # self.testdir.makepyfile(test_errors=_TEST_ERRORS_CONTENT)
+        self.testdir.makepyfile(test_pass=_TEST_PASS_CONTENT)
+        self.testdir.makepyfile(test_fail=_TEST_FAIL_CONTENT)
+        self.testdir.makepyfile(test_errors=_TEST_ERRORS_CONTENT)
         self.testdir.makepyfile(test_pass_on_retries=_TEST_PASS_ON_RETRIES_CONTENT)
-        # self.testdir.makepyfile(test_skip=_TEST_SKIP_CONTENT)
+        self.testdir.makepyfile(test_skip=_TEST_SKIP_CONTENT)
 
         rec = self.inline_run("--ddtrace", "-v", "-s", "--junit-xml=out.xml")
+        assert rec.ret == 1
+
         test_suite = ElementTree.parse(f"{self.testdir}/out.xml").find("testsuite")
-        assert test_suite.attrib["tests"] == "7"
-        assert test_suite.attrib["failures"] == "3"
+        assert test_suite.attrib["tests"] == "16"
+        assert test_suite.attrib["failures"] == "4"
+        assert test_suite.attrib["skipped"] == "4"
+        assert test_suite.attrib["errors"] == "2"

--- a/tests/contrib/pytest/test_pytest_atr.py
+++ b/tests/contrib/pytest/test_pytest_atr.py
@@ -318,7 +318,6 @@ class PytestATRTestCase(PytestTestCaseBase):
         assert len(spans) == 5
 
     def test_pytest_atr_junit_xml(self):
-        """Tests that an EFD session properly does the correct number of retries and sets the correct tags"""
         self.testdir.makepyfile(test_pass=_TEST_PASS_CONTENT)
         self.testdir.makepyfile(test_fail=_TEST_FAIL_CONTENT)
         self.testdir.makepyfile(test_errors=_TEST_ERRORS_CONTENT)
@@ -329,9 +328,10 @@ class PytestATRTestCase(PytestTestCaseBase):
         assert rec.ret == 1
 
         test_suite = ElementTree.parse(f"{self.testdir}/out.xml").find("testsuite")
+
+        # There are 15 tests, but we get 16 in the JUnit XML output, because a test that passes during call but fails
+        # during teardown is counted twice. This is a bug in pytest, not ddtrace.
         assert test_suite.attrib["tests"] == "16"
         assert test_suite.attrib["failures"] == "4"
         assert test_suite.attrib["skipped"] == "4"
         assert test_suite.attrib["errors"] == "2"
-
-        breakpoint()

--- a/tests/contrib/pytest/test_pytest_atr.py
+++ b/tests/contrib/pytest/test_pytest_atr.py
@@ -325,7 +325,7 @@ class PytestATRTestCase(PytestTestCaseBase):
         self.testdir.makepyfile(test_pass_on_retries=_TEST_PASS_ON_RETRIES_CONTENT)
         self.testdir.makepyfile(test_skip=_TEST_SKIP_CONTENT)
 
-        rec = self.inline_run("--ddtrace", "-v", "-s", "--junit-xml=out.xml")
+        rec = self.inline_run("--ddtrace", "--junit-xml=out.xml")
         assert rec.ret == 1
 
         test_suite = ElementTree.parse(f"{self.testdir}/out.xml").find("testsuite")

--- a/tests/contrib/pytest/test_pytest_attempt_to_fix.py
+++ b/tests/contrib/pytest/test_pytest_attempt_to_fix.py
@@ -245,16 +245,29 @@ class PytestAttemptToFixTestCase(PytestTestCaseBase):
         assert test_spans[-1].get_tag("test.test_management.attempt_to_fix_passed") is None
         assert test_spans[-1].get_tag("test.has_failed_all_retries") is None
 
-    def test_pytest_atr_junit_xml(self):
-        self.testdir.makepyfile(test_active=_TEST_PASS)
+    def test_pytest_attempt_to_fix_junit_xml_active(self):
+        self.testdir.makepyfile(test_active=_TEST_PASS + _TEST_FAIL + _TEST_SKIP)
 
-        rec = self.inline_run("--ddtrace", "--junit-xml=out.xml")
+        rec = self.inline_run("--ddtrace", "--junit-xml=out.xml", "-v", "-s")
+        assert rec.ret == 1
+
+        test_suite = ElementTree.parse(f"{self.testdir}/out.xml").find("testsuite")
+        assert test_suite.attrib["tests"] == "3"
+        assert test_suite.attrib["failures"] == "1"
+        assert test_suite.attrib["skipped"] == "1"
+        assert test_suite.attrib["errors"] == "0"
+
+    @pytest.mark.xfail(reason="JUnit XML miscounts quarantined tests")
+    def test_pytest_attempt_to_fix_junit_xml_quarantined(self):
+        self.testdir.makepyfile(test_quarantined=_TEST_PASS + _TEST_FAIL + _TEST_SKIP)
+
+        rec = self.inline_run("--ddtrace", "--junit-xml=out.xml", "-v", "-s")
         assert rec.ret == 0
 
         test_suite = ElementTree.parse(f"{self.testdir}/out.xml").find("testsuite")
-        assert test_suite.attrib["tests"] == "1"
+        assert test_suite.attrib["tests"] == "3"  # we currently get "2"
         assert test_suite.attrib["failures"] == "0"
-        assert test_suite.attrib["skipped"] == "0"
+        assert test_suite.attrib["skipped"] == "1"
         assert test_suite.attrib["errors"] == "0"
 
 

--- a/tests/contrib/pytest/test_pytest_attempt_to_fix.py
+++ b/tests/contrib/pytest/test_pytest_attempt_to_fix.py
@@ -257,7 +257,6 @@ class PytestAttemptToFixTestCase(PytestTestCaseBase):
         assert test_suite.attrib["skipped"] == "0"
         assert test_suite.attrib["errors"] == "0"
 
-        breakpoint()
 
 class PytestAttemptToFixITRTestCase(PytestTestCaseBase):
     @pytest.fixture(autouse=True, scope="function")

--- a/tests/contrib/pytest/test_pytest_efd.py
+++ b/tests/contrib/pytest/test_pytest_efd.py
@@ -6,8 +6,8 @@ are checked.
 - The same known tests are used to override fetching of known tests.
 - The session object is patched to never be a faulty session, by default.
 """
-from xml.etree import ElementTree
 from unittest import mock
+from xml.etree import ElementTree
 
 import pytest
 
@@ -293,7 +293,9 @@ class PytestEFDTestCase(PytestTestCaseBase):
         self.testdir.makepyfile(test_new_pass=_TEST_NEW_PASS_CONTENT)
         self.testdir.makepyfile(test_new_fail=_TEST_NEW_FAIL_CONTENT)
         self.testdir.makepyfile(test_new_flaky=_TEST_NEW_FLAKY_CONTENT)
+
         rec = self.inline_run("--ddtrace", "--junit-xml=out.xml")
+        assert rec.ret == 1
 
         test_suite = ElementTree.parse(f"{self.testdir}/out.xml").find("testsuite")
         assert test_suite.attrib["tests"] == "7"

--- a/tests/contrib/pytest/test_pytest_efd.py
+++ b/tests/contrib/pytest/test_pytest_efd.py
@@ -300,4 +300,3 @@ class PytestEFDTestCase(PytestTestCaseBase):
         test_suite = ElementTree.parse(f"{self.testdir}/out.xml").find("testsuite")
         assert test_suite.attrib["tests"] == "7"
         assert test_suite.attrib["failures"] == "3"
-        breakpoint()

--- a/tests/contrib/pytest/test_pytest_efd.py
+++ b/tests/contrib/pytest/test_pytest_efd.py
@@ -300,3 +300,4 @@ class PytestEFDTestCase(PytestTestCaseBase):
         test_suite = ElementTree.parse(f"{self.testdir}/out.xml").find("testsuite")
         assert test_suite.attrib["tests"] == "7"
         assert test_suite.attrib["failures"] == "3"
+        breakpoint()

--- a/tests/contrib/pytest/test_pytest_efd.py
+++ b/tests/contrib/pytest/test_pytest_efd.py
@@ -6,6 +6,7 @@ are checked.
 - The same known tests are used to override fetching of known tests.
 - The session object is patched to never be a faulty session, by default.
 """
+from xml.etree import ElementTree
 from unittest import mock
 
 import pytest
@@ -285,3 +286,15 @@ class PytestEFDTestCase(PytestTestCaseBase):
         assert fails_teardown_spans[0].get_tag("test.is_retry") != "true"
         assert rec.ret == 1
         assert len(spans) == 7
+
+    def test_pytest_efd_junit_xml(self):
+        self.testdir.makepyfile(test_known_pass=_TEST_KNOWN_PASS_CONTENT)
+        self.testdir.makepyfile(test_known_fail=_TEST_KNOWN_FAIL_CONTENT)
+        self.testdir.makepyfile(test_new_pass=_TEST_NEW_PASS_CONTENT)
+        self.testdir.makepyfile(test_new_fail=_TEST_NEW_FAIL_CONTENT)
+        self.testdir.makepyfile(test_new_flaky=_TEST_NEW_FLAKY_CONTENT)
+        rec = self.inline_run("--ddtrace", "--junit-xml=out.xml")
+
+        test_suite = ElementTree.parse(f"{self.testdir}/out.xml").find("testsuite")
+        assert test_suite.attrib["tests"] == "7"
+        assert test_suite.attrib["failures"] == "3"


### PR DESCRIPTION
The pytest JUnit XML plugin uses the test report's [`failed`](https://github.com/pytest-dev/pytest/blob/8.3.x/src/_pytest/junitxml.py#L562) and [`longrepr`](https://github.com/pytest-dev/pytest/blob/8.3.x/src/_pytest/junitxml.py#L201) properties to count failed tests and include them in the output. Because retried tests have their own special statuses (`dd_efd_final_failed`, etc), they don't count as failures, and are excluded from the JUnit XML count. This PR creates a subclass of TestReport that is aware of those special statuses and reports them as passed/failed/skipped accordingly.

This is honestly a bit of a hack. It would probably be best to rewrite the retry logic entirely so it would use normal pytest states, and pass the information that they are retries in some other way. But that will take more time, and I would like to fix the bug sooner rather than later.

~~One limitation of this approach is that the exception information from the failing retries is not included in the final report, and therefore don't show up in the JUnit XML.~~ The exception information for the initial attempt is included in the JUnit XML.

Known issue: quarantined failing tests are not counted. The way forward with this is to rewrite the retry logic, which I plan to do in a future PR.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
