### PR TITLE
chore: fix malformed release note blocking release script

### DIFF
--- a/releasenotes/notes/referrer-hostname-8aa6dc6edb9d53b1.yaml
+++ b/releasenotes/notes/referrer-hostname-8aa6dc6edb9d53b1.yaml
@@ -1,3 +1,4 @@
 ---
 features:
-  - tracer: extracts  the referrer hostname from HTTP requests and stored it as `http.referrer_hostname` tag.
+  - |
+    tracer: extracts  the referrer hostname from HTTP requests and stored it as `http.referrer_hostname` tag.


### PR DESCRIPTION
As the title suggests, we need this release note to be formatted correctly so the release script can parse it without issues. Otherwise, the GitHub release notes and the notebook generated are blank.

Long term, we should figure out a job that lints the release notes as part of the CI.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
