### PR TITLE
ci(iast): move iast_patched_module to utils instead of conftest

### DIFF
--- a/benchmarks/bm/iast_utils/aspects_benchmarks_generate.py
+++ b/benchmarks/bm/iast_utils/aspects_benchmarks_generate.py
@@ -15,7 +15,7 @@ from benchmarks.bm.utils import override_env
 
 
 with override_env({"DD_IAST_ENABLED": "True"}):
-    from tests.appsec.iast.aspects.conftest import _iast_patched_module
+    from tests.appsec.iast.iast_utils import _iast_patched_module
 
     mod_patched_methods = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods")
     mod_patched_methods_py3 = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods_py3")

--- a/tests/appsec/iast/_ast/test_proper_patching.py
+++ b/tests/appsec/iast/_ast/test_proper_patching.py
@@ -4,7 +4,7 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
 from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
 from tests.appsec.iast.aspects.aspect_utils import create_taint_range_with_format
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
 mod = _iast_patched_module("tests.appsec.iast._ast.fixtures.misleading_methods")

--- a/tests/appsec/iast/aspects/aspect_utils.py
+++ b/tests/appsec/iast/aspects/aspect_utils.py
@@ -12,7 +12,7 @@ from ddtrace.appsec._iast._taint_tracking import TaintRange
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
 from ddtrace.appsec._iast._taint_tracking import set_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject_with_ranges
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
 mod = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods")

--- a/tests/appsec/iast/aspects/conftest.py
+++ b/tests/appsec/iast/aspects/conftest.py
@@ -1,34 +1,8 @@
-import importlib
-import types
-
 import pytest
 
-from ddtrace.appsec._iast._ast.ast_patching import _should_iast_patch
-from ddtrace.appsec._iast._ast.ast_patching import astpatch_module
 from tests.appsec.iast.conftest import _end_iast_context_and_oce
 from tests.appsec.iast.conftest import _start_iast_context_and_oce
 from tests.utils import override_global_config
-
-
-class IastTestException(Exception):
-    pass
-
-
-def _iast_patched_module_and_patched_source(module_name, new_module_object=False):
-    module = importlib.import_module(module_name)
-    module_path, patched_source = astpatch_module(module)
-    compiled_code = compile(patched_source, module_path, "exec")
-    module_changed = types.ModuleType(module_name) if new_module_object else module
-    exec(compiled_code, module_changed.__dict__)
-    return module_changed, patched_source
-
-
-def _iast_patched_module(module_name, new_module_object=False):
-    if _should_iast_patch(module_name):
-        module, _ = _iast_patched_module_and_patched_source(module_name, new_module_object)
-    else:
-        raise IastTestException(f"IAST Test Error: module {module_name} was excluded")
-    return module
 
 
 @pytest.fixture(autouse=True)

--- a/tests/appsec/iast/aspects/test_add_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_add_aspect_fixtures.py
@@ -5,7 +5,7 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
 mod = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods")

--- a/tests/appsec/iast/aspects/test_add_inplace_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_add_inplace_aspect_fixtures.py
@@ -6,7 +6,7 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
 mod = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods")

--- a/tests/appsec/iast/aspects/test_asyncio.py
+++ b/tests/appsec/iast/aspects/test_asyncio.py
@@ -8,7 +8,7 @@ from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
 mod = _iast_patched_module("tests.appsec.iast.fixtures.aspects.asyncio_functions")

--- a/tests/appsec/iast/aspects/test_bytearray_extend_aspect.py
+++ b/tests/appsec/iast/aspects/test_bytearray_extend_aspect.py
@@ -10,7 +10,7 @@ from ddtrace.appsec._iast._taint_tracking._context import create_context
 from ddtrace.appsec._iast._taint_tracking._context import reset_context
 from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.utils import override_global_config
 
 

