### PR TITLE
ci(tracing): Update ddtrace microbenchmarks to cover the full OpenTelemetry Tracing API

### DIFF
--- a/benchmarks/otel_sdk_span/config.yaml
+++ b/benchmarks/otel_sdk_span/config.yaml
@@ -1,0 +1,50 @@
+# Scenarios should be consistent with dd-trace-py/benchmarks/span/config.yml
+start: &base
+  nspans: 1000
+  ntags: 0
+  ltags: 0
+  nmetrics: 0
+  finishspan: false
+  telemetry: false
+  add_event: false
+  add_link: false
+  get_context: false
+  is_recording: false
+  record_exception: false
+  set_status: false
+  update_name: false
+add-tags:
+  <<: *base
+  ntags: 100
+  ltags: 100
+add-metrics:
+  <<: *base
+  nmetrics: 100
+add-event:
+  <<: *base
+  add_event: true
+add-link:
+  <<: *base
+  add_link: true
+get-context:
+  <<: *base
+  get_context: true
+is-recording:
+  <<: *base
+  is_recording: true
+record-exception:
+  <<: *base
+  record_exception: true
+set-status:
+  <<: *base
+  set_status: true
+update-name:
+  <<: *base
+  update_name: true
+start-finish:
+  <<: *base
+  finishspan: true
+start-finish-telemetry:
+  <<: *base
+  finishspan: true
+  telemetry: true

--- a/benchmarks/otel_sdk_span/requirements_scenario.txt
+++ b/benchmarks/otel_sdk_span/requirements_scenario.txt
@@ -1,0 +1,2 @@
+opentelemetry-api==1.23.0
+opentelemetry-sdk==1.23.0

--- a/benchmarks/otel_sdk_span/requirements_scenario.txt
+++ b/benchmarks/otel_sdk_span/requirements_scenario.txt
@@ -1,2 +1,2 @@
-opentelemetry-api==1.23.0
-opentelemetry-sdk==1.23.0
+opentelemetry-api==1.24.0
+opentelemetry-sdk==1.24.0

--- a/benchmarks/otel_sdk_span/scenario.py
+++ b/benchmarks/otel_sdk_span/scenario.py
@@ -1,0 +1,90 @@
+import os
+
+import bm
+import bm.utils as utils
+from opentelemetry.trace import get_tracer
+from opentelemetry.trace import set_tracer_provider
+from opentelemetry.trace import Link
+from opentelemetry.trace import SpanContext
+from opentelemetry.trace.status import Status as OtelStatus
+from opentelemetry.trace.status import StatusCode as OtelStatusCode
+
+from opentelemetry.sdk.trace import TracerProvider
+
+
+set_tracer_provider(TracerProvider())
+otel_tracer = get_tracer(__name__)
+
+
+class OtelSdkSpan(bm.Scenario):
+    nspans: int
+    ntags: int
+    ltags: int
+    nmetrics: int
+    finishspan: bool
+    telemetry: bool
+    add_event: bool
+    add_link: bool
+    get_context: bool
+    is_recording: bool
+    record_exception: bool
+    set_status: bool
+    update_name: bool
+
+    def run(self):
+        # run scenario to also set tags on spans
+        tags = utils.gen_tags(self)
+        settags = len(tags) > 0
+
+        # run scenario to also set metrics on spans
+        metrics = utils.gen_metrics(self)
+        setmetrics = len(metrics) > 0
+
+        # run scenario to include finishing spans
+        # Note - if finishspan is False the span will be gc'd when the SpanAggregrator._traces is reset
+        # (ex: tracer.configure(filter) is called)
+        finishspan = self.finishspan
+        # config._telemetry_enabled = self.telemetry
+        add_event = self.add_event
+        add_link = self.add_link
+        get_context = self.get_context
+        is_recording = self.is_recording
+        record_exception = self.record_exception
+        set_status = self.set_status
+        update_name = self.update_name
+
+        # Pre-allocate all of the unique strings we'll need, that way the baseline memory overhead
+        # is held constant throughout all tests.
+        test_attributes = {"key": "value"}
+        test_exception = RuntimeError("test_exception")
+        test_link_context = SpanContext(trace_id=1, span_id=2, is_remote=False)
+        test_status = OtelStatus(OtelStatusCode.ERROR, "something went wrong")
+
+        def _(loops):
+            for _ in range(loops):
+                for i in range(self.nspans):
+                    s = otel_tracer.start_span("test." + str(i))
+                    result = False
+
+                    if settags:
+                        s.set_attributes(tags)
+                    if setmetrics:
+                        s.set_attributes(metrics)
+                    if add_event:
+                        s.add_event("test.event", test_attributes)
+                    if add_link:
+                        s.add_link(test_link_context)
+                    if get_context:
+                        result = s.get_span_context().is_remote
+                    if is_recording:
+                        result = s.is_recording()
+                    if record_exception:
+                        s.record_exception(test_exception)
+                    if set_status:
+                        s.set_status(test_status)
+                    if update_name:
+                        s.update_name("test.renamed." + str(i))
+                    if finishspan:
+                        s.end()
+
+        yield _

