### PR TITLE
feat(co): add in-product enablement support

### DIFF
--- a/ddtrace/debugging/_products/code_origin/span.py
+++ b/ddtrace/debugging/_products/code_origin/span.py
@@ -1,3 +1,5 @@
+import enum
+
 from ddtrace.settings.code_origin import config
 
 
@@ -9,23 +11,41 @@ def post_preload():
     pass
 
 
+def _start():
+    from ddtrace.debugging._origin.span import SpanCodeOriginProcessor
+
+    SpanCodeOriginProcessor.enable()
+
+
 def start():
     if config.span.enabled:
-        from ddtrace.debugging._origin.span import SpanCodeOriginProcessor
-
-        SpanCodeOriginProcessor.enable()
+        _start()
 
 
 def restart(join=False):
     pass
 
 
+def _stop():
+    from ddtrace.debugging._origin.span import SpanCodeOriginProcessor
+
+    SpanCodeOriginProcessor.disable()
+
+
 def stop(join=False):
     if config.span.enabled:
-        from ddtrace.debugging._origin.span import SpanCodeOriginProcessor
-
-        SpanCodeOriginProcessor.disable()
+        _stop()
 
 
 def at_exit(join=False):
     stop(join=join)
+
+
+class APMCapabilities(enum.IntFlag):
+    APM_TRACING_ENABLE_CODE_ORIGIN = 1 << 40
+
+
+def apm_tracing_rc(lib_config, _config):
+    if (enabled := lib_config.get("code_origin_enabled")) is not None:
+        should_start = (config.span.spec.enabled.full_name not in config.source or config.span.enabled) and enabled
+        _start() if should_start else _stop()

--- a/releasenotes/notes/feat-co-in-product-enablement-6b70fc52d62721fa.yaml
+++ b/releasenotes/notes/feat-co-in-product-enablement-6b70fc52d62721fa.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    code origin: added support for in-product enablement.


### PR DESCRIPTION
We add support for in-product enablement to code origin for spans.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
