### PR TITLE
fix(errortracking): wrong attributes check

### DIFF
--- a/ddtrace/errortracking/_handled_exceptions/bytecode_injector.py
+++ b/ddtrace/errortracking/_handled_exceptions/bytecode_injector.py
@@ -38,7 +38,7 @@ def _inject_handled_exception_reporting(func, callback: t.Optional[CallbackType]
 
     # If the function has the wrapper, the code we want to instrument is the wrapped code
     code_to_instr = func.__wrapped__ if hasattr(func, "__wrapped__") else func
-    if "__code__" not in dir(func):
+    if "__code__" not in dir(code_to_instr):
         return
 
     original_code = code_to_instr.__code__  # type: CodeType


### PR DESCRIPTION
We were checking if `func` has a __code__ while sometimes this was not what we were going to instrument. It led to crash on a real example.
No changelog as the feature is not publicly available yet and there is no release notes for it at the moment.

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
