### PR TITLE
fix(tracing): resolve atexit error log on app shutdown

### DIFF
--- a/ddtrace/_trace/product.py
+++ b/ddtrace/_trace/product.py
@@ -95,10 +95,10 @@ def stop(join=False):
 
 
 def at_exit(join=False):
-    from ddtrace.trace import tracer
-
-    if tracer.enabled:
-        tracer._atexit()
+    # at_exit hooks are currently registered when the tracer is created. This is
+    # required to support non-global tracers (ex: CiVisibility and the Dummy Tracers used in tests).
+    # TODO: Move the at_exit hooks from ddtrace.trace.Tracer._init__(....) to the product protocol,
+    pass
 
 
 class APMCapabilities(enum.IntFlag):

--- a/releasenotes/notes/remove-before_in_child-error-log-35bfbe07236adf92.yaml
+++ b/releasenotes/notes/remove-before_in_child-error-log-35bfbe07236adf92.yaml
@@ -1,0 +1,5 @@
+---
+
+fixes:
+  - |
+    Resolves the "sample_before_fork was unregistered without first being registered" warning by removing tracer at_exit hooks from the product protocol, ensuring hooks are registered and unregistered exactly once.

--- a/tests/commands/test_runner.py
+++ b/tests/commands/test_runner.py
@@ -522,3 +522,48 @@ def test_ddtrace_run_and_auto_sitecustomize():
     # no additional modules imported / side-effects
     final_modules = set(sys.modules.keys())
     assert final_modules - starting_modules == set(["ddtrace.auto"])
+
+
+@pytest.mark.subprocess(ddtrace_run=False, err="")
+def test_ddtrace_run_atexit():
+    """When ddtrace-run is used, ensure atexit hooks are registered exactly once"""
+    import sys
+
+    from mock import patch
+
+    registered_funcs = set()
+    unregistered_funcs = set()
+
+    def mock_register(func):
+        if func in registered_funcs:
+            raise AssertionError("Duplicate registered function: %s" % func)
+        registered_funcs.add(func)
+
+    def mock_unregister(func):
+        if func in unregistered_funcs:
+            raise AssertionError("Duplicate unregistered function: %s" % func)
+        unregistered_funcs.add(func)
+
+    with patch("ddtrace.internal.atexit.register", side_effect=mock_register), patch(
+        "ddtrace.internal.atexit.unregister", side_effect=mock_unregister
+    ), patch("ddtrace.internal.atexit.register_on_exit_signal", side_effect=mock_register), patch(
+        "atexit.register", side_effect=mock_register
+    ), patch(
+        "atexit.unregister", side_effect=mock_unregister
+    ):
+        # Create and shutdown a tracer
+        import ddtrace.auto  # noqa: F401
+        from ddtrace.trace import tracer
+
+        assert "ddtrace.bootstrap.sitecustomize" in sys.modules
+        assert sys.modules["ddtrace.bootstrap.sitecustomize"].loaded
+        tracer.shutdown()
+        tracer.shutdown()
+        tracer.shutdown()
+
+        assert len(registered_funcs) == len(
+            set(registered_funcs)
+        ), f"Duplicate registered functions: {registered_funcs}"
+        assert len(unregistered_funcs) == len(
+            set(unregistered_funcs)
+        ), f"Duplicate unregistered functions: {unregistered_funcs}"


### PR DESCRIPTION
## Description

The following statement in `ddtrace._trace.tracer` will always resolve to `True` for the global tracer because the `tracer.py` is loaded before `sitecustomize.py`. This results in tracer atexit hooks being registered by the product manager and on tracer initialization. 

```
if not isinstance(self, Tracer) or "ddtrace.bootstrap.sitecustomize" not in sys.modules:
  ....
```

This results in the following error log being generated on application shutdown: 
`This results in `before_in_child hook _sample_before_fork was unregistered without first being registered`.

## Changes

- Moved tracer at_exit hooks from the product protocol to Tracer.__init__ (reverts a recent change)
- Fixed a warning where `_sample_before_fork` hook was being unregistered without first being registered
- Ensures tracer at exit hooks are registered and unregistered exactly once

Currently 

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
