### PR TITLE
ci: dynamically patch active writer

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -285,13 +285,12 @@ def test_metrics_partial_flush_disabled():
 def test_single_trace_too_large():
     import mock
 
-    from ddtrace.internal.writer import AgentWriter
     from ddtrace.trace import tracer as t
     from tests.utils import AnyInt
     from tests.utils import AnyStr
 
     assert t._span_aggregator.partial_flush_enabled is True
-    with mock.patch.object(AgentWriter, "flush_queue", return_value=None), mock.patch(
+    with mock.patch.object(t._span_aggregator.writer, "flush_queue", return_value=None), mock.patch(
         "ddtrace.internal.writer.writer.log"
     ) as log:
         with t.trace("huge"):

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -691,11 +691,10 @@ def test_tracer_url_default():
 def test_tracer_shutdown_no_timeout():
     import mock
 
-    from ddtrace.internal.writer import AgentWriter
     from ddtrace.trace import tracer as t
 
-    with mock.patch.object(AgentWriter, "stop") as mock_stop:
-        with mock.patch.object(AgentWriter, "join") as mock_join:
+    with mock.patch.object(t._span_aggregator.writer, "stop") as mock_stop:
+        with mock.patch.object(t._span_aggregator.writer, "join") as mock_join:
             t.shutdown()
 
     mock_stop.assert_called()
@@ -706,10 +705,9 @@ def test_tracer_shutdown_no_timeout():
 def test_tracer_shutdown_timeout():
     import mock
 
-    from ddtrace.internal.writer import AgentWriter
     from ddtrace.trace import tracer as t
 
-    with mock.patch.object(AgentWriter, "stop") as mock_stop:
+    with mock.patch.object(t._span_aggregator.writer, "stop") as mock_stop:
         with t.trace("something"):
             pass
 
@@ -723,12 +721,11 @@ def test_tracer_shutdown_timeout():
 def test_tracer_shutdown():
     import mock
 
-    from ddtrace.internal.writer import AgentWriter
     from ddtrace.trace import tracer as t
 
     t.shutdown()
 
-    with mock.patch.object(AgentWriter, "write") as mock_write:
+    with mock.patch.object(t._span_aggregator.writer, "write") as mock_write:
         with t.trace("something"):
             pass
 


### PR DESCRIPTION
Extracted from #13071

Dynamically patch the currently active writer instead of patching `AgentWriter`. Prepares for a future when multiple writers are available.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
