### PR TITLE
ci: use base branch in import time analysis

### DIFF
--- a/.github/workflows/import-analysis.yml
+++ b/.github/workflows/import-analysis.yml
@@ -42,19 +42,25 @@ jobs:
           done
           deactivate
 
-      - name: Set up main environment
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.base_ref }}
+          persist-credentials: false
+          path: dd-trace-py
+  
+      - name: Set up base environment
         run: |
-          python -m venv .venv-main
-          source .venv-main/bin/activate
-          python -m pip install git+https://github.com/datadog/dd-trace-py.git@main
+          python -m venv .venv-base
+          source .venv-base/bin/activate
+          python -m pip install ./dd-trace-py
           python -c "import ddtrace.auto"
           deactivate
   
-      - name: Collect import data from main
+      - name: Collect import data from base
         run: |
-          source .venv-main/bin/activate
+          source .venv-base/bin/activate
           for n in {0..1000}; do
-            python -X importtime -c "import ddtrace.auto" 2> import-main-${n}.txt
+            python -X importtime -c "import ddtrace.auto" 2> import-base-${n}.txt
           done
           deactivate
 

--- a/scripts/import-analysis/import_analysis.py
+++ b/scripts/import-analysis/import_analysis.py
@@ -137,9 +137,9 @@ def z_test(x: Measure, y: Measure) -> float:
 
 def main() -> None:
     x = [ImportFlameGraph.load(f) for f in Path.cwd().glob("import-pr-*.txt")]
-    y = [ImportFlameGraph.load(f) for f in Path.cwd().glob("import-main-*.txt")]
+    y = [ImportFlameGraph.load(f) for f in Path.cwd().glob("import-base-*.txt")]
 
-    # PR - main
+    # PR - base
     graphs: tuple[ImportFlameGraph, ImportFlameGraph, ImportFlameGraph, ImportFlameGraph] = decompose_4way(x, y)
 
     x_measure = Measure([fg.norm() / 1000 for fg in x], "ms")
@@ -156,13 +156,13 @@ def main() -> None:
 
     print("## Bootstrap import analysis")
     print()
-    print("Comparison of import times between this PR and main.")
+    print("Comparison of import times between this PR and base.")
     print()
     print("### Summary")
     print()
-    print(f"The average import time in this PR is: {str(x_measure)}.\n")
-    print(f"The average import time in main is: {str(y_measure)}.\n")
-    print(f"The import time difference between this PR and main is: {str(diff_m)}.\n")
+    print(f"The average import time from this PR is: {str(x_measure)}.\n")
+    print(f"The average import time from base is: {str(y_measure)}.\n")
+    print(f"The import time difference between this PR and base is: {str(diff_m)}.\n")
     if (abs(z)) <= 1.96:
         print(f"The difference is not statistically significant (z = {z:.2f}).\n")
     print()


### PR DESCRIPTION
When generating an import time analysis in CI, we make sure to compare against the base branch instead of main. This makes the reports more meaningful on backport PRs.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
