### PR TITLE
chore(uwsgi): add to ssi denylist

### DIFF
--- a/lib-injection/sources/denied_executables.txt
+++ b/lib-injection/sources/denied_executables.txt
@@ -1201,3 +1201,4 @@ usr/libexec/grepconf.sh
 /usr/bin/sepolgen-ifgen
 /usr/bin/sepolicy
 /usr/bin/sesearch
+/usr/bin/uwsgi


### PR DESCRIPTION
According to our docs SSI does not support UWSGI. To make SSI+ddtrace-py more resilient we should add `/usr/bin/uwsgi` to the denylist. This is not a perfect solution since the uwsgi command can be stored elsewhere on a host but it's better than nothing.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
