### PR TITLE
ci: don't fail with perf regressions on releases

### DIFF
--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -183,6 +183,11 @@ benchmarks-pr-comment:
 
 check-big-regressions:
   stage: report
+  rules:
+    # Run and warn on release branches, but don't fail the pipeline
+    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+$/
+      allow_failure: true
+    - allow_failure: false
   when: always
   tags: ["arch:amd64"]
   image: $MICROBENCHMARKS_CI_IMAGE


### PR DESCRIPTION
This is a stop gap to unblock releases which introduce known performance regressions. In the future we need to continue to block releases that introduce a performance regression. This PR is meant as a quick fix since we don't have any other ways to signal to the release process that we accept the regression.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
