### PR TITLE
chore(filters): remove unused code

### DIFF
--- a/ddtrace/_trace/filters.py
+++ b/ddtrace/_trace/filters.py
@@ -1,12 +1,9 @@
 import abc
-import re
 from typing import TYPE_CHECKING  # noqa:F401
 from typing import List  # noqa:F401
 from typing import Optional  # noqa:F401
-from typing import Union  # noqa:F401
 
 from ddtrace._trace.processor import TraceProcessor
-from ddtrace.ext import http
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -22,51 +19,3 @@ class TraceFilter(TraceProcessor):
         None can be returned to prevent the trace from being exported.
         """
         pass
-
-
-class FilterRequestsOnUrl(TraceFilter):
-    r"""Filter out traces from incoming http requests based on the request's url.
-
-    This class takes as argument a list of regular expression patterns
-    representing the urls to be excluded from tracing. A trace will be excluded
-    if its root span contains a ``http.url`` tag and if this tag matches any of
-    the provided regular expression using the standard python regexp match
-    semantic (https://docs.python.org/3/library/re.html#re.match).
-
-    :param list regexps: a list of regular expressions (or a single string) defining
-                         the urls that should be filtered out.
-
-    Examples:
-    To filter out http calls to domain api.example.com::
-
-        FilterRequestsOnUrl(r'http://api\\.example\\.com')
-
-    To filter out http calls to all first level subdomains from example.com::
-
-        FilterRequestOnUrl(r'http://.*+\\.example\\.com')
-
-    To filter out calls to both http://test.example.com and http://example.com/healthcheck::
-
-        FilterRequestOnUrl([r'http://test\\.example\\.com', r'http://example\\.com/healthcheck'])
-    """
-
-    def __init__(self, regexps: Union[str, List[str]]):
-        if isinstance(regexps, str):
-            regexps = [regexps]
-        self._regexps = [re.compile(regexp) for regexp in regexps]
-
-    def process_trace(self, trace):
-        # type: (List[Span]) -> Optional[List[Span]]
-        """
-        When the filter is registered in the tracer, process_trace is called by
-        on each trace before it is sent to the agent, the returned value will
-        be fed to the next filter in the list. If process_trace returns None,
-        the whole trace is discarded.
-        """
-        for span in trace:
-            url = span.get_tag(http.URL)
-            if span.parent_id is None and url is not None:
-                for regexp in self._regexps:
-                    if regexp.match(url):
-                        return None
-        return trace

--- a/tests/tracer/test_filters.py
+++ b/tests/tracer/test_filters.py
@@ -1,41 +1,6 @@
-from unittest import TestCase
-
 import pytest
 
-from ddtrace._trace.filters import FilterRequestsOnUrl
-from ddtrace.ext.http import URL
-from ddtrace.trace import Span
 from ddtrace.trace import TraceFilter
-
-
-class FilterRequestOnUrlTests(TestCase):
-    def test_is_match(self):
-        span = Span(name="Name")
-        span.set_tag(URL, r"http://example.com")
-        filtr = FilterRequestsOnUrl("http://examp.*.com")
-        trace = filtr.process_trace([span])
-        self.assertIsNone(trace)
-
-    def test_is_not_match(self):
-        span = Span(name="Name")
-        span.set_tag(URL, r"http://anotherexample.com")
-        filtr = FilterRequestsOnUrl("http://examp.*.com")
-        trace = filtr.process_trace([span])
-        self.assertIsNotNone(trace)
-
-    def test_list_match(self):
-        span = Span(name="Name")
-        span.set_tag(URL, r"http://anotherdomain.example.com")
-        filtr = FilterRequestsOnUrl([r"http://domain\.example\.com", r"http://anotherdomain\.example\.com"])
-        trace = filtr.process_trace([span])
-        self.assertIsNone(trace)
-
-    def test_list_no_match(self):
-        span = Span(name="Name")
-        span.set_tag(URL, r"http://cooldomain.example.com")
-        filtr = FilterRequestsOnUrl([r"http://domain\.example\.com", r"http://anotherdomain\.example\.com"])
-        trace = filtr.process_trace([span])
-        self.assertIsNotNone(trace)
 
 
 def test_not_implemented_trace_filter():


### PR DESCRIPTION
Addresses: https://github.com/DataDog/dd-trace-py/issues/13157. 

`FilterRequestsOnUrl` was deprecated in v2.21.0 and removed from the public API in v3.0. Since `FilterRequestsOnUrl` is not used within the ddtrace library we can just remove this class. 

This page provides documentation on how to ignore traces with unwanted resource names: https://docs.datadoghq.com/tracing/guide/ignoring_apm_resources/?tab=datadogyaml&code-lang=python

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
