### PR TITLE
chore(llmobs): add internal support for creating/getting projects

### DIFF
--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -1,3 +1,4 @@
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -7,6 +8,10 @@ from typing import TypedDict
 from typing import Union
 
 from typing_extensions import NotRequired
+
+
+if TYPE_CHECKING:
+    from ddtrace.llmobs import LLMObs
 
 
 JSONType = Union[str, int, float, bool, None, List["JSONType"], Dict[str, "JSONType"]]
@@ -38,9 +43,10 @@ class Experiment:
         task: Callable[[Dict[str, NonNoneJSONType]], JSONType],
         dataset: Dataset,
         evaluators: List[Callable[[NonNoneJSONType, JSONType, JSONType], JSONType]],
+        project_name: str,
         description: str = "",
         config: Optional[Dict[str, Any]] = None,
-        _llmobs: Optional[Any] = None,  # LLMObs service (cannot import here due to circular dependency)
+        _llmobs_instance: Optional["LLMObs"] = None,
     ) -> None:
         self.name = name
         self._task = task
@@ -48,7 +54,16 @@ class Experiment:
         self._evaluators = evaluators
         self._description = description
         self._config: Dict[str, Any] = config or {}
-        self._llmobs = _llmobs
+        self._llmobs_instance = _llmobs_instance
+
+        if not project_name:
+            raise ValueError(
+                "project_name must be provided for the experiment, either configured via the `DD_LLMOBS_PROJECT_NAME` "
+                "environment variable, or an argument to `LLMObs.enable(project_name=...)`, "
+                "or as an argument to `LLMObs.experiment(project_name=...)`."
+            )
+        self._project_name = project_name
+        self._project_id: Optional[str] = None
         self._id: Optional[str] = None
 
     def run(self, jobs: int = 1, raise_errors: bool = False, sample_size: Optional[int] = None) -> None:

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -161,7 +161,8 @@ class LLMObsSpan:
 class LLMObs(Service):
     _instance = None  # type: LLMObs
     enabled = False
-    _app_key: str = os.environ.get("DD_APP_KEY", "")
+    _app_key: str = os.getenv("DD_APP_KEY", "")
+    _project_name: str = os.getenv("DD_LLMOBS_PROJECT_NAME", "")
 
     def __init__(
         self,
@@ -461,6 +462,7 @@ class LLMObs(Service):
         site: Optional[str] = None,
         api_key: Optional[str] = None,
         app_key: Optional[str] = None,
+        project_name: Optional[str] = None,
         env: Optional[str] = None,
         service: Optional[str] = None,
         span_processor: Optional[Callable[[LLMObsSpan], LLMObsSpan]] = None,
@@ -477,6 +479,7 @@ class LLMObs(Service):
         :param str site: Your datadog site.
         :param str api_key: Your datadog api key.
         :param str app_key: Your datadog application key.
+        :param str project_name: Your project name used for experiments.
         :param str env: Your environment name.
         :param str service: Your service name.
         :param Callable[[LLMObsSpan], LLMObsSpan] span_processor: A function that takes an LLMObsSpan and returns an
@@ -493,6 +496,7 @@ class LLMObs(Service):
         config._dd_site = site or config._dd_site
         config._dd_api_key = api_key or config._dd_api_key
         cls._app_key = app_key or cls._app_key
+        cls._project_name = project_name or cls._project_name
         config.env = env or config.env
         config.service = service or config.service
         config._llmobs_ml_app = ml_app or config._llmobs_ml_app
@@ -585,6 +589,7 @@ class LLMObs(Service):
         dataset: Dataset,
         evaluators: List[Callable[[NonNoneJSONType, JSONType, JSONType], JSONType]],
         description: str = "",
+        project_name: Optional[str] = None,
     ) -> Experiment:
         """Initializes an Experiment to run a task on a Dataset and evaluators.
 
@@ -594,6 +599,9 @@ class LLMObs(Service):
         :param evaluators: A list of evaluator functions to evaluate the task output.
                            Must accept parameters ``input_data``, ``output_data``, and ``expected_output``.
         :param description: A description of the experiment.
+        :param project_name: The name of the project to associate with the experiment. If not provided, defaults to the
+                             configured value set via environment variable `DD_LLMOBS_PROJECT_NAME`
+                             or `LLMObs.enable(project_name=...)`.
         """
         if not callable(task):
             raise TypeError("task must be a callable function.")
@@ -611,7 +619,17 @@ class LLMObs(Service):
             required_params = ("input_data", "output_data", "expected_output")
             if not all(param in params for param in required_params):
                 raise TypeError("Evaluator function must have parameters {}.".format(required_params))
-        return Experiment(name, task, dataset, evaluators, description=description, _llmobs=cls)
+        if project_name is None:
+            project_name = cls._project_name
+        return Experiment(
+            name,
+            task,
+            dataset,
+            evaluators,
+            project_name=project_name,
+            description=description,
+            _llmobs_instance=cls._instance,
+        )
 
     @classmethod
     def register_processor(cls, processor: Optional[Callable[[LLMObsSpan], LLMObsSpan]] = None) -> None:

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -363,6 +363,29 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
             )
         return Dataset(name, dataset_id, class_records)
 
