### PR TITLE
chore(iast): remove cyclic dependencies in IAST

### DIFF
--- a/ddtrace/appsec/_iast/_handlers.py
+++ b/ddtrace/appsec/_iast/_handlers.py
@@ -14,8 +14,8 @@ from ddtrace.appsec._iast._patch import _iast_instrument_starlette_url
 from ddtrace.appsec._iast._patch import try_wrap_function_wrapper
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import origin_to_str
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_utils import taint_dictionary
 from ddtrace.appsec._iast._taint_utils import taint_structure
 from ddtrace.appsec._iast.secure_marks.sanitizers import cmdi_sanitizer

--- a/ddtrace/appsec/_iast/_iast_env.py
+++ b/ddtrace/appsec/_iast/_iast_env.py
@@ -1,9 +1,9 @@
-from typing import Any
 from typing import Dict
 from typing import Optional
 
 from ddtrace._trace.span import Span
 from ddtrace.appsec._constants import IAST
+from ddtrace.appsec._iast.reporter import IastSpanReporter
 from ddtrace.internal import core
 
 
@@ -18,7 +18,7 @@ class IASTEnvironment:
         self.span = span or core.get_span()
 
         self.request_enabled: bool = False
-        self.iast_reporter: Optional[Any] = None
+        self.iast_reporter: Optional[IastSpanReporter] = None
         self.iast_span_metrics: Dict[str, int] = {}
         self.iast_stack_trace_reported: bool = False
 

--- a/ddtrace/appsec/_iast/_iast_env.py
+++ b/ddtrace/appsec/_iast/_iast_env.py
@@ -20,7 +20,6 @@ class IASTEnvironment:
         self.request_enabled: bool = False
         self.iast_reporter: Optional[Any] = None
         self.iast_span_metrics: Dict[str, int] = {}
-        self.iast_stack_trace_id: int = 0
         self.iast_stack_trace_reported: bool = False
 
 

--- a/ddtrace/appsec/_iast/_iast_request_context.py
+++ b/ddtrace/appsec/_iast/_iast_request_context.py
@@ -40,10 +40,7 @@ def get_iast_reporter() -> Optional[IastSpanReporter]:
 def _create_and_attach_iast_report_to_span(req_span: "Span", existing_data: Optional[str], merge: bool = False):
     report_data: Optional[IastSpanReporter] = get_iast_reporter()
     if merge and existing_data is not None and report_data is not None:
-        previous_data = IastSpanReporter()
-        previous_data._from_json(existing_data)
-
-        report_data._merge(previous_data)
+        report_data._merge_json(existing_data)
 
     if report_data is not None:
         data = report_data.build_and_scrub_value_parts()

--- a/ddtrace/appsec/_iast/_iast_request_context_base.py
+++ b/ddtrace/appsec/_iast/_iast_request_context_base.py
@@ -58,14 +58,6 @@ def set_iast_stacktrace_reported(reported: bool) -> None:
         env.iast_stack_trace_reported = reported
 
 
-def get_iast_stacktrace_id() -> int:
-    env = _get_iast_env()
-    if env:
-        env.iast_stack_trace_id += 1
-        return env.iast_stack_trace_id
-    return 0
-
-
 def set_iast_request_enabled(request_enabled) -> None:
     env = _get_iast_env()
     if env:

--- a/ddtrace/appsec/_iast/_langchain.py
+++ b/ddtrace/appsec/_iast/_langchain.py
@@ -1,6 +1,6 @@
 from ddtrace.appsec._iast._metrics import _set_iast_error_metric
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 from ddtrace.contrib.internal.trace_utils import unwrap
 from ddtrace.contrib.internal.trace_utils import wrap
 from ddtrace.internal.utils import get_argument_value

--- a/ddtrace/appsec/_iast/_patches/json_tainting.py
+++ b/ddtrace/appsec/_iast/_patches/json_tainting.py
@@ -43,8 +43,8 @@ def wrapped_loads(wrapped, instance, args, kwargs):
 
     obj = wrapped(*args, **kwargs)
     if asm_config._iast_enabled and asm_config.is_iast_request_enabled:
-        from .._taint_tracking._taint_objects import get_tainted_ranges
         from .._taint_tracking._taint_objects import taint_pyobject
+        from .._taint_tracking._taint_objects_base import get_tainted_ranges
 
         ranges = get_tainted_ranges(args[0])
 

--- a/ddtrace/appsec/_iast/_taint_tracking/_debug.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/_debug.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 from io import StringIO
 
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast._utils import _is_iast_propagation_debug_enabled
 from ddtrace.internal._unpatched import _threading as threading
 from ddtrace.internal.logger import get_logger

--- a/ddtrace/appsec/_iast/_taint_tracking/_taint_objects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/_taint_objects.py
@@ -1,125 +1,20 @@
 import itertools
 from typing import Any
 from typing import Sequence
-from typing import Tuple
 
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.appsec._iast._logs import iast_propagation_debug_log
-from ddtrace.appsec._iast._logs import iast_propagation_error_log
 from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_source
 from ddtrace.appsec._iast._span_metrics import increment_iast_span_metric
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import TaintRange
-from ddtrace.appsec._iast._taint_tracking import get_ranges
-from ddtrace.appsec._iast._taint_tracking import is_tainted
-from ddtrace.appsec._iast._taint_tracking import origin_to_str
-from ddtrace.appsec._iast._taint_tracking import set_ranges
-from ddtrace.appsec._iast._taint_tracking import set_ranges_from_values
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import _taint_pyobject_base
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
 
 
 log = get_logger(__name__)
-
-
-def is_pyobject_tainted(pyobject: Any) -> bool:
-    if not asm_config.is_iast_request_enabled:
-        return False
-    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
-        return False
-
-    try:
-        return is_tainted(pyobject)
-    except ValueError as e:
-        iast_propagation_error_log(f"Checking tainted object error: {e}")
-    return False
-
-
-def _taint_pyobject_base(pyobject: Any, source_name: Any, source_value: Any, source_origin=None) -> Any:
-    """Mark a Python object as tainted with information about its origin.
-
-    This function is the base for marking objects as tainted, setting their origin and range.
-    It is optimized for:
-    1. Early validations to avoid unnecessary operations
-    2. Efficient type conversions
-    3. Special case handling (empty objects)
-    4. Robust error handling
-
-    Performance optimizations:
-    - Early return for disabled IAST or non-taintable types
-    - Efficient string length calculation only when needed
-    - Optimized bytes/bytearray to string conversion using decode()
-    - Minimized object allocations and method calls
-
-    Args:
-        pyobject (Any): The object to mark as tainted. Must be a taintable type.
-        source_name (Any): Name of the taint source (e.g., parameter name).
-        source_value (Any): Original value that caused the taint.
-        source_origin (Optional[OriginType]): Origin of the taint. Defaults to PARAMETER.
-
-    Returns:
-        Any: The tainted object if operation was successful, original object if failed.
-
-    Note:
-        - Only applies to taintable types defined in IAST.TAINTEABLE_TYPES
-        - Returns unmodified object for empty strings
-        - Automatically handles bytes/bytearray to str conversion
-    """
-    # Early type validation
-    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
-        return pyobject
-
-    # Fast path for empty strings
-    if isinstance(pyobject, IAST.TEXT_TYPES) and not pyobject:
-        return pyobject
-
-    # Efficient source_name conversion
-    if isinstance(source_name, (bytes, bytearray)):
-        source_name = source_name.decode("utf-8", errors="ignore")
-    elif isinstance(source_name, OriginType):
-        source_name = origin_to_str(source_name)
-
-    # Efficient source_value conversion
-    if isinstance(source_value, (bytes, bytearray)):
-        source_value = source_value.decode("utf-8", errors="ignore")
-
-    # Default source_origin
-    if source_origin is None:
-        source_origin = OriginType.PARAMETER
-
-    try:
-        # Calculate length only for text types
-        pyobject_len = len(pyobject) if isinstance(pyobject, IAST.TEXT_TYPES) else 0
-        return set_ranges_from_values(pyobject, pyobject_len, source_name, source_value, source_origin)
-    except ValueError:
-        iast_propagation_debug_log(f"Tainting object error (pyobject type {type(pyobject)})", exc_info=True)
-        return pyobject
-
-
-def taint_pyobject_with_ranges(pyobject: Any, ranges: Tuple) -> bool:
-    if not asm_config.is_iast_request_enabled:
-        return False
-    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
-        return False
-    try:
-        set_ranges(pyobject, ranges)
-        return True
-    except ValueError as e:
-        iast_propagation_error_log(f"taint_pyobject_with_ranges error (pyobject type {type(pyobject)}): {e}")
-    return False
-
-
-def get_tainted_ranges(pyobject: Any) -> Tuple:
-    if not asm_config.is_iast_request_enabled:
-        return tuple()
-    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
-        return tuple()
-    try:
-        return get_ranges(pyobject)
-    except ValueError as e:
-        iast_propagation_error_log(f"get_tainted_ranges error (pyobject type {type(pyobject)}): {e}")
-    return tuple()
 
 
 def taint_pyobject(pyobject: Any, source_name: Any, source_value: Any, source_origin=None) -> Any:

