### PR TITLE
fix(llmobs): swap error type/message in openai agents sdk

### DIFF
--- a/ddtrace/llmobs/_integrations/openai_agents.py
+++ b/ddtrace/llmobs/_integrations/openai_agents.py
@@ -109,9 +109,10 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
             error_data = oai_span.get_error_data()
             span.error = 1
             """
-            Setting set type to "error message" since the OpenAI
-            Agents SDK usually sets error message to a concise string
-            describing the error, and the error data to the full error object.
+            The error message from openai agents is actually a more concise description of the error.
+            while the error data contains the full error object.
+            Thus, we set the LLM Obs span's error type to the openai span's error message
+            and the LLM Obs span's error message to the openai span's error data.
             """
             if error_msg:
                 span.set_tag("error.type", error_msg)

--- a/ddtrace/llmobs/_integrations/openai_agents.py
+++ b/ddtrace/llmobs/_integrations/openai_agents.py
@@ -108,10 +108,15 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
             error_msg = oai_span.get_error_message()
             error_data = oai_span.get_error_data()
             span.error = 1
+            """
+            Setting set type to "error message" since the OpenAI
+            Agents SDK usually sets error message to a concise string
+            describing the error, and the error data to the full error object.
+            """
             if error_msg:
-                span.set_tag("error.type", json.dumps(error_data))
+                span.set_tag("error.type", error_msg)
             if error_data and error_msg:
-                span.set_tag("error.message", error_msg)
+                span.set_tag("error.message", json.dumps(error_data))
 
         if span_type == "response":
             self._llmobs_set_response_attributes(span, oai_span)

--- a/releasenotes/notes/change-oai-error-e7b24f61c1cfdc83.yaml
+++ b/releasenotes/notes/change-oai-error-e7b24f61c1cfdc83.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    LLM Observability: This fix resolves an issue where error.message and error.type were swapped for the OpenAI Agents SDK, causing long error types.
+    LLM Observability: This fix resolves an issue where error type was being set to the full error data for OpenAI Agents SDK errors, causing long error types.

--- a/releasenotes/notes/change-oai-error-e7b24f61c1cfdc83.yaml
+++ b/releasenotes/notes/change-oai-error-e7b24f61c1cfdc83.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: This fix resolves an issue where error.message and error.type were swapped for the OpenAI Agents SDK, causing long error types.

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -78,8 +78,8 @@ def _assert_expected_agent_run(
             tool_call = tool_calls[i // 2]
             error_args = (
                 {
-                    "error": f'{{"tool_name": "{tool_call["tool_name"]}", "error": "This is a test error"}}',
-                    "error_message": "Error running tool (non-fatal)",
+                    "error_message": f'{{"tool_name": "{tool_call["tool_name"]}", "error": "This is a test error"}}',
+                    "error": "Error running tool (non-fatal)",
                 }
                 if tool_call["error"]
                 else {}


### PR DESCRIPTION
Swap error message & type for the openai agents sdk

The error data returned by openai is currently being set to the error type on the llm obs span. Since its verbose, this has caused some UX issues since error types are expected to be short.

The error "message" from oai agents tracing is actually more fit to be our error type, since its a concise message

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
