### PR TITLE
fix(llmobs): set session ID on span if annotated as a tag

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -944,6 +944,9 @@ class LLMObs(Service):
                     error = "invalid_tags"
                     log.warning("span tags must be a dictionary of string key - primitive value pairs.")
                 else:
+                    session_id = tags.get("session_id")
+                    if session_id:
+                        span._set_ctx_item(SESSION_ID, str(session_id))
                     cls._set_dict_attribute(span, TAGS, tags)
             span_kind = span._get_ctx_item(SPAN_KIND)
             if _name is not None:

--- a/releasenotes/notes/fix-llmobs-session-id-via-tags-6f6b0f7fca47e516.yaml
+++ b/releasenotes/notes/fix-llmobs-session-id-via-tags-6f6b0f7fca47e516.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    LLM Observability: Resolves an issue where annotating ``session_id`` on a LLM Observability span via ``LLMObs.annotate/annotation_context()`` 
+    as a tag only set it as a tag on the span, but did not update the span's actual session ID value.

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -440,6 +440,13 @@ def test_annotate_tag(llmobs):
         assert span._get_ctx_item(TAGS) == {"test_tag_name": "test_tag_value", "test_numeric_tag": 10}
 
 
+def test_annotate_tag_can_set_session_id(llmobs):
+    with llmobs.llm(model_name="test_model", name="test_llm_call", model_provider="test_provider") as span:
+        llmobs.annotate(span=span, tags={"session_id": "1234567890"})
+        assert span._get_ctx_item(TAGS) == {"session_id": "1234567890"}
+        assert span._get_ctx_item(SESSION_ID) == "1234567890"
+
+
 def test_annotate_tag_wrong_type(llmobs, mock_llmobs_logs):
     with llmobs.llm(model_name="test_model", name="test_llm_call", model_provider="test_provider") as span:
         llmobs.annotate(span=span, tags=12345)
@@ -1628,6 +1635,13 @@ def test_annotation_context_modifies_span_tags(llmobs):
     with llmobs.annotation_context(tags={"foo": "bar"}):
         with llmobs.agent(name="test_agent") as span:
             assert span._get_ctx_item(TAGS) == {"foo": "bar"}
+
+
+def test_annotation_context_can_update_session_id(llmobs):
+    with llmobs.annotation_context(tags={"session_id": "1234567890"}):
+        with llmobs.agent(name="test_agent") as span:
+            assert span._get_ctx_item(TAGS) == {"session_id": "1234567890"}
+            assert span._get_ctx_item(SESSION_ID) == "1234567890"
 
 
 def test_annotation_context_modifies_prompt(llmobs):


### PR DESCRIPTION
This PR makes a fix to how session ID is set on a LLM Obs span.

Session ID (for session tracking) can be explicitly set when starting a span via `LLMObs._start_span(session_id=...)`. We then set this both as the span's `session_id` field and as a tag on the span, `"session_id:..."`. 

However, currently session ID can also be set by using `LLMObs.annotate/annotation_context()` as a tag. This is meant for use cases where the session ID may not be immediately available. The issue here is that when setting as a tag, we don't actually set that value on the span's top level `session_id` field and only set it as a tag. This means that our backend and other event queries made by other products (like RUM/APM) can't 100% rely on that top level event field even if a user did indeed set it as a tag. (queries based on tags are also slower/more expensive than top-level queries)

This fixes the issue by adding a step when setting tags via `LLMObs.annotate/annotation_context()` that we also add a `session_id` tag as the span's top-level `session_id` field.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
