### PR TITLE
chore: update scripts/ddtest to improve startup time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,7 @@ services:
         # build:
         #  context: ./docker
         #  dockerfile: Dockerfile
-        image: ghcr.io/datadog/dd-trace-py/testrunner:bca6869fffd715ea9a731f7b606807fa1b75cb71@sha256:9e3f53fa98ffc4b838b959d74d969aa2c384c4cbee7a3047a03d501be5f58760
+        image: ghcr.io/datadog/dd-trace-py/testrunner:8b69a2610342b333f8832422ffc4f3a9327bed13@sha256:c2d067947ffdb305fc7dc7ff1f8eb7035cfa110bd1199917dd2519eadd166402
         command: bash
         environment:
           DD_SETUP_CACHE_DOWNLOADS: "1"

--- a/scripts/ddtest
+++ b/scripts/ddtest
@@ -9,23 +9,9 @@ then
     CMD=bash
 fi
 
-# Check if 'docker compose' is available (Docker version 20.10+)
-if docker compose version &>/dev/null; then
-    compose_cmd="docker compose"
-else
-    compose_cmd="docker-compose"
-fi
-# retry docker pull if fails
-for i in {1..3}; do $compose_cmd pull -q testrunner && break || sleep 3; done
-
-# TODO(DEV): Install riot in the docker image
-FULL_CMD="pip install -q --disable-pip-version-check riot==0.20.1 && $CMD"
-
-# install and upgrade riot in case testrunner image has not been updated
-# DEV: Use `--no-TTY` and `--quiet-pull` when running in CircleCI
-$compose_cmd run \
-             -e DD_TRACE_AGENT_URL \
-             --rm \
-             -i \
-             testrunner \
-             bash -c "git config --global --add safe.directory /root/project && $FULL_CMD"
+docker compose run \
+       -e DD_TRACE_AGENT_URL \
+       --rm \
+       -i \
+       testrunner \
+       bash -c "(git config --global --add safe.directory /root/project || true) && $CMD"


### PR DESCRIPTION
This PR updates the testrunner image used for local development/testing, along with improving the startup time of the `scripts/ddtest` script by removing the `pip install` at the start of the command.

A follow-up PR will update the testrunner image used in GitLab (we are waiting for it to get mirrored first)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
