### PR TITLE
fix(ci_visibility): use git tag as branch name if no branch name available

### DIFF
--- a/ddtrace/internal/ci_visibility/git_data.py
+++ b/ddtrace/internal/ci_visibility/git_data.py
@@ -15,7 +15,7 @@ class GitData:
 def get_git_data_from_tags(tags: t.Dict[str, t.Any]) -> GitData:
     return GitData(
         repository_url=tags.get(ci.git.REPOSITORY_URL),
-        branch=tags.get(ci.git.BRANCH),
+        branch=tags.get(ci.git.BRANCH) or tags.get(ci.git.TAG),
         commit_sha=tags.get(ci.git.COMMIT_SHA),
         commit_message=tags.get(ci.git.COMMIT_MESSAGE),
     )

--- a/releasenotes/notes/ci_visibility-fix-use-git-tag-as-branch-971227009e6496a6.yaml
+++ b/releasenotes/notes/ci_visibility-fix-use-git-tag-as-branch-971227009e6496a6.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    CI Visibility: This fix resolves an issue where running from a GitHub action triggered on a tag push would cause the
+    branch name to be null, causing errors when fetching Test Optimization settings from the backend.

--- a/tests/ci_visibility/test_git_data.py
+++ b/tests/ci_visibility/test_git_data.py
@@ -1,0 +1,56 @@
+from ddtrace.internal.ci_visibility.git_data import GitData
+from ddtrace.internal.ci_visibility.git_data import get_git_data_from_tags
+from ddtrace.ext import ci
+
+
+def test_git_data_with_branch():
+    tags = {
+        ci.git.REPOSITORY_URL: "github.com/some-org/some-repo",
+        ci.git.BRANCH: "some-branch",
+        ci.git.COMMIT_SHA: "some-sha",
+        ci.git.COMMIT_MESSAGE: "this is a message",
+    }
+
+    expected_git_data = GitData(
+        repository_url="github.com/some-org/some-repo",
+        branch="some-branch",
+        commit_sha="some-sha",
+        commit_message="this is a message"
+    )
+
+    assert get_git_data_from_tags(tags) == expected_git_data
+
+
+def test_git_data_with_tag():
+    tags = {
+        ci.git.REPOSITORY_URL: "github.com/some-org/some-repo",
+        ci.git.TAG: "v1.2.3",
+        ci.git.COMMIT_SHA: "some-sha",
+        ci.git.COMMIT_MESSAGE: "this is a message",
+    }
+
+    expected_git_data = GitData(
+        repository_url="github.com/some-org/some-repo",
+        branch="v1.2.3",
+        commit_sha="some-sha",
+        commit_message="this is a message"
+    )
+
+    assert get_git_data_from_tags(tags) == expected_git_data
+
+
+def test_git_data_with_neither_branch_nor_tag():
+    tags = {
+        ci.git.REPOSITORY_URL: "github.com/some-org/some-repo",
+        ci.git.COMMIT_SHA: "some-sha",
+        ci.git.COMMIT_MESSAGE: "this is a message",
+    }
+
+    expected_git_data = GitData(
+        repository_url="github.com/some-org/some-repo",
+        branch=None,
+        commit_sha="some-sha",
+        commit_message="this is a message"
+    )
+
+    assert get_git_data_from_tags(tags) == expected_git_data

--- a/tests/ci_visibility/test_git_data.py
+++ b/tests/ci_visibility/test_git_data.py
@@ -1,6 +1,6 @@
+from ddtrace.ext import ci
 from ddtrace.internal.ci_visibility.git_data import GitData
 from ddtrace.internal.ci_visibility.git_data import get_git_data_from_tags
-from ddtrace.ext import ci
 
 
 def test_git_data_with_branch():
@@ -15,7 +15,7 @@ def test_git_data_with_branch():
         repository_url="github.com/some-org/some-repo",
         branch="some-branch",
         commit_sha="some-sha",
-        commit_message="this is a message"
+        commit_message="this is a message",
     )
 
     assert get_git_data_from_tags(tags) == expected_git_data
@@ -33,7 +33,7 @@ def test_git_data_with_tag():
         repository_url="github.com/some-org/some-repo",
         branch="v1.2.3",
         commit_sha="some-sha",
-        commit_message="this is a message"
+        commit_message="this is a message",
     )
 
     assert get_git_data_from_tags(tags) == expected_git_data
@@ -50,7 +50,7 @@ def test_git_data_with_neither_branch_nor_tag():
         repository_url="github.com/some-org/some-repo",
         branch=None,
         commit_sha="some-sha",
-        commit_message="this is a message"
+        commit_message="this is a message",
     )
 
     assert get_git_data_from_tags(tags) == expected_git_data


### PR DESCRIPTION
When called from a GitHub action triggered on a _tag_ push (not a branch push), we would have no branch name available and make some requests to the backend with a `null` branch, causing a 400 to be returned. This PR changes it so that the tag name is used as the branch name in such circumstances.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
