### PR TITLE
feat(llmobs): trace tool call outputs for oai agents sdk

### DIFF
--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -735,12 +735,9 @@ class OaiSpanAdapter:
                     except json.JSONDecodeError:
                         output = {"output": output}
                 tool_call_ids.append(item["call_id"])
-                processed_item["tool_calls"] = [
-                    {
-                        "tool_id": item["call_id"],
-                        "type": item.get("type", "function_call_output"),
-                    }
-                ]
+                processed_item["role"] = "tool"
+                processed_item["content"] = item["output"]
+                processed_item["tool_id"] = item["call_id"]
             if processed_item:
                 processed.append(processed_item)
 

--- a/releasenotes/notes/oai-tool-outputs-f12664426a1ba81e.yaml
+++ b/releasenotes/notes/oai-tool-outputs-f12664426a1ba81e.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    LLM Observability: This introduces tracing for the content of tool call outputs passed to LLM spans for the OpenAI Agents integration.

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -322,7 +322,7 @@ async def test_llmobs_single_agent_with_tool_calls_llmobs(
                             }
                         ]
                     },
-                    {"tool_calls": [{"tool_id": mock.ANY, "type": "function_call_output"}]},
+                    {"role": "tool", "content": mock.ANY, "tool_id": mock.ANY},
                 ],
                 [{"role": "assistant", "content": result.final_output}],
             ),
@@ -396,7 +396,7 @@ async def test_llmobs_multiple_agent_handoffs(agents, mock_tracer, request_vcr, 
                             }
                         ]
                     },
-                    {"tool_calls": [{"tool_id": mock.ANY, "type": "function_call_output"}]},
+                    {"role": "tool", "content": mock.ANY, "tool_id": mock.ANY},
                 ],
                 [
                     {"role": "assistant", "content": mock.ANY},
@@ -487,7 +487,7 @@ async def test_llmobs_single_agent_with_tool_errors(
                             }
                         ]
                     },
-                    {"tool_calls": [{"tool_id": mock.ANY, "type": "function_call_output"}]},
+                    {"role": "tool", "content": mock.ANY, "tool_id": mock.ANY},
                 ],
                 [{"role": "assistant", "content": result.final_output}],
             ),


### PR DESCRIPTION
Introduces support for tracing the content of tool call outputs passed back into LLM spans via a new `tool` message type
Tool message types also contain `role` (always tool) and `content`, but also has a new `tool_id` field

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
