### PR TITLE
refactor(tracing): make function a span property

### DIFF
--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -12,7 +12,6 @@ from ddtrace import config
 from ddtrace._trace.sampler import DatadogSampler
 from ddtrace._trace.span import Span
 from ddtrace._trace.span import _get_64_highest_order_bits_as_hex
-from ddtrace._trace.span import _is_top_level
 from ddtrace.constants import _APM_ENABLED_METRIC_KEY as MK_APM_ENABLED
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
 from ddtrace.constants import USER_KEEP
@@ -190,7 +189,7 @@ class TopLevelSpanProcessor(SpanProcessor):
 
     def on_span_finish(self, span: Span) -> None:
         # DEV: Update span after finished to avoid race condition
-        if _is_top_level(span):
+        if span.is_top_level:
             span.set_metric("_dd.top_level", 1)
 
 

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -813,13 +813,13 @@ class Span(object):
             self.name,
         )
 
+    @property
+    def is_top_level(self) -> bool:
+        """Return whether the span is a "top level" span.
 
-def _is_top_level(span: Span) -> bool:
-    """Return whether the span is a "top level" span.
-
-    Top level meaning the root of the trace or a child span
-    whose service is different from its parent.
-    """
-    return (span._local_root is span) or (
-        span._parent is not None and span._parent.service != span.service and span.service is not None
-    )
+        Top level meaning the root of the trace or a child span
+        whose service is different from its parent.
+        """
+        return (self._local_root is self) or (
+            self._parent is not None and self._parent.service != self.service and self.service is not None
+        )

--- a/ddtrace/internal/processor/stats.py
+++ b/ddtrace/internal/processor/stats.py
@@ -6,7 +6,6 @@ import typing
 import ddtrace
 from ddtrace import config
 from ddtrace._trace.processor import SpanProcessor
-from ddtrace._trace.span import _is_top_level
 from ddtrace.internal import compat
 from ddtrace.internal.native import DDSketch
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
@@ -128,8 +127,7 @@ class SpanStatsProcessorV06(PeriodicService, SpanProcessor):
         if not self._enabled:
             return
 
-        is_top_level = _is_top_level(span)
-        if not is_top_level and not _is_measured(span):
+        if not (is_top_level := span.is_top_level) and not _is_measured(span):
             return
 
         with self._lock:

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -14,7 +14,6 @@ import mock
 import pytest
 
 import ddtrace
-from ddtrace._trace.span import _is_top_level
 from ddtrace.constants import _HOSTNAME_KEY
 from ddtrace.constants import _ORIGIN_KEY
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
@@ -1771,20 +1770,20 @@ def test_tracer_memory_leak_span_processors():
 
 def test_top_level(tracer):
     with tracer.trace("parent", service="my-svc") as parent_span:
-        assert _is_top_level(parent_span)
+        assert parent_span.is_top_level
         with tracer.trace("child") as child_span:
-            assert not _is_top_level(child_span)
+            assert not child_span.is_top_level
             with tracer.trace("subchild") as subchild_span:
-                assert not _is_top_level(subchild_span)
+                assert not subchild_span.is_top_level
             with tracer.trace("subchild2", service="svc-2") as subchild_span2:
-                assert _is_top_level(subchild_span2)
+                assert subchild_span2.is_top_level
 
     with tracer.trace("parent", service="my-svc") as parent_span:
-        assert _is_top_level(parent_span)
+        assert parent_span.is_top_level
         with tracer.trace("child", service="child-svc") as child_span:
-            assert _is_top_level(child_span)
+            assert child_span.is_top_level
         with tracer.trace("child2", service="child-svc") as child_span2:
-            assert _is_top_level(child_span2)
+            assert child_span2.is_top_level
 
 
 def test_finish_span_with_ancestors(tracer):


### PR DESCRIPTION
We turn a utility function into a span property.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
