### PR TITLE
chore: skip None line numbers in inspection

### DIFF
--- a/ddtrace/internal/utils/inspection.py
+++ b/ddtrace/internal/utils/inspection.py
@@ -22,7 +22,7 @@ def linenos(_) -> Set[int]:
 @linenos.register
 def _(code: CodeType) -> Set[int]:
     """Get the line numbers of a function."""
-    return {ln for _, ln in findlinestarts(code)} - {code.co_firstlineno}
+    return {ln for _, ln in findlinestarts(code) if ln is not None} - {code.co_firstlineno}
 
 
 @linenos.register

--- a/tests/internal/symbol_db/test_symbols.py
+++ b/tests/internal/symbol_db/test_symbols.py
@@ -1,6 +1,5 @@
 from importlib.machinery import ModuleSpec
 from pathlib import Path
-import sys
 from types import ModuleType
 import typing as t
 
@@ -23,7 +22,6 @@ def test_symbol_from_code():
     assert {s.name for s in symbols if s.symbol_type == SymbolType.LOCAL} == {"loc"}
 
 
-@pytest.mark.skipif(sys.version_info > (3, 12), reason="fails on 3.13")
 def test_symbols_class():
     class Sup:
         pass


### PR DESCRIPTION
We make sure to skip None line numbers when inspecting a code object for all the lines that it covers.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