--- a/tests/appsec/iast/aspects/test_common_aspects.py
+++ b/tests/appsec/iast/aspects/test_common_aspects.py
@@ -6,8 +6,8 @@ import os
 
 import pytest
 
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
 import tests.appsec.iast.fixtures.aspects.callees
+from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
 def generate_callers_from_callees(callees_module, callers_file="", callees_module_str=""):

--- a/tests/appsec/iast/aspects/test_common_aspects_generator.py
+++ b/tests/appsec/iast/aspects/test_common_aspects_generator.py
@@ -13,10 +13,9 @@ try:
 except (ImportError, AttributeError):
     pytest.skip("IAST not supported for this Python version", allow_module_level=True)
 
-
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
 import tests.appsec.iast.fixtures.aspects.callees
 import tests.appsec.iast.fixtures.aspects.obj_callees
+from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
 def generate_callers_from_callees(functions_module, callees_module, callers_file="", callees_module_str=""):

--- a/tests/appsec/iast/aspects/test_common_replace_aspects.py
+++ b/tests/appsec/iast/aspects/test_common_replace_aspects.py
@@ -5,7 +5,7 @@ from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
 from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
 mod = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods")

--- a/tests/appsec/iast/aspects/test_empty_arg_aspects.py
+++ b/tests/appsec/iast/aspects/test_empty_arg_aspects.py
@@ -7,7 +7,7 @@ import os
 import pytest
 
 from ddtrace.appsec._iast._taint_tracking import TagMappingMode  # noqa: F401
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
 def generate_callers_from_callees(callers_file=""):

--- a/tests/appsec/iast/aspects/test_encode_decode_aspect.py
+++ b/tests/appsec/iast/aspects/test_encode_decode_aspect.py
@@ -6,7 +6,7 @@ from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
 mod = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods")

--- a/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
@@ -15,7 +15,7 @@ from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_rang
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
 from tests.appsec.iast.aspects.aspect_utils import create_taint_range_with_format
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.utils import override_global_config
 
 

--- a/tests/appsec/iast/aspects/test_format_map_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_format_map_aspect_fixtures.py
@@ -8,7 +8,7 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
 from ddtrace.appsec._iast._taint_tracking import get_ranges
 from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
 mod = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods")

--- a/tests/appsec/iast/aspects/test_index_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_index_aspect_fixtures.py
@@ -8,7 +8,7 @@ from ddtrace.appsec._iast._taint_tracking._context import create_context
 from ddtrace.appsec._iast._taint_tracking._context import reset_context
 from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.utils import override_global_config
 
 

--- a/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
@@ -9,7 +9,7 @@ from ddtrace.appsec._iast._taint_tracking._context import create_context
 from ddtrace.appsec._iast._taint_tracking._context import reset_context
 from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.utils import override_global_config
 
 

--- a/tests/appsec/iast/aspects/test_modulo_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_modulo_aspect_fixtures.py
@@ -14,7 +14,7 @@ from ddtrace.appsec._iast._taint_tracking import get_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
 mod = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods")

--- a/tests/appsec/iast/aspects/test_ospath_aspects_fixtures.py
+++ b/tests/appsec/iast/aspects/test_ospath_aspects_fixtures.py
@@ -12,7 +12,7 @@ from ddtrace.appsec._iast._taint_tracking._context import create_context
 from ddtrace.appsec._iast._taint_tracking._context import reset_context
 from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.utils import override_global_config
 
 

--- a/tests/appsec/iast/aspects/test_other_patching.py
+++ b/tests/appsec/iast/aspects/test_other_patching.py
@@ -7,7 +7,7 @@ from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
 from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
 mod = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods")

--- a/tests/appsec/iast/aspects/test_re_aspects.py
+++ b/tests/appsec/iast/aspects/test_re_aspects.py
@@ -22,7 +22,7 @@ from ddtrace.appsec._iast._taint_tracking.aspects import re_search_aspect
 from ddtrace.appsec._iast._taint_tracking.aspects import re_sub_aspect
 from ddtrace.appsec._iast._taint_tracking.aspects import re_subn_aspect
 from ddtrace.appsec._iast._taint_tracking.aspects import split_aspect
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
 mod = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods_py3")

