### PR TITLE
chore(llmobs): support running experiment tasks

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -94,3 +94,6 @@ OAI_HANDOFF_TOOL_ARG = "{}"
 LITELLM_ROUTER_INSTANCE_KEY = "_dd.router_instance"
 
 PROXY_REQUEST = "llmobs.proxy_request"
+
+EXPERIMENT_ID_KEY = "_ml_obs.experiment_id"
+EXPERIMENT_EXPECTED_OUTPUT_KEY = "_ml_obs.meta.input.expected_output"

--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -96,4 +96,3 @@ LITELLM_ROUTER_INSTANCE_KEY = "_dd.router_instance"
 PROXY_REQUEST = "llmobs.proxy_request"
 
 EXPERIMENT_ID_KEY = "_ml_obs.experiment_id"
-EXPERIMENT_EXPECTED_OUTPUT_KEY = "_ml_obs.meta.input.expected_output"

--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -1,14 +1,25 @@
 from typing import TYPE_CHECKING
+from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
+import sys
+import time
+import traceback
 from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Iterator
 from typing import List
 from typing import Optional
+from typing import Tuple
 from typing import TypedDict
 from typing import Union
 
 from typing_extensions import NotRequired
+
+from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_STACK
+from ddtrace.constants import ERROR_TYPE
+from ddtrace.llmobs._constants import EXPERIMENT_EXPECTED_OUTPUT_KEY
 
 
 if TYPE_CHECKING:
@@ -18,6 +29,8 @@ if TYPE_CHECKING:
 
 JSONType = Union[str, int, float, bool, None, List["JSONType"], Dict[str, "JSONType"]]
 NonNoneJSONType = Union[str, int, float, bool, List[JSONType], Dict[str, JSONType]]
+API_PROCESSING_TIME_SLEEP = 6  # median events processor processing time in seconds
+FLUSH_EVERY = 10  # default number of records to process before flushing
 
 
 class DatasetRecord(TypedDict):
