### PR TITLE
test(internal): remove specific implementation from general module testing

### DIFF
--- a/tests/internal/test_module.py
+++ b/tests/internal/test_module.py
@@ -7,7 +7,6 @@ from warnings import warn
 import mock
 import pytest
 
-from ddtrace.internal.coverage.code import ModuleCodeCollector
 from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.internal.module import origin
 import tests.test_module
@@ -51,9 +50,17 @@ def module_watchdog():
     ModuleWatchdog.uninstall()
 
 
+@pytest.mark.subprocess
 def test_watchdog_install_uninstall():
+    import sys
+
+    from ddtrace.internal.module import ModuleWatchdog
+
+    if ModuleWatchdog.is_installed():
+        ModuleWatchdog.uninstall()
+
     assert not ModuleWatchdog.is_installed()
-    assert not any(isinstance(m, ModuleWatchdog) and not isinstance(m, ModuleCodeCollector) for m in sys.meta_path)
+    assert not any(isinstance(m, ModuleWatchdog) for m in sys.meta_path)
 
     ModuleWatchdog.install()
 
@@ -63,7 +70,7 @@ def test_watchdog_install_uninstall():
     ModuleWatchdog.uninstall()
 
     assert not ModuleWatchdog.is_installed()
-    assert not any(isinstance(m, ModuleWatchdog) and not isinstance(m, ModuleCodeCollector) for m in sys.meta_path)
+    assert not any(isinstance(m, ModuleWatchdog) for m in sys.meta_path)
 
 
 def test_import_origin_hook_for_imported_module(module_watchdog):


### PR DESCRIPTION
We refactor the internal module watchdog install-uninstall test to avoid referencing product-specific subclasses.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