--- a/benchmarks/otel_span/config.yaml
+++ b/benchmarks/otel_span/config.yaml
@@ -6,6 +6,13 @@ start: &base
   nmetrics: 0
   finishspan: false
   telemetry: false
+  add_event: false
+  add_link: false
+  get_context: false
+  is_recording: false
+  record_exception: false
+  set_status: false
+  update_name: false
 add-tags:
   <<: *base
   ntags: 100
@@ -13,6 +20,28 @@ add-tags:
 add-metrics:
   <<: *base
   nmetrics: 100
+add-event:
+  <<: *base
+  add_event: true
+# Run add-link scenario when the API is implemented in the Datadog OTel Tracing API
+# add-link:
+#   <<: *base
+#   add_link: true
+get-context:
+  <<: *base
+  get_context: true
+is-recording:
+  <<: *base
+  is_recording: true
+record-exception:
+  <<: *base
+  record_exception: true
+set-status:
+  <<: *base
+  set_status: true
+update-name:
+  <<: *base
+  update_name: true
 start-finish:
   <<: *base
   finishspan: true

--- a/benchmarks/otel_span/requirements_scenario.txt
+++ b/benchmarks/otel_span/requirements_scenario.txt
@@ -1,1 +1,1 @@
-opentelemetry-api==1.23.0
+opentelemetry-api==1.24.0

--- a/benchmarks/otel_span/requirements_scenario.txt
+++ b/benchmarks/otel_span/requirements_scenario.txt
@@ -1,1 +1,1 @@
-opentelemetry-api==1.18.0
+opentelemetry-api==1.23.0

--- a/benchmarks/otel_span/scenario.py
+++ b/benchmarks/otel_span/scenario.py
@@ -4,6 +4,10 @@ import bm
 import bm.utils as utils
 from opentelemetry.trace import get_tracer
 from opentelemetry.trace import set_tracer_provider
+from opentelemetry.trace import Link
+from opentelemetry.trace import SpanContext
+from opentelemetry.trace.status import Status as OtelStatus
+from opentelemetry.trace.status import StatusCode as OtelStatusCode
 
 from ddtrace import config
 from ddtrace.opentelemetry import TracerProvider  # Requires ``ddtrace>=1.11``
@@ -22,6 +26,13 @@ class OtelSpan(bm.Scenario):
     nmetrics: int
     finishspan: bool
     telemetry: bool
+    add_event: bool
+    add_link: bool
+    get_context: bool
+    is_recording: bool
+    record_exception: bool
+    set_status: bool
+    update_name: bool
 
     def run(self):
         # run scenario to also set tags on spans
@@ -37,18 +48,49 @@ class OtelSpan(bm.Scenario):
         # (ex: tracer.configure(filter) is called)
         finishspan = self.finishspan
         config._telemetry_enabled = self.telemetry
+        add_event = self.add_event
+        add_link = self.add_link
+        get_context = self.get_context
+        is_recording = self.is_recording
+        record_exception = self.record_exception
+        set_status = self.set_status
+        update_name = self.update_name
+
         # Recreate span processors and configure global tracer to avoid sending traces to the agent
         utils.drop_traces(tracer)
         utils.drop_telemetry_events()
+
+        # Pre-allocate all of the unique strings we'll need, that way the baseline memory overhead
+        # is held constant throughout all tests.
+        test_attributes = {"key": "value"}
+        test_exception = RuntimeError("test_exception")
+        test_link_context = SpanContext(trace_id=1, span_id=2, is_remote=False)
+        test_status = OtelStatus(OtelStatusCode.ERROR, "something went wrong")
 
         def _(loops):
             for _ in range(loops):
                 for i in range(self.nspans):
                     s = otel_tracer.start_span("test." + str(i))
+                    result = False
+
                     if settags:
                         s.set_attributes(tags)
                     if setmetrics:
                         s.set_attributes(metrics)
+                    if add_event:
+                        s.add_event("test.event", test_attributes)
+                    if add_link:
+                        s.add_link(test_link_context)
+                    if get_context:
+                        result = s.get_span_context().is_remote
+                    if is_recording:
+                        result = s.is_recording()
+                    if record_exception:
+                        s.record_exception(test_exception)
+                    if set_status:
+                        s.set_status(test_status)
+                    if update_name:
+                        s.update_name("test.renamed." + str(i))
                     if finishspan:
                         s.end()
 

