### PR TITLE
chore(aap): report config_errors for waf init failure

### DIFF
--- a/ddtrace/appsec/_metrics.py
+++ b/ddtrace/appsec/_metrics.py
@@ -71,18 +71,18 @@ def _set_waf_updates_metric(info: DDWaf_info, success: bool):
         logger.warning(WARNING_TAGS.TELEMETRY_METRICS, extra=extra, exc_info=True)
 
 
-def _set_waf_init_metric(info, success: bool):
+def _set_waf_init_metric(info: DDWaf_info, success: bool):
     try:
-        if info:
-            tags: typing.Tuple[typing.Tuple[str, str], ...] = (
-                ("event_rules_version", info.version or UNKNOWN_VERSION),
-                ("waf_version", ddwaf_version),
-                ("success", bool_str[success]),
-            )
-        else:
-            tags = (("waf_version", ddwaf_version), ("success", bool_str[success]))
+        tags: typing.Tuple[typing.Tuple[str, str], ...] = (
+            ("event_rules_version", info.version or UNKNOWN_VERSION),
+            ("waf_version", ddwaf_version),
+        )
 
-        telemetry.telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.APPSEC, "waf.init", 1, tags=tags)
+        telemetry.telemetry_writer.add_count_metric(
+            TELEMETRY_NAMESPACE.APPSEC, "waf.init", 1, tags=tags + (("success", bool_str[success]),)
+        )
+        if not success:
+            telemetry.telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.APPSEC, "waf.config_errors", 1, tags=tags)
     except Exception:
         extra = {"product": "appsec", "exec_limit": 6, "more_info": ":waf:init"}
         logger.warning(WARNING_TAGS.TELEMETRY_METRICS, extra=extra, exc_info=True)

--- a/ddtrace/appsec/_metrics.py
+++ b/ddtrace/appsec/_metrics.py
@@ -3,6 +3,7 @@ import typing
 from ddtrace.appsec import _asm_request_context
 from ddtrace.appsec import _constants
 from ddtrace.appsec._deduplications import deduplication
+from ddtrace.appsec._utils import DDWaf_info
 from ddtrace.internal import telemetry
 import ddtrace.internal.logger as ddlogger
 from ddtrace.internal.telemetry.constants import TELEMETRY_LOG_LEVEL
@@ -53,18 +54,18 @@ def _set_waf_error_log(msg: str, version: str, error_level: bool = True) -> None
         logger.warning(WARNING_TAGS.TELEMETRY_METRICS, extra=extra, exc_info=True)
 
 
-def _set_waf_updates_metric(info, success: bool):
+def _set_waf_updates_metric(info: DDWaf_info, success: bool):
     try:
-        if info:
-            tags: typing.Tuple[typing.Tuple[str, str], ...] = (
-                ("event_rules_version", info.version or UNKNOWN_VERSION),
-                ("waf_version", ddwaf_version),
-                ("success", bool_str[success]),
-            )
-        else:
-            tags = (("waf_version", ddwaf_version), ("success", bool_str[success]))
+        tags: typing.Tuple[typing.Tuple[str, str], ...] = (
+            ("event_rules_version", info.version or UNKNOWN_VERSION),
+            ("waf_version", ddwaf_version),
+        )
 
-        telemetry.telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.APPSEC, "waf.updates", 1, tags=tags)
+        telemetry.telemetry_writer.add_count_metric(
+            TELEMETRY_NAMESPACE.APPSEC, "waf.updates", 1, tags=tags + (("success", bool_str[success]),)
+        )
+        if not success:
+            telemetry.telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.APPSEC, "waf.config_errors", 1, tags=tags)
     except Exception:
         extra = {"product": "appsec", "exec_limit": 6, "more_info": ":waf:updates"}
         logger.warning(WARNING_TAGS.TELEMETRY_METRICS, extra=extra, exc_info=True)


### PR DESCRIPTION
- Ensure the `waf.config_errors` metrics is generated when there is a waf failed initialisation or update.
- Improve typing in telemetry module for appsec
- This will also be tested in system tests https://github.com/DataDog/system-tests/pull/4788

APPSEC-58013

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
