### PR TITLE
chore(iast): add route to starlette wrapper function

### DIFF
--- a/ddtrace/appsec/_iast/_handlers.py
+++ b/ddtrace/appsec/_iast/_handlers.py
@@ -556,3 +556,14 @@ async def _iast_instrument_starlette_request_body(wrapped, instance, args, kwarg
     return taint_pyobject(
         result, source_name=origin_to_str(OriginType.PATH), source_value=result, source_origin=OriginType.BODY
     )
+
+
+def _iast_instrument_starlette_scope(scope, route):
+    if scope.get("path_params"):
+        try:
+            for k, v in scope["path_params"].items():
+                scope["path_params"][k] = taint_pyobject(
+                    v, source_name=k, source_value=v, source_origin=OriginType.PATH_PARAMETER
+                )
+        except Exception:
+            iast_propagation_listener_log_log("Unexpected exception while tainting path parameters", exc_info=True)

--- a/ddtrace/appsec/_iast/_patch.py
+++ b/ddtrace/appsec/_iast/_patch.py
@@ -6,7 +6,6 @@ from wrapt import FunctionWrapper
 
 from ddtrace.appsec._common_module_patches import wrap_object
 from ddtrace.appsec._iast._logs import iast_instrumentation_wrapt_debug_log
-from ddtrace.appsec._iast._logs import iast_propagation_listener_log_log
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import origin_to_str
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
@@ -51,14 +50,3 @@ def _iast_instrument_starlette_url(wrapped, instance, args, kwargs):
 
     instance.__class__.path = property(path)
     wrapped(*args, **kwargs)
-
-
-def _iast_instrument_starlette_scope(scope):
-    if scope.get("path_params"):
-        try:
-            for k, v in scope["path_params"].items():
-                scope["path_params"][k] = taint_pyobject(
-                    v, source_name=k, source_value=v, source_origin=OriginType.PATH_PARAMETER
-                )
-        except Exception:
-            iast_propagation_listener_log_log("Unexpected exception while tainting path parameters", exc_info=True)

--- a/ddtrace/contrib/internal/starlette/patch.py
+++ b/ddtrace/contrib/internal/starlette/patch.py
@@ -169,9 +169,9 @@ def traced_handler(wrapped, instance, args, kwargs):
 
     if request_spans:
         if asm_config._iast_enabled:
-            from ddtrace.appsec._iast._patch import _iast_instrument_starlette_scope
+            from ddtrace.appsec._iast._handlers import _iast_instrument_starlette_scope
 
-            _iast_instrument_starlette_scope(scope)
+            _iast_instrument_starlette_scope(scope, request_spans[0].get_tag(http.ROUTE))
 
         trace_utils.set_http_meta(
             request_spans[0],


### PR DESCRIPTION
Splitting this pull request https://github.com/DataDog/dd-trace-py/pull/13347 into smaller pieces. For IAST, we need to pass the route to the `_iast_instrument_starlette_scope` function.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
