### PR TITLE
[MLOB-2776] full litellm instrumentation

### DIFF
--- a/ddtrace/contrib/internal/litellm/patch.py
+++ b/ddtrace/contrib/internal/litellm/patch.py
@@ -126,6 +126,8 @@ def patch():
     Pin().onto(litellm)
     integration = LiteLLMIntegration(integration_config=config.litellm)
     litellm._datadog_integration = integration
+    # attach litellm module to integration
+    integration._litellm_module = litellm
 
     wrap("litellm", "completion", traced_completion(litellm))
     wrap("litellm", "acompletion", traced_acompletion(litellm))

--- a/ddtrace/contrib/internal/litellm/patch.py
+++ b/ddtrace/contrib/internal/litellm/patch.py
@@ -52,7 +52,7 @@ def _traced_completion(litellm, pin, func, instance, args, kwargs, is_completion
         func.__name__,
         model=model,
         host=host,
-        submit_to_llmobs=integration.should_submit_to_llmobs(kwargs, model),
+        submit_to_llmobs=True,
     )
     stream = kwargs.get("stream", False)
     resp = None
@@ -85,7 +85,7 @@ async def _traced_acompletion(litellm, pin, func, instance, args, kwargs, is_com
         func.__name__,
         model=model,
         host=host,
-        submit_to_llmobs=integration.should_submit_to_llmobs(kwargs, model),
+        submit_to_llmobs=True,
     )
     stream = kwargs.get("stream", False)
     resp = None

--- a/ddtrace/contrib/internal/litellm/patch.py
+++ b/ddtrace/contrib/internal/litellm/patch.py
@@ -53,6 +53,7 @@ def _traced_completion(litellm, pin, func, instance, args, kwargs, is_completion
         model=model,
         host=host,
         submit_to_llmobs=True,
+        span_name = func.__name__,
     )
     stream = kwargs.get("stream", False)
     resp = None
@@ -86,6 +87,7 @@ async def _traced_acompletion(litellm, pin, func, instance, args, kwargs, is_com
         model=model,
         host=host,
         submit_to_llmobs=True,
+        span_name = func.__name__,
     )
     stream = kwargs.get("stream", False)
     resp = None

--- a/ddtrace/contrib/internal/litellm/patch.py
+++ b/ddtrace/contrib/internal/litellm/patch.py
@@ -53,7 +53,6 @@ def _traced_completion(litellm, pin, func, instance, args, kwargs, is_completion
         model=model,
         host=host,
         submit_to_llmobs=integration.should_submit_to_llmobs(kwargs, model),
-        span_name = func.__name__,
     )
     stream = kwargs.get("stream", False)
     resp = None
@@ -87,7 +86,6 @@ async def _traced_acompletion(litellm, pin, func, instance, args, kwargs, is_com
         model=model,
         host=host,
         submit_to_llmobs=integration.should_submit_to_llmobs(kwargs, model),
-        span_name = func.__name__,
     )
     stream = kwargs.get("stream", False)
     resp = None

--- a/ddtrace/contrib/internal/litellm/patch.py
+++ b/ddtrace/contrib/internal/litellm/patch.py
@@ -52,7 +52,7 @@ def _traced_completion(litellm, pin, func, instance, args, kwargs, is_completion
         func.__name__,
         model=model,
         host=host,
-        submit_to_llmobs=True,
+        submit_to_llmobs=integration.should_submit_to_llmobs(kwargs, model),
         span_name = func.__name__,
     )
     stream = kwargs.get("stream", False)
@@ -86,7 +86,7 @@ async def _traced_acompletion(litellm, pin, func, instance, args, kwargs, is_com
         func.__name__,
         model=model,
         host=host,
-        submit_to_llmobs=True,
+        submit_to_llmobs=integration.should_submit_to_llmobs(kwargs, model),
         span_name = func.__name__,
     )
     stream = kwargs.get("stream", False)

