### PR TITLE
fix(ci_visibility): ensure test span is finished even if pytest_runtest_protocol is overridden

### DIFF
--- a/ddtrace/contrib/internal/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v2.py
@@ -400,6 +400,10 @@ def _pytest_runtest_protocol_post_yield(item, nextitem, coverage_collector):
     suite_id = test_id.parent_id
     module_id = suite_id.parent_id
 
+    if not InternalTest.is_finished(test_id):
+        log.debug("Test %s was not finished normally during pytest_runtest_protocol, finishing it now", test_id)
+        InternalTest.finish(test_id)
+
     if coverage_collector is not None:
         _handle_collected_coverage(test_id, coverage_collector)
 

--- a/releasenotes/notes/ci_visibility-fix-ensure-test-finished-524a9bb93fd6b632.yaml
+++ b/releasenotes/notes/ci_visibility-fix-ensure-test-finished-524a9bb93fd6b632.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    CI Visibility: This fix resolves an inssue where test spans would be left unfinished if the
+    `pytest_runtest_protocol` hook was overridden in `conftest.py`, causing the corresponding module and suite to be
+    unfinished as well.


### PR DESCRIPTION
Currently, if the `pytest_runtest_protocol` hook is overridden in `conftest.py` and skips the Test Optimization hook, the corresponding test span will be left unfinished, which in turn will cause the suite and module to be unfinished until the end of the session. This PR ensures that the test will be finished by the `pytest_runtest_protocol` hook wrapper, so at least the other tests in the session are not affected.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
