### PR TITLE
chore(iast): fix iast span metrics [backport 2.21]

### DIFF
--- a/ddtrace/appsec/_iast/_metrics.py
+++ b/ddtrace/appsec/_iast/_metrics.py
@@ -8,6 +8,8 @@ from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.appsec._constants import TELEMETRY_INFORMATION_VERBOSITY
 from ddtrace.appsec._constants import TELEMETRY_MANDATORY_VERBOSITY
 from ddtrace.appsec._deduplications import deduplication
+from ddtrace.appsec._iast._taint_tracking import OriginType
+from ddtrace.appsec._iast._taint_tracking import origin_to_str
 from ddtrace.appsec._iast._utils import _is_iast_debug_enabled
 from ddtrace.internal import telemetry
 from ddtrace.internal.logger import get_logger
@@ -139,11 +141,7 @@ def _set_span_tag_iast_executed_sink(span):
 
 
 def _metric_key_as_snake_case(key):
-    from ._taint_tracking import OriginType
-
     if isinstance(key, OriginType):
-        from ._taint_tracking import origin_to_str
-
         key = origin_to_str(key)
     key = key.replace(".", "_")
     return key.lower()

--- a/ddtrace/appsec/_iast/_taint_utils.py
+++ b/ddtrace/appsec/_iast/_taint_utils.py
@@ -7,7 +7,6 @@ from typing import Union
 
 from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
-from ddtrace.appsec._iast.constants import DBAPI_INTEGRATIONS
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
 
@@ -514,17 +513,6 @@ class LazyTaintDict:
 
     def urlencode(self, safe=None):
         return self._taint(self._obj.urlencode(safe=safe), self._origin_value)
-
-
-def supported_dbapi_integration(integration_name):
-    return integration_name in DBAPI_INTEGRATIONS or integration_name.startswith(DBAPI_PREFIXES)
-
-
-def check_tainted_dbapi_args(args, kwargs, tracer, integration_name, method):
-    if supported_dbapi_integration(integration_name) and method.__name__ == "execute":
-        return len(args) and args[0] and is_pyobject_tainted(args[0])
-
-    return False
 
 
 if asm_config._iast_lazy_taint:

--- a/ddtrace/appsec/_iast/_taint_utils.py
+++ b/ddtrace/appsec/_iast/_taint_utils.py
@@ -7,6 +7,7 @@ from typing import Union
 
 from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast.constants import DBAPI_INTEGRATIONS
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
 
@@ -513,6 +514,17 @@ class LazyTaintDict:
 
     def urlencode(self, safe=None):
         return self._taint(self._obj.urlencode(safe=safe), self._origin_value)
+
+
+def supported_dbapi_integration(integration_name):
+    return integration_name in DBAPI_INTEGRATIONS or integration_name.startswith(DBAPI_PREFIXES)
+
+
+def check_tainted_dbapi_args(args, kwargs, integration_name, method):
+    if supported_dbapi_integration(integration_name) and method.__name__ == "execute":
+        return len(args) and args[0] and is_pyobject_tainted(args[0])
+
+    return False
 
 
 if asm_config._iast_lazy_taint:

--- a/ddtrace/appsec/_iast/taint_sinks/ast_taint.py
+++ b/ddtrace/appsec/_iast/taint_sinks/ast_taint.py
@@ -36,11 +36,15 @@ def ast_function(
         and cls_name == "Random"
         and func_name in DEFAULT_WEAK_RANDOMNESS_FUNCTIONS
     ):
-        if asm_config._iast_enabled and asm_config.is_iast_request_enabled:
-            # Weak, run the analyzer
+        if asm_config.is_iast_request_enabled:
+            if WeakRandomness.has_quota():
+                WeakRandomness.report(evidence_value=cls_name + "." + func_name)
+
+            # Reports Span Metrics
             increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, WeakRandomness.vulnerability_type)
+            # Report Telemetry Metrics
             _set_metric_iast_executed_sink(WeakRandomness.vulnerability_type)
-            WeakRandomness.report(evidence_value=cls_name + "." + func_name)
+
     elif hasattr(func, "__module__") and DEFAULT_PATH_TRAVERSAL_FUNCTIONS.get(func.__module__):
         if func_name in DEFAULT_PATH_TRAVERSAL_FUNCTIONS[func.__module__]:
             check_and_report_path_traversal(*args, **kwargs)

--- a/ddtrace/appsec/_iast/taint_sinks/code_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/code_injection.py
@@ -2,8 +2,10 @@ import inspect
 from typing import Text
 
 from ddtrace.appsec._common_module_patches import try_unwrap
+from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.appsec._iast import oce
+from ddtrace.appsec._iast._logs import iast_error
 from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
 from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
 from ddtrace.appsec._iast._metrics import increment_iast_span_metric
@@ -79,8 +81,14 @@ class CodeInjection(VulnerabilityBase):
 
 
 def _iast_report_code_injection(code_string: Text):
-    increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, CodeInjection.vulnerability_type)
-    _set_metric_iast_executed_sink(CodeInjection.vulnerability_type)
-    if asm_config.is_iast_request_enabled:
-        if is_pyobject_tainted(code_string):
-            CodeInjection.report(evidence_value=code_string)
+    reported = False
+    try:
+        if asm_config.is_iast_request_enabled:
+            if isinstance(code_string, IAST.TEXT_TYPES) and CodeInjection.has_quota():
+                if is_pyobject_tainted(code_string):
+                    CodeInjection.report(evidence_value=code_string)
+            increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, CodeInjection.vulnerability_type)
+            _set_metric_iast_executed_sink(CodeInjection.vulnerability_type)
+    except Exception as e:
+        iast_error(f"propagation::sink_point::Error in _iast_report_code_injection. {e}")
+    return reported

--- a/ddtrace/appsec/_iast/taint_sinks/command_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/command_injection.py
@@ -3,6 +3,7 @@ from typing import Union
 
 from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.appsec._iast import oce
+from ddtrace.appsec._iast._logs import iast_error
 from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
 from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
 from ddtrace.appsec._iast._metrics import increment_iast_span_metric
@@ -46,19 +47,25 @@ class CommandInjection(VulnerabilityBase):
 def _iast_report_cmdi(shell_args: Union[str, List[str]]) -> None:
     report_cmdi = ""
 
-    increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, CommandInjection.vulnerability_type)
-    _set_metric_iast_executed_sink(CommandInjection.vulnerability_type)
+    try:
+        if asm_config.is_iast_request_enabled:
+            if CommandInjection.has_quota():
+                from .._taint_tracking.aspects import join_aspect
 
-    if asm_config.is_iast_request_enabled and CommandInjection.has_quota():
-        from .._taint_tracking.aspects import join_aspect
+                if isinstance(shell_args, (list, tuple)):
+                    for arg in shell_args:
+                        if is_pyobject_tainted(arg):
+                            report_cmdi = join_aspect(" ".join, 1, " ", shell_args)
+                            break
+                elif is_pyobject_tainted(shell_args):
+                    report_cmdi = shell_args
 
-        if isinstance(shell_args, (list, tuple)):
-            for arg in shell_args:
-                if is_pyobject_tainted(arg):
-                    report_cmdi = join_aspect(" ".join, 1, " ", shell_args)
-                    break
-        elif is_pyobject_tainted(shell_args):
-            report_cmdi = shell_args
+                if report_cmdi:
+                    CommandInjection.report(evidence_value=report_cmdi)
 
-        if report_cmdi:
-            CommandInjection.report(evidence_value=report_cmdi)
+            # Reports Span Metrics
+            increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, CommandInjection.vulnerability_type)
+            # Report Telemetry Metrics
+            _set_metric_iast_executed_sink(CommandInjection.vulnerability_type)
+    except Exception as e:
+        iast_error(f"propagation::sink_point::Error in _iast_report_ssrf. {e}")

--- a/ddtrace/appsec/_iast/taint_sinks/header_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/header_injection.py
@@ -6,6 +6,8 @@ from wrapt.importer import when_imported
 from ddtrace.appsec._common_module_patches import try_unwrap
 from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.appsec._iast import oce
+from ddtrace.appsec._iast._logs import iast_error
+from ddtrace.appsec._iast._logs import iast_instrumentation_wrapt_debug_log
 from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
 from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
 from ddtrace.appsec._iast._metrics import increment_iast_span_metric
@@ -18,7 +20,6 @@ from ddtrace.appsec._iast.constants import VULN_HEADER_INJECTION
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
 
-from .._logs import iast_instrumentation_wrapt_debug_log
 from ._base import VulnerabilityBase
 
 
@@ -122,19 +123,23 @@ def _process_header(headers_args):
     header_name, header_value = headers_args
     if header_name is None:
         return
+    try:
+        for header_to_exclude in HEADER_INJECTION_EXCLUSIONS:
+            header_name_lower = header_name.lower()
+            if header_name_lower == header_to_exclude or header_name_lower.startswith(header_to_exclude):
+                return
 
-    for header_to_exclude in HEADER_INJECTION_EXCLUSIONS:
-        header_name_lower = header_name.lower()
-        if header_name_lower == header_to_exclude or header_name_lower.startswith(header_to_exclude):
-            return
+        if asm_config.is_iast_request_enabled:
+            if HeaderInjection.has_quota() and (is_pyobject_tainted(header_name) or is_pyobject_tainted(header_value)):
+                header_evidence = add_aspect(add_aspect(header_name, HEADER_NAME_VALUE_SEPARATOR), header_value)
+                HeaderInjection.report(evidence_value=header_evidence)
 
