### PR TITLE
chore: update span exit typing

### DIFF
--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -836,7 +836,12 @@ class Span(object):
     def __enter__(self) -> "Span":
         return self
 
-    def __exit__(self, exc_type: Type[BaseException], exc_val: BaseException, exc_tb: Optional[TracebackType]) -> None:
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
         try:
             if exc_type:
                 self.set_exc_info(exc_type, exc_val, exc_tb)

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -844,7 +844,7 @@ class Span(object):
     ) -> None:
         try:
             if exc_type:
-                self.set_exc_info(exc_type, exc_val, exc_tb)
+                self.set_exc_info(exc_type, exc_val, exc_tb)  # type: ignore
             self.finish()
         except Exception:
             log.exception("error closing trace")


### PR DESCRIPTION
[chore: fix Span exit type annotations](https://github.com/DataDog/dd-trace-py/pull/13813) 
opened a new PR for above because CI was struggling

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
