### PR TITLE
chore(profiling): explicitly set or clear NDEBUG for memalloc extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -614,7 +614,14 @@ if not IS_PYSTON:
                 "ddtrace/profiling/collector/_memalloc_reentrant.c",
             ],
             extra_compile_args=(
-                debug_compile_args + ["-D_POSIX_C_SOURCE=200809L", "-std=c11"] + fast_build_args
+                debug_compile_args
+                # If NDEBUG is set, assert statements are compiled out. Make
+                # sure we explicitly set this for normal builds, and explicitly
+                # _unset_ it for debug builds in case the CFLAGS from sysconfig
+                # include -DNDEBUG
+                + (["-DNDEBUG"] if not debug_compile_args else ["-UNDEBUG"])
+                + ["-D_POSIX_C_SOURCE=200809L", "-std=c11"]
+                + fast_build_args
                 if CURRENT_OS != "Windows"
                 else ["/std:c11"]
             ),


### PR DESCRIPTION
The memalloc C extension has debug assert statements. We want them off
by default in case they guard a costly call we wouldn't normally want to
happen. Depending on how the CPython interpreter running setup.py was
built, we may already get -DNDEBUG via the CFLAGS from sysconfig, which
disables asserts. See the [setuptools docs](https://setuptools.pypa.io/en/latest/userguide/ext_modules.html#compiler-and-linker-options).

But rather than rely on that, make sure that asserts
are explicitly disabled for normal builds and explicitly enabled for
debug builds.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
