### PR TITLE
bug(sqlalchemy): long postgres queries

### DIFF
--- a/tests/contrib/sqlalchemy/test_patch.py
+++ b/tests/contrib/sqlalchemy/test_patch.py
@@ -80,34 +80,16 @@ class SQLAlchemyPatchTestCase(TracerTestCase):
 
         emit_integration_and_version_to_test_agent("sqlalchemy", version)
 
+    @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_TRACE_WRITER_BUFFER_SIZE_BYTES="4294967295"))
     def test_long_sql_query(self):
-        # Tests a long query with one column
-        long_value = "nonsense query" * 1000000
-        results = self.conn.execute(text("SELECT :x as newcolumn"), {"x": long_value}).fetchall()
-        assert len(results) == 1
-
-        traces = self.pop_traces()
-        # trace composition
-        assert len(traces) == 1
-        assert len(traces[0]) == 1
-        span = traces[0][0]
-        # check subset of span fields
-        assert_is_measured(span)
-        assert span.name == "postgres.query"
-        assert span.service == "postgres"
-        assert span.resource == "SELECT %(x)s as newcolumn"
-
         # Tests a long query with multiple column
-        long_query = "SELECT " + ", ".join(
-            [
-                f"'nonsense query many words over and over and over and over and over and over and over and over to make this super long and over and over' as column{i}"
-                for i in range(1, 1000)
-            ]
-        )
+        repeated_string = "nonsense" * 10000
+        long_query = "SELECT " + ", ".join([f"'{repeated_string}' as column{i}" for i in range(1, 1000)])
         results = self.conn.execute(text(long_query)).fetchall()
         assert len(results) == 1
         traces = self.pop_traces()
         span = traces[0][0]
         assert span.name == "postgres.query"
         # The resulting resource name is super long
-        assert len(span.resource) == 151745
+        assert len(span.resource) == 79936880
+        self.tracer.flush()


### PR DESCRIPTION
Attempts to reproduce APMS-15401 with long pg queries in sql alchemy, except this isn't hitting the errors I expect so marking this as a draft.
## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
