### PR TITLE
feat(dsm): add manual checkpoint parameter to consume API

### DIFF
--- a/ddtrace/data_streams.py
+++ b/ddtrace/data_streams.py
@@ -2,7 +2,7 @@ import ddtrace
 from ddtrace.internal.datastreams.processor import PROPAGATION_KEY_BASE_64
 
 
-def set_consume_checkpoint(typ, source, carrier_get):
+def set_consume_checkpoint(typ, source, carrier_get, manual_checkpoint=True):
     """
     :param typ: The type of the checkpoint, usually the streaming technology being used.
         Examples include kafka, kinesis, sns etc. (str)
@@ -14,7 +14,10 @@ def set_consume_checkpoint(typ, source, carrier_get):
     if ddtrace.config._data_streams_enabled:
         processor = ddtrace.tracer.data_streams_processor
         processor.decode_pathway_b64(carrier_get(PROPAGATION_KEY_BASE_64))
-        return processor.set_checkpoint(["type:" + typ, "topic:" + source, "direction:in", "manual_checkpoint:true"])
+        tags = ["type:" + typ, "topic:" + source, "direction:in"]
+        if manual_checkpoint:
+            tags.append("manual_checkpoint:true")
+        return processor.set_checkpoint(tags)
 
 
 def set_produce_checkpoint(typ, target, carrier_set):

--- a/ddtrace/data_streams.py
+++ b/ddtrace/data_streams.py
@@ -8,7 +8,9 @@ def set_consume_checkpoint(typ, source, carrier_get, manual_checkpoint=True):
         Examples include kafka, kinesis, sns etc. (str)
     :param source: The source of data. This can be a topic, exchange or stream name. (str)
     :param carrier_get: A function used to extract context from the carrier (function (str) -> str)
-    :param manual_checkpoint: Whether this checkpoint was manually set. Keep true if manually instrumenting. Manual instrumentation always overrides automatic instrumentation in the case a call is both manually and automatically instrumented. (bool)
+    :param manual_checkpoint: Whether this checkpoint was manually set. Keep true if manually instrumenting.
+        Manual instrumentation always overrides automatic instrumentation in the case a call is both
+        manually and automatically instrumented. (bool)
 
     :returns DataStreamsCtx | None
     """

--- a/ddtrace/data_streams.py
+++ b/ddtrace/data_streams.py
@@ -8,7 +8,7 @@ def set_consume_checkpoint(typ, source, carrier_get, manual_checkpoint=True):
         Examples include kafka, kinesis, sns etc. (str)
     :param source: The source of data. This can be a topic, exchange or stream name. (str)
     :param carrier_get: A function used to extract context from the carrier (function (str) -> str)
-    :param manual_checkpoint: Whether this is a manual checkpoint. (bool)
+    :param manual_checkpoint: Whether this checkpoint was manually set. Keep true if manually instrumenting. (bool)
 
     :returns DataStreamsCtx | None
     """

--- a/ddtrace/data_streams.py
+++ b/ddtrace/data_streams.py
@@ -8,6 +8,7 @@ def set_consume_checkpoint(typ, source, carrier_get, manual_checkpoint=True):
         Examples include kafka, kinesis, sns etc. (str)
     :param source: The source of data. This can be a topic, exchange or stream name. (str)
     :param carrier_get: A function used to extract context from the carrier (function (str) -> str)
+    :param manual_checkpoint: Whether this is a manual checkpoint. (bool)
 
     :returns DataStreamsCtx | None
     """

--- a/ddtrace/data_streams.py
+++ b/ddtrace/data_streams.py
@@ -8,7 +8,7 @@ def set_consume_checkpoint(typ, source, carrier_get, manual_checkpoint=True):
         Examples include kafka, kinesis, sns etc. (str)
     :param source: The source of data. This can be a topic, exchange or stream name. (str)
     :param carrier_get: A function used to extract context from the carrier (function (str) -> str)
-    :param manual_checkpoint: Whether this checkpoint was manually set. Keep true if manually instrumenting. (bool)
+    :param manual_checkpoint: Whether this checkpoint was manually set. Keep true if manually instrumenting. Manual instrumentation always overrides automatic instrumentation in the case a call is both manually and automatically instrumented. (bool)
 
     :returns DataStreamsCtx | None
     """

--- a/releasenotes/notes/add-dsm-manual-checkpoint-flag-8ec40cc433070ee6.yaml
+++ b/releasenotes/notes/add-dsm-manual-checkpoint-flag-8ec40cc433070ee6.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    DSM: Add flag in set_consume_checkpoint() to indicate if DSM checkpoint was manually set.

--- a/tests/datastreams/test_public_api.py
+++ b/tests/datastreams/test_public_api.py
@@ -34,9 +34,10 @@ def test_public_api():
 
 def test_manual_checkpoint_behavior():
     headers = {}
-    with mock.patch("ddtrace.tracer", new=MockedTracer()):
+    mocked_tracer = MockedTracer()
+    with mock.patch("ddtrace.tracer", new=mocked_tracer):
         with mock.patch("ddtrace.config", new=MockedConfig()):
-            with mock.patch.object(MockedTracer().data_streams_processor, "set_checkpoint") as mock_set_checkpoint:
+            with mock.patch.object(mocked_tracer.data_streams_processor, "set_checkpoint") as mock_set_checkpoint:
                 set_consume_checkpoint("kinesis", "stream-123", headers.get)
                 called_tags = mock_set_checkpoint.call_args[0][0]
                 assert "manual_checkpoint:true" in called_tags


### PR DESCRIPTION
Adds a manual_checkpoint parameter in the public dsm set_consume_checkpoint(), this allows one to turn off the manual_checkpoint:true tag if use of function is not for explicit purpose of manually instrumenting (default remains as manual instrumentation). 



## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [X] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
