### PR TITLE
chore(ci): use datadog/ensure-ci-success instead of wechuli/allcheckspassed

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -14,7 +14,7 @@ jobs:
       checks: read
       contents: read
     steps:
-      - uses: DataDog/ensure-ci-success@f40e6ffd8e60280d478b9b92209aaa30d3d56895
+      - uses: DataDog/ensure-ci-success@727e7fe39ae2e1ce7ea336ec85a7369ab0731754 # v2.1.1
         with:
           initial-delay-seconds: 10  # wait for this delay before starting
           polling-interval-seconds: 1 # after a failure, how long do it wait before checking again

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -8,17 +8,21 @@ concurrency:
 
 jobs:
   all-green:
+    name: all-green  # do not change this name, see https://github.com/DataDog/ensure-ci-success/blob/main/docs/limitations.md
     runs-on: ubuntu-latest
     permissions:
       checks: read
       contents: read
     steps:
-      - uses: wechuli/allcheckspassed@e22f45a4f25f4cf821d1273705ac233355400db1
+      - uses: DataDog/ensure-ci-success@f40e6ffd8e60280d478b9b92209aaa30d3d56895
         with:
-          delay: 10  # wait for this delay before starting
-          polling_interval: 1 # after a failure, how long do it wait before checking again
-          retries: 60  # how many retries before stopping 
-          checks_exclude: 'Bootstrap import analysis,require-checklist,Validate changelog'
+          initial-delay-seconds: 10  # wait for this delay before starting
+          polling-interval-seconds: 1 # after a failure, how long do it wait before checking again
+          max-retries: 60  # how many retries before stopping 
+          ignored-name-patterns: |
+            Bootstrap import analysis
+            require-checklist
+            Validate changelog
 
 # Why some checks are excluded?
 #


### PR DESCRIPTION
This action offers several advantages : 

* it checks status from gitlab (which is THE main advantage)
* it perform an initial check if the job is retried, saving some time
* it's not subject to API limitation (the API call used in `wechuli/allcheckspassed` is limited to 1000 runs)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
