### PR TITLE
chore(iast): stackId should report inside vulnerability location

### DIFF
--- a/ddtrace/appsec/_iast/_stacktrace.c
+++ b/ddtrace/appsec/_iast/_stacktrace.c
@@ -217,7 +217,7 @@ get_ddtrace_path()
         res = strndup(path_str, path_len - suffix_len);
     }
 
-    exit:
+exit:
     Py_XDECREF(path);
     Py_XDECREF(ddtrace_mod);
     return res;

--- a/ddtrace/appsec/_iast/reporter.py
+++ b/ddtrace/appsec/_iast/reporter.py
@@ -66,10 +66,20 @@ class Evidence(NotNoneDictable):
 @dataclasses.dataclass(unsafe_hash=True)
 class Location:
     spanId: int = dataclasses.field(compare=False, hash=False, repr=False)
+    stackId: Optional[str] = dataclasses.field(init=False, compare=False)
     path: Optional[str] = None
     line: Optional[int] = None
     method: Optional[str] = dataclasses.field(compare=False, hash=False, repr=False, default="")
     class_name: Optional[str] = dataclasses.field(compare=False, hash=False, repr=False, default="")
+
+    def __post_init__(self):
+        self.hash = zlib.crc32(repr(self).encode())
+        stacktrace_id = get_iast_stacktrace_id()
+        self.stackId = None
+        if stacktrace_id:
+            str_id = str(stacktrace_id)
+            if report_stack(stack_id=str_id, namespace=STACK_TRACE.IAST):
+                self.stackId = str_id
 
     def __repr__(self):
         return f"Location(path='{self.path}', line={self.line})"
@@ -86,6 +96,8 @@ class Location:
             result["method"] = self.method
         if self.class_name:
             result["class"] = self.class_name
+        if self.stackId:
+            result["stackId"] = self.stackId
         return result
 
 
@@ -95,18 +107,9 @@ class Vulnerability:
     evidence: Evidence
     location: Location
     hash: int = dataclasses.field(init=False, compare=False, hash=("PYTEST_CURRENT_TEST" in os.environ), repr=False)
-    stackId: Optional[str] = dataclasses.field(init=False, compare=False)
 
     def __post_init__(self):
-        # avoid circular import
-
         self.hash = zlib.crc32(repr(self).encode())
-        stacktrace_id = get_iast_stacktrace_id()
-        self.stackId = None
-        if stacktrace_id:
-            str_id = str(stacktrace_id)
-            if report_stack(stack_id=str_id, namespace=STACK_TRACE.IAST):
-                self.stackId = str_id
 
     def __repr__(self):
         return f"Vulnerability(type='{self.type}', location={self.location})"
@@ -118,8 +121,6 @@ class Vulnerability:
             "location": self.location._to_dict(),
             "hash": self.hash,
         }
-        if self.stackId:
-            to_dict["stackId"] = self.stackId
         return to_dict
 
 

--- a/tests/appsec/iast/taint_sinks/test_ssrf.py
+++ b/tests/appsec/iast/taint_sinks/test_ssrf.py
@@ -55,6 +55,8 @@ def _check_report(tainted_path, label):
     assert vulnerability["location"]["line"] == line
     assert vulnerability["location"]["method"] == label
     assert "class" not in vulnerability["location"]
+    assert type(vulnerability["location"]["spanId"]) is int
+    assert "stackId" not in vulnerability["location"]
     assert vulnerability["hash"] == hash_value
 
 

--- a/tests/appsec/iast/taint_sinks/test_ssrf.py
+++ b/tests/appsec/iast/taint_sinks/test_ssrf.py
@@ -56,7 +56,6 @@ def _check_report(tainted_path, label):
     assert vulnerability["location"]["method"] == label
     assert "class" not in vulnerability["location"]
     assert type(vulnerability["location"]["spanId"]) is int
-    assert "stackId" not in vulnerability["location"]
     assert vulnerability["hash"] == hash_value
 
 

--- a/tests/appsec/integrations/django_tests/test_django_appsec_iast.py
+++ b/tests/appsec/integrations/django_tests/test_django_appsec_iast.py
@@ -79,6 +79,12 @@ def test_django_weak_hash(client, test_spans, tracer):
     assert str_json is not None, "no JSON tag in root span"
     vulnerability = json.loads(str_json)["vulnerabilities"][0]
     assert vulnerability["location"]["path"].endswith(TEST_FILE)
