### PR TITLE
fix(azure_functions): use span kind internal for azure functions timer trigger

### DIFF
--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -835,9 +835,9 @@ def _set_span_pointer(span: "Span", span_pointer_description: _SpanPointerDescri
     )
 
 
-def _set_azure_function_tags(span, azure_functions_config, function_name, trigger):
+def _set_azure_function_tags(span, azure_functions_config, function_name, trigger, span_kind=SpanKind.INTERNAL):
     span.set_tag_str(COMPONENT, azure_functions_config.integration_name)
-    span.set_tag_str(SPAN_KIND, SpanKind.SERVER)
+    span.set_tag_str(SPAN_KIND, span_kind)
     span.set_tag_str("aas.function.name", function_name)  # codespell:ignore
     span.set_tag_str("aas.function.trigger", trigger)  # codespell:ignore
 
@@ -860,7 +860,7 @@ def _on_azure_functions_request_span_modifier(ctx, azure_functions_config, req):
 
 def _on_azure_functions_start_response(ctx, azure_functions_config, res, function_name, trigger):
     span = ctx.get_item("req_span")
-    _set_azure_function_tags(span, azure_functions_config, function_name, trigger)
+    _set_azure_function_tags(span, azure_functions_config, function_name, trigger, SpanKind.SERVER)
     trace_utils.set_http_meta(
         span,
         azure_functions_config,

--- a/releasenotes/notes/fix-azure-functions-timer-trigger-span-kind-internal-a884095b43b2692b.yaml
+++ b/releasenotes/notes/fix-azure-functions-timer-trigger-span-kind-internal-a884095b43b2692b.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    azure_functions: This fix resolves an issue where timer triggers had a span kind of `server` instead of `internal`.

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_timer.json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_timer.json
@@ -15,7 +15,7 @@
       "component": "azure_functions",
       "language": "python",
       "runtime-id": "c20075ab351244ed9d9d5e688777e0b1",
-      "span.kind": "server"
+      "span.kind": "internal"
     },
     "metrics": {
       "_dd.top_level": 1,


### PR DESCRIPTION
This PR adds a fix to set the span kind to `internal` for Azure Functions timer triggers instead of `server`.

Follows https://github.com/DataDog/dd-trace-py/pull/13055

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
