### PR TITLE
fix: injection on try block start for CPython 3.11

### DIFF
--- a/ddtrace/internal/bytecode_injection/__init__.py
+++ b/ddtrace/internal/bytecode_injection/__init__.py
@@ -88,8 +88,9 @@ def _inject_hook(code: Bytecode, hook: HookType, lineno: int, arg: Any) -> None:
     # occurrences and inject the hook at each of them. An example of when this
     # happens is with finally blocks, which are duplicated at the end of the
     # bytecode.
-    locs: Deque[int] = deque()
+    locs: Deque[Tuple[int, str]] = deque()
     last_lineno = None
+    instrs = set()
     for i, instr in enumerate(code):
         try:
             if instr.lineno == last_lineno:
@@ -98,8 +99,9 @@ def _inject_hook(code: Bytecode, hook: HookType, lineno: int, arg: Any) -> None:
             # Some lines might be implemented across multiple instruction
             # offsets, and sometimes a NOP is used as a placeholder. We skip
             # those to avoid duplicate injections.
-            if instr.lineno == lineno and instr.name != "NOP":
-                locs.appendleft(i)
+            if instr.lineno == lineno:
+                locs.appendleft((i, instr.name))
+                instrs.add(instr.name)
         except AttributeError:
             # pseudo-instruction (e.g. label)
             pass
@@ -107,7 +109,18 @@ def _inject_hook(code: Bytecode, hook: HookType, lineno: int, arg: Any) -> None:
     if not locs:
         raise InvalidLine("Line %d does not exist or is either blank or a comment" % lineno)
 
-    for i in locs:
+    if instrs == {"NOP"}:
+        # If the line occurs on NOPs only, we instrument only the first one
+        last_instr = locs.pop()
+        locs.clear()
+        locs.append(last_instr)
+    elif "NOP" in instrs:
+        # If the line occurs on NOPs and other instructions, we remove the NOPs
+        # to avoid injecting the hook multiple times. The NOP in this case is
+        # just a placeholder.
+        locs = deque((i, instr) for i, instr in locs if instr != "NOP")
+
+    for i, _ in locs:
         code[i:i] = INJECTION_ASSEMBLY.bind(dict(hook=hook, arg=arg), lineno=lineno)
 
 

--- a/releasenotes/notes/fix-try-line-injection-7fdfc03e478066f9.yaml
+++ b/releasenotes/notes/fix-try-line-injection-7fdfc03e478066f9.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: fixed an issue that prevented line probes from
+    being instrumented on a line containing just the code ``try:`` for CPython
+    3.11 and later.

--- a/tests/internal/bytecode_injection/test_injection.py
+++ b/tests/internal/bytecode_injection/test_injection.py
@@ -19,7 +19,13 @@ def injected_hook(f, hook, arg, line=None):
     if line is None:
         line = min(linenos(f))
 
-    inject_hook(f, hook, line, arg)
+    try:
+        inject_hook(f, hook, line, arg)
+    except InvalidLine:
+        import dis
+
+        dis.dis(f)
+        raise
 
     yield f
 
@@ -251,5 +257,24 @@ def test_finally():
     with injected_hook(f, hook, arg, line=157):
         f()
     f()
+
+    hook.assert_called_once_with(arg)
+
+
+def test_try_except():
+    def target():
+        try:
+            response = 42
+            for a in range(100):
+                if a == response:
+                    break
+        except ValueError as e:
+            if not e.args:
+                raise
+
+    hook, arg = mock.Mock(), mock.Mock()
+
+    with injected_hook(target, hook, arg, line=target.__code__.co_firstlineno + 1):
+        target()
 
     hook.assert_called_once_with(arg)


### PR DESCRIPTION
We fix an issue with the injection of hooks on a line that contains just a `try:`. In later versions of Python this has become a mere `NOP` placeholder, which we previously ignored.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
