### PR TITLE
chore(telemetry): remove redundant lib_language tag in telemetry

### DIFF
--- a/ddtrace/appsec/_iast/_metrics.py
+++ b/ddtrace/appsec/_iast/_metrics.py
@@ -61,11 +61,7 @@ def _set_iast_error_metric(msg: Text) -> None:
             res.extend(result[1:])
 
             stack_trace = "".join(res)
-
-        tags = {
-            "lib_language": "python",
-        }
-        telemetry.telemetry_writer.add_log(TELEMETRY_LOG_LEVEL.ERROR, msg, stack_trace=stack_trace, tags=tags)
+        telemetry.telemetry_writer.add_log(TELEMETRY_LOG_LEVEL.ERROR, msg, stack_trace=stack_trace)
     except Exception:
         log.warning("iast::metrics::error::_set_iast_error_metric", exc_info=True)
 

--- a/ddtrace/appsec/_metrics.py
+++ b/ddtrace/appsec/_metrics.py
@@ -36,7 +36,6 @@ def _set_waf_error_log(msg: str, version: str, error_level: bool = True) -> None
         log_tags = {
             "waf_version": ddwaf_version,
             "event_rules_version": version or UNKNOWN_VERSION,
-            "lib_language": "python",
         }
         level = TELEMETRY_LOG_LEVEL.ERROR if error_level else TELEMETRY_LOG_LEVEL.WARNING
         telemetry.telemetry_writer.add_log(level, msg, tags=log_tags)

--- a/ddtrace/internal/telemetry/logging.py
+++ b/ddtrace/internal/telemetry/logging.py
@@ -39,7 +39,6 @@ class DDTelemetryLogHandler(logging.Handler):
                 self.telemetry_writer.add_log(
                     telemetry_level,
                     record.msg,
-                    tags={"lib_language": "python"},
                     stack_trace=stack_trace,
                 )
 


### PR DESCRIPTION
Avoid setting `lib_language` tag explicitly on telemetry. This tag is automatically added to all telemetry data based on the HTTP header `DD-Client-Library-Language`.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
