### PR TITLE
fix(llmobs): improve openai chat completions tool call inputs

### DIFF
--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -322,10 +322,11 @@ def openai_set_meta_tags_from_chat(span: Span, kwargs: Dict[str, Any], messages:
     """Extract prompt/response tags from a chat completion and set them as temporary "_ml_obs.meta.*" tags."""
     input_messages = []
     for m in kwargs.get("messages", []):
+        processed_m = {"content": str(_get_attr(m, "content", "")), "role": str(_get_attr(m, "role", ""))}
         tool_call_id = _get_attr(m, "tool_call_id", None)
         if tool_call_id:
             core.dispatch(DISPATCH_ON_TOOL_CALL_OUTPUT_USED, (tool_call_id, span))
-        processed_m = {"content": str(_get_attr(m, "content", "")), "role": str(_get_attr(m, "role", ""))}
+            processed_m["tool_id"] = tool_call_id
         if _get_attr(m, "tool_calls", []):
             processed_m["tool_calls"] = [
                 {

--- a/releasenotes/notes/fix-tool-calling-3d7dc093fa4b04a0.yaml
+++ b/releasenotes/notes/fix-tool-calling-3d7dc093fa4b04a0.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    LLM Observability: This fix resolves an issue where passing back tool call results to OpenAI Chat Completions caused an error with LLM Observability tracing enabled.
+  - |
+    LLM Observability: This fix resolves an issue where tool choice input messages for OpenAI Chat Completions were not being captured in LLM Observability tracing.

--- a/tests/contrib/openai/conftest.py
+++ b/tests/contrib/openai/conftest.py
@@ -71,6 +71,11 @@ def openai(openai_api_key, openai_organization, api_key_in_env):
 
 
 @pytest.fixture
+def oai_with_test_agent_backend(openai):
+    return openai.OpenAI(base_url="http://127.0.0.1:9126/vcr/openai")
+
+
+@pytest.fixture
 def azure_openai_config(openai):
     config = {
         "api_version": "2023-07-01-preview",

--- a/tests/contrib/openai/test_openai_llmobs.py
+++ b/tests/contrib/openai/test_openai_llmobs.py
@@ -737,7 +737,7 @@ class TestLLMObsOpenaiV1:
                                     }
                                 ],
                             },
-                            {"content": json.dumps(tool_result), "role": "tool"},
+                            {"content": json.dumps(tool_result), "role": "tool", "tool_id": tool_call_id},
                             {"content": "Can you summarize the student's academic performance?", "role": "user"},
                         ],
                         output_messages=[

--- a/tests/contrib/openai/test_openai_llmobs.py
+++ b/tests/contrib/openai/test_openai_llmobs.py
@@ -4,6 +4,7 @@ import pytest
 
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._utils import safe_json
+import json
 from tests.contrib.openai.utils import chat_completion_custom_functions
 from tests.contrib.openai.utils import chat_completion_input_description
 from tests.contrib.openai.utils import get_openai_vcr
@@ -648,6 +649,109 @@ class TestLLMObsOpenaiV1:
                 token_metrics={"input_tokens": 157, "output_tokens": 57, "total_tokens": 214},
                 tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.openai"},
             )
+        )
+
+    @pytest.mark.skipif(
+        parse_version(openai_module.version.VERSION) < (1, 1), reason="Tool calls available after v1.1.0"
+    )
+    def test_chat_completion_tool_call_with_follow_up(
+        self, oai_with_test_agent_backend, ddtrace_global_config, mock_llmobs_writer, mock_tracer
+    ):
+        """Test a conversation flow where a tool call response is used in a follow-up message."""
+        model = "gpt-3.5-turbo"
+        messages = [{"role": "user", "content": chat_completion_input_description}]
+        with get_openai_vcr(subdirectory_name="v1").use_cassette("chat_completion_tool_call_with_follow_up.yaml"):
+            first_resp = oai_with_test_agent_backend.chat.completions.create(
+                tools=chat_completion_custom_functions,
+                model=model,
+                messages=messages,
+                user="ddtrace-test",
+            )
+            tool_call_id = first_resp.choices[0].message.tool_calls[0].id
+            tool_name = first_resp.choices[0].message.tool_calls[0].function.name
+            tool_arguments_str = first_resp.choices[0].message.tool_calls[0].function.arguments
+
+            tool_result = {"status": "success", "gpa_verified": True}
+            messages += [
+                first_resp.choices[0].message,
+                {
+                    "role": "tool",
+                    "tool_call_id": first_resp.choices[0].message.tool_calls[0].id,
+                    "content": json.dumps(tool_result),
+                },
+                {"role": "user", "content": "Can you summarize the student's academic performance?"},
+            ]
+            second_resp = oai_with_test_agent_backend.chat.completions.create(
+                model=model,
+                messages=messages,
+                user="ddtrace-test",
+            )
+
+        spans = mock_tracer.pop_traces()
+        span1, span2 = spans[0][0], spans[1][0]
+        assert mock_llmobs_writer.enqueue.call_count == 2
+
+        mock_llmobs_writer.enqueue.assert_has_calls(
+            [
+                mock.call(
+                    _expected_llmobs_llm_span_event(
+                        span1,
+                        model_name=first_resp.model,
+                        model_provider="openai",
+                        input_messages=[{"content": chat_completion_input_description, "role": "user"}],
+                        output_messages=[
+                            {
+                                "content": "",
+                                "role": "assistant",
+                                "tool_calls": [
+                                    {
+                                        "name": tool_name,
+                                        "arguments": json.loads(tool_arguments_str),
+                                        "tool_id": tool_call_id,
+                                        "type": "function",
+                                    }
+                                ],
+                            }
+                        ],
+                        metadata={"user": "ddtrace-test"},
+                        token_metrics={"input_tokens": 166, "output_tokens": 43, "total_tokens": 209},
+                        tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.openai"},
+                    )
+                ),
+                mock.call(
+                    _expected_llmobs_llm_span_event(
+                        span2,
+                        model_name=second_resp.model,
+                        model_provider="openai",
+                        input_messages=[
+                            {"content": chat_completion_input_description, "role": "user"},
+                            {
+                                "content": "None",
+                                "role": "assistant",
+                                "tool_calls": [
+                                    {
+                                        "name": tool_name,
+                                        "arguments": tool_arguments_str,
+                                        "tool_id": tool_call_id,
+                                        "type": "function",
+                                    }
+                                ],
+                            },
+                            {"content": json.dumps(tool_result), "role": "tool"},
+                            {"content": "Can you summarize the student's academic performance?", "role": "user"},
+                        ],
+                        output_messages=[
+                            {
+                                "content": "David Nguyen is a sophomore majoring in computer science at Stanford University with a GPA of 3.8. His academic performance is strong, as evidenced by his high GPA.",
+                                "role": "assistant",
+                            }
+                        ],
+                        metadata={"user": "ddtrace-test"},
+                        token_metrics={"input_tokens": 143, "output_tokens": 35, "total_tokens": 178},
+                        tags={"ml_app": "<ml-app-name>", "service": "tests.contrib.openai"},
+                    )
+                ),
+            ]
         )
 
     @pytest.mark.skipif(


### PR DESCRIPTION
There's three issues with how we process tool call input messages in openai chats rn
- we use `get` instead of `_get_attr` for span linking purposes, which throws if the message is a pydantic model instead of a dict
- we don't record `tool_id` for tool messages, which are messages that represent the OUTPUT of an executed tool
- we don't record past tools that were chosen 

This pr fixes that logic, and adds a more comprehensive test that calls a tool, and then passes back the tool results into another LLM call

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
