### PR TITLE
refactor(ci_visibility): rename unique tests to known tests

### DIFF
--- a/ddtrace/internal/ci_visibility/_api_client.py
+++ b/ddtrace/internal/ci_visibility/_api_client.py
@@ -23,7 +23,7 @@ from ddtrace.internal.ci_visibility.constants import SKIPPABLE_ENDPOINT
 from ddtrace.internal.ci_visibility.constants import SUITE
 from ddtrace.internal.ci_visibility.constants import TEST
 from ddtrace.internal.ci_visibility.constants import TEST_MANAGEMENT_TESTS_ENDPOINT
-from ddtrace.internal.ci_visibility.constants import UNIQUE_TESTS_ENDPOINT
+from ddtrace.internal.ci_visibility.constants import KNOWN_TESTS_ENDPOINT
 from ddtrace.internal.ci_visibility.errors import CIVisibilityAuthenticationException
 from ddtrace.internal.ci_visibility.git_data import GitData
 from ddtrace.internal.ci_visibility.telemetry.api_request import APIRequestMetricNames
@@ -68,7 +68,7 @@ _BASE_HEADERS: t.Dict[str, str] = {
 
 _SKIPPABLE_ITEM_ID_TYPE = t.Union[InternalTestId, TestSuiteId]
 _CONFIGURATIONS_TYPE = t.Dict[str, t.Union[str, t.Dict[str, str]]]
-_UNIQUE_TESTS_TYPE = t.Set[InternalTestId]
+_KNOWN_TESTS_TYPE = t.Set[InternalTestId]
 
 _NETWORK_ERRORS = (TimeoutError, socket.timeout, RemoteDisconnected)
 
@@ -515,7 +515,7 @@ class _TestVisibilityAPIClientBase(abc.ABC):
             skippable_items=items_to_skip,
         )
 
-    def fetch_unique_tests(self) -> t.Optional[t.Set[InternalTestId]]:
+    def fetch_known_tests(self) -> t.Optional[t.Set[InternalTestId]]:
         metric_names = APIRequestMetricNames(
             count=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST.value,
             duration=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST_MS.value,
@@ -523,7 +523,7 @@ class _TestVisibilityAPIClientBase(abc.ABC):
             error=EARLY_FLAKE_DETECTION_TELEMETRY.REQUEST_ERRORS.value,
         )
 
