### PR TITLE
chore(telemetry): fix ssi instrumentation trackign

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -165,8 +165,9 @@ try:
         else:
             log.debug("additional sitecustomize found in: %s", sys.path)
 
-    if os.getenv("_DD_SSI_INJECT_SUCCESSFUL"):
-        # _DD_SSI_INJECT_SUCCESSFUL is set in lib-injection/sources/sitecustomize.py after ssi is completed
+    if os.getenv("_DD_PY_SSI_INJECT") == "1":
+        # _DD_PY_SSI_INJECT is set to `1` in lib-injection/sources/sitecustomize.py when ssi is started
+        # and doesn't abort.
         source = "ssi"
     elif os.path.join(os.path.dirname(ddtrace.__file__), "bootstrap") in sys.path:
         # Checks the python path to see if the bootstrap directory is present, this operation

--- a/ddtrace/settings/_config.py
+++ b/ddtrace/settings/_config.py
@@ -647,7 +647,8 @@ class Config(object):
         self._llmobs_agentless_enabled = _get_config("DD_LLMOBS_AGENTLESS_ENABLED", None, asbool)
 
         self._inject_force = _get_config("DD_INJECT_FORCE", None, asbool)
-        self._lib_was_injected = False
+        # Telemetetry for whether ssi was used is tracked by the `instrumentation_source` config
+        self._lib_was_injected = _get_config("_DD_PY_SSI_INJECT", False, asbool, report_telemetry=False)
         self._inject_enabled = _get_config("DD_INJECTION_ENABLED")
         self._inferred_proxy_services_enabled = _get_config("DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED", False, asbool)
 


### PR DESCRIPTION
Fixes the collection of instrumentation telemetry for ssi. 

Note this is not a customer facing fix, a release note is not required.

Resolves the following CI error: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/968352550

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
