### PR TITLE
chore(asm): make sure removal are first on waf updates

### DIFF
--- a/ddtrace/appsec/_ddwaf/waf_mock.py
+++ b/ddtrace/appsec/_ddwaf/waf_mock.py
@@ -1,21 +1,15 @@
 from typing import Any
 from typing import Dict
-from typing import List
+from typing import Sequence
 from typing import Tuple
 
 from ddtrace.appsec._constants import DEFAULT
 from ddtrace.appsec._ddwaf.waf_stubs import WAF
-
-# from ddtrace.appsec._ddwaf.ddwaf_types import py_remove_config
 from ddtrace.appsec._ddwaf.waf_stubs import DDWaf_info
 from ddtrace.appsec._ddwaf.waf_stubs import DDWaf_result
 from ddtrace.appsec._ddwaf.waf_stubs import DDWafRulesType
+from ddtrace.appsec._ddwaf.waf_stubs import PayloadType
 from ddtrace.appsec._ddwaf.waf_stubs import ddwaf_context_capsule
-
-# from ddtrace.appsec._ddwaf.waf_stubs import DDWafRulesType
-# from ddtrace.appsec._ddwaf.waf_stubs import ddwaf_builder_capsule
-# from ddtrace.appsec._ddwaf.waf_stubs import ddwaf_context_capsule
-# from ddtrace.appsec._ddwaf.waf_stubs import ddwaf_handle_capsule
 from ddtrace.appsec._utils import _observator
 from ddtrace.internal.logger import get_logger
 
@@ -52,7 +46,9 @@ class DDWaf(WAF):
         LOGGER.debug("DDWaf features disabled. dry run")
         return DDWaf_result(0, [], {}, 0.0, 0.0, False, self.empty_observator, {})
 
-    def update_rules(self, new_rules: List[Tuple[str, str, Any]]) -> bool:
+    def update_rules(
+        self, removals: Sequence[Tuple[str, str]], updates: Sequence[Tuple[str, str, PayloadType]]
+    ) -> bool:
         LOGGER.debug("DDWaf features disabled. dry update")
         return False
 

--- a/ddtrace/appsec/_ddwaf/waf_stubs.py
+++ b/ddtrace/appsec/_ddwaf/waf_stubs.py
@@ -6,6 +6,7 @@ from typing import Dict
 from typing import Generic
 from typing import List
 from typing import Optional
+from typing import Sequence
 from typing import Tuple
 from typing import Type
 from typing import TypeVar
@@ -14,6 +15,7 @@ from typing import Union
 from ddtrace.appsec._constants import DEFAULT
 from ddtrace.appsec._utils import _observator
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.remoteconfig import PayloadType
 
 
 LOGGER = get_logger(__name__)
@@ -138,7 +140,9 @@ class WAF(ABC):
         pass
 
     @abstractmethod
-    def update_rules(self, new_rules: List[Tuple[str, str, Any]]) -> bool:
+    def update_rules(
+        self, removals: Sequence[Tuple[str, str]], updates: Sequence[Tuple[str, str, PayloadType]]
+    ) -> bool:
         pass
 
     @abstractmethod

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -9,6 +9,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
 from typing import Set
 from typing import Tuple
 from typing import Union
@@ -197,13 +198,15 @@ class AppSecSpanProcessor(SpanProcessor):
         # we always need the response headers
         self._addresses_to_keep.add(WAF_DATA_NAMES.RESPONSE_HEADERS_NO_COOKIES)
 
-    def _update_rules(self, new_rules: List[Tuple[str, str, PayloadType]]) -> bool:
+    def _update_rules(
+        self, removals: Sequence[Tuple[str, str]], updates: Sequence[Tuple[str, str, PayloadType]]
+    ) -> bool:
         if not hasattr(self, "_ddwaf"):
             self.delayed_init()
         result = False
         if asm_config._asm_static_rule_file is not None:
             return result
-        result = self._ddwaf.update_rules(new_rules)
+        result = self._ddwaf.update_rules(removals, updates)
         self.metrics._set_waf_updates_metric(self._ddwaf.info, result)
         self._update_required()
         return result

