### PR TITLE
chore(tracer): remove http dependency to trace

### DIFF
--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -11,17 +11,16 @@ from typing import Tuple  # noqa:F401
 from typing import cast  # noqa:F401
 import urllib.parse
 
-import ddtrace
 from ddtrace._trace._span_link import SpanLink
+from ddtrace._trace.context import Context
+from ddtrace._trace.span import Span  # noqa:F401
 from ddtrace._trace.span import _get_64_highest_order_bits_as_hex
 from ddtrace._trace.span import _get_64_lowest_order_bits_as_int
 from ddtrace._trace.span import _MetaDictType
 from ddtrace.appsec._constants import APPSEC
-from ddtrace.internal.core import dispatch
+from ddtrace.internal import core
 from ddtrace.settings._config import config
 from ddtrace.settings.asm import config as asm_config
-from ddtrace.trace import Context
-from ddtrace.trace import Span  # noqa:F401
 
 from ..constants import AUTO_KEEP
 from ..constants import AUTO_REJECT
@@ -1046,7 +1045,7 @@ class HTTPPropagator(object):
         :param dict headers: HTTP headers to extend with tracing attributes.
         :param Span non_active_span: Only to be used if injecting a non-active span.
         """
-        dispatch("http.span_inject", (span_context, headers))
+        core.dispatch("http.span_inject", (span_context, headers))
         if not config._propagation_style_inject:
             return
         if non_active_span is not None and non_active_span.context is not span_context:
@@ -1059,15 +1058,15 @@ class HTTPPropagator(object):
 
             span_context = non_active_span.context
 
-        if hasattr(ddtrace, "tracer") and hasattr(ddtrace.tracer, "sample"):
+        if core.tracer and hasattr(core.tracer, "sample"):
             root_span: Optional[Span] = None
             if non_active_span is not None:
                 root_span = non_active_span._local_root
             else:
-                root_span = ddtrace.tracer.current_root_span()
+                root_span = core.tracer.current_root_span()
 
             if root_span is not None and root_span.context.sampling_priority is None:
-                ddtrace.tracer.sample(root_span)
+                core.tracer.sample(root_span)
         else:
             log.error("ddtrace.tracer.sample is not available, unable to sample span.")
 


### PR DESCRIPTION
Removing more static circular dependency in the tracer, this prevent a cycle between propagation.http and ddtrace.trace.

APPSEC-57233

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
