### PR TITLE
chore: format cpp files and block ci iff there's format diff

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/static_sample_pool.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/static_sample_pool.hpp
@@ -9,13 +9,13 @@ namespace Datadog {
 
 class StaticSamplePool
 {
-public:
+  public:
     static constexpr std::size_t CAPACITY = g_default_sample_pool_capacity;
 
     static std::optional<Sample*> take_sample();
     static std::optional<Sample*> return_sample(Sample* sample);
 
-private:
+  private:
     StaticSamplePool() = delete;
     StaticSamplePool(const StaticSamplePool&) = delete;
     StaticSamplePool& operator=(const StaticSamplePool&) = delete;

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/static_sample_pool.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/static_sample_pool.hpp
@@ -9,13 +9,13 @@ namespace Datadog {
 
 class StaticSamplePool
 {
-  public:
+public:
     static constexpr std::size_t CAPACITY = g_default_sample_pool_capacity;
 
     static std::optional<Sample*> take_sample();
     static std::optional<Sample*> return_sample(Sample* sample);
 
-  private:
+private:
     StaticSamplePool() = delete;
     StaticSamplePool(const StaticSamplePool&) = delete;
     StaticSamplePool& operator=(const StaticSamplePool&) = delete;

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/static_sample_pool.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/static_sample_pool.cpp
@@ -1,23 +1,28 @@
 #include "static_sample_pool.hpp"
+
 #include "sample.hpp"
-#include <optional>
 #include <atomic>
 #include <cstddef>
+#include <optional>
 
 namespace Datadog {
 
 static constexpr std::size_t CAPACITY = StaticSamplePool::CAPACITY;
 static std::atomic<Sample*> pool[CAPACITY];
 
-struct StaticSamplePoolInitializer {
-    StaticSamplePoolInitializer() {
+struct StaticSamplePoolInitializer
+{
+    StaticSamplePoolInitializer()
+    {
         for (std::size_t i = 0; i < CAPACITY; ++i) {
             pool[i].store(nullptr, std::memory_order_relaxed);
         }
     }
 } initializer;
 
-std::optional<Sample*> StaticSamplePool::take_sample() {
+std::optional<Sample*>
+StaticSamplePool::take_sample()
+{
     for (std::size_t i = 0; i < CAPACITY; ++i) {
         Sample* s = pool[i].exchange(nullptr, std::memory_order_acq_rel);
         if (s != nullptr) {
@@ -27,12 +32,12 @@ std::optional<Sample*> StaticSamplePool::take_sample() {
     return std::nullopt;
 }
 
-std::optional<Sample*> StaticSamplePool::return_sample(Sample* sample) {
+std::optional<Sample*>
+StaticSamplePool::return_sample(Sample* sample)
+{
     for (std::size_t i = 0; i < CAPACITY; ++i) {
         Sample* expected = nullptr;
-        if (pool[i].compare_exchange_strong(expected, sample,
-                                            std::memory_order_acq_rel,
-                                            std::memory_order_relaxed)) {
+        if (pool[i].compare_exchange_strong(expected, sample, std::memory_order_acq_rel, std::memory_order_relaxed)) {
             return std::nullopt;
         }
     }

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/static_sample_pool.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/static_sample_pool.cpp
@@ -1,28 +1,23 @@
 #include "static_sample_pool.hpp"
-
 #include "sample.hpp"
+#include <optional>
 #include <atomic>
 #include <cstddef>
-#include <optional>
 
 namespace Datadog {
 
 static constexpr std::size_t CAPACITY = StaticSamplePool::CAPACITY;
 static std::atomic<Sample*> pool[CAPACITY];
 
-struct StaticSamplePoolInitializer
-{
-    StaticSamplePoolInitializer()
-    {
+struct StaticSamplePoolInitializer {
+    StaticSamplePoolInitializer() {
         for (std::size_t i = 0; i < CAPACITY; ++i) {
             pool[i].store(nullptr, std::memory_order_relaxed);
         }
     }
 } initializer;
 
-std::optional<Sample*>
-StaticSamplePool::take_sample()
-{
+std::optional<Sample*> StaticSamplePool::take_sample() {
     for (std::size_t i = 0; i < CAPACITY; ++i) {
         Sample* s = pool[i].exchange(nullptr, std::memory_order_acq_rel);
         if (s != nullptr) {
@@ -32,12 +27,12 @@ StaticSamplePool::take_sample()
     return std::nullopt;
 }
 
-std::optional<Sample*>
-StaticSamplePool::return_sample(Sample* sample)
-{
+std::optional<Sample*> StaticSamplePool::return_sample(Sample* sample) {
     for (std::size_t i = 0; i < CAPACITY; ++i) {
         Sample* expected = nullptr;
-        if (pool[i].compare_exchange_strong(expected, sample, std::memory_order_acq_rel, std::memory_order_relaxed)) {
+        if (pool[i].compare_exchange_strong(expected, sample,
+                                            std::memory_order_acq_rel,
+                                            std::memory_order_relaxed)) {
             return std::nullopt;
         }
     }

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
@@ -59,9 +59,8 @@ Datadog::Uploader::upload(ddog_prof_Profile& profile)
 {
     // Serialize the profile
     ddog_prof_Profile_SerializeResult serialize_result = ddog_prof_Profile_serialize(&profile, nullptr, nullptr);
-    if (serialize_result.tag !=
-        DDOG_PROF_PROFILE_SERIALIZE_RESULT_OK) { // NOLINT (cppcoreguidelines-pro-type-union-access)
-        auto err = serialize_result.err;         // NOLINT (cppcoreguidelines-pro-type-union-access)
+    if (serialize_result.tag != DDOG_PROF_PROFILE_SERIALIZE_RESULT_OK) { // NOLINT (cppcoreguidelines-pro-type-union-access)
+        auto err = serialize_result.err;                                 // NOLINT (cppcoreguidelines-pro-type-union-access)
         errmsg = err_to_msg(&err, "Error serializing pprof");
         std::cerr << errmsg << std::endl;
         ddog_Error_drop(&err);

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
@@ -59,8 +59,9 @@ Datadog::Uploader::upload(ddog_prof_Profile& profile)
 {
     // Serialize the profile
     ddog_prof_Profile_SerializeResult serialize_result = ddog_prof_Profile_serialize(&profile, nullptr, nullptr);
-    if (serialize_result.tag != DDOG_PROF_PROFILE_SERIALIZE_RESULT_OK) { // NOLINT (cppcoreguidelines-pro-type-union-access)
-        auto err = serialize_result.err;                                 // NOLINT (cppcoreguidelines-pro-type-union-access)
+    if (serialize_result.tag !=
+        DDOG_PROF_PROFILE_SERIALIZE_RESULT_OK) { // NOLINT (cppcoreguidelines-pro-type-union-access)
+        auto err = serialize_result.err;         // NOLINT (cppcoreguidelines-pro-type-union-access)
         errmsg = err_to_msg(&err, "Error serializing pprof");
         std::cerr << errmsg << std::endl;
         ddog_Error_drop(&err);

--- a/scripts/cformat.sh
+++ b/scripts/cformat.sh
@@ -83,13 +83,15 @@ if [[ "$UPDATE_MODE" == "true" ]]; then
         done
 else
     # Check mode: Compare formatted output to existing files
-    enumerate_files \
-        | exclude_patterns \
-        | while IFS= read -r filename; do
-            CFORMAT_TMP=$(mktemp)
-            ${CLANG_FORMAT} "$filename" > "$CFORMAT_TMP"
-            diff -u "$filename" "$CFORMAT_TMP" || true
-            rm -f "$CFORMAT_TMP"
-        done
+    has_diff=0
+    while IFS= read -r filename; do
+        CFORMAT_TMP=$(mktemp)
+        ${CLANG_FORMAT} "$filename" > "$CFORMAT_TMP"
+        if ! diff -u "$filename" "$CFORMAT_TMP"; then
+            has_diff=1
+        fi
+        rm -f "$CFORMAT_TMP"
+    done < <(enumerate_files | exclude_patterns)
+    exit $has_diff
 fi
 

--- a/scripts/cformat.sh
+++ b/scripts/cformat.sh
@@ -19,7 +19,6 @@ exclude_patterns() {
         '.riot/'
         '_taint_tracking/_vendor/'
         'ddtrace/appsec/_iast/_taint_tracking/cmake-build-debug/'
-        'ddtrace/profiling/collector/vendor/'
     )
 
     # Join all patterns with '|'

--- a/scripts/cformat.sh
+++ b/scripts/cformat.sh
@@ -19,6 +19,7 @@ exclude_patterns() {
         '.riot/'
         '_taint_tracking/_vendor/'
         'ddtrace/appsec/_iast/_taint_tracking/cmake-build-debug/'
+        'ddtrace/profiling/collector/vendor/'
     )
 
     # Join all patterns with '|'


### PR DESCRIPTION
On main even if there's diff `scripts/cformat.sh` doesn't exit with code other than 0, and our CI `hatch run lint:fmt` doesn't block the rest of CI to be run. Modify `cformat.sh` to exit with 1 if there's diff, 0 otherwise. 

Format cpp files and add cwisstable.h to ignore list. 

prechecks doesn't stop CI even though there are diffs on main https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/950723647
prechecks fails on c3b072d27a666d9411bd80da232fee5283603d46 https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/951192540

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
