### PR TITLE
chore(llmobs): add codeowner entries for oai_agents integration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -155,6 +155,8 @@ ddtrace/contrib/internal/langgraph                      @DataDog/ml-observabilit
 ddtrace/contrib/_langgraph.py                           @DataDog/ml-observability
 ddtrace/contrib/internal/crewai                         @DataDog/ml-observability
 ddtrace/contrib/_crewai.py                              @DataDog/ml-observability
+ddtrace/contrib/internal/openai_agents                  @DataDog/ml-observability
+ddtrace/contrib/_openai_agents.py                       @DataDog/ml-observability
 tests/llmobs                                            @DataDog/ml-observability
 tests/contrib/openai                                    @DataDog/ml-observability
 tests/contrib/langchain                                 @DataDog/ml-observability
@@ -167,6 +169,7 @@ tests/contrib/google_generativeai                       @DataDog/ml-observabilit
 tests/contrib/vertexai                                  @DataDog/ml-observability
 tests/contrib/langgraph                                 @DataDog/ml-observability
 tests/contrib/crewai                                    @DataDog/ml-observability
+tests/contrib/openai_agents                             @DataDog/ml-observability
 .gitlab/tests/llmobs.yml                                @DataDog/ml-observability
 
 # Remote Config


### PR DESCRIPTION
Adds codeowner entries that were accidentally omitted in #13081.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
