### PR TITLE
fix(tracing): make context picklable

### DIFF
--- a/ddtrace/_trace/context.py
+++ b/ddtrace/_trace/context.py
@@ -30,6 +30,7 @@ _ContextState = Tuple[
     List[SpanLink],  #  span_links
     Dict[str, Any],  # baggage
     bool,  # is_remote
+    bool, # _reactivate
 ]
 
 
@@ -104,11 +105,21 @@ class Context(object):
             self._span_links,
             self._baggage,
             self._is_remote,
+            self._reactivate,
             # Note: self._lock is not serializable
         )
 
     def __setstate__(self, state: _ContextState) -> None:
-        self.trace_id, self.span_id, self._meta, self._metrics, self._span_links, self._baggage, self._is_remote = state
+        (
+            self.trace_id,
+            self.span_id,
+            self._meta,
+            self._metrics,
+            self._span_links,
+            self._baggage,
+            self._is_remote,
+            self._reactivate,
+        ) = state
         # We cannot serialize and lock, so we must recreate it unless we already have one
         self._lock = threading.RLock()
 

--- a/releasenotes/notes/make-reactivate-serializable-4228bdd7a01f6ebb.yaml
+++ b/releasenotes/notes/make-reactivate-serializable-4228bdd7a01f6ebb.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    tracing: Resolves a bug where pickling ``ddtrace.trace.Context`` broke distributed tracing in coroutines. This bug was introduced in v3.7.0.

--- a/tests/tracer/test_context.py
+++ b/tests/tracer/test_context.py
@@ -112,6 +112,14 @@ def test_context_serializable(context):
     assert context == restored
 
 
+def test_context_serializable_reactivate():
+    context = Context()
+    assert not context._reactivate, "default value should be False to maintain backwards compatibility"
+    context._reactivate = True
+    serialized_context = pickle.loads(pickle.dumps(context))
+    assert context._reactivate == serialized_context._reactivate
+
+
 @pytest.mark.parametrize(
     "context,expected_traceparent",
     [


### PR DESCRIPTION
Resolves: https://github.com/DataDog/dd-trace-py/issues/13409

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
