### PR TITLE
chore(ssi): track ssi source across subprocesses

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -164,12 +164,16 @@ try:
             log.debug("additional sitecustomize not found")
         else:
             log.debug("additional sitecustomize found in: %s", sys.path)
-    # Detect if ddtrace-run is being used by checking if the bootstrap directory is in the python path
-    bootstrap_dir = os.path.join(os.path.dirname(ddtrace.__file__), "bootstrap")
-    if bootstrap_dir in sys.path:
-        telemetry_writer.add_configuration("instrumentation_source", "cmd_line", "code")
+
+    if os.getenv("_DD_SSI_INJECT_SUCCESSFUL"):
+        telemetry_writer.add_configuration("instrumentation_source", "ssi", "code")
     else:
-        telemetry_writer.add_configuration("instrumentation_source", "manual", "code")
+        # Detect if ddtrace-run is being used by checking if the bootstrap directory is in the python path
+        bootstrap_dir = os.path.join(os.path.dirname(ddtrace.__file__), "bootstrap")
+        if bootstrap_dir in sys.path:
+            telemetry_writer.add_configuration("instrumentation_source", "cmd_line", "code")
+        else:
+            telemetry_writer.add_configuration("instrumentation_source", "manual", "code")
     # Loading status used in tests to detect if the `sitecustomize` has been
     # properly loaded without exceptions. This must be the last action in the module
     # when the execution ends with a success.

--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -166,14 +166,17 @@ try:
             log.debug("additional sitecustomize found in: %s", sys.path)
 
     if os.getenv("_DD_SSI_INJECT_SUCCESSFUL"):
-        telemetry_writer.add_configuration("instrumentation_source", "ssi", "code")
+        # _DD_SSI_INJECT_SUCCESSFUL is set in lib-injection/sources/sitecustomize.py after ssi is completed
+        source = "ssi"
+    elif os.path.join(os.path.dirname(ddtrace.__file__), "bootstrap") in sys.path:
+        # Checks the python path to see if the bootstrap directory is present, this operation
+        # is performed in ddtrace/commands/ddtrace_run.py and is triggered by ddtrace-run
+        source = "cmd_line"
     else:
-        # Detect if ddtrace-run is being used by checking if the bootstrap directory is in the python path
-        bootstrap_dir = os.path.join(os.path.dirname(ddtrace.__file__), "bootstrap")
-        if bootstrap_dir in sys.path:
-            telemetry_writer.add_configuration("instrumentation_source", "cmd_line", "code")
-        else:
-            telemetry_writer.add_configuration("instrumentation_source", "manual", "code")
+        # If none of the above, then the user must have manually configured ddtrace instrumentation
+        # ex: import ddtrace.auto
+        source = "manual"
+    telemetry_writer.add_configuration("instrumentation_source", source, "code")
     # Loading status used in tests to detect if the `sitecustomize` has been
     # properly loaded without exceptions. This must be the last action in the module
     # when the execution ends with a success.

--- a/lib-injection/sources/sitecustomize.py
+++ b/lib-injection/sources/sitecustomize.py
@@ -431,6 +431,7 @@ def _inject():
                 )
                 # Track whether library injection was successful
                 ddtrace.config._lib_was_injected = True
+                os.environ["_DD_SSI_INJECT_SUCCESSFUL"] = "true"
                 ddtrace.internal.telemetry.telemetry_writer.add_configuration("instrumentation_source", "ssi", "code")
             except Exception as e:
                 TELEMETRY_DATA.append(

--- a/lib-injection/sources/sitecustomize.py
+++ b/lib-injection/sources/sitecustomize.py
@@ -431,7 +431,7 @@ def _inject():
                 )
                 # Track whether library injection was successful
                 ddtrace.config._lib_was_injected = True
-                os.environ["_DD_SSI_INJECT_SUCCESSFUL"] = "true"
+                os.environ["_DD_SSI_INJECT_SUCCESSFUL"] = "1"
                 ddtrace.internal.telemetry.telemetry_writer.add_configuration("instrumentation_source", "ssi", "code")
             except Exception as e:
                 TELEMETRY_DATA.append(


### PR DESCRIPTION
This change ensures all processes that were instrumented via ssi accurately report their instrumentation source.

When a python process is instrumented via ssi the instrumentation source will be reported as `ssi`. This is expected. However if this process forks the source of the child process will be reported as `cmd_line`. This is unexpected. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