--- a/tests/appsec/iast/aspects/test_side_effects.py
+++ b/tests/appsec/iast/aspects/test_side_effects.py
@@ -5,7 +5,7 @@ from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_rang
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject_with_ranges
 import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.appsec.iast.iast_utils_side_effects import MagicMethodsException
 
 

--- a/tests/appsec/iast/aspects/test_slice_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_slice_aspect_fixtures.py
@@ -9,7 +9,7 @@ from ddtrace.appsec._iast._taint_tracking._context import create_context
 from ddtrace.appsec._iast._taint_tracking._context import reset_context
 from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.utils import override_global_config
 
 

--- a/tests/appsec/iast/aspects/test_str_aspect.py
+++ b/tests/appsec/iast/aspects/test_str_aspect.py
@@ -13,7 +13,7 @@ from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
 from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
 from tests.appsec.iast.aspects.aspect_utils import create_taint_range_with_format
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
 mod = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods")

--- a/tests/appsec/iast/aspects/test_str_py3.py
+++ b/tests/appsec/iast/aspects/test_str_py3.py
@@ -3,7 +3,7 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
 from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
 from tests.appsec.iast.aspects.aspect_utils import create_taint_range_with_format
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
 mod = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods")

--- a/tests/appsec/iast/iast_utils.py
+++ b/tests/appsec/iast/iast_utils.py
@@ -1,13 +1,22 @@
+import importlib
 import re
+import types
 from typing import Optional
 from typing import Text
 import zlib
+
+from ddtrace.appsec._iast._ast.ast_patching import _should_iast_patch
+from ddtrace.appsec._iast._ast.ast_patching import astpatch_module
 
 
 # Check if the log contains "iast::" to raise an error if that’s the case BUT, if the logs contains
 # "iast::instrumentation::" or "iast::instrumentation::"
 # are valid logs
 IAST_VALID_LOG = re.compile(r"^iast::(?!instrumentation::|propagation::context::).*$")
+
+
+class IastTestException(Exception):
+    pass
 
 
 def get_line(label: Text, filename: Optional[Text] = None):
