### PR TITLE
fix(azure_functions): match method signature using functools instead of hardcoding it

### DIFF
--- a/ddtrace/contrib/internal/azure_functions/patch.py
+++ b/ddtrace/contrib/internal/azure_functions/patch.py
@@ -67,7 +67,7 @@ def _patched_route(wrapped, instance, args, kwargs):
                 core.dispatch("azure.functions.request_call_modifier", (ctx, config.azure_functions, req))
                 res = None
                 try:
-                    res = func(req)
+                    res = func(*args, **kwargs)
                     return res
                 finally:
                     core.dispatch(

--- a/ddtrace/contrib/internal/azure_functions/patch.py
+++ b/ddtrace/contrib/internal/azure_functions/patch.py
@@ -1,3 +1,5 @@
+import functools
+
 import azure.functions as azure_functions
 from wrapt import wrap_function_wrapper as _w
 
@@ -39,6 +41,7 @@ def patch():
 
 def _patched_route(wrapped, instance, args, kwargs):
     trigger = "Http"
+    trigger_arg_name = kwargs.get("trigger_arg_name", "req")
 
     pin = Pin.get_from(instance)
     if not pin or not pin.enabled():
@@ -47,7 +50,9 @@ def _patched_route(wrapped, instance, args, kwargs):
     def _wrapper(func):
         function_name = func.__name__
 
-        def wrap_function(req: azure_functions.HttpRequest, context: azure_functions.Context):
+        @functools.wraps(func)
+        def wrap_function(*args, **kwargs):
+            req = kwargs.get(trigger_arg_name)
             operation_name = schematize_cloud_faas_operation(
                 "azure.functions.invoke", cloud_provider="azure", cloud_service="functions"
             )
@@ -68,9 +73,6 @@ def _patched_route(wrapped, instance, args, kwargs):
                     core.dispatch(
                         "azure.functions.start_response", (ctx, config.azure_functions, res, function_name, trigger)
                     )
-
-        # Needed to correctly display function name when running 'func start' locally
-        wrap_function.__name__ = function_name
 
         return wrapped(*args, **kwargs)(wrap_function)
 

--- a/releasenotes/notes/fix-azure-functions-method-signature-0468812f17348843.yaml
+++ b/releasenotes/notes/fix-azure-functions-method-signature-0468812f17348843.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    azure_functions: This fix resolves an issue where a function would not start if the `trigger_arg_name` parameter was set to anything other than `req`.

--- a/tests/contrib/azure_functions/azure_function_app/function_app.py
+++ b/tests/contrib/azure_functions/azure_function_app/function_app.py
@@ -22,3 +22,13 @@ def http_get_error(req: func.HttpRequest) -> func.HttpResponse:
 @app.route(route="httppostok", auth_level=func.AuthLevel.ANONYMOUS, methods=[func.HttpMethod.POST])
 def http_post_ok(req: func.HttpRequest) -> func.HttpResponse:
     return func.HttpResponse("Hello Datadog!")
+
+
+@app.route(
+    route="httpgettriggerarg",
+    auth_level=func.AuthLevel.ANONYMOUS,
+    methods=[func.HttpMethod.GET],
+    trigger_arg_name="reqarg",
+)
+def http_get_trigger_arg(reqarg: func.HttpRequest) -> func.HttpResponse:
+    return func.HttpResponse("Hello Datadog!")

--- a/tests/contrib/azure_functions/test_azure_functions_snapshot.py
+++ b/tests/contrib/azure_functions/test_azure_functions_snapshot.py
@@ -62,3 +62,8 @@ def test_http_post_ok(azure_functions_client: Client) -> None:
     assert (
         azure_functions_client.post("/api/httppostok", headers=DEFAULT_HEADERS, data={"key": "val"}).status_code == 200
     )
+
+
+@pytest.mark.snapshot
+def test_http_get_trigger_arg(azure_functions_client: Client) -> None:
+    assert azure_functions_client.get("/api/httpgettriggerarg", headers=DEFAULT_HEADERS).status_code == 200

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_trigger_arg.json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_trigger_arg.json
@@ -1,0 +1,33 @@
+[[
+  {
+    "name": "azure.functions.invoke",
+    "service": "test-func",
+    "resource": "GET /api/httpgettriggerarg",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "serverless",
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "67ec4e5e00000000",
+      "aas.function.name": "http_get_trigger_arg",
+      "aas.function.trigger": "Http",
+      "component": "azure_functions",
+      "http.method": "GET",
+      "http.route": "/api/httpgettriggerarg",
+      "http.status_code": "200",
+      "http.url": "http://0.0.0.0:7071/api/httpgettriggerarg",
+      "http.useragent": "python-httpx/x.xx.x",
+      "language": "python",
+      "runtime-id": "8d8fe775192b47b6b8cc67c801687aef",
+      "span.kind": "server"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 66098
+    },
+    "duration": 282750,
+    "start": 1743539806219103595
+  }]]


### PR DESCRIPTION
This PR adds a fix to match the Azure Function method signature using `functools` instead of hardcoding it.

### Additional Notes:
Previously the arguments for the wrap function were hardcoded, resulting in an exception when starting a function where the `trigger_arg_name` was not set to `req` (the default value).

```
Exception: FunctionLoadError: cannot load the http_get_trigger_arg function: the following parameters are declared in Python but not in function.json: {'req'}
```

```
@app.route(
    route="httpgettriggerarg",
    auth_level=func.AuthLevel.ANONYMOUS,
    methods=[func.HttpMethod.GET],
    trigger_arg_name="reqarg",
)
def http_get_trigger_arg(reqarg: func.HttpRequest) -> func.HttpResponse:
    return func.HttpResponse("Hello Datadog!")
```

https://learn.microsoft.com/en-us/python/api/azure-functions/azure.functions.functionapp?view=azure-python#azure-functions-functionapp-route

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
