### PR TITLE
chore(iast): fix taint tracking in langchain 0.3.60

### DIFF
--- a/tests/appsec/integrations/langchain_tests/test_iast_langchain.py
+++ b/tests/appsec/integrations/langchain_tests/test_iast_langchain.py
@@ -29,7 +29,6 @@ from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast.constants import VULN_CMDI
 from tests.appsec.iast.conftest import iast_span_defaults  # noqa: F401
 from tests.appsec.iast.taint_sinks.conftest import _get_span_report
-from tests.utils import flaky
 
 
 TEST_FILE = "tests/appsec/integrations/langchain_tests/test_iast_langchain.py"
@@ -79,7 +78,6 @@ def test_openai_functions_agent_output_parser(iast_span_defaults):  # noqa: F811
     assert is_pyobject_tainted(result.tool_input["arg1"])
 
 
-@flaky(until=1752674136)
 def test_llm_generate(iast_span_defaults):  # noqa: F811
     llm = FakeListLLM(responses=["I am a fake LLM"])
     prompt = prepare_tainted_prompt()
@@ -87,7 +85,6 @@ def test_llm_generate(iast_span_defaults):  # noqa: F811
     assert is_pyobject_tainted(result)
 
 
-@flaky(until=1752674136)
 async def test_llm_agenerate(iast_span_defaults):  # noqa: F811
     llm = FakeListLLM(responses=["I am a fake LLM"])
     prompt = prepare_tainted_prompt()
@@ -95,7 +92,6 @@ async def test_llm_agenerate(iast_span_defaults):  # noqa: F811
     assert is_pyobject_tainted(result)
 
 
-@flaky(until=1752674136)
 def test_chatmodel_generate(iast_span_defaults):  # noqa: F811
     chatmodel = FakeListChatModel(responses=["I am a fake chat model"])
     prompt = prepare_tainted_prompt()
@@ -103,7 +99,6 @@ def test_chatmodel_generate(iast_span_defaults):  # noqa: F811
     assert is_pyobject_tainted(result.content)
 
 
-@flaky(until=1752674136)
 async def test_chatmodel_agenerate(iast_span_defaults):  # noqa: F811
     chatmodel = FakeListChatModel(responses=["I am a fake chat model"])
     prompt = prepare_tainted_prompt()
@@ -143,7 +138,6 @@ async def test_cmdi_with_shelltool_ainvoke(iast_span_defaults):  # noqa: F811
     assert span_report
 
 
-@flaky(until=1752674136)
 def test_cmdi_with_agent_invoke(iast_span_defaults):  # noqa: F811
     agent = prepare_cmdi_agent()
     prompt = prepare_tainted_prompt()
@@ -158,7 +152,6 @@ def test_cmdi_with_agent_invoke(iast_span_defaults):  # noqa: F811
     assert "class" not in location
 
 
-@flaky(until=1752674136)
 async def test_cmdi_with_agent_ainvoke(iast_span_defaults):  # noqa: F811
     agent = prepare_cmdi_agent()
     prompt = prepare_tainted_prompt()


### PR DESCRIPTION
* Langchain PR https://github.com/langchain-ai/langchain/pull/31238 released in langchain-core 0.3.60 changed the `text` field for generations, which uses to be a field and is now a property. We'll use `_text` when available.
* This reverts commit dba2b3e320a4a0995613fc80d47c7b45b04b133a (PR: https://github.com/DataDog/dd-trace-py/pull/13435)
* Not adding release notes since this only affects unreleased code in https://github.com/DataDog/dd-trace-py/pull/13256

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
