### PR TITLE
chore: add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,6 @@ tests/appsec/iast/fixtures/aspects/unpatched_callers.py
 
 # Setup download cache
 .download_cache/
+
+# .env file
+.env


### PR DESCRIPTION
A .env file can be used to configure the local development environment (e.g. enabling build features like `DD_SETUP_CACHE_DOWNLOADS`. We add this file to the .gitignore so that it can be ignored from the index.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
