### PR TITLE
chore(config): use DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED instead of DD_TRACE_RUNTIME_ID_ENABLED

### DIFF
--- a/ddtrace/settings/_config.py
+++ b/ddtrace/settings/_config.py
@@ -535,7 +535,7 @@ class Config(object):
             "DD_RUNTIME_METRICS_ENABLED", False, asbool, "OTEL_METRICS_EXPORTER"
         )
         self._runtime_metrics_runtime_id_enabled = _get_config(
-            ["DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED", "DD_TRACE_RUNTIME_ID_ENABLED"], False, asbool
+            ["DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED", "DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED"], False, asbool
         )
         self._experimental_features_enabled = _get_config(
             "DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED", set(), lambda x: set(x.strip().upper().split(","))

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -856,7 +856,7 @@ Other
          These metrics track the memory management and concurrency of the python runtime. 
          Refer to the following `docs <https://docs.datadoghq.com/tracing/metrics/runtime_metrics/python/>` _ for more information.
 
-   DD_TRACE_RUNTIME_ID_ENABLED:
+   DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED:
      type: Boolean
      default: False
      version_added:

--- a/releasenotes/notes/add_DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED-8e9d518dfd0028f2.yaml
+++ b/releasenotes/notes/add_DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED-8e9d518dfd0028f2.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    tracer: Adds the environment variable ``DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED`` to enable runtime metrics for tagging runtime metrics with the current runtime ID. This is useful for tracking runtime metrics across multiple processes. Previously, this was ``DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED``.

--- a/releasenotes/notes/add_DD_TRACE_RUNTIME_ID_ENABLED-8e9d518dfd0028f2.yaml
+++ b/releasenotes/notes/add_DD_TRACE_RUNTIME_ID_ENABLED-8e9d518dfd0028f2.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    tracer: Adds the environment variable ``DD_TRACE_RUNTIME_ID_ENABLED`` to enable runtime metrics for tagging runtime metrics with the current runtime ID. This is useful for tracking runtime metrics across multiple processes. Previously, this was ``DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED``.

--- a/tests/runtime/test_runtime_metrics_api.py
+++ b/tests/runtime/test_runtime_metrics_api.py
@@ -201,7 +201,7 @@ def test_runtime_metrics_enable_environ(monkeypatch, environ):
 @pytest.mark.subprocess(
     parametrize={
         "DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED": ["true", "false"],
-        "DD_TRACE_RUNTIME_ID_ENABLED": ["true", "false"],
+        "DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED": ["true", "false"],
     }
 )
 def test_runtime_metrics_experimental_runtime_tag():
@@ -223,17 +223,19 @@ def test_runtime_metrics_experimental_runtime_tag():
 
     runtime_id_tag = f"runtime-id:{get_runtime_id()}"
     if (
-        os.environ["DD_TRACE_RUNTIME_ID_ENABLED"] == "true"
+        os.environ["DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED"] == "true"
         or os.environ["DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED"] == "true"
     ):
         assert runtime_id_tag in worker_instance._platform_tags, worker_instance._platform_tags
     elif (
-        os.environ["DD_TRACE_RUNTIME_ID_ENABLED"] == "false"
+        os.environ["DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED"] == "false"
         or os.environ["DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED"] == "false"
     ):
         assert runtime_id_tag not in worker_instance._platform_tags, worker_instance._platform_tags
     else:
-        raise pytest.fail("Invalid value for DD_TRACE_RUNTIME_ID_ENABLED or DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED")
+        raise pytest.fail(
+            "Invalid value for DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED or DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED"
+        )
 
 
 @pytest.mark.subprocess(


### PR DESCRIPTION
## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