-    increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, HeaderInjection.vulnerability_type)
-    _set_metric_iast_executed_sink(HeaderInjection.vulnerability_type)
-
-    if asm_config.is_iast_request_enabled and HeaderInjection.has_quota():
-        if is_pyobject_tainted(header_name) or is_pyobject_tainted(header_value):
-            header_evidence = add_aspect(add_aspect(header_name, HEADER_NAME_VALUE_SEPARATOR), header_value)
-            HeaderInjection.report(evidence_value=header_evidence)
+            # Reports Span Metrics
+            increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, HeaderInjection.vulnerability_type)
+            # Report Telemetry Metrics
+            _set_metric_iast_executed_sink(HeaderInjection.vulnerability_type)
+    except Exception as e:
+        iast_error(f"propagation::sink_point::Error in _iast_report_header_injection. {e}")
 
 
 def _iast_report_header_injection(headers_or_args) -> None:

--- a/ddtrace/appsec/_iast/taint_sinks/path_traversal.py
+++ b/ddtrace/appsec/_iast/taint_sinks/path_traversal.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.appsec._iast import oce
+from ddtrace.appsec._iast._logs import iast_error
 from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
 from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
 from ddtrace.appsec._iast._metrics import increment_iast_span_metric
@@ -30,9 +31,15 @@ def check_and_report_path_traversal(*args: Any, **kwargs: Any) -> None:
         _set_metric_iast_instrumented_sink(VULN_PATH_TRAVERSAL)
         IS_REPORTED_INTRUMENTED_SINK = True
 
-    if asm_config.is_iast_request_enabled and PathTraversal.has_quota():
-        filename_arg = args[0] if args else kwargs.get("file", None)
-        if is_pyobject_tainted(filename_arg):
-            PathTraversal.report(evidence_value=filename_arg)
-    increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, PathTraversal.vulnerability_type)
-    _set_metric_iast_executed_sink(PathTraversal.vulnerability_type)
+    try:
+        if asm_config.is_iast_request_enabled:
+            filename_arg = args[0] if args else kwargs.get("file", None)
+            if PathTraversal.has_quota() and is_pyobject_tainted(filename_arg):
+                PathTraversal.report(evidence_value=filename_arg)
+
+            # Reports Span Metrics
+            increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, PathTraversal.vulnerability_type)
+            # Report Telemetry Metrics
+            _set_metric_iast_executed_sink(PathTraversal.vulnerability_type)
+    except Exception as e:
+        iast_error(f"propagation::sink_point::Error in check_and_report_path_traversal. {e}")

--- a/ddtrace/appsec/_iast/taint_sinks/sql_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/sql_injection.py
@@ -1,8 +1,62 @@
-from .. import oce
-from ..constants import VULN_SQL_INJECTION
-from ._base import VulnerabilityBase
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Text
+
+from ddtrace.appsec._constants import IAST_SPAN_TAGS
+from ddtrace.appsec._iast import oce
+from ddtrace.appsec._iast._logs import iast_error
+from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
+from ddtrace.appsec._iast._span_metrics import increment_iast_span_metric
+from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_utils import DBAPI_PREFIXES
+from ddtrace.appsec._iast.constants import DBAPI_INTEGRATIONS
+from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
+from ddtrace.appsec._iast.taint_sinks._base import VulnerabilityBase
+from ddtrace.settings.asm import config as asm_config
 
 
 @oce.register
 class SqlInjection(VulnerabilityBase):
     vulnerability_type = VULN_SQL_INJECTION
+
+
+def check_and_report_sqli(
+    args: List[Any], kwargs: Dict[str, Any], integration_name: Text, method: Callable[..., Any]
+) -> bool:
+    """Check for SQL injection vulnerabilities in database operations and report them.
+
+    This function analyzes database operation arguments for potential SQL injection
+    vulnerabilities. It checks if the operation is from a supported DBAPI integration,
+    if the method is 'execute', and if the first argument contains tainted data that
+    hasn't been marked as secure.
+
+    Note:
+        This function is part of the IAST (Interactive Application Security Testing)
+        system and is used to detect potential SQL injection vulnerabilities at runtime.
+    """
+    reported = False
+    try:
+        if asm_config.is_iast_request_enabled:
+            if SqlInjection.has_quota() and check_tainted_dbapi_args(args, kwargs, integration_name, method):
+                SqlInjection.report(evidence_value=args[0], dialect=integration_name)
+
+            # Reports Span Metrics
+            increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, SqlInjection.vulnerability_type)
+            # Report Telemetry Metrics
+            _set_metric_iast_executed_sink(SqlInjection.vulnerability_type)
+    except Exception as e:
+        iast_error(f"propagation::sink_point::Error in check_and_report_sqli. {e}")
+    return reported
+
+
+def check_tainted_dbapi_args(args, kwargs, integration_name, method):
+    if supported_dbapi_integration(integration_name) and method.__name__ == "execute":
+        return len(args) and args[0] and is_pyobject_tainted(args[0])
+
+    return False
+
+
+def supported_dbapi_integration(integration_name):
+    return integration_name in DBAPI_INTEGRATIONS or integration_name.startswith(DBAPI_PREFIXES)

--- a/ddtrace/appsec/_iast/taint_sinks/sql_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/sql_injection.py
@@ -8,10 +8,8 @@ from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.appsec._iast import oce
 from ddtrace.appsec._iast._logs import iast_error
 from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
-from ddtrace.appsec._iast._span_metrics import increment_iast_span_metric
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
-from ddtrace.appsec._iast._taint_utils import DBAPI_PREFIXES
-from ddtrace.appsec._iast.constants import DBAPI_INTEGRATIONS
+from ddtrace.appsec._iast._metrics import increment_iast_span_metric
+from ddtrace.appsec._iast._taint_utils import check_tainted_dbapi_args
 from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.appsec._iast.taint_sinks._base import VulnerabilityBase
 from ddtrace.settings.asm import config as asm_config
@@ -49,14 +47,3 @@ def check_and_report_sqli(
     except Exception as e:
         iast_error(f"propagation::sink_point::Error in check_and_report_sqli. {e}")
     return reported
-
-
-def check_tainted_dbapi_args(args, kwargs, integration_name, method):
-    if supported_dbapi_integration(integration_name) and method.__name__ == "execute":
-        return len(args) and args[0] and is_pyobject_tainted(args[0])
-
-    return False
-
-
-def supported_dbapi_integration(integration_name):
-    return integration_name in DBAPI_INTEGRATIONS or integration_name.startswith(DBAPI_PREFIXES)

--- a/ddtrace/appsec/_iast/taint_sinks/ssrf.py
+++ b/ddtrace/appsec/_iast/taint_sinks/ssrf.py
@@ -4,7 +4,7 @@ from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.appsec._iast import oce
 from ddtrace.appsec._iast._logs import iast_error
 from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
-from ddtrace.appsec._iast._span_metrics import increment_iast_span_metric
+from ddtrace.appsec._iast._metrics import increment_iast_span_metric
 from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast.constants import VULN_SSRF
 from ddtrace.appsec._iast.taint_sinks._base import VulnerabilityBase

--- a/ddtrace/appsec/_iast/taint_sinks/ssrf.py
+++ b/ddtrace/appsec/_iast/taint_sinks/ssrf.py
@@ -2,17 +2,17 @@ from typing import Callable
 
 from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.appsec._iast import oce
+from ddtrace.appsec._iast._logs import iast_error
 from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
-from ddtrace.appsec._iast._metrics import increment_iast_span_metric
+from ddtrace.appsec._iast._span_metrics import increment_iast_span_metric
 from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast.constants import VULN_SSRF
+from ddtrace.appsec._iast.taint_sinks._base import VulnerabilityBase
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import ArgumentError
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.importlib import func_name
 from ddtrace.settings.asm import config as asm_config
-
-from ._base import VulnerabilityBase
 
 
 log = get_logger(__name__)
@@ -48,11 +48,14 @@ def _iast_report_ssrf(func: Callable, *args, **kwargs):
         return
 
     if report_ssrf:
-        _set_metric_iast_executed_sink(SSRF.vulnerability_type)
-        increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, SSRF.vulnerability_type)
-        if asm_config.is_iast_request_enabled and SSRF.has_quota():
+        if asm_config.is_iast_request_enabled:
             try:
-                if is_pyobject_tainted(report_ssrf):
+                if SSRF.has_quota() and is_pyobject_tainted(report_ssrf):
                     SSRF.report(evidence_value=report_ssrf)
-            except Exception:
-                log.debug("Unexpected exception while reporting vulnerability", exc_info=True)
+
+                # Reports Span Metrics
+                _set_metric_iast_executed_sink(SSRF.vulnerability_type)
+                # Report Telemetry Metrics
+                increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, SSRF.vulnerability_type)
+            except Exception as e:
+                iast_error(f"propagation::sink_point::Error in _iast_report_ssrf. {e}")

--- a/ddtrace/appsec/_iast/taint_sinks/weak_cipher.py
+++ b/ddtrace/appsec/_iast/taint_sinks/weak_cipher.py
@@ -13,6 +13,7 @@ from ddtrace.appsec._iast.constants import RC2_DEF
 from ddtrace.appsec._iast.constants import RC4_DEF
 from ddtrace.appsec._iast.constants import VULN_WEAK_CIPHER_TYPE
 from ddtrace.internal.logger import get_logger
+from ddtrace.settings.asm import config as asm_config
 
 from .. import oce
 from .._metrics import _set_metric_iast_executed_sink
@@ -131,11 +132,15 @@ def wrapped_aux_blowfish_function(wrapped, instance, args, kwargs):
 
 @WeakCipher.wrap
 def wrapped_rc4_function(wrapped: Callable, instance: Any, args: Any, kwargs: Any) -> Any:
