### PR TITLE
ci(iast): fix flaky test

### DIFF
--- a/tests/appsec/iast_tdd_propagation/test_flask.py
+++ b/tests/appsec/iast_tdd_propagation/test_flask.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import json
+from unittest.mock import ANY
 
 import pytest
 
@@ -106,7 +107,7 @@ def test_iast_flask_headers():
         content = json.loads(tainted_response.content)
         assert content["param"] == [
             ["Host", f"0.0.0.0:{_PORT}"],
-            ["User-Agent", "python-requests/2.32.3"],
+            ["User-Agent", ANY],
             ["Accept-Encoding", "gzip, deflate, br"],
             ["Accept", "*/*"],
             ["Connection", "keep-alive"],


### PR DESCRIPTION
Fix flaky iast flaky test with different requests version:

```
        [
            'User-Agent',
  -         'python-requests/2.32.3',
  ?                               ^
  +         'python-requests/2.32.4',
  ?                               ^
        ],
```

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
