### PR TITLE
chore(asm): add support for error.type or error.message private span tags

### DIFF
--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -116,6 +116,8 @@ class APPSEC(metaclass=Constant_Class):
     RC_CLIENT_ID: Literal["_dd.rc.client_id"] = "_dd.rc.client_id"
     WAF_ERROR: Literal["_dd.appsec.waf.error"] = "_dd.appsec.waf.error"
     RASP_ERROR: Literal["_dd.appsec.rasp.error"] = "_dd.appsec.rasp.error"
+    ERROR_TYPE: Literal["_dd.appsec.error.type"] = "_dd.appsec.error.type"
+    ERROR_MESSAGE: Literal["_dd.appsec.error.message"] = "_dd.appsec.error.message"
 
 
 TELEMETRY_OFF_NAME = "OFF"


### PR DESCRIPTION
- add support for new private span tags
- add a use case for waf callback failure
- update relevant unit test

APPSEC-56592

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
