### PR TITLE
ci(tracing): fix flaky span event encoding test

### DIFF
--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -12,7 +12,6 @@ from hypothesis.strategies import dictionaries
 from hypothesis.strategies import floats
 from hypothesis.strategies import integers
 from hypothesis.strategies import text
-import mock
 import msgpack
 import pytest
 
@@ -31,7 +30,6 @@ from ddtrace.internal.encoding import JSONEncoderV2
 from ddtrace.internal.encoding import MsgpackEncoderV04
 from ddtrace.internal.encoding import MsgpackEncoderV05
 from ddtrace.internal.encoding import _EncoderBase
-from ddtrace.settings._agent import config as agent_config
 from ddtrace.trace import Context
 from ddtrace.trace import Span
 from tests.utils import DummyTracer


### PR DESCRIPTION
This PR ensures the `agent_config.trace_native_span_events` global configuration does not leak between test runs. 

Resolves the following ci failures: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/928971572.

Introduced by: https://github.com/DataDog/dd-trace-py/commit/a754504fcd3756f75a54a9f8c95c5257c998d037

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
