### PR TITLE
chore(configuration): replace instances of os.environ

### DIFF
--- a/ddtrace/contrib/internal/pytest/_plugin_v1.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v1.py
@@ -71,6 +71,7 @@ from ddtrace.internal.coverage.code import ModuleCodeCollector
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.inspection import undecorated
+from ddtrace.settings._config import _get_config
 from ddtrace.vendor.debtcollector import deprecate
 
 
@@ -80,7 +81,7 @@ _global_skipped_elements = 0
 
 # COVER_SESSION is an experimental feature flag that provides full coverage (similar to coverage run), and is an
 # experimental feature. It currently significantly increases test import time and should not be used.
-COVER_SESSION = asbool(os.environ.get("_DD_COVER_SESSION", "false"))
+COVER_SESSION = _get_config("_DD_COVER_SESSION", False, asbool)
 
 
 def encode_test_parameter(parameter):
@@ -426,7 +427,7 @@ def pytest_load_initial_conftests(early_config, parser, args):
         # Freezegun is proactively patched to avoid it interfering with internal timing
         ddtrace.patch(freezegun=True)
 
-        COVER_SESSION = asbool(os.environ.get("_DD_COVER_SESSION", "false"))
+        COVER_SESSION = _get_config("_DD_COVER_SESSION", False, asbool)
 
         if USE_DD_COVERAGE:
             from ddtrace.ext.git import extract_workspace_path

--- a/ddtrace/contrib/internal/pytest/_utils.py
+++ b/ddtrace/contrib/internal/pytest/_utils.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 import json
-import os
 from pathlib import Path
 import re
 import typing as t
@@ -25,13 +24,14 @@ from ddtrace.internal.test_visibility.api import InternalTest
 from ddtrace.internal.utils.cache import cached
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.inspection import undecorated
+from ddtrace.settings._config import _get_config
 
 
 log = get_logger(__name__)
 
 _NODEID_REGEX = re.compile("^(((?P<module>.*)/)?(?P<suite>[^/]*?))::(?P<name>.*?)$")
 
-_USE_PLUGIN_V2 = not asbool(os.environ.get("_DD_PYTEST_USE_LEGACY_PLUGIN", "false"))
+_USE_PLUGIN_V2 = not _get_config("_DD_PYTEST_USE_LEGACY_PLUGIN", False, asbool)
 
 
 class _PYTEST_STATUS:
@@ -129,8 +129,8 @@ def _get_session_command(session: pytest.Session):
     command = "pytest"
     if getattr(session.config, "invocation_params", None):
         command += " {}".format(" ".join(session.config.invocation_params.args))
-    if os.environ.get("PYTEST_ADDOPTS"):
-        command += " {}".format(os.environ.get("PYTEST_ADDOPTS"))
+    if _get_config("PYTEST_ADDOPTS", False, asbool):
+        command += " {}".format(_get_config("PYTEST_ADDOPTS", False, asbool))
     return command
 
 


### PR DESCRIPTION
Replaces any instances of os.environ with _get_config for the pytest integration.

Motivation: [APMAPI-1210](https://datadoghq.atlassian.net/browse/APMAPI-1210)

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)


[APMAPI-1210]: https://datadoghq.atlassian.net/browse/APMAPI-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