@@ -77,7 +90,7 @@ class Experiment:
     def __init__(
         self,
         name: str,
-        task: Callable[[Dict[str, NonNoneJSONType]], JSONType],
+        task: Callable[[Dict[str, NonNoneJSONType], Optional[Dict[str, JSONType]]], JSONType],
         dataset: Dataset,
         evaluators: List[Callable[[NonNoneJSONType, JSONType, JSONType], JSONType]],
         project_name: str,
@@ -128,8 +141,59 @@ class Experiment:
         self._run_evaluators(task_results, raise_errors=raise_errors)
         return
 
+    def _process_record(self, idx_record: Tuple[int, DatasetRecord]) -> Dict[str, Any]:
+        idx, record = idx_record
+        start_ns = time.time_ns()
+        with self._llmobs_instance._experiment(name=self._task.__name__, experiment_id=self._id) as span:
+            span_context = self._llmobs_instance.export_span(span=span)
+            span_id = span_context.get("span_id", "")
+            trace_id = span_context.get("trace_id", "")
+            input_data = record["input_data"]
+            record_id = record.get("record_id", "")
+            expected_output = record["expected_output"]
+            tags = {"dataset_id": self._dataset._id, "dataset_record_id": record_id, "experiment_id": self._id}
+            output_data = None
+            try:
+                output_data = self._task(input_data)  # FIXME: support config?
+            except Exception:
+                span.set_exc_info(*sys.exc_info())
+            self._llmobs_instance.annotate(span, input_data=input_data, output_data=output_data, tags=tags)
+            span._set_ctx_item(EXPERIMENT_EXPECTED_OUTPUT_KEY, expected_output)  # FIXME: should we be doing this here?
+            return {
+                "idx": idx,
+                "output": output_data,
+                "metadata": {
+                    "timestamp": start_ns,
+                    "duration": time.time_ns() - start_ns,
+                    "dataset_record_index": idx,
+                    "experiment_name": self.name,
+                    "dataset_name": self._dataset.name,
+                    "span_id": span_id,
+                    "trace_id": trace_id,
+                },
+                "error": {
+                    "message": span.get_tag(ERROR_MSG),
+                    "stack": span.get_tag(ERROR_STACK),
+                    "type": span.get_tag(ERROR_TYPE),
+                },
+            }
+
     def _run_task(self, jobs: int, raise_errors: bool = False, sample_size: Optional[int] = None) -> List[Any]:
-        return []
+        if sample_size is not None and sample_size < len(self._dataset):
+            subset_data = [deepcopy(record) for record in self._dataset._data[:sample_size]]
+            subset_name = "[Test subset of {} records] {}".format(sample_size, self._dataset.name)
+            subset_dataset = Dataset(name=subset_name, dataset_id=self._dataset._id, data=subset_data)
+        else:
+            subset_dataset = self._dataset
+        task_results = []
+        with ThreadPoolExecutor(max_workers=jobs) as executor:
+            for result in executor.map(self._process_record, enumerate(subset_dataset)):
+                task_results.append(result)
+                if raise_errors and result["error"]["message"]:
+                    raise RuntimeError("Error on record {}: {}".format(result["idx"], result["error"]["message"]))
+        self._llmobs_instance.flush()
+        time.sleep(API_PROCESSING_TIME_SLEEP)
+        return task_results
 
     def _run_evaluators(self, task_results, raise_errors: bool = False) -> None:
         pass

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -630,8 +630,8 @@ class LLMObs(Service):
             raise TypeError("task must be a callable function.")
         sig = inspect.signature(task)
         params = sig.parameters
-        if "input_data" not in params:
-            raise TypeError("Task function must have an 'input_data' parameter.")
+        if "input_data" not in params or "config" not in params:
+            raise TypeError("Task function must have 'input_data' and 'config' parameters.")
         if not isinstance(dataset, Dataset):
             raise TypeError("Dataset must be an LLMObs Dataset object.")
         if not evaluators or not all(callable(evaluator) for evaluator in evaluators):

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -48,6 +48,7 @@ from ddtrace.llmobs._constants import DECORATOR
 from ddtrace.llmobs._constants import DISPATCH_ON_LLM_TOOL_CHOICE
 from ddtrace.llmobs._constants import DISPATCH_ON_TOOL_CALL
 from ddtrace.llmobs._constants import DISPATCH_ON_TOOL_CALL_OUTPUT_USED
+from ddtrace.llmobs._constants import EXPERIMENT_ID_KEY
 from ddtrace.llmobs._constants import INPUT_DOCUMENTS
 from ddtrace.llmobs._constants import INPUT_MESSAGES
 from ddtrace.llmobs._constants import INPUT_PROMPT
@@ -605,7 +606,7 @@ class LLMObs(Service):
     def experiment(
         cls,
         name: str,
-        task: Callable[[Dict[str, NonNoneJSONType]], JSONType],
+        task: Callable[[Dict[str, NonNoneJSONType], Optional[Dict[str, JSONType]]], JSONType],
         dataset: Dataset,
         evaluators: List[Callable[[NonNoneJSONType, JSONType, JSONType], JSONType]],
         description: str = "",
@@ -1136,6 +1137,33 @@ class LLMObs(Service):
         return cls._instance._start_span(
             "retrieval", name=name, session_id=session_id, ml_app=ml_app, _decorator=_decorator
         )
+
+    @classmethod
+    def _experiment(
+        cls,
+        name: Optional[str] = None,
+        session_id: Optional[str] = None,
+        ml_app: Optional[str] = None,
+        experiment_id: Optional[str] = None,
+    ) -> Span:
+        """
+        Trace an LLM experiment, only used internally by the experiments SDK.
+        :param str name: The name of the traced operation. If not provided, a default value of "agent" will be set.
+        :param str session_id: The ID of the underlying user session. Required for tracking sessions.
+        :param str ml_app: The name of the ML application that the agent is orchestrating. If not provided, the default
+                           value will be set to the value of `DD_LLMOBS_ML_APP`.
+        :param str experiment_id: The ID of the experiment to associate with this span and its children.
+        :returns: The Span object representing the traced operation.
+        """
+        if cls.enabled is False:
+            log.warning(SPAN_START_WHILE_DISABLED_WARNING)
+        span = cls._instance._start_span("experiment", name=name, session_id=session_id, ml_app=ml_app)
+
+        # Set experiment_id in baggage if provided
+        if experiment_id:
+            span.context.set_baggage_item(EXPERIMENT_ID_KEY, experiment_id)
+
+        return span
 
     @classmethod
     def annotate(

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -346,7 +346,7 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
     def dataset_batch_update(self, dataset_id: str, records: List[DatasetRecord]) -> int:
         rs: JSONType = [
             {
-                "input": r["input_data"],
+                "input": cast(Dict[str, JSONType], r["input_data"]),
                 "expected_output": r["expected_output"],
                 "metadata": r.get("metadata", {}),
                 "record_id": r.get("record_id", None),

--- a/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_3bf4897d-e6aa-43a3-8d9c-5097b1f85177_batch_update_post_2d58a82a.yaml
+++ b/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_3bf4897d-e6aa-43a3-8d9c-5097b1f85177_batch_update_post_2d58a82a.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: '{"data": {"type": "datasets", "attributes": {"insert_records": [{"input":
+      {"prompt": "What is the capital of France?"}, "expected_output": {"answer":
+      "Paris"}, "metadata": {}, "record_id": null}, {"input": {"prompt": "What is
+      the capital of Canada?"}, "expected_output": {"answer": "Ottawa"}, "metadata":
+      {}, "record_id": null}]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept-Encoding
+      : - identity
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '331'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://api.datadoghq.com/api/unstable/llm-obs/v1/datasets/3bf4897d-e6aa-43a3-8d9c-5097b1f85177/batch_update
+  response:
+    body:
+      string: '{"data":[{"id":"3eda96b0-5590-4886-8633-34154e381dc3","type":"datasets","attributes":{"author":{"id":"df7d11c9-da50-11ed-af19-2e9f609a4672"},"created_at":"2025-07-14T23:18:56.69063271Z","dataset_id":"3bf4897d-e6aa-43a3-8d9c-5097b1f85177","expected_output":{"answer":"Paris"},"input":{"prompt":"What
+        is the capital of France?"},"metadata":{},"updated_at":"2025-07-14T23:18:56.69063271Z","version":1}},{"id":"54fd2188-bdae-47d5-bf76-4c5d8c9fba9f","type":"datasets","attributes":{"author":{"id":"df7d11c9-da50-11ed-af19-2e9f609a4672"},"created_at":"2025-07-14T23:18:56.69063271Z","dataset_id":"3bf4897d-e6aa-43a3-8d9c-5097b1f85177","expected_output":{"answer":"Ottawa"},"input":{"prompt":"What
+        is the capital of Canada?"},"metadata":{},"updated_at":"2025-07-14T23:18:56.69063271Z","version":1}}]}'
+    headers:
+      content-length:
+      - '793'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.com
+      content-type:
+      - application/vnd.api+json
+      date:
+      - Mon, 14 Jul 2025 23:18:56 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_67c7b6cc-ce98-481e-ab9b-e4925564826c_batch_update_post_a1f44751.yaml
+++ b/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_67c7b6cc-ce98-481e-ab9b-e4925564826c_batch_update_post_a1f44751.yaml
@@ -1,0 +1,47 @@
+interactions:
+- request:
+    body: '{"data": {"type": "datasets", "attributes": {"insert_records": [{"input":
+      {"prompt": "What is the capital of France?"}, "expected_output": {"answer":
+      "Paris"}, "metadata": {}, "record_id": null}]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept-Encoding
+      : - identity
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '198'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://api.datadoghq.com/api/unstable/llm-obs/v1/datasets/67c7b6cc-ce98-481e-ab9b-e4925564826c/batch_update
+  response:
+    body:
+      string: '{"data":[{"id":"ddffedb3-cfa9-459c-80d1-cdfcb7062ec9","type":"datasets","attributes":{"author":{"id":"df7d11c9-da50-11ed-af19-2e9f609a4672"},"created_at":"2025-07-14T23:19:03.665305678Z","dataset_id":"67c7b6cc-ce98-481e-ab9b-e4925564826c","expected_output":{"answer":"Paris"},"input":{"prompt":"What
+        is the capital of France?"},"metadata":{},"updated_at":"2025-07-14T23:19:03.665305678Z","version":1}}]}'
+    headers:
+      content-length:
+      - '403'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.com
+      content-type:
+      - application/vnd.api+json
+      date:
+      - Mon, 14 Jul 2025 23:19:03 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_delete_post_264c9f32.yaml
+++ b/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_delete_post_264c9f32.yaml
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: '{"data": {"type": "datasets", "attributes": {"type": "soft", "dataset_ids":
+      ["67c7b6cc-ce98-481e-ab9b-e4925564826c"]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept-Encoding
+      : - identity
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '119'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://api.datadoghq.com/api/unstable/llm-obs/v1/datasets/delete
+  response:
+    body:
+      string: '{"data":[{"id":"67c7b6cc-ce98-481e-ab9b-e4925564826c","type":"datasets","attributes":{"author":{"id":"df7d11c9-da50-11ed-af19-2e9f609a4672"},"created_at":"2025-07-14T23:19:03.530317Z","current_version":1,"deleted_at":"2025-07-14T23:19:09.996669Z","description":"A
+        test dataset","name":"test-dataset-test_experiment_run_task_error[test_dataset_records0]","updated_at":"2025-07-14T23:19:03.816944Z"}}]}'
+    headers:
+      content-length:
+      - '400'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.com
+      content-type:
+      - application/vnd.api+json
+      date:
+      - Mon, 14 Jul 2025 23:19:10 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_delete_post_d28fa230.yaml
+++ b/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_delete_post_d28fa230.yaml
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: '{"data": {"type": "datasets", "attributes": {"type": "soft", "dataset_ids":
+      ["3bf4897d-e6aa-43a3-8d9c-5097b1f85177"]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept-Encoding
+      : - identity
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '119'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://api.datadoghq.com/api/unstable/llm-obs/v1/datasets/delete
+  response:
+    body:
+      string: '{"data":[{"id":"3bf4897d-e6aa-43a3-8d9c-5097b1f85177","type":"datasets","attributes":{"author":{"id":"df7d11c9-da50-11ed-af19-2e9f609a4672"},"created_at":"2025-07-14T23:18:56.592831Z","current_version":1,"deleted_at":"2025-07-14T23:19:03.156151Z","description":"A
+        test dataset","name":"test-dataset-test_experiment_run_task[test_dataset_records0]","updated_at":"2025-07-14T23:18:56.822333Z"}}]}'
+    headers:
+      content-length:
+      - '394'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.com
+      content-type:
+      - application/vnd.api+json
+      date:
+      - Mon, 14 Jul 2025 23:19:03 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_post_35e295b1.yaml
+++ b/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_post_35e295b1.yaml
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: '{"data": {"type": "datasets", "attributes": {"name": "test-dataset-test_experiment_run_task[test_dataset_records0]",
+      "description": "A test dataset"}}}'
+    headers:
+      Accept:
+      - '*/*'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept-Encoding
+      : - identity
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '151'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://api.datadoghq.com/api/unstable/llm-obs/v1/datasets
+  response:
+    body:
+      string: '{"data":{"id":"3bf4897d-e6aa-43a3-8d9c-5097b1f85177","type":"datasets","attributes":{"author":{"id":"df7d11c9-da50-11ed-af19-2e9f609a4672"},"created_at":"2025-07-14T23:18:56.592831479Z","current_version":0,"description":"A
+        test dataset","name":"test-dataset-test_experiment_run_task[test_dataset_records0]","updated_at":"2025-07-14T23:18:56.592831479Z"}}}'
+    headers:
+      content-length:
+      - '355'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.com
+      content-type:
+      - application/vnd.api+json
+      date:
+      - Mon, 14 Jul 2025 23:18:56 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_post_3f098e52.yaml
+++ b/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_post_3f098e52.yaml
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: '{"data": {"type": "datasets", "attributes": {"name": "test-dataset-test_experiment_run_task_error[test_dataset_records0]",
+      "description": "A test dataset"}}}'
+    headers:
+      Accept:
+      - '*/*'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept-Encoding
+      : - identity
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '157'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - application/json
+      User-Agent:
+      - python-requests/2.32.4
+    method: POST
+    uri: https://api.datadoghq.com/api/unstable/llm-obs/v1/datasets
+  response:
+    body:
+      string: '{"data":{"id":"67c7b6cc-ce98-481e-ab9b-e4925564826c","type":"datasets","attributes":{"author":{"id":"df7d11c9-da50-11ed-af19-2e9f609a4672"},"created_at":"2025-07-14T23:19:03.530317651Z","current_version":0,"description":"A
+        test dataset","name":"test-dataset-test_experiment_run_task_error[test_dataset_records0]","updated_at":"2025-07-14T23:19:03.530317651Z"}}}'
+    headers:
+      content-length:
+      - '361'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.com
+      content-type:
+      - application/vnd.api+json
+      date:
+      - Mon, 14 Jul 2025 23:19:03 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -15,13 +15,14 @@ import re
 from typing import Generator
 from typing import List
 
