### PR TITLE
chore(ci_visibility): do not require coverage.py for Test Impact Analysis with pytest

### DIFF
--- a/ddtrace/contrib/internal/unittest/patch.py
+++ b/ddtrace/contrib/internal/unittest/patch.py
@@ -25,6 +25,7 @@ from ddtrace.ext import SpanTypes
 from ddtrace.ext import test
 from ddtrace.ext.ci import RUNTIME_VERSION
 from ddtrace.ext.ci import _get_runtime_and_os_metadata
+from ddtrace.internal.ci_visibility.coverage import is_coverage_available
 from ddtrace.internal.ci_visibility import CIVisibility as _CIVisibility
 from ddtrace.internal.ci_visibility.constants import EVENT_TYPE as _EVENT_TYPE
 from ddtrace.internal.ci_visibility.constants import ITR_CORRELATION_ID_TAG_NAME
@@ -99,6 +100,8 @@ def _set_tracer(tracer: ddtrace.tracer):
 
 
 def _is_test_coverage_enabled(test_object) -> bool:
+    if not is_coverage_available():
+        return False
     return _CIVisibility._instance._collect_coverage_enabled and not _is_skipped_test(test_object)
 
 
@@ -813,7 +816,7 @@ def _finish_test_session_span():
         _CIVisibility._unittest_data["suites"], _CIVisibility._unittest_data["modules"]
     )
     _update_test_skipping_count_span(_CIVisibility._datadog_session_span)
-    if _CIVisibility._instance._collect_coverage_enabled and _module_has_dd_coverage_enabled(unittest):
+    if _CIVisibility._instance._collect_coverage_enabled and is_coverage_available() and _module_has_dd_coverage_enabled(unittest):
         _stop_coverage(unittest)
     if _is_coverage_patched() and _is_coverage_invoked_by_coverage_run():
         run_coverage_report()

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -323,12 +323,6 @@ class CIVisibility(Service):
             os.getenv("_DD_CIVISIBILITY_ITR_FORCE_ENABLE_COVERAGE", default=False)
         ):
             return False
-        # if not is_coverage_available():
-        #     log.warning(
-        #         "CI Visibility code coverage tracking is enabled, but the `coverage` package is not installed."
-        #         "To use code coverage tracking, please install `coverage` from https://pypi.org/project/coverage/"
-        #     )
-        #     return False
         return True
 
     def _check_enabled_features(self) -> TestVisibilityAPISettings:

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -51,7 +51,6 @@ from ddtrace.internal.ci_visibility.constants import TEST
 from ddtrace.internal.ci_visibility.constants import TRACER_PARTIAL_FLUSH_MIN_SPANS
 from ddtrace.internal.ci_visibility.constants import UNSUPPORTED_PROVIDER
 from ddtrace.internal.ci_visibility.context import CIContextProvider
-from ddtrace.internal.ci_visibility.coverage import is_coverage_available
 from ddtrace.internal.ci_visibility.errors import CIVisibilityAuthenticationException
 from ddtrace.internal.ci_visibility.errors import CIVisibilityError
 from ddtrace.internal.ci_visibility.filters import TraceCiVisibilityFilter
@@ -324,12 +323,12 @@ class CIVisibility(Service):
             os.getenv("_DD_CIVISIBILITY_ITR_FORCE_ENABLE_COVERAGE", default=False)
         ):
             return False
-        if not is_coverage_available():
-            log.warning(
-                "CI Visibility code coverage tracking is enabled, but the `coverage` package is not installed."
-                "To use code coverage tracking, please install `coverage` from https://pypi.org/project/coverage/"
-            )
-            return False
+        # if not is_coverage_available():
+        #     log.warning(
+        #         "CI Visibility code coverage tracking is enabled, but the `coverage` package is not installed."
+        #         "To use code coverage tracking, please install `coverage` from https://pypi.org/project/coverage/"
+        #     )
+        #     return False
         return True
 
     def _check_enabled_features(self) -> TestVisibilityAPISettings:

--- a/releasenotes/notes/ci_visibility-upgrade-pytest-without-coverage-py-884beebdfd122661.yaml
+++ b/releasenotes/notes/ci_visibility-upgrade-pytest-without-coverage-py-884beebdfd122661.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    CI Visibility: Code coverage collection for Test Impact Analysis with ``pytest`` does not require ``coverage.py`` as
+    a dependency anymore.


### PR DESCRIPTION
Our pytest v2 plugin (which was officially released in ddtrace 3.0.0) does not use `coverage.py` for code coverage, but a ddtrace internal code coverage collection mechanism. However, unittest still uses `coverage.py`, and we've been requiring it to be installed for code coverage collection regardless of the test framework used.

This PR makes this dependency unittest-specific, and does not require `coverage.py` for pytest runs anymore.

I have tested this manually (pytest and unittest, with and without `coverage` installed). Writing tests for this is somewhat annoying because `coverage` is always present as a dependency in our pipeline. 

unittest will be switched to the new coverage mechanism once the plugin is rewritten to use the new testing API.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
