### PR TITLE
chore(aap): telemetry wrapper for ato sdk v1

### DIFF
--- a/ddtrace/appsec/trace_utils/__init__.py
+++ b/ddtrace/appsec/trace_utils/__init__.py
@@ -1,13 +1,38 @@
 """Public API for User events"""
+from functools import wraps
 
+from ddtrace.appsec import _metrics
 from ddtrace.appsec._trace_utils import block_request  # noqa: F401
 from ddtrace.appsec._trace_utils import block_request_if_user_blocked  # noqa: F401
 from ddtrace.appsec._trace_utils import should_block_user  # noqa: F401
-from ddtrace.appsec._trace_utils import track_custom_event  # noqa: F401
-from ddtrace.appsec._trace_utils import track_user_login_failure_event  # noqa: F401
-from ddtrace.appsec._trace_utils import track_user_login_success_event  # noqa: F401
-from ddtrace.appsec._trace_utils import track_user_signup_event  # noqa: F401
+from ddtrace.appsec._trace_utils import track_custom_event
+from ddtrace.appsec._trace_utils import track_user_login_failure_event
+from ddtrace.appsec._trace_utils import track_user_login_success_event
+from ddtrace.appsec._trace_utils import track_user_signup_event
 import ddtrace.internal.core
 
 
 ddtrace.internal.core.on("set_user_for_asm", block_request_if_user_blocked, "block_user")
+
+
+def _telemetry_report_factory(event_name: str):
+    """
+    Factory function to create a telemetry report decorator.
+    This decorator will report the event name when the decorated function is called.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            _metrics._report_ato_sdk_usage(event_name, False)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+track_custom_event = _telemetry_report_factory("custom")(track_custom_event)
+track_user_login_success_event = _telemetry_report_factory("login_success")(track_user_login_success_event)
+track_user_login_failure_event = _telemetry_report_factory("login_failure")(track_user_login_failure_event)
+track_user_signup_event = _telemetry_report_factory("signup")(track_user_signup_event)


### PR DESCRIPTION
Add telemetry support for the legacy ATO SDK.

This will also be tested using system tests https://github.com/DataDog/system-tests/pull/4806

APPSEC-58051

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
