### PR TITLE
chore(docs): clarify release draft step

### DIFF
--- a/docs/contributing-release.rst
+++ b/docs/contributing-release.rst
@@ -43,7 +43,9 @@ Ensure you have followed the prerequisite steps above.
     $ git checkout <branch>
     $ reno report --branch=origin/<branch> | pandoc -f rst -t gfm | less
 
-5. Make sure the “Set as pre-release" box is CHECKED and the “Set as latest release" box is UNCHECKED. Click “save draft”.
+5. Make sure the “Set as pre-release" box is CHECKED if publishing a release candidate.
+   Make sure the “Set as latest release" box is CHECKED only if publishing a new minor release or a patch release for the latest minor version.
+   Click “save draft”.
 
 6. Share the link to the GitHub draft release with someone who can confirm it's correct
 


### PR DESCRIPTION
Modifies a step in the contributing-release doc to clarify when one should check the `pre-release` and `latest-release` boxes.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
