### PR TITLE
perf(symdb): stream module instead of fully consuming it

### DIFF
--- a/ddtrace/internal/symbol_db/symbols.py
+++ b/ddtrace/internal/symbol_db/symbols.py
@@ -204,10 +204,11 @@ class Scope:
             except Exception:
                 log.debug("Cannot get child scope %r for module %s", child, module.__name__, exc_info=True)
 
-        source_bytes = module_origin.read_bytes()
         source_git_hash = sha1()
-        source_git_hash.update(f"blob {len(source_bytes)}\0".encode())
-        source_git_hash.update(source_bytes)
+        source_git_hash.update(f"blob {module_origin.stat().st_size}\0".encode())
+        with module_origin.open("rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                source_git_hash.update(chunk)
 
         return Scope(
             scope_type=ScopeType.MODULE,

--- a/tests/internal/symbol_db/test_symbols.py
+++ b/tests/internal/symbol_db/test_symbols.py
@@ -3,9 +3,10 @@ from pathlib import Path
 import sys
 from types import ModuleType
 import typing as t
-import resource
-
+import tempfile
 import pytest
+import atexit
+import os
 
 from ddtrace.internal.symbol_db.symbols import Scope
 from ddtrace.internal.symbol_db.symbols import ScopeData
@@ -197,22 +198,30 @@ def test_symbols_to_json():
     }
 
 @pytest.mark.parametrize(
-    "num_attributes",
+    "file_size,num_attributes",
     [
-        5,
-        20,
-        50,
-        100,
-        1000,
+        (1000, 5),
+        (10_000, 50),
+        (100_000, 200),
+        (1_000_000, 1000),
     ]
 )
-def test_benchmark_module_get_from(benchmark, num_attributes):
+def test_benchmark_module_get_from(benchmark, file_size, num_attributes):
     """Benchmark performance of Scope._get_from with modules of different complexities."""
     # Create a module with the specified number of attributes
     module_name = f"test_module_{num_attributes}"
     test_module = ModuleType(module_name)
     test_module.__spec__ = ModuleSpec(module_name, None)
-    test_module.__spec__.origin = __file__
+
+    # Create temp files with the specified size
+    temp_file = tempfile.NamedTemporaryFile(delete=False)
+    for i in range(file_size):
+        temp_file.write(b"0")
+    temp_file.close()
+    test_module.__spec__.origin = temp_file.name
+
+    # Register cleanup to delete temp file after test
+    atexit.register(lambda: os.unlink(temp_file.name))
 
     # Add attributes
     for i in range(num_attributes):
@@ -221,7 +230,8 @@ def test_benchmark_module_get_from(benchmark, num_attributes):
     # Define a wrapper function that creates a fresh ScopeData object for each benchmark run
     def benchmark_wrapper():
         data = ScopeData(Path(__file__), set())
-        return Scope._get_from(test_module, data)
+        result = Scope._get_from(test_module, data)
+        return result
 
     # Run the benchmark
     result = benchmark(benchmark_wrapper)
@@ -235,6 +245,8 @@ def test_benchmark_module_get_from(benchmark, num_attributes):
     attr_names = {symbol.name for symbol in result.symbols}
     for i in range(num_attributes):
         assert f"attr_{i}" in attr_names
+
+    assert result.language_specifics["file_hash"] != ""
 
 
 @pytest.mark.subprocess(ddtrace_run=True, env=dict(DD_SYMBOL_DATABASE_UPLOAD_ENABLED="1"))


### PR DESCRIPTION
## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
