### PR TITLE
chore(iast): fix fstring log message

### DIFF
--- a/benchmarks/bm/iast_fixtures/str_methods.py
+++ b/benchmarks/bm/iast_fixtures/str_methods.py
@@ -1263,10 +1263,6 @@ def do_customspec_formatspec():
     return f"{c!s:<20s}"
 
 
-def do_fstring(a, b):
-    return f"{a} + {b} = {a + b}"
-
-
 def _preprocess_lexer_input(text):
     """Apply preprocessing such as decoding the input, removing BOM and normalizing newlines."""
     # text now *is* a unicode string

--- a/benchmarks/bm/iast_fixtures/str_methods_py3.py
+++ b/benchmarks/bm/iast_fixtures/str_methods_py3.py
@@ -20,6 +20,10 @@ def do_fstring(a: str) -> str:
     return f"{a}"
 
 
+def do_fstring_operations(a, b):
+    return f"{a} + {b} = {a + b}"
+
+
 def do_zero_padding_fstring(a: int, spec: str = "05d") -> str:
     return f"{a:{spec}}"
 

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -449,7 +449,7 @@ def format_value_aspect(
         return format(new_text)
 
     if format_spec:
-        new_new_text = f"{new_text:{format_spec}}"
+        new_new_text = f"{new_text:{format_spec}}"  # type: ignore[str-bytes-safe]
         try:
             # Apply formatting
             text_ranges = get_tainted_ranges(new_text)

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -449,11 +449,11 @@ def format_value_aspect(
         return format(new_text)
 
     if format_spec:
+        new_new_text = f"{new_text:{format_spec}}"
         try:
             # Apply formatting
             text_ranges = get_tainted_ranges(new_text)
             if text_ranges:
-                new_new_text = ("{:%s}" % format_spec).format(new_text)
                 try:
                     new_ranges = list()
                     for text_range in text_ranges:
@@ -462,12 +462,12 @@ def format_value_aspect(
                         taint_pyobject_with_ranges(new_new_text, tuple(new_ranges))
                     return new_new_text
                 except ValueError:
-                    return ("{:%s}" % format_spec).format(new_text)
+                    return new_new_text
             else:
-                return ("{:%s}" % format_spec).format(new_text)
+                return new_new_text
         except Exception as e:
             iast_propagation_error_log(f"format_value_aspect. {e}")
-            return ("{:%s}" % format_spec).format(new_text)
+            return new_new_text
 
     return format(new_text)
 

--- a/tests/appsec/iast/aspects/aspect_utils.py
+++ b/tests/appsec/iast/aspects/aspect_utils.py
@@ -65,47 +65,48 @@ def create_taint_range_with_format(text_input: Any, fn_origin: str = "") -> Any:
     return text_output
 
 
-class BaseReplacement:
-    def _to_tainted_string_with_origin(self, text: TEXT_TYPE) -> TEXT_TYPE:
-        if not isinstance(text, (str, bytes, bytearray)):
-            return text
+def _to_tainted_string_with_origin(text: TEXT_TYPE) -> TEXT_TYPE:
+    if not isinstance(text, (str, bytes, bytearray)):
+        return text
 
-        # CAVEAT: the sequences ":+-" and "-+:" can be escaped with  "::++--" and "--+*::"
-        elements = re.split(r"(\:\+-<[0-9a-zA-Z\-]+>|<[0-9a-zA-Z\-]+>-\+\:)", text)
+    # CAVEAT: the sequences ":+-" and "-+:" can be escaped with  "::++--" and "--+*::"
+    elements = re.split(r"(\:\+-<[0-9a-zA-Z\-]+>|<[0-9a-zA-Z\-]+>-\+\:)", text)
 
-        ranges: List[TaintRange] = []
-        ranges_append = ranges.append
-        new_text = text.__class__()
-        context: Optional[EscapeContext] = None
-        for index, element in enumerate(elements):
-            if index % 2 == 0:
-                element = element.replace("::++--", ":+-")
-                element = element.replace("--++::", "-+:")
-                new_text += element
+    ranges: List[TaintRange] = []
+    ranges_append = ranges.append
+    new_text = text.__class__()
+    context: Optional[EscapeContext] = None
+    for index, element in enumerate(elements):
+        if index % 2 == 0:
+            element = element.replace("::++--", ":+-")
+            element = element.replace("--++::", "-+:")
+            new_text += element
+        else:
+            separator = element
+            if element.startswith(":"):
+                id_evidence = separator[4:-1]
+                start = len(new_text)
+                context = EscapeContext(id_evidence, start)
             else:
-                separator = element
-                if element.startswith(":"):
-                    id_evidence = separator[4:-1]
-                    start = len(new_text)
-                    context = EscapeContext(id_evidence, start)
-                else:
-                    id_evidence = separator[1:-4]
-                    end = len(new_text)
-                    assert context is not None
-                    start = context.position
-                    if start != end:
-                        assert isinstance(id_evidence, str)
+                id_evidence = separator[1:-4]
+                end = len(new_text)
+                assert context is not None
+                start = context.position
+                if start != end:
+                    assert isinstance(id_evidence, str)
 
-                        ranges_append(
-                            TaintRange(
-                                start,
-                                end - start,
-                                Source(name=id_evidence, value=new_text[start:], origin=OriginType.PARAMETER),
-                            )
+                    ranges_append(
+                        TaintRange(
+                            start,
+                            end - start,
+                            Source(name=id_evidence, value=new_text[start:], origin=OriginType.PARAMETER),
                         )
-        set_ranges(new_text, tuple(ranges))
-        return new_text
+                    )
+    set_ranges(new_text, tuple(ranges))
+    return new_text
 
+
+class BaseReplacement:
     def _assert_format_result(
         self,
         taint_escaped_template: TEXT_TYPE,
@@ -113,8 +114,8 @@ class BaseReplacement:
         expected_result: TEXT_TYPE,
         escaped_expected_result: TEXT_TYPE,
     ) -> None:
-        template = self._to_tainted_string_with_origin(taint_escaped_template)
-        parameter = self._to_tainted_string_with_origin(taint_escaped_parameter)
+        template = _to_tainted_string_with_origin(taint_escaped_template)
+        parameter = _to_tainted_string_with_origin(taint_escaped_parameter)
         result = mod.do_format_with_positional_parameter(template, parameter)
 
         assert result == expected_result

--- a/tests/appsec/iast/aspects/test_format_map_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_format_map_aspect_fixtures.py
@@ -8,6 +8,7 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
 from ddtrace.appsec._iast._taint_tracking import get_ranges
 from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
+from tests.appsec.iast.aspects.aspect_utils import _to_tainted_string_with_origin
 from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
@@ -22,8 +23,8 @@ class TestOperatorFormatMapReplacement(BaseReplacement):
         expected_result,  # type: str
         escaped_expected_result,  # type: str
     ):  # type: (...) -> None
-        template = self._to_tainted_string_with_origin(taint_escaped_template)
-        mapping = {key: self._to_tainted_string_with_origin(value) for key, value in taint_escaped_mapping.items()}
+        template = _to_tainted_string_with_origin(taint_escaped_template)
+        mapping = {key: _to_tainted_string_with_origin(value) for key, value in taint_escaped_mapping.items()}
 
         assert isinstance(template, str)
         result = mod.do_format_map(template, mapping)

--- a/tests/appsec/iast/aspects/test_fstrings.py
+++ b/tests/appsec/iast/aspects/test_fstrings.py
@@ -11,7 +11,6 @@ from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
-from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
 from tests.appsec.iast.aspects.aspect_utils import create_taint_range_with_format
 from tests.appsec.iast.iast_utils import CustomStr
 from tests.appsec.iast.iast_utils import _iast_patched_module
@@ -154,7 +153,6 @@ def test_int_fstring_zero_padding_integers(integers_to_test):
     ),
 )
 def test_int_fstring_zero_padding_text(text, spec):
-    print(f"{text}: {spec}")
     with pytest.raises(ValueError) as excinfo:
         f"{text:{spec}}"
     assert str(excinfo.value) == f"Unknown format code '{spec}' for object of type 'str'"
@@ -164,91 +162,97 @@ def test_int_fstring_zero_padding_text(text, spec):
     assert str(excinfo.value) == f"Unknown format code '{spec}' for object of type 'str'"
 
 
-class TestOperatorsReplacement(BaseReplacement):
-    def test_string_build_string_tainted(self):
-        string_input = "foo"
-        result = mod_py3.do_fmt_value(string_input)  # pylint: disable=no-member
-        assert result == "foo     bar"
+def test_string_build_string_tainted():
+    string_input = "foo"
+    result = mod_py3.do_fmt_value(string_input)  # pylint: disable=no-member
+    assert result == "foo     bar"
 
-        string_input = create_taint_range_with_format(":+-foo-+:")
-        result = mod_py3.do_fmt_value(string_input)  # pylint: disable=no-member
-        assert result == "foo     bar"
-        assert as_formatted_evidence(result) == ":+-foo-+:     bar"
+    string_input = create_taint_range_with_format(":+-foo-+:")
+    result = mod_py3.do_fmt_value(string_input)  # pylint: disable=no-member
+    assert result == "foo     bar"
+    assert as_formatted_evidence(result) == ":+-foo-+:     bar"
 
-    def test_string_fstring_tainted(self):
-        string_input = "foo"
-        result = mod_py3.do_repr_fstring(string_input)
-        assert result == "'foo'"
 
-        string_input = create_taint_range_with_format(":+-foo-+:")
+def test_string_fstring_tainted():
+    string_input = "foo"
+    result = mod_py3.do_repr_fstring(string_input)
+    assert result == "'foo'"
 
-        result = mod_py3.do_repr_fstring(string_input)  # pylint: disable=no-member
-        assert as_formatted_evidence(result) == "':+-foo-+:'"
+    string_input = create_taint_range_with_format(":+-foo-+:")
 
-    def test_string_fstring_with_format_tainted(self):
-        string_input = "foo"
-        result = mod_py3.do_repr_fstring_with_format(string_input)
-        assert result == "'foo'     "
+    result = mod_py3.do_repr_fstring(string_input)  # pylint: disable=no-member
+    assert as_formatted_evidence(result) == "':+-foo-+:'"
 
-        string_input = create_taint_range_with_format(":+-foo-+:")
 
-        result = mod_py3.do_repr_fstring_with_format(string_input)  # pylint: disable=no-member
-        assert as_formatted_evidence(result) == "':+-foo-+:'     "
+def test_string_fstring_with_format_tainted():
+    string_input = "foo"
+    result = mod_py3.do_repr_fstring_with_format(string_input)
+    assert result == "'foo'     "
 
-    def test_string_fstring_repr_str_twice_tainted(self):
-        string_input = "foo"
+    string_input = create_taint_range_with_format(":+-foo-+:")
 
-        result = mod_py3.do_repr_fstring_twice(string_input)  # pylint: disable=no-member
-        assert result == "'foo' 'foo'"
+    result = mod_py3.do_repr_fstring_with_format(string_input)  # pylint: disable=no-member
+    assert as_formatted_evidence(result) == "':+-foo-+:'     "
 
-        string_input = create_taint_range_with_format(":+-foo-+:")
 
-        result = mod_py3.do_repr_fstring_twice(string_input)  # pylint: disable=no-member
-        assert result == "'foo' 'foo'"
-        assert as_formatted_evidence(result) == "':+-foo-+:' ':+-foo-+:'"
+def test_string_fstring_repr_str_twice_tainted():
+    string_input = "foo"
 
-    def test_string_fstring_repr_object_twice_tainted(self):
-        string_input = "foo"
-        result = mod.MyObject(string_input)
-        assert repr(result) == "foo a"
+    result = mod_py3.do_repr_fstring_twice(string_input)  # pylint: disable=no-member
+    assert result == "'foo' 'foo'"
 
-        result = mod_py3.do_repr_fstring_twice(result)  # pylint: disable=no-member
-        assert result == "foo a foo a"
+    string_input = create_taint_range_with_format(":+-foo-+:")
 
-        string_input = create_taint_range_with_format(":+-foo-+:")
-        obj = mod.MyObject(string_input)  # pylint: disable=no-member
+    result = mod_py3.do_repr_fstring_twice(string_input)  # pylint: disable=no-member
+    assert result == "'foo' 'foo'"
+    assert as_formatted_evidence(result) == "':+-foo-+:' ':+-foo-+:'"
 
-        result = mod_py3.do_repr_fstring_twice(obj)  # pylint: disable=no-member
-        assert result == "foo a foo a"
-        assert as_formatted_evidence(result) == ":+-foo-+: a :+-foo-+: a"
 
-    def test_string_fstring_twice_different_objects_tainted(self):
-        string_input = create_taint_range_with_format(":+-foo-+:")
-        obj = mod.MyObject(string_input)  # pylint: disable=no-member
-        obj2 = mod.MyObject(string_input)  # pylint: disable=no-member
+def test_string_fstring_repr_object_twice_tainted():
+    string_input = "foo"
+    result = mod.MyObject(string_input)
+    assert repr(result) == "foo a"
 
-        result = mod_py3.do_repr_fstring_twice_different_objects(obj, obj2)  # pylint: disable=no-member
-        assert result == "foo a foo a"
-        assert as_formatted_evidence(result) == ":+-foo-+: a :+-foo-+: a"
+    result = mod_py3.do_repr_fstring_twice(result)  # pylint: disable=no-member
+    assert result == "foo a foo a"
 
-    def test_string_fstring_twice_different_objects_tainted_twice(self):
-        string_input = create_taint_range_with_format(":+-foo-+:")
-        obj = mod.MyObject(string_input)  # pylint: disable=no-member
+    string_input = create_taint_range_with_format(":+-foo-+:")
+    obj = mod.MyObject(string_input)  # pylint: disable=no-member
 
-        result = mod_py3.do_repr_fstring_with_format_twice(obj)  # pylint: disable=no-member
-        assert result == "foo a      foo a      "
-        assert as_formatted_evidence(result) == ":+-foo-+: a      :+-foo-+: a      "
+    result = mod_py3.do_repr_fstring_twice(obj)  # pylint: disable=no-member
+    assert result == "foo a foo a"
+    assert as_formatted_evidence(result) == ":+-foo-+: a :+-foo-+: a"
 
-    @pytest.mark.parametrize(
-        "function",
-        [
-            mod_py3.do_repr_fstring_with_expression1,
-            mod_py3.do_repr_fstring_with_expression2,
-            mod_py3.do_repr_fstring_with_expression3,
-            mod_py3.do_repr_fstring_with_expression4,
-            mod_py3.do_repr_fstring_with_expression5,
-        ],
-    )
-    def test_string_fstring_non_string(self, function):
-        result = function()  # pylint: disable=no-member
-        assert result == "Hello world, True!"
+
+def test_string_fstring_twice_different_objects_tainted():
+    string_input = create_taint_range_with_format(":+-foo-+:")
+    obj = mod.MyObject(string_input)  # pylint: disable=no-member
+    obj2 = mod.MyObject(string_input)  # pylint: disable=no-member
+
+    result = mod_py3.do_repr_fstring_twice_different_objects(obj, obj2)  # pylint: disable=no-member
+    assert result == "foo a foo a"
+    assert as_formatted_evidence(result) == ":+-foo-+: a :+-foo-+: a"
+
+
+def test_string_fstring_twice_different_objects_tainted_twice():
+    string_input = create_taint_range_with_format(":+-foo-+:")
+    obj = mod.MyObject(string_input)  # pylint: disable=no-member
+
+    result = mod_py3.do_repr_fstring_with_format_twice(obj)  # pylint: disable=no-member
+    assert result == "foo a      foo a      "
+    assert as_formatted_evidence(result) == ":+-foo-+: a      :+-foo-+: a      "
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        mod_py3.do_repr_fstring_with_expression1,
+        mod_py3.do_repr_fstring_with_expression2,
+        mod_py3.do_repr_fstring_with_expression3,
+        mod_py3.do_repr_fstring_with_expression4,
+        mod_py3.do_repr_fstring_with_expression5,
+    ],
+)
+def test_string_fstring_non_string(function):
+    result = function()  # pylint: disable=no-member
+    assert result == "Hello world, True!"