+import mock
 import pytest
 
 from ddtrace.llmobs._experiment import Dataset
 from ddtrace.llmobs._experiment import DatasetRecord
 
 
-def dummy_task(input_data):
+def dummy_task(input_data, config):
     return input_data
 
 
@@ -103,9 +104,15 @@ def test_experiment_invalid_task_type_raises(llmobs, test_dataset):
 
 
 def test_experiment_invalid_task_signature_raises(llmobs, test_dataset):
-    with pytest.raises(TypeError, match="Task function must have an 'input_data' parameter."):
+    with pytest.raises(TypeError, match="Task function must have 'input_data' and 'config' parameters."):
 
         def my_task(not_input):
+            pass
+
+        llmobs.experiment("test_experiment", my_task, test_dataset, [dummy_evaluator])
+    with pytest.raises(TypeError, match="Task function must have 'input_data' and 'config' parameters."):
+
+        def my_task(input_data, not_config):
             pass
 
         llmobs.experiment("test_experiment", my_task, test_dataset, [dummy_evaluator])
@@ -186,3 +193,82 @@ def test_experiment_create(llmobs, test_dataset):
     )
     assert exp_id is not None
     assert exp_run_name.startswith("test_experiment")
+
+
+@pytest.mark.parametrize(
+    "test_dataset_records",
+    [
+        [
+            DatasetRecord(input_data={"prompt": "What is the capital of France?"}, expected_output={"answer": "Paris"}),
+            DatasetRecord(
+                input_data={"prompt": "What is the capital of Canada?"}, expected_output={"answer": "Ottawa"}
+            ),
+        ]
+    ],
+)
+def test_experiment_run_task(llmobs, test_dataset, test_dataset_records):
+    exp = llmobs.experiment("test_experiment", dummy_task, test_dataset, [dummy_evaluator], project_name="test-project")
+    task_results = exp._run_task(1, raise_errors=False)
+    assert len(task_results) == 2
+    assert task_results[0] == {
+        "idx": 0,
+        "output": {"prompt": "What is the capital of France?"},
+        "metadata": {
+            "timestamp": mock.ANY,
+            "duration": mock.ANY,
+            "dataset_record_index": 0,
+            "experiment_name": "test_experiment",
+            "dataset_name": "test-dataset-test_experiment_run_task[test_dataset_records0]",
+            "span_id": mock.ANY,
+            "trace_id": mock.ANY,
+        },
+        "error": mock.ANY,
+    }
+    assert task_results[1] == {
+        "idx": 1,
+        "output": {"prompt": "What is the capital of Canada?"},
+        "metadata": {
+            "timestamp": mock.ANY,
+            "duration": mock.ANY,
+            "dataset_record_index": 1,
+            "experiment_name": "test_experiment",
+            "dataset_name": "test-dataset-test_experiment_run_task[test_dataset_records0]",
+            "span_id": mock.ANY,
+            "trace_id": mock.ANY,
+        },
+        "error": mock.ANY,
+    }
+
+
+@pytest.mark.parametrize(
+    "test_dataset_records",
+    [[DatasetRecord(input_data={"prompt": "What is the capital of France?"}, expected_output={"answer": "Paris"})]],
+)
+def test_experiment_run_task_error(llmobs, test_dataset, test_dataset_records):
+    def faulty_task(input_data, config):
+        raise ValueError("This is a test error")
+
+    exp = llmobs.experiment(
+        "test_experiment", faulty_task, test_dataset, [dummy_evaluator], project_name="test-project"
+    )
+    task_results = exp._run_task(1, raise_errors=False)
+    assert len(task_results) == 1
+    assert task_results == [
+        {
+            "idx": 0,
+            "output": None,
+            "metadata": {
+                "timestamp": mock.ANY,
+                "duration": mock.ANY,
+                "dataset_record_index": 0,
+                "experiment_name": "test_experiment",
+                "dataset_name": "test-dataset-test_experiment_run_task_error[test_dataset_records0]",
+                "span_id": mock.ANY,
+                "trace_id": mock.ANY,
+            },
+            "error": mock.ANY,
+        }
+    ]
+    assert task_results[0]["error"]["message"] == "This is a test error"
+    assert task_results[0]["error"]["stack"] is not None
+    assert task_results[0]["error"]["type"] == "builtins.ValueError"


### PR DESCRIPTION
[MLOB-3272]

Adds support for running experiment task functions concurrently, and tracing said experiment tasks.
Also does the following:
- Make `DatasetRecord.input_data` a more strict `Dict[str, NonNoneJSONType]`. There was a discrepancy between previous iterations of input_data from the DatasetRecord class and the required signature for `task` functions.
- Makes `config` a required input param (can be optional though) for task functions. Making it possibly optional is too clunky of an experience and users should be required to set it
- Private helper to create experiment spans to trace the experiment task run. Note that this is still submitted to the regular LLMObs span track, future PR will handle custom scoping and experiment custom I/O annotation on said span.


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)


[MLOB-3272]: https://datadoghq.atlassian.net/browse/MLOB-3272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