-    increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, WeakCipher.vulnerability_type)
-    _set_metric_iast_executed_sink(WeakCipher.vulnerability_type)
-    WeakCipher.report(
-        evidence_value="RC4",
-    )
+    if asm_config.is_iast_request_enabled:
+        WeakCipher.report(
+            evidence_value="RC4",
+        )
+        # Reports Span Metrics
+        increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, WeakCipher.vulnerability_type)
+        # Report Telemetry Metrics
+        _set_metric_iast_executed_sink(WeakCipher.vulnerability_type)
+
     if hasattr(wrapped, "__func__"):
         return wrapped.__func__(instance, *args, **kwargs)
     return wrapped(*args, **kwargs)
@@ -143,13 +148,16 @@ def wrapped_rc4_function(wrapped: Callable, instance: Any, args: Any, kwargs: An
 
 @WeakCipher.wrap
 def wrapped_function(wrapped: Callable, instance: Any, args: Any, kwargs: Any) -> Any:
-    if hasattr(instance, "_dd_weakcipher_algorithm"):
-        evidence = instance._dd_weakcipher_algorithm + "_" + str(instance.__class__.__name__)
-        increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, WeakCipher.vulnerability_type)
-        _set_metric_iast_executed_sink(WeakCipher.vulnerability_type)
-        WeakCipher.report(
-            evidence_value=evidence,
-        )
+    if asm_config.is_iast_request_enabled:
+        if hasattr(instance, "_dd_weakcipher_algorithm"):
+            evidence = instance._dd_weakcipher_algorithm + "_" + str(instance.__class__.__name__)
+            WeakCipher.report(evidence_value=evidence)
+
+            # Reports Span Metrics
+            increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, WeakCipher.vulnerability_type)
+            # Report Telemetry Metrics
+            _set_metric_iast_executed_sink(WeakCipher.vulnerability_type)
+
     if hasattr(wrapped, "__func__"):
         return wrapped.__func__(instance, *args, **kwargs)
     return wrapped(*args, **kwargs)
@@ -157,13 +165,18 @@ def wrapped_function(wrapped: Callable, instance: Any, args: Any, kwargs: Any) -
 
 @WeakCipher.wrap
 def wrapped_cryptography_function(wrapped: Callable, instance: Any, args: Any, kwargs: Any) -> Any:
-    algorithm_name = instance.algorithm.name.lower()
-    if algorithm_name in get_weak_cipher_algorithms():
-        increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, WeakCipher.vulnerability_type)
-        _set_metric_iast_executed_sink(WeakCipher.vulnerability_type)
-        WeakCipher.report(
-            evidence_value=algorithm_name,
-        )
+    if asm_config.is_iast_request_enabled:
+        algorithm_name = instance.algorithm.name.lower()
+        if algorithm_name in get_weak_cipher_algorithms():
+            WeakCipher.report(
+                evidence_value=algorithm_name,
+            )
+
+            # Reports Span Metrics
+            increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, WeakCipher.vulnerability_type)
+            # Report Telemetry Metrics
+            _set_metric_iast_executed_sink(WeakCipher.vulnerability_type)
+
     if hasattr(wrapped, "__func__"):
         return wrapped.__func__(instance, *args, **kwargs)
     return wrapped(*args, **kwargs)

--- a/ddtrace/contrib/dbapi/__init__.py
+++ b/ddtrace/contrib/dbapi/__init__.py
@@ -4,7 +4,6 @@ Generic dbapi tracing code.
 import wrapt
 
 from ddtrace import config
-from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
@@ -103,18 +102,9 @@ class TracedCursor(wrapt.ObjectProxy):
             s.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
             if asm_config._iast_enabled:
-                try:
-                    from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
-                    from ddtrace.appsec._iast._metrics import increment_iast_span_metric
-                    from ddtrace.appsec._iast._taint_utils import check_tainted_dbapi_args
-                    from ddtrace.appsec._iast.taint_sinks.sql_injection import SqlInjection
+                from ddtrace.appsec._iast.taint_sinks.sql_injection import check_and_report_sqli
 
-                    increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, SqlInjection.vulnerability_type)
-                    _set_metric_iast_executed_sink(SqlInjection.vulnerability_type)
-                    if check_tainted_dbapi_args(args, kwargs, pin.tracer, self._self_config.integration_name, method):
-                        SqlInjection.report(evidence_value=args[0], dialect=self._self_config.integration_name)
-                except Exception:
-                    log.debug("Unexpected exception while reporting vulnerability", exc_info=True)
+                check_and_report_sqli(args, kwargs, self._self_config.integration_name, method)
 
             # set analytics sample rate if enabled but only for non-FetchTracedCursor
             if not isinstance(self, FetchTracedCursor):

--- a/ddtrace/contrib/dbapi_async/__init__.py
+++ b/ddtrace/contrib/dbapi_async/__init__.py
@@ -1,5 +1,4 @@
 from ddtrace import config
-from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
@@ -78,15 +77,9 @@ class TracedAsyncCursor(TracedCursor):
             s.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
             if asm_config._iast_enabled:
-                from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
-                from ddtrace.appsec._iast._metrics import increment_iast_span_metric
-                from ddtrace.appsec._iast._taint_utils import check_tainted_dbapi_args
-                from ddtrace.appsec._iast.taint_sinks.sql_injection import SqlInjection
+                from ddtrace.appsec._iast.taint_sinks.sql_injection import check_and_report_sqli
 
-                increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK, SqlInjection.vulnerability_type)
-                _set_metric_iast_executed_sink(SqlInjection.vulnerability_type)
-                if check_tainted_dbapi_args(args, kwargs, pin.tracer, self._self_config.integration_name, method):
-                    SqlInjection.report(evidence_value=args[0], dialect=self._self_config.integration_name)
+                check_and_report_sqli(args, kwargs, self._self_config.integration_name, method)
 
             # set analytics sample rate if enabled but only for non-FetchTracedCursor
             if not isinstance(self, FetchTracedAsyncCursor):

--- a/tests/appsec/iast/test_taint_utils.py
+++ b/tests/appsec/iast/test_taint_utils.py
@@ -198,19 +198,18 @@ def test_checked_tainted_args(iast_context_defaults):
 
     # Returns False: Untainted first argument
     assert not check_tainted_dbapi_args(
-        args=(untainted_arg,), kwargs=None, tracer=None, integration_name="sqlite", method=cursor.execute
+        args=(untainted_arg,), kwargs=None, integration_name="sqlite", method=cursor.execute
     )
 
     # Returns False: Untainted first argument
     assert not check_tainted_dbapi_args(
-        args=(untainted_arg, tainted_arg), kwargs=None, tracer=None, integration_name="sqlite", method=cursor.execute
+        args=(untainted_arg, tainted_arg), kwargs=None, integration_name="sqlite", method=cursor.execute
     )
 
     # Returns False: Integration name not in list
     assert not check_tainted_dbapi_args(
         args=(tainted_arg,),
         kwargs=None,
-        tracer=None,
         integration_name="nosqlite",
         method=cursor.execute,
     )
@@ -219,24 +218,23 @@ def test_checked_tainted_args(iast_context_defaults):
     assert not check_tainted_dbapi_args(
         args=(tainted_arg,),
         kwargs=None,
-        tracer=None,
         integration_name="sqlite",
         method=cursor.executemany,
     )
 
     # Returns True:
     assert check_tainted_dbapi_args(
-        args=(tainted_arg, untainted_arg), kwargs=None, tracer=None, integration_name="sqlite", method=cursor.execute
+        args=(tainted_arg, untainted_arg), kwargs=None, integration_name="sqlite", method=cursor.execute
     )
 
     # Returns True:
     assert check_tainted_dbapi_args(
-        args=(tainted_arg, untainted_arg), kwargs=None, tracer=None, integration_name="mysql", method=cursor.execute
+        args=(tainted_arg, untainted_arg), kwargs=None, integration_name="mysql", method=cursor.execute
     )
 
     # Returns True:
     assert check_tainted_dbapi_args(
-        args=(tainted_arg, untainted_arg), kwargs=None, tracer=None, integration_name="psycopg", method=cursor.execute
+        args=(tainted_arg, untainted_arg), kwargs=None, integration_name="psycopg", method=cursor.execute
     )
 
 

--- a/tests/appsec/integrations/django_tests/conftest.py
+++ b/tests/appsec/integrations/django_tests/conftest.py
@@ -64,3 +64,34 @@ def test_spans(tracer):
         yield container
         _end_iast_context_and_oce()
         container.reset()
+
+
+@pytest.fixture
+def iast_spans_with_zero_sampling(tracer):
+    """Fixture that provides a span container with IAST enabled but 0% sampling rate.
+
+    This fixture is used to test IAST behavior when sampling is disabled (0%).
+    It sets up a test environment where:
+    - IAST is enabled
+    - Deduplication is disabled
+    - Sampling rate is set to 0%
+    - A span container is provided for collecting traces
+
+    Args:
+        tracer: The test tracer instance
+
+    Yields:
+        TracerSpanContainer: A container for collecting spans during the test
+    """
+    with override_global_config(
+        dict(
+            _iast_enabled=True,
+            _iast_deduplication_enabled=False,
+            _iast_request_sampling=0.0,
+        )
+    ):
+        container = TracerSpanContainer(tracer)
+        _start_iast_context_and_oce()
+        yield container
+        _end_iast_context_and_oce()
+        container.reset()