--- a/tests/appsec/iast/aspects/test_fstrings.py
+++ b/tests/appsec/iast/aspects/test_fstrings.py
@@ -96,7 +96,7 @@ def test_fstring_fill_spaces_tainted(text):
     result = mod_py3.do_fmt_value(string_input)
     assert result == mod_py3.do_fmt_value(text)
     assert result == f"{text:<8s}bar"
-    if text != "\x00":
+    if text not in ["\x00", "\x000"]:
         assert is_pyobject_tainted(result)
 
 

--- a/tests/appsec/iast/aspects/test_fstrings.py
+++ b/tests/appsec/iast/aspects/test_fstrings.py
@@ -45,7 +45,8 @@ def test_fstring_tainted(text):
     result = mod_py3.do_fstring(string_input)
     assert result == mod_py3.do_fstring(text)
     assert result == f"{text}"
-    assert is_pyobject_tainted(result)
+    if text != "\x00":
+        assert is_pyobject_tainted(result)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="Python3.8 works different with fstrings")
@@ -57,7 +58,8 @@ def test_fstring_fill_spaces_tainted(text):
     result = mod_py3.do_fmt_value(string_input)
     assert result == mod_py3.do_fmt_value(text)
     assert result == f"{text:<8s}bar"
-    assert is_pyobject_tainted(result)
+    if text != "\x00":
+        assert is_pyobject_tainted(result)
 
 
 @given(

--- a/tests/appsec/iast/aspects/test_modulo_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_modulo_aspect_fixtures.py
@@ -14,6 +14,7 @@ from ddtrace.appsec._iast._taint_tracking import get_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
+from tests.appsec.iast.aspects.aspect_utils import _to_tainted_string_with_origin
 from tests.appsec.iast.iast_utils import _iast_patched_module
 
 
@@ -28,13 +29,13 @@ class TestOperatorModuloReplacement(BaseReplacement):
         expected_result,  # type: Text
         escaped_expected_result,  # type: Text
     ):  # type: (...) -> None
