### PR TITLE
fix(di): prevent exception when removing unresolved probe

### DIFF
--- a/ddtrace/debugging/_probe/registry.py
+++ b/ddtrace/debugging/_probe/registry.py
@@ -159,10 +159,10 @@ class ProbeRegistry(dict):
                 self._log_probe_status_unlocked(entry)
 
     def _remove_pending(self, probe: Probe) -> None:
-        location = _get_probe_location(probe)
-
-        # Pending probes must have valid location information
-        assert location is not None, probe  # nosec
+        if (location := _get_probe_location(probe)) is None:
+            # If the probe has no location information, then it cannot be
+            # pending.
+            return
 
         pending_probes = self._pending[location]
         try:

--- a/releasenotes/notes/fix-unresolved-pending-probe-removal-80fbf85a9c068122.yaml
+++ b/releasenotes/notes/fix-unresolved-pending-probe-removal-80fbf85a9c068122.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: prevent an exception when trying to remove a probe
+    that did not resolve to a valid source code location.

--- a/tests/debugging/probe/test_registry.py
+++ b/tests/debugging/probe/test_registry.py
@@ -56,6 +56,9 @@ def test_registry_location_error():
     # Check that the probe is not pending
     assert not registry.get_pending(__file__)
 
+    # Check that unregistering the probe does not cause an exception
+    registry.unregister(probe)
+
     # Check that we emitted the correct diagnostic error message
     for e in status_logger.queue:
         del e["timestamp"]


### PR DESCRIPTION
We prevent an exception from occurring when trying to remove a probe that did not resolve to a valid source code location.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
