### PR TITLE
chore(serverless): remove flaky mark from two serverless tests [backport 3.2]

### DIFF
--- a/tests/contrib/aws_lambda/test_aws_lambda.py
+++ b/tests/contrib/aws_lambda/test_aws_lambda.py
@@ -1,3 +1,5 @@
+import contextlib
+
 import pytest
 
 from ddtrace.contrib.internal.aws_lambda.patch import patch
@@ -46,10 +48,13 @@ def get_env(env=None):
     return {**common_env, **env}
 
 
-@pytest.fixture(autouse=True)
-def setup():
-    yield
-    unpatch()
+@contextlib.contextmanager
+def override_env_and_patch(env):
+    # patching and unpatching must be done while the environment is set
+    with override_env(env):
+        patch()
+        yield
+        unpatch()
 
 
 @flaky(1735812000)
@@ -64,9 +69,7 @@ def test_timeout_traces(context, customApmFlushDeadline):
         }
     )
 
-    with override_env(env):
-        patch()
-
+    with override_env_and_patch(env):
         datadog(timeout_handler)({}, context())
 
 
@@ -83,9 +86,7 @@ def test_continue_on_early_trace_ending(context):
         }
     )
 
-    with override_env(env):
-        patch()
-
+    with override_env_and_patch(env):
         datadog(finishing_spans_early_handler)({}, context())
 
 
@@ -98,11 +99,8 @@ async def test_file_patching(context):
         }
     )
 
-    with override_env(env):
-        patch()
-
+    with override_env_and_patch(env):
         result = datadog(handler)({}, context())
-
         assert result == {"success": True}
 
 
@@ -117,11 +115,8 @@ async def test_module_patching(mocker, context):
         }
     )
 
-    with override_env(env):
-        patch()
-
+    with override_env_and_patch(env):
         result = manually_wrapped_handler({}, context())
-
         assert result == {"success": True}
 
 
@@ -144,8 +139,6 @@ def test_class_based_handlers(context, handler, function_name):
         }
     )
 
-    with override_env(env):
-        patch()
-
+    with override_env_and_patch(env):
         result = datadog(handler)({}, context())
         assert result == {"success": True}

--- a/tests/contrib/aws_lambda/test_aws_lambda.py
+++ b/tests/contrib/aws_lambda/test_aws_lambda.py
@@ -13,7 +13,6 @@ from tests.contrib.aws_lambda.handlers import instance_handler_with_code
 from tests.contrib.aws_lambda.handlers import manually_wrapped_handler
 from tests.contrib.aws_lambda.handlers import static_handler
 from tests.contrib.aws_lambda.handlers import timeout_handler
-from tests.utils import flaky
 from tests.utils import override_env
 
 
@@ -57,7 +56,6 @@ def override_env_and_patch(env):
         unpatch()
 
 
-@flaky(1735812000)
 @pytest.mark.parametrize("customApmFlushDeadline", [("-100"), ("10"), ("100"), ("200")])
 @pytest.mark.snapshot
 def test_timeout_traces(context, customApmFlushDeadline):
@@ -130,7 +128,6 @@ async def test_module_patching(mocker, context):
     ],
 )
 @pytest.mark.snapshot
-@flaky(1741838400, reason="Did not receive expected traces: 'aws.lambda' for [handler3-instance_handler_with_code]")
 def test_class_based_handlers(context, handler, function_name):
     env = get_env(
         {


### PR DESCRIPTION
Backport 612d8023f01211303d36501e101760b2231c9e3b from #13039 to 3.2.

This PR addresses two flaky tests in `tests/contrib/aws_lambda/test_aws_lambda.py`. The issue that needed fixing was that env vars are checked during patch/unpatch. Since unpatch was being called after the env was reset, they were never being unpatched correctly. This PR ensures that the patching and unpatching occurs within the env override.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
