### PR TITLE
ci: pin system-tests version

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           persist-credentials: false
           repository: 'DataDog/system-tests'
+          # Automatically managed, use scripts/update-system-tests-version to update
+          ref: '0d628ef0d9e1e7f58a0a62c770f723640f3175d4'
 
       - name: Build agent
         run: ./build.sh -i agent
@@ -66,6 +68,8 @@ jobs:
         with:
           persist-credentials: false
           repository: 'DataDog/system-tests'
+          # Automatically managed, use scripts/update-system-tests-version to update
+          ref: '0d628ef0d9e1e7f58a0a62c770f723640f3175d4'
 
       - name: Checkout dd-trace-py
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -118,6 +122,8 @@ jobs:
         with:
           persist-credentials: false
           repository: 'DataDog/system-tests'
+          # Automatically managed, use scripts/update-system-tests-version to update
+          ref: '0d628ef0d9e1e7f58a0a62c770f723640f3175d4'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -299,6 +305,8 @@ jobs:
         with:
           persist-credentials: false
           repository: 'DataDog/system-tests'
+          # Automatically managed, use scripts/update-system-tests-version to update
+          ref: '0d628ef0d9e1e7f58a0a62c770f723640f3175d4'
       - name: Checkout dd-trace-py
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/scripts/update-system-tests-version.py
+++ b/scripts/update-system-tests-version.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# ///
+import subprocess
+
+system_tests_repo = "https://github.com/DataDog/system-tests.git"
+system_tests_workflows_path = ".github/workflows/system-tests.yml"
+
+
+def get_latest_system_tests_version() -> str:
+    result = subprocess.check_output(["git", "ls-remote", system_tests_repo, "refs/heads/main"])
+    commit_hash, _, _ = result.decode("utf-8").partition("\t")
+    return commit_hash
+
+
+def get_current_system_tests_version() -> str:
+    with open(system_tests_workflows_path, "r") as file:
+        content = file.read()
+
+    parse_ref = False
+    lines = content.splitlines()
+    for line in lines:
+        if "repository: 'DataDog/system-tests'" in line:
+            parse_ref = True
+        if parse_ref and line.strip().startswith("ref:"):
+            _, _, ref_value = line.partition(":")
+            return ref_value.strip().strip("'\r\n")
+    raise ValueError(f"Could not find the current system-tests version in {system_tests_workflows_path}.")
+
+
+def update_system_tests_version(latest_version: str):
+    with open(system_tests_workflows_path, "r") as file:
+        content = file.read()
+
+    lines = content.splitlines()
+    update_ref = False
+    for i in range(len(lines)):
+        # Only update the ref if the repository is DataDog/system-tests
+        if "repository: 'DataDog/system-tests'" in lines[i]:
+            update_ref = True
+        if update_ref and lines[i].strip().startswith("ref:"):
+            pre, _, _ = lines[i].partition(":")
+            lines[i] = f"{pre}: '{latest_version}'"
+            update_ref = False
+
+    with open(system_tests_workflows_path, "w") as file:
+        file.write("\n".join(lines))
+
+
+if __name__ == "__main__":
+    current_version = get_current_system_tests_version()
+    print(f"Current system-tests version: {current_version}")
+    latest_version = get_latest_system_tests_version()
+    print(f"Latest system-tests version: {latest_version}")
+    update_system_tests_version(latest_version)
+    print(f"Updated {system_tests_workflows_path} with the latest version.")

--- a/scripts/update-system-tests-version.py
+++ b/scripts/update-system-tests-version.py
@@ -2,7 +2,9 @@
 # /// script
 # requires-python = ">=3.12"
 # ///
+
 import subprocess
+
 
 system_tests_repo = "https://github.com/DataDog/system-tests.git"
 system_tests_workflows_path = ".github/workflows/system-tests.yml"


### PR DESCRIPTION
Adds a script to help manage updating the pinned system-tests version.

The goal is to introduce some stability into our CI pipeline, especially when managing backport PRs to older branches.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
