### PR TITLE
refactor: move RC registration logic to RC product

### DIFF
--- a/ddtrace/internal/remoteconfig/product.py
+++ b/ddtrace/internal/remoteconfig/product.py
@@ -1,5 +1,46 @@
+import enum
+
 from ddtrace import config
+from ddtrace.internal.remoteconfig._connectors import PublisherSubscriberConnector
+from ddtrace.internal.remoteconfig._publishers import RemoteConfigPublisher
+from ddtrace.internal.remoteconfig._pubsub import PubSub
+from ddtrace.internal.remoteconfig._pubsub import RemoteConfigSubscriber
 from ddtrace.internal.remoteconfig.client import config as rc_config
+
+
+class GlobalConfigPubSub(PubSub):
+    __publisher_class__ = RemoteConfigPublisher
+    __subscriber_class__ = RemoteConfigSubscriber
+    __shared_data__ = PublisherSubscriberConnector()
+
+    def __init__(self, callback):
+        self._publisher = self.__publisher_class__(self.__shared_data__, None)
+        self._subscriber = self.__subscriber_class__(self.__shared_data__, callback, "GlobalConfig")
+
+
+class Capabilities(enum.IntFlag):
+    APM_TRACING_SAMPLE_RATE = 1 << 12
+    APM_TRACING_LOGS_INJECTION = 1 << 13
+    APM_TRACING_HTTP_HEADER_TAGS = 1 << 14
+    APM_TRACING_CUSTOM_TAGS = 1 << 15
+    APM_TRACING_ENABLED = 1 << 19
+    APM_TRACING_SAMPLE_RULES = 1 << 29
+
+
+# TODO: Modularize better into their own respective components
+def _register_rc_products() -> None:
+    """Enable fetching configuration from Datadog."""
+    from ddtrace.internal.flare.flare import Flare
+    from ddtrace.internal.flare.handler import _handle_tracer_flare
+    from ddtrace.internal.flare.handler import _tracerFlarePubSub
+    from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
+
+    remoteconfig_pubsub = GlobalConfigPubSub(config._handle_remoteconfig)
+    flare = Flare(trace_agent_url=config._trace_agent_url, api_key=config._dd_api_key, ddconfig=config.__dict__)
+    tracerflare_pubsub = _tracerFlarePubSub()(_handle_tracer_flare, flare)
+    remoteconfig_poller.register("APM_TRACING", remoteconfig_pubsub, capabilities=Capabilities)
+    remoteconfig_poller.register("AGENT_CONFIG", tracerflare_pubsub)
+    remoteconfig_poller.register("AGENT_TASK", tracerflare_pubsub)
 
 
 def post_preload():
@@ -11,7 +52,7 @@ def start():
         from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
 
         remoteconfig_poller.enable()
-        config._enable_remote_configuration()
+        _register_rc_products()
 
 
 def restart(join=False):

--- a/ddtrace/settings/_config.py
+++ b/ddtrace/settings/_config.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-import enum
 import json
 import os
 import re
@@ -386,15 +385,6 @@ def _default_config() -> Dict[str, _ConfigItem]:
             modifier=asbool,
         ),
     }
-
-
-class Capabilities(enum.IntFlag):
-    APM_TRACING_SAMPLE_RATE = 1 << 12
-    APM_TRACING_LOGS_INJECTION = 1 << 13
-    APM_TRACING_HTTP_HEADER_TAGS = 1 << 14
-    APM_TRACING_CUSTOM_TAGS = 1 << 15
-    APM_TRACING_ENABLED = 1 << 19
-    APM_TRACING_SAMPLE_RULES = 1 << 29
 
 
 class Config(object):
@@ -816,23 +806,6 @@ class Config(object):
         # type: (str) -> str
         return self._config[item].source()
 
-    def _remoteconfigPubSub(self):
-        from ddtrace.internal.remoteconfig._connectors import PublisherSubscriberConnector
-        from ddtrace.internal.remoteconfig._publishers import RemoteConfigPublisher
-        from ddtrace.internal.remoteconfig._pubsub import PubSub
-        from ddtrace.internal.remoteconfig._pubsub import RemoteConfigSubscriber
-
-        class _GlobalConfigPubSub(PubSub):
-            __publisher_class__ = RemoteConfigPublisher
-            __subscriber_class__ = RemoteConfigSubscriber
-            __shared_data__ = PublisherSubscriberConnector()
-
-            def __init__(self, callback):
-                self._publisher = self.__publisher_class__(self.__shared_data__, None)
-                self._subscriber = self.__subscriber_class__(self.__shared_data__, callback, "GlobalConfig")
-
-        return _GlobalConfigPubSub
-
     def _handle_remoteconfig(self, data_list, test_tracer=None):
         # data_list is a list of Payload objects
         # type: (Any, Any) -> None
@@ -901,21 +874,6 @@ class Config(object):
         else:
             pairs = [t.split(":") for t in tags]  # type: ignore[union-attr,misc]
         return {k: v for k, v in pairs}
-
-    def _enable_remote_configuration(self):
-        # type: () -> None
-        """Enable fetching configuration from Datadog."""
-        from ddtrace.internal.flare.flare import Flare
-        from ddtrace.internal.flare.handler import _handle_tracer_flare
-        from ddtrace.internal.flare.handler import _tracerFlarePubSub
-        from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
-
-        remoteconfig_pubsub = self._remoteconfigPubSub()(self._handle_remoteconfig)
-        flare = Flare(trace_agent_url=self._trace_agent_url, api_key=self._dd_api_key, ddconfig=self.__dict__)
-        tracerflare_pubsub = _tracerFlarePubSub()(_handle_tracer_flare, flare)
-        remoteconfig_poller.register("APM_TRACING", remoteconfig_pubsub, capabilities=Capabilities)
-        remoteconfig_poller.register("AGENT_CONFIG", tracerflare_pubsub)
-        remoteconfig_poller.register("AGENT_TASK", tracerflare_pubsub)
 
     def _remove_invalid_rules(self, rc_rules: List) -> List:
         """Remove invalid sampling rules from the given list"""


### PR DESCRIPTION
We move some of the RC registration logic out of the global configuration and into the RC product to remove circular import paths. We leave it to follow-up work to improve on the modularisation of the current solution.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
