### PR TITLE
fix(symdb): switch `_shallow` to `shallow` in install

### DIFF
--- a/ddtrace/internal/symbol_db/symbols.py
+++ b/ddtrace/internal/symbol_db/symbols.py
@@ -668,5 +668,5 @@ class SymbolDatabaseUploader(BaseModuleWatchdog):
 
     @classmethod
     def install(cls, shallow=True):
-        cls._shallow = shallow
+        cls.shallow = shallow
         return super().install()

--- a/releasenotes/notes/fix-symdb-uploads-cfff7f4d568ff882.yaml
+++ b/releasenotes/notes/fix-symdb-uploads-cfff7f4d568ff882.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: fixes an issue where only module scopes were being uploaded,
+    preventing method probes from being created.

--- a/tests/internal/symbol_db/test_symbols.py
+++ b/tests/internal/symbol_db/test_symbols.py
@@ -270,7 +270,8 @@ def test_symbols_force_upload():
 
     SymbolDatabaseUploader._upload_context = staticmethod(_upload_context)
 
-    SymbolDatabaseUploader.install()
+    SymbolDatabaseUploader.install(shallow=False)
+    assert SymbolDatabaseUploader.shallow is False
 
     def get_scope(contexts, name):
         for context in (_.to_json() for _ in contexts):


### PR DESCRIPTION
This fixes a bug introduced by https://github.com/DataDog/dd-trace-py/pull/12957 where the shallow mode for SymDB was introduced.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
