### PR TITLE
refactor(iast): move sql injection logic to iast folder

### DIFF
--- a/ddtrace/appsec/_iast/_taint_utils.py
+++ b/ddtrace/appsec/_iast/_taint_utils.py
@@ -520,7 +520,7 @@ def supported_dbapi_integration(integration_name):
     return integration_name in DBAPI_INTEGRATIONS or integration_name.startswith(DBAPI_PREFIXES)
 
 
-def check_tainted_dbapi_args(args, kwargs, tracer, integration_name, method):
+def check_tainted_dbapi_args(args, kwargs, integration_name, method):
     if supported_dbapi_integration(integration_name) and method.__name__ == "execute":
         return len(args) and args[0] and is_pyobject_tainted(args[0])
 

--- a/ddtrace/appsec/_iast/taint_sinks/sql_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/sql_injection.py
@@ -1,4 +1,18 @@
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Text
+
+from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.appsec._iast import oce
+from ddtrace.appsec._iast._logs import iast_error
+from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
+from ddtrace.appsec._iast._metrics import increment_iast_span_metric
+from ddtrace.appsec._iast._taint_tracking import VulnerabilityType
+from ddtrace.appsec._iast._taint_utils import DBAPI_PREFIXES
+from ddtrace.appsec._iast._taint_utils import check_tainted_dbapi_args
+from ddtrace.appsec._iast.constants import DBAPI_INTEGRATIONS
 from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.appsec._iast.taint_sinks._base import VulnerabilityBase
 
@@ -6,3 +20,33 @@ from ddtrace.appsec._iast.taint_sinks._base import VulnerabilityBase
 @oce.register
 class SqlInjection(VulnerabilityBase):
     vulnerability_type = VULN_SQL_INJECTION
+    secure_mark = VulnerabilityType.SQL_INJECTION
+
+
+def check_and_report_sqli(
+    args: List[Any], kwargs: Dict[str, Any], integration_name: Text, method: Callable[..., Any]
+) -> bool:
+    """Check for SQL injection vulnerabilities in database operations and report them.
+
+    This function analyzes database operation arguments for potential SQL injection
+    vulnerabilities. It checks if the operation is from a supported DBAPI integration,
+    if the method is 'execute', and if the first argument contains tainted data that
+    hasn't been marked as secure.
+
+    Note:
+        This function is part of the IAST (Interactive Application Security Testing)
+        system and is used to detect potential SQL injection vulnerabilities at runtime.
+    """
+    reported = False
+    try:
+        if check_tainted_dbapi_args(args, kwargs, integration_name, method):
+            SqlInjection.report(evidence_value=args[0], dialect=integration_name)
+        increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, SqlInjection.vulnerability_type)
+        _set_metric_iast_executed_sink(SqlInjection.vulnerability_type)
+    except Exception as e:
+        iast_error(f"propagation::sink_point::Error in check_and_report_sqli. {e}")
+    return reported
+
+
+def supported_dbapi_integration(integration_name):
+    return integration_name in DBAPI_INTEGRATIONS or integration_name.startswith(DBAPI_PREFIXES)

--- a/ddtrace/contrib/dbapi.py
+++ b/ddtrace/contrib/dbapi.py
@@ -4,7 +4,6 @@ Generic dbapi tracing code.
 import wrapt
 
 from ddtrace import config
-from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
@@ -103,19 +102,9 @@ class TracedCursor(wrapt.ObjectProxy):
             s.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
             if asm_config._iast_enabled:
-                try:
-                    from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
-                    from ddtrace.appsec._iast._metrics import increment_iast_span_metric
-                    from ddtrace.appsec._iast._taint_utils import check_tainted_dbapi_args
-                    from ddtrace.appsec._iast.taint_sinks.sql_injection import SqlInjection
+                from ddtrace.appsec._iast.taint_sinks.sql_injection import check_and_report_sqli
 
-                    increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, SqlInjection.vulnerability_type)
-                    _set_metric_iast_executed_sink(SqlInjection.vulnerability_type)
-                    if check_tainted_dbapi_args(args, kwargs, pin.tracer, self._self_config.integration_name, method):
-                        SqlInjection.report(evidence_value=args[0], dialect=self._self_config.integration_name)
-                except Exception:
-                    log.debug("Unexpected exception while reporting vulnerability", exc_info=True)
-
+                check_and_report_sqli(args, kwargs, self._self_config.integration_name, method)
             # set analytics sample rate if enabled but only for non-FetchTracedCursor
             if not isinstance(self, FetchTracedCursor):
                 s.set_tag(_ANALYTICS_SAMPLE_RATE_KEY, self._self_config.get_analytics_sample_rate())

