### PR TITLE
chore(ci_visibility): remove RetryTestReport, clean up Attempt-to-Fix

### DIFF
--- a/ddtrace/contrib/internal/pytest/_atr_utils.py
+++ b/ddtrace/contrib/internal/pytest/_atr_utils.py
@@ -96,7 +96,11 @@ def atr_handle_retries(
         when=TestPhase.CALL,
         longrepr=longrepr,
         outcome=final_outcomes[atr_outcome],
-        user_properties=item.user_properties + [(UserProperty.RETRY_REASON, RetryReason.AUTO_TEST_RETRY)],
+        user_properties=item.user_properties
+        + [
+            (UserProperty.RETRY_REASON, RetryReason.AUTO_TEST_RETRY),
+            (UserProperty.RETRY_FINAL_OUTCOME, atr_outcome.value),
+        ],
     )
     item.ihook.pytest_runtest_logreport(report=final_report)
 

--- a/ddtrace/contrib/internal/pytest/_attempt_to_fix.py
+++ b/ddtrace/contrib/internal/pytest/_attempt_to_fix.py
@@ -79,6 +79,7 @@ def attempt_to_fix_handle_retries(
 
     retries_outcome = _do_retries(item, outcomes)
     longrepr = InternalTest.stash_get(test_id, "failure_longrepr")
+    is_active = USER_PROPERTY_QUARANTINED not in item.user_properties
 
     final_report = pytest_TestReport(
         nodeid=item.nodeid,
@@ -86,7 +87,7 @@ def attempt_to_fix_handle_retries(
         keywords={k: 1 for k in item.keywords},
         when=TestPhase.CALL,
         longrepr=longrepr,
-        outcome=final_outcomes[retries_outcome] if not is_quarantined else PYTEST_STATUS.PASSED,
+        outcome=final_outcomes[retries_outcome] if is_active else PYTEST_STATUS.PASSED,
         user_properties=item.user_properties
         + [
             (UserProperty.RETRY_REASON, RetryReason.ATTEMPT_TO_FIX),

--- a/ddtrace/contrib/internal/pytest/_efd_utils.py
+++ b/ddtrace/contrib/internal/pytest/_efd_utils.py
@@ -340,13 +340,13 @@ def efd_get_teststatus(report: pytest_TestReport) -> _pytest_report_teststatus_r
 
     if get_user_property(report, UserProperty.RETRY_REASON) == RetryReason.EARLY_FLAKE_DETECTION:
         efd_outcome = get_user_property(report, UserProperty.RETRY_FINAL_OUTCOME)
-        if efd_outcome == "passed":
+        if efd_outcome == EFDTestStatus.ALL_PASS.value:
             return (_EFD_RETRY_OUTCOMES.EFD_FINAL_PASSED, ".", ("EFD FINAL STATUS: PASSED", {"green": True}))
-        if efd_outcome == "failed":
+        if efd_outcome == EFDTestStatus.ALL_FAIL.value:
             return (_EFD_RETRY_OUTCOMES.EFD_FINAL_FAILED, "F", ("EFD FINAL STATUS: FAILED", {"red": True}))
-        if efd_outcome == "skipped":
+        if efd_outcome == EFDTestStatus.ALL_SKIP.value:
             return (_EFD_RETRY_OUTCOMES.EFD_FINAL_SKIPPED, "S", ("EFD FINAL STATUS: SKIPPED", {"yellow": True}))
-        if efd_outcome == "flaky":
+        if efd_outcome == EFDTestStatus.FLAKY.value:
             # Flaky tests are the only one that have a pretty string because they are intended to be displayed in the
             # final count of terminal summary
             return (_EFD_FLAKY_OUTCOME, "K", ("EFD FINAL STATUS: FLAKY", {"yellow": True}))

--- a/ddtrace/contrib/internal/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v2.py
@@ -500,7 +500,7 @@ def _pytest_run_one_test(item, nextitem):
             item=item,
             test_reports=reports_dict,
             test_outcome=test_outcome,
-            is_quarantined=is_quarantined or is_disabled,
+            is_quarantined=is_quarantined,
         )
     else:
         # If no retry handler, we log the reports ourselves.

--- a/ddtrace/contrib/internal/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v2.py
@@ -500,7 +500,7 @@ def _pytest_run_one_test(item, nextitem):
             item=item,
             test_reports=reports_dict,
             test_outcome=test_outcome,
-            is_quarantined=is_quarantined,
+            is_quarantined=is_quarantined or is_disabled,
         )
     else:
         # If no retry handler, we log the reports ourselves.

--- a/ddtrace/contrib/internal/pytest/_retry_utils.py
+++ b/ddtrace/contrib/internal/pytest/_retry_utils.py
@@ -5,7 +5,6 @@ import typing as t
 from _pytest.runner import runtestprotocol
 import pytest
 
-from ddtrace.contrib.internal.pytest._types import pytest_TestReport
 from ddtrace.contrib.internal.pytest._utils import TestPhase
 from ddtrace.contrib.internal.pytest._utils import _TestOutcome
 from ddtrace.contrib.internal.pytest._utils import excinfo_by_report

--- a/ddtrace/contrib/internal/pytest/_retry_utils.py
+++ b/ddtrace/contrib/internal/pytest/_retry_utils.py
@@ -85,33 +85,3 @@ def _get_outcome_from_retry(
     item.ihook.pytest_runtest_logfinish(nodeid=item.nodeid, location=item.location)
 
     return _TestOutcome(status=_outcome_status, skip_reason=_outcome_skip_reason, exc_info=_outcome_exc_info)
-
-
-class RetryTestReport(pytest_TestReport):
-    """
-    A RetryTestReport behaves just like a normal pytest TestReport, except that the the failed/passed/skipped
-    properties are aware of retry final states (dd_efd_final_*, etc). This affects the test counts in JUnit XML output,
-    for instance.
-
-    The object should be initialized with the `longrepr` of the _initial_ test attempt. A `longrepr` set to `None` means
-    the initial attempt either succeeded (which means it was already counted by pytest) or was quarantined (which means
-    we should not count it at all), so we don't need to count it here.
-    """
-
-    @property
-    def failed(self):
-        if self.longrepr is None:
-            return False
-        return "final_failed" in self.outcome
-
-    @property
-    def passed(self):
-        if self.longrepr is None:
-            return False
-        return "final_passed" in self.outcome or "final_flaky" in self.outcome
-
-    @property
-    def skipped(self):
-        if self.longrepr is None:
-            return False
-        return "final_skipped" in self.outcome

--- a/ddtrace/contrib/internal/pytest/_utils.py
+++ b/ddtrace/contrib/internal/pytest/_utils.py
@@ -240,7 +240,9 @@ class _TestOutcome(t.NamedTuple):
 
 
 def get_user_property(report, key, default=None):
-    for k, v in report.user_properties:
+    # DEV: `CollectReport` does not have `user_properties`.
+    user_properties = getattr(report, "user_properties", [])
+    for k, v in user_properties:
         if k == key:
             return v
     return default

--- a/tests/contrib/pytest/test_pytest_attempt_to_fix.py
+++ b/tests/contrib/pytest/test_pytest_attempt_to_fix.py
@@ -257,7 +257,6 @@ class PytestAttemptToFixTestCase(PytestTestCaseBase):
         assert test_suite.attrib["skipped"] == "1"
         assert test_suite.attrib["errors"] == "0"
 
-    @pytest.mark.xfail(reason="JUnit XML miscounts quarantined tests")
     def test_pytest_attempt_to_fix_junit_xml_quarantined(self):
         self.testdir.makepyfile(test_quarantined=_TEST_PASS + _TEST_FAIL + _TEST_SKIP)
 


### PR DESCRIPTION
Remove `RetryTestReport` for good, as part of the effort to support `pytest-xdist`. Attempt-to-Fix was the only retry mechanism that still used it; this PR brings it in line with the recent EFD and ATR refactors (#13448 and #13288).

As a bonus, this fixes the miscounting of active Attempt-to-Fix tests in the JUnit XML output.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
