### PR TITLE
chore: use `functools.wraps` in `callonce` decorator

### DIFF
--- a/ddtrace/internal/utils/cache.py
+++ b/ddtrace/internal/utils/cache.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from inspect import FullArgSpec
 from inspect import getfullargspec
 from inspect import isgeneratorfunction
@@ -130,6 +131,7 @@ def callonce(f):
     if is_not_void_function(f, argspec):
         raise ValueError("The callonce decorator can only be applied to functions with no arguments")
 
+    @wraps(f)
     def _():
         # type: () -> Any
         try:


### PR DESCRIPTION
With this you have a more ergonomic way of referring to the original inner function decorated with `@callonce` decorator. 

```Python
from ddtrace.internal.packages import _package_for_root_module_mapping

# Without this PR
original_func = _package_for_root_module_mapping.__closure__[0].cell_contents

# With this PR
original_func = _package_for_root_module_mapping.__wrapped__

```

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
