### PR TITLE
ci: benchmarks fetch version from pypi on main

### DIFF
--- a/.gitlab/benchmarks/steps/detect-baseline.sh
+++ b/.gitlab/benchmarks/steps/detect-baseline.sh
@@ -19,7 +19,14 @@ UPSTREAM_BRANCH=${UPSTREAM_BRANCH:-$CI_COMMIT_REF_NAME}
 # If this is a build on the `main` branch then test against the latest released version
 if [ "${UPSTREAM_BRANCH}" == "main" ]; then
   echo "BASELINE_BRANCH=main" | tee baseline.env
-  BASELINE_TAG=$(git describe --tags --abbrev=0 --exclude "*rc*" "origin/main" || echo "")
+
+  PYPI_VERSION=$(curl https://pypi.org/pypi/ddtrace/json | jq -r .info.version)
+  if [[ "${PYPI_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    BASELINE_TAG="v${PYPI_VERSION}"
+  else
+    BASELINE_TAG=$(git describe --tags --abbrev=0 --exclude "*rc*" "origin/main" || echo "")
+  fi
+
 
 # If this is a release tag (e.g. `v2.21.3`) then test against the latest version from that point (e.g. v2.21.2, or v2.20.x)
 elif [[ "${UPSTREAM_BRANCH}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then


### PR DESCRIPTION
This script expects release tags to be added on the `main` branch, but previously we would add them only in release branches. This means we might not be able to detect the most recent version.

This update tries to grab the latest version from PyPI directly. We will download the wheel from PyPI anyways.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
