### PR TITLE
ci(benchmarks): skip django startup benchmarks

### DIFF
--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -158,6 +158,9 @@ microbenchmarks:
         # - "appsec_iast_django_startup"
         - "appsec_iast_propagation"
         - "errortracking_django_simple"
+        # They take a long time to run and frequently time out
+        # TODO: Make benchmarks faster, or run less frequently, or as macrobenchmarks
+        - "appsec_iast_django_startup"
         - "errortracking_flask_sqli"
         # Flaky. Timeout errors
         # - "encoder"
@@ -171,15 +174,6 @@ microbenchmarks:
         # They take a long time to run, and now need the agent running
         # TODO: Make benchmarks faster, or run less frequently, or as macrobenchmarks
         # - "startup"
-
-"microbenchmarks flaky":
-  extends: .benchmarks
-  allow_failure: true
-  parallel:
-    matrix:
-      - SCENARIO:
-        # Flaky timeouts on starting up
-        - "appsec_iast_django_startup"
 
 benchmarks-pr-comment:
   image: $MICROBENCHMARKS_CI_IMAGE

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -160,7 +160,7 @@ microbenchmarks:
         - "errortracking_django_simple"
         # They take a long time to run and frequently time out
         # TODO: Make benchmarks faster, or run less frequently, or as macrobenchmarks
-        - "appsec_iast_django_startup"
+        # - "appsec_iast_django_startup"
         - "errortracking_flask_sqli"
         # Flaky. Timeout errors
         # - "encoder"


### PR DESCRIPTION
These jobs frequently timeout

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
