### PR TITLE
chore(iast): fix api version to send metastruct data if appsec is disabled

### DIFF
--- a/ddtrace/appsec/_iast/taint_sinks/code_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/code_injection.py
@@ -49,7 +49,7 @@ def unpatch():
 
 
 def _iast_coi(wrapped, instance, args, kwargs):
-    if len(args) >= 1 and asm_config.is_iast_request_enabled:
+    if len(args) >= 1:
         _iast_report_code_injection(args[0])
 
     caller_frame = None

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -479,7 +479,13 @@ class AgentWriter(HTTPWriter):
         is_windows = sys.platform.startswith("win") or sys.platform.startswith("cygwin")
 
         default_api_version = "v0.5"
-        if is_windows or in_gcp_function() or in_azure_function() or asm_config._asm_enabled:
+        if (
+            is_windows
+            or in_gcp_function()
+            or in_azure_function()
+            or asm_config._asm_enabled
+            or asm_config._iast_enabled
+        ):
             default_api_version = "v0.4"
 
         self._api_version = api_version or config._trace_api or default_api_version

--- a/tests/appsec/app.py
+++ b/tests/appsec/app.py
@@ -217,6 +217,15 @@ def iast_header_injection_vulnerability():
     return resp
 
 
+@app.route("/iast-code-injection", methods=["GET"])
+def iast_code_injection_vulnerability():
+    filename = request.args.get("filename")
+    a = ""  # noqa: F841
+    c = eval("a + '" + filename + "'")
+    resp = Response(f"OK:{tracer._span_aggregator.writer._api_version}:{c}")
+    return resp
+
+
 @app.route("/shutdown", methods=["GET"])
 def shutdown_view():
     tracer._span_aggregator.writer.flush_queue()