--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -27,6 +27,7 @@ SPAN_START_WHILE_DISABLED_WARNING = (
 
 GEMINI_APM_SPAN_NAME = "gemini.request"
 LANGCHAIN_APM_SPAN_NAME = "langchain.request"
+LITELLM_APM_SPAN_NAME = "litellm.request"
 OPENAI_APM_SPAN_NAME = "openai.request"
 VERTEXAI_APM_SPAN_NAME = "vertexai.request"
 CREWAI_APM_SPAN_NAME = "crewai.request"

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -300,9 +300,6 @@ def openai_set_meta_tags_from_completion(span: Span, kwargs: Dict[str, Any], com
     parameters = {
         k: v for k, v in kwargs.items() if k not in ("model", "prompt", "api_key", "user_api_key", "user_api_key_hash")
     }
-    # add model to metadata if it's a litellm client request
-    if span.name == "litellm.request" and kwargs.get("api_base", None) and "model" in kwargs:
-        parameters["model"] = kwargs["model"]
     output_messages = [{"content": ""}]
     if not span.error and completions:
         choices = getattr(completions, "choices", completions)
@@ -329,9 +326,6 @@ def openai_set_meta_tags_from_chat(span: Span, kwargs: Dict[str, Any], messages:
         for k, v in kwargs.items()
         if k not in ("model", "messages", "tools", "functions", "api_key", "user_api_key", "user_api_key_hash")
     }
-    # add model to metadata if it's a litellm client request
-    if span.name == "litellm.request" and kwargs.get("api_base", None) and "model" in kwargs:
-        parameters["model"] = kwargs["model"]
     span._set_ctx_items({INPUT_MESSAGES: input_messages, METADATA: parameters})
 
     if span.error or not messages:

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -300,6 +300,9 @@ def openai_set_meta_tags_from_completion(span: Span, kwargs: Dict[str, Any], com
     parameters = {
         k: v for k, v in kwargs.items() if k not in ("model", "prompt", "api_key", "user_api_key", "user_api_key_hash")
     }
+    # add model to metadata if it's a litellm client request
+    if span.name == "litellm.request" and kwargs.get("api_base", None) and "model" in kwargs:
+        parameters["model"] = kwargs["model"]
     output_messages = [{"content": ""}]
     if not span.error and completions:
         choices = getattr(completions, "choices", completions)
@@ -326,6 +329,9 @@ def openai_set_meta_tags_from_chat(span: Span, kwargs: Dict[str, Any], messages:
         for k, v in kwargs.items()
         if k not in ("model", "messages", "tools", "functions", "api_key", "user_api_key", "user_api_key_hash")
     }
+    # add model to metadata if it's a litellm client request
+    if span.name == "litellm.request" and kwargs.get("api_base", None) and "model" in kwargs:
+        parameters["model"] = kwargs["model"]
     span._set_ctx_items({INPUT_MESSAGES: input_messages, METADATA: parameters})
 
     if span.error or not messages:

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -16,6 +16,7 @@ from ddtrace.llmobs._constants import INTERNAL_CONTEXT_VARIABLE_KEYS
 from ddtrace.llmobs._constants import INTERNAL_QUERY_VARIABLE_KEYS
 from ddtrace.llmobs._constants import IS_EVALUATION_SPAN
 from ddtrace.llmobs._constants import LANGCHAIN_APM_SPAN_NAME
+from ddtrace.llmobs._constants import LITELLM_APM_SPAN_NAME
 from ddtrace.llmobs._constants import ML_APP
 from ddtrace.llmobs._constants import NAME
 from ddtrace.llmobs._constants import OPENAI_APM_SPAN_NAME
@@ -33,6 +34,7 @@ STANDARD_INTEGRATION_SPAN_NAMES = (
     GEMINI_APM_SPAN_NAME,
     LANGCHAIN_APM_SPAN_NAME,
     VERTEXAI_APM_SPAN_NAME,
+    LITELLM_APM_SPAN_NAME,
 )
 
 

--- a/tests/contrib/litellm/test_litellm_llmobs.py
+++ b/tests/contrib/litellm/test_litellm_llmobs.py
@@ -219,7 +219,7 @@ class TestLLMObsLiteLLM:
                     pass
 
         assert len(llmobs_events) == 1
-        assert llmobs_events[0]["name"] == "OpenAI.createChatCompletion" if not stream else "litellm.request"
+        assert llmobs_events[0]["name"] == "OpenAI.createChatCompletion" if not stream else "completion"
 
     def test_completion_proxy(self, litellm, request_vcr_include_localhost, llmobs_events, mock_tracer, stream, n):
         with request_vcr_include_localhost.use_cassette(get_cassette_name(stream, n, proxy=True)):

--- a/tests/contrib/litellm/utils.py
+++ b/tests/contrib/litellm/utils.py
@@ -137,6 +137,30 @@ def parse_response(resp, is_completion=False):
     }
     return output_messages, token_metrics
 
+def get_litellm_metadata(stream, n, include_usage=True, tool_choice=None, include_router_settings=True, api_base=None, model=None):
+    metadata = {
+        "stream": stream,
+        "n": n,
+        "stream_options": {
+            "include_usage": include_usage,
+        },
+    }
+    if include_router_settings:
+        metadata["router_settings"] = {
+            "router_general_settings": None,
+            "routing_strategy": None,
+            "routing_strategy_args": None,
+            "provider_budget_config": None,
+            "retry_policy": None,
+            "model_list": [],
+        }
+    if tool_choice:
+        metadata["tool_choice"] = tool_choice
+    if api_base:
+        metadata["api_base"] = api_base
+    if model:
+        metadata["model"] = model
+    return metadata
 
 tools = [
     {


### PR DESCRIPTION
This PR makes the following changes to the LiteLLM integration:

1. Updates the span names for LiteLLM LLM Obs spans from `litellm.request` to the function name (e.g. `completion`, `acompletion`, etc.) which will help distinguish spans in the case that there is more than one LLM Obs span from LiteLLM from a single request.
2. Updates the logic for when to submit LiteLLM spans to LLM Obs. Previously, we would submit LLM Obs spans from the LiteLLM integration as long as the request was not a client calling the LiteLLM proxy OR the LLM request was not going to be captured by the Open AI integration. Now the behavior is that we always submit LLM Obs spans except if the proxy is not being used AND the LLM request will not be captured from within the Open AI integration. This results in more complete coverage of the request.
3. Additionally, this PR adds routing metadata to proxy spans submitted from the LiteLLM integration.

# Examples

## Using proxy server only
[Chat completion request](https://dd.datad0g.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&llmPanels=%5B%7B%22t%22%3A%22sampleDetailPanel%22%2C%22rEID%22%3A%22AwAAAZbUjsVw0Wa0sgAAABhBWmJVanNWd0FBQS02Z2djVWd1VUFBQUEAAAAkMDE5NmQ0OGUtYzU3MS00MTU2LWE2ZTMtNmRiZTVhYmNhY2ZmAAAAAQ%22%7D%5D&sidepanelTab=trace&spanId=13658129256296168811&start=1747322055909&end=1747322955909&paused=false)
```
curl -X POST 'http://0.0.0.0:4000/chat/completions' \
-H 'Content-Type: application/json' \
-d '{
    "model": "gpt-3.5-turbo",
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful math tutor. Guide the user through the solution step by step."
      },
      {
        "role": "user",
        "content": "how can I solve 8x + 7 = -23"
      }
    ]
}'
```
![image](https://github.com/user-attachments/assets/fb1e970e-ce43-40c4-9346-abd98c0ff80d)


[Text completion request](https://dd.datad0g.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&llmPanels=%5B%7B%22t%22%3A%22sampleDetailPanel%22%2C%22rEID%22%3A%22AwAAAZbUkBQo_nUzzAAAABhBWmJVa0JRb0FBQ29ia092WkhpRkFBQUEAAAAkMDE5NmQ0OTAtMTQyYi00MWE5LTg4MjEtZDhlZjNjN2ZmYzhmAAAABA%22%7D%5D&sidepanelTab=trace&spanId=13591958454851212344&start=1747322112921&end=1747323012921&paused=false)
```
curl -X POST 'http://0.0.0.0:4000/completions' \     
-H 'Content-Type: application/json' \
-d '{
    "model": "gpt-3.5-turbo",
    "prompt": "How are you today?"
}'
```
![image](https://github.com/user-attachments/assets/0399bac7-a168-4eaf-b45a-e401531f248c)


## Using Open AI / Anthropic / etc interface to route requests to the proxy
[Regular chat completion request](https://dd.datad0g.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&llmPanels=%5B%7B%22t%22%3A%22sampleDetailPanel%22%2C%22rEID%22%3A%22AwAAAZbVBryNg4GHtwAAABhBWmJWQnJ5TkFBQU5XVFQ1UkRsYUFBQUEAAAAkMDE5NmQ1MDYtZDcwOC00NDZlLWJjNTUtMWU5MzY1OWRmOTExAAAABw%22%7D%5D&sidepanelTab=trace&spanId=14925876530859606099&start=1747329825108&end=1747330725108&paused=false)
```
import os
import openai
client = openai.OpenAI(
    api_key=os.environ["OPENAI_API_KEY"],
    base_url="http://0.0.0.0:4000"
)

response = client.chat.completions.create(
    model="gpt-3.5-turbo",
    messages = [
        {
            "role": "user",
            "content": "this is a test request, write a short poem"
        }
    ],
)
```
![image](https://github.com/user-attachments/assets/ef5f7541-0a3f-48da-bfc4-55ba297609ca)


## Using LiteLLM SDK to route requests to the proxy
[Regular chat completion](https://dd.datad0g.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&llmPanels=%5B%7B%22t%22%3A%22sampleDetailPanel%22%2C%22rEID%22%3A%22AwAAAZbUiguACTNQrQAAABhBWmJVaWd1QUFBRGVkdHlscHNXM0FBQUEAAAAkMDE5NmQ0OGEtMTFiMS00ODkzLWFjMGQtNmE4ZjVhNzM5MTgwAAAAEA%22%7D%5D&sidepanelTab=trace&spanId=222005630019449499&start=1747321652351&end=1747322552351&paused=false)
```
response = completion(model="gpt-3.5-turbo", messages=messages, api_base="http://0.0.0.0:4000", n=n, stream=stream)
```
![image](https://github.com/user-attachments/assets/26cfda98-dd2f-464b-9ee9-41c79a0c6661)


[Asynchronous text completion](https://dd.datad0g.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&llmPanels=%5B%7B%22t%22%3A%22sampleDetailPanel%22%2C%22rEID%22%3A%22AwAAAZbUihGei2PlegAAABhBWmJVaWhHZUFBRFJkSVczNjFZWkFBQUEAAAAkMDE5NmQ0OGEtMTFiMS00ODkzLWFjMGQtNmE4ZjVhNzM5MTgwAAAABg%22%7D%5D&sidepanelTab=trace&spanId=2683498521329145475&start=1747321652351&end=1747322552351&paused=false)
```
response = await atext_completion(model="gpt-3.5-turbo", prompt=prompt, api_base="http://0.0.0.0:4000", n=n, stream=stream)
```
![image](https://github.com/user-attachments/assets/96a34c92-9449-409d-a545-51a002f4b5c3)



## Using LiteLLM SDK (no proxy)
[Regular chat completion request (with Open AI enabled)](https://dd.datad0g.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&llmPanels=%5B%7B%22t%22%3A%22sampleDetailPanel%22%2C%22rEID%22%3A%22AwAAAZbVAxQEiUwcWwAAABhBWmJWQXhRRUFBQnU5dHVMR0ZfU0FBQUEAAAAkMDE5NmQ1MDMtMTQwNC00NmE3LTk0NTEtMDg0M2JiMDBmMzNkAAAAAA%22%7D%5D&sidepanelTab=trace&spanId=15403865905705224088&start=1747329609258&end=1747330509258&paused=false)
```
response = completion(model="gpt-3.5-turbo", messages=messages, n=n, stream=stream)
```

![image](https://github.com/user-attachments/assets/86dc3bba-49d6-40b5-a9f8-0cf1c0018eb5)

[Regular chat completion request (with Open AI disabled)](https://dd.datad0g.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&llmPanels=%5B%7B%22t%22%3A%22sampleDetailPanel%22%2C%22rEID%22%3A%22AwAAAZbVA68lzo2eigAAABhBWmJWQTY4bEFBQVZ0WFRpRkFWbUFBQUEAAAAkMDE5NmQ1MDMtYjkxYS00M2YxLTgxY2QtOWM1NGExYmI3NTk0AAAAAg%22%7D%5D&sidepanelTab=trace&spanId=6785600910041033499&start=1747329650030&end=1747330550030&paused=false)
```
response = completion(model="gpt-3.5-turbo", messages=messages, n=n, stream=stream)
```

![image](https://github.com/user-attachments/assets/63bf6561-d0b7-445b-bee6-7b61f507ba27)


## Example using Tag-Based Routing
Config yaml for tag based routing where providing tags in the request helps the proxy determine which model to use.
```
model_list:
  - model_name: gpt-3.5-turbo
    litellm_params:
      model: openai/gpt-4o
      api_key: "os.environ/OPENAI_API_KEY"
      temperature: 0.2
      tags: ["pick-me"]
  - model_name: gpt-3.5-turbo
    litellm_params:
      model: openai/gpt-3.5-turbo
      api_key: "os.environ/OPENAI_API_KEY"
      temperature: 0.2
      tags: ["dont-pick-me"]

router_settings:
  enable_tag_filtering: True
```

This [trace](https://dd.datad0g.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&llmPanels=%5B%7B%22t%22%3A%22sampleDetailPanel%22%2C%22rEID%22%3A%22AwAAAZbZeQSUx4I5SwAAABhBWmJaZVFTVUFBQWxhNDRTTUNVcEFBQUEAAABdMDE5NmQ5NzktNDcwNS00ZjA5LTliMWMtYjgzMjE4OGQzYmViLXN5bnRoZXRpYy10aW1lLTE3NDc0MDQwMDAwMDAwMDAwMDBjLTE3NDc0MDUzMjYwODUwMDAwMDFvAAAADQ%22%7D%5D&sidepanelTab=trace&spanId=7126614061495521498&start=1747404524272&end=1747405424272&paused=false) results from the following request, where the model picked is `gpt-4o` because of the `pick-me` tag. The metadata on the workflow span includes the fact that the `pick-me` tag was included in the request and also notes which tags are associated with which models in the model list.
```
curl -i http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-3.5-turbo",
    "messages": [
      {"role": "user", "content": "Heyyyyyy"}
    ],
    "tags": ["pick-me"]
  }
'
```

## Example using Budget Routing

The following config yaml includes provider budget configurations.
```
model_list:
    - model_name: gpt-3.5-turbo
      litellm_params:
        model: openai/gpt-3.5-turbo
        api_key: os.environ/OPENAI_API_KEY

router_settings:
  provider_budget_config: 
    openai: 
      budget_limit: 0.000000000001
      time_period: 1d 
```

Running the following curl command leads to this [trace](https://dd.datad0g.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&llmPanels=%5B%7B%22t%22%3A%22sampleDetailPanel%22%2C%22rEID%22%3A%22AwAAAZbZxFvi9Ggw6wAAABhBWmJaeEZ2aUFBQm56UXUyeFFQb0FBQUEAAAAkMDE5NmQ5YzQtNWJmNS00YjZlLWI1MDAtOTJjZWRiMmMxMTljAAAAAg%22%7D%5D&sidepanelTab=trace&spanId=4691234302765559760&start=1747409447277&end=1747410347277&paused=false) where you can see the provider budget config in the workflow span's metadata.
```
curl -i http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-3.5-turbo",
    "messages": [
      {"role": "user", "content": "Heyyyyyy"}
    ],
  }
'
```
**NOTE**: A subsequent LLM call will fail to produce *any* LLM Obs span since the budget is exceeded. Additional instrumentation beyond what is implemented in this PR will need to be added in order to capture information about these types of errors.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
