### PR TITLE
ci(benchmarks): add cache operations and additional variants to Django benchmark

### DIFF
--- a/benchmarks/django_simple/config.yaml
+++ b/benchmarks/django_simple/config.yaml
@@ -4,6 +4,10 @@ baseline: &baseline
   appsec_enabled: false
   iast_enabled: false
   path: ""
+  django_instrument_middleware: true
+  django_instrument_caches: true
+  django_instrument_databases: true
+  django_instrument_templates: true
 tracer: &tracer
   <<: *baseline
   tracer_enabled: true
@@ -28,3 +32,15 @@ exception-replay-enabled:
   <<: *tracer
   exception_replay_enabled: true
   path: "exc/"
+tracer-no-middleware:
+  <<: *tracer
+  django_instrument_middleware: false
+tracer-no-caches:
+  <<: *tracer
+  django_instrument_caches: false
+tracer-no-databases:
+  <<: *tracer
+  django_instrument_databases: false
+tracer-no-templates:
+  <<: *tracer
+  django_instrument_templates: false

--- a/benchmarks/django_simple/scenario.py
+++ b/benchmarks/django_simple/scenario.py
@@ -11,9 +11,17 @@ class DjangoSimple(bm.Scenario):
     span_code_origin_enabled: bool
     exception_replay_enabled: bool
     path: str
+    django_instrument_middleware: bool
+    django_instrument_caches: bool
+    django_instrument_databases: bool
+    django_instrument_templates: bool
 
     def run(self):
         os.environ["DJANGO_SETTINGS_MODULE"] = "app"
+        os.environ["DD_DJANGO_INSTRUMENT_MIDDLEWARE"] = "1" if self.django_instrument_middleware else "0"
+        os.environ["DD_DJANGO_INSTRUMENT_CACHES"] = "1" if self.django_instrument_caches else "0"
+        os.environ["DD_DJANGO_INSTRUMENT_DATABASES"] = "1" if self.django_instrument_databases else "0"
+        os.environ["DD_DJANGO_INSTRUMENT_TEMPLATES"] = "1" if self.django_instrument_templates else "0"
 
         if self.profiler_enabled:
             os.environ.update(


### PR DESCRIPTION
- Add cache configuration and operations to simulate cache miss/hit patterns
- Add benchmark configurations to test performance with individual components disabled

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
