### PR TITLE
fix(azure_functions): add await so async functions are instrumented without errors

### DIFF
--- a/ddtrace/contrib/internal/azure_functions/patch.py
+++ b/ddtrace/contrib/internal/azure_functions/patch.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 
 import azure.functions as azure_functions
 from wrapt import wrap_function_wrapper as _w
@@ -57,22 +58,42 @@ def _patched_route(wrapped, instance, args, kwargs):
     def _wrapper(func):
         function_name = get_function_name(pin, instance, func)
 
-        @functools.wraps(func)
-        def wrap_function(*args, **kwargs):
-            req = kwargs.get(trigger_arg_name)
-            with create_context("azure.functions.patched_route_request", pin) as ctx, ctx.span:
-                ctx.set_item("req_span", ctx.span)
-                core.dispatch("azure.functions.request_call_modifier", (ctx, config.azure_functions, req))
-                res = None
-                try:
-                    res = func(*args, **kwargs)
-                    return res
-                finally:
-                    core.dispatch(
-                        "azure.functions.start_response", (ctx, config.azure_functions, res, function_name, trigger)
-                    )
+        if inspect.iscoroutinefunction(func):
 
-        return wrapped(*args, **kwargs)(wrap_function)
+            @functools.wraps(func)
+            async def async_wrap_function(*args, **kwargs):
+                req = kwargs.get(trigger_arg_name)
+                with create_context("azure.functions.patched_route_request", pin) as ctx, ctx.span:
+                    ctx.set_item("req_span", ctx.span)
+                    core.dispatch("azure.functions.request_call_modifier", (ctx, config.azure_functions, req))
+                    res = None
+                    try:
+                        res = await func(*args, **kwargs)
+                        return res
+                    finally:
+                        core.dispatch(
+                            "azure.functions.start_response", (ctx, config.azure_functions, res, function_name, trigger)
+                        )
+
+            return wrapped(*args, **kwargs)(async_wrap_function)
+        else:
+
+            @functools.wraps(func)
+            def wrap_function(*args, **kwargs):
+                req = kwargs.get(trigger_arg_name)
+                with create_context("azure.functions.patched_route_request", pin) as ctx, ctx.span:
+                    ctx.set_item("req_span", ctx.span)
+                    core.dispatch("azure.functions.request_call_modifier", (ctx, config.azure_functions, req))
+                    res = None
+                    try:
+                        res = func(*args, **kwargs)
+                        return res
+                    finally:
+                        core.dispatch(
+                            "azure.functions.start_response", (ctx, config.azure_functions, res, function_name, trigger)
+                        )
+
+            return wrapped(*args, **kwargs)(wrap_function)
 
     return _wrapper
 
@@ -88,17 +109,32 @@ def _patched_timer_trigger(wrapped, instance, args, kwargs):
         function_name = get_function_name(pin, instance, func)
         resource_name = f"{trigger} {function_name}"
 
-        @functools.wraps(func)
-        def wrap_function(*args, **kwargs):
-            with create_context("azure.functions.patched_timer", pin, resource_name) as ctx, ctx.span:
-                ctx.set_item("trigger_span", ctx.span)
-                core.dispatch(
-                    "azure.functions.trigger_call_modifier",
-                    (ctx, config.azure_functions, function_name, trigger),
-                )
-                func(*args, **kwargs)
+        if inspect.iscoroutinefunction(func):
 
-        return wrapped(*args, **kwargs)(wrap_function)
+            @functools.wraps(func)
+            async def async_wrap_function(*args, **kwargs):
+                with create_context("azure.functions.patched_timer", pin, resource_name) as ctx, ctx.span:
+                    ctx.set_item("trigger_span", ctx.span)
+                    core.dispatch(
+                        "azure.functions.trigger_call_modifier",
+                        (ctx, config.azure_functions, function_name, trigger),
+                    )
+                    await func(*args, **kwargs)
+
+            return wrapped(*args, **kwargs)(async_wrap_function)
+        else:
+
+            @functools.wraps(func)
+            def wrap_function(*args, **kwargs):
+                with create_context("azure.functions.patched_timer", pin, resource_name) as ctx, ctx.span:
+                    ctx.set_item("trigger_span", ctx.span)
+                    core.dispatch(
+                        "azure.functions.trigger_call_modifier",
+                        (ctx, config.azure_functions, function_name, trigger),
+                    )
+                    func(*args, **kwargs)
+
+            return wrapped(*args, **kwargs)(wrap_function)
 
     return _wrapper
 

--- a/releasenotes/notes/fix-azure-functions-async-b9f61567dfb7eaba.yaml
+++ b/releasenotes/notes/fix-azure-functions-async-b9f61567dfb7eaba.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    azure_functions: This fix resolves an issue where async functions throw an error when instrumented.
+    

--- a/tests/contrib/azure_functions/azure_function_app/function_app.py
+++ b/tests/contrib/azure_functions/azure_function_app/function_app.py
@@ -14,6 +14,11 @@ def http_get_ok(req: func.HttpRequest) -> func.HttpResponse:
     return func.HttpResponse("Hello Datadog!")
 
 
