### PR TITLE
fix(azure_functions): add trigger type to resource name for azure functions timer trigger

### DIFF
--- a/ddtrace/contrib/internal/azure_functions/patch.py
+++ b/ddtrace/contrib/internal/azure_functions/patch.py
@@ -86,10 +86,11 @@ def _patched_timer_trigger(wrapped, instance, args, kwargs):
 
     def _wrapper(func):
         function_name = get_function_name(pin, instance, func)
+        resource_name = f"{trigger} {function_name}"
 
         @functools.wraps(func)
         def wrap_function(*args, **kwargs):
-            with create_context("azure.functions.patched_timer", pin, function_name) as ctx, ctx.span:
+            with create_context("azure.functions.patched_timer", pin, resource_name) as ctx, ctx.span:
                 ctx.set_item("trigger_span", ctx.span)
                 core.dispatch(
                     "azure.functions.trigger_call_modifier",

--- a/releasenotes/notes/fix-azure-functions-timer-trigger-resource-name-5048d2e3bfea7a6c.yaml
+++ b/releasenotes/notes/fix-azure-functions-timer-trigger-resource-name-5048d2e3bfea7a6c.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    azure_functions: This fix resolves an issue where spans generated from timer triggers did not include the trigger type in the resource name.

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_timer.json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_timer.json
@@ -2,7 +2,7 @@
   {
     "name": "azure.functions.invoke",
     "service": "test-func",
-    "resource": "timer",
+    "resource": "Timer timer",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 0,


### PR DESCRIPTION
Add trigger type to resource name for azure functions timer trigger. This is consistent with the resource naming for Azure Functions in the [.NET tracer](https://github.com/DataDog/dd-trace-dotnet/blob/b2f1c6464cf6212d413eaf449efc7e6784412ade/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs#L163).

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
