### PR TITLE
fix(loguru): avoids overriding user set contextual fields

### DIFF
--- a/ddtrace/contrib/internal/loguru/patch.py
+++ b/ddtrace/contrib/internal/loguru/patch.py
@@ -28,10 +28,8 @@ def _tracer_injection(event_dict):
     if config._logs_injection == LogInjectionState.DISABLED:
         # log injection is opt-out for structured logging
         return event_dict
-    event_dd_attributes = ddtrace.tracer.get_log_correlation_context()
-    event_dict.update(event_dd_attributes)
-
-    return event_dd_attributes
+    event_dict.update(ddtrace.tracer.get_log_correlation_context())
+    return event_dict
 
 
 def _w_configure(func, instance, args, kwargs):

--- a/releasenotes/notes/fix-loguru-e44b3ace560da724.yaml
+++ b/releasenotes/notes/fix-loguru-e44b3ace560da724.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    loguru: Fixed an issue where the ddtrace Loguru integration replaced all contextual (extra) fields with its own log correlation data.
+    It now adds its attributes alongside existing fields.


### PR DESCRIPTION
Fixed an issue where the ddtrace Loguru integration removed all contextual (extra) fields from a logger and replaced these values with log ddtrace log correlation attributes (ex: span_id, trace_id).

This PR ensures log correlation fields are now added alongside existing fields.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
