### PR TITLE
ci: update arm64 runners to arm-4core-linux-ubuntu24.04

### DIFF
--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -33,7 +33,7 @@ jobs:
           MATRIX_INCLUDE=$(
             {
               cibuildwheel --print-build-identifiers --platform linux --arch x86_64,i686 | jq -cR '{only: ., os: "ubuntu-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform linux --arch aarch64  | jq -cR '{only: ., os: "arm-4core-linux"}' \
+              && cibuildwheel --print-build-identifiers --platform linux --arch aarch64  | jq -cR '{only: ., os: "arm-4core-linux-ubuntu24.04"}' \
               && cibuildwheel --print-build-identifiers --platform windows --arch AMD64,x86 | grep -v 313 | jq -cR '{only: ., os: "windows-latest"}' \
               && cibuildwheel --print-build-identifiers --platform macos --arch x86_64 | jq -cR '{only: ., os: "macos-13"}' \
               && cibuildwheel --print-build-identifiers --platform macos --arch arm64 | jq -cR '{only: ., os: "macos-latest"}'
@@ -59,33 +59,20 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
-        if: matrix.os != 'arm-4core-linux'
+        if: matrix.os != 'arm-4core-linux-ubuntu24.04'
         name: Install Python
         with:
           python-version: '3.8'
 
-      - name: Install docker and pipx
-        if: matrix.os == 'arm-4core-linux'
-        # The ARM64 Ubuntu has less things installed by default
-        # We need docker, pip and venv for cibuildwheel
-        # acl allows us to use docker in the same session
-        run: |
-          curl -fsSL https://get.docker.com -o get-docker.sh
-          sudo sh get-docker.sh
-          sudo usermod -a -G docker $USER
-          sudo apt install -y acl python3.10-venv python3-pip
-          sudo setfacl --modify user:runner:rw /var/run/docker.sock
-          python3 -m pip install pipx
-
       - name: Set up QEMU
-        if: runner.os == 'Linux' && matrix.os != 'arm-4core-linux'
+        if: runner.os == 'Linux' && matrix.os != 'arm-4core-linux-ubuntu24.04'
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
           platforms: all
 
       - name: Build wheels arm64
-        if: always() && matrix.os == 'arm-4core-linux'
-        run: /home/runner/.local/bin/pipx run cibuildwheel==2.22.0 --only ${{ matrix.only }}
+        if: always() && matrix.os == 'arm-4core-linux-ubuntu24.04'
+        run: pipx run cibuildwheel==2.22.0 --only ${{ matrix.only }}
         env:
           CIBW_SKIP: ${{ inputs.cibw_skip }}
           CIBW_PRERELEASE_PYTHONS: ${{ inputs.cibw_prerelease_pythons }}
@@ -119,7 +106,7 @@ jobs:
           # CIBW_BUILD_VERBOSITY_MACOS: 3
 
       - name: Build wheels
-        if: always() && matrix.os != 'arm-4core-linux'
+        if: always() && matrix.os != 'arm-4core-linux-ubuntu24.04'
         uses: pypa/cibuildwheel@d04cacbc9866d432033b1d09142936e6a0e2121a # v2.23.2
         with:
           only: ${{ matrix.only }}


### PR DESCRIPTION
These new images are more similar to the default ones, including Docker.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
