### PR TITLE
ci(benchmark): remove check-big-regressions job

### DIFF
--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -203,35 +203,6 @@ benchmarks-pr-comment:
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA # The commit revision the project is built for.
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-py
 
-check-big-regressions:
-  stage: report
-  rules:
-    # Run and warn on releases, but don't fail the pipeline
-    #   v2.10.0
-    #   v2.10.1
-    #   v2.10.0rc0
-    #   v2.10.0rc5
-    - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
-      allow_failure: true
-    - allow_failure: false
-  when: always
-  tags: ["arch:amd64"]
-  image: $MICROBENCHMARKS_CI_IMAGE
-  script: |
-    export ARTIFACTS_DIR="$(pwd)/reports/"
-    if [[ -n "$CI_JOB_TOKEN" ]];
-    then
-      git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
-    fi
-    git clone --branch "${BENCHMARKING_BRANCH}" https://github.com/DataDog/benchmarking-platform /platform
-    export PATH="$PATH:/platform/steps"
-
-    bp-runner /platform/bp-runner.fail-on-regression.yml --debug
-  variables:
-    # Gitlab and BP specific env vars. Do not modify.
-    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-py
-
-
 check-slo-breaches:
   stage: gate
   when: always


### PR DESCRIPTION
Now that we have the SLO thresholds/gates we no longer need the 20% threshold check.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
