### PR TITLE
Revert "ci(flaky): mark `mariadb` test as flaky for 30 days"

### DIFF
--- a/tests/contrib/mariadb/test_mariadb.py
+++ b/tests/contrib/mariadb/test_mariadb.py
@@ -280,7 +280,6 @@ def test_query_many_fetchall_snapshot(tracer):
 
 
 @snapshot(include_tracer=True, variants=SNAPSHOT_VARIANTS)
-@flaky(until=1743713962, reason="Did not receive expected traces: 'mariadb.connection.commit'")
 def test_commit_snapshot(tracer):
     with get_connection(tracer) as connection:
         connection.commit()


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#12606