### PR TITLE
fix(llmobs): bedrock converse tracing is resistant to modifying the stream

### DIFF
--- a/ddtrace/contrib/internal/botocore/services/bedrock.py
+++ b/ddtrace/contrib/internal/botocore/services/bedrock.py
@@ -124,7 +124,7 @@ class TracedBotocoreConverseStream(wrapt.ObjectProxy):
         self._execution_ctx = ctx
 
     def __iter__(self):
-        stream_processor = self._execution_ctx["bedrock_integration"]._output_stream_processor()
+        stream_processor = self._execution_ctx["bedrock_integration"]._converse_output_stream_processor()
         exception_raised = False
         try:
             next(stream_processor)

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -81,6 +81,11 @@ class BedrockIntegration(BaseLLMIntegration):
             if ctx["resource"] == "Converse":
                 output_messages = self._extract_output_message_for_converse(response)
             elif ctx["resource"] == "ConverseStream":
+                """
+                At this point, we signal to `_output_stream_processor` that we're done with the stream
+                and ready to get the final results. This causes `_output_stream_processor` to break out of the
+                while loop, do some final processing, and return the final results.
+                """
                 try:
                     response.send(None)
                 except StopIteration as e:

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -1,9 +1,9 @@
 from typing import Any
 from typing import Dict
+from typing import Generator
 from typing import List
 from typing import Optional
 from typing import Tuple
-from typing import Generator
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._constants import INPUT_MESSAGES
@@ -165,7 +165,8 @@ class BedrockIntegration(BaseLLMIntegration):
         ]
     ):
         """
-        Listens for output chunks from a converse stream response and builds a list of output messages, usage metrics, and metadata.
+        Listens for output chunks from a converse stream response and builds a
+        list of output messages, usage metrics, and metadata.
 
         Converse stream response comes in chunks. The chunks we care about are:
         - a message start/stop event, or

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -165,7 +165,7 @@ class BedrockIntegration(BaseLLMIntegration):
         ]
     ):
         """
-        Listens for output chunks from a converse stream response and builds a
+        Listens for output chunks from a converse streamed response and builds a
         list of output messages, usage metrics, and metadata.
 
         Converse stream response comes in chunks. The chunks we care about are:

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -82,8 +82,8 @@ class BedrockIntegration(BaseLLMIntegration):
                 output_messages = self._extract_output_message_for_converse(response)
             elif ctx["resource"] == "ConverseStream":
                 """
-                At this point, we signal to `_output_stream_processor` that we're done with the stream
-                and ready to get the final results. This causes `_output_stream_processor` to break out of the
+                At this point, we signal to `_converse_output_stream_processor` that we're done with the stream
+                and ready to get the final results. This causes `_converse_output_stream_processor` to break out of the
                 while loop, do some final processing, and return the final results.
                 """
                 try:
@@ -157,7 +157,7 @@ class BedrockIntegration(BaseLLMIntegration):
         return get_messages_from_converse_content(role, content)
 
     @staticmethod
-    def _output_stream_processor() -> (
+    def _converse_output_stream_processor() -> (
         Generator[
             None,
             Dict[str, Any],

--- a/releasenotes/notes/fix-bedrock-stream-0bd52763872967a5.yaml
+++ b/releasenotes/notes/fix-bedrock-stream-0bd52763872967a5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: This fix resolves an issue where modifying bedrock converse streamed chunks caused traced spans to show modified content.


### PR DESCRIPTION
Fixes an issue where modifying chunks returned from a bedrock stream impacted our tracing of those chunks. Instead, our tracing should reflect the original response returned regardless of whether or not it was modified.

This is relevant when libraries like langchain delete data from the raw streamed response (e.g. [popping](https://github.com/langchain-ai/langchain-aws/blob/40abb584979a349019d89bbf1cba7d8c56d23664/libs/aws/langchain_aws/chat_models/bedrock_converse.py#L995) `usageMetadata`).

The fix uses an approach where we immediately process stream chunks as they are iterated over, instead of waiting until the entire stream has finished. 

The data flow is like this:
1. a streamed chunk is read from `TracedBotocoreConverseStream`
2. we send that chunk to `_output_stream_processor`, which reads all the relevant data from that chunk and builds the final output messages, token usage, metadata. This should block until we reach the next yield, at which point we've read all the data we needed for this chunk. The parsing logic is **unchanged** from the previous helper we used to parse the stream stream, except this method is now a generator.
4. we yield the chunk back to the user

In terms of manual testing, i've verified that it fixes the langchain x bedrock converse streaming issue
<img width="908" alt="image" src="https://github.com/user-attachments/assets/e4d1e4e5-3d1c-4f2d-a822-f7c7cdb169a6" />

if this logic looks good, it may be a pattern we will want to implement for our other integrations as well

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
