### PR TITLE
chore(tracer): handle None in activate_distributed_headers

### DIFF
--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -510,7 +510,9 @@ def activate_distributed_headers(tracer, int_config=None, request_headers=None, 
 
     if override or (int_config and distributed_tracing_enabled(int_config)):
         context = HTTPPropagator.extract(request_headers)
-
+        # bail out if no context was extracted
+        if context is None:
+            return None
         # Only need to activate the new context if something was propagated
         # The new context must have one of these values in order for it to be activated
         if not context.trace_id and not context._baggage and not context._span_links:

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -22,6 +22,7 @@ from ddtrace.ext import net
 from ddtrace.internal.compat import ensure_text
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
+from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.settings import IntegrationConfig
 from ddtrace.settings._config import Config
 from ddtrace.trace import Context
@@ -29,7 +30,7 @@ from ddtrace.trace import Pin
 from ddtrace.trace import Span
 from tests.appsec.utils import asm_context
 from tests.utils import override_global_config
-from ddtrace.propagation.http import HTTPPropagator
+
 
 @pytest.fixture
 def int_config():
@@ -973,13 +974,15 @@ def test_activate_distributed_headers_no_headers(int_config, tracer):
     trace_utils.activate_distributed_headers(tracer, int_config=int_config.myint, request_headers=None)
     assert tracer.context_provider.active() is None
 
+
 @mock.patch.object(HTTPPropagator, "extract", return_value=None)
 def test_activate_distributed_headers_missing_headers(int_config, tracer):
     # Verify that when HTTPPropagator.extract returns None (no incoming headers),
     # activate_distributed_headers returns early without error and leaves the tracer’s context empty.
     int_config.myint["distributed_tracing_enabled"] = True
-    trace_utils.activate_distributed_headers(tracer, int_config=int_config.myint, request_headers=None, override =True)
+    trace_utils.activate_distributed_headers(tracer, int_config=int_config.myint, request_headers=None, override=True)
     assert tracer.context_provider.active() is None
+
 
 def test_activate_distributed_headers_override_true(int_config, tracer):
     int_config.myint["distributed_tracing_enabled"] = False

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -29,7 +29,7 @@ from ddtrace.trace import Pin
 from ddtrace.trace import Span
 from tests.appsec.utils import asm_context
 from tests.utils import override_global_config
-
+from ddtrace.propagation.http import HTTPPropagator
 
 @pytest.fixture
 def int_config():
@@ -973,6 +973,13 @@ def test_activate_distributed_headers_no_headers(int_config, tracer):
     trace_utils.activate_distributed_headers(tracer, int_config=int_config.myint, request_headers=None)
     assert tracer.context_provider.active() is None
 
+@mock.patch.object(HTTPPropagator, "extract", return_value=None)
+def test_activate_distributed_headers_missing_headers(int_config, tracer):
+    # Verify that when HTTPPropagator.extract returns None (no incoming headers),
+    # activate_distributed_headers returns early without error and leaves the tracer’s context empty.
+    int_config.myint["distributed_tracing_enabled"] = True
+    trace_utils.activate_distributed_headers(tracer, int_config=int_config.myint, request_headers=None, override =True)
+    assert tracer.context_provider.active() is None
 
 def test_activate_distributed_headers_override_true(int_config, tracer):
     int_config.myint["distributed_tracing_enabled"] = False


### PR DESCRIPTION
The function `activate_distributed_headers` unconditionally calls

`context = HTTPPropagator.extract(request_headers)`

and then immediately does` context.trace_id`, but under some circumstances (e.g. no distributed-trace headers present) `extract()` can return `None`. This leads to an uncaught

`AttributeError: 'NoneType' object has no attribute 'trace_id'`. 


Fixes issue: #13277

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