@@ -30,3 +39,20 @@ def get_line_and_hash(label: Text, vuln_type: Text, filename=None, fixed_line=No
     hash_value = zlib.crc32(rep.encode())
 
     return line, hash_value
+
+
+def _iast_patched_module_and_patched_source(module_name, new_module_object=False):
+    module = importlib.import_module(module_name)
+    module_path, patched_source = astpatch_module(module)
+    compiled_code = compile(patched_source, module_path, "exec")
+    module_changed = types.ModuleType(module_name) if new_module_object else module
+    exec(compiled_code, module_changed.__dict__)
+    return module_changed, patched_source
+
+
+def _iast_patched_module(module_name, new_module_object=False):
+    if _should_iast_patch(module_name):
+        module, _ = _iast_patched_module_and_patched_source(module_name, new_module_object)
+    else:
+        raise IastTestException(f"IAST Test Error: module {module_name} was excluded")
+    return module

--- a/tests/appsec/iast/taint_sinks/test_code_injection.py
+++ b/tests/appsec/iast/taint_sinks/test_code_injection.py
@@ -5,7 +5,7 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast.constants import VULN_CODE_INJECTION
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.appsec.iast.taint_sinks.conftest import _get_iast_data
 from tests.appsec.iast.taint_sinks.conftest import _get_span_report
 

--- a/tests/appsec/iast/taint_sinks/test_path_traversal.py
+++ b/tests/appsec/iast/taint_sinks/test_path_traversal.py
@@ -7,7 +7,7 @@ from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast.constants import DEFAULT_PATH_TRAVERSAL_FUNCTIONS
 from ddtrace.appsec._iast.constants import VULN_PATH_TRAVERSAL
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.appsec.iast.iast_utils import get_line_and_hash
 from tests.appsec.iast.taint_sinks.conftest import _get_iast_data
 from tests.appsec.iast.taint_sinks.conftest import _get_span_report

--- a/tests/appsec/iast/taint_sinks/test_sql_injection.py
+++ b/tests/appsec/iast/taint_sinks/test_sql_injection.py
@@ -6,7 +6,7 @@ from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tain
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.appsec._iast.taint_sinks._base import VulnerabilityBase
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.appsec.iast.iast_utils import get_line_and_hash
 from tests.appsec.iast.taint_sinks.conftest import _get_iast_data
 

--- a/tests/appsec/iast/taint_sinks/test_weak_randomness.py
+++ b/tests/appsec/iast/taint_sinks/test_weak_randomness.py
@@ -4,7 +4,7 @@ import pytest
 
 from ddtrace.appsec._iast.constants import DEFAULT_WEAK_RANDOMNESS_FUNCTIONS
 from ddtrace.appsec._iast.constants import VULN_WEAK_RANDOMNESS
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.appsec.iast.iast_utils import get_line_and_hash
 from tests.appsec.iast.taint_sinks.conftest import _get_span_report
 

--- a/tests/appsec/iast/test_iast_propagation_path.py
+++ b/tests/appsec/iast/test_iast_propagation_path.py
@@ -5,7 +5,7 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast.constants import VULN_PATH_TRAVERSAL
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.appsec.iast.iast_utils import get_line_and_hash
 from tests.appsec.iast.taint_sinks.conftest import _get_span_report
 

--- a/tests/appsec/iast/test_telemetry.py
+++ b/tests/appsec/iast/test_telemetry.py
@@ -27,7 +27,7 @@ from ddtrace.contrib.internal.sqlite3.patch import patch as sqli_sqlite3_patch
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.internal.telemetry.constants import TELEMETRY_TYPE_GENERATE_METRICS
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.appsec.utils import asm_context
 from tests.utils import DummyTracer
 from tests.utils import override_global_config

--- a/tests/appsec/iast_memcheck/test_iast_mem_check.py
+++ b/tests/appsec/iast_memcheck/test_iast_mem_check.py
@@ -13,7 +13,7 @@ from ddtrace.appsec._iast._taint_tracking._context import create_context
 from ddtrace.appsec._iast._taint_tracking._context import reset_context
 from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
+from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.appsec.iast.taint_sinks.conftest import _get_span_report
 from tests.appsec.iast_memcheck._stacktrace_py import get_info_frame as get_info_frame_py
 from tests.appsec.iast_memcheck.fixtures.stacktrace import func_1

--- a/tests/appsec/integrations/flask_tests/test_iast_langchain.py
+++ b/tests/appsec/integrations/flask_tests/test_iast_langchain.py
@@ -2,8 +2,8 @@ import pytest
 
 from ddtrace.appsec._iast.constants import VULN_CMDI
 from ddtrace.internal.module import is_module_installed
-from tests.appsec.iast.aspects.conftest import _iast_patched_module
 from tests.appsec.iast.conftest import iast_context_defaults  # noqa: F401
+from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.appsec.iast.iast_utils import get_line_and_hash
 from tests.appsec.iast.taint_sinks.conftest import _get_span_report
 from tests.utils import override_env


### PR DESCRIPTION
## Overview
This PR moves the `iast_patched_module` fixture from conftest.py to a utils module to improve code organization and reusability in IAST tests.

## Motivation
- Reduces test configuration complexity by moving test utilities out of conftest
- Makes the patched module functionality more accessible and reusable across different test files
- Follows better practices by keeping fixtures focused and moving utility code to dedicated modules

## Changes
- Moved `iast_patched_module` from conftest.py to a dedicated utils module
- Updated related test files to use the new import location
- No functional changes, only code reorganization


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
