### PR TITLE
fix(iast): invalid f-string type conversions exception in format_value_aspect

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -449,8 +449,8 @@ def format_value_aspect(
             return format(new_text, format_spec)
         return format(new_text)
 
-    try:
-        if format_spec:
+    if format_spec:
+        try:
             # Apply formatting
             text_ranges = get_tainted_ranges(new_text)
             if text_ranges:
@@ -466,11 +466,11 @@ def format_value_aspect(
                     return ("{:%s}" % format_spec).format(new_text)
             else:
                 return ("{:%s}" % format_spec).format(new_text)
-        else:
-            return format(new_text)
-    except Exception as e:
-        iast_propagation_error_log(f"format_value_aspect. {e}")
-        return new_text
+        except Exception as e:
+            iast_propagation_error_log(f"format_value_aspect. {e}")
+            return ("{:%s}" % format_spec).format(new_text)
+
+    return format(new_text)
 
 
 def incremental_translation(self, incr_coder, funcode, empty):

--- a/releasenotes/notes/iast-fstring-exception-d460a37b6e44f972.yaml
+++ b/releasenotes/notes/iast-fstring-exception-d460a37b6e44f972.yaml
@@ -1,7 +1,4 @@
 ---
 fixes:
   - |
-    Code Security: This fixes a bug with f-strings when IAST is enabled: when building an invalid string that 
-    should raise an "Unknown format code X" exception, the error wasn't being triggered in certain cases.
-
-
+    IAST: Fixes a bug where invalid f-strings didn’t raise the expected "Unknown format code" error when IAST was enabled.

--- a/releasenotes/notes/iast-fstring-exception-d460a37b6e44f972.yaml
+++ b/releasenotes/notes/iast-fstring-exception-d460a37b6e44f972.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Code Security: This fixes a bug with f-strings when IAST is enabled: when building an invalid string that 
+    should raise an "Unknown format code X" exception, the error wasn't being triggered in certain cases.
+
+

--- a/tests/appsec/iast/aspects/test_str_py3.py
+++ b/tests/appsec/iast/aspects/test_str_py3.py
@@ -1,3 +1,5 @@
+from hypothesis import given
+from hypothesis.strategies import text
 import pytest
 
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
@@ -8,6 +10,17 @@ from tests.appsec.iast.iast_utils import _iast_patched_module
 
 mod = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods")
 mod_py3 = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods_py3")
+
+
+@given(text())
+def test_int_fstring_zero_padding_text(text):
+    with pytest.raises(ValueError) as excinfo:
+        f"{text:05d}"
+    assert str(excinfo.value) == "Unknown format code 'd' for object of type 'str'"
+
+    with pytest.raises(ValueError) as excinfo:
+        mod_py3.do_zero_padding_fstring(text)
+    assert str(excinfo.value) == "Unknown format code 'd' for object of type 'str'"
 
 
 class TestOperatorsReplacement(BaseReplacement):


### PR DESCRIPTION
This fixes a bug with f-strings when IAST is enabled: when building an invalid string that should raise an "Unknown format code X" exception, the error wasn't being triggered in certain cases. like
```
 f"{text:05d}"
```
Should raise a ValueError("Unknown format code 'd' for object of type 'str'")

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
