### PR TITLE
docs: reduce backport volume promised in docs

### DIFF
--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -36,8 +36,8 @@ Support levels
 
        .. _versioning_support_ga:
    * - General Availability (GA)
-     - Bugfixes are released on the most recent General Availability minor release line. New features are released periodically
-       as minor version changes. Critical security fixes are backported to the three most recent minor release lines.
+     - Bug fixes are released on the most recent General Availability minor release line. New features are released periodically
+       as minor version changes. Critical fixes are backported to the three most recent minor release lines.
 
        .. _versioning_support_maintenance:
    * - Maintenance

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -37,7 +37,7 @@ Support levels
        .. _versioning_support_ga:
    * - General Availability (GA)
      - Bugfixes are released on the most recent General Availability minor release line. New features are released periodically
-       as minor version changes.
+       as minor version changes. Critical security fixes are backported to the three most recent minor release lines.
 
        .. _versioning_support_maintenance:
    * - Maintenance

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -13,13 +13,13 @@ Release support
    * - Release
      - :ref:`Support level<versioning_support_levels>`
      - Minimum Datadog Agent
-   * - ``<1``
+   * - ``<2``
      - :ref:`End of Life<versioning_support_eol>`
      -
-   * - ``>=1.0,<2``
+   * - ``>=2.0,<3``
      - :ref:`Maintenance<versioning_support_maintenance>`
      - 7.28
-   * - ``>=2.0,<3``
+   * - ``>=3.0,<4``
      - :ref:`General Availability<versioning_support_ga>`
      - 7.28
 
@@ -36,11 +36,12 @@ Support levels
 
        .. _versioning_support_ga:
    * - General Availability (GA)
-     - All fixes are backported to the three most recent General Availability minor release lines.
+     - Bugfixes are released on the most recent General Availability minor release line. New features are released periodically
+       as minor version changes.
 
        .. _versioning_support_maintenance:
    * - Maintenance
-     - The most recent Maintenance minor release line receives security fixes and selected bug fixes.
+     - The most recent Maintenance minor release line receives critical fixes.
 
        .. _versioning_support_eol:
    * - End-of-Life (EOL)


### PR DESCRIPTION
This change updates the support level boundaries for the 3.0 release. It also updates language around backports to reduce the amount of bugfixing that happens on old minor versions.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