--- a/ddtrace/contrib/dbapi_async.py
+++ b/ddtrace/contrib/dbapi_async.py
@@ -1,5 +1,4 @@
 from ddtrace import config
-from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
@@ -78,15 +77,9 @@ class TracedAsyncCursor(TracedCursor):
             s.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
             if asm_config._iast_enabled:
-                from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
-                from ddtrace.appsec._iast._metrics import increment_iast_span_metric
-                from ddtrace.appsec._iast._taint_utils import check_tainted_dbapi_args
-                from ddtrace.appsec._iast.taint_sinks.sql_injection import SqlInjection
+                from ddtrace.appsec._iast.taint_sinks.sql_injection import check_and_report_sqli
 
-                increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, SqlInjection.vulnerability_type)
-                _set_metric_iast_executed_sink(SqlInjection.vulnerability_type)
-                if check_tainted_dbapi_args(args, kwargs, pin.tracer, self._self_config.integration_name, method):
-                    SqlInjection.report(evidence_value=args[0], dialect=self._self_config.integration_name)
+                check_and_report_sqli(args, kwargs, self._self_config.integration_name, method)
 
             # set analytics sample rate if enabled but only for non-FetchTracedCursor
             if not isinstance(self, FetchTracedAsyncCursor):

--- a/tests/appsec/iast/test_taint_utils.py
+++ b/tests/appsec/iast/test_taint_utils.py
@@ -198,19 +198,18 @@ def test_checked_tainted_args(iast_context_defaults):
 
     # Returns False: Untainted first argument
     assert not check_tainted_dbapi_args(
-        args=(untainted_arg,), kwargs=None, tracer=None, integration_name="sqlite", method=cursor.execute
+        args=(untainted_arg,), kwargs=None, integration_name="sqlite", method=cursor.execute
     )
 
     # Returns False: Untainted first argument
     assert not check_tainted_dbapi_args(
-        args=(untainted_arg, tainted_arg), kwargs=None, tracer=None, integration_name="sqlite", method=cursor.execute
+        args=(untainted_arg, tainted_arg), kwargs=None, integration_name="sqlite", method=cursor.execute
     )
 
     # Returns False: Integration name not in list
     assert not check_tainted_dbapi_args(
         args=(tainted_arg,),
         kwargs=None,
-        tracer=None,
         integration_name="nosqlite",
         method=cursor.execute,
     )
@@ -219,24 +218,23 @@ def test_checked_tainted_args(iast_context_defaults):
     assert not check_tainted_dbapi_args(
         args=(tainted_arg,),
         kwargs=None,
-        tracer=None,
         integration_name="sqlite",
         method=cursor.executemany,
     )
 
     # Returns True:
     assert check_tainted_dbapi_args(
-        args=(tainted_arg, untainted_arg), kwargs=None, tracer=None, integration_name="sqlite", method=cursor.execute
+        args=(tainted_arg, untainted_arg), kwargs=None, integration_name="sqlite", method=cursor.execute
     )
 
     # Returns True:
     assert check_tainted_dbapi_args(
-        args=(tainted_arg, untainted_arg), kwargs=None, tracer=None, integration_name="mysql", method=cursor.execute
+        args=(tainted_arg, untainted_arg), kwargs=None, integration_name="mysql", method=cursor.execute
     )
 
     # Returns True:
     assert check_tainted_dbapi_args(
-        args=(tainted_arg, untainted_arg), kwargs=None, tracer=None, integration_name="psycopg", method=cursor.execute
+        args=(tainted_arg, untainted_arg), kwargs=None, integration_name="psycopg", method=cursor.execute
     )
 
 


### PR DESCRIPTION
This PR reorganizes the SQL injection detection logic by moving it to the IAST folder structure. The changes include:

- Relocated SQL injection detection code from contrib to ddtrace/appsec/_iast/
- Consolidated SQL injection related functionality in a dedicated location
- Improved code organization and maintainability
- Maintained existing functionality while improving code structure
- Updated imports and references to reflect new file locations

This refactoring aligns with our ongoing efforts to better organize IAST-related code and makes the codebase more maintainable by grouping related security features together.

No functional changes are included in this PR, it's purely organizational.

Related to: https://github.com/DataDog/dd-trace-py/pull/13044 and APPSEC-56946

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
