### PR TITLE
ci: add pip cache to CI jobs

### DIFF
--- a/.gitlab/scripts/get-riot-hashes.sh
+++ b/.gitlab/scripts/get-riot-hashes.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e -u -o pipefail
+
+SUITE_NAME="${1:-}"
+riot list --hash-only "${SUITE_NAME}" | sort | ./.gitlab/ci-split-input.sh

--- a/.gitlab/scripts/get-riot-pip-cache-key.sh
+++ b/.gitlab/scripts/get-riot-pip-cache-key.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e -u -o pipefail
+
+SUITE_NAME="${1:-}"
+hashes=( $(./.gitlab/scripts/get-riot-hashes.sh "${SUITE_NAME}") )
+# Get the sha256sum of all the requirements files combined
+for hash in "${hashes[@]}"; do
+  req_file="./.riot/requirements/${hash}.txt"
+  if [ -f "${req_file}" ]; then
+    cat "${req_file}"
+  fi
+done | sort | sha256sum | awk '{print $1}'

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -73,7 +73,7 @@ include:
     - unset DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED
   script:
     - |
-      hashes=( $(riot list --hash-only "${SUITE_NAME}" | sort | ./.gitlab/ci-split-input.sh) )
+      hashes=( $(.gitlab/scripts/get-riot-hashes.sh "${SUITE_NAME}") )
       if [[ ${#hashes[@]} -eq 0 ]]; then
         echo "No riot hashes found for ${SUITE_NAME}"
         exit 1

--- a/scripts/gen_gitlab_config.py
+++ b/scripts/gen_gitlab_config.py
@@ -7,6 +7,7 @@
 
 from dataclasses import dataclass
 import os
+import subprocess
 import typing as t
 
 
@@ -48,9 +49,11 @@ class JobSpec:
         wait_for = services.copy()
         if self.snapshot:
             wait_for.add("testagent")
-        if wait_for:
+        if wait_for or self.runner == "riot":
             lines.append("  before_script:")
             lines.append(f"    - !reference [{base}, before_script]")
+            if self.runner == "riot":
+                lines.append("    - pip cache info")
             if self.runner == "riot" and wait_for:
                 lines.append(f"    - riot -v run -s --pass-env wait -- {' '.join(wait_for)}")
 
@@ -58,6 +61,17 @@ class JobSpec:
         if not env or "SUITE_NAME" not in env:
             env = env or {}
             env["SUITE_NAME"] = self.pattern or self.name
+
+        if self.runner == "riot":
+            suite_name = env["SUITE_NAME"]
+            env["PIP_CACHE_DIR"] = "${CI_PROJECT_DIR}/.cache/pip"
+            env["PIP_CACHE_KEY"] = (
+                subprocess.check_output([".gitlab/scripts/get-riot-pip-cache-key.sh", suite_name]).decode().strip()
+            )
+            lines.append("  cache:")
+            lines.append("    key: v0-pip-${PIP_CACHE_KEY}-cache")
+            lines.append("    paths:")
+            lines.append("      - .cache")
 
         lines.append("  variables:")
         for key, value in env.items():


### PR DESCRIPTION
Adds a pip cache to a large number of our CI jobs.

For riot: this does this by using a unique pip cache key per-job based on the sha256sum of all of the `.riot/requirements/*.txt` files for all the venvs matching the suite name or pattern. This way if any deps change we'll invalidate the cache to ensure it doesn't grow in size forever.

For hatch: this uses the job name as the key.

The goal is to cache the downloaded wheels/distributions to save on network bandwidth and effort for downloading every time. This will also help cache built wheels if the downloaded distribution is a source distribution.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