--- a/tests/appsec/integrations/django_tests/test_django_appsec_iast.py
+++ b/tests/appsec/integrations/django_tests/test_django_appsec_iast.py
@@ -40,7 +40,7 @@ def _aux_appsec_get_root_span(
     if cookies is None:
         cookies = {}
     # Hack: need to pass an argument to configure so that the processors are recreated
-    tracer._recreate()
+    tracer._configure(api_version="v0.4")
     # Set cookies
     client.cookies.load(cookies)
     if payload is None:

--- a/tests/appsec/integrations/django_tests/test_django_appsec_iast.py
+++ b/tests/appsec/integrations/django_tests/test_django_appsec_iast.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 import json
+from urllib.parse import urlencode
 
 import pytest
 
+from ddtrace.appsec._common_module_patches import patch_common_modules
 from ddtrace.appsec._constants import IAST
-from ddtrace.appsec._iast import oce
-from ddtrace.appsec._iast._patch_modules import patch_iast
+from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.appsec._iast.constants import VULN_CMDI
 from ddtrace.appsec._iast.constants import VULN_HEADER_INJECTION
 from ddtrace.appsec._iast.constants import VULN_INSECURE_COOKIE
 from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
-from ddtrace.internal.compat import urlencode
+from ddtrace.appsec._iast.constants import VULN_STACKTRACE_LEAK
 from ddtrace.settings.asm import config as asm_config
 from tests.appsec.iast.iast_utils import get_line_and_hash
-from tests.utils import override_env
 from tests.utils import override_global_config
 
 
@@ -22,7 +22,9 @@ TEST_FILE = "tests/appsec/integrations/django_tests/django_app/views.py"
 
 @pytest.fixture(autouse=True)
 def iast_context():
-    with override_env({IAST.ENV: "True", IAST.ENV_REQUEST_SAMPLING: "100", "DD_IAST_DEDUPLICATION_ENABLED": "false"}):
+    with override_global_config(
+        dict(_iast_enabled=True, _iast_deduplication_enabled=False, _iast_request_sampling=100.0)
+    ):
         yield
 
 
@@ -39,7 +41,7 @@ def _aux_appsec_get_root_span(
     if cookies is None:
         cookies = {}
     # Hack: need to pass an argument to configure so that the processors are recreated
-    tracer._configure(api_version="v0.4")
+    tracer._recreate()
     # Set cookies
     client.cookies.load(cookies)
     if payload is None:
@@ -82,32 +84,50 @@ def _aux_appsec_get_root_span_with_exception(
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_weak_hash(client, test_spans, tracer):
-    with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
-        oce.reconfigure()
-        patch_iast({"weak_hash": True})
-        root_span, _ = _aux_appsec_get_root_span(client, test_spans, tracer, url="/appsec/weak-hash/")
-        str_json = root_span.get_tag(IAST.JSON)
-        assert str_json is not None, "no JSON tag in root span"
-        vulnerability = json.loads(str_json)["vulnerabilities"][0]
-        assert vulnerability["location"]["path"].endswith(TEST_FILE)
-        assert vulnerability["evidence"]["value"] == "md5"
+    root_span, _ = _aux_appsec_get_root_span(client, test_spans, tracer, url="/appsec/weak-hash/")
+    str_json = root_span.get_tag(IAST.JSON)
+    assert str_json is not None, "no JSON tag in root span"
+    vulnerability = json.loads(str_json)["vulnerabilities"][0]
+    assert vulnerability["location"]["path"].endswith(TEST_FILE)
+    assert vulnerability["evidence"]["value"] == "md5"
+
+
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_weak_hash_span_metrics(client, test_spans, tracer):
+    root_span, _ = _aux_appsec_get_root_span(client, test_spans, tracer, url="/appsec/weak-hash/")
+    assert root_span.get_metric(IAST.ENABLED) == 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK + ".weak_hash") == 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK + ".header_injection") > 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_header_name") > 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_header") > 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_path") > 1.0
+
+
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_weak_hash_span_metrics_disabled(client, iast_spans_with_zero_sampling, tracer):
+    root_span, _ = _aux_appsec_get_root_span(client, iast_spans_with_zero_sampling, tracer, url="/appsec/weak-hash/")
+    assert root_span.get_metric(IAST.ENABLED) == 0.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK + ".weak_hash") is None
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK + ".header_injection") is None
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_header_name") is None
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_header") is None
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_path") is None
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_tainted_user_agent_iast_enabled(client, test_spans, tracer):
-    with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
-        root_span, response = _aux_appsec_get_root_span(
-            client,
-            test_spans,
-            tracer,
-            payload=urlencode({"mytestingbody_key": "mytestingbody_value"}),
-            content_type="application/x-www-form-urlencoded",
-            url="/appsec/taint-checking-enabled/?q=aaa",
-            headers={"HTTP_USER_AGENT": "test/1.2.3"},
-        )
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        payload=urlencode({"mytestingbody_key": "mytestingbody_value"}),
+        content_type="application/x-www-form-urlencoded",
+        url="/appsec/taint-checking-enabled/?q=aaa",
+        headers={"HTTP_USER_AGENT": "test/1.2.3"},
+    )
 
-        assert response.status_code == 200
-        assert response.content == b"test/1.2.3"
+    assert response.status_code == 200
+    assert response.content == b"test/1.2.3"
 
 
 @pytest.mark.parametrize(
@@ -137,7 +157,7 @@ def test_django_tainted_user_agent_iast_enabled(client, test_spans, tracer):
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_view_with_exception(client, test_spans, tracer, payload, content_type, deduplication, sampling):
     with override_global_config(
-        dict(_iast_enabled=True, _deduplication_enabled=deduplication, _iast_request_sampling=sampling)
+        dict(_iast_enabled=True, _iast_deduplication_enabled=deduplication, _iast_request_sampling=sampling)
     ):
         response = _aux_appsec_get_root_span_with_exception(
             client,
@@ -153,8 +173,6 @@ def test_django_view_with_exception(client, test_spans, tracer, payload, content
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_tainted_user_agent_iast_disabled(client, test_spans, tracer):
     with override_global_config(dict(_iast_enabled=False, _iast_deduplication_enabled=False)):
-        oce.reconfigure()
-
         root_span, response = _aux_appsec_get_root_span(
             client,
             test_spans,
@@ -173,192 +191,268 @@ def test_django_tainted_user_agent_iast_disabled(client, test_spans, tracer):
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_tainted_user_agent_iast_enabled_sqli_http_request_parameter(client, test_spans, tracer):
-    with override_global_config(
-        dict(_iast_enabled=True, _iast_deduplication_enabled=False, _iast_request_sampling=100.0)
-    ):
-        root_span, response = _aux_appsec_get_root_span(
-            client,
-            test_spans,
-            tracer,
-            payload=urlencode({"mytestingbody_key": "mytestingbody_value"}),
-            content_type="application/x-www-form-urlencoded",
-            url="/appsec/sqli_http_request_parameter/?q=SELECT 1 FROM sqlite_master WHERE name='",
-            headers={"HTTP_USER_AGENT": "test/1.2.3"},
-        )
+def test_django_sqli_http_request_parameter_metrics(client, test_spans, tracer):
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        payload=urlencode({"SELECT": "unused"}),
+        content_type="application/x-www-form-urlencoded",
+        url="/appsec/sqli_http_request_parameter_name_post/",
+        headers={"HTTP_USER_AGENT": "test/1.2.3"},
+    )
+    assert root_span.get_metric(IAST.ENABLED) == 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_REQUEST_TAINTED) > 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK + ".sql_injection") == 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK + ".header_injection") >= 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_body") == 2
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_parameter_name") >= 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_header") >= 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_header_name") >= 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_path") >= 1.0
 
-        vuln_type = "SQL_INJECTION"
 
-        assert response.status_code == 200
-        assert response.content == b"test/1.2.3"
+@pytest.mark.django_db()
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_sqli_http_request_parameter_metrics_disabled(client, iast_spans_with_zero_sampling, tracer):
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        iast_spans_with_zero_sampling,
+        tracer,
+        payload=urlencode({"SELECT": "unused"}),
+        content_type="application/x-www-form-urlencoded",
+        url="/appsec/sqli_http_request_parameter_name_post/",
+        headers={"HTTP_USER_AGENT": "test/1.2.3"},
+    )
+    assert root_span.get_metric(IAST.ENABLED) == 0.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_REQUEST_TAINTED) is None
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK + ".sql_injection") is None
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK + ".header_injection") is None
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_body") is None
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_parameter_name") is None
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_header") is None
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_header_name") is None
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_path") is None
 
-        loaded = json.loads(root_span.get_tag(IAST.JSON))
 
-        line, hash_value = get_line_and_hash("iast_enabled_sqli_http_request_parameter", vuln_type, filename=TEST_FILE)
+@pytest.mark.django_db()
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_sqli_http_request_parameter(client, test_spans, tracer):
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        payload=urlencode({"mytestingbody_key": "mytestingbody_value"}),
+        content_type="application/x-www-form-urlencoded",
+        url="/appsec/sqli_http_request_parameter/?q=SELECT 1 FROM sqlite_master WHERE name='",
+        headers={"HTTP_USER_AGENT": "test/1.2.3"},
+    )
 
-        assert loaded["sources"] == [
-            {
-                "name": "q",
-                "origin": "http.request.parameter",
-                "pattern": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN",
-                "redacted": True,
-            }
-        ]
+    vuln_type = "SQL_INJECTION"
 
