### PR TITLE
fix(llmobs): avoid missing ml app error if llmobs is disabled

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -800,6 +800,10 @@ class LLMObs(Service):
         if name is None:
             name = operation_kind
         span = self.tracer.trace(name, resource=operation_kind, span_type=SpanTypes.LLM)
+
+        if not self.enabled:
+            return span
+
         span._set_ctx_item(SPAN_KIND, operation_kind)
         if model_name is not None:
             span._set_ctx_item(MODEL_NAME, model_name)

--- a/releasenotes/notes/fix-llmobs-ml-app-disabled-7879e1fcb2d1e0da.yaml
+++ b/releasenotes/notes/fix-llmobs-ml-app-disabled-7879e1fcb2d1e0da.yaml
@@ -1,5 +1,4 @@
 ---
 fixes:
   - |
-    LLM Observability: Resolved an issue where manual instrumentation would raise ``DD_LLMOBS_ML_APP`` missing errors, 
-    even when LLM Observability was disabled.
+    LLM Observability: Resolved an issue where manual instrumentation would raise ``DD_LLMOBS_ML_APP`` missing errors when LLM Observability was disabled.

--- a/releasenotes/notes/fix-llmobs-ml-app-disabled-7879e1fcb2d1e0da.yaml
+++ b/releasenotes/notes/fix-llmobs-ml-app-disabled-7879e1fcb2d1e0da.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    LLM Observability: Resolved an issue where manual instrumentation would raise ``DD_LLMOBS_ML_APP`` missing errors, 
+    even when LLM Observability was disabled.

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -226,6 +226,11 @@ def test_start_span_with_no_ml_app_throws(llmobs_no_ml_app):
             pass
 
 
+def test_start_span_without_ml_app_does_noop():
+    with llmobs_service.task():
+        pass
+
+
 def test_ml_app_local_precedence(llmobs, tracer):
     with tracer.trace("apm") as apm_span:
         apm_span.context._meta[PROPAGATED_ML_APP_KEY] = "propagated-ml-app"


### PR DESCRIPTION
Our `_start_span()` method does a bunch of llmobs-instrumentation/modifications under the hood, even if LLMObs is disabled. Specifically our llm/task/tool/agent/retrieval/workflow/embeddings() methods only log a warning if ML_APP is missing, but still route to our `_start_span()` method, which then continues on to do a ML_APP check (and raises if this is missing), even if LLMObs is disabled. This means if ML_APP is missing, any manual instrumentation will break customer apps if they disable LLMObs.

We need to make `_start_span()` a no-op wrapper around `tracer.trace(...)`. This fix ensures that if llmobs is disabled, we return the span immediately before we start doing llmobs-specific logic.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
