### PR TITLE
feat(DI): add config to create probes through a file

### DIFF
--- a/ddtrace/settings/dynamic_instrumentation.py
+++ b/ddtrace/settings/dynamic_instrumentation.py
@@ -3,6 +3,7 @@ import typing as t
 
 from ddtrace import config as ddconfig
 from ddtrace.internal import gitmetadata
+from ddtrace.internal.compat import Path
 from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
 from ddtrace.internal.utils.config import get_application_name
 from ddtrace.settings._agent import config as agent_config
@@ -136,6 +137,14 @@ class DynamicInstrumentationConfig(DDConfig):
         default=set(),
         help_type="List",
         help="List of identifiers to exclude from redaction",
+    )
+
+    probe_file = DDConfig.v(
+        t.Optional[Path],
+        "probe_file",
+        default=None,
+        help_type="Path",
+        help="Path to a file containing probe definitions",
     )
 
 

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -366,6 +366,7 @@ import ddtrace.settings.exception_replay
         {"name": "DD_DYNAMIC_INSTRUMENTATION_ENABLED", "origin": "default", "value": False},
         {"name": "DD_DYNAMIC_INSTRUMENTATION_MAX_PAYLOAD_SIZE", "origin": "default", "value": 1048576},
         {"name": "DD_DYNAMIC_INSTRUMENTATION_METRICS_ENABLED", "origin": "default", "value": True},
+        {"name": "DD_DYNAMIC_INSTRUMENTATION_PROBE_FILE", "origin": "default", "value": None},
         {"name": "DD_DYNAMIC_INSTRUMENTATION_REDACTED_IDENTIFIERS", "origin": "default", "value": "set()"},
         {"name": "DD_DYNAMIC_INSTRUMENTATION_REDACTED_TYPES", "origin": "default", "value": "set()"},
         {"name": "DD_DYNAMIC_INSTRUMENTATION_REDACTION_EXCLUDED_IDENTIFIERS", "origin": "default", "value": "set()"},


### PR DESCRIPTION
This pull request introduces support for loading probe definitions from a file in JSON format, enabling dynamic instrumentation via external configuration. The changes include updates to the `DynamicInstrumentationConfig` class, the debugger's initialization logic, and new tests to validate the functionality.

This can be configured via `DD_DYNAMIC_INSTRUMENTATION_PROBE_FILE` and used in combination with RC.

The JSON should be an array of probe objects in the same format as received via the RC config object, for example:

```
[
        {
            "id": "12e4866b-c2d0-4948-baf8-bd98027cd457",
            "version": 0,
            "type": "LOG_PROBE",
            "language": "python",
            "where": {
                "sourceFile": "tests/submod/stuff.py",
                "lines": [36],
            },
            "tags": [],
            "template": "Hello new monitoring API",
            "captureSnapshot": True,
            "capture": {"maxReferenceDepth": 3},
            "evaluateAt": "EXIT",
        }
    ]
```


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
