### PR TITLE
fix(profiling): update echion to pick up a potential undefined behavior fix

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack_v2/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/stack_v2/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 
 # Add echion
 set(ECHION_COMMIT
-    "7bbe444ecd9c9474c5bf568b6d6ac756185a0456" # https://github.com/P403n1x87/echion/commit/7bbe444ecd9c9474c5bf568b6d6ac756185a0456
+    "0876677add34925dbb5beaa7048226fabaddd0df" # https://github.com/P403n1x87/echion/commit/0876677add34925dbb5beaa7048226fabaddd0df
     CACHE STRING "Commit hash of echion to use")
 FetchContent_Declare(
     echion

--- a/releasenotes/notes/profiling-update-echion-queue-ub-fix-b14e8c603f2e115f.yaml
+++ b/releasenotes/notes/profiling-update-echion-queue-ub-fix-b14e8c603f2e115f.yaml
@@ -5,3 +5,7 @@ fixes:
     crash. The stack sampler could read off of an empty queue of frames after
     failing to resolve specific frame information, triggering undefined
     behavior.
+upgrades:
+  - |
+    profiling: Upgrades echion, improving the performance of the stack sampler
+    by reusing memory and reducing the frequency of memory allocation.

--- a/releasenotes/notes/profiling-update-echion-queue-ub-fix-b14e8c603f2e115f.yaml
+++ b/releasenotes/notes/profiling-update-echion-queue-ub-fix-b14e8c603f2e115f.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    profiling: Upgrades echion to pick up a fix which resolves a potential
+    crash. The stack sampler could read off of an empty queue of frames after
+    failing to resolve specific frame information, triggering undefined
+    behavior.

--- a/releasenotes/notes/profiling-update-echion-queue-ub-fix-b14e8c603f2e115f.yaml
+++ b/releasenotes/notes/profiling-update-echion-queue-ub-fix-b14e8c603f2e115f.yaml
@@ -5,7 +5,7 @@ fixes:
     crash. The stack sampler could read off of an empty queue of frames after
     failing to resolve specific frame information, triggering undefined
     behavior.
-upgrades:
+upgrade:
   - |
     profiling: Upgrades echion, improving the performance of the stack sampler
     by reusing memory and reducing the frequency of memory allocation.


### PR DESCRIPTION
The stack sampler could read off of an empty queue of frames after
failing to resolve specific frame information, triggering undefined
behavior. This commit updates echion to pick up https://github.com/P403n1x87/echion/commit/0876677add34925dbb5beaa7048226fabaddd0df,
which should fix the issue.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