-        assert loaded["vulnerabilities"][0]["type"] == vuln_type
-        assert loaded["vulnerabilities"][0]["evidence"] == {
-            "valueParts": [
-                {"source": 0, "value": "SELECT "},
-                {"pattern": "h", "redacted": True, "source": 0},
-                {"source": 0, "value": " FROM sqlite_master WHERE name='"},
-                {"redacted": True},
-                {"value": "'"},
-            ]
+    assert response.status_code == 200
+    assert response.content == b"test/1.2.3"
+
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
+
+    line, hash_value = get_line_and_hash("iast_enabled_sqli_http_request_parameter", vuln_type, filename=TEST_FILE)
+
+    assert loaded["sources"] == [
+        {
+            "name": "q",
+            "origin": "http.request.parameter",
+            "pattern": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN",
+            "redacted": True,
         }
-        assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
-        assert loaded["vulnerabilities"][0]["location"]["line"] == line
-        assert loaded["vulnerabilities"][0]["hash"] == hash_value
+    ]
+
+    assert loaded["vulnerabilities"][0]["type"] == vuln_type
+    assert loaded["vulnerabilities"][0]["evidence"] == {
+        "valueParts": [
+            {"source": 0, "value": "SELECT "},
+            {"pattern": "h", "redacted": True, "source": 0},
+            {"source": 0, "value": " FROM sqlite_master WHERE name='"},
+            {"redacted": True},
+            {"value": "'"},
+        ]
+    }
+    assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
+    assert loaded["vulnerabilities"][0]["location"]["line"] == line
+    assert loaded["vulnerabilities"][0]["hash"] == hash_value
 
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_sqli_http_request_parameter_name_get(client, test_spans, tracer):
-    with override_global_config(
-        dict(_iast_enabled=True, _iast_deduplication_enabled=False, _iast_request_sampling=100.0)
-    ):
-        root_span, response = _aux_appsec_get_root_span(
-            client,
-            test_spans,
-            tracer,
-            content_type="application/x-www-form-urlencoded",
-            url="/appsec/sqli_http_request_parameter_name_get/?SELECT=unused",
-            headers={"HTTP_USER_AGENT": "test/1.2.3"},
-        )
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        content_type="application/x-www-form-urlencoded",
+        url="/appsec/sqli_http_request_parameter_name_get/?SELECT=unused",
+        headers={"HTTP_USER_AGENT": "test/1.2.3"},
+    )
 
-        vuln_type = "SQL_INJECTION"
+    vuln_type = "SQL_INJECTION"
 
-        assert response.status_code == 200
-        assert response.content == b"test/1.2.3"
+    assert response.status_code == 200
+    assert response.content == b"test/1.2.3"
 
-        loaded = json.loads(root_span.get_tag(IAST.JSON))
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
 
-        line, hash_value = get_line_and_hash(
-            "iast_enabled_sqli_http_request_parameter_name_get", vuln_type, filename=TEST_FILE
-        )
+    line, hash_value = get_line_and_hash(
+        "iast_enabled_sqli_http_request_parameter_name_get", vuln_type, filename=TEST_FILE
+    )
 
-        assert loaded["sources"] == [
-            {
-                "name": "SELECT",
-                "origin": "http.request.parameter.name",
-                "value": "SELECT",
-            }
-        ]
-
-        assert loaded["vulnerabilities"][0]["type"] == vuln_type
-        assert loaded["vulnerabilities"][0]["evidence"] == {
-            "valueParts": [
-                {"source": 0, "value": "SELECT"},
-                {
-                    "value": " ",
-                },
-                {
-                    "redacted": True,
-                },
-            ]
+    assert loaded["sources"] == [
+        {
+            "name": "SELECT",
+            "origin": "http.request.parameter.name",
+            "value": "SELECT",
         }
-        assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
-        assert loaded["vulnerabilities"][0]["location"]["line"] == line
-        assert loaded["vulnerabilities"][0]["hash"] == hash_value
+    ]
+
+    assert loaded["vulnerabilities"][0]["type"] == vuln_type
+    assert loaded["vulnerabilities"][0]["evidence"] == {
+        "valueParts": [
+            {"source": 0, "value": "SELECT"},
+            {
+                "value": " ",
+            },
+            {
+                "redacted": True,
+            },
+        ]
+    }
+    assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
+    assert loaded["vulnerabilities"][0]["location"]["line"] == line
+    assert loaded["vulnerabilities"][0]["hash"] == hash_value
 
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_sqli_http_request_parameter_name_post(client, test_spans, tracer):
-    with override_global_config(
-        dict(_iast_enabled=True, _iast_deduplication_enabled=False, _iast_request_sampling=100.0)
-    ):
-        root_span, response = _aux_appsec_get_root_span(
-            client,
-            test_spans,
-            tracer,
-            payload=urlencode({"SELECT": "unused"}),
-            content_type="application/x-www-form-urlencoded",
-            url="/appsec/sqli_http_request_parameter_name_post/",
-            headers={"HTTP_USER_AGENT": "test/1.2.3"},
-        )
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        payload=urlencode({"SELECT": "unused"}),
+        content_type="application/x-www-form-urlencoded",
+        url="/appsec/sqli_http_request_parameter_name_post/",
+        headers={"HTTP_USER_AGENT": "test/1.2.3"},
+    )
 
-        vuln_type = "SQL_INJECTION"
+    vuln_type = "SQL_INJECTION"
 
-        assert response.status_code == 200
-        assert response.content == b"test/1.2.3"
+    assert response.status_code == 200
+    assert response.content == b"test/1.2.3"
 
-        loaded = json.loads(root_span.get_tag(IAST.JSON))
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
 
-        line, hash_value = get_line_and_hash(
-            "iast_enabled_sqli_http_request_parameter_name_post", vuln_type, filename=TEST_FILE
-        )
+    line, hash_value = get_line_and_hash(
+        "iast_enabled_sqli_http_request_parameter_name_post", vuln_type, filename=TEST_FILE
+    )
 
-        assert loaded["sources"] == [
-            {
-                "name": "SELECT",
-                "origin": "http.request.parameter.name",
-                "value": "SELECT",
-            }
-        ]
-
-        assert loaded["vulnerabilities"][0]["type"] == vuln_type
-        assert loaded["vulnerabilities"][0]["evidence"] == {
-            "valueParts": [
-                {"source": 0, "value": "SELECT"},
-                {
-                    "value": " ",
-                },
-                {
-                    "redacted": True,
-                },
-            ]
+    assert loaded["sources"] == [
+        {
+            "name": "SELECT",
+            "origin": "http.request.parameter.name",
+            "value": "SELECT",
         }
-        assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
-        assert loaded["vulnerabilities"][0]["location"]["line"] == line
-        assert loaded["vulnerabilities"][0]["hash"] == hash_value
+    ]
+
+    assert loaded["vulnerabilities"][0]["type"] == vuln_type
+    assert loaded["vulnerabilities"][0]["evidence"] == {
+        "valueParts": [
+            {"source": 0, "value": "SELECT"},
+            {
+                "value": " ",
+            },
+            {
+                "redacted": True,
+            },
+        ]
+    }
+    assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
+    assert loaded["vulnerabilities"][0]["location"]["line"] == line
+    assert loaded["vulnerabilities"][0]["hash"] == hash_value
+
+
+@pytest.mark.django_db()
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_sqli_query_no_redacted(client, test_spans, tracer):
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/sqli_query_no_redacted/?q=sqlite_master",
+    )
+
+    vuln_type = "SQL_INJECTION"
+
+    assert response.status_code == 200
+    assert response.content == b"OK"
+
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
+
+    line, hash_value = get_line_and_hash("sqli_query_no_redacted", vuln_type, filename=TEST_FILE)
+
+    assert loaded["sources"] == [
+        {
+            "name": "q",
+            "origin": "http.request.parameter",
+            "value": "sqlite_master",
+        }
+    ]
+
+    assert loaded["vulnerabilities"][0]["type"] == vuln_type
+    assert loaded["vulnerabilities"][0]["evidence"] == {
+        "valueParts": [
+            {"value": "SELECT * FROM "},
+            {"source": 0, "value": "sqlite_master"},
+            {"value": " ORDER BY name"},
+        ]
+    }
+    assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
+    assert loaded["vulnerabilities"][0]["location"]["line"] == line
+    assert loaded["vulnerabilities"][0]["hash"] == hash_value
 
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_sqli_http_request_header_value(client, test_spans, tracer):
-    with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
-        root_span, response = _aux_appsec_get_root_span(
-            client,
-            test_spans,
-            tracer,
-            payload=urlencode({"mytestingbody_key": "mytestingbody_value"}),
-            content_type="application/x-www-form-urlencoded",
-            url="/appsec/sqli_http_request_header_value/",
-            headers={"HTTP_USER_AGENT": "master"},
-        )
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        payload=urlencode({"mytestingbody_key": "mytestingbody_value"}),
+        content_type="application/x-www-form-urlencoded",
+        url="/appsec/sqli_http_request_header_value/",
+        headers={"HTTP_USER_AGENT": "master"},
+    )
 
-        assert response.status_code == 200
-        assert response.content == b"master"
+    assert response.status_code == 200
+    assert response.content == b"master"
 
-        loaded = json.loads(root_span.get_tag(IAST.JSON))
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
 
-        assert loaded["sources"] == [{"origin": "http.request.header", "name": "HTTP_USER_AGENT", "value": "master"}]
-        assert loaded["vulnerabilities"][0]["type"] == VULN_SQL_INJECTION
-        assert loaded["vulnerabilities"][0]["evidence"] == {
-            "valueParts": [
-                {"value": "SELECT "},
-                {"redacted": True},
-                {"value": " FROM sqlite_"},
-                {"source": 0, "value": "master"},
-            ]
-        }
+    assert loaded["sources"] == [{"origin": "http.request.header", "name": "HTTP_USER_AGENT", "value": "master"}]
+    assert loaded["vulnerabilities"][0]["type"] == VULN_SQL_INJECTION
+    assert loaded["vulnerabilities"][0]["evidence"] == {
+        "valueParts": [
+            {"value": "SELECT "},
+            {"redacted": True},
+            {"value": " FROM sqlite_"},
+            {"source": 0, "value": "master"},
+        ]
+    }
 
