### PR TITLE
chore(profiling): make recorder an optional parameter for collectors

### DIFF
--- a/ddtrace/profiling/collector/__init__.py
+++ b/ddtrace/profiling/collector/__init__.py
@@ -20,7 +20,7 @@ class CollectorUnavailable(CollectorError):
 class Collector(service.Service):
     """A profile collector."""
 
-    def __init__(self, recorder: Recorder, *args, **kwargs):
+    def __init__(self, recorder: typing.Optional[Recorder] = None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.recorder = recorder
 
@@ -77,7 +77,7 @@ class CaptureSampler(object):
 
 
 class CaptureSamplerCollector(Collector):
-    def __init__(self, recorder, capture_pct=config.capture_pct, *args, **kwargs):
+    def __init__(self, recorder: typing.Optional[Recorder] = None, capture_pct=config.capture_pct, *args, **kwargs):
         super().__init__(recorder, *args, **kwargs)
         self.capture_pct = capture_pct
         self._capture_sampler = CaptureSampler(self.capture_pct)

--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -313,7 +313,7 @@ class LockCollector(collector.CaptureSamplerCollector):
 
     def __init__(
         self,
-        recorder,
+        recorder: typing.Optional[Recorder] = None,
         nframes=config.max_frames,
         endpoint_collection_enabled=config.endpoint_collection,
         export_libdd_enabled=config.export.libdd_enabled,

--- a/ddtrace/profiling/collector/memalloc.py
+++ b/ddtrace/profiling/collector/memalloc.py
@@ -69,7 +69,7 @@ class MemoryCollector(collector.PeriodicCollector):
 
     def __init__(
         self,
-        recorder: Recorder,
+        recorder: Optional[Recorder] = None,
         _interval: float = _DEFAULT_INTERVAL,
         _max_events: Optional[int] = None,
         max_nframe: Optional[int] = None,

--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -471,7 +471,7 @@ class StackCollector(collector.PeriodicCollector):
     )
 
     def __init__(self,
-                 recorder: Recorder,
+                 recorder: typing.Optional[Recorder] = None,
                  max_time_usage_pct: float = config.max_time_usage_pct,
                  nframes: int = config.max_frames,
                  ignore_profiler: bool = config.ignore_profiler,

--- a/tests/profiling_v2/collector/test_asyncio.py
+++ b/tests/profiling_v2/collector/test_asyncio.py
@@ -51,7 +51,7 @@ class TestAsyncioLockCollector:
                 print("Error while deleting file: ", e)
 
     async def test_asyncio_lock_events(self):
-        with collector_asyncio.AsyncioLockCollector(None, capture_pct=100, export_libdd_enabled=True):
+        with collector_asyncio.AsyncioLockCollector(capture_pct=100, export_libdd_enabled=True):
             lock = asyncio.Lock()  # !CREATE! test_asyncio_lock_events
             await lock.acquire()  # !ACQUIRE! test_asyncio_lock_events
             assert lock.locked()
@@ -89,7 +89,7 @@ class TestAsyncioLockCollector:
         resource = str(uuid.uuid4())
         span_type = ext.SpanTypes.WEB
 
-        with collector_asyncio.AsyncioLockCollector(None, capture_pct=100, export_libdd_enabled=True, tracer=tracer):
+        with collector_asyncio.AsyncioLockCollector(capture_pct=100, export_libdd_enabled=True, tracer=tracer):
             lock = asyncio.Lock()  # !CREATE! test_asyncio_lock_events_tracer_1
             await lock.acquire()  # !ACQUIRE! test_asyncio_lock_events_tracer_1
             with tracer.trace("test", resource=resource, span_type=span_type) as t:

--- a/tests/profiling_v2/collector/test_memalloc.py
+++ b/tests/profiling_v2/collector/test_memalloc.py
@@ -58,7 +58,7 @@ def test_memory_collector(tmp_path):
     )
     ddup.start()
 
-    mc = memalloc.MemoryCollector(None)
+    mc = memalloc.MemoryCollector()
     with mc:
         _allocate_1k()
         mc.periodic()
@@ -106,7 +106,7 @@ def test_memory_collector_ignore_profiler(tmp_path):
     )
     ddup.start()
 
-    mc = memalloc.MemoryCollector(None, ignore_profiler=True)
+    mc = memalloc.MemoryCollector(ignore_profiler=True)
     quit_thread = threading.Event()
 
     with mc:

--- a/tests/profiling_v2/collector/test_stack.py
+++ b/tests/profiling_v2/collector/test_stack.py
@@ -77,7 +77,7 @@ def test_stack_locations(tmp_path):
     def foo():
         bar()
 
-    with stack.StackCollector(None, _stack_collector_v2_enabled=True):
+    with stack.StackCollector(_stack_collector_v2_enabled=True):
         for _ in range(10):
             foo()
     ddup.upload()
@@ -126,7 +126,6 @@ def test_push_span(tmp_path, tracer):
     span_type = ext.SpanTypes.WEB
 
     with stack.StackCollector(
-        None,
         tracer=tracer,
         endpoint_collection_enabled=True,
         ignore_profiler=True,  # this is not necessary, but it's here to trim samples
@@ -175,7 +174,6 @@ def test_push_span_unregister_thread(tmp_path, monkeypatch, tracer):
                 time.sleep(0.1)
 
         with stack.StackCollector(
-            None,
             tracer=tracer,
             endpoint_collection_enabled=True,
             ignore_profiler=True,  # this is not necessary, but it's here to trim samples
@@ -223,7 +221,6 @@ def test_push_non_web_span(tmp_path, tracer):
     span_type = ext.SpanTypes.SQL
 
     with stack.StackCollector(
-        None,
         tracer=tracer,
         endpoint_collection_enabled=True,
         ignore_profiler=True,  # this is not necessary, but it's here to trim samples
@@ -267,7 +264,6 @@ def test_push_span_none_span_type(tmp_path, tracer):
     resource = str(uuid.uuid4())
 
     with stack.StackCollector(
-        None,
         tracer=tracer,
         endpoint_collection_enabled=True,
         ignore_profiler=True,  # this is not necessary, but it's here to trim samples
@@ -309,7 +305,7 @@ def test_exception_collection(stack_v2_enabled, tmp_path):
     ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
     ddup.start()
 
-    with stack.StackCollector(None, ignore_profiler=True, _stack_collector_v2_enabled=stack_v2_enabled):
+    with stack.StackCollector(ignore_profiler=True, _stack_collector_v2_enabled=stack_v2_enabled):
         try:
             raise ValueError("hello")
         except Exception:
@@ -356,7 +352,7 @@ def test_exception_collection_threads(stack_v2_enabled, tmp_path):
     ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
     ddup.start()
 
-    with stack.StackCollector(None, ignore_profiler=True, _stack_collector_v2_enabled=stack_v2_enabled):
+    with stack.StackCollector(ignore_profiler=True, _stack_collector_v2_enabled=stack_v2_enabled):
 
         def target_fun():
             try:
@@ -417,7 +413,7 @@ def test_exception_collection_trace(stack_v2_enabled, tmp_path, tracer):
     ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
     ddup.start()
 
-    with stack.StackCollector(None, tracer=tracer, ignore_profiler=True, _stack_collector_v2_enabled=stack_v2_enabled):
+    with stack.StackCollector(tracer=tracer, ignore_profiler=True, _stack_collector_v2_enabled=stack_v2_enabled):
         with tracer.trace("foobar", resource="resource", span_type=ext.SpanTypes.WEB):
             try:
                 raise ValueError("hello")
@@ -472,7 +468,7 @@ def test_collect_once_with_class(tmp_path):
     ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
     ddup.start()
 
-    with stack.StackCollector(None, ignore_profiler=True, _stack_collector_v2_enabled=True):
+    with stack.StackCollector(ignore_profiler=True, _stack_collector_v2_enabled=True):
         SomeClass.sleep_class()
 
     ddup.upload()
@@ -526,7 +522,7 @@ def test_collect_once_with_class_not_right_type(tmp_path):
     ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
     ddup.start()
 
-    with stack.StackCollector(None, ignore_profiler=True, _stack_collector_v2_enabled=True):
+    with stack.StackCollector(ignore_profiler=True, _stack_collector_v2_enabled=True):
         SomeClass.sleep_class(123)
 
     ddup.upload()
@@ -610,7 +606,7 @@ def test_collect_gevent_thread_task():
 
     threads = []
 
-    with stack.StackCollector(None, _stack_collector_v2_enabled=False):
+    with stack.StackCollector(_stack_collector_v2_enabled=False):
         for i in range(5):
             t = threading.Thread(target=_dofib, name="TestThread %d" % i)
             t.start()
@@ -647,12 +643,12 @@ def test_collect_gevent_thread_task():
 
 def test_max_time_usage():
     with pytest.raises(ValueError):
-        stack.StackCollector(None, max_time_usage_pct=0)
+        stack.StackCollector(max_time_usage_pct=0)
 
 
 def test_max_time_usage_over():
     with pytest.raises(ValueError):
-        stack.StackCollector(None, max_time_usage_pct=200)
+        stack.StackCollector(max_time_usage_pct=200)
 
 
 @pytest.mark.parametrize(
@@ -675,7 +671,7 @@ def test_ignore_profiler(stack_v2_enabled, ignore_profiler, tmp_path):
     ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
     ddup.start()
 
-    s = stack.StackCollector(None, ignore_profiler=ignore_profiler, _stack_collector_v2_enabled=stack_v2_enabled)
+    s = stack.StackCollector(ignore_profiler=ignore_profiler, _stack_collector_v2_enabled=stack_v2_enabled)
     collector_worker_thread_id = None
 
     with s:

--- a/tests/profiling_v2/collector/test_threading.py
+++ b/tests/profiling_v2/collector/test_threading.py
@@ -49,7 +49,7 @@ def test_repr():
 
 
 def test_wrapper():
-    collector = collector_threading.ThreadingLockCollector(None)
+    collector = collector_threading.ThreadingLockCollector()
     with collector:
 
         class Foobar(object):
@@ -71,7 +71,7 @@ def test_wrapper():
 
 def test_patch():
     lock = threading.Lock
-    collector = collector_threading.ThreadingLockCollector(None)
+    collector = collector_threading.ThreadingLockCollector()
     collector.start()
     assert lock == collector._original
     # wrapt makes this true
@@ -156,7 +156,7 @@ def test_wrapt_disable_extensions():
     assert os.environ.get("WRAPT_DISABLE_EXTENSIONS")
     assert _lock.WRAPT_C_EXT is False
 
-    with collector_threading.ThreadingLockCollector(None, capture_pct=100):
+    with collector_threading.ThreadingLockCollector(capture_pct=100):
         th_lock = threading.Lock()  # !CREATE! test_wrapt_disable_extensions
         with th_lock:  # !ACQUIRE! !RELEASE! test_wrapt_disable_extensions
             pass
@@ -226,7 +226,7 @@ def test_lock_gevent_tasks():
         lock.acquire()  # !ACQUIRE! test_lock_gevent_tasks
         lock.release()  # !RELEASE! test_lock_gevent_tasks
 
-    with collector_threading.ThreadingLockCollector(None, capture_pct=100, export_libdd_enabled=True):
+    with collector_threading.ThreadingLockCollector(capture_pct=100, export_libdd_enabled=True):
         t = threading.Thread(name="foobar", target=play_with_lock)
         t.start()
         t.join()
@@ -299,7 +299,7 @@ class TestThreadingLockCollector:
     def test_lock_events(self):
         # The first argument is the recorder.Recorder which is used for the
         # v1 exporter. We don't need it for the v2 exporter.
-        with collector_threading.ThreadingLockCollector(None, capture_pct=100, export_libdd_enabled=True):
+        with collector_threading.ThreadingLockCollector(capture_pct=100, export_libdd_enabled=True):
             lock = threading.Lock()  # !CREATE! test_lock_events
             lock.acquire()  # !ACQUIRE! test_lock_events
             lock.release()  # !RELEASE! test_lock_events
@@ -329,7 +329,7 @@ class TestThreadingLockCollector:
         )
 
     def test_lock_acquire_events_class(self):
-        with collector_threading.ThreadingLockCollector(None, capture_pct=100, export_libdd_enabled=True):
+        with collector_threading.ThreadingLockCollector(capture_pct=100, export_libdd_enabled=True):
 
             class Foobar(object):
                 def lockfunc(self):
@@ -360,7 +360,6 @@ class TestThreadingLockCollector:
         resource = str(uuid.uuid4())
         span_type = ext.SpanTypes.WEB
         with collector_threading.ThreadingLockCollector(
-            None,
             tracer=tracer,
             capture_pct=100,
             export_libdd_enabled=True,
@@ -423,7 +422,6 @@ class TestThreadingLockCollector:
         resource = str(uuid.uuid4())
         span_type = ext.SpanTypes.SQL
         with collector_threading.ThreadingLockCollector(
-            None,
             tracer=tracer,
             capture_pct=100,
             export_libdd_enabled=True,
@@ -467,7 +465,6 @@ class TestThreadingLockCollector:
         resource = str(uuid.uuid4())
         span_type = ext.SpanTypes.WEB
         with collector_threading.ThreadingLockCollector(
-            None,
             tracer=tracer,
             capture_pct=100,
             export_libdd_enabled=True,
@@ -524,7 +521,6 @@ class TestThreadingLockCollector:
         resource = str(uuid.uuid4())
         span_type = ext.SpanTypes.WEB
         with collector_threading.ThreadingLockCollector(
-            None,
             tracer=tracer,
             capture_pct=100,
             export_libdd_enabled=True,
@@ -583,7 +579,7 @@ class TestThreadingLockCollector:
         )
 
     def test_lock_enter_exit_events(self):
-        with collector_threading.ThreadingLockCollector(None, capture_pct=100, export_libdd_enabled=True):
+        with collector_threading.ThreadingLockCollector(capture_pct=100, export_libdd_enabled=True):
             th_lock = threading.Lock()  # !CREATE! test_lock_enter_exit_events
             with th_lock:  # !ACQUIRE! !RELEASE! test_lock_enter_exit_events
                 pass
@@ -622,7 +618,7 @@ class TestThreadingLockCollector:
         with mock.patch("ddtrace.settings.profiling.config.lock.name_inspect_dir", inspect_dir_enabled):
             expected_lock_name = "foo_lock" if inspect_dir_enabled else None
 
-            with collector_threading.ThreadingLockCollector(None, capture_pct=100, export_libdd_enabled=True):
+            with collector_threading.ThreadingLockCollector(capture_pct=100, export_libdd_enabled=True):
                 foobar = Foo()
                 foobar.foo()
                 bar = Bar()
@@ -666,7 +662,7 @@ class TestThreadingLockCollector:
                 with self.__lock:  # !RELEASE! !ACQUIRE! test_private_lock
                     pass
 
-        with collector_threading.ThreadingLockCollector(None, capture_pct=100, export_libdd_enabled=True):
+        with collector_threading.ThreadingLockCollector(capture_pct=100, export_libdd_enabled=True):
             foo = Foo()
             foo.foo()
 
@@ -705,7 +701,7 @@ class TestThreadingLockCollector:
                 with self.foo.foo_lock:  # !RELEASE! !ACQUIRE! test_inner_lock
                     pass
 
-        with collector_threading.ThreadingLockCollector(None, capture_pct=100, export_libdd_enabled=True):
+        with collector_threading.ThreadingLockCollector(capture_pct=100, export_libdd_enabled=True):
             bar = Bar()
             bar.bar()
 
@@ -737,7 +733,7 @@ class TestThreadingLockCollector:
         )
 
     def test_anonymous_lock(self):
-        with collector_threading.ThreadingLockCollector(None, capture_pct=100, export_libdd_enabled=True):
+        with collector_threading.ThreadingLockCollector(capture_pct=100, export_libdd_enabled=True):
             with threading.Lock():  # !CREATE! !ACQUIRE! !RELEASE! test_anonymous_lock
                 pass
         ddup.upload()
@@ -764,7 +760,7 @@ class TestThreadingLockCollector:
         )
 
     def test_global_locks(self):
-        with collector_threading.ThreadingLockCollector(None, capture_pct=100, export_libdd_enabled=True):
+        with collector_threading.ThreadingLockCollector(capture_pct=100, export_libdd_enabled=True):
             from tests.profiling.collector import global_locks
 
             global_locks.foo()


### PR DESCRIPTION
Main motivation to this PR is to reduce the diffs when removing recorder from the codebase as part of removing the legacy exporter. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
