### PR TITLE
chore(et): improve error_tracking documentation

### DIFF
--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -151,7 +151,7 @@ Automatic Instrumentation
 
 .. important::
 
-  This feature is available on Python3.10+ and ddtrace 3.8.0+
+  This feature is available on Python3.10+ and ddtrace 3.8.0+.
 
 To enable automatic reporting of handled errors, you can set one of the two environment variables:
 
@@ -178,7 +178,7 @@ Manual Instrumentation
 
 .. important::
 
-  This feature is available in ddtrace 3.1.1+
+  This feature is available in ddtrace 3.1.1+.
 
 You can report handled errors manually using ``span.record_exception(e)``::
 

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -143,6 +143,9 @@ the ``set_asyncio_event_loop_policy`` method::
 Error Tracking
 ~~~~~~~~~~~~~~
 
+``dd-trace`` can report handled errors. Reported errors will be directly available
+in Error Tracking as well as attached as a span event to the span in which they were handled.
+
 Automatic Instrumentation
 -------------------------
 
@@ -153,14 +156,15 @@ Automatic Instrumentation
 To enable automatic reporting of handled errors, you can set one of the two environment variables:
 
 - ``DD_ERROR_TRACKING_HANDLED_ERRORS`` = ``user|third_party|all``. Report handled errors of: user code, third party packages or both.
-- ``DD_ERROR_TRACKING_HANDLED_ERRORS_INCLUDE`` = ``module1, module2...``. List of modules for which you want to report handled errors.
+- ``DD_ERROR_TRACKING_HANDLED_ERRORS_INCLUDE`` = ``module1, module2...``. List of modules for which handled errors will be reported.
 
-You need to specify the full name of the module. For instance, to instrument the module `security` in your `mysite` app, you need to specify
-`mysite.security`
+  To include a module, you need to specify its full name. For instance, to instrument the module ``security`` in your ``mysite`` app,
+  you need to specify ``mysite.security``. Note that when instrumenting a module, all the submodules are also instrumented.
 
-Handled errors will be report in Error Tracking and attached to spans through span events.
+  You can also use this variable to choose the third-party packages you want to instrument. For instance, providing ``numpy`` will report
+  all the errors from the package.
 
-If you are on Python3.10 or Python3.11 and you want to instrument ``__main__`` module, you need to add::
+If you are on Python3.10 or Python3.11, and you want to instrument the ``__main__`` module, you need to add::
 
   from ddtrace.errortracking._handled_exceptions.bytecode_reporting import instrument_main
 
@@ -171,6 +175,10 @@ This code should be added after the functions definitions with handled errors.
 
 Manual Instrumentation
 ----------------------
+
+.. important::
+
+  This feature is available in ddtrace 3.1.1+
 
 You can report handled errors manually using ``span.record_exception(e)``::
 
@@ -183,8 +191,6 @@ You can report handled errors manually using ``span.record_exception(e)``::
     if span:
       span.record_exception(e)
 
-This call will create a span event on the span with the error information and will report
-the error to Error Tracking.
 You can also provide additional attributes using::
 
   span.record_exception(e, {"foo": "bar"})


### PR DESCRIPTION
## Description

Improves and corrects documentation in the Error Tracking section of `basic_usage.rst`

## Motivation

While writing the Ruby documentation, I found that the python one was missing some precision on the `_INCLUDE` env variable. 

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
