### PR TITLE
feat(debugging): add support for Decimal

### DIFF
--- a/ddtrace/debugging/_expressions.py
+++ b/ddtrace/debugging/_expressions.py
@@ -25,6 +25,7 @@ Full grammar:
 """  # noqa
 
 from dataclasses import dataclass
+from decimal import Decimal
 from itertools import chain
 import re
 import sys
@@ -344,7 +345,7 @@ class DDCompiler:
 
     def _compile_literal(self, ast: DDASTType) -> Optional[List[Instr]]:
         # literal  =>  <number> | true | false | "string" | null
-        if not (isinstance(ast, (str, int, float, bool)) or ast is None):
+        if not (isinstance(ast, (str, int, float, bool, Decimal)) or ast is None):
             return None
 
         return [Instr("LOAD_CONST", ast)]

--- a/ddtrace/debugging/_signal/utils.py
+++ b/ddtrace/debugging/_signal/utils.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from collections import defaultdict
 from collections import deque
 from collections.abc import Collection
+from decimal import Decimal
 from itertools import islice
 from itertools import takewhile
 from types import BuiltinFunctionType
@@ -41,7 +42,7 @@ EXCLUDED_FIELDS = frozenset(["__class__", "__dict__", "__weakref__", "__doc__", 
 
 NoneType = type(None)
 
-BUILTIN_SIMPLE_TYPES = frozenset([int, float, str, bytes, bool, NoneType, type, complex])
+BUILTIN_SIMPLE_TYPES = frozenset([int, float, str, bytes, bool, NoneType, type, complex, Decimal])
 BUILTIN_MAPPING_TYPES = frozenset([dict, defaultdict, Counter, OrderedDict])
 BUILTIN_SEQUENCE_TYPES = frozenset([list, tuple, set, frozenset, deque])
 BUILTIN_CONTAINER_TYPES = BUILTIN_MAPPING_TYPES | BUILTIN_SEQUENCE_TYPES

--- a/releasenotes/notes/chore-di-support-decimal-e75525e282c50a2f.yaml
+++ b/releasenotes/notes/chore-di-support-decimal-e75525e282c50a2f.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    dynamic instrumentation: added support for the Decimal type from the
+    Python standard library.

--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -1,4 +1,5 @@
 from collections import Counter
+from decimal import Decimal
 import os.path
 import sys
 from threading import Thread
@@ -425,6 +426,16 @@ def test_debugger_metric_probe_simple_count(mock_metrics, stuff):
         stuff.Stuff().instancestuff()
         assert (
             call("probe.test.counter", 1.0, ["foo:bar", "debugger.probeid:metric-probe-test"])
+            in mock_metrics.increment.mock_calls
+        )
+
+
+def test_debugger_metric_probe_decimal(mock_metrics, stuff):
+    with debugger() as d:
+        d.add_probes(create_stuff_line_metric_probe(MetricProbeKind.COUNTER, value=Decimal(value := 3.14)))
+        stuff.Stuff().instancestuff()
+        assert (
+            call("probe.test.counter", value, ["foo:bar", "debugger.probeid:metric-probe-test"])
             in mock_metrics.increment.mock_calls
         )
 


### PR DESCRIPTION
We add support to Dynamic Instrumentation for the Decimal type from the standard library. With this change, values of this type will have a more explicit representation in dynamic logs, and can be used, after a convertion to float, in metrics and other expressions.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
