### PR TITLE
chore(iast): fix potenialflask error on request.url_rule

### DIFF
--- a/ddtrace/appsec/_iast/_handlers.py
+++ b/ddtrace/appsec/_iast/_handlers.py
@@ -434,9 +434,10 @@ def _on_pre_tracedrequest_iast(ctx):
 
 
 def _on_set_request_tags_iast(request, span, flask_config):
-    if asm_config._iast_enabled and asm_config.is_iast_request_enabled:
+    if asm_config.is_iast_request_enabled:
         try:
-            set_iast_request_endpoint(request.method, request.url_rule.rule)
+            if request.url_rule is not None:
+                set_iast_request_endpoint(request.method, request.url_rule.rule)
             request.cookies = taint_structure(
                 request.cookies,
                 OriginType.COOKIE_NAME,
@@ -462,12 +463,7 @@ def _on_set_request_tags_iast(request, span, flask_config):
 
 
 def _on_django_finalize_response_pre(ctx, after_request_tags, request, response):
-    if (
-        not response
-        or not asm_config._iast_enabled
-        or not asm_config.is_iast_request_enabled
-        or get_iast_stacktrace_reported()
-    ):
+    if not response or not asm_config.is_iast_request_enabled or get_iast_stacktrace_reported():
         return
 
     try:
@@ -496,12 +492,7 @@ def _on_django_technical_500_response(request, response, exc_type, exc_value, tb
 
 
 def _on_flask_finalize_request_post(response, _):
-    if (
-        not response
-        or not asm_config._iast_enabled
-        or not asm_config.is_iast_request_enabled
-        or get_iast_stacktrace_reported()
-    ):
+    if not response or not asm_config.is_iast_request_enabled or get_iast_stacktrace_reported():
         return
 
     try:
@@ -515,7 +506,7 @@ def _on_flask_finalize_request_post(response, _):
 
 
 def _on_asgi_finalize_response(body, _):
-    if not body or not asm_config._iast_enabled or not asm_config.is_iast_request_enabled:
+    if not body or not asm_config.is_iast_request_enabled:
         return
 
     try:


### PR DESCRIPTION
This PR includes two improvements to the IAST handler code:

1. Add null check for `request.url_rule`
   - Fix potential AttributeError when accessing `request.url_rule` which could be None

2. Code cleanup: Remove redundant IAST configuration checks
   - Remove duplicate check for `asm_config._iast_enabled` since it's already implied by `asm_config.is_iast_request_enabled`
   - Simplifies code flow and removes unnecessary condition


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