-        line, hash_value = get_line_and_hash(
-            "iast_enabled_sqli_http_request_header_value", VULN_SQL_INJECTION, filename=TEST_FILE
-        )
-        assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
-        assert loaded["vulnerabilities"][0]["location"]["line"] == line
-        assert loaded["vulnerabilities"][0]["hash"] == hash_value
+    line, hash_value = get_line_and_hash(
+        "iast_enabled_sqli_http_request_header_value", VULN_SQL_INJECTION, filename=TEST_FILE
+    )
+    assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
+    assert loaded["vulnerabilities"][0]["location"]["line"] == line
+    assert loaded["vulnerabilities"][0]["hash"] == hash_value
 
 
 @pytest.mark.django_db()
@@ -384,39 +478,38 @@ def test_django_iast_disabled_sqli_http_request_header_value(client, test_spans,
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_sqli_http_request_header_name(client, test_spans, tracer):
-    with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
-        root_span, response = _aux_appsec_get_root_span(
-            client,
-            test_spans,
-            tracer,
-            payload=urlencode({"mytestingbody_key": "mytestingbody_value"}),
-            content_type="application/x-www-form-urlencoded",
-            url="/appsec/sqli_http_request_header_name/",
-            headers={"master": "test/1.2.3"},
-        )
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        payload=urlencode({"mytestingbody_key": "mytestingbody_value"}),
+        content_type="application/x-www-form-urlencoded",
+        url="/appsec/sqli_http_request_header_name/",
+        headers={"master": "test/1.2.3"},
+    )
 
-        assert response.status_code == 200
-        assert response.content == b"test/1.2.3"
+    assert response.status_code == 200
+    assert response.content == b"test/1.2.3"
 
-        loaded = json.loads(root_span.get_tag(IAST.JSON))
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
 
-        assert loaded["sources"] == [{"origin": "http.request.header.name", "name": "master", "value": "master"}]
-        assert loaded["vulnerabilities"][0]["type"] == VULN_SQL_INJECTION
-        assert loaded["vulnerabilities"][0]["evidence"] == {
-            "valueParts": [
-                {"value": "SELECT "},
-                {"redacted": True},
-                {"value": " FROM sqlite_"},
-                {"value": "master", "source": 0},
-            ]
-        }
+    assert loaded["sources"] == [{"origin": "http.request.header.name", "name": "master", "value": "master"}]
+    assert loaded["vulnerabilities"][0]["type"] == VULN_SQL_INJECTION
+    assert loaded["vulnerabilities"][0]["evidence"] == {
+        "valueParts": [
+            {"value": "SELECT "},
+            {"redacted": True},
+            {"value": " FROM sqlite_"},
+            {"value": "master", "source": 0},
+        ]
+    }
 
-        line, hash_value = get_line_and_hash(
-            "iast_enabled_sqli_http_request_header_name", VULN_SQL_INJECTION, filename=TEST_FILE
-        )
-        assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
-        assert loaded["vulnerabilities"][0]["location"]["line"] == line
-        assert loaded["vulnerabilities"][0]["hash"] == hash_value
+    line, hash_value = get_line_and_hash(
+        "iast_enabled_sqli_http_request_header_name", VULN_SQL_INJECTION, filename=TEST_FILE
+    )
+    assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
+    assert loaded["vulnerabilities"][0]["location"]["line"] == line
+    assert loaded["vulnerabilities"][0]["hash"] == hash_value
 
 
 @pytest.mark.django_db()
@@ -495,41 +588,40 @@ def test_django_iast_disabled_sqli_http_path_parameter(client, test_spans, trace
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_sqli_http_cookies_name(client, test_spans, tracer):
-    with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
-        root_span, response = _aux_appsec_get_root_span(
-            client,
-            test_spans,
-            tracer,
-            url="/appsec/sqli_http_request_cookie_name/",
-            cookies={"master": "test/1.2.3"},
-        )
-        assert response.status_code == 200
-        assert response.content == b"test/1.2.3"
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/sqli_http_request_cookie_name/",
+        cookies={"master": "test/1.2.3"},
+    )
+    assert response.status_code == 200
+    assert response.content == b"test/1.2.3"
 
-        loaded = json.loads(root_span.get_tag(IAST.JSON))
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
 
-        vulnerability = False
-        for vuln in loaded["vulnerabilities"]:
-            if vuln["type"] == VULN_SQL_INJECTION:
-                vulnerability = vuln
+    vulnerability = False
+    for vuln in loaded["vulnerabilities"]:
+        if vuln["type"] == VULN_SQL_INJECTION:
+            vulnerability = vuln
 
-        assert vulnerability, "No {} reported".format(VULN_SQL_INJECTION)
+    assert vulnerability, "No {} reported".format(VULN_SQL_INJECTION)
 
-        assert loaded["sources"] == [{"origin": "http.request.cookie.name", "name": "master", "value": "master"}]
-        assert vulnerability["evidence"] == {
-            "valueParts": [
-                {"value": "SELECT "},
-                {"redacted": True},
-                {"value": " FROM sqlite_"},
-                {"value": "master", "source": 0},
-            ]
-        }
-        line, hash_value = get_line_and_hash(
-            "iast_enabled_sqli_http_cookies_name", VULN_SQL_INJECTION, filename=TEST_FILE
-        )
-        assert vulnerability["location"]["path"] == TEST_FILE
-        assert vulnerability["location"]["line"] == line
-        assert vulnerability["hash"] == hash_value
+    assert loaded["sources"] == [{"origin": "http.request.cookie.name", "name": "master", "value": "master"}]
+    assert vulnerability["evidence"] == {
+        "valueParts": [
+            {"value": "SELECT "},
+            {"redacted": True},
+            {"value": " FROM sqlite_"},
+            {"value": "master", "source": 0},
+        ]
+    }
+    line, hash_value = get_line_and_hash("iast_enabled_sqli_http_cookies_name", VULN_SQL_INJECTION, filename=TEST_FILE)
+    assert vulnerability["location"]["path"] == TEST_FILE
+    assert vulnerability["location"]["line"] == line
+    assert vulnerability["location"]["method"] == "sqli_http_request_cookie_name"
+    assert vulnerability["location"]["class_name"] == ""
+    assert vulnerability["hash"] == hash_value
 
 
 @pytest.mark.django_db()
@@ -553,43 +645,42 @@ def test_django_iast_disabled_sqli_http_cookies_name(client, test_spans, tracer)
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_sqli_http_cookies_value(client, test_spans, tracer):
-    with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
-        root_span, response = _aux_appsec_get_root_span(
-            client,
-            test_spans,
-            tracer,
-            url="/appsec/sqli_http_request_cookie_value/",
-            cookies={"master": "master"},
-        )
-        assert response.status_code == 200
-        assert response.content == b"master"
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/sqli_http_request_cookie_value/",
+        cookies={"master": "master"},
+    )
+    assert response.status_code == 200
+    assert response.content == b"master"
 
-        loaded = json.loads(root_span.get_tag(IAST.JSON))
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
 
-        vulnerability = False
-        for vuln in loaded["vulnerabilities"]:
-            if vuln["type"] == VULN_SQL_INJECTION:
-                vulnerability = vuln
+    vulnerability = False
+    for vuln in loaded["vulnerabilities"]:
+        if vuln["type"] == VULN_SQL_INJECTION:
+            vulnerability = vuln
 
-        assert vulnerability, "No {} reported".format(VULN_SQL_INJECTION)
-        assert loaded["sources"] == [{"origin": "http.request.cookie.value", "name": "master", "value": "master"}]
-        assert vulnerability["type"] == "SQL_INJECTION"
+    assert vulnerability, "No {} reported".format(VULN_SQL_INJECTION)
+    assert loaded["sources"] == [{"origin": "http.request.cookie.value", "name": "master", "value": "master"}]
+    assert vulnerability["type"] == "SQL_INJECTION"
 
-        assert vulnerability["evidence"] == {
-            "valueParts": [
-                {"value": "SELECT "},
-                {"redacted": True},
-                {"value": " FROM sqlite_"},
-                {"value": "master", "source": 0},
-            ]
-        }
+    assert vulnerability["evidence"] == {
+        "valueParts": [
+            {"value": "SELECT "},
+            {"redacted": True},
+            {"value": " FROM sqlite_"},
+            {"value": "master", "source": 0},
+        ]
+    }
 
-        line, hash_value = get_line_and_hash(
-            "iast_enabled_sqli_http_cookies_value", VULN_SQL_INJECTION, filename=TEST_FILE
-        )
-        assert vulnerability["location"]["line"] == line
-        assert vulnerability["location"]["path"] == TEST_FILE
-        assert vulnerability["hash"] == hash_value
+    line, hash_value = get_line_and_hash("iast_enabled_sqli_http_cookies_value", VULN_SQL_INJECTION, filename=TEST_FILE)
+    assert vulnerability["location"]["line"] == line
+    assert vulnerability["location"]["path"] == TEST_FILE
+    assert vulnerability["location"]["method"] == "sqli_http_request_cookie_value"
+    assert vulnerability["location"]["class_name"] == ""
+    assert vulnerability["hash"] == hash_value
 
 
 @pytest.mark.django_db()
@@ -620,35 +711,34 @@ def test_django_iast_disabled_sqli_http_cookies_value(client, test_spans, tracer
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_sqli_http_body(client, test_spans, tracer, payload, content_type):
-    with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
-        root_span, response = _aux_appsec_get_root_span(
-            client,
-            test_spans,
-            tracer,
-            url="/appsec/sqli_http_request_body/",
-            payload=payload,
-            content_type=content_type,
-        )
-        loaded = json.loads(root_span.get_tag(IAST.JSON))
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/sqli_http_request_body/",
+        payload=payload,
+        content_type=content_type,
+    )
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
 
