### PR TITLE
chore: auto opt in all PRs to backport to 2.21

### DIFF
--- a/.github/workflows/add-2x-backport-tag.yml
+++ b/.github/workflows/add-2x-backport-tag.yml
@@ -14,13 +14,16 @@ jobs:
         with:
           script: |
             const prTitle = context.payload.pull_request.title;
-            if (prTitle.includes("[backport ")) {
-              console.log("Skipping label: PR is a backport.");
-            } else {
+            const pattern = /^(ci:|fix:|fix\(|chore\(ci\)|fix\(ci\))/i;
+            if (!prTitle.includes("[backport ") && pattern.test(prTitle)) {
               github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,
                 labels: ["backport 2.21"]
               });
+              console.log("Label added.");
+            } else {
+              console.log("Skipping label: PR does not meet conditions.");
+            }
             }

--- a/.github/workflows/add-2x-backport-tag.yml
+++ b/.github/workflows/add-2x-backport-tag.yml
@@ -26,4 +26,3 @@ jobs:
             } else {
               console.log("Skipping label: PR does not meet conditions.");
             }
-            }

--- a/.github/workflows/add-2x-backport-tag.yml
+++ b/.github/workflows/add-2x-backport-tag.yml
@@ -1,0 +1,26 @@
+name: Add 2.21 backport tag
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    permissions:
+        pull-requests: write
+    steps:
+      - name: Add Label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prTitle = context.payload.pull_request.title;
+            if (prTitle.includes("[backport ")) {
+              console.log("Skipping label: PR is a backport.");
+            } else {
+              github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: ["backport 2.21"]
+              });
+            }

--- a/.github/workflows/add-2x-backport-tag.yml
+++ b/.github/workflows/add-2x-backport-tag.yml
@@ -10,7 +10,7 @@ jobs:
         pull-requests: write
     steps:
       - name: Add Label
-        uses: actions/github-script@v7
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const prTitle = context.payload.pull_request.title;

--- a/.github/workflows/add-2x-backport-tag.yml
+++ b/.github/workflows/add-2x-backport-tag.yml
@@ -1,7 +1,7 @@
 name: Add 2.21 backport tag
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened]
     
 jobs:
   add-label:


### PR DESCRIPTION
Quick GitHub workflow to always label PRs with `backport 2.21` so backporting to the 2.21 branch is an opt OUT, not an opt IN. This should help prevent critical backports from being missed in the 2.21 branch.

It will only skip PRs that are already backports, but by depending on the PR title.

Tested with this PR.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
