### PR TITLE
feat(appsec): add metric for unsupported lambda event types

### DIFF
--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -121,6 +121,7 @@ class APPSEC(metaclass=Constant_Class):
     RASP_ERROR: Literal["_dd.appsec.rasp.error"] = "_dd.appsec.rasp.error"
     ERROR_TYPE: Literal["_dd.appsec.error.type"] = "_dd.appsec.error.type"
     ERROR_MESSAGE: Literal["_dd.appsec.error.message"] = "_dd.appsec.error.message"
+    UNSUPPORTED_EVENT_TYPE: Literal["_dd.appsec.unsupported_event_type"] = "_dd.appsec.unsupported_event_type"
 
 
 TELEMETRY_OFF_NAME = "OFF"

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -185,9 +185,9 @@ class AppSecSpanProcessor(SpanProcessor):
             return
 
         if span.span_type == SpanTypes.SERVERLESS:
-            skip_event = core.get_item("asm_skip_next_lambda_event")
+            skip_event = core.get_item("appsec_skip_next_lambda_event")
             if skip_event:
-                core.discard_item("asm_skip_next_lambda_event")
+                core.discard_item("appsec_skip_next_lambda_event")
                 log.debug(
                     "appsec: ignoring unsupported lamdba event",
                 )

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -14,6 +14,9 @@ from typing import Set
 from typing import Tuple
 from typing import Union
 
+from ddtrace.ext import SpanTypes
+from ddtrace.internal import core
+
 
 if TYPE_CHECKING:
     import ddtrace.appsec._ddwaf as ddwaf
@@ -180,6 +183,16 @@ class AppSecSpanProcessor(SpanProcessor):
 
         if span.span_type not in asm_config._asm_processed_span_types:
             return
+
+        if span.span_type == SpanTypes.SERVERLESS:
+            skip_event = core.get_item("asm_skip_next_lambda_event")
+            if skip_event:
+                core.discard_item("asm_skip_next_lambda_event")
+                log.debug(
+                    "appsec: ignoring unsupported lamdba event",
+                )
+                span.set_metric(APPSEC.UNSUPPORTED_EVENT_TYPE, 1.0)
+                return
 
         ctx = self._ddwaf._at_request_start()
         _asm_request_context.start_context(span, ctx.rc_products if ctx is not None else "")

--- a/ddtrace/settings/asm.py
+++ b/ddtrace/settings/asm.py
@@ -177,6 +177,7 @@ class ASMConfig(DDConfig):
         "_asm_static_rule_file",
         "_asm_obfuscation_parameter_key_regexp",
         "_asm_obfuscation_parameter_value_regexp",
+        "_asm_processed_span_types",
         "_apm_tracing_enabled",
         "_bypass_instrumentation_for_waf",
         "_iast_enabled",

--- a/tests/appsec/utils.py
+++ b/tests/appsec/utils.py
@@ -53,6 +53,7 @@ def get_waf_addresses(address: str) -> typing.Optional[typing.Any]:
 def asm_context(
     tracer=None,
     span_name: str = "",
+    span_type: str = SpanTypes.WEB,
     ip_addr: typing.Optional[str] = None,
     headers_case_sensitive: bool = False,
     headers: typing.Optional[typing.Dict[str, str]] = None,
@@ -80,7 +81,7 @@ def asm_context(
             headers=headers,
             block_request_callable=block_request_callable,
             service=service,
-        ), tracer.trace(span_name or "test", span_type=SpanTypes.WEB, service=service) as span:
+        ), tracer.trace(span_name or "test", span_type=span_type, service=service) as span:
             yield span
         unpatch_for_waf_addresses()
 


### PR DESCRIPTION
## Motivation

Avoid billing when Appsec is enabled for unsupported lambda events. To keep track of executions with unsupported events, we add a span metric.

## Changes

- Selectively skip processing the span based on the event

To make the information available, I used the same pattern as the asm context initialization by storing temporary information inside the `ExecutionContext`.

The only difference is that in the case of lambda we only have a single global `ExecutionContext` so we have to clean it up.

## Notes

This PR relies on: https://github.com/DataDog/datadog-lambda-python/pull/627



## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
