### PR TITLE
ci: add circular import detection

### DIFF
--- a/.github/workflows/import-analysis.yml
+++ b/.github/workflows/import-analysis.yml
@@ -72,3 +72,59 @@ jobs:
           comment_tag: import_analysis
           mode: upsert
         if: always()
+
+  import_cycles:
+    name: "Circular import analysis"
+    runs-on: ubuntu-latest
+    permissions:
+       pull-requests: write
+    steps:
+      - name: "Install Python 3.12"
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version: '3.12'
+
+      - name: "Checkout the PR"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          path: dd-trace-py
+            
+      - name: "Install dependencies"
+        run: python -m pip install -r dd-trace-py/scripts/import-analysis/requirements-cycles.txt
+
+      # TODO: Remove this step
+      - name: Cache the cycle script
+        run: cp dd-trace-py/scripts/import-analysis/cycles.py .
+
+      - name: "Analyze imports on PR"
+        run: python dd-trace-py/scripts/import-analysis/cycles.py analyze cycles-pr.json
+
+      - name: "Checkout the base branch"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.base_ref }}
+          persist-credentials: false
+          path: dd-trace-py
+
+      # TODO: Remove this step
+      - name: Ensure cycle script is available
+        run: |
+          mkdir -p dd-trace-py/scripts/import-analysis || true
+          mv cycles.py dd-trace-py/scripts/import-analysis/cycles.py
+
+      - name: "Analyze imports on base branch"
+        run: python dd-trace-py/scripts/import-analysis/cycles.py analyze cycles-base.json
+
+      - name: "Compare import cycles"
+        run: python dd-trace-py/scripts/import-analysis/cycles.py compare cycles-base.json cycles-pr.json > cycles_report.txt
+
+      - name: "Report analysis result on PR"
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2.5.0
+        with:
+          filePath: cycles_report.txt
+          comment_tag: import_cycles
+          mode: upsert
+        if: failure()
+
+      

--- a/scripts/import-analysis/cycles.py
+++ b/scripts/import-analysis/cycles.py
@@ -1,0 +1,103 @@
+from argparse import ArgumentParser
+from collections import defaultdict
+from collections import deque
+import json
+from pathlib import Path
+import sys
+import typing as t
+
+from betsy import DependencyGraph
+
+
+ROOT = Path(__file__).parents[2] / "ddtrace"
+
+
+g = DependencyGraph(root=ROOT, include={"ddtrace"}).data  # modules and what they import
+q: t.Deque[str] = deque()
+f = defaultdict(set)  # modules and who imports them
+for importer, imports in list(g.items()):
+    if not imports:
+        q.append(importer)
+        del g[importer]
+    else:
+        for i in imports:
+            f[i].add(importer)
+
+
+def dfs(v: str, visited: t.Set[str], stack: t.List[str], cycles: dict[frozenset, tuple]):
+    for i in g.get(v, set()):
+        if i not in visited:
+            dfs(i, {*visited, v}, [*stack, v], cycles)
+        else:
+            if i in stack:
+                cycle = tuple(stack[stack.index(i) :] + [v, i])
+                if cycle not in cycles:
+                    cycles[frozenset(cycle)] = cycle
+
+
+def analyze(args):
+    dfs("ddtrace", set(), [], cycles := {})
+
+    args.output.write_text(json.dumps(list(cycles.values())))
+
+
+def compare(args):
+    def to_dict(path: Path) -> dict[frozenset, tuple]:
+        return {frozenset(cycle): cycle for cycle in json.loads(path.read_text())}
+
+    base, pr = map(to_dict, [args.base, args.pr])
+
+    def print_cycles(cycles: list[tuple]):
+        print("```")
+        for cycle in cycles:
+            print(" -> ".join(cycle))
+        print("```")
+        print()
+
+    if new_cycles := pr.keys() - base.keys():
+        print("# Circular import analysis")
+        print()
+        print("## 🚨 New circular imports detected 🚨")
+        print()
+        print(
+            "The following circular imports among modules have been detected on "
+            "this PR, when compared to the base branch:"
+        )
+        print()
+        print_cycles([pr[_] for _ in new_cycles])
+        print(
+            "Please consider refactoring your changes in accordance to the "
+            "[Separation of Concerns](https://en.wikipedia.org/wiki/Separation_of_concerns) principle."
+        )
+        print()
+
+    if removed_cycles := base.keys() - pr.keys():
+        print(
+            "The following circular imports among modules have been removed on "
+            "this PR, when compared to the base branch:"
+        )
+        print()
+        print_cycles([base[_] for _ in removed_cycles])
+
+    return bool(new_cycles)
+
+
+def main() -> None:
+    argp = ArgumentParser()
+
+    subp = argp.add_subparsers(dest="command")
+
+    subp_analyze = subp.add_parser("analyze")
+    subp_analyze.add_argument("output", type=Path)
+
+    subp_compare = subp.add_parser("compare")
+    subp_compare.add_argument("base", type=Path)
+    subp_compare.add_argument("pr", type=Path)
+
+    args = argp.parse_args()
+
+    globals()[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/import-analysis/requirements-cycles.txt
+++ b/scripts/import-analysis/requirements-cycles.txt
@@ -1,0 +1,1 @@
+betsy @ git+https://github.com/p403n1x87/betsy.git


### PR DESCRIPTION
We extend the import analysis to include a detection of new circular imports that are potentially introduced by the PR the check runs on. Detection is based on the comparison against the base branch, and not in absolute terms. The new checks ensures that no new cycles are introduced, but is not a guarantee that the library itself is cycle-free.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
