### PR TITLE
chore(iast): avoid hardcoding array sizes

### DIFF
--- a/ddtrace/appsec/_iast/_ast/iastpatch.c
+++ b/ddtrace/appsec/_iast/_ast/iastpatch.c
@@ -17,11 +17,10 @@ static char** cached_packages = NULL;
 static size_t cached_packages_count = 0;
 
 /* Static Lists */
-static size_t static_allowlist_count = 8;
 static const char* static_allowlist[] = { "jinja2.",           "pygments.", "multipart.", "sqlalchemy.",
                                           "python_multipart.", "attrs",     "jsonschema", "s3fs" };
+static const size_t static_allowlist_count = sizeof(static_allowlist) / sizeof(static_allowlist[0]);
 
-static size_t static_denylist_count = 145;
 static const char* static_denylist[] = { "django.apps.config.",
                                          "django.apps.registry.",
                                          "django.conf.",
@@ -167,8 +166,8 @@ static const char* static_denylist[] = { "django.apps.config.",
                                          "django_filters.rest_framework.filterset.",
                                          "django_filters.utils.",
                                          "django_filters.widgets." };
+static const size_t static_denylist_count = sizeof(static_denylist) / sizeof(static_denylist[0]);
 
-static size_t static_stdlib_count = 215;
 static const char* static_stdlib_denylist[] = {
     "__future__",   "_ast",        "_compression", "_thread",
     "abc",          "aifc",        "argparse",     "array",
@@ -225,6 +224,7 @@ static const char* static_stdlib_denylist[] = {
     "xml",          "xmlrpc",      "zipapp",       "zipfile",
     "zipimport",    "zlib",        "zoneinfo",
 };
+static const size_t static_stdlib_denylist_count = sizeof(static_stdlib_denylist) / sizeof(static_stdlib_denylist[0]);
 
 /* --- Helper function: str_in_list ---
    Returns 1 (true) if string is in a list of chars.
@@ -448,7 +448,7 @@ init_globals(void)
     }
 
     builtin_count = (size_t)PyTuple_Size(builtin_names);
-    builtins_denylist_count = static_stdlib_count + builtin_count;
+    builtins_denylist_count = static_stdlib_denylist_count + builtin_count;
 
     builtins_denylist = malloc(builtins_denylist_count * sizeof(char*));
     if (!builtins_denylist) {
@@ -456,7 +456,7 @@ init_globals(void)
         return -1;
     }
     /* Copy static stdlib names */
-    for (i = 0; i < static_stdlib_count; i++) {
+    for (i = 0; i < static_stdlib_denylist_count; i++) {
         char* dup = strdup(static_stdlib_denylist[i]);
         if (!dup)
             return -1;
@@ -478,7 +478,7 @@ init_globals(void)
                 for (char* p = dup; *p; p++) {
                     *p = tolower(*p);
                 }
-                builtins_denylist[static_stdlib_count + i] = dup;
+                builtins_denylist[static_stdlib_denylist_count + i] = dup;
             }
         }
     }


### PR DESCRIPTION
- Stopped hardcoding sizes of allow/denylists in `iastpatch.c`.
- Renamed one of the variables to have uniform naming across allow/denylists count variables.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