-        line, hash_value = get_line_and_hash("iast_enabled_sqli_http_body", VULN_SQL_INJECTION, filename=TEST_FILE)
+    line, hash_value = get_line_and_hash("iast_enabled_sqli_http_body", VULN_SQL_INJECTION, filename=TEST_FILE)
 
-        assert loaded["sources"] == [{"origin": "http.request.body", "name": "http.request.body", "value": "master"}]
-        assert loaded["vulnerabilities"][0]["type"] == VULN_SQL_INJECTION
-        assert loaded["vulnerabilities"][0]["hash"] == hash_value
-        assert loaded["vulnerabilities"][0]["evidence"] == {
-            "valueParts": [
-                {"value": "SELECT "},
-                {"redacted": True},
-                {"value": " FROM sqlite_"},
-                {"value": "master", "source": 0},
-            ]
-        }
-        assert loaded["vulnerabilities"][0]["location"]["line"] == line
-        assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
+    assert loaded["sources"] == [{"origin": "http.request.body", "name": "http.request.body", "value": "master"}]
+    assert loaded["vulnerabilities"][0]["type"] == VULN_SQL_INJECTION
+    assert loaded["vulnerabilities"][0]["hash"] == hash_value
+    assert loaded["vulnerabilities"][0]["evidence"] == {
+        "valueParts": [
+            {"value": "SELECT "},
+            {"redacted": True},
+            {"value": " FROM sqlite_"},
+            {"value": "master", "source": 0},
+        ]
+    }
+    assert loaded["vulnerabilities"][0]["location"]["line"] == line
+    assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
 
-        assert response.status_code == 200
-        assert response.content == b"master"
+    assert response.status_code == 200
+    assert response.content == b"master"
 
 
 @pytest.mark.parametrize(
@@ -678,7 +768,7 @@ def test_django_sqli_http_body(client, test_spans, tracer, payload, content_type
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_tainted_http_body_empty(client, test_spans, tracer, payload, content_type, deduplication, sampling):
     with override_global_config(
-        dict(_iast_enabled=True, _deduplication_enabled=deduplication, _iast_request_sampling=sampling)
+        dict(_iast_enabled=True, _iast_deduplication_enabled=deduplication, _iast_request_sampling=sampling)
     ):
         root_span, response = _aux_appsec_get_root_span(
             client,
@@ -715,178 +805,358 @@ def test_django_iast_disabled_sqli_http_body(client, test_spans, tracer):
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_querydict(client, test_spans, tracer):
-    with override_global_config(dict(_iast_enabled=True)):
-        root_span, response = _aux_appsec_get_root_span(
-            client,
-            test_spans,
-            tracer,
-            url="/appsec/validate_querydict/?x=1&y=2&x=3",
-        )
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/validate_querydict/?x=1&y=2&x=3",
+    )
 
-        assert root_span.get_tag(IAST.JSON) is None
-        assert response.status_code == 200
-        assert (
-            response.content == b"x=['1', '3'], all=[('x', ['1', '3']), ('y', ['2'])],"
-            b" keys=['x', 'y'], urlencode=x=1&x=3&y=2"
-        )
+    assert root_span.get_tag(IAST.JSON) is None
+    assert response.status_code == 200
+    assert (
+        response.content == b"x=['1', '3'], all=[('x', ['1', '3']), ('y', ['2'])],"
+        b" keys=['x', 'y'], urlencode=x=1&x=3&y=2"
+    )
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_command_injection(client, test_spans, tracer):
-    with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
-        oce.reconfigure()
-        patch_iast({"command_injection": True})
-        from ddtrace.appsec._common_module_patches import patch_common_modules
+    patch_common_modules()
+    root_span, _ = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/command-injection/",
+        payload="master",
+        content_type="application/json",
+    )
 
-        patch_common_modules()
-        root_span, _ = _aux_appsec_get_root_span(
-            client,
-            test_spans,
-            tracer,
-            url="/appsec/command-injection/",
-            payload="master",
-            content_type="application/json",
-        )
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
 
-        loaded = json.loads(root_span.get_tag(IAST.JSON))
+    line, hash_value = get_line_and_hash("iast_command_injection", VULN_CMDI, filename=TEST_FILE)
 
-        line, hash_value = get_line_and_hash("iast_command_injection", VULN_CMDI, filename=TEST_FILE)
+    assert loaded["sources"] == [
+        {"name": "http.request.body", "origin": "http.request.body", "pattern": "abcdef", "redacted": True}
+    ]
+    assert loaded["vulnerabilities"][0]["type"] == VULN_CMDI
+    assert loaded["vulnerabilities"][0]["hash"] == hash_value
+    assert loaded["vulnerabilities"][0]["evidence"] == {
+        "valueParts": [{"value": "dir "}, {"redacted": True}, {"pattern": "abcdef", "redacted": True, "source": 0}]
+    }
+    assert loaded["vulnerabilities"][0]["location"]["line"] == line
+    assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
 
-        assert loaded["sources"] == [
-            {"name": "http.request.body", "origin": "http.request.body", "pattern": "abcdef", "redacted": True}
-        ]
-        assert loaded["vulnerabilities"][0]["type"] == VULN_CMDI
-        assert loaded["vulnerabilities"][0]["hash"] == hash_value
-        assert loaded["vulnerabilities"][0]["evidence"] == {
-            "valueParts": [{"value": "dir "}, {"redacted": True}, {"pattern": "abcdef", "redacted": True, "source": 0}]
-        }
-        assert loaded["vulnerabilities"][0]["location"]["line"] == line
-        assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
+
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_command_injection_span_metrics(client, test_spans, tracer):
+    patch_common_modules()
+    root_span, _ = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/command-injection/",
+        payload="master",
+        content_type="application/json",
+    )
+    assert root_span.get_metric(IAST.ENABLED) == 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK + ".command_injection") == 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK + ".header_injection") > 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_body") == 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_header_name") > 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_header") > 1.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_path") > 1.0
+
+
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_command_injection_span_metrics_disabled(client, iast_spans_with_zero_sampling, tracer):
+    patch_common_modules()
+    root_span, _ = _aux_appsec_get_root_span(
+        client,
+        iast_spans_with_zero_sampling,
+        tracer,
+        url="/appsec/command-injection/",
+        payload="master",
+        content_type="application/json",
+    )
+    assert root_span.get_metric(IAST.ENABLED) == 0.0
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK + ".command_injection") is None
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK + ".header_injection") is None
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_body") is None
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_header_name") is None
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_header") is None
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE + ".http_request_path") is None
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_header_injection(client, test_spans, tracer):
-    with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
-        oce.reconfigure()
-        patch_iast({"header_injection": True})
-        root_span, _ = _aux_appsec_get_root_span(
-            client,
-            test_spans,
-            tracer,
-            url="/appsec/header-injection/",
-            payload="master",
-            content_type="application/json",
-        )
+    root_span, _ = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/header-injection/",
+        payload="master",
+        content_type="application/json",
+    )
 
-        loaded = json.loads(root_span.get_tag(IAST.JSON))
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
 
-        line, hash_value = get_line_and_hash("iast_header_injection", VULN_HEADER_INJECTION, filename=TEST_FILE)
+    line, hash_value = get_line_and_hash("iast_header_injection", VULN_HEADER_INJECTION, filename=TEST_FILE)
 
-        assert loaded["sources"] == [{"origin": "http.request.body", "name": "http.request.body", "value": "master"}]
-        assert loaded["vulnerabilities"][0]["type"] == VULN_HEADER_INJECTION
-        assert loaded["vulnerabilities"][0]["hash"] == hash_value
-        assert loaded["vulnerabilities"][0]["evidence"] == {
-            "valueParts": [{"value": "Header-Injection: "}, {"source": 0, "value": "master"}]
-        }
-        assert loaded["vulnerabilities"][0]["location"]["line"] == line
-        assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
+    assert loaded["sources"] == [{"origin": "http.request.body", "name": "http.request.body", "value": "master"}]
+    assert loaded["vulnerabilities"][0]["type"] == VULN_HEADER_INJECTION
+    assert loaded["vulnerabilities"][0]["hash"] == hash_value
+    assert loaded["vulnerabilities"][0]["evidence"] == {
+        "valueParts": [{"value": "Header-Injection: "}, {"source": 0, "value": "master"}]
+    }
+    assert loaded["vulnerabilities"][0]["location"]["line"] == line
+    assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_insecure_cookie(client, test_spans, tracer):
-    with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
-        oce.reconfigure()
-        root_span, _ = _aux_appsec_get_root_span(
-            client,
-            test_spans,
-            tracer,
-            url="/appsec/insecure-cookie/test_insecure/",
-        )
+    root_span, _ = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/insecure-cookie/test_insecure/",
+    )
 
-        assert root_span.get_metric(IAST.ENABLED) == 1.0
+    assert root_span.get_metric(IAST.ENABLED) == 1.0
 
