### PR TITLE
chore: revert add DD_BUILD_EXT_INCLUDES and DD_BUILD_EXT_EXCLUDES to setup.py

### DIFF
--- a/docs/build_system.rst
+++ b/docs/build_system.rst
@@ -204,29 +204,3 @@ These environment variables modify aspects of the build process.
 
     version_added:
         v2.16.0:
-
-  DD_BUILD_EXT_INCLUDES:
-    type: String
-    default: ""
-
-    description: |
-        Comma separated list of ``fnmatch`` patterns for native extensions to build when installing the package from source.
-        Example: ``DD_BUILD_EXT_INCLUDES="ddtrace.internal.*" pip install -e .`` to only build native extensions found in ``ddtrace/internal/`` folder.
-
-        ``DD_BUILD_EXT_EXCLUDES`` takes precedence over ``DD_BUILD_EXT_INCLUDES``.
-
-    version_added:
-        v3.3.0:
-
-  DD_BUILD_EXT_EXCLUDES:
-    type: String
-    default: ""
-
-    description: |
-        Comma separated list of ``fnmatch`` patterns for native extensions to skip when installing the package from source.
-        Example: ``DD_BUILD_EXT_EXCLUDES="*._encoding" pip install -e .`` to build all native extensions except ``ddtrace.internal._encoding``.
-
-        ``DD_BUILD_EXT_EXCLUDES`` takes precedence over ``DD_BUILD_EXT_INCLUDES``.
-
-    version_added:
-        v3.3.0:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import atexit
-import fnmatch
 import hashlib
 import os
 import platform
@@ -664,29 +663,6 @@ def check_rust_toolchain():
         raise EnvironmentError("Rust toolchain not found. Please install Rust from https://rustup.rs/")
 
 
-DD_BUILD_EXT_INCLUDES = [_.strip() for _ in os.getenv("DD_BUILD_EXT_INCLUDES", "").split(",") if _.strip()]
-DD_BUILD_EXT_EXCLUDES = [_.strip() for _ in os.getenv("DD_BUILD_EXT_EXCLUDES", "").split(",") if _.strip()]
-
-
-def filter_extensions(
-    extensions: t.List[t.Union[Extension, Cython.Distutils.Extension, RustExtension]],
-) -> t.List[t.Union[Extension, Cython.Distutils.Extension, RustExtension]]:
-    if not DD_BUILD_EXT_INCLUDES and not DD_BUILD_EXT_EXCLUDES:
-        return extensions
-
-    filtered: t.List[t.Union[Extension, Cython.Distutils.Extension, RustExtension]] = []
-    for ext in extensions:
-        if DD_BUILD_EXT_EXCLUDES and any(fnmatch.fnmatch(ext.name, pattern) for pattern in DD_BUILD_EXT_EXCLUDES):
-            print(f"INFO: Excluding extension {ext.name}")
-            continue
-        elif DD_BUILD_EXT_INCLUDES and not any(fnmatch.fnmatch(ext.name, pattern) for pattern in DD_BUILD_EXT_INCLUDES):
-            print(f"INFO: Excluding extension {ext.name}")
-            continue
-        print(f"INFO: Including extension {ext.name}")
-        filtered.append(ext)
-    return filtered
-
-
 # Before adding any extensions, check that system pre-requisites are satisfied
 try:
     check_rust_toolchain()
@@ -846,60 +822,57 @@ setup(
         "ext_hashes": ExtensionHashes,
     },
     setup_requires=["setuptools_scm[toml]>=4", "cython", "cmake>=3.24.2,<3.28", "setuptools-rust"],
