### PR TITLE
chore: fix racy test

### DIFF
--- a/tests/contrib/gunicorn/wsgi_mw_app.py
+++ b/tests/contrib/gunicorn/wsgi_mw_app.py
@@ -4,7 +4,6 @@ gunicorn
 """
 
 import os
-import time
 
 
 if os.getenv("_DD_TEST_IMPORT_AUTO"):


### PR DESCRIPTION
The application in test 
1. imports profiler which would result in setting `bootstrap.profiler._scheduler._last_export` to a value > 0. 
2. and sets the variable to a sentinel value from the module.

This code is racy and could lead to unexpected failure, if 2. happens after 1. which was the case in [perf(profiling): code provenance outputs directories/.py files instead of all seen files](https://github.com/DataDog/dd-trace-py/pull/12616/files)

https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/895566565


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