+@app.route(route="httpgetokasync", auth_level=func.AuthLevel.ANONYMOUS, methods=[func.HttpMethod.GET])
+async def http_get_ok_async(req: func.HttpRequest) -> func.HttpResponse:
+    return func.HttpResponse("Hello Datadog!")
+
+
 @app.route(route="httpgeterror", auth_level=func.AuthLevel.ANONYMOUS, methods=[func.HttpMethod.GET])
 def http_get_error(req: func.HttpRequest) -> func.HttpResponse:
     raise Exception("Test Error")
@@ -47,4 +52,9 @@ def http_get_function_name_no_decorator(req: func.HttpRequest) -> func.HttpRespo
 
 @app.timer_trigger(schedule="0 0 0 1 1 *", arg_name="timer")
 def timer(timer: func.TimerRequest) -> None:
+    pass
+
+
+@app.timer_trigger(schedule="0 0 0 1 1 *", arg_name="timer")
+async def timer_async(timer: func.TimerRequest) -> None:
     pass

--- a/tests/contrib/azure_functions/test_azure_functions_snapshot.py
+++ b/tests/contrib/azure_functions/test_azure_functions_snapshot.py
@@ -53,6 +53,11 @@ def test_http_get_ok(azure_functions_client: Client) -> None:
     assert azure_functions_client.get("/api/httpgetok?key=val", headers=DEFAULT_HEADERS).status_code == 200
 
 
+@pytest.mark.snapshot
+def test_http_get_ok_async(azure_functions_client: Client) -> None:
+    assert azure_functions_client.get("/api/httpgetokasync?key=val", headers=DEFAULT_HEADERS).status_code == 200
+
+
 @pytest.mark.snapshot(ignores=["meta.error.stack"])
 def test_http_get_error(azure_functions_client: Client) -> None:
     assert azure_functions_client.get("/api/httpgeterror", headers=DEFAULT_HEADERS).status_code == 500
@@ -85,6 +90,18 @@ def test_timer(azure_functions_client: Client) -> None:
     assert (
         azure_functions_client.post(
             "/admin/functions/timer",
+            headers={"User-Agent": "python-httpx/x.xx.x", "Content-Type": "application/json"},
+            data=json.dumps({"input": None}),
+        ).status_code
+        == 202
+    )
+
+
+@pytest.mark.snapshot
+def test_timer_async(azure_functions_client: Client) -> None:
+    assert (
+        azure_functions_client.post(
+            "/admin/functions/timer_async",
             headers={"User-Agent": "python-httpx/x.xx.x", "Content-Type": "application/json"},
             data=json.dumps({"input": None}),
         ).status_code

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_ok_async.json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_http_get_ok_async.json
@@ -1,0 +1,33 @@
+[[
+  {
+    "name": "azure.functions.invoke",
+    "service": "test-func",
+    "resource": "GET /api/httpgetokasync",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "serverless",
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "680bbffe00000000",
+      "aas.function.name": "http_get_ok_async",
+      "aas.function.trigger": "Http",
+      "component": "azure_functions",
+      "http.method": "GET",
+      "http.route": "/api/httpgetokasync",
+      "http.status_code": "200",
+      "http.url": "http://0.0.0.0:7071/api/httpgetokasync?key=val",
+      "http.useragent": "python-httpx/x.xx.x",
+      "language": "python",
+      "runtime-id": "dc1bd0201db346a887fac16721f3b0e5",
+      "span.kind": "server"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 17518
+    },
+    "duration": 794292,
+    "start": 1745600510630485377
+  }]]

--- a/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_timer_async.json
+++ b/tests/snapshots/tests.contrib.azure_functions.test_azure_functions_snapshot.test_timer_async.json
@@ -1,0 +1,28 @@
+[[
+  {
+    "name": "azure.functions.invoke",
+    "service": "test-func",
+    "resource": "Timer timer_async",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "serverless",
+    "meta": {
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "680bbf7f00000000",
+      "aas.function.name": "timer_async",
+      "aas.function.trigger": "Timer",
+      "component": "azure_functions",
+      "language": "python",
+      "runtime-id": "60d7e0785b414408a3dafc9fb92d939e",
+      "span.kind": "internal"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 7776
+    },
+    "duration": 193000,
+    "start": 1745600383620687347
+  }]]


### PR DESCRIPTION
Add await for async Azure Functions to prevent errors on instrumentation.

https://datadoghq.atlassian.net/browse/SVLS-6703

<img width="1075" alt="Screenshot 2025-04-24 at 8 58 00 PM" src="https://github.com/user-attachments/assets/9567fe6a-12ee-4b15-9509-78fe7b5bf3e5" />

### Additional Notes:
There is an opportunity for some refactoring in order to better reuse code. In the interest of getting this fix out as quickly as possible I plan on handling that refactor in a separate PR.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
