### PR TITLE
chore(rc): migrate to type hints in subscribers

### DIFF
--- a/ddtrace/internal/remoteconfig/_subscribers.py
+++ b/ddtrace/internal/remoteconfig/_subscribers.py
@@ -2,12 +2,12 @@ import os
 from typing import Callable
 from typing import Sequence
 
+from ddtrace import config
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.periodic import PeriodicService
 from ddtrace.internal.remoteconfig import Payload
 from ddtrace.internal.remoteconfig._connectors import PublisherSubscriberConnector
 from ddtrace.internal.remoteconfig._connectors import SharedDataType
-from ddtrace.internal.remoteconfig.utils import get_poll_interval_seconds
 
 
 log = get_logger(__name__)
@@ -17,7 +17,7 @@ class RemoteConfigSubscriber(PeriodicService):
     def __init__(
         self, data_connector: PublisherSubscriberConnector, callback: Callable[[Sequence[Payload]], None], name: str
     ) -> None:
-        super().__init__(get_poll_interval_seconds() / 2)
+        super().__init__(config._remote_config_poll_interval / 2)
 
         self._data_connector = data_connector
         self._callback = callback

--- a/ddtrace/internal/remoteconfig/_subscribers.py
+++ b/ddtrace/internal/remoteconfig/_subscribers.py
@@ -1,28 +1,22 @@
 import os
-from typing import TYPE_CHECKING  # noqa:F401
+from typing import Callable
+from typing import Sequence
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.periodic import PeriodicService
+from ddtrace.internal.remoteconfig import Payload
+from ddtrace.internal.remoteconfig._connectors import PublisherSubscriberConnector
+from ddtrace.internal.remoteconfig._connectors import SharedDataType
 from ddtrace.internal.remoteconfig.utils import get_poll_interval_seconds
-
-
-if TYPE_CHECKING:  # pragma: no cover
-    from typing import Callable  # noqa:F401
-    from typing import Optional  # noqa:F401
-    from typing import Sequence  # noqa:F401
-
-    from ddtrace.internal.remoteconfig import Payload  # noqa:F401
-    from ddtrace.internal.remoteconfig._connectors import PublisherSubscriberConnector  # noqa:F401
-    from ddtrace.internal.remoteconfig._connectors import SharedDataType  # noqa:F401
-    from ddtrace.trace import Tracer  # noqa:F401
 
 
 log = get_logger(__name__)
 
 
 class RemoteConfigSubscriber(PeriodicService):
-    def __init__(self, data_connector, callback, name):
-        # type: (PublisherSubscriberConnector, Callable[[Sequence[Payload]], None], str) -> None
+    def __init__(
+        self, data_connector: PublisherSubscriberConnector, callback: Callable[[Sequence[Payload]], None], name: str
+    ) -> None:
         super().__init__(get_poll_interval_seconds() / 2)
 
         self._data_connector = data_connector
@@ -31,14 +25,12 @@ class RemoteConfigSubscriber(PeriodicService):
 
         log.debug("[PID %d] %s initialized", os.getpid(), self)
 
-    def _exec_callback(self, data):
-        # type: (SharedDataType) -> None
+    def _exec_callback(self, data: SharedDataType) -> None:
         if data:
             log.debug("[PID %d] %s _exec_callback: %s", os.getpid(), self, str(data)[:50])
             self._callback(data)
 
-    def _get_data_from_connector_and_exec(self):
-        # type: () -> None
+    def _get_data_from_connector_and_exec(self) -> None:
         data = self._data_connector.read()
         self._exec_callback(data)
 

--- a/ddtrace/internal/remoteconfig/utils.py
+++ b/ddtrace/internal/remoteconfig/utils.py
@@ -1,6 +1,0 @@
-from ddtrace import config
-
-
-def get_poll_interval_seconds():
-    # type:() -> float
-    return config._remote_config_poll_interval

--- a/ddtrace/internal/remoteconfig/worker.py
+++ b/ddtrace/internal/remoteconfig/worker.py
@@ -12,7 +12,6 @@ from ddtrace.internal.remoteconfig._pubsub import PubSub  # noqa:F401
 from ddtrace.internal.remoteconfig.client import RemoteConfigClient
 from ddtrace.internal.remoteconfig.client import config as rc_config
 from ddtrace.internal.remoteconfig.constants import REMOTE_CONFIG_AGENT_ENDPOINT
-from ddtrace.internal.remoteconfig.utils import get_poll_interval_seconds
 from ddtrace.internal.service import ServiceStatus
 from ddtrace.internal.utils.time import StopWatch
 
@@ -30,13 +29,13 @@ class RemoteConfigPoller(periodic.PeriodicService):
     _enable = True
 
     def __init__(self):
-        super(RemoteConfigPoller, self).__init__(interval=get_poll_interval_seconds())
+        super(RemoteConfigPoller, self).__init__(interval=ddconfig._remote_config_poll_interval)
         self._client = RemoteConfigClient()
         self._state = self._agent_check
         self._parent_id = os.getpid()
         self._products_to_restart_on_fork = set()
         self._capabilities_map: Dict[enum.IntFlag, str] = dict()
-        log.debug("RemoteConfigWorker created with polling interval %d", get_poll_interval_seconds())
+        log.debug("RemoteConfigWorker created with polling interval %d", ddconfig._remote_config_poll_interval)
 
     def _agent_check(self) -> None:
         try:


### PR DESCRIPTION
We migrate to type hints in the RC subscribers source. This allows us to clean up some of the imports and avoid a few circular references.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
