### PR TITLE
perf(rc): avoid call subscriber on duplicate values

### DIFF
--- a/ddtrace/settings/_config.py
+++ b/ddtrace/settings/_config.py
@@ -322,6 +322,18 @@ class _ConfigItem:
         else:
             log.warning("Invalid source: %s", source)
 
+    def get_value_source(self, source: _ConfigSource) -> _JSONType:
+        if source == "code":
+            return self._code_value
+        elif source == "remote_config":
+            return self._rc_value
+        elif source == "env_var":
+            return self._env_value
+        elif source == "default":
+            return self._default_value
+        else:
+            log.warning("Invalid source: %s", source)
+
     def set_code(self, value: _JSONType) -> None:
         self._code_value = value
 
@@ -789,8 +801,11 @@ class Config(object):
         # type: (List[Tuple[str, Any, _ConfigSource]]) -> None
         item_names = []
         for key, value, origin in items:
-            item_names.append(key)
             item = self._config[key]
+            if item.get_value_source(origin) == value:
+                # No change in config value, no need to notify subscribers or report telemetry
+                continue
+            item_names.append(key)
             item.set_value_source(value, origin)
             telemetry_writer.add_configuration(item._name, item.value(), item.source())
         self._notify_subscribers(item_names)


### PR DESCRIPTION
## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
