### PR TITLE
fix(llmobs): make sure correct llmobs trace id is returned from `export_span`

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -737,7 +737,8 @@ class LLMObs(Service):
                 log.warning("Span must be an LLMObs-generated span.")
                 return None
             return ExportedLLMObsSpan(
-                span_id=str(span.span_id), trace_id=format_trace_id(span._get_ctx_item(LLMOBS_TRACE_ID))
+                span_id=str(span.span_id),
+                trace_id=format_trace_id(span._get_ctx_item(LLMOBS_TRACE_ID) or span.trace_id),
             )
         except (TypeError, AttributeError):
             error = "invalid_span"

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -1414,7 +1414,6 @@ class LLMObs(Service):
 
             span_id = span_context.get("span_id")
             trace_id = span_context.get("trace_id")
-            print(f"USING SPAN ID: {span_id} and TRACE ID: {trace_id}")
             if not (span_id and trace_id):
                 error = "invalid_span"
                 log.warning(

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -736,7 +736,9 @@ class LLMObs(Service):
                 error = "invalid_span"
                 log.warning("Span must be an LLMObs-generated span.")
                 return None
-            return ExportedLLMObsSpan(span_id=str(span.span_id), trace_id=format_trace_id(span.trace_id))
+            return ExportedLLMObsSpan(
+                span_id=str(span.span_id), trace_id=format_trace_id(span._get_ctx_item(LLMOBS_TRACE_ID))
+            )
         except (TypeError, AttributeError):
             error = "invalid_span"
             log.warning("Failed to export span. Span must be a valid Span object.")
@@ -1412,6 +1414,7 @@ class LLMObs(Service):
 
             span_id = span_context.get("span_id")
             trace_id = span_context.get("trace_id")
+            print(f"USING SPAN ID: {span_id} and TRACE ID: {trace_id}")
             if not (span_id and trace_id):
                 error = "invalid_span"
                 log.warning(

--- a/releasenotes/notes/llmobs-fix-incorrect-exported-trace-id-d35aeea97a8419c4.yaml
+++ b/releasenotes/notes/llmobs-fix-incorrect-exported-trace-id-d35aeea97a8419c4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes an issue where the trace ID exported from ``export_span`` was incorrect.

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -16,6 +16,7 @@ from ddtrace.llmobs._constants import INPUT_MESSAGES
 from ddtrace.llmobs._constants import INPUT_PROMPT
 from ddtrace.llmobs._constants import INPUT_VALUE
 from ddtrace.llmobs._constants import IS_EVALUATION_SPAN
+from ddtrace.llmobs._constants import LLMOBS_TRACE_ID
 from ddtrace.llmobs._constants import METADATA
 from ddtrace.llmobs._constants import METRICS
 from ddtrace.llmobs._constants import ML_APP
@@ -914,7 +915,7 @@ def test_export_span_specified_span_returns_span_context(llmobs):
         span_context = llmobs.export_span(span=span)
         assert span_context is not None
         assert span_context["span_id"] == str(span.span_id)
-        assert span_context["trace_id"] == format_trace_id(span.trace_id)
+        assert span_context["trace_id"] == format_trace_id(span._get_ctx_item(LLMOBS_TRACE_ID))
 
 
 def test_export_span_no_specified_span_no_active_span_raises_warning(llmobs, mock_llmobs_logs):
@@ -933,7 +934,7 @@ def test_export_span_no_specified_span_returns_exported_active_span(llmobs):
         span_context = llmobs.export_span()
         assert span_context is not None
         assert span_context["span_id"] == str(span.span_id)
-        assert span_context["trace_id"] == format_trace_id(span.trace_id)
+        assert span_context["trace_id"] == format_trace_id(span._get_ctx_item(LLMOBS_TRACE_ID))
 
 
 def test_submit_evaluation_ml_app_raises_warning(llmobs, mock_llmobs_logs):
@@ -1197,7 +1198,7 @@ def test_submit_evaluation_enqueues_writer_with_categorical_metric(llmobs, mock_
         _expected_llmobs_eval_metric_event(
             ml_app="dummy",
             span_id=str(span.span_id),
-            trace_id=format_trace_id(span.trace_id),
+            trace_id=format_trace_id(span._get_ctx_item(LLMOBS_TRACE_ID)),
             label="toxicity",
             metric_type="categorical",
             categorical_value="high",
@@ -1226,7 +1227,7 @@ def test_submit_evaluation_enqueues_writer_with_score_metric(llmobs, mock_llmobs
     mock_llmobs_eval_metric_writer.enqueue.assert_called_with(
         _expected_llmobs_eval_metric_event(
             span_id=str(span.span_id),
-            trace_id=format_trace_id(span.trace_id),
+            trace_id=format_trace_id(span._get_ctx_item(LLMOBS_TRACE_ID)),
             label="sentiment",
             metric_type="score",
             score_value=0.9,
@@ -1263,7 +1264,7 @@ def test_submit_evaluation_with_numerical_metric_enqueues_writer_with_score_metr
         _expected_llmobs_eval_metric_event(
             ml_app="dummy",
             span_id=str(span.span_id),
-            trace_id=format_trace_id(span.trace_id),
+            trace_id=format_trace_id(span._get_ctx_item(LLMOBS_TRACE_ID)),
             label="token_count",
             metric_type="score",
             score_value=35,
@@ -2148,7 +2149,7 @@ def test_submit_evaluation_for_enqueues_writer_with_categorical_metric(llmobs, m
         _expected_llmobs_eval_metric_event(
             ml_app="dummy",
             span_id=str(span.span_id),
-            trace_id=format_trace_id(span.trace_id),
+            trace_id=format_trace_id(span._get_ctx_item(LLMOBS_TRACE_ID)),
             label="toxicity",
             metric_type="categorical",
             categorical_value="high",
@@ -2177,7 +2178,7 @@ def test_submit_evaluation_for_enqueues_writer_with_score_metric(llmobs, mock_ll
     mock_llmobs_eval_metric_writer.enqueue.assert_called_with(
         _expected_llmobs_eval_metric_event(
             span_id=str(span.span_id),
-            trace_id=format_trace_id(span.trace_id),
+            trace_id=format_trace_id(span._get_ctx_item(LLMOBS_TRACE_ID)),
             label="sentiment",
             metric_type="score",
             score_value=0.9,


### PR DESCRIPTION
We recently changed how we record our LLMObs trace IDs - from APM trace IDs to new randomly generated ones. However, we missed updating `export_span`. This PR ensures we export the correct trace ID from `export_span`.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
