### PR TITLE
feat(packages): symlinked .runfile pkgs should not be usercode

### DIFF
--- a/tests/debugging/origin/test_span.py
+++ b/tests/debugging/origin/test_span.py
@@ -63,8 +63,8 @@ class SpanProbeTestCase(TracerTestCase):
 
         # Check for the expected tags on the exit span
         assert _exit.get_tag("_dd.code_origin.type") == "exit"
-        assert _exit.get_tag("_dd.code_origin.frames.2.file") == str(Path(__file__).resolve())
-        assert _exit.get_tag("_dd.code_origin.frames.2.line") == str(self.test_span_origin.__code__.co_firstlineno)
+        assert _exit.get_tag("_dd.code_origin.frames.0.file") == str(Path(__file__).resolve())
+        assert _exit.get_tag("_dd.code_origin.frames.0.line") == str(self.test_span_origin.__code__.co_firstlineno)
 
     def test_span_origin_session(self):
         def entry_call():


### PR DESCRIPTION
While dogfooding, we noticed that code origins was still sending third-party code for bazel, e.g. this path:

```
/app/domains/dashboardsnotebooks_backend/sharing/apps/apis/shared_dd_query/shared_dd_query.runfiles/dd_source/external/pypi_linux_x86_64_ddtrace/site-packages/ddtrace/_trace/tracer.py
```

We have code specifically to handle the `*.runfiles` path, but we pass the string to a Path and call the resolve which removes the `*.runfiles` segment.

To fix this, we update the path resolution logic in `ddtrace/internal/packages.py` to improve handling of symlinks and add a new test to ensure correct behavior when symlinks are involved. 

## Changes

### Path resolution improvements:
* [`ddtrace/internal/packages.py`](diffhunk://#diff-362935abfa156805410cbcdbfa453d011dbc4c77ce21a20c68402ec130c2e76fL116-R117): Updated `_root_module` to use `path` instead of `path.resolve()` to ensure symlinks are searched properly. Similarly, updated `filename_to_package` to use `path` for consistent path handling. [[1]](diffhunk://#diff-362935abfa156805410cbcdbfa453d011dbc4c77ce21a20c68402ec130c2e76fL116-R117) [[2]](diffhunk://#diff-362935abfa156805410cbcdbfa453d011dbc4c77ce21a20c68402ec130c2e76fL225-R226)

### New test for symlink handling:
* [`tests/internal/test_packages.py`](diffhunk://#diff-bd71856276db697cbc2cd49e26c7598838b0ca0c67af35876ad8f8944014cd10R107-R136): Added `test_third_party_packages_symlinks` to verify that symlinks, particularly those with `.runfiles` in their paths, are correctly excluded from being identified as user code. This ensures the logic remains robust in environments with symlinked directories.

Refs: DEBUG-3926

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
