### PR TITLE
chore: bump python version in benchmark dockerfile

### DIFF
--- a/benchmarks/Dockerfile
+++ b/benchmarks/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:buster-slim as base
 
-ARG PYTHON_VERSION=3.12.10
-ARG PYENV_VERSION=2.4.1
+ARG PYTHON_VERSION=3.13
+ARG PYENV_VERSION=2.5.5
 RUN apt-get update && apt-get install --no-install-recommends -y \
     make build-essential libssl-dev zlib1g-dev \
     libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
@@ -14,7 +14,7 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git --branch "v$PYENV_VER
 RUN pyenv install "$PYTHON_VERSION"
 
 FROM debian:buster-slim
-ARG PYTHON_VERSION=3.12.10
+ARG PYTHON_VERSION=3.13
 
 COPY --from=base /pyenv /pyenv
 ENV PYENV_ROOT "/pyenv"

--- a/benchmarks/Dockerfile
+++ b/benchmarks/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim as base
 
-ARG PYTHON_VERSION=3.9.15
+ARG PYTHON_VERSION=3.12.10
 ARG PYENV_VERSION=2.4.1
 RUN apt-get update && apt-get install --no-install-recommends -y \
     make build-essential libssl-dev zlib1g-dev \
@@ -14,7 +14,7 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git --branch "v$PYENV_VER
 RUN pyenv install "$PYTHON_VERSION"
 
 FROM debian:buster-slim
-ARG PYTHON_VERSION=3.9.15
+ARG PYTHON_VERSION=3.12.10
 
 COPY --from=base /pyenv /pyenv
 ENV PYENV_ROOT "/pyenv"


### PR DESCRIPTION
## The change
Bumping the benchmark docker python version to the latest maintenance version of Python3.12.

## Motivation: 
In a subsequent PR I'm adding benchmarks for a new errortracking feature. The feature is enabled starting from Python3.10.
However starting from Python3.12 we are using a method which potentially adds some overhead. Therefore the errortracking benchmarks need to run on python3.12.


## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
