### PR TITLE
chore(llmobs): support dataset versioning/description

### DIFF
--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -22,13 +22,17 @@ class DatasetRecord(TypedDict):
 
 class Dataset:
     name: str
+    description: str
     _id: str
     _data: List[DatasetRecord]
+    _version: int
 
-    def __init__(self, name: str, dataset_id: str, data: List[DatasetRecord]) -> None:
+    def __init__(self, name: str, dataset_id: str, data: List[DatasetRecord], description: str, version: int) -> None:
         self.name = name
+        self.description = description
         self._id = dataset_id
         self._data = data
+        self._version = version
 
 
 class Experiment:

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -330,7 +330,8 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
             raise ValueError(f"Failed to create dataset {name}: {resp.status} {resp.get_json()}")
         response_data = resp.get_json()
         dataset_id = response_data["data"]["id"]
-        return Dataset(name, dataset_id, [])
+        curr_version = response_data["data"]["attributes"]["current_version"]
+        return Dataset(name, dataset_id, [], description, curr_version)
 
     def dataset_pull(self, name: str) -> Dataset:
         path = f"/api/unstable/llm-obs/v1/datasets?filter[name]={quote(name)}"
@@ -343,6 +344,8 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
         if not data:
             raise ValueError(f"Dataset '{name}' not found")
 
+        curr_version = data[0]["attributes"]["current_version"]
+        dataset_description = data[0]["attributes"]["description"]
         dataset_id = data[0]["id"]
         url = f"/api/unstable/llm-obs/v1/datasets/{dataset_id}/records"
         resp = self.request("GET", url)
@@ -361,7 +364,7 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
                     "metadata": attrs.get("metadata", {}),
                 }
             )
-        return Dataset(name, dataset_id, class_records)
+        return Dataset(name, dataset_id, class_records, dataset_description, curr_version)
 
 
 class LLMObsSpanWriter(BaseLLMObsWriter):

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -53,6 +53,9 @@ def test_dataset_pull_non_existent(llmobs):
 def test_dataset_pull(llmobs, test_dataset):
     dataset = llmobs.pull_dataset(name=test_dataset.name)
     assert dataset._id is not None
+    assert dataset.name == test_dataset.name
+    assert dataset.description == test_dataset.description
+    assert dataset._version == test_dataset._version
 
 
 def test_experiment_invalid_task_type_raises(llmobs, test_dataset):


### PR DESCRIPTION
[MLOB-3267]

This PR adds description and version as attributes on Datasets. These are existing fields on the Dataset object returned by the dataset create/pull requests, we are just adding them on the Dataset class and pulling them from the create/pull methods so that we can unblock creating experiments (which requires versioning).

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
