### PR TITLE
ci(benchmarks): use json.dumps to pass data from configs to test runs

### DIFF
--- a/benchmarks/base/run.py
+++ b/benchmarks/base/run.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import json
 import os
 import subprocess
 import sys
@@ -45,7 +46,7 @@ def run(scenario_py, cname, cvars, output_dir):
     ]
     for cvarname, cvarval in cvars.items():
         cmd.append("--{}".format(cvarname))
-        cmd.append(str(cvarval))
+        cmd.append(json.dumps(cvarval))
 
     proc = subprocess.Popen(cmd)
     proc.wait()


### PR DESCRIPTION
this fixes an issue with the startup benchmarks not being able to properly set env variables

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