-    ext_modules=filter_extensions(ext_modules)
+    ext_modules=ext_modules
     + cythonize(
-        filter_extensions(
-            [
-                Cython.Distutils.Extension(
-                    "ddtrace.internal._rand",
-                    sources=["ddtrace/internal/_rand.pyx"],
-                    language="c",
-                ),
-                Cython.Distutils.Extension(
-                    "ddtrace.internal._tagset",
-                    sources=["ddtrace/internal/_tagset.pyx"],
-                    language="c",
-                ),
-                Extension(
-                    "ddtrace.internal._encoding",
-                    ["ddtrace/internal/_encoding.pyx"],
-                    include_dirs=["."],
-                    libraries=encoding_libraries,
-                    define_macros=[(f"__{sys.byteorder.upper()}_ENDIAN__", "1")],
-                ),
-                Extension(
-                    "ddtrace.internal.telemetry.metrics_namespaces",
-                    ["ddtrace/internal/telemetry/metrics_namespaces.pyx"],
-                    language="c",
-                ),
-                Cython.Distutils.Extension(
-                    "ddtrace.profiling.collector.stack",
-                    sources=["ddtrace/profiling/collector/stack.pyx"],
-                    language="c",
-                    # cython generated code errors on build in toolchains that are strict about int->ptr conversion
-                    # OTOH, the MSVC toolchain is different.  In a perfect world we'd deduce the underlying
-                    # toolchain and emit the right flags, but as a compromise we assume Windows implies MSVC and
-                    # everything else is on a GNU-like toolchain
-                    extra_compile_args=extra_compile_args
-                    + (["-Wno-int-conversion"] if CURRENT_OS != "Windows" else []),
-                ),
-                Cython.Distutils.Extension(
-                    "ddtrace.profiling.collector._traceback",
-                    sources=["ddtrace/profiling/collector/_traceback.pyx"],
-                    language="c",
-                ),
-                Cython.Distutils.Extension(
-                    "ddtrace.profiling._threading",
-                    sources=["ddtrace/profiling/_threading.pyx"],
-                    language="c",
-                ),
-                Cython.Distutils.Extension(
-                    "ddtrace.profiling.collector._task",
-                    sources=["ddtrace/profiling/collector/_task.pyx"],
-                    language="c",
-                ),
-            ]
-        ),
+        [
+            Cython.Distutils.Extension(
+                "ddtrace.internal._rand",
+                sources=["ddtrace/internal/_rand.pyx"],
+                language="c",
+            ),
+            Cython.Distutils.Extension(
+                "ddtrace.internal._tagset",
+                sources=["ddtrace/internal/_tagset.pyx"],
+                language="c",
+            ),
+            Extension(
+                "ddtrace.internal._encoding",
+                ["ddtrace/internal/_encoding.pyx"],
+                include_dirs=["."],
+                libraries=encoding_libraries,
+                define_macros=[(f"__{sys.byteorder.upper()}_ENDIAN__", "1")],
+            ),
+            Extension(
+                "ddtrace.internal.telemetry.metrics_namespaces",
+                ["ddtrace/internal/telemetry/metrics_namespaces.pyx"],
+                language="c",
+            ),
+            Cython.Distutils.Extension(
+                "ddtrace.profiling.collector.stack",
+                sources=["ddtrace/profiling/collector/stack.pyx"],
+                language="c",
+                # cython generated code errors on build in toolchains that are strict about int->ptr conversion
+                # OTOH, the MSVC toolchain is different.  In a perfect world we'd deduce the underlying
+                # toolchain and emit the right flags, but as a compromise we assume Windows implies MSVC and
+                # everything else is on a GNU-like toolchain
+                extra_compile_args=extra_compile_args + (["-Wno-int-conversion"] if CURRENT_OS != "Windows" else []),
+            ),
+            Cython.Distutils.Extension(
+                "ddtrace.profiling.collector._traceback",
+                sources=["ddtrace/profiling/collector/_traceback.pyx"],
+                language="c",
+            ),
+            Cython.Distutils.Extension(
+                "ddtrace.profiling._threading",
+                sources=["ddtrace/profiling/_threading.pyx"],
+                language="c",
+            ),
+            Cython.Distutils.Extension(
+                "ddtrace.profiling.collector._task",
+                sources=["ddtrace/profiling/collector/_task.pyx"],
+                language="c",
+            ),
+        ],
         compile_time_env={
             "PY_MAJOR_VERSION": sys.version_info.major,
             "PY_MINOR_VERSION": sys.version_info.minor,
@@ -910,16 +883,14 @@ setup(
         annotate=os.getenv("_DD_CYTHON_ANNOTATE") == "1",
         compiler_directives={"language_level": "3"},
     )
-    + filter_extensions(get_exts_for("psutil")),
-    rust_extensions=filter_extensions(
-        [
-            RustExtension(
-                "ddtrace.internal.native._native",
-                path="src/native/Cargo.toml",
-                py_limited_api="auto",
-                binding=Binding.PyO3,
-                debug=os.getenv("_DD_RUSTC_DEBUG") == "1",
-            ),
-        ]
-    ),
+    + get_exts_for("psutil"),
+    rust_extensions=[
+        RustExtension(
+            "ddtrace.internal.native._native",
+            path="src/native/Cargo.toml",
+            py_limited_api="auto",
+            binding=Binding.PyO3,
+            debug=os.getenv("_DD_RUSTC_DEBUG") == "1",
+        ),
+    ],
 )


### PR DESCRIPTION
With the recent changes that have introduced some incremental build support for CMake, there doesn't seem to be a reason to maintain this extra feature, so we can revert the change and simplify setup.py a bit.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