--- a/ddtrace/appsec/_iast/_taint_tracking/_taint_objects_base.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/_taint_objects_base.py
@@ -1,0 +1,112 @@
+from typing import Any
+from typing import Tuple
+
+from ddtrace.appsec._constants import IAST
+from ddtrace.appsec._iast._logs import iast_propagation_debug_log
+from ddtrace.appsec._iast._logs import iast_propagation_error_log
+from ddtrace.appsec._iast._taint_tracking import OriginType
+from ddtrace.appsec._iast._taint_tracking import get_ranges
+from ddtrace.appsec._iast._taint_tracking import is_tainted
+from ddtrace.appsec._iast._taint_tracking import origin_to_str
+from ddtrace.appsec._iast._taint_tracking import set_ranges
+from ddtrace.appsec._iast._taint_tracking import set_ranges_from_values
+from ddtrace.settings.asm import config as asm_config
+
+
+def _taint_pyobject_base(pyobject: Any, source_name: Any, source_value: Any, source_origin=None) -> Any:
+    """Mark a Python object as tainted with information about its origin.
+
+    This function is the base for marking objects as tainted, setting their origin and range.
+    It is optimized for:
+    1. Early validations to avoid unnecessary operations
+    2. Efficient type conversions
+    3. Special case handling (empty objects)
+    4. Robust error handling
+
+    Performance optimizations:
+    - Early return for disabled IAST or non-taintable types
+    - Efficient string length calculation only when needed
+    - Optimized bytes/bytearray to string conversion using decode()
+    - Minimized object allocations and method calls
+
+    Args:
+        pyobject (Any): The object to mark as tainted. Must be a taintable type.
+        source_name (Any): Name of the taint source (e.g., parameter name).
+        source_value (Any): Original value that caused the taint.
+        source_origin (Optional[OriginType]): Origin of the taint. Defaults to PARAMETER.
+
+    Returns:
+        Any: The tainted object if operation was successful, original object if failed.
+
+    Note:
+        - Only applies to taintable types defined in IAST.TAINTEABLE_TYPES
+        - Returns unmodified object for empty strings
+        - Automatically handles bytes/bytearray to str conversion
+    """
+    # Early type validation
+    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
+        return pyobject
+
+    # Fast path for empty strings
+    if isinstance(pyobject, IAST.TEXT_TYPES) and not pyobject:
+        return pyobject
+
+    # Efficient source_name conversion
+    if isinstance(source_name, (bytes, bytearray)):
+        source_name = source_name.decode("utf-8", errors="ignore")
+    elif isinstance(source_name, OriginType):
+        source_name = origin_to_str(source_name)
+
+    # Efficient source_value conversion
+    if isinstance(source_value, (bytes, bytearray)):
+        source_value = source_value.decode("utf-8", errors="ignore")
+
+    # Default source_origin
+    if source_origin is None:
+        source_origin = OriginType.PARAMETER
+
+    try:
+        # Calculate length only for text types
+        pyobject_len = len(pyobject) if isinstance(pyobject, IAST.TEXT_TYPES) else 0
+        return set_ranges_from_values(pyobject, pyobject_len, source_name, source_value, source_origin)
+    except ValueError:
+        iast_propagation_debug_log(f"Tainting object error (pyobject type {type(pyobject)})", exc_info=True)
+        return pyobject
+
+
+def get_tainted_ranges(pyobject: Any) -> Tuple:
+    if not asm_config.is_iast_request_enabled:
+        return tuple()
+    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
+        return tuple()
+    try:
+        return get_ranges(pyobject)
+    except ValueError as e:
+        iast_propagation_error_log(f"get_tainted_ranges error (pyobject type {type(pyobject)}): {e}")
+    return tuple()
+
+
+def is_pyobject_tainted(pyobject: Any) -> bool:
+    if not asm_config.is_iast_request_enabled:
+        return False
+    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
+        return False
+
+    try:
+        return is_tainted(pyobject)
+    except ValueError as e:
+        iast_propagation_error_log(f"Checking tainted object error: {e}")
+    return False
+
+
+def taint_pyobject_with_ranges(pyobject: Any, ranges: Tuple) -> bool:
+    if not asm_config.is_iast_request_enabled:
+        return False
+    if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
+        return False
+    try:
+        set_ranges(pyobject, ranges)
+        return True
+    except ValueError as e:
+        iast_propagation_error_log(f"taint_pyobject_with_ranges error (pyobject type {type(pyobject)}): {e}")
+    return False

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -49,9 +49,9 @@ from ddtrace.appsec._iast._taint_tracking import shift_taint_range
 from ddtrace.appsec._iast._taint_tracking._native import aspects  # noqa: F401
 from ddtrace.appsec._iast._taint_tracking._taint_objects import copy_ranges_to_iterable_with_strings
 from ddtrace.appsec._iast._taint_tracking._taint_objects import copy_ranges_to_string
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
-from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject_with_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import taint_pyobject_with_ranges
 
 
 TEXT_TYPES = Union[str, bytes, bytearray]
