### PR TITLE
chore(docs): add migration section in upgrade docs for v3

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -64,9 +64,36 @@ Use the following patterns to identify the deprecated environment variables in a
       -e "DD_REMOTECONFIG_POLL_SECONDS" \
       -e "DD_CALL_BASIC_CONFIG"
 
-
 Legacy tracing interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Reference the 2.0 release note (``../releasenotes/notes/release-2.0-3af0045e2261bd02.yaml``) to identify and remove the deprecated legacy tracing
+interfaces in a code base.
+
+.. _upgrade-2.x:
+
+Upgrade to 3.0
+**************
+
+Environment variables
+^^^^^^^^^^^^^^^^^^^^^
+
+Use the following patterns to identify the deprecated environment variables in a code base::
+
+    git grep -P -e "DD_LLMOBS_APP_NAME" \
+        -e "_DD_LLMOBS_EVALUATOR_SAMPLING_RULES" \
+        -e "_DD_LLMOBS_EVALUATORS" \
+        -e "DD_TRACE_PROPAGATION_STYLE=.*b3 single header" \
+        -e "DD_TRACE_SAMPLE_RATE" \
+        -e "DD_TRACE_API_VERSION=v0.3" \
+        -e "DD_ANALYTICS_ENABLED" \
+        -e "DD_TRACE_ANALYTICS_ENABLED" \
+        -e "DD_HTTP_CLIENT_TAG_QUERY_STRING" \
+        -e "DD_TRACE_SPAN_AGGREGATOR_RLOCK" \
+        -e "DD_TRACE_METHODS=.*\[\]"
+
+Legacy tracing interfaces
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Reference the [3.0 release note](https://github.com/DataDog/dd-trace-py/releases/tag/v3.0.0) to identify and remove the deprecated legacy tracing
 interfaces in a code base.


### PR DESCRIPTION
We had a migration section for v1 and v2 but not v3, so adding this for completeness.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
