### PR TITLE
chore(tracer): upgrade mypy to last version

### DIFF
--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -977,7 +977,7 @@ class Tracer(object):
                 atexit.unregister(self._atexit)
                 forksafe.unregister(self._child_after_fork)
 
-        self.start_span = self._start_span_after_shutdown  # type: ignore[assignment]
+        self.start_span = self._start_span_after_shutdown  # type: ignore[method-assign]
 
     @staticmethod
     def _use_log_writer() -> bool:

--- a/ddtrace/appsec/_iast/_ast/visitor.py
+++ b/ddtrace/appsec/_iast/_ast/visitor.py
@@ -671,7 +671,7 @@ class AstVisitor(ast.NodeTransformer):
         # Assign.targets, thus the manual copy
 
         func_arg1 = copy.deepcopy(augassign_node.target)
-        func_arg1.ctx = ast.Load()  # type: ignore[attr-defined]
+        func_arg1.ctx = ast.Load()
         func_arg2 = copy.deepcopy(augassign_node.value)
         func_arg2.ctx = ast.Load()  # type: ignore[attr-defined]
 

--- a/ddtrace/appsec/_iast/_taint_tracking/_taint_objects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/_taint_objects.py
@@ -26,7 +26,7 @@ log = get_logger(__name__)
 def is_pyobject_tainted(pyobject: Any) -> bool:
     if not asm_config.is_iast_request_enabled:
         return False
-    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):  # type: ignore[misc]
+    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
         return False
 
     try:
