### PR TITLE
refactor(tracing): wrapping context for asyncio patching

### DIFF
--- a/ddtrace/contrib/internal/asyncio/patch.py
+++ b/ddtrace/contrib/internal/asyncio/patch.py
@@ -1,10 +1,7 @@
 import asyncio
 from typing import Dict
 
-from ddtrace.internal.utils import get_argument_value
-from ddtrace.internal.utils import set_argument_value
-from ddtrace.internal.wrapping import unwrap
-from ddtrace.internal.wrapping import wrap
+from ddtrace.contrib.internal.trace_utils import PatchingWrappingContext
 from ddtrace.trace import Pin
 
 
@@ -17,6 +14,38 @@ def _supported_versions() -> Dict[str, str]:
     return {"asyncio": "*"}
 
 
+class CreateTaskWrappingContext(PatchingWrappingContext):
+    def __enter__(self) -> "CreateTaskWrappingContext":
+        super().__enter__()
+
+        if not (pin := Pin.get_from(asyncio)) or not pin.enabled():
+            return self
+
+        # Only wrap the coroutine if we have an active trace context
+        if not (dd_active := pin.tracer.current_trace_context()):
+            return self
+
+        # Get the original coroutine
+        coro = self.get_local("coro")
+
+        # Wrap the coroutine and ensure the current trace context is propagated
+        async def traced_coro(*args_c, **kwargs_c):
+            if dd_active != pin.tracer.current_trace_context():
+                pin.tracer.context_provider.activate(dd_active)
+            await coro
+
+        # DEV: try to persist the original function name (useful for debugging)
+        tc = traced_coro()
+        if hasattr(coro, "__name__"):
+            tc.__name__ = coro.__name__
+        if hasattr(coro, "__qualname__"):
+            tc.__qualname__ = coro.__qualname__
+
+        self.set_local("coro", tc)
+
+        return self
+
+
 def patch():
     """Patches current loop `create_task()` method to enable spawned tasks to
     parent to the base task context.
@@ -25,7 +54,7 @@ def patch():
         return
     asyncio._datadog_patch = True
     Pin().onto(asyncio)
-    wrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)
+    CreateTaskWrappingContext(asyncio.BaseEventLoop.create_task).wrap()
 
 
 def unpatch():
@@ -34,38 +63,4 @@ def unpatch():
     if getattr(asyncio, "_datadog_patch", False):
         return
     asyncio._datadog_patch = False
-    unwrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)
-
-
-def _wrapped_create_task(wrapped, args, kwargs):
-    """This function ensures the current active trace context is propagated to scheduled tasks.
-    By default the trace context is propagated when a task is executed and NOT when it is created.
-    """
-    pin = Pin.get_from(asyncio)
-    if not pin or not pin.enabled():
-        return wrapped(*args, **kwargs)
-
-    # Get current trace context
-    dd_active = pin.tracer.current_trace_context()
-    # Only wrap the coroutine if we have an active trace context
-    if not dd_active:
-        return wrapped(*args, **kwargs)
-
-    # Get the coroutine
-    coro = get_argument_value(args, kwargs, 1, "coro")
-
-    # Wrap the coroutine and ensure the current trace context is propagated
-    async def traced_coro(*args_c, **kwargs_c):
-        if dd_active != pin.tracer.current_trace_context():
-            pin.tracer.context_provider.activate(dd_active)
-        return await coro
-
-    # DEV: try to persist the original function name (useful for debugging)
-    tc = traced_coro()
-    if hasattr(coro, "__name__"):
-        tc.__name__ = coro.__name__
-    if hasattr(coro, "__qualname__"):
-        tc.__qualname__ = coro.__qualname__
-    args, kwargs = set_argument_value(args, kwargs, 1, "coro", tc)
-
-    return wrapped(*args, **kwargs)
+    CreateTaskWrappingContext.extract(asyncio.BaseEventLoop.create_task).unwrap()


### PR DESCRIPTION
We introduce a subclass of the wrapping context that can be used to modify local variables. We use it to implement the wrapping of the `create_task` method of asyncio loops to propagate the tracing context to wrapped coroutines.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
