### PR TITLE
fix: generator wrapping with Python 3.10

### DIFF
--- a/ddtrace/internal/wrapping/context.py
+++ b/ddtrace/internal/wrapping/context.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from contextvars import ContextVar
 from inspect import iscoroutinefunction
+from inspect import isgeneratorfunction
 import sys
 from types import FrameType
 from types import FunctionType
@@ -677,9 +678,9 @@ class _UniversalWrappingContext(BaseWrappingContext):
                     pass
                 i += 1
 
-            # Search for the GEN_START instruction
+            # Search for the GEN_START instruction, which needs to stay on top.
             i = 0
-            if sys.version_info >= (3, 10) and iscoroutinefunction(f):
+            if sys.version_info >= (3, 10) and (iscoroutinefunction(f) or isgeneratorfunction(f)):
                 for i, instr in enumerate(bc, 1):
                     try:
                         if instr.name == "GEN_START":

--- a/releasenotes/notes/fix-generator-wrapping-86af0ae55ba2723a.yaml
+++ b/releasenotes/notes/fix-generator-wrapping-86af0ae55ba2723a.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: fixed an issue with the instrumentation of
+    generators with Python 3.10.


### PR DESCRIPTION
We fix an issue with generator wrapping with Python 3.10 that could have caused an exception to be raised after the generator had been used and exhausted.

## Testing Strategy

The issue has been caught by the exploration tests.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