@@ -67,7 +67,7 @@ def _taint_pyobject_base(pyobject: Any, source_name: Any, source_value: Any, sou
         - Automatically handles bytes/bytearray to str conversion
     """
     # Early type validation
-    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):  # type: ignore[misc]
+    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
         return pyobject
 
     # Fast path for empty strings
@@ -100,7 +100,7 @@ def _taint_pyobject_base(pyobject: Any, source_name: Any, source_value: Any, sou
 def taint_pyobject_with_ranges(pyobject: Any, ranges: Tuple) -> bool:
     if not asm_config.is_iast_request_enabled:
         return False
-    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):  # type: ignore[misc]
+    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
         return False
     try:
         set_ranges(pyobject, ranges)
@@ -113,7 +113,7 @@ def taint_pyobject_with_ranges(pyobject: Any, ranges: Tuple) -> bool:
 def get_tainted_ranges(pyobject: Any) -> Tuple:
     if not asm_config.is_iast_request_enabled:
         return tuple()
-    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):  # type: ignore[misc]
+    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
         return tuple()
     try:
         return get_ranges(pyobject)
@@ -140,7 +140,7 @@ def taint_pyobject(pyobject: Any, source_name: Any, source_value: Any, source_or
 def copy_ranges_to_string(pyobject: str, ranges: Sequence[TaintRange]) -> str:
     # NB this function uses comment-based type annotation because TaintRange is conditionally imported
     if asm_config.is_iast_request_enabled:
-        if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):  # type: ignore[misc]
+        if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
             return pyobject
 
         for r in ranges:

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -251,7 +251,7 @@ class AppSecSpanProcessor(SpanProcessor):
         # persistent addresses must be sent if api security is used
         force_keys = custom_data.get("PROCESSOR_SETTINGS", {}).get("extract-schema", False) if custom_data else False
 
-        for key, waf_name in iter_data:  # type: ignore[attr-defined]
+        for key, waf_name in iter_data:
             if key in data_already_sent and not force_sent:
                 continue
             # ensure ephemeral addresses are sent, event when value is None

--- a/ddtrace/internal/ci_visibility/git_client.py
+++ b/ddtrace/internal/ci_visibility/git_client.py
@@ -113,7 +113,7 @@ class CIVisibilityGitClient(object):
         # type: (Optional[str]) -> None
         if not self._get_git_dir(cwd=cwd):
             log.debug("Missing .git directory; skipping git metadata upload")
-            self._metadata_upload_status.value = METADATA_UPLOAD_STATUS.FAILED  # type: ignore[attr-defined]
+            self._metadata_upload_status.value = METADATA_UPLOAD_STATUS.FAILED
             return
 
         self._tags = ci.tags(cwd=cwd)

--- a/ddtrace/internal/compat.py
+++ b/ddtrace/internal/compat.py
@@ -131,7 +131,7 @@ else:
             setattr(cls, "__annotations__", cls.__func__.__annotations__)
         return self.dispatcher.register(cls, func=method)
 
-    singledispatchmethod.register = _register  # type: ignore[assignment]
+    singledispatchmethod.register = _register  # type: ignore[method-assign]
 
 
 if PYTHON_VERSION_INFO >= (3, 9):

--- a/ddtrace/internal/core/__init__.py
+++ b/ddtrace/internal/core/__init__.py
@@ -372,5 +372,5 @@ def get_span() -> Optional["Span"]:
 def get_root_span() -> Optional["Span"]:
     span = get_span()
     if span is None:
-        return None if tracer is None else tracer.current_root_span()  # type: ignore
+        return None if tracer is None else tracer.current_root_span()
     return span._local_root or span

--- a/ddtrace/internal/gitmetadata.py
+++ b/ddtrace/internal/gitmetadata.py
@@ -73,7 +73,7 @@ def _get_tags_from_package(main_package):
             import importlib_metadata  # type: ignore[no-redef]
 
         source_code_link = ""
-        for val in importlib_metadata.metadata(main_package).get_all("Project-URL"):
+        for val in importlib_metadata.metadata(main_package).get_all("Project-URL") or []:
             capt_val = val.split(", ")
             if len(capt_val) > 1 and capt_val[0] == "source_code_link":
                 source_code_link = capt_val[1].strip()

--- a/ddtrace/internal/periodic.py
+++ b/ddtrace/internal/periodic.py
@@ -68,7 +68,7 @@ class PeriodicService(service.Service):
         """Stop the periodic collector."""
         if self._worker:
             self._worker.stop()
-        super(PeriodicService, self)._stop_service(*args, **kwargs)
+        super(PeriodicService, self)._stop_service(*args, **kwargs)  # type: ignore[safe-super]
 
     def join(
         self,

--- a/ddtrace/internal/utils/time.py
+++ b/ddtrace/internal/utils/time.py
@@ -95,7 +95,7 @@ class HourGlass(object):
         self._started_at = t - duration
         self._end_at = t
 
-        self.trickling = self._trickled  # type: ignore[assignment]
+        self.trickling = self._trickled  # type: ignore[method-assign]
 
     def turn(self) -> None:
         """Turn the hourglass."""
@@ -106,7 +106,7 @@ class HourGlass(object):
         self._started_at = t
         self._end_at = t + bottom
 
-        self.trickling = self._trickling  # type: ignore[assignment]
+        self.trickling = self._trickling  # type: ignore[method-assign]
 
     def trickling(self):
         # type: () -> bool
@@ -123,7 +123,7 @@ class HourGlass(object):
             return True
 
         # No longer trickling, so we change state
-        self.trickling = self._trickled  # type: ignore[assignment]
+        self.trickling = self._trickled  # type: ignore[method-assign]
 
         return False
 

--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -348,12 +348,12 @@ class LockCollector(collector.CaptureSamplerCollector):
         # type: (...) -> None
         """Start collecting lock usage."""
         self.patch()
-        super(LockCollector, self)._start_service()
+        super(LockCollector, self)._start_service()  # type: ignore[safe-super]
 
     def _stop_service(self):
         # type: (...) -> None
         """Stop collecting lock usage."""
-        super(LockCollector, self)._stop_service()
+        super(LockCollector, self)._stop_service()  # type: ignore[safe-super]
         self.unpatch()
 
     def patch(self):

--- a/ddtrace/profiling/collector/pytorch.py
+++ b/ddtrace/profiling/collector/pytorch.py
@@ -62,12 +62,12 @@ class MLProfilerCollector(collector.CaptureSamplerCollector):
             raise collector.CollectorUnavailable(e)
         self._torch_module = torch
         self.patch()
-        super()._start_service()
+        super()._start_service()  # type: ignore[safe-super]
 
     def _stop_service(self):
         # type: (...) -> None
         """Stop collecting framework profiler usage."""
-        super()._stop_service()
+        super()._stop_service()  # type: ignore[safe-super]
         self.unpatch()
 
     def patch(self):
@@ -105,7 +105,8 @@ class TorchProfilerCollector(MLProfilerCollector):
         return self._torch_module.profiler.profile
 
     def _set_patch_target(
-        self, value  # type: typing.Any
+        self,
+        value,  # type: typing.Any
     ):
         # type: (...) -> None
         self._torch_module.profiler.profile = value

--- a/ddtrace/profiling/collector/threading.py
+++ b/ddtrace/profiling/collector/threading.py
@@ -37,10 +37,11 @@ class ThreadingLockCollector(_lock.LockCollector):
         return threading.Lock
 
     def _set_patch_target(
-        self, value  # type: typing.Any
+        self,
+        value,  # type: typing.Any
     ):
         # type: (...) -> None
-        threading.Lock = value  # type: ignore[misc]
+        threading.Lock = value
 
 
 # Also patch threading.Thread so echion can track thread lifetimes

--- a/ddtrace/profiling/recorder.py
+++ b/ddtrace/profiling/recorder.py
@@ -50,7 +50,7 @@ class Recorder:
         # type: (...) -> None
         # NOTE: do not try to push events if the process forked
         # This means we don't know the state of _events_lock and it might be unusable — we'd deadlock
-        self.push_events = self._push_events_noop  # type: ignore[assignment]
+        self.push_events = self._push_events_noop  # type: ignore[method-assign]
 
     def _push_events_noop(self, events):
         pass

--- a/hatch.toml
+++ b/hatch.toml
@@ -7,7 +7,7 @@ dependencies = [
     "cython-lint==0.15.0",
     "codespell==2.3.0",
     "bandit==1.7.5",
-    "mypy==0.991",
+    "mypy==1.15.0",
     "coverage==7.3.0",
     "envier==0.6.1",
     "types-docutils==0.19.1.1",


### PR DESCRIPTION
Upgrade mypy from 0.991 (Nov 2022) to 1.15.0 (Feb 2025)

update type comments and code accordingly

What could be done next: enable more rules in the mypy rule book.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
