### PR TITLE
fix(aap): fixing missing tracking user tags in the new sdk

### DIFF
--- a/ddtrace/appsec/track_user_sdk.py
+++ b/ddtrace/appsec/track_user_sdk.py
@@ -73,8 +73,21 @@ def track_user(
         span.set_tag_str(_constants.APPSEC.USER_LOGIN_USERID, str(user_id))
     if login:
         span.set_tag_str(_constants.APPSEC.USER_LOGIN_USERNAME, str(login))
-
-    _trace_utils.set_user(None, user_id, session_id=session_id, may_block=False)
+    meta = metadata or {}
+    usr_name = meta.get("name") or meta.get("usr.name")
+    usr_email = meta.get("email") or meta.get("usr.email")
+    usr_scope = meta.get("scope") or meta.get("usr.scope")
+    usr_role = meta.get("role") or meta.get("usr.role")
+    _trace_utils.set_user(
+        None,
+        user_id,
+        name=usr_name if isinstance(usr_name, str) else None,
+        email=usr_email if isinstance(usr_email, str) else None,
+        scope=usr_scope if isinstance(usr_scope, str) else None,
+        role=usr_role if isinstance(usr_role, str) else None,
+        session_id=session_id,
+        may_block=False,
+    )
     if metadata:
         _trace_utils.track_custom_event(None, "auth_sdk", metadata=metadata)
     span.set_tag_str(_constants.APPSEC.AUTO_LOGIN_EVENTS_COLLECTION_MODE, _constants.LOGIN_EVENTS_MODE.SDK)

--- a/releasenotes/notes/fix_track_user_missing_data-6267b4a000f6bbed.yaml
+++ b/releasenotes/notes/fix_track_user_missing_data-6267b4a000f6bbed.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    AAP: This fix resolves an issue where the new ATO SDK track_user was reporting differently email, name, scope and role of the tracked user.


### PR DESCRIPTION
The new SDK for tracking user was reporting name, email, scope and role of tracked user with different tags than the legacy SDK, leading to missing information in the security UI.

This PR fixes that.

Ticket #2164160

APPSEC-58040

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