@@ -702,9 +702,7 @@ def aspect_replace_api(
                     empty,
                 ]
                 + (
-                    list(candidate_text)
-                    if isinstance(candidate_text, str)
-                    else [bytes([x]) for x in candidate_text]  # type: ignore
+                    list(candidate_text) if isinstance(candidate_text, str) else [bytes([x]) for x in candidate_text]  # type: ignore
                 )
                 + [
                     empty,

--- a/ddtrace/appsec/_iast/_taint_utils.py
+++ b/ddtrace/appsec/_iast/_taint_utils.py
@@ -6,8 +6,8 @@ from typing import Optional
 from typing import Union
 
 from ddtrace.appsec._constants import IAST
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
 

--- a/ddtrace/appsec/_iast/reporter.py
+++ b/ddtrace/appsec/_iast/reporter.py
@@ -285,7 +285,7 @@ class IastSpanReporter(NotNoneDictable):
         Returns:
         - Tuple[Set[Source], List[Dict]]: Set of Source objects and list of tainted ranges as dictionaries.
         """
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
         sources = list()
         tainted_ranges = get_tainted_ranges(pyobject)

--- a/ddtrace/appsec/_iast/secure_marks/sanitizers.py
+++ b/ddtrace/appsec/_iast/secure_marks/sanitizers.py
@@ -9,7 +9,7 @@ from typing import Callable
 from typing import Sequence
 
 from ddtrace.appsec._iast._taint_tracking import VulnerabilityType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
 
 def create_sanitizer(

--- a/ddtrace/appsec/_iast/secure_marks/validators.py
+++ b/ddtrace/appsec/_iast/secure_marks/validators.py
@@ -9,7 +9,7 @@ from typing import Callable
 from typing import Sequence
 
 from ddtrace.appsec._iast._taint_tracking import VulnerabilityType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
 
 def create_validator(

--- a/ddtrace/appsec/_iast/sources/ast_taint.py
+++ b/ddtrace/appsec/_iast/sources/ast_taint.py
@@ -3,8 +3,8 @@ from typing import Callable
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import Source
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 from ddtrace.settings.asm import config as asm_config
 
 from ..constants import DEFAULT_SOURCE_IO_FUNCTIONS

--- a/ddtrace/appsec/_iast/taint_sinks/_base.py
+++ b/ddtrace/appsec/_iast/taint_sinks/_base.py
@@ -92,7 +92,7 @@ class VulnerabilityBase(Operation):
             ),
         )
         if report:
-            report.vulnerabilities.add(vulnerability)
+            report._append_vulnerability(vulnerability)
         else:
             report = IastSpanReporter(vulnerabilities={vulnerability})
         report.add_ranges_to_evidence_and_extract_sources(vulnerability)

--- a/scripts/iast/leak_functions.py
+++ b/scripts/iast/leak_functions.py
@@ -13,7 +13,7 @@ from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
 from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
 from ddtrace.appsec._iast._iast_request_context_base import start_iast_context
 from ddtrace.appsec._iast._taint_tracking import active_map_addreses_size
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from tests.utils import override_env
 
 

--- a/scripts/iast/mod_leak_functions.py
+++ b/scripts/iast/mod_leak_functions.py
@@ -13,8 +13,8 @@ from pydantic_core import SchemaValidator
 import requests
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
 
 v = SchemaValidator(

--- a/scripts/iast/test_references.py
+++ b/scripts/iast/test_references.py
@@ -6,7 +6,7 @@ from mod_leak_functions import test_doit
 
 from ddtrace.appsec._iast._taint_tracking._context import create_context
 from ddtrace.appsec._iast._taint_tracking._context import reset_context
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
 
 async def test_main():

--- a/tests/appsec/app.py
+++ b/tests/appsec/app.py
@@ -1,5 +1,5 @@
-""" This Flask application is imported on tests.appsec.appsec_utils.gunicorn_server
-"""
+"""This Flask application is imported on tests.appsec.appsec_utils.gunicorn_server"""
+
 import copy
 import os
 import re
@@ -15,7 +15,7 @@ from wrapt import FunctionWrapper
 import ddtrace.auto  # noqa: F401  # isort: skip
 from ddtrace import tracer
 from ddtrace.appsec._iast import ddtrace_iast_flask_patch
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.internal.utils.formats import asbool
 from tests.appsec.iast_packages.packages.pkg_aiohttp import pkg_aiohttp
 from tests.appsec.iast_packages.packages.pkg_aiosignal import pkg_aiosignal

--- a/tests/appsec/iast/aspects/aspect_utils.py
+++ b/tests/appsec/iast/aspects/aspect_utils.py
@@ -9,7 +9,7 @@ from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
 from ddtrace.appsec._iast._taint_tracking import set_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject_with_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import taint_pyobject_with_ranges
 from tests.appsec.iast.iast_utils import TEXT_TYPE
 from tests.appsec.iast.iast_utils import _iast_patched_module
 

--- a/tests/appsec/iast/aspects/test_add_aspect.py
+++ b/tests/appsec/iast/aspects/test_add_aspect.py
@@ -11,9 +11,9 @@ from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking._context import create_context
 from ddtrace.appsec._iast._taint_tracking._context import reset_context
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import TaintRange_
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
 from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect
 from tests.appsec.iast.conftest import _end_iast_context_and_oce

--- a/tests/appsec/iast/aspects/test_add_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_add_aspect_fixtures.py
@@ -3,8 +3,8 @@ import unittest
 import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 from tests.appsec.iast.iast_utils import _iast_patched_module
 
 

--- a/tests/appsec/iast/aspects/test_add_inplace_aspect.py
+++ b/tests/appsec/iast/aspects/test_add_inplace_aspect.py
@@ -6,9 +6,9 @@ import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import TaintRange_
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
 from tests.appsec.iast.iast_utils import string_strategies
 

--- a/tests/appsec/iast/aspects/test_add_inplace_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_add_inplace_aspect_fixtures.py
@@ -5,8 +5,8 @@ import sys
 import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 from tests.appsec.iast.iast_utils import _iast_patched_module
 
 

--- a/tests/appsec/iast/aspects/test_asyncio.py
+++ b/tests/appsec/iast/aspects/test_asyncio.py
@@ -5,9 +5,9 @@ from typing import Coroutine
 import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from tests.appsec.iast.iast_utils import _iast_patched_module
 
 

--- a/tests/appsec/iast/aspects/test_bytearray_extend_aspect.py
+++ b/tests/appsec/iast/aspects/test_bytearray_extend_aspect.py
@@ -8,8 +8,8 @@ from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
 from ddtrace.appsec._iast._taint_tracking._context import create_context
 from ddtrace.appsec._iast._taint_tracking._context import reset_context
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.utils import override_global_config
 

--- a/tests/appsec/iast/aspects/test_common_replace_aspects.py
+++ b/tests/appsec/iast/aspects/test_common_replace_aspects.py
@@ -3,8 +3,8 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 from tests.appsec.iast.iast_utils import _iast_patched_module
 
 

--- a/tests/appsec/iast/aspects/test_encode_decode_aspect.py
+++ b/tests/appsec/iast/aspects/test_encode_decode_aspect.py
@@ -3,8 +3,8 @@
 import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
 from tests.appsec.iast.iast_utils import _iast_patched_module
 

--- a/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
@@ -13,8 +13,8 @@ from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
 from ddtrace.appsec._iast._taint_tracking._context import create_context
 from ddtrace.appsec._iast._taint_tracking._context import reset_context
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
 from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
 from tests.appsec.iast.aspects.aspect_utils import create_taint_range_with_format
@@ -84,7 +84,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
             taint_escaped_template=":+-<input1>template<input1>-+: {}",
             taint_escaped_parameter=":+-<input2>parameter<input2>-+:",
             expected_result="template parameter",
-            escaped_expected_result=":+-<input1>template<input1>-+: " ":+-<input2>parameter<input2>-+:",
+            escaped_expected_result=":+-<input1>template<input1>-+: :+-<input2>parameter<input2>-+:",
         )
 
     def test_format_when_tainted_template_range_with_brackets_and_tainted_param_then_tainted(self):
@@ -93,7 +93,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
             taint_escaped_template=":+-<input1>template {}<input1>-+:",
             taint_escaped_parameter=":+-<input1>parameter<input2>-+:",
             expected_result="template parameter",
-            escaped_expected_result=":+-<input1>template <input1>-+:" ":+-<input2>parameter<input2>-+:",
+            escaped_expected_result=":+-<input1>template <input1>-+::+-<input2>parameter<input2>-+:",
         )
 
     def test_format_when_ranges_overlap_then_give_preference_to_ranges_from_parameter(self):
@@ -113,7 +113,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
             taint_escaped_template=":+-<input1>template⚠️<input1>-+: {}",
             taint_escaped_parameter=":+-<input2>parameter⚠️<input2>-+:",
             expected_result="template⚠️ parameter⚠️",
-            escaped_expected_result=":+-<input1>template⚠️<input1>-+: " ":+-<input2>parameter⚠️<input2>-+:",
+            escaped_expected_result=":+-<input1>template⚠️<input1>-+: :+-<input2>parameter⚠️<input2>-+:",
         )
 
     def test_format_when_tainted_unicode_emoji_strings_then_tainted_result(self):
@@ -122,7 +122,7 @@ class TestOperatorFormatReplacement(BaseReplacement):
             taint_escaped_template=":+-<input1>template⚠️<input1>-+: {}",
             taint_escaped_parameter=":+-<input2>parameter⚠️<input2>-+:",
             expected_result="template⚠️ parameter⚠️",
-            escaped_expected_result=":+-<input1>template⚠️<input1>-+: " ":+-<input2>parameter⚠️<input2>-+:",
+            escaped_expected_result=":+-<input1>template⚠️<input1>-+: :+-<input2>parameter⚠️<input2>-+:",
         )
 
     def test_format_when_tainted_template_range_no_brackets_and_param_not_str_then_tainted(self):
@@ -146,9 +146,9 @@ class TestOperatorFormatReplacement(BaseReplacement):
     def test_format_when_texts_tainted_and_contain_escape_sequences_then_result_uncorrupted(self):
         # type: () -> None
         self._assert_format_result(
-            taint_escaped_template=":+-<input1>template ::++--<0>my_code<0>--++::" "<input1>-+: {}",
-            taint_escaped_parameter=":+-<input2>parameter<input2>-+: " "::++--<0>my_code<0>--++::",
-            expected_result="template :+-<0>my_code<0>-+: parameter " ":+-<0>my_code<0>-+:",
+            taint_escaped_template=":+-<input1>template ::++--<0>my_code<0>--++::<input1>-+: {}",
+            taint_escaped_parameter=":+-<input2>parameter<input2>-+: ::++--<0>my_code<0>--++::",
+            expected_result="template :+-<0>my_code<0>-+: parameter :+-<0>my_code<0>-+:",
             escaped_expected_result=":+-<input1>template :+-<0>my_code<0>-+:<input1>-+: "
             ":+-<input2>parameter<input2>-+: "
             ":+-<0>my_code<0>-+:",

--- a/tests/appsec/iast/aspects/test_fstrings.py
+++ b/tests/appsec/iast/aspects/test_fstrings.py
@@ -9,8 +9,8 @@ import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
 from tests.appsec.iast.aspects.aspect_utils import create_taint_range_with_format
 from tests.appsec.iast.iast_utils import CustomStr

--- a/tests/appsec/iast/aspects/test_index_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_index_aspect_fixtures.py
@@ -6,8 +6,8 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking._context import create_context
 from ddtrace.appsec._iast._taint_tracking._context import reset_context
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.utils import override_global_config
 

--- a/tests/appsec/iast/aspects/test_io_aspects.py
+++ b/tests/appsec/iast/aspects/test_io_aspects.py
@@ -2,9 +2,9 @@
 import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect
 from ddtrace.appsec._iast._taint_tracking.aspects import bytesio_aspect
 from ddtrace.appsec._iast._taint_tracking.aspects import stringio_aspect

--- a/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
@@ -7,8 +7,8 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking._context import create_context
 from ddtrace.appsec._iast._taint_tracking._context import reset_context
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.utils import override_global_config
 

--- a/tests/appsec/iast/aspects/test_modulo_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_modulo_aspect_fixtures.py
@@ -11,8 +11,8 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
 from ddtrace.appsec._iast._taint_tracking import get_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
 from tests.appsec.iast.iast_utils import _iast_patched_module
 
@@ -108,7 +108,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
             taint_escaped_template=":+-<input1>template<input1>-+: %s",
             taint_escaped_parameter=":+-<input2>parameter<input2>-+:",
             expected_result="template parameter",
-            escaped_expected_result=":+-<input1>template<input1>-+: " ":+-<input2>parameter<input2>-+:",
+            escaped_expected_result=":+-<input1>template<input1>-+: :+-<input2>parameter<input2>-+:",
         )
 
     def test_modulo_when_tainted_template_range_with_percent_and_tainted_param_then_tainted(self):  # type: () -> None
@@ -116,7 +116,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
             taint_escaped_template=":+-<input1>template %s<input1>-+:",
             taint_escaped_parameter=":+-<input1>parameter<input2>-+:",
             expected_result="template parameter",
-            escaped_expected_result=":+-<input1>template <input1>-+:" ":+-<input2>parameter<input2>-+:",
+            escaped_expected_result=":+-<input1>template <input1>-+::+-<input2>parameter<input2>-+:",
         )
 
     def test_modulo_when_ranges_overlap_then_give_preference_to_ranges_from_parameter(self):  # type: () -> None
@@ -134,7 +134,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
             taint_escaped_template=":+-<input1>template⚠️<input1>-+: %s",
             taint_escaped_parameter=":+-<input2>parameter⚠️<input2>-+:",
             expected_result="template⚠️ parameter⚠️",
-            escaped_expected_result=":+-<input1>template⚠️<input1>-+: " ":+-<input2>parameter⚠️<input2>-+:",
+            escaped_expected_result=":+-<input1>template⚠️<input1>-+: :+-<input2>parameter⚠️<input2>-+:",
         )
 
     def test_modulo_when_tainted_unicode_emoji_strings_then_tainted_result(self):  # type: () -> None
@@ -142,7 +142,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
             taint_escaped_template=":+-<input1>template⚠️<input1>-+: %s",
             taint_escaped_parameter=":+-<input2>parameter⚠️<input2>-+:",
             expected_result="template⚠️ parameter⚠️",
-            escaped_expected_result=":+-<input1>template⚠️<input1>-+: " ":+-<input2>parameter⚠️<input2>-+:",
+            escaped_expected_result=":+-<input1>template⚠️<input1>-+: :+-<input2>parameter⚠️<input2>-+:",
         )
 
     def test_modulo_when_tainted_template_range_no_percent_and_param_not_str_then_tainted(self):  # type: () -> None
@@ -165,9 +165,9 @@ class TestOperatorModuloReplacement(BaseReplacement):
         self,
     ):  # type: () -> None
         self._assert_modulo_result(
-            taint_escaped_template=":+-<input1>template ::++--<0>my_code<0>--++::" "<input1>-+: %s",
-            taint_escaped_parameter=":+-<input2>parameter<input2>-+: " "::++--<0>my_code<0>--++::",
-            expected_result="template :+-<0>my_code<0>-+: parameter " ":+-<0>my_code<0>-+:",
+            taint_escaped_template=":+-<input1>template ::++--<0>my_code<0>--++::<input1>-+: %s",
+            taint_escaped_parameter=":+-<input2>parameter<input2>-+: ::++--<0>my_code<0>--++::",
+            expected_result="template :+-<0>my_code<0>-+: parameter :+-<0>my_code<0>-+:",
             escaped_expected_result=":+-<input1>template :+-<0>my_code<0>-+:<input1>-+: "
             ":+-<input2>parameter<input2>-+: "
             ":+-<0>my_code<0>-+:",

--- a/tests/appsec/iast/aspects/test_ospath_aspects.py
+++ b/tests/appsec/iast/aspects/test_ospath_aspects.py
@@ -21,8 +21,8 @@ if sys.version_info >= (3, 12) or os.name == "nt":
     from ddtrace.appsec._iast._taint_tracking.aspects import ospathsplitdrive_aspect
 if sys.version_info >= (3, 12):
     from ddtrace.appsec._iast._taint_tracking.aspects import ospathsplitroot_aspect
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
 
 def test_ospathjoin_first_arg_nottainted_noslash():

--- a/tests/appsec/iast/aspects/test_ospath_aspects_fixtures.py
+++ b/tests/appsec/iast/aspects/test_ospath_aspects_fixtures.py
@@ -10,8 +10,8 @@ from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
 from ddtrace.appsec._iast._taint_tracking._context import create_context
 from ddtrace.appsec._iast._taint_tracking._context import reset_context
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.utils import override_global_config
 

--- a/tests/appsec/iast/aspects/test_other_patching.py
+++ b/tests/appsec/iast/aspects/test_other_patching.py
@@ -5,8 +5,8 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
@@ -85,7 +85,7 @@ def test_index_lower_add():
 
 @pytest.mark.skipif(
     sys.version_info >= (3, 11),
-    reason="Python 3.11 and 3.12 raise TypeError: don't know how to" "disassemble _lru_cache_wrapper objects",
+    reason="Python 3.11 and 3.12 raise TypeError: don't know how todisassemble _lru_cache_wrapper objects",
 )
 def test_urlib_parse_patching():
     _iast_patched_module("urllib.parse")

--- a/tests/appsec/iast/aspects/test_re_aspects.py
+++ b/tests/appsec/iast/aspects/test_re_aspects.py
@@ -6,9 +6,9 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect
 from ddtrace.appsec._iast._taint_tracking.aspects import index_aspect
 from ddtrace.appsec._iast._taint_tracking.aspects import re_expand_aspect

--- a/tests/appsec/iast/aspects/test_replace_aspect.py
+++ b/tests/appsec/iast/aspects/test_replace_aspect.py
@@ -9,8 +9,8 @@ from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
 from ddtrace.appsec._iast._taint_tracking import set_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
 from ddtrace.internal.compat import PYTHON_VERSION_INFO
 

--- a/tests/appsec/iast/aspects/test_side_effects.py
+++ b/tests/appsec/iast/aspects/test_side_effects.py
@@ -1,9 +1,9 @@
 import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
-from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject_with_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import taint_pyobject_with_ranges
 import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
 from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.appsec.iast.iast_utils_side_effects import MagicMethodsException

--- a/tests/appsec/iast/aspects/test_slice_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_slice_aspect_fixtures.py
@@ -7,8 +7,8 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking._context import create_context
 from ddtrace.appsec._iast._taint_tracking._context import reset_context
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.utils import override_global_config
 

--- a/tests/appsec/iast/aspects/test_str_aspect.py
+++ b/tests/appsec/iast/aspects/test_str_aspect.py
@@ -11,9 +11,9 @@ from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
 from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
 from tests.appsec.iast.aspects.aspect_utils import create_taint_range_with_format

--- a/tests/appsec/iast/aspects/test_strip_aspect.py
+++ b/tests/appsec/iast/aspects/test_strip_aspect.py
@@ -3,9 +3,9 @@ from hypothesis.strategies import one_of
 import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
 from tests.appsec.iast.iast_utils import string_strategies
 

--- a/tests/appsec/iast/fixtures/entrypoint/views.py
+++ b/tests/appsec/iast/fixtures/entrypoint/views.py
@@ -4,8 +4,8 @@ from flask import Flask
 def add_test():
     from ddtrace.appsec._iast._taint_tracking import OriginType
     from ddtrace.appsec._iast._taint_tracking._context import create_context
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
     from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
     string_to_taint = "abc"
     create_context()

--- a/tests/appsec/iast/taint_sinks/test_command_injection.py
+++ b/tests/appsec/iast/taint_sinks/test_command_injection.py
@@ -8,8 +8,8 @@ import pytest
 
 from ddtrace.appsec._iast._iast_request_context import get_iast_reporter
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect
 from ddtrace.appsec._iast.constants import VULN_CMDI
 from ddtrace.appsec._iast.secure_marks import cmdi_sanitizer

--- a/tests/appsec/iast/taint_sinks/test_header_injection_redacted.py
+++ b/tests/appsec/iast/taint_sinks/test_header_injection_redacted.py
@@ -5,8 +5,8 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import origin_to_str
 from ddtrace.appsec._iast._taint_tracking import str_to_origin
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect
 from ddtrace.appsec._iast.constants import VULN_HEADER_INJECTION
 from ddtrace.appsec._iast.reporter import Evidence

--- a/tests/appsec/iast/taint_sinks/test_path_traversal_redacted.py
+++ b/tests/appsec/iast/taint_sinks/test_path_traversal_redacted.py
@@ -6,8 +6,8 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import origin_to_str
 from ddtrace.appsec._iast._taint_tracking import str_to_origin
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast.constants import VULN_PATH_TRAVERSAL
 from ddtrace.appsec._iast.reporter import Evidence
 from ddtrace.appsec._iast.reporter import IastSpanReporter

--- a/tests/appsec/iast/taint_sinks/test_sql_injection_redacted.py
+++ b/tests/appsec/iast/taint_sinks/test_sql_injection_redacted.py
@@ -3,8 +3,8 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import origin_to_str
 from ddtrace.appsec._iast._taint_tracking import str_to_origin
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect
 from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.appsec._iast.reporter import Evidence

--- a/tests/appsec/iast/taint_tracking/test_taint_tracking.py
+++ b/tests/appsec/iast/taint_tracking/test_taint_tracking.py
@@ -10,8 +10,8 @@ from ddtrace.appsec._iast._taint_tracking import TaintRange
 from ddtrace.appsec._iast._taint_tracking import num_objects_tainted
 from ddtrace.appsec._iast._taint_tracking import set_ranges
 from ddtrace.appsec._iast._taint_tracking._context import reset_context
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect
 from ddtrace.appsec._iast.reporter import IastSpanReporter
 from ddtrace.appsec._iast.reporter import Source

--- a/tests/appsec/iast/test_grpc_iast.py
+++ b/tests/appsec/iast/test_grpc_iast.py
@@ -25,7 +25,7 @@ def iast_c_context():
 
 
 def _check_test_range(value):
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
     ranges = get_tainted_ranges(value)
     assert len(ranges) == 1, f"found {len(ranges)} ranges"

--- a/tests/appsec/iast/test_json_tainting.py
+++ b/tests/appsec/iast/test_json_tainting.py
@@ -4,8 +4,8 @@ import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking._context import create_context
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_utils import LazyTaintDict
 from ddtrace.appsec._iast._taint_utils import LazyTaintList
 from tests.utils import override_global_config

--- a/tests/appsec/iast/test_taint_utils.py
+++ b/tests/appsec/iast/test_taint_utils.py
@@ -1,8 +1,8 @@
 import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_utils import LazyTaintDict
 from ddtrace.appsec._iast._taint_utils import LazyTaintList
 

--- a/tests/appsec/iast_memcheck/test_iast_mem_check.py
+++ b/tests/appsec/iast_memcheck/test_iast_mem_check.py
@@ -11,8 +11,8 @@ from ddtrace.appsec._iast._taint_tracking import initializer_size
 from ddtrace.appsec._iast._taint_tracking import num_objects_tainted
 from ddtrace.appsec._iast._taint_tracking._context import create_context
 from ddtrace.appsec._iast._taint_tracking._context import reset_context
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.appsec.iast.taint_sinks.conftest import _get_span_report
 from tests.appsec.iast_memcheck.fixtures.stacktrace import func_1

--- a/tests/appsec/iast_packages/packages/pkg_attrs.py
+++ b/tests/appsec/iast_packages/packages/pkg_attrs.py
@@ -2,6 +2,7 @@
 attrs==23.2.0
 https://pypi.org/project/attrs/
 """
+
 from flask import Blueprint
 from flask import request
 
@@ -37,7 +38,7 @@ def pkg_attrs_view():
 def pkg_attrs_propagation_view():
     import attrs
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     if not is_pyobject_tainted(response.package_param):

--- a/tests/appsec/iast_packages/packages/pkg_beautifulsoup4.py
+++ b/tests/appsec/iast_packages/packages/pkg_beautifulsoup4.py
@@ -3,6 +3,7 @@ beautifulsoup4==4.12.3
 
 https://pypi.org/project/beautifulsoup4/
 """
+
 from flask import Blueprint
 from flask import request
 
@@ -30,7 +31,7 @@ def pkg_beautifulsoup4_view():
 def pkg_beautifulsoup4_propagation_view():
     from bs4 import BeautifulSoup
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     if not is_pyobject_tainted(response.package_param):

--- a/tests/appsec/iast_packages/packages/pkg_cachetools.py
+++ b/tests/appsec/iast_packages/packages/pkg_cachetools.py
@@ -3,6 +3,7 @@ cachetools==5.3.3
 
 https://pypi.org/project/cachetools/
 """
+
 from flask import Blueprint
 from flask import jsonify
 from flask import request
@@ -50,7 +51,7 @@ def pkg_cachetools_view():
 def pkg_cachetools_propagation_view():
     import cachetools
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
 

--- a/tests/appsec/iast_packages/packages/pkg_chartset_normalizer.py
+++ b/tests/appsec/iast_packages/packages/pkg_chartset_normalizer.py
@@ -3,6 +3,7 @@ charset-normalizer==3.3.2
 
 https://pypi.org/project/charset-normalizer/
 """
+
 from flask import Blueprint
 from flask import request
 
@@ -25,7 +26,7 @@ def pkg_charset_normalizer_view():
 def pkg_charset_normalizer_propagation_view():
     from charset_normalizer import from_bytes
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     if not is_pyobject_tainted(response.package_param):

--- a/tests/appsec/iast_packages/packages/pkg_cryptography.py
+++ b/tests/appsec/iast_packages/packages/pkg_cryptography.py
@@ -2,6 +2,7 @@
 cryptography==42.0.7
 https://pypi.org/project/cryptography/
 """
+
 from flask import Blueprint
 from flask import request
 
@@ -41,7 +42,7 @@ def pkg_cryptography_view():
 def pkg_cryptography_propagation_view():
     from cryptography.fernet import Fernet
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     if not is_pyobject_tainted(response.package_param):

--- a/tests/appsec/iast_packages/packages/pkg_docutils.py
+++ b/tests/appsec/iast_packages/packages/pkg_docutils.py
@@ -3,6 +3,7 @@ docutils==0.21.2
 
 https://pypi.org/project/docutils/
 """
+
 from flask import Blueprint
 from flask import jsonify
 from flask import request
@@ -43,7 +44,7 @@ def pkg_docutils_view():
 def pkg_docutils_propagation_view():
     import docutils.core
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
 

--- a/tests/appsec/iast_packages/packages/pkg_exceptiongroup.py
+++ b/tests/appsec/iast_packages/packages/pkg_exceptiongroup.py
@@ -3,6 +3,7 @@ exceptiongroup==1.2.1
 
 https://pypi.org/project/exceptiongroup/
 """
+
 from flask import Blueprint
 from flask import request
 
@@ -46,7 +47,7 @@ def pkg_exceptiongroup_view():
 def pkg_exceptiongroup_propagation_view():
     from exceptiongroup import ExceptionGroup
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     try:

--- a/tests/appsec/iast_packages/packages/pkg_idna.py
+++ b/tests/appsec/iast_packages/packages/pkg_idna.py
@@ -3,6 +3,7 @@ idna==3.6
 
 https://pypi.org/project/idna/
 """
+
 from flask import Blueprint
 from flask import request
 
@@ -27,7 +28,7 @@ def pkg_idna_view():
 def pkg_idna_propagation_view():
     import idna
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     if not is_pyobject_tainted(response.package_param):

--- a/tests/appsec/iast_packages/packages/pkg_iniconfig.py
+++ b/tests/appsec/iast_packages/packages/pkg_iniconfig.py
@@ -3,6 +3,7 @@ iniconfig==2.0.0
 
 https://pypi.org/project/iniconfig/
 """
+
 import os
 
 from flask import Blueprint
@@ -50,7 +51,7 @@ def pkg_iniconfig_view():
 def pkg_iniconfig_propagation_view():
     import iniconfig
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     try:

--- a/tests/appsec/iast_packages/packages/pkg_jinja2.py
+++ b/tests/appsec/iast_packages/packages/pkg_jinja2.py
@@ -3,6 +3,7 @@ jinja2==3.1.4
 
 https://pypi.org/project/jinja2/
 """
+
 from flask import Blueprint
 from flask import request
 
@@ -36,7 +37,7 @@ def pkg_jinja2_view():
 def pkg_jinja2_propagation_view():
     from jinja2 import Template
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     if not is_pyobject_tainted(response.package_param):

--- a/tests/appsec/iast_packages/packages/pkg_lxml.py
+++ b/tests/appsec/iast_packages/packages/pkg_lxml.py
@@ -3,6 +3,7 @@ lxml==5.2.2
 
 https://pypi.org/project/lxml/
 """
+
 from flask import Blueprint
 from flask import request
 
@@ -39,7 +40,7 @@ def pkg_lxml_view():
 def pkg_lxml_propagation_view():
     from lxml import etree
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     if not is_pyobject_tainted(response.package_param):

--- a/tests/appsec/iast_packages/packages/pkg_multidict.py
+++ b/tests/appsec/iast_packages/packages/pkg_multidict.py
@@ -3,6 +3,7 @@ multidict==6.0.5
 
 https://pypi.org/project/multidict/
 """
+
 from flask import Blueprint
 from flask import request
 
@@ -36,7 +37,7 @@ def pkg_multidict_view():
 def pkg_multidict_propagation_view():
     from multidict import MultiDict
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     if not is_pyobject_tainted(response.package_param):

--- a/tests/appsec/iast_packages/packages/pkg_platformdirs.py
+++ b/tests/appsec/iast_packages/packages/pkg_platformdirs.py
@@ -3,6 +3,7 @@ platformdirs==4.2.2
 
 https://pypi.org/project/platformdirs/
 """
+
 import os
 
 from flask import Blueprint
@@ -47,7 +48,7 @@ def pkg_platformdirs_view():
 def pkg_platformdirs_propagation_view():
     from platformdirs import user_data_dir
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     if not is_pyobject_tainted(response.package_param):

--- a/tests/appsec/iast_packages/packages/pkg_pyasn1.py
+++ b/tests/appsec/iast_packages/packages/pkg_pyasn1.py
@@ -2,6 +2,7 @@
 pyasn1==0.6.0
 https://pypi.org/project/pyasn1/
 """
+
 from flask import Blueprint
 from flask import request
 
@@ -52,7 +53,7 @@ def pkg_pyasn1_propagation_view():
     from pyasn1.type import namedtype
     from pyasn1.type import univ
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     if not is_pyobject_tainted(response.package_param):

--- a/tests/appsec/iast_packages/packages/pkg_pygments.py
+++ b/tests/appsec/iast_packages/packages/pkg_pygments.py
@@ -3,6 +3,7 @@ Pygments==2.18.0
 
 https://pypi.org/project/Pygments/
 """
+
 from flask import Blueprint
 from flask import jsonify
 from flask import request
@@ -45,7 +46,7 @@ def pkg_pygments_propagation_view():
     from pygments.formatters import HtmlFormatter
     from pygments.lexers import PythonLexer
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
 

--- a/tests/appsec/iast_packages/packages/pkg_pynacl.py
+++ b/tests/appsec/iast_packages/packages/pkg_pynacl.py
@@ -3,6 +3,7 @@ PyNaCl==1.5.0
 
 https://pypi.org/project/PyNaCl/
 """
+
 from flask import Blueprint
 from flask import jsonify
 from flask import request
@@ -53,7 +54,7 @@ def pkg_pynacl_propagation_view():
     from nacl import secret
     from nacl import utils
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
 

--- a/tests/appsec/iast_packages/packages/pkg_pyparsing.py
+++ b/tests/appsec/iast_packages/packages/pkg_pyparsing.py
@@ -3,6 +3,7 @@ pyparsing==3.1.2
 
 https://pypi.org/project/pyparsing/
 """
+
 from flask import Blueprint
 from flask import jsonify
 from flask import request
@@ -47,7 +48,7 @@ def pkg_pyparsing_view():
 def pkg_pyparsing_propagation_view():
     import pyparsing as pp
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
 

--- a/tests/appsec/iast_packages/packages/pkg_python_multipart.py
+++ b/tests/appsec/iast_packages/packages/pkg_python_multipart.py
@@ -33,7 +33,7 @@ def pkg_multipart_view():
 def pkg_multipart_propagation_view():
     from multipart.multipart import parse_options_header
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     if not is_pyobject_tainted(response.package_param):

--- a/tests/appsec/iast_packages/packages/pkg_pyyaml.py
+++ b/tests/appsec/iast_packages/packages/pkg_pyyaml.py
@@ -3,6 +3,7 @@ PyYAML==6.0.1
 
 https://pypi.org/project/PyYAML/
 """
+
 import json
 
 from flask import Blueprint
@@ -30,7 +31,7 @@ def pkg_pyyaml_view():
 def pkg_pyyaml_propagation_view():
     import yaml
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     if not is_pyobject_tainted(response.package_param):

--- a/tests/appsec/iast_packages/packages/pkg_rsa.py
+++ b/tests/appsec/iast_packages/packages/pkg_rsa.py
@@ -3,6 +3,7 @@ rsa==4.9
 
 https://pypi.org/project/rsa/
 """
+
 from flask import Blueprint
 from flask import request
 
@@ -36,7 +37,7 @@ def pkg_rsa_view():
 def pkg_rsa_propagation_view():
     import rsa
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     if not is_pyobject_tainted(response.package_param):

--- a/tests/appsec/iast_packages/packages/pkg_soupsieve.py
+++ b/tests/appsec/iast_packages/packages/pkg_soupsieve.py
@@ -3,6 +3,7 @@ soupsieve==2.5
 
 https://pypi.org/project/soupsieve/
 """
+
 from flask import Blueprint
 from flask import request
 
@@ -43,7 +44,7 @@ def pkg_soupsieve_propagation_view():
     from bs4 import BeautifulSoup
     import soupsieve as sv
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     if not is_pyobject_tainted(response.package_param):

--- a/tests/appsec/iast_packages/packages/pkg_sqlalchemy.py
+++ b/tests/appsec/iast_packages/packages/pkg_sqlalchemy.py
@@ -2,6 +2,7 @@
 sqlalchemy==2.0.30
 https://pypi.org/project/sqlalchemy/
 """
+
 from flask import Blueprint
 from flask import request
 
@@ -58,7 +59,7 @@ def pkg_sqlalchemy_propagation_view():
     from sqlalchemy import create_engine
     from sqlalchemy.orm import declarative_base
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     if not is_pyobject_tainted(response.package_param):

--- a/tests/appsec/iast_packages/packages/pkg_tomli.py
+++ b/tests/appsec/iast_packages/packages/pkg_tomli.py
@@ -3,6 +3,7 @@ tomli==2.0.1
 
 https://pypi.org/project/tomli/
 """
+
 from flask import Blueprint
 from flask import request
 
@@ -38,7 +39,7 @@ def pkg_tomli_view():
 def pkg_tomli_propagation_view():
     import tomli
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     if not is_pyobject_tainted(response.package_param):

--- a/tests/appsec/iast_packages/packages/pkg_wrapt.py
+++ b/tests/appsec/iast_packages/packages/pkg_wrapt.py
@@ -3,6 +3,7 @@ wrapt==1.16.0
 
 https://pypi.org/project/wrapt/
 """
+
 from flask import Blueprint
 from flask import jsonify
 from flask import request
@@ -46,7 +47,7 @@ def pkg_wrapt_view():
 
 @pkg_wrapt.route("/wrapt_propagation")
 def pkg_wrapt_propagation_view():
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
 

--- a/tests/appsec/iast_packages/packages/pkg_yarl.py
+++ b/tests/appsec/iast_packages/packages/pkg_yarl.py
@@ -3,6 +3,7 @@ yarl==1.9.4
 
 https://pypi.org/project/yarl/
 """
+
 from flask import Blueprint
 from flask import request
 
@@ -24,11 +25,7 @@ def pkg_yarl_view():
         try:
             url = URL(url_param)
             result_output = (
-                f"Original URL: {url}\n"
-                f"Scheme: {url.scheme}\n"
-                f"Host: {url.host}\n"
-                f"Path: {url.path}\n"
-                f"Query: {url.query}\n"
+                f"Original URL: {url}\nScheme: {url.scheme}\nHost: {url.host}\nPath: {url.path}\nQuery: {url.query}\n"
             )
         except Exception as e:
             result_output = f"Error: {str(e)}"
@@ -44,7 +41,7 @@ def pkg_yarl_view():
 def pkg_yarl_propagation_view():
     from yarl import URL
 
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
     response = ResultResponse(request.args.get("package_param"))
     if not is_pyobject_tainted(response.package_param):

--- a/tests/appsec/iast_packages/packages/utils.py
+++ b/tests/appsec/iast_packages/packages/utils.py
@@ -2,7 +2,7 @@ from tests.utils import override_env
 
 
 with override_env({"DD_IAST_ENABLED": "True"}):
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
 
 class ResultResponse:

--- a/tests/appsec/iast_tdd_propagation/flask_orm_app.py
+++ b/tests/appsec/iast_tdd_propagation/flask_orm_app.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
-""" This Flask application is imported on tests.appsec.appsec_utils.gunicorn_server
-"""
-
+"""This Flask application is imported on tests.appsec.appsec_utils.gunicorn_server"""
 
 import importlib
 import os
@@ -18,7 +16,7 @@ from tests.utils import override_env
 
 
 with override_env({"DD_IAST_ENABLED": "True"}):
-    from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+    from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
 import ddtrace.auto  # noqa: F401  # isort: skip
 

--- a/tests/appsec/iast_tdd_propagation/flask_propagation_views.py
+++ b/tests/appsec/iast_tdd_propagation/flask_propagation_views.py
@@ -3,7 +3,7 @@ import sys
 from flask import Flask
 from flask import request
 
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.trace import tracer
 
 

--- a/tests/appsec/iast_tdd_propagation/flask_taint_sinks_views.py
+++ b/tests/appsec/iast_tdd_propagation/flask_taint_sinks_views.py
@@ -5,7 +5,7 @@ from Crypto.Cipher import ARC4
 from flask import Flask
 from flask import request
 
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.trace import tracer
 from tests.appsec.iast.taint_sinks.conftest import _get_span_report
 

--- a/tests/appsec/integrations/django_tests/django_app/views.py
+++ b/tests/appsec/integrations/django_tests/django_app/views.py
@@ -19,7 +19,7 @@ from django.utils.safestring import mark_safe
 
 from ddtrace.appsec import _asm_request_context
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast.reporter import IastSpanReporter
 from ddtrace.appsec._trace_utils import block_request_if_user_blocked
 from ddtrace.trace import tracer

--- a/tests/appsec/integrations/fastapi_tests/test_fastapi_appsec_iast.py
+++ b/tests/appsec/integrations/fastapi_tests/test_fastapi_appsec_iast.py
@@ -19,7 +19,7 @@ from ddtrace.appsec._iast._handlers import _on_iast_fastapi_patch
 from ddtrace.appsec._iast._overhead_control_engine import oce
 from ddtrace.appsec._iast._patch_modules import patch_iast
 from ddtrace.appsec._iast._taint_tracking import origin_to_str
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 from ddtrace.appsec._iast.constants import VULN_HEADER_INJECTION
 from ddtrace.appsec._iast.constants import VULN_INSECURE_COOKIE
 from ddtrace.appsec._iast.constants import VULN_NO_HTTPONLY_COOKIE
@@ -257,7 +257,7 @@ def test_header_value_source_typing_param(fastapi_application, client, tracer, t
     @fastapi_application.get("/index.html")
     async def test_route(iast_header: typing.Annotated[str, Header()] = None):
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
         ranges_result = get_tainted_ranges(iast_header)
 
@@ -291,7 +291,7 @@ def test_cookies_source(fastapi_application, client, tracer, test_spans):
     @fastapi_application.get("/index.html")
     async def test_route(request: Request):
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
         query_params = request.cookies.get("iast_cookie")
         ranges_result = get_tainted_ranges(query_params)
@@ -327,7 +327,7 @@ def test_cookies_source_typing_param(fastapi_application, client, tracer, test_s
     @fastapi_application.get("/index.html")
     async def test_route(iast_cookie: typing.Annotated[str, Cookie()] = "ddd"):
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
         ranges_result = get_tainted_ranges(iast_cookie)
 
@@ -361,7 +361,7 @@ def test_path_param_source(fastapi_application, client, tracer, test_spans):
     @fastapi_application.get("/index.html/{item_id}")
     async def test_route(item_id):
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
         ranges_result = get_tainted_ranges(item_id)
 
@@ -394,7 +394,7 @@ def test_path_source(fastapi_application, client, tracer, test_spans):
     @fastapi_application.get("/path_source/")
     async def test_route(request: Request):
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
         path = request.url.path
         ranges_result = get_tainted_ranges(path)
@@ -428,7 +428,7 @@ def test_path_body_receive_source(fastapi_application, client, tracer, test_span
     @fastapi_application.post("/index.html")
     async def test_route(request: Request):
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
         body = await request.receive()
         result = body["body"]
@@ -465,7 +465,7 @@ def test_path_body_body_source(fastapi_application, client, tracer, test_spans):
     @fastapi_application.post("/index.html")
     async def test_route(request: Request):
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
         body = await request.body()
         ranges_result = get_tainted_ranges(body)
@@ -503,7 +503,7 @@ def test_path_body_body_source_formdata_latest(fastapi_application, client, trac
     @fastapi_application.post("/index.html")
     async def test_route(path: typing.Annotated[str, Form()]):
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
         ranges_result = get_tainted_ranges(path)
 
@@ -534,7 +534,7 @@ def test_path_body_body_source_formdata_90(fastapi_application, client, tracer, 
     @fastapi_application.post("/index.html")
     async def test_route(path: str = Form(...)):
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
         ranges_result = get_tainted_ranges(path)
 
@@ -574,7 +574,7 @@ def test_path_body_source_pydantic(fastapi_application, client, tracer, test_spa
     @fastapi_application.post("/index")
     async def test_route(item: Item):
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
         ranges_result = get_tainted_ranges(item.name)
 
@@ -607,7 +607,7 @@ def test_path_body_source_pydantic(fastapi_application, client, tracer, test_spa
 def test_path_body_body_upload(fastapi_application, client, tracer, test_spans):
     @fastapi_application.post("/uploadfile/")
     async def create_upload_file(files: typing.List[UploadFile]):
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
         ranges_result = get_tainted_ranges(files[0])
         return JSONResponse(
@@ -639,7 +639,7 @@ def test_fastapi_sqli_path_param(fastapi_application, client, tracer, test_spans
     async def test_route(param_str):
         import sqlite3
 
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
         from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect
 
         assert is_pyobject_tainted(param_str)
@@ -692,7 +692,7 @@ def test_fastapi_insecure_cookie(fastapi_application, client, tracer, test_spans
     @fastapi_application.route("/insecure_cookie/", methods=["GET"])
     def insecure_cookie(request: Request):
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
         query_params = request.query_params.get("iast_queryparam")
         ranges_result = get_tainted_ranges(query_params)
@@ -740,7 +740,7 @@ def test_fastapi_insecure_cookie_empty(fastapi_application, client, tracer, test
     @fastapi_application.route("/insecure_cookie/", methods=["GET"])
     def insecure_cookie(request: Request):
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
         query_params = request.query_params.get("iast_queryparam")
         ranges_result = get_tainted_ranges(query_params)
@@ -777,7 +777,7 @@ def test_fastapi_no_http_only_cookie(fastapi_application, client, tracer, test_s
     @fastapi_application.route("/insecure_cookie/", methods=["GET"])
     def insecure_cookie(request: Request):
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
         query_params = request.query_params.get("iast_queryparam")
         ranges_result = get_tainted_ranges(query_params)
@@ -825,7 +825,7 @@ def test_fastapi_no_http_only_cookie_empty(fastapi_application, client, tracer, 
     @fastapi_application.route("/insecure_cookie/", methods=["GET"])
     def insecure_cookie(request: Request):
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
         query_params = request.query_params.get("iast_queryparam")
         ranges_result = get_tainted_ranges(query_params)
@@ -860,7 +860,7 @@ def test_fastapi_no_samesite_cookie(fastapi_application, client, tracer, test_sp
     @fastapi_application.route("/insecure_cookie/", methods=["GET"])
     def insecure_cookie(request: Request):
         from ddtrace.appsec._iast._taint_tracking import origin_to_str
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
         query_params = request.query_params.get("iast_queryparam")
         ranges_result = get_tainted_ranges(query_params)
@@ -907,7 +907,7 @@ def test_fastapi_no_samesite_cookie(fastapi_application, client, tracer, test_sp
 def test_fastapi_header_injection(fastapi_application, client, tracer, test_spans):
     @fastapi_application.get("/header_injection/")
     async def header_injection(request: Request):
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
         tainted_string = request.headers.get("test")
         assert is_pyobject_tainted(tainted_string)
@@ -953,7 +953,7 @@ def test_fastapi_header_injection(fastapi_application, client, tracer, test_span
 def test_fastapi_header_injection_inline_response(fastapi_application, client, tracer, test_spans):
     @fastapi_application.get("/header_injection_inline_response/", response_class=PlainTextResponse)
     async def header_injection_inline_response(request: Request):
-        from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+        from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
         tainted_string = request.headers.get("test")
         assert is_pyobject_tainted(tainted_string)

--- a/tests/appsec/integrations/fixtures/sql_injection_mysqldb.py
+++ b/tests/appsec/integrations/fixtures/sql_injection_mysqldb.py
@@ -1,8 +1,8 @@
 import MySQLdb
 from MySQLdb import OperationalError
 
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from tests.appsec.integrations.packages_tests.db_utils import MYSQL_HOST
 
 

--- a/tests/appsec/integrations/fixtures/sql_injection_psycopg2.py
+++ b/tests/appsec/integrations/fixtures/sql_injection_psycopg2.py
@@ -2,8 +2,8 @@ from psycopg2.errors import DuplicateTable
 from psycopg2.errors import InFailedSqlTransaction
 from psycopg2.errors import QueryCanceled
 
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from tests.appsec.integrations.packages_tests.db_utils import get_psycopg2_connection
 
 

--- a/tests/appsec/integrations/fixtures/sql_injection_pymysql.py
+++ b/tests/appsec/integrations/fixtures/sql_injection_pymysql.py
@@ -1,7 +1,7 @@
 from pymysql.err import OperationalError
 
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from tests.appsec.integrations.packages_tests.db_utils import get_pymysql_connection
 
 

--- a/tests/appsec/integrations/fixtures/sql_injection_sqlalchemy.py
+++ b/tests/appsec/integrations/fixtures/sql_injection_sqlalchemy.py
@@ -2,8 +2,8 @@ from sqlalchemy import create_engine
 from sqlalchemy import text
 from sqlalchemy.exc import ProgrammingError
 
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from tests.appsec.integrations.packages_tests.db_utils import POSTGRES_HOST
 
 

--- a/tests/appsec/integrations/fixtures/sql_injection_sqlite3.py
+++ b/tests/appsec/integrations/fixtures/sql_injection_sqlite3.py
@@ -1,7 +1,7 @@
 import sqlite3
 
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 
 
 def sqli_simple(table):

--- a/tests/appsec/integrations/flask_tests/test_iast_flask.py
+++ b/tests/appsec/integrations/flask_tests/test_iast_flask.py
@@ -9,7 +9,7 @@ from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._iast_request_context_base import _iast_start_request
 from ddtrace.appsec._iast._overhead_control_engine import oce
 from ddtrace.appsec._iast._patches.json_tainting import patch as patch_json
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast.constants import VULN_HEADER_INJECTION
 from ddtrace.appsec._iast.constants import VULN_INSECURE_COOKIE
 from ddtrace.appsec._iast.constants import VULN_NO_HTTPONLY_COOKIE
@@ -341,7 +341,7 @@ class FlaskAppSecIASTEnabledTestCase(BaseFlaskTestCase):
             from flask import request
 
             from ddtrace.appsec._iast._taint_tracking import OriginType
-            from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
+            from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
             header_ranges = get_tainted_ranges(request.headers["User-Agent"])
             assert header_ranges

--- a/tests/appsec/integrations/langchain_tests/test_iast_langchain.py
+++ b/tests/appsec/integrations/langchain_tests/test_iast_langchain.py
@@ -24,8 +24,8 @@ from langchain_core.prompts import PromptTemplate
 import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast.constants import VULN_CMDI
 from tests.appsec.iast.conftest import iast_span_defaults  # noqa: F401
 from tests.appsec.iast.taint_sinks.conftest import _get_span_report

--- a/tests/appsec/integrations/packages_tests/test_iast_psycopg2_extensions.py
+++ b/tests/appsec/integrations/packages_tests/test_iast_psycopg2_extensions.py
@@ -1,6 +1,6 @@
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_utils import LazyTaintList
 from tests.appsec.iast.iast_utils import _iast_patched_module
 

--- a/tests/appsec/integrations/packages_tests/test_iast_sanitizers.py
+++ b/tests/appsec/integrations/packages_tests/test_iast_sanitizers.py
@@ -1,8 +1,8 @@
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import VulnerabilityType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import get_tainted_ranges
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from tests.appsec.iast.iast_utils import _iast_patched_module
 
 

--- a/tests/appsec/integrations/packages_tests/test_iast_sql_injection.py
+++ b/tests/appsec/integrations/packages_tests/test_iast_sql_injection.py
@@ -2,8 +2,8 @@ import pytest
 
 from ddtrace import patch
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._taint_objects import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.appsec._iast.taint_sinks._base import VulnerabilityBase
 from tests.appsec.iast.iast_utils import _iast_patched_module


### PR DESCRIPTION
## Description

This PR adds a type hint to the `reporter` member of the `IASTEnvironment` class. To avoid introducing a circular dependency, the following modifications are performed:

- Move the `stacktrace_id` counter from the `IASTEnvironment` to the `IastSpanReporter`
- Extract a few functions of the `_taint_objects` module in a new `_taint_objects_base` module to be able to import them independently


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
