### PR TITLE
refactor(profiler): clear frozen map instead of using invalid iterator

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_heap_map.c
+++ b/ddtrace/profiling/collector/_memalloc_heap_map.c
@@ -160,12 +160,9 @@ memalloc_heap_map_destructive_copy(memalloc_heap_map_t* dst, memalloc_heap_map_t
     HeapSamples_Iter it = HeapSamples_iter(&src->map);
     for (const HeapSamples_Entry* e = HeapSamples_Iter_get(&it); e != NULL; e = HeapSamples_Iter_next(&it)) {
         HeapSamples_insert(&dst->map, e);
-        /* Erasing the element doesn't free up the backing storage. This is
-         * probably fine; even at full capacity the table will probably only be
-         * ~1-2MiB
-         */
-        HeapSamples_erase_at(it);
     }
+    /* Can't erase inside the loop or the iterator is invalidated */
+    HeapSamples_clear(&src->map);
 }
 
 void


### PR DESCRIPTION
The cwisstable docs say conflicting things about what happens to an
iterator after an erase_at call. The map_api.h example from the repo
says the iterator is invalid. The internal CWISS_RawTable_erase_at
function, which is source of truth, says the iterator is invalid after
the call. Fix memalloc_heap_map_destructive_copy to just clear after
copying over the entries rather than erasing the iterator.

Note that this is currently dead code. We take the heap profiler lock
prior to freezing the heap profiler and emptying it out. So we can't add
an entry to the frozen array because we'll fail to acquire the lock
needed to do so. This means the map is empty and we won't see the
invalidated iterator. However, this code will run once we rework the
locking. I saw this code crash when pulling in the heap map code into my
work-in-progress branch where it actually runs. So we don't technically
_need_ to fix this right now. However, I'd like the code on main to be
right even if it's not running yet :)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
