### PR TITLE
chore(serverless): remove flaky mark from two serverless tests

### DIFF
--- a/tests/contrib/aws_lambda/test_aws_lambda.py
+++ b/tests/contrib/aws_lambda/test_aws_lambda.py
@@ -11,7 +11,6 @@ from tests.contrib.aws_lambda.handlers import instance_handler_with_code
 from tests.contrib.aws_lambda.handlers import manually_wrapped_handler
 from tests.contrib.aws_lambda.handlers import static_handler
 from tests.contrib.aws_lambda.handlers import timeout_handler
-from tests.utils import flaky
 from tests.utils import override_env
 
 
@@ -52,7 +51,6 @@ def setup():
     unpatch()
 
 
-@flaky(1744053478)
 @pytest.mark.parametrize("customApmFlushDeadline", [("-100"), ("10"), ("100"), ("200")])
 @pytest.mark.snapshot
 def test_timeout_traces(context, customApmFlushDeadline):
@@ -135,7 +133,6 @@ async def test_module_patching(mocker, context):
     ],
 )
 @pytest.mark.snapshot
-@flaky(1744053478, reason="Did not receive expected traces: 'aws.lambda' for [handler3-instance_handler_with_code]")
 def test_class_based_handlers(context, handler, function_name):
     env = get_env(
         {


### PR DESCRIPTION
This PR addresses two flaky tests in `tests/contrib/aws_lambda/test_aws_lambda.py`. The issue that needed fixing was that env vars are checked during patch/unpatch. Since unpatch was being called after the env was reset, they were never being unpatched correctly. This PR ensures that the patching and unpatching occurs within the env override.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