+    assert type(vulnerability["location"]["spanId"]) is int
+    assert vulnerability["location"]["spanId"] > 0
+    assert vulnerability["location"]["stackId"] == "1"
+    assert vulnerability["location"]["line"] > 0
+    assert vulnerability["location"]["method"] == "weak_hash_view"
+    assert vulnerability["location"]["class"] == ""
     assert vulnerability["evidence"]["value"] == "md5"
 
 
@@ -266,8 +272,13 @@ def test_django_sqli_http_request_parameter(client, test_spans, tracer):
             {"value": "'"},
         ]
     }
+    print(loaded["vulnerabilities"][0]["location"])
     assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
     assert loaded["vulnerabilities"][0]["location"]["line"] == line
+    assert loaded["vulnerabilities"][0]["location"]["spanId"] > 0
+    assert loaded["vulnerabilities"][0]["location"]["stackId"] == "1"
+    assert loaded["vulnerabilities"][0]["location"]["method"] == "sqli_http_request_parameter"
+    assert "class" not in loaded["vulnerabilities"][0]["location"]
     assert loaded["vulnerabilities"][0]["hash"] == hash_value
 
 
@@ -316,6 +327,10 @@ def test_django_sqli_http_request_parameter_name_get(client, test_spans, tracer)
     }
     assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
     assert loaded["vulnerabilities"][0]["location"]["line"] == line
+    assert loaded["vulnerabilities"][0]["location"]["spanId"] > 0
+    assert loaded["vulnerabilities"][0]["location"]["stackId"] == "1"
+    assert loaded["vulnerabilities"][0]["location"]["method"] == "sqli_http_request_parameter"
+    assert "class" not in loaded["vulnerabilities"][0]["location"]
     assert loaded["vulnerabilities"][0]["hash"] == hash_value
 
 
@@ -365,6 +380,10 @@ def test_django_sqli_http_request_parameter_name_post(client, test_spans, tracer
     }
     assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
     assert loaded["vulnerabilities"][0]["location"]["line"] == line
+    assert loaded["vulnerabilities"][0]["location"]["spanId"] > 0
+    assert loaded["vulnerabilities"][0]["location"]["stackId"] == "1"
+    assert loaded["vulnerabilities"][0]["location"]["method"] == "sqli_http_request_parameter_name_post"
+    assert "class" not in loaded["vulnerabilities"][0]["location"]
     assert loaded["vulnerabilities"][0]["hash"] == hash_value
 
 
@@ -835,6 +854,10 @@ def test_django_command_injection(client, test_spans, tracer):
     }
     assert loaded["vulnerabilities"][0]["location"]["line"] == line
     assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
+    assert loaded["vulnerabilities"][0]["location"]["spanId"] > 0
+    assert loaded["vulnerabilities"][0]["location"]["stackId"] == "1"
+    assert loaded["vulnerabilities"][0]["location"]["method"] == "command_injection"
+    assert "class" not in loaded["vulnerabilities"][0]["location"]
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")

--- a/tests/appsec/integrations/django_tests/test_django_appsec_iast.py
+++ b/tests/appsec/integrations/django_tests/test_django_appsec_iast.py
@@ -84,7 +84,7 @@ def test_django_weak_hash(client, test_spans, tracer):
     assert vulnerability["location"]["stackId"] == "1"
     assert vulnerability["location"]["line"] > 0
     assert vulnerability["location"]["method"] == "weak_hash_view"
-    assert vulnerability["location"]["class"] == ""
+    assert "class" not in vulnerability["location"]
     assert vulnerability["evidence"]["value"] == "md5"
 
 
@@ -329,7 +329,7 @@ def test_django_sqli_http_request_parameter_name_get(client, test_spans, tracer)
     assert loaded["vulnerabilities"][0]["location"]["line"] == line
     assert loaded["vulnerabilities"][0]["location"]["spanId"] > 0
     assert loaded["vulnerabilities"][0]["location"]["stackId"] == "1"
-    assert loaded["vulnerabilities"][0]["location"]["method"] == "sqli_http_request_parameter"
+    assert loaded["vulnerabilities"][0]["location"]["method"] == "sqli_http_request_parameter_name_get"
     assert "class" not in loaded["vulnerabilities"][0]["location"]
     assert loaded["vulnerabilities"][0]["hash"] == hash_value
 


### PR DESCRIPTION
stackId should report inside vulnerability location, following this system test PR:
https://github.com/DataDog/system-tests/pull/4607

Tests confirmed locally:
![image](https://github.com/user-attachments/assets/c7c22cb0-4a89-4366-999a-d157df95653d)


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
