### PR TITLE
ci: prevent git fatal warning in download artifacts job [backport 2.21]

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -6,6 +6,9 @@ download_ddtrace_artifacts:
     - aws ssm get-parameter --region us-east-1 --name ci.$CI_PROJECT_NAME.gh_token --with-decryption --query "Parameter.Value" --out text > token
     - gh auth login --with-token < token
     - rm token
+    # Prevent git operation errors:
+    #   failed to determine base repo: failed to run git: fatal: detected dubious ownership in repository at ...
+    - git config --global --add safe.directory "${CI_PROJECT_DIR}"
     - .gitlab/download-wheels-from-gh-actions.sh
   artifacts:
     paths:


### PR DESCRIPTION
Backport of #12627 to `2.21`


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