-        template = self._to_tainted_string_with_origin(taint_escaped_template)
+        template = _to_tainted_string_with_origin(taint_escaped_template)
 
         parameter = tuple()  # type: Any
         if isinstance(taint_escaped_parameter, (tuple, List)):
-            parameter = tuple([self._to_tainted_string_with_origin(item) for item in taint_escaped_parameter])
+            parameter = tuple([_to_tainted_string_with_origin(item) for item in taint_escaped_parameter])
         else:
-            parameter = self._to_tainted_string_with_origin(taint_escaped_parameter)
+            parameter = _to_tainted_string_with_origin(taint_escaped_parameter)
 
         result = mod.do_modulo(template, parameter)
 

--- a/tests/appsec/iast/aspects/test_side_effects.py
+++ b/tests/appsec/iast/aspects/test_side_effects.py
@@ -10,6 +10,7 @@ from tests.appsec.iast.iast_utils_side_effects import MagicMethodsException
 
 
 mod = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods")
+mod_py3 = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods_py3")
 
 STRING_TO_TAINT = "abc"
 
@@ -363,7 +364,7 @@ def test_format_value_aspect_side_effects():
     result = f"{object_with_side_effects} + {b} = {object_with_side_effects + b}"
     assert result == "abc + bar = abcbar"
 
