### PR TITLE
feat(llmobs): trace system prompt in openai agents

### DIFF
--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -484,13 +484,6 @@ class OaiSpanAdapter:
         self._raw_oai_span = oai_span  # openai span data type
 
     @property
-    def instructions(self) -> Optional[str]:
-        """Get the instructions from the span data."""
-        if not hasattr(self._raw_oai_span, "span_data"):
-            return None
-        return getattr(self._raw_oai_span.span_data, "instructions", None)
-
-    @property
     def span_id(self) -> str:
         """Get the span ID."""
         return self._raw_oai_span.span_id

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -484,6 +484,13 @@ class OaiSpanAdapter:
         self._raw_oai_span = oai_span  # openai span data type
 
     @property
+    def instructions(self) -> Optional[str]:
+        """Get the instructions from the span data."""
+        if not hasattr(self._raw_oai_span, "span_data"):
+            return None
+        return getattr(self._raw_oai_span.span_data, "instructions", None)
+
+    @property
     def span_id(self) -> str:
         """Get the span ID."""
         return self._raw_oai_span.span_id
@@ -591,6 +598,13 @@ class OaiSpanAdapter:
         return self.response.output_text
 
     @property
+    def response_system_instructions(self) -> Optional[str]:
+        """Get the system instructions from the response."""
+        if not self.response:
+            return None
+        return getattr(self.response, "instructions", None)
+
+    @property
     def llmobs_model_name(self) -> Optional[str]:
         """Get the model name formatted for LLMObs."""
         if not hasattr(self._raw_oai_span, "span_data"):
@@ -686,6 +700,9 @@ class OaiSpanAdapter:
         messages = self.input
         processed: List[Dict[str, Any]] = []
         tool_call_ids: List[str] = []
+
+        if self.response_system_instructions:
+            processed.append({"role": "system", "content": self.response_system_instructions})
 
         if not messages:
             return processed, tool_call_ids

--- a/releasenotes/notes/oai-sys-prompt-46909baa4e9b44c1.yaml
+++ b/releasenotes/notes/oai-sys-prompt-46909baa4e9b44c1.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    LLM Observability: This introduces tracing for system prompts in the OpenAI Agents SDK.

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -130,7 +130,13 @@ async def test_llmobs_single_agent(agents, mock_tracer, request_vcr, llmobs_even
         tools=[],
         llm_calls=[
             (
-                [{"role": "user", "content": "What is the capital of France?"}],
+                [
+                    {
+                        "role": "system",
+                        "content": simple_agent.instructions,
+                    },
+                    {"role": "user", "content": "What is the capital of France?"},
+                ],
                 [{"role": "assistant", "content": result.final_output}],
             )
         ],
@@ -173,7 +179,13 @@ async def test_llmobs_streamed_single_agent(agents, mock_tracer, request_vcr, ll
         tools=[],
         llm_calls=[
             (
-                [{"role": "user", "content": "What is the capital of France?"}],
+                [
+                    {
+                        "role": "system",
+                        "content": simple_agent.instructions,
+                    },
+                    {"role": "user", "content": "What is the capital of France?"},
+                ],
                 [{"role": "assistant", "content": result.final_output}],
             )
         ],
@@ -209,7 +221,13 @@ def test_llmobs_single_agent_sync(agents, mock_tracer, request_vcr, llmobs_event
         tools=[],
         llm_calls=[
             (
-                [{"role": "user", "content": "What is the capital of France?"}],
+                [
+                    {
+                        "role": "system",
+                        "content": simple_agent.instructions,
+                    },
+                    {"role": "user", "content": "What is the capital of France?"},
+                ],
                 [{"role": "assistant", "content": result.final_output}],
             )
         ],
@@ -258,7 +276,13 @@ async def test_llmobs_manual_tracing_llmobs(agents, mock_tracer, request_vcr, ll
         tools=[],
         llm_calls=[
             (
-                [{"role": "user", "content": "What is the capital of France?"}],
+                [
+                    {
+                        "role": "system",
+                        "content": simple_agent.instructions,
+                    },
+                    {"role": "user", "content": "What is the capital of France?"},
+                ],
                 [{"role": "assistant", "content": result.final_output}],
             )
         ],
@@ -295,7 +319,10 @@ async def test_llmobs_single_agent_with_tool_calls_llmobs(
         tools=["add"],
         llm_calls=[
             (
-                [{"role": "user", "content": "What is the sum of 1 and 2?"}],
+                [
+                    {"role": "system", "content": addition_agent.instructions},
+                    {"role": "user", "content": "What is the sum of 1 and 2?"},
+                ],
                 [
                     {
                         "tool_calls": [
@@ -311,6 +338,7 @@ async def test_llmobs_single_agent_with_tool_calls_llmobs(
             ),
             (
                 [
+                    {"role": "system", "content": "You are a helpful assistant specialized in addition calculations."},
                     {"role": "user", "content": "What is the sum of 1 and 2?"},
                     {
                         "tool_calls": [
@@ -363,9 +391,13 @@ async def test_llmobs_multiple_agent_handoffs(agents, mock_tracer, request_vcr, 
             (
                 [
                     {
+                        "role": "system",
+                        "content": research_workflow.instructions,
+                    },
+                    {
                         "role": "user",
                         "content": "What is a brief summary of what happened yesterday in the soccer world??",
-                    }
+                    },
                 ],
                 [
                     {
@@ -382,6 +414,10 @@ async def test_llmobs_multiple_agent_handoffs(agents, mock_tracer, request_vcr, 
             ),
             (
                 [
+                    {
+                        "role": "system",
+                        "content": research_workflow.instructions,
+                    },
                     {
                         "content": "What is a brief summary of what happened yesterday in the soccer world??",
                         "role": "user",
@@ -460,7 +496,13 @@ async def test_llmobs_single_agent_with_tool_errors(
         tools=["add"],
         llm_calls=[
             (
-                [{"role": "user", "content": "What is the sum of 1 and 2?"}],
+                [
+                    {
+                        "role": "system",
+                        "content": addition_agent_with_tool_errors.instructions,
+                    },
+                    {"role": "user", "content": "What is the sum of 1 and 2?"},
+                ],
                 [
                     {
                         "tool_calls": [
@@ -476,6 +518,10 @@ async def test_llmobs_single_agent_with_tool_errors(
             ),
             (
                 [
+                    {
+                        "role": "system",
+                        "content": addition_agent_with_tool_errors.instructions,
+                    },
                     {"role": "user", "content": "What is the sum of 1 and 2?"},
                     {
                         "tool_calls": [


### PR DESCRIPTION
Parse `response.instructions` as the system prompt for llm spans in openai agents

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
