### PR TITLE
fix(llmobs): resolve `ValueError` from token metrics through LLMs with `langchain`

### DIFF
--- a/ddtrace/llmobs/_integrations/langchain.py
+++ b/ddtrace/llmobs/_integrations/langchain.py
@@ -499,6 +499,8 @@ class LangChainIntegration(BaseLLMIntegration):
                 # do not append to the count, just set it once
                 if not is_workflow and not tokens_set_top_level:
                     tokens, run_id = self.check_token_usage_ai_message(chat_completion_msg)
+                    if run_id is None:
+                        continue
                     input_tokens, output_tokens, total_tokens = tokens
                     tokens_per_choice_run_id[run_id]["input_tokens"] = input_tokens
                     tokens_per_choice_run_id[run_id]["output_tokens"] = output_tokens
@@ -726,7 +728,7 @@ class LangChainIntegration(BaseLLMIntegration):
 
         return input_tokens, output_tokens, total_tokens
 
-    def check_token_usage_ai_message(self, ai_message):
+    def check_token_usage_ai_message(self, ai_message) -> Tuple[Tuple[int, int, int], Optional[str]]:
         """Checks for token usage on an AI message object"""
         # depending on the provider + langchain-core version, the usage metadata can be in different places
         # either chat_completion_msg.usage_metadata or chat_completion_msg.response_metadata.{token}_usage
@@ -735,10 +737,10 @@ class LangChainIntegration(BaseLLMIntegration):
         run_id = getattr(ai_message, "id", None) or getattr(ai_message, "run_id", "")
         run_id_base = "-".join(run_id.split("-")[:-1]) if run_id else ""
 
-        response_metadata = getattr(ai_message, "response_metadata", {}) or {}
-        usage = usage or response_metadata.get("usage", {}) or response_metadata.get("token_usage", {})
+        response_metadata = getattr(ai_message, "response_metadata", {})
+        usage = usage or response_metadata.get("usage") or response_metadata.get("token_usage")
         if usage is None or not isinstance(usage, dict):  # in case it is explicitly set to None
-            return 0, 0, 0
+            return (0, 0, 0), run_id_base
 
         # could either be "{prompt,completion}_tokens" or "{input,output}_tokens"
         input_tokens = usage.get("input_tokens", 0) or usage.get("prompt_tokens", 0)

--- a/releasenotes/notes/langchain-llmobs-token-value-error-e157dce357408791.yaml
+++ b/releasenotes/notes/langchain-llmobs-token-value-error-e157dce357408791.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixed an issue where grabbing token values for some providers through ``langchain`` libraries raised a ``ValueError``.

--- a/tests/contrib/langchain/conftest.py
+++ b/tests/contrib/langchain/conftest.py
@@ -362,7 +362,9 @@ def openai_chat_completion_no_usage(respx_mock):
 
     completion = _openai_chat_completion_object(n=2, include_usage=False)
 
-    respx_mock.post("/v1/chat/completions").mock(return_value=httpx.Response(200, json=completion.model_dump(mode="json")))
+    respx_mock.post("/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=completion.model_dump(mode="json"))
+    )
 
 
 @pytest.fixture

--- a/tests/contrib/langchain/conftest.py
+++ b/tests/contrib/langchain/conftest.py
@@ -250,6 +250,7 @@ def _openai_completion_object(
 def _openai_chat_completion_object(
     n: int = 1,
     tools: bool = False,
+    include_usage: bool = True,
 ):
     from datetime import datetime
 
@@ -274,11 +275,6 @@ def _openai_chat_completion_object(
         object="chat.completion",
         choices=choices,
         created=int(datetime.now().timestamp()),
-        usage=CompletionUsage(
-            prompt_tokens=5,
-            completion_tokens=5,
-            total_tokens=10,
-        ),
     )
 
     if tools:
@@ -296,6 +292,13 @@ def _openai_chat_completion_object(
 
         for choice in completion.choices:
             choice.message.tool_calls = [tool_call]
+
+    if include_usage:
+        completion.usage = CompletionUsage(
+            prompt_tokens=5,
+            completion_tokens=5,
+            total_tokens=10,
+        )
 
     return completion
 
@@ -350,6 +353,16 @@ def openai_chat_completion(respx_mock):
     respx_mock.post("/v1/chat/completions").mock(
         return_value=httpx.Response(200, json=completion.model_dump(mode="json"))
     )
+
+
+@pytest.fixture
+@pytest.mark.respx()
+def openai_chat_completion_no_usage(respx_mock):
+    import httpx
+
+    completion = _openai_chat_completion_object(n=2, include_usage=False)
+
+    respx_mock.post("/v1/chat/completions").mock(return_value=httpx.Response(200, json=completion.model_dump(mode="json")))
 
 
 @pytest.fixture

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -130,6 +130,16 @@ def test_llmobs_openai_chat_model(langchain_openai, llmobs_events, tracer, opena
     )
 
 
+def test_llmobs_openai_chat_model_no_usage(langchain_openai, llmobs_events, tracer, openai_chat_completion_no_usage):
+    chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256)
+    chat_model.invoke([HumanMessage(content="When do you use 'who' instead of 'whom'?")])
+    
+    assert len(llmobs_events) == 1
+    assert llmobs_events[0]["metrics"].get("input_tokens") is None
+    assert llmobs_events[0]["metrics"].get("output_tokens") is None
+    assert llmobs_events[0]["metrics"].get("total_tokens") is None
+
+
 @mock.patch("langchain_core.language_models.chat_models.BaseChatModel._generate_with_cache")
 def test_llmobs_openai_chat_model_proxy(mock_generate, langchain_openai, llmobs_events, tracer, openai_chat_completion):
     mock_generate.return_value = mock_langchain_chat_generate_response

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -133,7 +133,7 @@ def test_llmobs_openai_chat_model(langchain_openai, llmobs_events, tracer, opena
 def test_llmobs_openai_chat_model_no_usage(langchain_openai, llmobs_events, tracer, openai_chat_completion_no_usage):
     chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256)
     chat_model.invoke([HumanMessage(content="When do you use 'who' instead of 'whom'?")])
-    
+
     assert len(llmobs_events) == 1
     assert llmobs_events[0]["metrics"].get("input_tokens") is None
     assert llmobs_events[0]["metrics"].get("output_tokens") is None


### PR DESCRIPTION
Fixes a `ValueError` in a bad return when checking for and grabbing token metrics when they aren't available as a top-level field on the langchain chat message response.

```
ValueError: too many values to unpack (expected 2)
```

Additionally, adds a regression test that asserts no tokens are added should both the top-level and sub-level token metrics are missing, and checks that it does not log (since we catch and log these exceptions).

MLOB-3231

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
