### PR TITLE
refactor(profiling): fix memalloc error string formatting

### DIFF
--- a/ddtrace/profiling/collector/_memalloc.c
+++ b/ddtrace/profiling/collector/_memalloc.c
@@ -260,21 +260,21 @@ memalloc_start(PyObject* Py_UNUSED(module), PyObject* args)
         return NULL;
 
     if (max_nframe < 1 || max_nframe > TRACEBACK_MAX_NFRAME) {
-        PyErr_Format(PyExc_ValueError, "the number of frames must be in range [1; %lu]", TRACEBACK_MAX_NFRAME);
+        PyErr_Format(PyExc_ValueError, "the number of frames must be in range [1; %u]", TRACEBACK_MAX_NFRAME);
         return NULL;
     }
 
     global_memalloc_ctx.max_nframe = (uint16_t)max_nframe;
 
     if (max_events < 1 || max_events > TRACEBACK_ARRAY_MAX_COUNT) {
-        PyErr_Format(PyExc_ValueError, "the number of events must be in range [1; %lu]", TRACEBACK_ARRAY_MAX_COUNT);
+        PyErr_Format(PyExc_ValueError, "the number of events must be in range [1; %u]", TRACEBACK_ARRAY_MAX_COUNT);
         return NULL;
     }
 
     global_memalloc_ctx.max_events = (uint16_t)max_events;
 
     if (heap_sample_size < 0 || heap_sample_size > MAX_HEAP_SAMPLE_SIZE) {
-        PyErr_Format(PyExc_ValueError, "the heap sample size must be in range [0; %lu]", MAX_HEAP_SAMPLE_SIZE);
+        PyErr_Format(PyExc_ValueError, "the heap sample size must be in range [0; %u]", MAX_HEAP_SAMPLE_SIZE);
         return NULL;
     }
 


### PR DESCRIPTION
The error format strings for memalloc aren't quite right. On my macbook,
running the memalloc tests fails like this:

	>       with pytest.raises(ValueError, match="the heap sample size must be in range \\[0; 4294967295\\]"):
	E       AssertionError: Regex pattern did not match.
	E        Regex: 'the heap sample size must be in range \\[0; 4294967295\\]'
	E        Input: 'the heap sample size must be in range [0; 18446744073709551615]'

The error format string in question uses the %lu format specifier to
print the sample size limit, which is currently UINT32_MAX.

Use %u instead, which is correct for the platforms we support. We could
also use PRIu32 from inttypes.h, but on Windows that expands to I32u,
while the Python Unicode formatting routines want POSIX-style
specifiers.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