+    def project_create(self, name: str) -> str:
+        path = "/api/unstable/llm-obs/v1/projects"
+        resp = self.request(
+            "POST",
+            path,
+            body={"data": {"type": "projects", "attributes": {"name": name, "description": ""}}},
+        )
+        if resp.status != 200:
+            raise ValueError(f"Failed to create project {name}: {resp.status} {resp.get_json()}")
+        response_data = resp.get_json()
+        return response_data["data"]["id"]
+
+    def project_get(self, name: str) -> str:
+        path = f"/api/unstable/llm-obs/v1/projects?filter[name]={quote(name)}"
+        resp = self.request("GET", path)
+        if resp.status != 200:
+            raise ValueError(f"Failed to get project {name}: {resp.status} {resp.get_json()}")
+        response_data = resp.get_json()
+        data = response_data["data"]
+        if not data:
+            raise ValueError(f"Project {name} not found")
+        return data[0]["id"]
+
 
 class LLMObsSpanWriter(BaseLLMObsWriter):
     """Writes span events to the LLMObs Span Endpoint."""

--- a/tests/llmobs/conftest.py
+++ b/tests/llmobs/conftest.py
@@ -178,6 +178,7 @@ def llmobs_env():
     return {
         "DD_API_KEY": os.environ.get("DD_API_KEY", "<default-not-a-real-key>"),
         "DD_LLMOBS_ML_APP": "unnamed-ml-app",
+        "DD_LLMOBS_PROJECT_NAME": "test-project",
     }
 
 

--- a/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_projects_filter_name__test-project_get_068dd9a1.yaml
+++ b/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_projects_filter_name__test-project_get_068dd9a1.yaml
@@ -1,0 +1,45 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept-Encoding
+      : - identity
+      Connection:
+      - keep-alive
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Length
+      : - '0'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: GET
+    uri: https://api.datadoghq.com/api/unstable/llm-obs/v1/projects?filter%5Bname%5D=test-project
+  response:
+    body:
+      string: '{"data":[{"id":"dc4158e7-c60f-446e-bcf1-540aa68ffa0f","type":"projects","attributes":{"author":{"id":"df7d11c9-da50-11ed-af19-2e9f609a4672"},"created_at":"2025-07-11T18:06:01.105202Z","name":"test-project","updated_at":"2025-07-11T18:06:01.105202Z"}}],"meta":{"after":""}}'
+    headers:
+      content-length:
+      - '272'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.com
+      content-type:
+      - application/vnd.api+json
+      date:
+      - Fri, 11 Jul 2025 18:07:06 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_projects_post_954d8c3a.yaml
+++ b/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_projects_post_954d8c3a.yaml
@@ -1,0 +1,45 @@
+interactions:
+- request:
+    body: '{"data": {"type": "projects", "attributes": {"name": "test-project", "description":
+      ""}}}'
+    headers:
+      Accept:
+      - '*/*'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept-Encoding
+      : - identity
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '89'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://api.datadoghq.com/api/unstable/llm-obs/v1/projects
+  response:
+    body:
+      string: '{"data":{"id":"dc4158e7-c60f-446e-bcf1-540aa68ffa0f","type":"projects","attributes":{"author":{"id":"df7d11c9-da50-11ed-af19-2e9f609a4672"},"created_at":"2025-07-11T18:06:01.10520285Z","name":"test-project","updated_at":"2025-07-11T18:06:01.10520285Z"}}}'
+    headers:
+      content-length:
+      - '254'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.com
+      content-type:
+      - application/vnd.api+json
+      date:
+      - Fri, 11 Jul 2025 18:06:01 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -55,6 +55,16 @@ def test_dataset_pull(llmobs, test_dataset):
     assert dataset._id is not None
 
 
+def test_project_create(llmobs):
+    project_id = llmobs._instance._dne_client.project_create(name="test-project")
+    assert project_id == "dc4158e7-c60f-446e-bcf1-540aa68ffa0f"
+
+
+def test_project_get(llmobs):
+    project_id = llmobs._instance._dne_client.project_get(name="test-project")
+    assert project_id == "dc4158e7-c60f-446e-bcf1-540aa68ffa0f"
+
+
 def test_experiment_invalid_task_type_raises(llmobs, test_dataset):
     with pytest.raises(TypeError, match="task must be a callable function."):
         llmobs.experiment("test_experiment", 123, test_dataset, [dummy_evaluator])
@@ -104,8 +114,23 @@ def test_experiment_invalid_evaluator_signature_raises(llmobs, test_dataset):
 
 
 def test_experiment_create(llmobs, test_dataset):
-    exp = llmobs.experiment("test_experiment", dummy_task, test_dataset, [dummy_evaluator], description="lorem ipsum")
+    exp = llmobs.experiment(
+        "test_experiment",
+        dummy_task,
+        test_dataset,
+        [dummy_evaluator],
+        description="lorem ipsum",
+        project_name="test-project",
+    )
     assert exp.name == "test_experiment"
     assert exp._task == dummy_task
     assert exp._dataset == test_dataset
     assert exp._evaluators == [dummy_evaluator]
+
+
+def test_experiment_create_no_project_name_raises(llmobs, test_dataset):
+    project_name = llmobs._project_name
+    llmobs._project_name = None
+    with pytest.raises(ValueError, match="project_name must be provided for the experiment"):
+        llmobs.experiment("test_experiment", dummy_task, test_dataset, [dummy_evaluator], project_name=None)
+    llmobs._project_name = project_name  # reset to original value for other tests


### PR DESCRIPTION
[MLOB-3265]
This PR does the following:
- Adds support for the DNE client to create and get project IDs based on a project name.
- Adds (undocumented) support for configuring a project name for experiments, via
1. `DD_LLMOBS_PROJECT_NAME` env var, and
2. `LLMObs.enable(..., project_name=...)`
- Makes `project_name` an arg for creating an experiment. If not provided either above or as an arg to the experiment constructor, then raise an error since project names are required.

Minor note: this change also makes LLMObs an instance that is stored on each experiment, not the class, and adds type hints for this.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)


[MLOB-3265]: https://datadoghq.atlassian.net/browse/MLOB-3265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