--- a/tests/appsec/appsec_utils.py
+++ b/tests/appsec/appsec_utils.py
@@ -44,7 +44,7 @@ def gunicorn_server(
 @contextmanager
 def flask_server(
     python_cmd="python",
-    appsec_enabled="true",
+    appsec_enabled="false",
     remote_configuration_enabled="true",
     iast_enabled="false",
     tracer_enabled="true",

--- a/tests/appsec/integrations/django_tests/conftest.py
+++ b/tests/appsec/integrations/django_tests/conftest.py
@@ -67,9 +67,17 @@ def tracer():
 
 @pytest.fixture
 def test_spans(tracer):
+    container = TracerSpanContainer(tracer)
+    yield container
+    container.reset()
+
+
+@pytest.fixture
+def iast_span(tracer):
     with override_global_config(
         dict(
             _iast_enabled=True,
+            _appsec_enabled=False,
             _iast_deduplication_enabled=False,
             _iast_request_sampling=100.0,
         )

--- a/tests/appsec/integrations/django_tests/test_django_appsec_iast.py
+++ b/tests/appsec/integrations/django_tests/test_django_appsec_iast.py
@@ -5,6 +5,7 @@ import pytest
 
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._constants import IAST_SPAN_TAGS
+from ddtrace.appsec._constants import STACK_TRACE
 from ddtrace.appsec._iast.constants import VULN_CMDI
 from ddtrace.appsec._iast.constants import VULN_HEADER_INJECTION
 from ddtrace.appsec._iast.constants import VULN_INSECURE_COOKIE
@@ -18,9 +19,15 @@ from tests.utils import override_global_config
 TEST_FILE = "tests/appsec/integrations/django_tests/django_app/views.py"
 
 
+def get_iast_stack_trace(root_span):
+    appsec_traces = root_span.get_struct_tag(STACK_TRACE.TAG) or {}
+    stacks = appsec_traces.get("vulnerability", [])
+    return stacks
+
+
 def _aux_appsec_get_root_span(
     client,
-    test_spans,
+    iast_span,
     tracer,
     payload=None,
     url="/",
@@ -44,12 +51,12 @@ def _aux_appsec_get_root_span(
             response = client.post(url, payload, content_type=content_type, **headers)
         else:
             response = client.post(url, payload, content_type=content_type)
-    return test_spans.spans[0], response
+    return iast_span.spans[0], response
 
 
 def _aux_appsec_get_root_span_with_exception(
     client,
-    test_spans,
+    iast_span,
     tracer,
     payload=None,
     url="/",
@@ -60,7 +67,7 @@ def _aux_appsec_get_root_span_with_exception(
     try:
         return _aux_appsec_get_root_span(
             client,
-            test_spans,
+            iast_span,
             tracer,
             payload=payload,
             url=url,
@@ -73,8 +80,8 @@ def _aux_appsec_get_root_span_with_exception(
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_weak_hash(client, test_spans, tracer):
-    root_span, _ = _aux_appsec_get_root_span(client, test_spans, tracer, url="/appsec/weak-hash/")
+def test_django_weak_hash(client, iast_span, tracer):
+    root_span, _ = _aux_appsec_get_root_span(client, iast_span, tracer, url="/appsec/weak-hash/")
     str_json = root_span.get_tag(IAST.JSON)
     assert str_json is not None, "no JSON tag in root span"
     vulnerability = json.loads(str_json)["vulnerabilities"][0]
@@ -89,8 +96,8 @@ def test_django_weak_hash(client, test_spans, tracer):
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_weak_hash_span_metrics(client, test_spans, tracer):
-    root_span, _ = _aux_appsec_get_root_span(client, test_spans, tracer, url="/appsec/weak-hash/")
+def test_django_weak_hash_span_metrics(client, iast_span, tracer):
+    root_span, _ = _aux_appsec_get_root_span(client, iast_span, tracer, url="/appsec/weak-hash/")
     assert root_span.get_metric(IAST.ENABLED) == 1.0
     assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK + ".weak_hash") == 1.0
     assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK + ".header_injection") > 1.0
@@ -111,10 +118,10 @@ def test_django_weak_hash_span_metrics_disabled(client, iast_spans_with_zero_sam
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_tainted_user_agent_iast_enabled(client, test_spans, tracer):
+def test_django_tainted_user_agent_iast_enabled(client, iast_span, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         payload=urlencode({"mytestingbody_key": "mytestingbody_value"}),
         content_type="application/x-www-form-urlencoded",
@@ -151,13 +158,13 @@ def test_django_tainted_user_agent_iast_enabled(client, test_spans, tracer):
     ],
 )
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_view_with_exception(client, test_spans, tracer, payload, content_type, deduplication, sampling):
+def test_django_view_with_exception(client, iast_span, tracer, payload, content_type, deduplication, sampling):
     with override_global_config(
         dict(_iast_enabled=True, _iast_deduplication_enabled=deduplication, _iast_request_sampling=sampling)
     ):
         response = _aux_appsec_get_root_span_with_exception(
             client,
-            test_spans,
+            iast_span,
             tracer,
             content_type=content_type,
             url="/appsec/view_with_exception/?q=" + payload,
@@ -167,11 +174,11 @@ def test_django_view_with_exception(client, test_spans, tracer, payload, content
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_tainted_user_agent_iast_disabled(client, test_spans, tracer):
+def test_django_tainted_user_agent_iast_disabled(client, iast_span, tracer):
     with override_global_config(dict(_iast_enabled=False, _iast_deduplication_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
-            test_spans,
+            iast_span,
             tracer,
             payload=urlencode({"mytestingbody_key": "mytestingbody_value"}),
             content_type="application/x-www-form-urlencoded",
@@ -187,10 +194,10 @@ def test_django_tainted_user_agent_iast_disabled(client, test_spans, tracer):
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_sqli_http_request_parameter_metrics(client, test_spans, tracer):
+def test_django_sqli_http_request_parameter_metrics(client, iast_span, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         payload=urlencode({"SELECT": "unused"}),
         content_type="application/x-www-form-urlencoded",
@@ -233,10 +240,10 @@ def test_django_sqli_http_request_parameter_metrics_disabled(client, iast_spans_
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_sqli_http_request_parameter(client, test_spans, tracer):
+def test_django_sqli_http_request_parameter(client, iast_span, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         payload=urlencode({"mytestingbody_key": "mytestingbody_value"}),
         content_type="application/x-www-form-urlencoded",
@@ -272,7 +279,6 @@ def test_django_sqli_http_request_parameter(client, test_spans, tracer):
             {"value": "'"},
         ]
     }
-    print(loaded["vulnerabilities"][0]["location"])
     assert loaded["vulnerabilities"][0]["location"]["path"] == TEST_FILE
     assert loaded["vulnerabilities"][0]["location"]["line"] == line
     assert loaded["vulnerabilities"][0]["location"]["spanId"] > 0
@@ -284,10 +290,10 @@ def test_django_sqli_http_request_parameter(client, test_spans, tracer):
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_sqli_http_request_parameter_name_get(client, test_spans, tracer):
+def test_django_sqli_http_request_parameter_name_get_and_stacktrace(client, iast_span, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         content_type="application/x-www-form-urlencoded",
         url="/appsec/sqli_http_request_parameter_name_get/?SELECT=unused",
@@ -299,8 +305,11 @@ def test_django_sqli_http_request_parameter_name_get(client, test_spans, tracer)
     assert response.status_code == 200
     assert response.content == b"test/1.2.3"
 
-    loaded = json.loads(root_span.get_tag(IAST.JSON))
+    # api_version = iast_span.tracer._span_aggregator.writer._api_version
+    # assert api_version == "v0.4", f"Agent API version {api_version} not supported"
 
+    loaded = json.loads(root_span.get_tag(IAST.JSON))
+    assert get_iast_stack_trace(root_span)
     line, hash_value = get_line_and_hash(
         "iast_enabled_sqli_http_request_parameter_name_get", vuln_type, filename=TEST_FILE
     )
@@ -336,10 +345,10 @@ def test_django_sqli_http_request_parameter_name_get(client, test_spans, tracer)
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_sqli_http_request_parameter_name_post(client, test_spans, tracer):
+def test_django_sqli_http_request_parameter_name_post(client, iast_span, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         payload=urlencode({"SELECT": "unused"}),
         content_type="application/x-www-form-urlencoded",
@@ -389,10 +398,10 @@ def test_django_sqli_http_request_parameter_name_post(client, test_spans, tracer
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_sqli_query_no_redacted(client, test_spans, tracer):
+def test_django_sqli_query_no_redacted(client, iast_span, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/sqli_query_no_redacted/?q=sqlite_master",
     )
@@ -429,10 +438,10 @@ def test_django_sqli_query_no_redacted(client, test_spans, tracer):
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_sqli_http_request_header_value(client, test_spans, tracer):
+def test_django_sqli_http_request_header_value(client, iast_span, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         payload=urlencode({"mytestingbody_key": "mytestingbody_value"}),
         content_type="application/x-www-form-urlencoded",
@@ -466,11 +475,11 @@ def test_django_sqli_http_request_header_value(client, test_spans, tracer):
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_iast_disabled_sqli_http_request_header_value(client, test_spans, tracer):
+def test_django_iast_disabled_sqli_http_request_header_value(client, iast_span, tracer):
     with override_global_config(dict(_iast_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
-            test_spans,
+            iast_span,
             tracer,
             payload=urlencode({"mytestingbody_key": "mytestingbody_value"}),
             content_type="application/x-www-form-urlencoded",
@@ -486,10 +495,10 @@ def test_django_iast_disabled_sqli_http_request_header_value(client, test_spans,
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_sqli_http_request_header_name(client, test_spans, tracer):
+def test_django_sqli_http_request_header_name(client, iast_span, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         payload=urlencode({"mytestingbody_key": "mytestingbody_value"}),
         content_type="application/x-www-form-urlencoded",
@@ -523,11 +532,11 @@ def test_django_sqli_http_request_header_name(client, test_spans, tracer):
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_iast_disabled_sqli_http_request_header_name(client, test_spans, tracer):
+def test_django_iast_disabled_sqli_http_request_header_name(client, iast_span, tracer):
     with override_global_config(dict(_iast_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
-            test_spans,
+            iast_span,
             tracer,
             payload=urlencode({"mytestingbody_key": "mytestingbody_value"}),
             content_type="application/x-www-form-urlencoded",
@@ -543,10 +552,10 @@ def test_django_iast_disabled_sqli_http_request_header_name(client, test_spans, 
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_sqli_http_path_parameter(client, test_spans, tracer):
+def test_django_sqli_http_path_parameter(client, iast_span, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/sqli_http_path_parameter/sqlite_master/",
         headers={"HTTP_USER_AGENT": "test/1.2.3"},
@@ -578,11 +587,11 @@ def test_django_sqli_http_path_parameter(client, test_spans, tracer):
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_iast_disabled_sqli_http_path_parameter(client, test_spans, tracer):
+def test_django_iast_disabled_sqli_http_path_parameter(client, iast_span, tracer):
     with override_global_config(dict(_iast_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
-            test_spans,
+            iast_span,
             tracer,
             url="/appsec/sqli_http_path_parameter/sqlite_master/",
             headers={"HTTP_USER_AGENT": "test/1.2.3"},
@@ -596,10 +605,10 @@ def test_django_iast_disabled_sqli_http_path_parameter(client, test_spans, trace
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_sqli_http_cookies_name(client, test_spans, tracer):
+def test_django_sqli_http_cookies_name(client, iast_span, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/sqli_http_request_cookie_name/",
         cookies={"master": "test/1.2.3"},
@@ -635,11 +644,11 @@ def test_django_sqli_http_cookies_name(client, test_spans, tracer):
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_iast_disabled_sqli_http_cookies_name(client, test_spans, tracer):
+def test_django_iast_disabled_sqli_http_cookies_name(client, iast_span, tracer):
     with override_global_config(dict(_iast_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
-            test_spans,
+            iast_span,
             tracer,
             url="/appsec/sqli_http_request_cookie_name/",
             cookies={"master": "test/1.2.3"},
@@ -653,10 +662,10 @@ def test_django_iast_disabled_sqli_http_cookies_name(client, test_spans, tracer)
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_sqli_http_cookies_value(client, test_spans, tracer):
+def test_django_sqli_http_cookies_value(client, iast_span, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/sqli_http_request_cookie_value/",
         cookies={"master": "master"},
@@ -694,11 +703,11 @@ def test_django_sqli_http_cookies_value(client, test_spans, tracer):
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_iast_disabled_sqli_http_cookies_value(client, test_spans, tracer):
+def test_django_iast_disabled_sqli_http_cookies_value(client, iast_span, tracer):
     with override_global_config(dict(_iast_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
-            test_spans,
+            iast_span,
             tracer,
             url="/appsec/sqli_http_request_cookie_value/",
             cookies={"master": "master"},
@@ -719,10 +728,10 @@ def test_django_iast_disabled_sqli_http_cookies_value(client, test_spans, tracer
 )
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_sqli_http_body(client, test_spans, tracer, payload, content_type):
+def test_django_sqli_http_body(client, iast_span, tracer, payload, content_type):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/sqli_http_request_body/",
         payload=payload,
@@ -775,13 +784,13 @@ def test_django_sqli_http_body(client, test_spans, tracer, payload, content_type
 )
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_tainted_http_body_empty(client, test_spans, tracer, payload, content_type, deduplication, sampling):
+def test_django_tainted_http_body_empty(client, iast_span, tracer, payload, content_type, deduplication, sampling):
     with override_global_config(
         dict(_iast_enabled=True, _iast_deduplication_enabled=deduplication, _iast_request_sampling=sampling)
     ):
         root_span, response = _aux_appsec_get_root_span(
             client,
-            test_spans,
+            iast_span,
             tracer,
             url="/appsec/source/body/",
             payload=payload,
@@ -795,11 +804,11 @@ def test_django_tainted_http_body_empty(client, test_spans, tracer, payload, con
 
 @pytest.mark.django_db()
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_iast_disabled_sqli_http_body(client, test_spans, tracer):
+def test_django_iast_disabled_sqli_http_body(client, iast_span, tracer):
     with override_global_config(dict(_iast_enabled=False)):
         root_span, response = _aux_appsec_get_root_span(
             client,
-            test_spans,
+            iast_span,
             tracer,
             url="/appsec/sqli_http_request_body/",
             payload="master",
@@ -813,10 +822,10 @@ def test_django_iast_disabled_sqli_http_body(client, test_spans, tracer):
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_querydict(client, test_spans, tracer):
+def test_django_querydict(client, iast_span, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/validate_querydict/?x=1&y=2&x=3",
     )
@@ -830,10 +839,10 @@ def test_django_querydict(client, test_spans, tracer):
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_command_injection(client, test_spans, tracer):
+def test_django_command_injection(client, iast_span, tracer):
     root_span, _ = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/command-injection/",
         payload="master",
@@ -861,10 +870,10 @@ def test_django_command_injection(client, test_spans, tracer):
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_command_injection_subprocess(client, test_spans, tracer):
+def test_django_command_injection_subprocess(client, iast_span, tracer):
     root_span, _ = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/command-injection-subprocess/",
         payload=urlencode({"cmd": "ls"}),
@@ -888,10 +897,10 @@ def test_django_command_injection_subprocess(client, test_spans, tracer):
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_command_injection_span_metrics(client, test_spans, tracer):
+def test_django_command_injection_span_metrics(client, iast_span, tracer):
     root_span, _ = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/command-injection/",
         payload="master",
@@ -926,10 +935,10 @@ def test_django_command_injection_span_metrics_disabled(client, iast_spans_with_
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_command_injection_secure_mark(client, test_spans, tracer):
+def test_django_command_injection_secure_mark(client, iast_span, tracer):
     root_span, _ = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/command-injection/secure-mark/",
         payload="master",
@@ -941,10 +950,10 @@ def test_django_command_injection_secure_mark(client, test_spans, tracer):
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_xss_secure_mark(client, test_spans, tracer):
+def test_django_xss_secure_mark(client, iast_span, tracer):
     root_span, _ = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/xss/secure-mark/",
         payload='<script>alert("XSS")</script>',
@@ -956,10 +965,10 @@ def test_django_xss_secure_mark(client, test_spans, tracer):
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_header_injection(client, test_spans, tracer):
+def test_django_header_injection(client, iast_span, tracer):
     root_span, _ = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/header-injection/",
         payload="master",
@@ -981,10 +990,10 @@ def test_django_header_injection(client, test_spans, tracer):
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_insecure_cookie(client, test_spans, tracer):
+def test_django_insecure_cookie(client, iast_span, tracer):
     root_span, _ = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/insecure-cookie/test_insecure/",
     )
@@ -1005,10 +1014,10 @@ def test_django_insecure_cookie(client, test_spans, tracer):
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_insecure_cookie_secure(client, test_spans, tracer):
+def test_django_insecure_cookie_secure(client, iast_span, tracer):
     root_span, _ = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/insecure-cookie/test_secure/",
     )
@@ -1019,10 +1028,10 @@ def test_django_insecure_cookie_secure(client, test_spans, tracer):
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_insecure_cookie_empty_cookie(client, test_spans, tracer):
+def test_django_insecure_cookie_empty_cookie(client, iast_span, tracer):
     root_span, _ = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/insecure-cookie/test_empty_cookie/",
     )
@@ -1033,10 +1042,10 @@ def test_django_insecure_cookie_empty_cookie(client, test_spans, tracer):
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_insecure_cookie_2_insecure_1_secure(client, test_spans, tracer):
+def test_django_insecure_cookie_2_insecure_1_secure(client, iast_span, tracer):
     root_span, _ = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/insecure-cookie/test_insecure_2_1/",
     )
@@ -1049,10 +1058,10 @@ def test_django_insecure_cookie_2_insecure_1_secure(client, test_spans, tracer):
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_insecure_cookie_special_characters(client, test_spans, tracer):
+def test_django_insecure_cookie_special_characters(client, iast_span, tracer):
     root_span, _ = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/insecure-cookie/test_insecure_special/",
     )
@@ -1075,10 +1084,10 @@ def test_django_insecure_cookie_special_characters(client, test_spans, tracer):
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
-def test_django_stacktrace_leak(client, test_spans, tracer):
+def test_django_stacktrace_leak(client, iast_span, tracer):
     root_span, _ = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/stacktrace_leak/",
     )
@@ -1098,10 +1107,10 @@ def test_django_stacktrace_leak(client, test_spans, tracer):
     assert vulnerability["hash"]
 
 
-def test_django_stacktrace_from_technical_500_response(client, test_spans, tracer, debug_mode):
+def test_django_stacktrace_from_technical_500_response(client, iast_span, tracer, debug_mode):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/stacktrace_leak_500/",
         content_type="text/html",
@@ -1121,10 +1130,10 @@ def test_django_stacktrace_from_technical_500_response(client, test_spans, trace
     assert vulnerability["hash"]
 
 
-def test_django_xss(client, test_spans, tracer):
+def test_django_xss(client, iast_span, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/xss/?input=<script>alert('XSS')</script>",
     )
@@ -1157,10 +1166,10 @@ def test_django_xss(client, test_spans, tracer):
     assert loaded["vulnerabilities"][0]["hash"] == hash_value
 
 
-def test_django_xss_safe_template_tag(client, test_spans, tracer):
+def test_django_xss_safe_template_tag(client, iast_span, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/xss/safe/?input=<script>alert('XSS')</script>",
     )
@@ -1193,10 +1202,10 @@ def test_django_xss_safe_template_tag(client, test_spans, tracer):
     assert loaded["vulnerabilities"][0]["hash"] == hash_value
 
 
-def test_django_xss_autoscape(client, test_spans, tracer):
+def test_django_xss_autoscape(client, iast_span, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/xss/autoscape/?input=<script>alert('XSS')</script>",
     )
@@ -1211,10 +1220,10 @@ def test_django_xss_autoscape(client, test_spans, tracer):
     assert loaded is None
 
 
-def test_django_xss_secure(client, test_spans, tracer):
+def test_django_xss_secure(client, iast_span, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/xss/secure/?input=<script>alert('XSS')</script>",
     )
@@ -1229,10 +1238,10 @@ def test_django_xss_secure(client, test_spans, tracer):
     assert loaded is None
 
 
-def test_django_ospathjoin_propagation(client, test_spans, tracer):
+def test_django_ospathjoin_propagation(client, iast_span, tracer):
     root_span, response = _aux_appsec_get_root_span(
         client,
-        test_spans,
+        iast_span,
         tracer,
         url="/appsec/propagation/ospathjoin/?input=test/propagation/errors",
     )


### PR DESCRIPTION
###  Description

This PR addresses an issue in the Interactive Application Security Testing (IAST) module where metastruct data was not being sent if Application Security (AppSec) was disabled.

**Key Changes:**

* Updated the API version handling to ensure metastruct data is transmitted regardless of the AppSec enablement status.
* Refactored the metastruct data sending logic to decouple it from AppSec's state.
* Added tests to validate the correct behavior when AppSec is disabled.

These changes ensure that IAST continues to function correctly and send necessary data even when AppSec is turned off.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
