### PR TITLE
fix(profiling): sample types are refreshed on fork

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profile.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profile.hpp
@@ -28,7 +28,7 @@ class Profile
     std::mutex profile_mtx{};
 
     // Configuration
-    SampleType type_mask{ 0 };
+    SampleType type_mask{ SampleType::All };
     unsigned int max_nframes{ g_default_max_nframes };
     ddog_prof_Period default_period{};
 
@@ -46,9 +46,12 @@ class Profile
     ddog_prof_Profile cur_profile{};
     ddog_prof_Profile last_profile{};
 
+
+
   public:
     // State management
     void one_time_init(SampleType type, unsigned int _max_nframes);
+    void one_time_init_impl(SampleType type, unsigned int _max_nframes);
     bool cycle_buffers();
     void reset();
     void postfork_child();

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/types.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/types.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
 namespace Datadog {
-enum SampleType : unsigned int
+
+enum class SampleType : unsigned int
 {
     Invalid = 0,
     CPU = 1 << 0,
@@ -14,8 +15,25 @@ enum SampleType : unsigned int
     GPUTime = 1 << 7,
     GPUMemory = 1 << 8,
     GPUFlops = 1 << 9,
-    All = CPU | Wall | Exception | LockAcquire | LockRelease | Allocation | Heap | GPUTime | GPUMemory | GPUFlops
+    All = CPU | Wall | Exception | LockAcquire | LockRelease | Allocation | Heap | GPUTime | GPUMemory | GPUFlops,
 };
+
+inline SampleType operator|(SampleType a, SampleType b) {
+    return static_cast<SampleType>(static_cast<unsigned int>(a) | static_cast<unsigned int>(b));
+}
+
+inline SampleType operator&(SampleType a, SampleType b) {
+    return static_cast<SampleType>(static_cast<unsigned int>(a) & static_cast<unsigned int>(b));
+}
+
+inline bool is_valid_type(SampleType a) {
+    a = a & SampleType::All; // bits outside of the valid set get masked off
+    return a != SampleType::Invalid;
+}
+
+inline bool mask_has_type(SampleType mask, SampleType type) {
+    return is_valid_type(mask & type);
+}
 
 // Every Sample object has a corresponding `values` vector, since libdatadog expects contiguous values per sample.
 // The index into that vector is determined by the configured sample types, which is encoded below.

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
@@ -175,7 +175,7 @@ Datadog::Sample::push_cputime(int64_t cputime, int64_t count)
 {
     // NB all push-type operations return bool for semantic uniformity,
     // even if they can't error.  This should promote generic code.
-    if (0U != (type_mask & SampleType::CPU)) {
+    if (mask_has_type(type_mask, SampleType::CPU)) {
         values[profile_state.val().cpu_time] += cputime * count;
         values[profile_state.val().cpu_count] += count;
         return true;
@@ -187,7 +187,7 @@ Datadog::Sample::push_cputime(int64_t cputime, int64_t count)
 bool
 Datadog::Sample::push_walltime(int64_t walltime, int64_t count)
 {
-    if (0U != (type_mask & SampleType::Wall)) {
+      if (mask_has_type(type_mask, SampleType::Wall)) {
         values[profile_state.val().wall_time] += walltime * count;
         values[profile_state.val().wall_count] += count;
         return true;
@@ -199,7 +199,7 @@ Datadog::Sample::push_walltime(int64_t walltime, int64_t count)
 bool
 Datadog::Sample::push_exceptioninfo(std::string_view exception_type, int64_t count)
 {
-    if (0U != (type_mask & SampleType::Exception)) {
+      if (mask_has_type(type_mask, SampleType::Exception)) {
         push_label(ExportLabelKey::exception_type, exception_type);
         values[profile_state.val().exception_count] += count;
         return true;
@@ -211,7 +211,7 @@ Datadog::Sample::push_exceptioninfo(std::string_view exception_type, int64_t cou
 bool
 Datadog::Sample::push_acquire(int64_t acquire_time, int64_t count) // NOLINT (bugprone-easily-swappable-parameters)
 {
-    if (0U != (type_mask & SampleType::LockAcquire)) {
+      if (mask_has_type(type_mask, SampleType::LockAcquire)) {
         values[profile_state.val().lock_acquire_time] += acquire_time;
         values[profile_state.val().lock_acquire_count] += count;
         return true;
@@ -223,7 +223,7 @@ Datadog::Sample::push_acquire(int64_t acquire_time, int64_t count) // NOLINT (bu
 bool
 Datadog::Sample::push_release(int64_t lock_time, int64_t count) // NOLINT (bugprone-easily-swappable-parameters)
 {
-    if (0U != (type_mask & SampleType::LockRelease)) {
+      if (mask_has_type(type_mask, SampleType::LockRelease)) {
         values[profile_state.val().lock_release_time] += lock_time;
         values[profile_state.val().lock_release_count] += count;
         return true;
@@ -240,7 +240,7 @@ Datadog::Sample::push_alloc(int64_t size, int64_t count) // NOLINT (bugprone-eas
         return false;
     }
 
-    if (0U != (type_mask & SampleType::Allocation)) {
+    if (mask_has_type(type_mask, SampleType::Allocation)) {
         values[profile_state.val().alloc_space] += size;
         values[profile_state.val().alloc_count] += count;
         return true;
@@ -257,7 +257,7 @@ Datadog::Sample::push_heap(int64_t size)
         return false;
     }
 
-    if (0U != (type_mask & SampleType::Heap)) {
+      if (mask_has_type(type_mask, SampleType::Heap)) {
         values[profile_state.val().heap_space] += size;
         return true;
     }
@@ -268,7 +268,7 @@ Datadog::Sample::push_heap(int64_t size)
 bool
 Datadog::Sample::push_gpu_gputime(int64_t time, int64_t count)
 {
-    if (0U != (type_mask & SampleType::GPUTime)) {
+      if (mask_has_type(type_mask, SampleType::GPUTime)) {
         values[profile_state.val().gpu_time] += time * count;
         values[profile_state.val().gpu_count] += count;
         return true;
@@ -280,7 +280,7 @@ Datadog::Sample::push_gpu_gputime(int64_t time, int64_t count)
 bool
 Datadog::Sample::push_gpu_memory(int64_t size, int64_t count)
 {
-    if (0U != (type_mask & SampleType::GPUMemory)) {
+      if (mask_has_type(type_mask, SampleType::GPUMemory)) {
         values[profile_state.val().gpu_alloc_space] += size * count;
         values[profile_state.val().gpu_alloc_count] += count;
         return true;
@@ -292,7 +292,7 @@ Datadog::Sample::push_gpu_memory(int64_t size, int64_t count)
 bool
 Datadog::Sample::push_gpu_flops(int64_t size, int64_t count)
 {
-    if (0U != (type_mask & SampleType::GPUFlops)) {
+      if (mask_has_type(type_mask, SampleType::GPUFlops)) {
         values[profile_state.val().gpu_flops] += size * count;
         values[profile_state.val().gpu_flops_samples] += count;
         return true;

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample_manager.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample_manager.cpp
@@ -4,7 +4,7 @@
 void
 Datadog::SampleManager::add_type(unsigned int type)
 {
-    type_mask = static_cast<SampleType>((type_mask | type) & SampleType::All);
+    type_mask = static_cast<SampleType>((static_cast<unsigned int>(type_mask) | type)) & SampleType::All;
 }
 
 void
@@ -80,6 +80,8 @@ Datadog::SampleManager::postfork_child()
         // and the fork happened in the middle of that operation.
         sample_pool = std::make_unique<SynchronizedSamplePool>(sample_pool_capacity);
     }
+
+    Datadog::Sample::profile_state.one_time_init_impl(type_mask, max_nframes);
 }
 
 void


### PR DESCRIPTION
I still don't know how it happens, but customers are reporting that with the introduction of stack v2  as the default stack collector(and hence, the libdatadog-based collection and export) a lot of log spam related to profiler not having the right sample types (these logs originate from within libdatadog and show an uninitialized Profiling object).

My best guess is that this is related to early forking, so this PR mostly tries to address that by re-initializing even more things on fork.

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
