### PR TITLE
chore(datastreams) : make get context case insenstive

### DIFF
--- a/ddtrace/internal/datastreams/botocore.py
+++ b/ddtrace/internal/datastreams/botocore.py
@@ -142,7 +142,6 @@ def get_datastreams_context(message):
         - message.MesssageAttributes._datadog.BinaryValue.decode() (SNS -> SQS, raw)
     """
     context_json = None
-    message_body = message
     try:
         message_body = message.get("Body") or message.get("body")
         message_body = json.loads(message_body)
@@ -163,7 +162,7 @@ def get_datastreams_context(message):
         k.lower(): v for k, v in message_lower["messageattributes"]["_datadog"].items()
     }
 
-    if message_body.get("type", "").lower() == "notification":
+    if message_body and message_body.get("type", "").lower() == "notification":
         # This is potentially a DSM SNS notification
         if datadog_attribute_lower.get("type", "").lower() == "binary":
             context_json = json.loads(base64.b64decode(datadog_attribute_lower["value"]).decode())

--- a/ddtrace/internal/datastreams/botocore.py
+++ b/ddtrace/internal/datastreams/botocore.py
@@ -146,7 +146,7 @@ def get_datastreams_context(message):
     try:
         message_body = message.get("Body") or message.get("body")
         message_body = json.loads(message_body)
-    except ValueError:
+    except (ValueError, TypeError):
         log.debug("Unable to parse message body, treat as non-json")
 
     message_lower = {k.lower(): v for k, v in message.items()}

--- a/tests/datastreams/test_context.py
+++ b/tests/datastreams/test_context.py
@@ -1,0 +1,33 @@
+import json
+
+from ddtrace.internal.datastreams.botocore import get_datastreams_context
+
+
+def test_lowercase_message_attributes():
+    """Test case-insensitivity for 'messageAttributes' key"""
+    test_data = {"test_key": "test_value"}
+    message = {
+        "messageAttributes": {  # lowercase instead of MessageAttributes
+            "_datadog": {
+                "StringValue": json.dumps(test_data),
+            }
+        }
+    }
+
+    context = get_datastreams_context(message)
+    assert context == test_data
+
+
+def test_lowercase_string_value():
+    """Test case-insensitivity for 'stringValue' key"""
+    test_data = {"test_key": "test_value"}
+    message = {
+        "MessageAttributes": {
+            "_datadog": {
+                "stringValue": json.dumps(test_data),  # lowercase instead of StringValue
+            }
+        }
+    }
+
+    context = get_datastreams_context(message)
+    assert context == test_data


### PR DESCRIPTION
Make get_datastreams_context case insensitive so does not break when JSON format does not match perfectly

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