-        unique_test_ids: t.Set[InternalTestId] = set()
+        known_test_ids: t.Set[InternalTestId] = set()
 
         payload = {
             "data": {
@@ -540,7 +540,7 @@ class _TestVisibilityAPIClientBase(abc.ABC):
 
         try:
             parsed_response = self._do_request_with_telemetry(
-                "POST", UNIQUE_TESTS_ENDPOINT, json.dumps(payload), metric_names
+                "POST", KNOWN_TESTS_ENDPOINT, json.dumps(payload), metric_names
             )
         except Exception:  # noqa: E722
             return None
@@ -562,15 +562,15 @@ class _TestVisibilityAPIClientBase(abc.ABC):
                 for suite, tests in suites.items():
                     suite_id = TestSuiteId(module_id, suite)
                     for test in tests:
-                        unique_test_ids.add(InternalTestId(suite_id, test))
+                        known_test_ids.add(InternalTestId(suite_id, test))
         except Exception:  # noqa: E722
             log.debug("Failed to parse unique tests data", exc_info=True)
             record_api_request_error(metric_names.error, ERROR_TYPES.UNKNOWN)
             return None
 
-        record_early_flake_detection_tests_count(len(unique_test_ids))
+        record_early_flake_detection_tests_count(len(known_test_ids))
 
-        return unique_test_ids
+        return known_test_ids
 
     def fetch_test_management_tests(self) -> t.Optional[t.Dict[InternalTestId, TestProperties]]:
         metric_names = APIRequestMetricNames(

--- a/ddtrace/internal/ci_visibility/_api_client.py
+++ b/ddtrace/internal/ci_visibility/_api_client.py
@@ -17,13 +17,13 @@ from ddtrace.internal.ci_visibility.constants import AGENTLESS_DEFAULT_SITE
 from ddtrace.internal.ci_visibility.constants import EVP_PROXY_AGENT_BASE_PATH
 from ddtrace.internal.ci_visibility.constants import EVP_SUBDOMAIN_HEADER_API_VALUE
 from ddtrace.internal.ci_visibility.constants import EVP_SUBDOMAIN_HEADER_NAME
+from ddtrace.internal.ci_visibility.constants import KNOWN_TESTS_ENDPOINT
 from ddtrace.internal.ci_visibility.constants import REQUESTS_MODE
 from ddtrace.internal.ci_visibility.constants import SETTING_ENDPOINT
 from ddtrace.internal.ci_visibility.constants import SKIPPABLE_ENDPOINT
 from ddtrace.internal.ci_visibility.constants import SUITE
 from ddtrace.internal.ci_visibility.constants import TEST
 from ddtrace.internal.ci_visibility.constants import TEST_MANAGEMENT_TESTS_ENDPOINT
-from ddtrace.internal.ci_visibility.constants import KNOWN_TESTS_ENDPOINT
 from ddtrace.internal.ci_visibility.errors import CIVisibilityAuthenticationException
 from ddtrace.internal.ci_visibility.git_data import GitData
 from ddtrace.internal.ci_visibility.telemetry.api_request import APIRequestMetricNames

--- a/ddtrace/internal/ci_visibility/constants.py
+++ b/ddtrace/internal/ci_visibility/constants.py
@@ -48,7 +48,7 @@ AGENTLESS_DEFAULT_SITE = "datadoghq.com"
 GIT_API_BASE_PATH = "/api/v2/git"
 SETTING_ENDPOINT = "/api/v2/libraries/tests/services/setting"
 SKIPPABLE_ENDPOINT = "/api/v2/ci/tests/skippable"
-UNIQUE_TESTS_ENDPOINT = "/api/v2/ci/libraries/tests"
+KNOWN_TESTS_ENDPOINT = "/api/v2/ci/libraries/tests"
 TEST_MANAGEMENT_TESTS_ENDPOINT = "/api/v2/test/libraries/test-management/tests"
 
 # Intelligent Test Runner constants

--- a/ddtrace/internal/ci_visibility/coverage.py
+++ b/ddtrace/internal/ci_visibility/coverage.py
@@ -110,7 +110,7 @@ def _coverage_has_valid_data(coverage_data: Coverage, silent_mode: bool = False)
 
 
 def _switch_coverage_context(
-    coverage_data: Coverage, unique_test_name: str, framework: Optional[TEST_FRAMEWORKS] = None
+    coverage_data: Coverage, known_test_name: str, framework: Optional[TEST_FRAMEWORKS] = None
 ):
     record_code_coverage_started(COVERAGE_LIBRARY.COVERAGEPY, framework)
     # Experimental feature to use internal coverage collection
@@ -124,7 +124,7 @@ def _switch_coverage_context(
         return
     coverage_data._collector.data.clear()  # type: ignore[union-attr]
     try:
-        coverage_data.switch_context(unique_test_name)
+        coverage_data.switch_context(known_test_name)
     except RuntimeError as err:
         record_code_coverage_error()
         log.warning(err)

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -209,7 +209,7 @@ class CIVisibility(Service):
         self._should_upload_git_metadata = True
         self._itr_meta: Dict[str, Any] = {}
         self._itr_data: Optional[ITRData] = None
-        self._unique_test_ids: Set[InternalTestId] = set()
+        self._known_test_ids: Set[InternalTestId] = set()
         self._test_properties: Dict[InternalTestId, TestProperties] = {}
 
         self._session: Optional[TestVisibilitySession] = None
@@ -500,10 +500,10 @@ class CIVisibility(Service):
         except Exception:  # noqa: E722
             log.debug("Error fetching skippable items", exc_info=True)
 
-    def _fetch_unique_tests(self) -> Optional[Set[InternalTestId]]:
+    def _fetch_known_tests(self) -> Optional[Set[InternalTestId]]:
         try:
             if self._api_client is not None:
-                return self._api_client.fetch_unique_tests()
+                return self._api_client.fetch_known_tests()
             log.warning("API client not initialized, cannot fetch unique tests")
         except Exception:
             log.debug("Error fetching unique tests", exc_info=True)
@@ -617,12 +617,12 @@ class CIVisibility(Service):
             log.info("ITR correlation ID: %s", self._itr_data.correlation_id)
 
         if CIVisibility.is_efd_enabled():
-            unique_test_ids = self._fetch_unique_tests()
-            if unique_test_ids is None:
+            known_test_ids = self._fetch_known_tests()
+            if known_test_ids is None:
                 log.warning("Failed to fetch unique tests for Early Flake Detection")
             else:
-                self._unique_test_ids = unique_test_ids
-                log.info("Unique tests fetched for Early Flake Detection: %s", len(self._unique_test_ids))
+                self._known_test_ids = known_test_ids
+                log.info("Unique tests fetched for Early Flake Detection: %s", len(self._known_test_ids))
         else:
             if (
                 self._api_settings.early_flake_detection.enabled
@@ -956,7 +956,7 @@ class CIVisibility(Service):
         client.set_metadata("test", capabilities.tags())
 
     @classmethod
-    def is_unique_test(cls, test_id: Union[TestId, InternalTestId]) -> bool:
+    def is_known_test(cls, test_id: Union[TestId, InternalTestId]) -> bool:
         instance = cls.get_instance()
         if instance is None:
             return False
@@ -964,10 +964,10 @@ class CIVisibility(Service):
         # The assumption that we were not able to fetch unique tests properly if the length is 0 is acceptable
         # because the current EFD usage would cause the session to be faulty even if the query was successful but
         # not unique tests exist. In this case, we assume all tests are unique.
-        if len(instance._unique_test_ids) == 0:
+        if len(instance._known_test_ids) == 0:
             return True
 
-        return test_id in instance._unique_test_ids
+        return test_id in instance._known_test_ids
 
     @classmethod
     def get_test_properties(cls, test_id: Union[TestId, InternalTestId]) -> Optional[TestProperties]:
@@ -1234,10 +1234,10 @@ def _on_discover_test(discover_args: Test.DiscoverArgs) -> None:
     suite = CIVisibility.get_suite_by_id(discover_args.test_id.parent_id)
 
     # New tests are currently only considered for EFD:
-    # - if known tests were fetched properly (enforced by is_unique_test)
+    # - if known tests were fetched properly (enforced by is_known_test)
     # - if they have no parameters
     if CIVisibility.is_efd_enabled() and discover_args.test_id.parameters is None:
-        is_new = not CIVisibility.is_unique_test(discover_args.test_id)
+        is_new = not CIVisibility.is_known_test(discover_args.test_id)
     else:
         is_new = False
 

--- a/tests/ci_visibility/api/fake_runner_efd_all_pass.py
+++ b/tests/ci_visibility/api/fake_runner_efd_all_pass.py
@@ -26,7 +26,7 @@ def _hack_test_duration(test_id: api.InternalTestId, duration: float):
 
 
 def _make_test_ids():
-    _unique_test_ids = {
+    _known_test_ids = {
         "m1": {
             "m1_s1": [
                 ["m1_s1_t3"],
@@ -55,7 +55,7 @@ def _make_test_ids():
     }
 
     test_ids = set()
-    for module, suites in _unique_test_ids.items():
+    for module, suites in _known_test_ids.items():
         module_id = ext_api.TestModuleId(module)
         for suite, tests in suites.items():
             suite_id = ext_api.TestSuiteId(module_id, suite)
@@ -287,7 +287,7 @@ def main():
         ext_api.enable_test_visibility()
 
         with mock.patch(
-            "ddtrace.internal.ci_visibility.recorder.CIVisibility._instance._unique_test_ids",
+            "ddtrace.internal.ci_visibility.recorder.CIVisibility._instance._known_test_ids",
             _make_test_ids(),
         ):
             run_tests()

--- a/tests/ci_visibility/api/fake_runner_efd_faulty_session.py
+++ b/tests/ci_visibility/api/fake_runner_efd_faulty_session.py
@@ -16,7 +16,7 @@ from ddtrace.internal.test_visibility import api
 
 
 def _make_test_ids():
-    _unique_test_ids = {
+    _known_test_ids = {
         "m1": {
             "m1_s1": [
                 ["m1_s1_t3"],
@@ -32,7 +32,7 @@ def _make_test_ids():
     }
 
     test_ids = set()
-    for module, suites in _unique_test_ids.items():
+    for module, suites in _known_test_ids.items():
         module_id = ext_api.TestModuleId(module)
         for suite, tests in suites.items():
             suite_id = ext_api.TestSuiteId(module_id, suite)
@@ -221,7 +221,7 @@ def main():
         ext_api.enable_test_visibility()
 
         with mock.patch(
-            "ddtrace.internal.ci_visibility.recorder.CIVisibility._instance._unique_test_ids",
+            "ddtrace.internal.ci_visibility.recorder.CIVisibility._instance._known_test_ids",
             _make_test_ids(),
         ):
             run_tests()

--- a/tests/ci_visibility/api/fake_runner_efd_mix_fail.py
+++ b/tests/ci_visibility/api/fake_runner_efd_mix_fail.py
@@ -26,7 +26,7 @@ def _hack_test_duration(test_id: api.InternalTestId, duration: float):
 
 
 def _make_test_ids():
-    _unique_test_ids = {
+    _known_test_ids = {
         "m1": {
             "m1_s1": [
                 ["m1_s1_t3"],
@@ -55,7 +55,7 @@ def _make_test_ids():
     }
 
     test_ids = set()
-    for module, suites in _unique_test_ids.items():
+    for module, suites in _known_test_ids.items():
         module_id = ext_api.TestModuleId(module)
         for suite, tests in suites.items():
             suite_id = ext_api.TestSuiteId(module_id, suite)
@@ -287,7 +287,7 @@ def main():
         ext_api.enable_test_visibility()
 
         with mock.patch(
-            "ddtrace.internal.ci_visibility.recorder.CIVisibility._instance._unique_test_ids",
+            "ddtrace.internal.ci_visibility.recorder.CIVisibility._instance._known_test_ids",
             _make_test_ids(),
         ):
             run_tests()

--- a/tests/ci_visibility/api/fake_runner_efd_mix_pass.py
+++ b/tests/ci_visibility/api/fake_runner_efd_mix_pass.py
@@ -26,7 +26,7 @@ def _hack_test_duration(test_id: api.InternalTestId, duration: float):
 
 
 def _make_test_ids():
-    _unique_test_ids = {
+    _known_test_ids = {
         "m1": {
             "m1_s1": [
                 ["m1_s1_t3"],
@@ -55,7 +55,7 @@ def _make_test_ids():
     }
 
     test_ids = set()
-    for module, suites in _unique_test_ids.items():
+    for module, suites in _known_test_ids.items():
         module_id = ext_api.TestModuleId(module)
         for suite, tests in suites.items():
             suite_id = ext_api.TestSuiteId(module_id, suite)
@@ -291,7 +291,7 @@ def main():
         ext_api.enable_test_visibility()
 
         with mock.patch(
-            "ddtrace.internal.ci_visibility.recorder.CIVisibility._instance._unique_test_ids",
+            "ddtrace.internal.ci_visibility.recorder.CIVisibility._instance._known_test_ids",
             _make_test_ids(),
         ):
             run_tests()

--- a/tests/ci_visibility/api_client/test_ci_visibility_api_client.py
+++ b/tests/ci_visibility/api_client/test_ci_visibility_api_client.py
@@ -268,10 +268,10 @@ class TestTestVisibilityAPIClient(TestTestVisibilityAPIClientBase):
         "requests_mode_settings",
         request_mode_settings_parameters,
     )
-    def test_civisibility_api_client_unique_tests_do_request(
+    def test_civisibility_api_client_known_tests_do_request(
         self, requests_mode_settings, client_timeout, request_timeout
     ):
-        """Tests that the correct payload and headers are sent to the correct API URL for unique tests requests"""
+        """Tests that the correct payload and headers are sent to the correct API URL for known tests requests"""
         client = self._get_test_client(
             requests_mode=requests_mode_settings["mode"],
             api_key=requests_mode_settings.get("api_key"),
@@ -288,8 +288,8 @@ class TestTestVisibilityAPIClient(TestTestVisibilityAPIClientBase):
         with mock.patch(
             "ddtrace.internal.ci_visibility._api_client.get_connection", return_value=mock_connection
         ) as mock_get_connection:
-            unique_tests = client.fetch_unique_tests()
-            assert unique_tests == set()
+            known_tests = client.fetch_known_tests()
+            assert known_tests == set()
             mock_get_connection.assert_called_once_with(
                 requests_mode_settings["expected_urls"]["tests"],
                 client_timeout if client_timeout is not None else 12.34,

--- a/tests/ci_visibility/api_client/test_ci_visibility_api_client_unique_tests_responses.py
+++ b/tests/ci_visibility/api_client/test_ci_visibility_api_client_unique_tests_responses.py
@@ -12,11 +12,11 @@ from tests.ci_visibility.api_client._util import _get_tests_api_response
 from tests.ci_visibility.api_client._util import _make_fqdn_test_ids
 
 
-class TestTestVisibilityAPIClientUniqueTestResponses(TestTestVisibilityAPIClientBase):
-    """Tests that unique tests responses from the API client are parsed properly"""
+class TestTestVisibilityAPIClientKnownTestResponses(TestTestVisibilityAPIClientBase):
+    """Tests that known tests responses from the API client are parsed properly"""
 
     @pytest.mark.parametrize(
-        "unique_test_response,expected_tests",
+        "known_test_response,expected_tests",
         [
             # Defaults
             (_get_tests_api_response({}), set()),
@@ -25,7 +25,7 @@ class TestTestVisibilityAPIClientUniqueTestResponses(TestTestVisibilityAPIClient
                 _get_tests_api_response({"module1": {"suite1.py": ["test1"]}}),
                 set(_make_fqdn_test_ids([("module1", "suite1.py", "test1")])),
             ),
-            # Multiple unique items
+            # Multiple known items
             (
                 _get_tests_api_response({"module1": {"suite1.py": ["test1"]}}),
                 set(_make_fqdn_test_ids([("module1", "suite1.py", "test1")])),
@@ -63,11 +63,11 @@ class TestTestVisibilityAPIClientUniqueTestResponses(TestTestVisibilityAPIClient
             ),
         ],
     )
-    def test_civisibility_api_client_unique_tests_parsed(self, unique_test_response, expected_tests):
-        """Tests that the client correctly returns unique tests from API response"""
+    def test_civisibility_api_client_known_tests_parsed(self, known_test_response, expected_tests):
+        """Tests that the client correctly returns known tests from API response"""
         client = self._get_test_client()
-        with mock.patch.object(client, "_do_request", return_value=unique_test_response):
-            assert client.fetch_unique_tests() == expected_tests
+        with mock.patch.object(client, "_do_request", return_value=known_test_response):
+            assert client.fetch_known_tests() == expected_tests
 
     @pytest.mark.parametrize(
         "do_request_side_effect",
@@ -98,9 +98,9 @@ class TestTestVisibilityAPIClientUniqueTestResponses(TestTestVisibilityAPIClient
             ),
         ],
     )
-    def test_civisibility_api_client_unique_tests_errors(self, do_request_side_effect):
-        """Tests that the client correctly handles errors in the unique test API response"""
+    def test_civisibility_api_client_known_tests_errors(self, do_request_side_effect):
+        """Tests that the client correctly handles errors in the known test API response"""
         client = self._get_test_client()
         with mock.patch.object(client, "_do_request", side_effect=[do_request_side_effect]):
-            settings = client.fetch_unique_tests()
+            settings = client.fetch_known_tests()
             assert settings is None

--- a/tests/ci_visibility/util.py
+++ b/tests/ci_visibility/util.py
@@ -43,12 +43,12 @@ def _get_default_civisibility_ddconfig(itr_skipping_level: ITR_SKIPPING_LEVEL = 
     return new_ddconfig
 
 
-def _fetch_unique_tests_side_effect(unique_test_ids: t.Optional[t.Set[InternalTestId]] = None):
-    if unique_test_ids is None:
-        unique_test_ids = set()
+def _fetch_known_tests_side_effect(known_test_ids: t.Optional[t.Set[InternalTestId]] = None):
+    if known_test_ids is None:
+        known_test_ids = set()
 
     def _side_effect():
-        CIVisibility._instance._unique_test_ids = unique_test_ids
+        CIVisibility._instance._known_test_ids = known_test_ids
 
     return _side_effect
 
@@ -72,7 +72,7 @@ def set_up_mock_civisibility(
     require_git: bool = False,
     suite_skipping_mode: bool = False,
     skippable_items=None,
-    unique_test_ids: t.Optional[t.Set[InternalTestId]] = None,
+    known_test_ids: t.Optional[t.Set[InternalTestId]] = None,
     efd_settings: t.Optional[EarlyFlakeDetectionSettings] = None,
 ):
     """This is a one-stop-shop that patches all parts of CI Visibility for testing.
@@ -127,8 +127,8 @@ def set_up_mock_civisibility(
         "ddtrace.internal.ci_visibility.recorder.CIVisibility._fetch_tests_to_skip",
         side_effect=_fake_fetch_tests_to_skip,
     ), mock.patch(
-        "ddtrace.internal.ci_visibility.recorder.CIVisibility._fetch_unique_tests",
-        return_value=_fetch_unique_tests_side_effect(unique_test_ids),
+        "ddtrace.internal.ci_visibility.recorder.CIVisibility._fetch_known_tests",
+        return_value=_fetch_known_tests_side_effect(known_test_ids),
     ), mock.patch.multiple(
         CIVisibilityGitClient,
         _get_repository_url=classmethod(lambda *args, **kwargs: "git@github.com:TestDog/dd-test-py.git"),

--- a/tests/contrib/pytest/test_pytest_efd.py
+++ b/tests/contrib/pytest/test_pytest_efd.py
@@ -16,7 +16,7 @@ from ddtrace.contrib.internal.pytest._utils import _pytest_version_supports_efd
 from ddtrace.internal.ci_visibility._api_client import EarlyFlakeDetectionSettings
 from ddtrace.internal.ci_visibility._api_client import TestVisibilityAPISettings
 from tests.ci_visibility.api_client._util import _make_fqdn_test_ids
-from tests.ci_visibility.util import _fetch_unique_tests_side_effect
+from tests.ci_visibility.util import _fetch_known_tests_side_effect
 from tests.ci_visibility.util import _get_default_civisibility_ddconfig
 from tests.contrib.pytest.test_pytest import PytestTestCaseBase
 from tests.contrib.pytest.test_pytest import _get_spans_from_list
@@ -108,7 +108,7 @@ class PytestEFDTestCase(PytestTestCaseBase):
     @pytest.fixture(autouse=True, scope="function")
     def set_up_efd(self):
         with mock.patch(
-            "ddtrace.internal.ci_visibility.recorder.CIVisibility._fetch_unique_tests",
+            "ddtrace.internal.ci_visibility.recorder.CIVisibility._fetch_known_tests",
             return_value=_KNOWN_TEST_IDS,
         ), mock.patch(
             "ddtrace.internal.ci_visibility.recorder.CIVisibility._check_enabled_features",
@@ -136,8 +136,8 @@ class PytestEFDTestCase(PytestTestCaseBase):
         self.testdir.makepyfile(test_new_fail=_TEST_NEW_FAIL_CONTENT)
         self.testdir.makepyfile(test_new_flaky=_TEST_NEW_FLAKY_CONTENT)
         with mock.patch(
-            "ddtrace.internal.ci_visibility.recorder.CIVisibility._fetch_unique_tests",
-            side_effect=_fetch_unique_tests_side_effect(set()),
+            "ddtrace.internal.ci_visibility.recorder.CIVisibility._fetch_known_tests",
+            side_effect=_fetch_known_tests_side_effect(set()),
         ):
             rec = self.inline_run("--ddtrace")
             rec.assertoutcome(passed=4, failed=3)


### PR DESCRIPTION
CI Visibility: Small renaming from unique tests to known tests

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