--- a/benchmarks/span/config.yaml
+++ b/benchmarks/span/config.yaml
@@ -6,6 +6,13 @@ start: &base
   finishspan: false
   traceid128: false
   telemetry: false
+  add_event: false
+  add_link: false
+  get_context: false
+  is_recording: false
+  record_exception: false
+  set_status: false
+  update_name: false
 start-traceid128:
   <<: *base
   traceid128: true
@@ -16,6 +23,28 @@ add-tags:
 add-metrics:
   <<: *base
   nmetrics: 100
+add-event:
+  <<: *base
+  add_event: true
+# Run add-link scenario when the API is implemented in the Datadog Tracing API
+# add-link:
+#   <<: *base
+#   add_link: true
+get-context:
+  <<: *base
+  get_context: true
+is-recording:
+  <<: *base
+  is_recording: true
+record-exception:
+  <<: *base
+  record_exception: true
+set-status:
+  <<: *base
+  set_status: true
+update-name:
+  <<: *base
+  update_name: true
 start-finish:
   <<: *base
   finishspan: true

--- a/benchmarks/span/scenario.py
+++ b/benchmarks/span/scenario.py
@@ -2,6 +2,7 @@ from bm import Scenario
 import bm.utils as utils
 
 from ddtrace import config
+from ddtrace.constants import ERROR_MSG
 from ddtrace.trace import tracer
 
 
@@ -13,6 +14,13 @@ class Span(Scenario):
     finishspan: bool
     traceid128: bool
     telemetry: bool
+    add_event: bool
+    add_link: bool
+    get_context: bool
+    is_recording: bool
+    record_exception: bool
+    set_status: bool
+    update_name: bool
 
     def run(self):
         # run scenario to also set tags on spans
@@ -29,9 +37,22 @@ class Span(Scenario):
         finishspan = self.finishspan
         config._128_bit_trace_id_enabled = self.traceid128
         config._telemetry_enabled = config._telemetry_metrics_enabled = self.telemetry
+        add_event = self.add_event
+        add_link = self.add_link
+        get_context = self.get_context
+        is_recording = self.is_recording
+        record_exception = self.record_exception
+        set_status = self.set_status
+        update_name = self.update_name
+
         # Recreate span processors and configure global tracer to avoid sending traces to the agent
         utils.drop_traces(tracer)
         utils.drop_telemetry_events()
+
+        # Pre-allocate all of the unique strings we'll need, that way the baseline memory overhead
+        # is held constant throughout all tests.
+        test_attributes = {"key": "value"}
+        test_exception = RuntimeError("test_exception")
 
         def _(loops):
             for _ in range(loops):
@@ -41,6 +62,23 @@ class Span(Scenario):
                         s.set_tags(tags)
                     if setmetrics:
                         s.set_metrics(metrics)
+                    if add_event:
+                        s._add_event("test.event", test_attributes)
+                    if add_link:
+                        s.set_link(trace_id=1, span_id=2)
+                    if get_context:
+                        result = s.context._is_remote
+                    if is_recording:
+                        result = not s.finished
+                    if record_exception:
+                        s.record_exception(test_exception)
+                    if set_status:
+                        # Perform the equivalent operation for
+                        # test_status = OtelStatus(OtelStatusCode.ERROR, "something went wrong")
+                        s.error = 1
+                        s.set_tag(ERROR_MSG, "something went wrong")
+                    if update_name:
+                        s.resource = "test.renamed." + str(i)
                     if finishspan:
                         s.finish()
 


### PR DESCRIPTION
## Summary
Extend ddtrace microbenchmarks to test the following scenarios:
- `otel_span`: Update the benchmark to test the full OTel Tracing API by testing these additional Span methods:
  - `Span.add_event`
  - `Span.add_link`
  - `Span.get_span_context`
  - `Span.is_recording`
  - `Span.record_exception`
  - `Span.set_status`
  - `Span.update_name`
- `span`: Update the benchmarks to test ddtrace APIs that match the full OTel Tracing API mentioned above
- `otel_sdk_span`: Add a new benchmark that _does not run ddtrace_ and instead runs opentelemetry-sdk, so that we can compare the performance of ddtrace (`otel_span` benchmark) against opentelemetry-sdk

Two notes:
- The `otel_span` and `span` benchmarks are not currently executing the span link methods because they're not publicly available. This should be addressed in a follow-up PR
- Since the `otel_sdk_span` doesn't run ddtrace, should we actually test this on every commit? I'd suggest running this on some recurring basis so we can accurately determine where we introduce overhead as compared to the OpenTelemetry SDK, but it may be wasteful to run this on every commit. WDYT? I'm happy to revise this as requested.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
