### PR TITLE
fix(llmobs): fix parsing stream when response.completed chunk is missing

### DIFF
--- a/ddtrace/contrib/internal/openai/utils.py
+++ b/ddtrace/contrib/internal/openai/utils.py
@@ -295,8 +295,8 @@ def _process_finished_stream(integration, span, kwargs, streamed_chunks, operati
     prompts = kwargs.get("prompt", None)
     request_messages = kwargs.get("messages", None)
     try:
-        if operation_type == "response" and streamed_chunks and streamed_chunks[0]:
-            formatted_completions = streamed_chunks[0][0]
+        if operation_type == "response":
+            formatted_completions = streamed_chunks[0][0] if streamed_chunks and streamed_chunks[0] else []
         elif operation_type == "completion":
             formatted_completions = [
                 openai_construct_completion_from_streamed_chunks(choice) for choice in streamed_chunks

--- a/ddtrace/contrib/internal/openai/utils.py
+++ b/ddtrace/contrib/internal/openai/utils.py
@@ -295,7 +295,7 @@ def _process_finished_stream(integration, span, kwargs, streamed_chunks, operati
     prompts = kwargs.get("prompt", None)
     request_messages = kwargs.get("messages", None)
     try:
-        if operation_type == "response":
+        if operation_type == "response" and streamed_chunks and streamed_chunks[0]:
             formatted_completions = streamed_chunks[0][0]
         elif operation_type == "completion":
             formatted_completions = [

--- a/ddtrace/contrib/internal/openai/utils.py
+++ b/ddtrace/contrib/internal/openai/utils.py
@@ -277,7 +277,11 @@ def _loop_handler(span, chunk, streamed_chunks):
         span.set_tag_str("openai.response.model", model)
 
     response = getattr(chunk, "response", None)
-    if getattr(chunk, "type", "") == "response.completed":
+    if (
+        getattr(chunk, "type", "") == "response.completed"
+        or getattr(chunk, "type", "") == "response.incomplete"
+        or getattr(chunk, "type", "") == "response.failed"
+    ):
         streamed_chunks[0].append(response)
 
     # Completions/chat completions are returned as `choices`

--- a/ddtrace/contrib/internal/openai/utils.py
+++ b/ddtrace/contrib/internal/openai/utils.py
@@ -296,7 +296,7 @@ def _process_finished_stream(integration, span, kwargs, streamed_chunks, operati
     request_messages = kwargs.get("messages", None)
     try:
         if operation_type == "response":
-            formatted_completions = streamed_chunks[0][0] if streamed_chunks and streamed_chunks[0] else []
+            formatted_completions = streamed_chunks[0][0] if streamed_chunks and streamed_chunks[0] else None
         elif operation_type == "completion":
             formatted_completions = [
                 openai_construct_completion_from_streamed_chunks(choice) for choice in streamed_chunks

--- a/releasenotes/notes/fix-responses-stream-84dfe439b0d9f635.yaml
+++ b/releasenotes/notes/fix-responses-stream-84dfe439b0d9f635.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: This fix resolves an issue where incomplete streamed responses returned from OpenAI responses API caused an index error with LLM Observability tracing.

--- a/tests/contrib/openai/conftest.py
+++ b/tests/contrib/openai/conftest.py
@@ -54,6 +54,11 @@ def openai_organization():
 
 
 @pytest.fixture
+def oai_with_test_agent_backend(openai):
+    return openai.OpenAI(base_url="http://127.0.0.1:9126/vcr/openai")
+
+
+@pytest.fixture
 def openai(openai_api_key, openai_organization, api_key_in_env):
     import openai
 


### PR DESCRIPTION
The openai responses api stream may end with the following chunk types
- `response.completed`, `response.incomplete`, or `response.failed`

These chunk kinds contain the `response` field which has all the data we need to set attributes on our llmobs span.
However, currently, we are only accounting for `response.completed`. This actually results in an `IndexError` when the `response.completed` chunk is not present.

This pr accounts for failed/incomplete chunks, while also defaulting `formatted_completions` to `None` if none of these chunk types are present.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
