### PR TITLE
chore(er): ensure max frame per trace (#12791)

### DIFF
--- a/ddtrace/debugging/_exception/replay.py
+++ b/ddtrace/debugging/_exception/replay.py
@@ -20,6 +20,7 @@ from ddtrace.internal.packages import is_user_code
 from ddtrace.internal.rate_limiter import BudgetRateLimiterWithJitter as RateLimiter
 from ddtrace.internal.rate_limiter import RateLimitExceeded
 from ddtrace.internal.utils.time import HourGlass
+from ddtrace.settings.exception_replay import config
 from ddtrace.trace import Span
 
 
@@ -38,6 +39,7 @@ DEBUG_INFO_TAG = "error.debug_info_captured"
 
 # used to rate limit decision on the entire local trace (stored at the root span)
 CAPTURE_TRACE_TAG = "_dd.debug.error.trace_captured"
+SNAPSHOT_COUNT_TAG = "_dd.debug.error.snapshot_count"
 
 # unique exception id
 EXCEPTION_HASH_TAG = "_dd.debug.error.exception_hash"
@@ -201,6 +203,18 @@ def can_capture(span: Span) -> bool:
     raise ValueError(msg)
 
 
+def get_snapshot_count(span: Span) -> int:
+    root = span._local_root
+    if root is None:
+        return 0
+
+    count = root.get_metric(SNAPSHOT_COUNT_TAG)
+    if count is None:
+        return 0
+
+    return int(count)
+
+
 class SpanExceptionHandler:
     __uploader__ = LogsIntakeUploaderV1
 
@@ -225,7 +239,8 @@ class SpanExceptionHandler:
 
         seq = count(1)  # 1-based sequence number
 
-        while chain:
+        frames_captured = get_snapshot_count(span)
+        while chain and frames_captured < config.max_frames:
             exc, _tb = chain.pop()  # LIFO: reverse the chain
 
             if _tb is None or _tb.tb_frame is None:
@@ -233,10 +248,11 @@ class SpanExceptionHandler:
                 continue
 
             # DEV: We go from the handler up to the root exception
-            while _tb:
+            while _tb and frames_captured < config.max_frames:
                 frame = _tb.tb_frame
                 code = frame.f_code
                 seq_nr = next(seq)
+                frames_captured += self._capture_tb_frame_for_span(span, _tb, exc_id, next(seq))
 
                 if is_user_code(Path(frame.f_code.co_filename)):
                     snapshot_id = frame.f_locals.get(SNAPSHOT_KEY, None)
@@ -275,6 +291,11 @@ class SpanExceptionHandler:
             span.set_tag_str(DEBUG_INFO_TAG, "true")
             span.set_tag_str(EXCEPTION_HASH_TAG, str(exc_ident))
             span.set_tag_str(EXCEPTION_ID_TAG, str(exc_id))
+
+            # Update the snapshot count
+            root = span._local_root
+            if root is not None:
+                root.set_metric(SNAPSHOT_COUNT_TAG, frames_captured)
 
     @classmethod
     def enable(cls) -> None:


### PR DESCRIPTION
We make sure that the max frame settings is honoured for a whole trace instead of a single span to avoid capturing too many snapshots.

- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

- [ ] Reviewer has checked that all the criteria below are met
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

(cherry picked from commit 560b7a6d96b59850dd01ef209cf8531be8faccf2)

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
