### PR TITLE
ci: update testrunner env vars for scripts/ddtest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,14 +175,17 @@ services:
         image: ghcr.io/datadog/dd-trace-py/testrunner:bca6869fffd715ea9a731f7b606807fa1b75cb71@sha256:9e3f53fa98ffc4b838b959d74d969aa2c384c4cbee7a3047a03d501be5f58760
         command: bash
         environment:
-            - TOX_SKIP_DIST=True
+          DD_SETUP_CACHE_DOWNLOADS: "1"
+          DD_CMAKE_INCREMENTAL_BUILD: "1"
+          DD_FAST_BUILD: "1"
+          CMAKE_BUILD_PARALLEL_LEVEL: "12"
+          CARGO_BUILD_JOBS: "12"
         network_mode: host
         userns_mode: host
         working_dir: /root/project/
         volumes:
           - ddagent:/tmp/ddagent
           - ./:/root/project
-          - ./.ddtox:/root/project/.tox
           - ./.riot:/root/project/.riot
 
     localstack:

--- a/scripts/ddtest
+++ b/scripts/ddtest
@@ -23,35 +23,9 @@ FULL_CMD="pip install -q --disable-pip-version-check riot==0.20.1 && $CMD"
 
 # install and upgrade riot in case testrunner image has not been updated
 # DEV: Use `--no-TTY` and `--quiet-pull` when running in CircleCI
-if [[ "${CIRCLECI}" = "true" ]]; then
-    $compose_cmd run \
-                   -e CIRCLE_NODE_TOTAL \
-                   -e CIRCLE_NODE_INDEX \
-                   -e CIRCLE_WORKFLOW_ID \
-                   -e CIRCLE_BRANCH \
-                   -e CIRCLE_SHA1 \
-                   -e CIRCLE_REPOSITORY_URL \
-                   -e CIRCLE_TAG \
-                   -e CIRCLE_WORKFLOW_ID \
-                   -e CIRCLE_PROJECT_REPONAME \
-                   -e CIRCLE_BUILD_NUM \
-                   -e CIRCLE_BUILD_URL \
-                   -e CIRCLE_JOB \
-                   -e CIRCLE_WORKING_DIRECTORY \
-                   -e DD_TRACE_AGENT_URL \
-                   -e _CI_DD_API_KEY \
-                   -e _CI_DD_APP_KEY \
-                   -e RIOT_RUN_RECOMPILE_REQS \
-                   --no-TTY \
-                   --quiet-pull \
-                   --rm \
-                   testrunner \
-                   bash -c "ulimit -c unlimited || true && $FULL_CMD || (./scripts/bt && false)"
-else
-    $compose_cmd run \
-                   -e DD_TRACE_AGENT_URL \
-                   --rm \
-                   -i \
-                   testrunner \
-                   bash -c "git config --global --add safe.directory /root/project && $FULL_CMD"
-fi
+$compose_cmd run \
+             -e DD_TRACE_AGENT_URL \
+             --rm \
+             -i \
+             testrunner \
+             bash -c "git config --global --add safe.directory /root/project && $FULL_CMD"


### PR DESCRIPTION
We have some new build env vars to help speed up builds, we should use these in the `scripts/ddtest` by default.

also, we don't use CircleCI anymore, so removing that breach from `scripts/ddtest`

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
