### PR TITLE
chore(setup): add dependency to crashtracker_exe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -798,7 +798,10 @@ if not IS_PYSTON:
                 "ddtrace.internal.datadog.profiling.crashtracker._crashtracker",
                 source_dir=CRASHTRACKER_DIR,
                 optional=False,
-                dependencies=[CRASHTRACKER_DIR.parent / "libdd_wrapper"],
+                dependencies=[
+                    CRASHTRACKER_DIR / "crashtracker_exe",
+                    CRASHTRACKER_DIR.parent / "libdd_wrapper",
+                ],
             )
         )
 


### PR DESCRIPTION
We add the dependency on the crashtracker executable to the crashtracker CMake extension to allow incremental builds to use it to decide when to recompile the extension. This also ensures that the executable is cached in our CI jobs and resored as appropriate.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
