### PR TITLE
fix(llmobs) [13336]: support unix-like connections

### DIFF
--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -19,6 +19,7 @@ from ddtrace.internal import agent
 from ddtrace.internal import forksafe
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.periodic import PeriodicService
+from ddtrace.internal.utils.http import get_connection
 from ddtrace.internal.utils.http import verify_url
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from ddtrace.llmobs import _telemetry as telemetry
@@ -201,7 +202,7 @@ class BaseLLMObsWriter(PeriodicService):
             )
 
     def _send_payload(self, payload: bytes, num_events: int):
-        conn = self._get_connection()
+        conn = get_connection(self._intake, self._timeout)
         try:
             conn.request("POST", self._endpoint, payload, self._headers)
             resp = conn.getresponse()
@@ -225,15 +226,6 @@ class BaseLLMObsWriter(PeriodicService):
             raise
         finally:
             conn.close()
-
-    def _get_connection(self):
-        """Return the connection to the LLM Observability endpoint."""
-        parsed = verify_url(self._intake)
-        if parsed.scheme == "https":
-            return httplib.HTTPSConnection(parsed.hostname or "", parsed.port, timeout=self._timeout)
-        elif parsed.scheme == "http":
-            return httplib.HTTPConnection(parsed.hostname or "", parsed.port, timeout=self._timeout)
-        raise ConnectionError("Unable to connect, invalid URL: %s", self._intake)
 
     @property
     def _url(self) -> str:


### PR DESCRIPTION
Use `get_connection` from the common utilities, which is what the rest of the codebase uses, to get the connection object based on the input URL instead of the self-made one in the class. This method also supports unix sockets, which are currently not supported as mentioned in !13336.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
