### PR TITLE
perf(telemetry): remove call to `importlib.metadata` from `get_module_distribution_versions`

### DIFF
--- a/ddtrace/internal/debug.py
+++ b/ddtrace/internal/debug.py
@@ -75,7 +75,7 @@ def collect(tracer):
 
     is_venv = in_venv()
 
-    packages_available = {p.name: p.version for p in get_distributions()}
+    packages_available = {name: version for (name, version) in get_distributions().items()}
     integration_configs = {}  # type: Dict[str, Union[Dict[str, Any], str]]
     for module, enabled in ddtrace._monkey.PATCH_MODULES.items():
         # TODO: this check doesn't work in all cases... we need a mapping

--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -70,17 +70,17 @@ def get_module_distribution_versions(module_name: str) -> t.Optional[t.Tuple[str
     dist_map = get_distributions()
     while names == []:
         # First try to resolve the module name from package distributions
+        version = dist_map.get(module_name)
+        if version:
+            return (module_name, version)
+        # Since we've failed to resolve, try to resolve the parent package
         names = pkgs.get(module_name, [])
         if not names:
-            # try to resolve the parent package
             p = module_name.rfind(".")
             if p > 0:
                 module_name = module_name[:p]
             else:
                 break
-        version = dist_map.get(module_name)
-        if version:
-            return (module_name, version)
     if len(names) != 1:
         # either it was not resolved due to multiple packages with the same name
         # or it's a multipurpose package (like '__pycache__')

--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -78,11 +78,9 @@ def get_module_distribution_versions(module_name: str) -> t.Optional[t.Tuple[str
                 module_name = module_name[:p]
             else:
                 break
-        try:
-            dist = dist_map[module_name]
-            return (dist.name, dist.version)
-        except Exception:
-            pass
+        version = dist_map.get(module_name)
+        if version:
+            return (module_name, version)
     if len(names) != 1:
         # either it was not resolved due to multiple packages with the same name
         # or it's a multipurpose package (like '__pycache__')

--- a/releasenotes/notes/perf-telemetry-d9881d20f22013f7.yaml
+++ b/releasenotes/notes/perf-telemetry-d9881d20f22013f7.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    telemetry: improves periodic telemetry writer performance by  removing
+    unnecessary calls to ``importlib.metadata`` for reporting imported dependencies.
+

--- a/tests/internal/test_packages.py
+++ b/tests/internal/test_packages.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from ddtrace.internal.packages import _third_party_packages

--- a/tests/internal/test_packages.py
+++ b/tests/internal/test_packages.py
@@ -40,28 +40,26 @@ def test_get_distributions():
     pkg_resources_ws = {pkg.project_name.lower() for pkg in pkg_resources.working_set}
 
     importlib_pkgs = set()
-    for pkg in get_distributions():
-        assert pkg.name
-        assert pkg.version
-        assert os.path.exists(pkg.path)
+    for name, version in get_distributions().items():
+        assert version
         # The package name in typing_extensions-4.x.x.dist-info/METADATA is set to `typing_extensions`
         # this is inconsistent with the package name found in pkg_resources. The block below corrects this.
         # The correct package name is typing-extensions.
         # The issue exists in pkgutil-resolve-name package.
-        if pkg.name == "typing_extensions" and "typing-extensions" in pkg_resources_ws:
+        if name == "typing_extensions" and "typing-extensions" in pkg_resources_ws:
             importlib_pkgs.add("typing-extensions")
-        elif pkg.name == "pkgutil_resolve_name" and "pkgutil-resolve-name" in pkg_resources_ws:
+        elif name == "pkgutil_resolve_name" and "pkgutil-resolve-name" in pkg_resources_ws:
             importlib_pkgs.add("pkgutil-resolve-name")
-        elif pkg.name == "importlib_metadata" and "importlib-metadata" in pkg_resources_ws:
+        elif name == "importlib_metadata" and "importlib-metadata" in pkg_resources_ws:
             importlib_pkgs.add("importlib-metadata")
-        elif pkg.name == "importlib-metadata" and "importlib_metadata" in pkg_resources_ws:
+        elif name == "importlib-metadata" and "importlib_metadata" in pkg_resources_ws:
             importlib_pkgs.add("importlib_metadata")
-        elif pkg.name == "importlib-resources" and "importlib_resources" in pkg_resources_ws:
+        elif name == "importlib-resources" and "importlib_resources" in pkg_resources_ws:
             importlib_pkgs.add("importlib_resources")
-        elif pkg.name == "importlib_resources" and "importlib-resources" in pkg_resources_ws:
+        elif name == "importlib_resources" and "importlib-resources" in pkg_resources_ws:
             importlib_pkgs.add("importlib-resources")
         else:
-            importlib_pkgs.add(pkg.name)
+            importlib_pkgs.add(name)
 
     # assert that pkg_resources and importlib.metadata return the same packages
     assert pkg_resources_ws == importlib_pkgs


### PR DESCRIPTION
<img width="1343" alt="Screenshot 2025-04-25 at 3 14 50 PM" src="https://github.com/user-attachments/assets/7960c991-fd34-4035-85df-b6a051148aef" />

TelemetryWriter periodically reports imported dependencies via calling `get_module_distribution_versions()` when new modules are imported. Typically when application is loaded up for the first time, the TelemetryWriter would notice new imports and then it calls with new module names. The function unnecessarily invoked `importlib.metadata`  and replaced the usage with cached distribution name to version mapping. 

See below for benchmark results. 


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