-    result_tainted = mod.do_fstring(object_with_side_effects, b)
+    result_tainted = mod_py3.do_fstring_operations(object_with_side_effects, b)
     assert result_tainted == result
 
     setattr(MagicMethodsException, "__format__", _old_method_format)

--- a/tests/appsec/iast/aspects/test_side_effects.py
+++ b/tests/appsec/iast/aspects/test_side_effects.py
@@ -349,8 +349,6 @@ def test_repr_aspect_side_effects():
 
 def test_format_value_aspect_side_effects():
     def __format__(self, *args, **kwargs):
-        print(args)
-        print(kwargs)
         return self._data
 
     def __add__(self, b):

--- a/tests/appsec/iast/conftest.py
+++ b/tests/appsec/iast/conftest.py
@@ -137,11 +137,12 @@ def check_native_code_exception_in_each_python_aspect_test(request, caplog):
         ), caplog.at_level(logging.DEBUG):
             yield
 
-        log_messages = [record.message for record in caplog.get_records("call")]
+        for record in caplog.get_records("call"):
+            if IAST_VALID_LOG.search(record.message):
+                import traceback
 
-        for message in log_messages:
-            if IAST_VALID_LOG.search(message):
-                pytest.fail(message)
+                formatted_trace = "".join(traceback.format_exception(*record.exc_info))
+                pytest.fail(f"{record.message}:\n{formatted_trace}")
         # TODO(avara1986): iast tests throw a timeout in gitlab
         #   list_metrics_logs = list(telemetry_writer._logs)
         #   assert len(list_metrics_logs) == 0


### PR DESCRIPTION
Fix IAST validation in fstring aspect. We're considering as unexpected error, format errors like: `Unknown format code 'd' for object of type 'str'`

this PR fixes an error in https://github.com/DataDog/dd-trace-py/pull/13600/files#r2128401733

part of https://github.com/DataDog/dd-trace-py/pull/13600

APPSEC-57578

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
