### PR TITLE
fix(appsec): text/plain response bodies must not be parsed

### DIFF
--- a/ddtrace/appsec/_http_utils.py
+++ b/ddtrace/appsec/_http_utils.py
@@ -57,7 +57,7 @@ def parse_http_body(
         elif content_type.startswith("multipart/form-data"):
             return http_utils.parse_form_multipart(body, normalized_headers)
         elif content_type == "text/plain":
-            return body
+            return None
         else:
             return None
 

--- a/tests/appsec/appsec/test_appsec_http_utils.py
+++ b/tests/appsec/appsec/test_appsec_http_utils.py
@@ -23,13 +23,6 @@ def test_normalize_headers(input_headers, expected):
     [
         # Body is None
         ({}, None, False, None),
-        # Base64 encoded body - text/plain
-        (
-            {"content-type": "text/plain"},
-            "dGV4dCBib2R5",
-            True,
-            "text body",
-        ),
         # Base64 encoded body - application/json
         (
             {"content-type": "application/json"},
@@ -37,9 +30,9 @@ def test_normalize_headers(input_headers, expected):
             True,
             {"key": "value"},
         ),
-        # Base64 decoding failure - text/plain
+        # Base64 decoding failure - application/json
         (
-            {"content-type": "text/plain"},
+            {"content-type": "application/json"},
             "invalid_base64_string",
             True,
             None,
@@ -59,7 +52,7 @@ def test_normalize_headers(input_headers, expected):
         ({"content-type": "application/xml"}, "<root><key>value</key></root>", False, {"root": {"key": "value"}}),
         ({"content-type": "text/xml"}, "<root><key>value</key></root>", False, {"root": {"key": "value"}}),
         # Text plain
-        ({"content-type": "text/plain"}, "simple text body", False, "simple text body"),
+        ({"content-type": "text/plain"}, "simple text body", False, None),
         # Unsupported content type
         ({"content-type": "application/octet-stream"}, "binary data", False, None),
         # No content type provided


### PR DESCRIPTION
Quick fix to remove parsing of plain text bodies:

matching failing system test: https://github.com/DataDog/system-tests/blob/9a0d53da8e422e7ff84e2690038daa0ceaeaa0f0/tests/appsec/test_blocking_addresses.py#L479-L493

```python
    def setup_non_blocking_plain_text(self):
        self.setup_blocking()
        self.rm_req_nonblock_plain_text = weblog.post(
            "/waf", data=b'{"value4": "bsldhkuqwgervf"}', headers={"content-type": "text/plain"}
        )


    @irrelevant(
        context.weblog_variant in ("akka-http", "play", "jersey-grizzly2", "resteasy-netty3"),
        reason="Blocks on text/plain if parsed to a String",
    )
    def test_non_blocking_plain_text(self):
        self.test_blocking()
        # TODO: This test is pending a better definition of when text/plain is considered parsed body,
        # which depends on application logic.
        assert self.rm_req_nonblock_plain_text.status_code == 200
```


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
