### PR TITLE
ci: include stage in GitLab job name

### DIFF
--- a/.gitlab/templates/build-base-venvs.yml
+++ b/.gitlab/templates/build-base-venvs.yml
@@ -1,4 +1,4 @@
-setup/build_base_venvs:
+build_base_venvs:
   extends: .cached_testrunner
   stage: setup
   needs: []

--- a/.gitlab/templates/build-base-venvs.yml
+++ b/.gitlab/templates/build-base-venvs.yml
@@ -1,4 +1,4 @@
-build_base_venvs:
+setup/build_base_venvs:
   extends: .cached_testrunner
   stage: setup
   needs: []

--- a/.gitlab/templates/debugging/exploration.yml
+++ b/.gitlab/templates/debugging/exploration.yml
@@ -1,4 +1,4 @@
-"exploration::boto3":
+"debugging/exploration/boto3":
   stage: debugging
   extends: .cached_testrunner
   timeout: 30m

--- a/scripts/gen_gitlab_config.py
+++ b/scripts/gen_gitlab_config.py
@@ -36,7 +36,7 @@ class JobSpec:
         if self.snapshot:
             base += "_snapshot"
 
-        lines.append(f"{self.name}:")
+        lines.append(f"{self.stage}/{self.name.replace('::', '/')}:")
         lines.append(f"  extends: {base}")
 
         # Set stage


### PR DESCRIPTION
We include the stage name of each job so that the running jobs can be grouped-sorted together in many UI settings.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
