### PR TITLE
chore(asm): keep trace without events if waf decides

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '64afc5f8c1c2aa19adefdf1abf5559b62af8e784'
+          ref: '40654a690db784079c5969bfc0a6031964f833a8'
 
       - name: Build agent
         run: ./build.sh -i agent
@@ -69,7 +69,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '64afc5f8c1c2aa19adefdf1abf5559b62af8e784'
+          ref: '40654a690db784079c5969bfc0a6031964f833a8'
 
       - name: Checkout dd-trace-py
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -123,7 +123,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '64afc5f8c1c2aa19adefdf1abf5559b62af8e784'
+          ref: '40654a690db784079c5969bfc0a6031964f833a8'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -310,7 +310,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '64afc5f8c1c2aa19adefdf1abf5559b62af8e784'
+          ref: '40654a690db784079c5969bfc0a6031964f833a8'
       - name: Checkout dd-trace-py
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -11,33 +11,6 @@ on:
     - cron: '00 04 * * 2-6'
 
 jobs:
-  system-tests-build-agent:
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Checkout system tests
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-          repository: 'DataDog/system-tests'
-          # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '40654a690db784079c5969bfc0a6031964f833a8'
-
-      - name: Build agent
-        run: ./build.sh -i agent
-
-      - name: Save
-        id: save
-        run: |
-          docker image save system_tests/agent:latest | gzip > agent_${{ github.sha }}.tar.gz
-
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: agent_${{ github.sha }}
-          path: |
-            agent_${{ github.sha }}.tar.gz
-          retention-days: 2
-
   system-tests-build-weblog:
     runs-on: ubuntu-latest
     strategy:
@@ -98,7 +71,7 @@ jobs:
 
   system-tests:
     runs-on: ubuntu-latest
-    needs: [system-tests-build-agent, system-tests-build-weblog]
+    needs: [system-tests-build-weblog]
     strategy:
       matrix:
         weblog-variant: [flask-poc, uwsgi-poc , django-poc, fastapi, python3.12, django-py3.13]
@@ -133,16 +106,10 @@ jobs:
           name: ${{ matrix.weblog-variant }}_${{ github.sha }}
           path: images_artifacts/
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: agent_${{ github.sha }}
-          path: images_artifacts/
-
       - name: docker load
         id: docker_load
         run: |
           docker load < images_artifacts/${{ matrix.weblog-variant}}_weblog_${{ github.sha }}.tar.gz
-          docker load < images_artifacts/agent_${{ github.sha }}.tar.gz
 
       - name: Run DEFAULT
         if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'other'


### PR DESCRIPTION
The new version of libddwaf can decide to keep a trace even without security events.
This PR allows to do so.

Also: update system tests version with last commit and remove the agent build step that is now deprecated.

This new internal feature is already checked by new system tests.

APPSEC-58012

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
