### PR TITLE
chore(ci): remove freezegun from hatch since it's in riot

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -757,24 +757,6 @@ view = [
     "python scripts/ci_visibility/view_snapshot.py {args:}",
 ]
 
-[envs.freezegun]
-template = "freezegun"
-dependencies = [
-    "freezegun{matrix:freezegun}",
-    "pytest",
-    "pytest-cov",
-    "hypothesis",
-]
-
-[envs.freezegun.scripts]
-test = [
-    "pytest tests/contrib/freezegun {args:}",
-]
-
-[[envs.freezegun.matrix]]
-python = ["3.10", "3.12"]
-freezegun = ["~=1.3.0", "~=1.5.0"]
-
 [envs.selenium]
 template = "selenium"
 dependencies = [


### PR DESCRIPTION
On #13612 I added freezegun to riot but forgot to remove it from hatch. This fixes it.

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