-        loaded = json.loads(root_span.get_tag(IAST.JSON))
-        assert loaded["sources"] == []
-        assert len(loaded["vulnerabilities"]) == 1
-        vulnerability = loaded["vulnerabilities"][0]
-        assert vulnerability["type"] == VULN_INSECURE_COOKIE
-        assert vulnerability["evidence"] == {"valueParts": [{"value": "insecure"}]}
-        assert "path" not in vulnerability["location"].keys()
-        assert "line" not in vulnerability["location"].keys()
-        assert vulnerability["location"]["spanId"]
-        assert vulnerability["hash"]
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
+    assert loaded["sources"] == []
+    assert len(loaded["vulnerabilities"]) == 1
+    vulnerability = loaded["vulnerabilities"][0]
+    assert vulnerability["type"] == VULN_INSECURE_COOKIE
+    assert vulnerability["evidence"] == {"valueParts": [{"value": "insecure"}]}
+    assert vulnerability["location"]["spanId"]
+    assert vulnerability["hash"]
+    line, hash_value = get_line_and_hash("test_django_insecure_cookie", VULN_INSECURE_COOKIE, filename=TEST_FILE)
+    assert vulnerability["location"]["line"] == line
+    assert vulnerability["location"]["path"] == TEST_FILE
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_insecure_cookie_secure(client, test_spans, tracer):
-    with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
-        oce.reconfigure()
-        root_span, _ = _aux_appsec_get_root_span(
-            client,
-            test_spans,
-            tracer,
-            url="/appsec/insecure-cookie/test_secure/",
-        )
+    root_span, _ = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/insecure-cookie/test_secure/",
+    )
 
-        assert root_span.get_metric(IAST.ENABLED) == 1.0
+    assert root_span.get_metric(IAST.ENABLED) == 1.0
 
-        assert root_span.get_tag(IAST.JSON) is None
+    assert root_span.get_tag(IAST.JSON) is None
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_insecure_cookie_empty_cookie(client, test_spans, tracer):
-    with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
-        oce.reconfigure()
-        root_span, _ = _aux_appsec_get_root_span(
-            client,
-            test_spans,
-            tracer,
-            url="/appsec/insecure-cookie/test_empty_cookie/",
-        )
+    root_span, _ = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/insecure-cookie/test_empty_cookie/",
+    )
 
-        assert root_span.get_metric(IAST.ENABLED) == 1.0
+    assert root_span.get_metric(IAST.ENABLED) == 1.0
 
-        assert root_span.get_tag(IAST.JSON) is None
+    assert root_span.get_tag(IAST.JSON) is None
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_insecure_cookie_2_insecure_1_secure(client, test_spans, tracer):
-    with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
-        oce.reconfigure()
-        root_span, _ = _aux_appsec_get_root_span(
-            client,
-            test_spans,
-            tracer,
-            url="/appsec/insecure-cookie/test_insecure_2_1/",
-        )
+    root_span, _ = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/insecure-cookie/test_insecure_2_1/",
+    )
 
-        assert root_span.get_metric(IAST.ENABLED) == 1.0
+    assert root_span.get_metric(IAST.ENABLED) == 1.0
 
-        loaded = json.loads(root_span.get_tag(IAST.JSON))
-        assert loaded["sources"] == []
-        assert len(loaded["vulnerabilities"]) == 2
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
+    assert loaded["sources"] == []
+    assert len(loaded["vulnerabilities"]) == 2
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
 def test_django_insecure_cookie_special_characters(client, test_spans, tracer):
-    with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=False)):
-        oce.reconfigure()
-        root_span, _ = _aux_appsec_get_root_span(
-            client,
-            test_spans,
-            tracer,
-            url="/appsec/insecure-cookie/test_insecure_special/",
-        )
+    root_span, _ = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/insecure-cookie/test_insecure_special/",
+    )
 
-        assert root_span.get_metric(IAST.ENABLED) == 1.0
+    assert root_span.get_metric(IAST.ENABLED) == 1.0
 
-        loaded = json.loads(root_span.get_tag(IAST.JSON))
-        assert loaded["sources"] == []
-        assert len(loaded["vulnerabilities"]) == 1
-        vulnerability = loaded["vulnerabilities"][0]
-        assert vulnerability["type"] == VULN_INSECURE_COOKIE
-        assert vulnerability["evidence"] == {"valueParts": [{"value": "insecure"}]}
-        assert "path" not in vulnerability["location"].keys()
-        assert "line" not in vulnerability["location"].keys()
-        assert vulnerability["location"]["spanId"]
-        assert vulnerability["hash"]
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
+    assert loaded["sources"] == []
+    assert len(loaded["vulnerabilities"]) == 1
+    vulnerability = loaded["vulnerabilities"][0]
+    assert vulnerability["type"] == VULN_INSECURE_COOKIE
+    assert vulnerability["evidence"] == {"valueParts": [{"value": "insecure"}]}
+    assert vulnerability["location"]["spanId"]
+    assert vulnerability["hash"]
+    line, hash_value = get_line_and_hash(
+        "test_django_insecure_cookie_special_characters", VULN_INSECURE_COOKIE, filename=TEST_FILE
+    )
+    assert vulnerability["location"]["line"] == line
+    assert vulnerability["location"]["path"] == TEST_FILE
+
+
+@pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
+def test_django_stacktrace_leak(client, test_spans, tracer):
+    root_span, _ = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/stacktrace_leak/",
+    )
+
+    assert root_span.get_metric(IAST.ENABLED) == 1.0
+
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
+    assert loaded["sources"] == []
+    assert len(loaded["vulnerabilities"]) == 1
+    vulnerability = loaded["vulnerabilities"][0]
+    assert vulnerability["type"] == VULN_STACKTRACE_LEAK
+    assert vulnerability["evidence"] == {
+        "valueParts": [
+            {"value": 'Module: ".home.foobaruser.sources.minimal-django-example.app.py"\nException: IndexError'}
+        ]
+    }
+    assert vulnerability["hash"]
+
+
+def test_django_stacktrace_from_technical_500_response(client, test_spans, tracer, debug_mode):
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/stacktrace_leak_500/",
+        content_type="text/html",
+    )
+
+    assert response.status_code == 500, "Expected a 500 status code"
+    assert root_span.get_metric(IAST.ENABLED) == 1.0
+
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
+    # technical_500_response reports a XSS also
+    vulnerability = [vln for vln in loaded["vulnerabilities"] if vln["type"] == VULN_STACKTRACE_LEAK][0]
+    assert vulnerability["evidence"] == {
+        "valueParts": [
+            {"value": "Module: tests.appsec.integrations.django_tests.django_app.views\nException: Exception"}
+        ]
+    }
+    assert vulnerability["hash"]
+
+
+def test_django_xss(client, test_spans, tracer):
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/xss/?input=<script>alert('XSS')</script>",
+    )
+
+    vuln_type = "XSS"
+
+    assert response.status_code == 200
+    assert response.content == b"<html>\n<body>\n<p>Input: <script>alert('XSS')</script></p>\n</body>\n</html>"
+
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
+
+    line, hash_value = get_line_and_hash("xss_http_request_parameter_mark_safe", vuln_type, filename=TEST_FILE)
+
+    assert loaded["sources"] == [
+        {
+            "name": "input",
+            "origin": "http.request.parameter",
+            "value": "<script>alert('XSS')</script>",
+        }
+    ]
+
+    assert loaded["vulnerabilities"][0]["type"] == vuln_type
+    assert loaded["vulnerabilities"][0]["evidence"] == {
+        "valueParts": [
+            {"source": 0, "value": "<script>alert('XSS')</script>"},
+        ]
+    }
+    assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
+    assert loaded["vulnerabilities"][0]["location"]["line"] == line
+    assert loaded["vulnerabilities"][0]["hash"] == hash_value
+
+
+def test_django_xss_safe_template_tag(client, test_spans, tracer):
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/xss/safe/?input=<script>alert('XSS')</script>",
+    )
+
+    vuln_type = "XSS"
+
+    assert response.status_code == 200
+    assert response.content == b"<html>\n<body>\n<p>Input: <script>alert('XSS')</script></p>\n</body>\n</html>"
+
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
+
+    line, hash_value = get_line_and_hash("xss_http_request_parameter_template_safe", vuln_type, filename=TEST_FILE)
+
+    assert loaded["sources"] == [
+        {
+            "name": "input",
+            "origin": "http.request.parameter",
+            "value": "<script>alert('XSS')</script>",
+        }
+    ]
+
+    assert loaded["vulnerabilities"][0]["type"] == vuln_type
+    assert loaded["vulnerabilities"][0]["evidence"] == {
+        "valueParts": [
+            {"source": 0, "value": "<script>alert('XSS')</script>"},
+        ]
+    }
+    assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
+    assert loaded["vulnerabilities"][0]["location"]["line"] == line
+    assert loaded["vulnerabilities"][0]["hash"] == hash_value
+
+
+def test_django_xss_autoscape(client, test_spans, tracer):
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/xss/autoscape/?input=<script>alert('XSS')</script>",
+    )
+
+    assert response.status_code == 200
+    assert (
+        response.content
+        == b"<html>\n<body>\n<p>\n    &lt;script&gt;alert(&#x27;XSS&#x27;)&lt;/script&gt;\n</p>\n</body>\n</html>\n"
+    ), f"Error. content is {response.content}"
+
+    loaded = root_span.get_tag(IAST.JSON)
+    assert loaded is None
+
+
+def test_django_xss_secure(client, test_spans, tracer):
+    root_span, response = _aux_appsec_get_root_span(
+        client,
+        test_spans,
+        tracer,
+        url="/appsec/xss/secure/?input=<script>alert('XSS')</script>",
+    )
+
+    assert response.status_code == 200
+    assert (
+        response.content
+        == b"<html>\n<body>\n<p>Input: &lt;script&gt;alert(&#x27;XSS&#x27;)&lt;/script&gt;</p>\n</body>\n</html>"
+    )
+
+    loaded = root_span.get_tag(IAST.JSON)
+    assert loaded is None


### PR DESCRIPTION
backport https://github.com/DataDog/dd-trace-py/pull/13075 to 2.21

Partial backport of #13046 to align the functions parameters.


(cherry picked from commit 9c8c6d0eb66c67ae261329c0f098dd32b6e67b21)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
