### PR TITLE
chore: replace hooks usage with core api for provider and tracer

### DIFF
--- a/ddtrace/profiling/collector/stack.pyx
+++ b/ddtrace/profiling/collector/stack.pyx
@@ -11,6 +11,7 @@ from ddtrace.internal._unpatched import _threading as ddtrace_threading
 from ddtrace._trace import context
 from ddtrace._trace import span as ddspan
 from ddtrace.trace import Tracer
+from ddtrace.internal import core
 from ddtrace.internal._threads import periodic_threads
 from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.internal.datadog.profiling import stack_v2
@@ -458,7 +459,7 @@ class StackCollector(collector.PeriodicCollector):
         if self.tracer is not None:
             self._thread_span_links = _ThreadSpanLinks()
             link_span = stack_v2.link_span if self._stack_collector_v2_enabled else self._thread_span_links.link_span
-            self.tracer.context_provider._on_activate(link_span)
+            core.on("ddtrace.context_provider.activate", link_span)
 
         # If stack v2 is enabled, then use the v2 sampler
         if self._stack_collector_v2_enabled:
@@ -483,7 +484,7 @@ class StackCollector(collector.PeriodicCollector):
         super(StackCollector, self)._stop_service()
         if self.tracer is not None:
             link_span = stack_v2.link_span if self._stack_collector_v2_enabled else self._thread_span_links.link_span
-            self.tracer.context_provider._deregister_on_activate(link_span)
+            core.reset_listeners("ddtrace.context_provider.activate", link_span)
         LOG.debug("Profiling StackCollector stopped")
 
         # Also tell the native thread running the v2 sampler to stop, if needed


### PR DESCRIPTION
Unify around a single event dispatch model.

Removes the need for the profiling to access the tracer context provider to listen for events.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
