### PR TITLE
chore(iast): security controls metrics

### DIFF
--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -177,7 +177,7 @@ class IAST_SPAN_TAGS(metaclass=Constant_Class):
 
     TELEMETRY_REQUEST_TAINTED: Literal["_dd.iast.telemetry.request.tainted"] = "_dd.iast.telemetry.request.tainted"
     TELEMETRY_EXECUTED_SINK: Literal["_dd.iast.telemetry.executed.sink"] = "_dd.iast.telemetry.executed.sink"
-    TELEMETRY_SUPPRESED_VULNERABILITY: Literal[
+    TELEMETRY_SUPPRESSED_VULNERABILITY: Literal[
         "_dd.iast.telemetry.suppressed.vulnerabilities"
     ] = "_dd.iast.telemetry.suppressed.vulnerabilities"
     TELEMETRY_EXECUTED_SOURCE: Literal["_dd.iast.telemetry.executed.source"] = "_dd.iast.telemetry.executed.source"

--- a/ddtrace/appsec/_iast/_span_metrics.py
+++ b/ddtrace/appsec/_iast/_span_metrics.py
@@ -21,7 +21,7 @@ def _set_span_tag_iast_executed_sink(span):
             if (
                 key.startswith(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SINK)
                 or key.startswith(IAST_SPAN_TAGS.TELEMETRY_EXECUTED_SOURCE)
-                or key.startswith(IAST_SPAN_TAGS.TELEMETRY_SUPPRESED_VULNERABILITY)
+                or key.startswith(IAST_SPAN_TAGS.TELEMETRY_SUPPRESSED_VULNERABILITY)
             ):
                 span.set_tag(key, value)
 

--- a/ddtrace/appsec/_iast/taint_sinks/_base.py
+++ b/ddtrace/appsec/_iast/taint_sinks/_base.py
@@ -225,5 +225,5 @@ class VulnerabilityBase:
             else:
                 return True
         else:
-            increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_SUPPRESED_VULNERABILITY, cls.vulnerability_type)
+            increment_iast_span_metric(IAST_SPAN_TAGS.TELEMETRY_SUPPRESSED_VULNERABILITY, cls.vulnerability_type)
         return False

--- a/tests/appsec/integrations/django_tests/test_iast_django.py
+++ b/tests/appsec/integrations/django_tests/test_iast_django.py
@@ -928,7 +928,7 @@ def test_django_command_injection_secure_mark(client, iast_span, tracer):
 
     loaded = root_span.get_tag(IAST.JSON)
     assert loaded is None
-    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_SUPPRESED_VULNERABILITY + ".command_injection")
+    assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_SUPPRESSED_VULNERABILITY + ".command_injection")
 
 
 @pytest.mark.skipif(not asm_config._iast_supported, reason="Python version not supported by IAST")
@@ -1001,7 +1001,7 @@ def test_django_command_injection_security_control(client, tracer, security_cont
         loaded = root_span.get_tag(IAST.JSON)
         if match_function:
             assert loaded is None
-            assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_SUPPRESED_VULNERABILITY + ".command_injection")
+            assert root_span.get_metric(IAST_SPAN_TAGS.TELEMETRY_SUPPRESSED_VULNERABILITY + ".command_injection")
         else:
             assert loaded is not None
         _end_iast_context_and_oce()


### PR DESCRIPTION
Add more IAST span metrics to monitor if a vulnerability was suppressed by secure_marks / security controls

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