--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -101,16 +101,19 @@ def _appsec_callback(payload_list: Sequence[Payload], test_tracer: Optional[Trac
 
     local_tracer = test_tracer or tracer
 
-    for_the_waf: List[tuple[str, str, PayloadType]] = []
+    for_the_waf_updates: List[tuple[str, str, PayloadType]] = []
+    for_the_waf_removals: List[tuple[str, str]] = []
     for_the_tracer: List[Payload] = []
     for payload in payload_list:
         if payload.metadata.product_name == "ASM_FEATURES":
             for_the_tracer.append(payload)
+        elif payload.content is None:
+            for_the_waf_removals.append((payload.metadata.product_name, payload.path))
         else:
-            for_the_waf.append((payload.metadata.product_name, payload.path, payload.content))
+            for_the_waf_updates.append((payload.metadata.product_name, payload.path, payload.content))
     _process_asm_features(for_the_tracer, local_tracer)
     if local_tracer._appsec_processor is not None:
-        local_tracer._appsec_processor._update_rules(for_the_waf)
+        local_tracer._appsec_processor._update_rules(for_the_waf_removals, for_the_waf_updates)
 
 
 def _update_asm_features(payload_list: Sequence[Payload], cache: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:

--- a/tests/appsec/appsec/test_processor.py
+++ b/tests/appsec/appsec/test_processor.py
@@ -224,6 +224,7 @@ def test_ip_not_block(tracer, ip):
 def test_ip_update_rules_and_block(tracer):
     with asm_context(tracer=tracer, ip_addr=rules._IP.BLOCKED, config=config_asm) as span1:
         tracer._appsec_processor._update_rules(
+            [],
             [
                 (
                     "ASM",
@@ -240,7 +241,7 @@ def test_ip_update_rules_and_block(tracer):
                         ]
                     },
                 )
-            ]
+            ],
         )
         with tracer.trace("test", span_type=SpanTypes.WEB) as span:
             set_http_meta(
@@ -255,6 +256,7 @@ def test_ip_update_rules_and_block(tracer):
 def test_ip_update_rules_expired_no_block(tracer):
     with asm_context(tracer=tracer, ip_addr=rules._IP.BLOCKED, config=config_asm):
         tracer._appsec_processor._update_rules(
+            [],
             [
                 (
                     "ASM",
@@ -271,7 +273,7 @@ def test_ip_update_rules_expired_no_block(tracer):
                         ]
                     },
                 )
-            ]
+            ],
         )
         with tracer.trace("test", span_type=SpanTypes.WEB) as span:
             set_http_meta(
@@ -701,7 +703,7 @@ def test_required_addresses():
         "usr.id",
     }
 
-    processor._update_rules(CUSTOM_RULE_METHOD)
+    processor._update_rules([], CUSTOM_RULE_METHOD)
 
     assert processor._addresses_to_keep == {
         "grpc.server.request.message",
@@ -727,7 +729,7 @@ def test_ephemeral_addresses(mock_run, persistent, ephemeral):
     from ddtrace.trace import tracer
 
     processor = AppSecSpanProcessor()
-    processor._update_rules(CUSTOM_RULE_METHOD)
+    processor._update_rules([], CUSTOM_RULE_METHOD)
 
     with asm_context(tracer=tracer, config=config_asm) as span:
         # first call must send all data to the waf

--- a/tests/appsec/appsec/test_telemetry.py
+++ b/tests/appsec/appsec/test_telemetry.py
@@ -186,7 +186,7 @@ def test_log_metric_error_ddwaf_timeout(telemetry_writer, tracer):
 def test_log_metric_error_ddwaf_update(telemetry_writer):
     with override_global_config(dict(_asm_enabled=True, _asm_deduplication_enabled=False)):
         span_processor = AppSecSpanProcessor()
-        span_processor._update_rules(invalid_rule_update)
+        span_processor._update_rules([], invalid_rule_update)
 
         list_metrics_logs = list(telemetry_writer._logs)
         assert len(list_metrics_logs) == 1
@@ -219,10 +219,10 @@ def test_log_metric_error_ddwaf_internal_error(telemetry_writer):
 def test_log_metric_error_ddwaf_update_deduplication(telemetry_writer):
     with override_global_config(dict(_asm_enabled=True)):
         span_processor = AppSecSpanProcessor()
-        span_processor._update_rules(invalid_rule_update)
+        span_processor._update_rules([], invalid_rule_update)
         telemetry_writer.reset_queues()
         span_processor = AppSecSpanProcessor()
-        span_processor._update_rules(invalid_rule_update)
+        span_processor._update_rules([], invalid_rule_update)
         list_metrics_logs = list(telemetry_writer._logs)
         assert len(list_metrics_logs) == 0
 
@@ -234,14 +234,14 @@ def test_log_metric_error_ddwaf_update_deduplication_timelapse(telemetry_writer)
         with override_global_config(dict(_asm_enabled=True)):
             sleep(0.2)
             span_processor = AppSecSpanProcessor()
-            span_processor._update_rules(invalid_rule_update)
+            span_processor._update_rules([], invalid_rule_update)
             list_metrics_logs = list(telemetry_writer._logs)
             assert len(list_metrics_logs) == 1
             assert list_metrics_logs[0]["message"] == invalid_error
             telemetry_writer.reset_queues()
             sleep(0.2)
             span_processor = AppSecSpanProcessor()
-            span_processor._update_rules(invalid_rule_update)
+            span_processor._update_rules([], invalid_rule_update)
             list_metrics_logs = list(telemetry_writer._logs)
             assert len(list_metrics_logs) == 1
     finally:


### PR DESCRIPTION
We need to make sure that removals are applied first in the waf builder.
This PR makes sure of that.


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
