### PR TITLE
chore(iast): restructure functions

### DIFF
--- a/ddtrace/appsec/_iast/_iast_request_context_base.py
+++ b/ddtrace/appsec/_iast/_iast_request_context_base.py
@@ -9,7 +9,7 @@ from ddtrace.appsec._iast._iast_env import _get_iast_env
 from ddtrace.appsec._iast._overhead_control_engine import oce
 from ddtrace.appsec._iast._taint_tracking._context import create_context as create_propagation_context
 from ddtrace.appsec._iast._taint_tracking._context import reset_context as reset_propagation_context
-from ddtrace.appsec._iast._utils import _request_tainted
+from ddtrace.appsec._iast._utils import _num_objects_tainted_in_request
 from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import asbool
@@ -22,7 +22,7 @@ log = get_logger(__name__)
 
 
 def _set_span_tag_iast_request_tainted(span):
-    total_objects_tainted = _request_tainted()
+    total_objects_tainted = _num_objects_tainted_in_request()
 
     if total_objects_tainted > 0:
         span.set_tag(IAST_SPAN_TAGS.TELEMETRY_REQUEST_TAINTED, total_objects_tainted)

--- a/ddtrace/appsec/_iast/_metrics.py
+++ b/ddtrace/appsec/_iast/_metrics.py
@@ -10,7 +10,7 @@ from ddtrace.appsec._deduplications import deduplication
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import origin_to_str
 from ddtrace.appsec._iast._utils import _is_iast_debug_enabled
-from ddtrace.appsec._iast._utils import _request_tainted
+from ddtrace.appsec._iast._utils import _num_objects_tainted_in_request
 from ddtrace.internal import telemetry
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.telemetry.constants import TELEMETRY_LOG_LEVEL
@@ -109,7 +109,7 @@ def _set_metric_iast_executed_sink(vulnerability_type):
 
 @metric_verbosity(TELEMETRY_INFORMATION_VERBOSITY)
 def _set_metric_iast_request_tainted():
-    total_objects_tainted = _request_tainted()
+    total_objects_tainted = _num_objects_tainted_in_request()
     if total_objects_tainted > 0:
         telemetry.telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.IAST, "request.tainted", total_objects_tainted)
 

--- a/ddtrace/appsec/_iast/_span_metrics.py
+++ b/ddtrace/appsec/_iast/_span_metrics.py
@@ -3,11 +3,11 @@ from typing import Dict
 from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.appsec._iast._iast_env import _get_iast_env
 from ddtrace.appsec._iast._metrics import _metric_key_as_snake_case
-from ddtrace.appsec._iast._utils import _request_tainted
+from ddtrace.appsec._iast._utils import _num_objects_tainted_in_request
 
 
 def _set_span_tag_iast_request_tainted(span):
-    total_objects_tainted = _request_tainted()
+    total_objects_tainted = _num_objects_tainted_in_request()
 
     if total_objects_tainted > 0:
         span.set_tag(IAST_SPAN_TAGS.TELEMETRY_REQUEST_TAINTED, total_objects_tainted)

--- a/ddtrace/appsec/_iast/_taint_utils.py
+++ b/ddtrace/appsec/_iast/_taint_utils.py
@@ -524,3 +524,9 @@ if asm_config._iast_lazy_taint:
             return LazyTaintDict(main_obj, (origin_key, origin_value), override_pyobject_tainted)
         elif isinstance(main_obj, abc.Sequence):
             return LazyTaintList(main_obj, (origin_key, origin_value), override_pyobject_tainted)
+
+
+def taint_dictionary(origin_key, origin_value, original_func, instance, args, kwargs):
+    result = original_func(*args, **kwargs)
+
+    return taint_structure(result, origin_key, origin_value, override_pyobject_tainted=True)

--- a/ddtrace/appsec/_iast/_utils.py
+++ b/ddtrace/appsec/_iast/_utils.py
@@ -21,5 +21,5 @@ def _is_iast_propagation_debug_enabled():
     return asm_config._iast_propagation_debug
 
 
-def _request_tainted():
+def _num_objects_tainted_in_request():
     return num_objects_tainted()


### PR DESCRIPTION
## Overview

This PR reorganizes functions in the IAST module to improve code organization and maintainability. The changes include:

- Restructuring functions for better logical grouping
- Improving code organization
- No functional changes, purely organizational improvements

## Motivation

The reorganization helps improve code readability and maintainability by grouping related functions together in a more logical way.

## Testing Strategy

Since this is a reorganization change with no functional modifications, existing tests continue to validate the behavior remains unchanged.

Related to: https://github.com/DataDog/dd-trace-py/pull/13239 / APPSEC-56947

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
