### PR TITLE
fix(debugging): make probe instances hashable [backport #13309 to 2.21]

### DIFF
--- a/ddtrace/debugging/_probe/model.py
+++ b/ddtrace/debugging/_probe/model.py
@@ -65,6 +65,12 @@ class CaptureLimits:
 DEFAULT_CAPTURE_LIMITS = CaptureLimits()
 
 
+# NOTE: Probe dataclasses are mutable, but have an identity, so can be hashed.
+# When defining a probe class, the `eq` parameter of the `dataclass` decorator
+# should be set to `False` to allow the `__hash__` method from the base Probe
+# class to be used.
+
+
 @dataclass
 class Probe(abc.ABC):
     __context_creator__ = False
@@ -193,12 +199,12 @@ class MetricProbeMixin(AbstractProbeMixIn):
     value: Optional[DDExpression]
 
 
-@dataclass
+@dataclass(eq=False)
 class MetricLineProbe(Probe, LineLocationMixin, MetricProbeMixin, ProbeConditionMixin):
     pass
 
 
-@dataclass
+@dataclass(eq=False)
 class MetricFunctionProbe(Probe, FunctionLocationMixin, TimingMixin, MetricProbeMixin, ProbeConditionMixin):
     pass
 
@@ -246,13 +252,13 @@ class LogProbeMixin(AbstractProbeMixIn):
     limits: CaptureLimits = field(compare=False)
 
 
-@dataclass
+@dataclass(eq=False)
 class LogLineProbe(Probe, LineLocationMixin, LogProbeMixin, ProbeConditionMixin, RateLimitMixin):
     def is_global_rate_limited(self) -> bool:
         return self.take_snapshot
 
 
-@dataclass
+@dataclass(eq=False)
 class LogFunctionProbe(Probe, FunctionLocationMixin, TimingMixin, LogProbeMixin, ProbeConditionMixin, RateLimitMixin):
     def is_global_rate_limited(self) -> bool:
         return self.take_snapshot
@@ -263,7 +269,7 @@ class SpanProbeMixin:
     pass
 
 
-@dataclass
+@dataclass(eq=False)
 class SpanFunctionProbe(Probe, FunctionLocationMixin, SpanProbeMixin, ProbeConditionMixin):
     __context_creator__: bool = field(default=True, init=False, repr=False, compare=False)
 
@@ -291,12 +297,12 @@ class SpanDecorationMixin:
     decorations: List[SpanDecoration]
 
 
-@dataclass
+@dataclass(eq=False)
 class SpanDecorationLineProbe(Probe, LineLocationMixin, SpanDecorationMixin):
     pass
 
 
-@dataclass
+@dataclass(eq=False)
 class SpanDecorationFunctionProbe(Probe, FunctionLocationMixin, TimingMixin, SpanDecorationMixin):
     pass
 

--- a/releasenotes/notes/fix-debugger-hashable-probes-4a9ae0b7f1d40791.yaml
+++ b/releasenotes/notes/fix-debugger-hashable-probes-4a9ae0b7f1d40791.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: fix incompatibility between code origin and
+    dynamic instrumentation probe on exit span functions.

--- a/tests/debugging/probe/test_model.py
+++ b/tests/debugging/probe/test_model.py
@@ -43,3 +43,17 @@ def test_mutability():
     before.update(after)
 
     assert before == after
+
+
+def test_probe_hash():
+    probe = create_log_line_probe(
+        probe_id="test_mutability",
+        version=2,
+        condition=DDExpression(dsl="True", callable=dd_compile(True)),
+        source_file="foo",
+        line=1,
+        template="",
+        segments=[],
+    )
+
+    assert hash(probe)

--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -58,6 +58,9 @@ def simple_debugger_test(probe, func):
 
         d.add_probes(probe)
 
+        # Check that we can still hash the code object
+        assert hash(func.__code__)
+
         try:
             func()
         except Exception:


### PR DESCRIPTION
Backport 3c2015eacdd64496f510fdc37f4743f0c5537b65 from #13309 to 2.21.

Probes are mutable but have an identity that allows them to be hashed. We make sure that probe instances are hashable. This in turns makes code objects where probes are injected hashable and usable for lookups.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
