### PR TITLE
chore(sampling_rules): remove support for regex and callable matchers

### DIFF
--- a/ddtrace/_trace/sampler.py
+++ b/ddtrace/_trace/sampler.py
@@ -56,7 +56,6 @@ class DatadogSampler:
     """
     The DatadogSampler samples traces based on the following (in order of precedence):
        - A list of sampling rules, applied in the order they are provided. The first matching rule is used.
-       - A default sample rate, stored as the final sampling rule (lowest precedence sampling rule).
        - A global rate limit, applied only if a rule is matched or if `rate_limit_always_on` is set to `True`.
        - Sample rates provided by the agent (priority sampling, maps sample rates to service and env tags).
        - By default, spans are sampled at a rate of 1.0 and assigned an `AUTO_KEEP` priority, allowing
@@ -91,9 +90,13 @@ class DatadogSampler:
         Constructor for DatadogSampler sampler
 
         :param rules: List of :class:`SamplingRule` rules to apply to the root span of every trace, default no rules
-        :param default_sample_rate: The default sample rate to apply if no rules matched
         :param rate_limit: Global rate limit (traces per second) to apply to all traces regardless of the rules
             applied to them, (default: ``100``)
+        :param rate_limit_window: The time window in nanoseconds for the rate limit, default is 1 second
+        :param rate_limit_always_on: If set to `True`, the rate limit is always applied, even if no sampling rules
+            are provided.
+        :param agent_based_samplers: A dictionary of service-based samplers, mapping a key in the format
+            `service:<service>,env:<env>` to a :class:`RateSampler` instance.
         """
         # Set sampling rules
         global_sampling_rules = config._trace_sampling_rules

--- a/ddtrace/_trace/sampling_rule.py
+++ b/ddtrace/_trace/sampling_rule.py
@@ -1,4 +1,3 @@
-import re
 from typing import TYPE_CHECKING  # noqa:F401
 from typing import Any
 from typing import Optional
@@ -93,26 +92,6 @@ class SamplingRule(object):
             return True
         if isinstance(pattern, GlobMatcher):
             return pattern.match(str(prop))
-
-        # If the pattern is callable (e.g. a function) then call it passing the prop
-        #   The expected return value is a boolean so cast the response in case it isn't
-        if callable(pattern):
-            try:
-                return bool(pattern(prop))
-            except Exception:
-                log.warning("%r pattern %r failed with %r", self, pattern, prop, exc_info=True)
-                # Their function failed to validate, assume it is a False
-                return False
-
-        # The pattern is a regular expression and the prop is a string
-        if isinstance(pattern, re.Pattern):
-            try:
-                return bool(pattern.match(str(prop)))
-            except (ValueError, TypeError):
-                # This is to guard us against the casting to a string (shouldn't happen, but still)
-                log.warning("%r pattern %r failed with %r", self, pattern, prop, exc_info=True)
-                return False
-
         # Exact match on the values
         return prop == pattern
 
@@ -205,21 +184,11 @@ class SamplingRule(object):
             return val
 
     def choose_matcher(self, prop):
-        # We currently support the ability to pass in a function, a regular expression, or a string
-        # If a string is passed in we create a GlobMatcher to handle the matching
-        if callable(prop) or isinstance(prop, re.Pattern):
-            log.error(
-                "Using methods or regular expressions for SamplingRule matching is not supported: %s ."
-                "Please move to passing in a string for Glob matching.",
-                str(prop),
-            )
-            return "None"
         # Name and Resource will never be None, but service can be, since we str()
         #  whatever we pass into the GlobMatcher, we can just use its matching
-        elif prop is None:
+        if prop is None:
             prop = "None"
-        else:
-            return GlobMatcher(prop) if prop != SamplingRule.NO_RULE else SamplingRule.NO_RULE
+        return SamplingRule.NO_RULE if prop == SamplingRule.NO_RULE else GlobMatcher(prop)
 
     def __repr__(self):
         return "{}(sample_rate={!r}, service={!r}, name={!r}, resource={!r}, tags={!r}, provenance={!r})".format(


### PR DESCRIPTION
With ddtrace v3.0 sampling rules only support glob matching. This PR removes the deprecated callable and regex pattern matchers. These matchers are internal to the ddtrace library and are unused. So we can remove them in a minor version.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
