### PR TITLE
chore: handle products that fail to load

### DIFF
--- a/ddtrace/internal/products.py
+++ b/ddtrace/internal/products.py
@@ -107,7 +107,7 @@ class ProductManager:
                 "Circular dependencies among products detected. These products won't be enabled: %s.", list(f.keys())
             )
 
-        return [(name, self.__products__[name]) for name in ordering if name not in f]
+        return [(name, self.__products__[name]) for name in ordering if name not in f and name in self.__products__]
 
     @property
     def products(self) -> t.List[t.Tuple[str, Product]]:

--- a/tests/internal/test_products.py
+++ b/tests/internal/test_products.py
@@ -5,10 +5,10 @@ from ddtrace.internal.products import ProductManager
 
 
 class ProductManagerTest(ProductManager):
-    def __init__(self, products) -> None:
+    def __init__(self, products, failed=set()) -> None:
         self._products = None
         self.__products__ = products
-        self._failed = set()
+        self._failed = failed
 
 
 class BaseProduct(Product):
@@ -56,6 +56,17 @@ def test_product_manager_cycles():
 
     # c and d don't have cycles so they will start
     assert c.started and d.started
+
+
+def test_product_manager_load_fail():
+    class C(BaseProduct):
+        requires = ["b"]
+
+    a = BaseProduct()
+    c = C()
+
+    manager = ProductManagerTest({"a": a, "c": c}, failed={"b"})
+    assert manager.products == [("a", a), ("c", c)]
 
 
 def test_product_manager_start_fail():


### PR DESCRIPTION
We fix the product manager to handle products that have failed to load.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
