### PR TITLE
ci(testrunner): add dd-octo-sts and gh cli tools to testrunner image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,6 +55,19 @@ RUN apt-get update \
       zlib1g-dev \
       awscli
 
+# Install dd-octo-sts
+COPY --from=registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1@sha256:6f958fc9f929ee97cc84815021d3d80899fab0fac73636eebefdffad4830f790 /usr/local/bin/dd-octo-sts /usr/local/bin/dd-octo-sts
+
+# Install gh cli
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+	  && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+	  && cat $out | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+	  && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+	  && mkdir -p -m 755 /etc/apt/sources.list.d \
+	  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+	  && apt-get update \
+	  && apt-get install -y --no-install-recommends gh
+
 # Allow running datadog-ci in CI with npx
 RUN apt-get install -y --no-install-recommends nodejs npm \
   && npm install -g @datadog/datadog-ci


### PR DESCRIPTION
Needed for #13948 so we can migrate `test-gen` job to `dd-octo-sts`.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
