### PR TITLE
chore(llmobs): handle pydantic validation for adding datadog spans to langchain instances

### DIFF
--- a/ddtrace/llmobs/_integrations/langchain.py
+++ b/ddtrace/llmobs/_integrations/langchain.py
@@ -125,7 +125,11 @@ class LangChainIntegration(BaseLLMIntegration):
 
         spans: Dict[int, Span] = getattr(parent_instance, "_datadog_spans", {})
         spans[id(instance)] = span
-        setattr(parent_instance, "_datadog_spans", spans)
+
+        try:
+            setattr(parent_instance, "_datadog_spans", spans)
+        except Exception:
+            parent_instance.__dict__["_datadog_spans"] = spans
 
     def _llmobs_set_tags(
         self,


### PR DESCRIPTION
validated by running tests enabled in #13181 (we're moving test enablement to that PR, but want to land this fix separately to get in into the 3.5 release, as [we're enabling span linking by default](https://github.com/DataDog/dd-trace-py/pull/13077) in 3.5 for langchain. this is why the PR is a `chore` and not a `fix`, as the feature hasn't landed in a release yet)

before fix:

```
    @no_type_check
    def __setattr__(self, name, value):  # noqa: C901 (ignore complexity)
        if name in self.__private_attributes__ or name in DUNDER_ATTRIBUTES:
            return object_setattr(self, name, value)
    
        if self.__config__.extra is not Extra.allow and name not in self.__fields__:
>           raise ValueError(f'"{self.__class__.__name__}" object has no field "{name}"')
E           ValueError: "RunnableSequence" object has no field "_datadog_spans"
```

after the fix, it passes.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
