### PR TITLE
chore(asm/lambda): add forgotten path parameters

### DIFF
--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -96,6 +96,7 @@ def _on_lambda_start_request(
     route: str,
     method: str,
     parsed_query: Dict[str, Any],
+    request_path_parameters: Optional[Dict[str, Any]],
 ):
     if not (asm_config._asm_enabled and span.span_type in asm_config._asm_http_span_types):
         return
@@ -113,7 +114,7 @@ def _on_lambda_start_request(
         headers,
         request_cookies,
         parsed_query,
-        None,
+        request_path_parameters,
         request_body,
         None,
         None,


### PR DESCRIPTION
## Description
This is a followup on #13638, to add the forgotten waf address: `request_path_parameters`.


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
