### PR TITLE
fix(asm): add __deepcopy__ for wrapped builtin functions in asm or iast [backport 2.21]

### DIFF
--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -1,5 +1,4 @@
 # This module must not import other modules unconditionally that require iast
-
 import ctypes
 import os
 from typing import Any
@@ -317,6 +316,7 @@ def wrap_object(module, name, factory, args=(), kwargs=None):
     (parent, attribute, original) = resolve_path(module, name)
     wrapper = factory(original, *args, **kwargs)
     apply_patch(parent, attribute, wrapper)
+    wrapper.__deepcopy__ = lambda memo: wrapper
     return wrapper
 
 

--- a/releasenotes/notes/appsec-deepcopy-error-0f898629251881d2.yaml
+++ b/releasenotes/notes/appsec-deepcopy-error-0f898629251881d2.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    ASM: Fixed a NotImplementedError that occurred when trying to deepcopy wrapped builtin functions (like `open`)
+    while ASM or IAST were enabled. The error was caused by the wrapper not implementing the `__deepcopy__` method.

--- a/tests/appsec/app.py
+++ b/tests/appsec/app.py
@@ -1,6 +1,6 @@
 """ This Flask application is imported on tests.appsec.appsec_utils.gunicorn_server
 """
-
+import copy
 import os
 import re
 import subprocess  # nosec
@@ -8,6 +8,7 @@ import subprocess  # nosec
 from flask import Flask
 from flask import Response
 from flask import request
+from wrapt import FunctionWrapper
 
 
 import ddtrace.auto  # noqa: F401  # isort: skip
@@ -966,6 +967,12 @@ def iast_ast_patching_non_re_search():
     except Exception as e:
         print(e)
     return resp
+
+
+@app.route("/common-modules-patch-read", methods=["GET"])
+def test_flask_common_modules_patch_read():
+    copy_open = copy.deepcopy(open)
+    return Response(f"OK: {isinstance(copy_open, FunctionWrapper)}")
 
 
 if __name__ == "__main__":

--- a/tests/appsec/appsec/test_common_modules.py
+++ b/tests/appsec/appsec/test_common_modules.py
@@ -1,0 +1,132 @@
+import builtins
+import copy
+import types
+
+import pytest
+from wrapt import FunctionWrapper
+
+from ddtrace.appsec._common_module_patches import patch_common_modules
+from ddtrace.appsec._common_module_patches import try_unwrap
+from ddtrace.appsec._common_module_patches import try_wrap_function_wrapper
+from ddtrace.appsec._common_module_patches import unpatch_common_modules
+
+
+def test_patch_read():
+    unpatch_common_modules()
+    copy_open = copy.deepcopy(open)
+
+    assert copy_open is open
+    assert type(open) == types.BuiltinFunctionType
+    assert not isinstance(open, FunctionWrapper)
+    assert not isinstance(copy_open, FunctionWrapper)
+    assert isinstance(open, types.BuiltinFunctionType)
+
+
+def test_patch_read_enabled():
+    unpatch_common_modules()
+    original_open = open
+    try:
+        patch_common_modules()
+        copy_open = copy.deepcopy(open)
+
+        assert type(open) == FunctionWrapper
+        assert isinstance(copy_open, FunctionWrapper)
+        assert isinstance(open, FunctionWrapper)
+        assert hasattr(open, "__wrapped__")
+        assert open.__wrapped__ is original_open
+    finally:
+        unpatch_common_modules()
+
+
+@pytest.mark.parametrize(
+    "builtin_function_name",
+    [
+        "all",
+        "any",
+        "ascii",
+        "bin",
+        "bool",
+        "breakpoint",
+        "bytearray",
+        "bytes",
+        "callable",
+        "chr",
+        "classmethod",
+        "compile",
+        "complex",
+        "copyright",
+        "credits",
+        "delattr",
+        "dict",
+        "dir",
+        "divmod",
+        "enumerate",
+        "eval",
+        "exec",
+        "exit",
+        "filter",
+        "float",
+        "format",
+        "frozenset",
+        "getattr",
+        "globals",
+        "hasattr",
+        "hash",
+        "help",
+        "hex",
+        "id",
+        "input",
+        "int",
+        "isinstance",
+        "issubclass",
+        "iter",
+        "len",
+        "license",
+        "list",
+        "locals",
+        "map",
+        "max",
+        "memoryview",
+        "min",
+        "next",
+        "object",
+        "oct",
+        "open",
+        "ord",
+        "pow",
+        "print",
+        "property",
+        "quit",
+        "range",
+        "repr",
+        "reversed",
+        "round",
+        "set",
+        "setattr",
+        "slice",
+        "sorted",
+        "staticmethod",
+        "str",
+        "sum",
+        "super",
+        "tuple",
+        "vars",
+        "zip",
+    ],
+)
+def test_other_builtin_functions(builtin_function_name):
+    def dummywrapper(callable, instance, args, kwargs):  # noqa: A002
+        return callable(*args, **kwargs)
+
+    try:
+        try_wrap_function_wrapper("builtins", builtin_function_name, dummywrapper)
+
+        original_func = getattr(builtins, builtin_function_name)
+        copy_func = copy.deepcopy(original_func)
+
+        assert type(original_func) == FunctionWrapper
+        assert isinstance(copy_func, FunctionWrapper)
+        assert isinstance(original_func, FunctionWrapper)
+        assert hasattr(original_func, "__wrapped__")
+    finally:
+        try_unwrap("builtins", builtin_function_name)


### PR DESCRIPTION
Backport https://github.com/DataDog/dd-trace-py/pull/12716 to 2.21.

This refactor of IAST log messages includes:
- most of the logs have prefixes but no normalized, such as "IAST: ...", "[IAST] ...", "IAST ...".
- Create a hierarchy/namespaces of IAST features (instrumentation, metrics, propagation) and sub-levels:
```
iast::instrumentation::
iast::instrumentation::ast_patching::ast::
iast::instrumentation::ast_patching::compiling::
iast::instrumentation::wrapt::

iast::metrics::error::

iast::propagation::context::
iast::propagation::listener::
iast::propagation::sink_point::
iast::propagation::native::
iast::propagation::native::error::
```
With all these levels, filtering and grouping messages becomes easier, both for use in dashboards and for testing

A lot of logs have been added to analyze the IAST instrumentation process in depth

This PR is a cherry-pick of one of the commits of this PR https://github.com/DataDog/dd-trace-py/pull/12639

(cherry picked from commit bfeef47162f947977eac6f594c797c28ff5afb29)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
