### PR TITLE
chore(llmobs): try to fix flaky llm obs writer test 

### DIFF
--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -1438,15 +1438,20 @@ def test_listener_hooks_enqueue_correct_writer(run_python_code_in_subprocess):
     pypath = [os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))]
     if "PYTHONPATH" in env:
         pypath.append(env["PYTHONPATH"])
-    env.update({"PYTHONPATH": ":".join(pypath), "DD_TRACE_ENABLED": "0"})
+    env.update({"PYTHONPATH": ":".join(pypath), "DD_TRACE_ENABLED": "0", "_DD_LLMOBS_WRITER_INTERVAL": "0.001"})
     out, err, status, pid = run_python_code_in_subprocess(
         """
 import mock
+import sys
+import time
 from ddtrace.llmobs import LLMObs
 
 LLMObs.enable(ml_app="repro-issue", agentless_enabled=True, api_key="foobar.baz", site="datad0g.com")
 with LLMObs.agent("dummy"):
     pass
+time.sleep(0.01)
+sys.stdout.flush()
+sys.stderr.flush()
 """,
         env=env,
     )


### PR DESCRIPTION
This test has been flaky and relies on the subprocess outputting certain error logs

Try to make it less flaky by
1. increasing the likelihood the error log happens by decreasing the writer interval time. i think on exit, periodic should be called anyway, but this shouldn't hurt
2. sleep a bit before exiting
3. flush stderr/stdout manually before exiting

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
