### PR TITLE
ci: fix comment action parameters

### DIFF
--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
-          filePath: resolved.txt
-          comment_tag: codeowners_resolved
+          file-path: resolved.txt
+          comment-tag: codeowners_resolved
           mode: upsert
           message: |
             `CODEOWNERS` have been resolved as:

--- a/.github/workflows/import-analysis.yml
+++ b/.github/workflows/import-analysis.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Report analysis result on PR
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
-          filePath: import_analysis.txt
-          comment_tag: import_analysis
+          file-path: import_analysis.txt
+          comment-tag: import_analysis
           mode: upsert
         if: always()
 
@@ -128,8 +128,8 @@ jobs:
       - name: "Report analysis result on PR"
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
-          filePath: cycles_report.txt
-          comment_tag: import_cycles
+          file-path: cycles_report.txt
+          comment-tag: import_cycles
           mode: upsert
         if: failure()
 


### PR DESCRIPTION
With the automatic bumping of action versions by dependabot, the comment action broke as it expects parameters with a different name.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
