### PR TITLE
chore: fix stale PR closing workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,9 @@
 name: 'Close stale issues and PRs'
 on:
+  # TEST
+  push:
+    branches:
+      - erikayasuda/fix-stale-close
   workflow_dispatch:
   schedule:
     # 00:00:000 UTC

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,12 +12,15 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9.1.0
         with:
           # DEV: GitHub Actions have an API rate limit of 1000 operations per hour per repository
           #      This limit is shared across all actions
           operations-per-run: 200
-          days-before-pr-close: 30
+          # DEV: Mark PR as stale after 30 days
+          days-before-pr-stale: 30
+          # DEV: Close stale PR after 1 day of no activity
+          days-before-pr-close: 1
           days-before-issue-close: 90
           exempt-issue-labels: 'proposal'
           exempt-pr-labels: 'proposal'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,9 +1,5 @@
 name: 'Close stale issues and PRs'
 on:
-  # TEST
-  push:
-    branches:
-      - erikayasuda/fix-stale-close
   workflow_dispatch:
   schedule:
     # 00:00:000 UTC

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,6 @@
 name: 'Close stale issues and PRs'
 on:
+  workflow_dispatch:
   schedule:
     # 00:00:000 UTC
     - cron: '0 0 * * *'


### PR DESCRIPTION
We have a GHA workflow to auto-close stale PRs, but it seems to not have been closing any.

Adding the missing config variable to let stale PRs (30 days old) get auto-closed after 1 day of no activity.

Successful run [here](https://github.com/DataDog/dd-trace-py/actions/runs/14451814062/job/40526057672).
Example PR with bot comment and close [here](https://github.com/DataDog/dd-trace-py/pull/10886)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
