### PR TITLE
fix(ci_visibility): disable and deprecate freezegun integration

### DIFF
--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -48,7 +48,7 @@ PATCH_MODULES = {
     "elasticsearch": True,
     "algoliasearch": True,
     "futures": True,
-    "freezegun": True,
+    "freezegun": False,  # deprecated, to be removed in ddtrace 4.x
     "google_generativeai": True,
     "google_genai": True,
     "gevent": True,

--- a/ddtrace/contrib/internal/freezegun/patch.py
+++ b/ddtrace/contrib/internal/freezegun/patch.py
@@ -1,33 +1,13 @@
 from typing import Dict
 
+from ddtrace import DDTraceDeprecationWarning
 from ddtrace.internal.logger import get_logger
-from ddtrace.internal.wrapping.context import WrappingContext
+from ddtrace.vendor.debtcollector import deprecate
 
 
 log = get_logger(__name__)
 
 DDTRACE_MODULE_NAME = "ddtrace"
-
-
-class FreezegunConfigWrappingContext(WrappingContext):
-    """Wraps the call to freezegun.configure to ensure that ddtrace remains patched if default_ignore_list is passed
-    in as an argument
-    """
-
-    # __exit__ comes from the parent class
-    # no-dd-sa:python-best-practices/ctx-manager-enter-exit-defined
-    def __enter__(self) -> "FreezegunConfigWrappingContext":
-        super().__enter__()
-        try:
-            default_ignore_list = self.get_local("default_ignore_list")
-        except KeyError:
-            log.debug("Could not get default_ignore_list on call to configure()")
-            return
-
-        if default_ignore_list is not None and DDTRACE_MODULE_NAME not in default_ignore_list:
-            default_ignore_list.append(DDTRACE_MODULE_NAME)
-
-        return self
 
 
 def get_version() -> str:
@@ -45,30 +25,13 @@ def _supported_versions() -> Dict[str, str]:
 
 
 def patch() -> None:
-    import freezegun
-
-    if getattr(freezegun, "_datadog_patch", False):
-        return
-
-    FreezegunConfigWrappingContext(freezegun.configure).wrap()
-
-    freezegun.configure(extend_ignore_list=[DDTRACE_MODULE_NAME])
-
-    freezegun._datadog_patch = True
+    deprecate(
+        "the freezegun integration is deprecated",
+        message="this integration is not needed anymore for the correct reporting of span durations.",
+        removal_version="4.0.0",
+        category=DDTraceDeprecationWarning,
+    )
 
 
 def unpatch() -> None:
-    import freezegun
-
-    if not getattr(freezegun, "_datadog_patch", False):
-        return
-
-    if FreezegunConfigWrappingContext.is_wrapped(freezegun.configure):
-        FreezegunConfigWrappingContext.extract(freezegun.configure).unwrap()
-
-    # Note: we do not want to restore to the original ignore list, as it may have been modified by the user, but we do
-    # want to remove the ddtrace module from the ignore list
-    new_ignore_list = [m for m in freezegun.config.settings.default_ignore_list if m != DDTRACE_MODULE_NAME]
-    freezegun.configure(default_ignore_list=new_ignore_list)
-
-    freezegun._datadog_patch = False
+    pass

--- a/ddtrace/contrib/internal/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v2.py
@@ -242,11 +242,6 @@ def _pytest_load_initial_conftests_pre_yield(early_config, parser, args):
 
     try:
         take_over_logger_stream_handler()
-        if not asbool(os.getenv("_DD_PYTEST_FREEZEGUN_SKIP_PATCH")):
-            from ddtrace._monkey import patch
-
-            # Freezegun is proactively patched to avoid it interfering with internal timing
-            patch(freezegun=True)
         dd_config.test_visibility.itr_skipping_level = ITR_SKIPPING_LEVEL.SUITE
         enable_test_visibility(config=dd_config.pytest)
         if InternalTestSession.should_collect_coverage():

--- a/releasenotes/notes/ci_visibility-deprecate-freezegun-integration-ff99aa77e3907204.yaml
+++ b/releasenotes/notes/ci_visibility-deprecate-freezegun-integration-ff99aa77e3907204.yaml
@@ -1,0 +1,10 @@
+---
+deprecations:
+  - |
+    CI Visibility: The ``freezegun`` integration is deprecated and will be removed in 4.0.0.
+    The ``freezegun`` integration is not necessary anymore for the correct reporting of test
+    durations and timestamps.
+fixes:
+  - |
+    CI Visibility: This fix resolves an issue where ``freezegun`` would not work with tests defined in ``unittest``
+    classes.

--- a/tests/contrib/freezegun/test_freezegun.py
+++ b/tests/contrib/freezegun/test_freezegun.py
@@ -7,7 +7,6 @@ import pytest
 from ddtrace.internal.utils.time import StopWatch
 from ddtrace.trace import tracer as dd_tracer
 from tests.contrib.pytest.test_pytest import PytestTestCaseBase
-from tests.utils import flaky
 
 
 class TestFreezegunTestCase:
@@ -19,20 +18,6 @@ class TestFreezegunTestCase:
         patch()
         yield
         unpatch()
-
-    @flaky(1759346444)
-    def test_freezegun_unpatch(self):
-        import freezegun
-
-        from ddtrace.contrib.internal.freezegun.patch import unpatch
-
-        unpatch()
-
-        with freezegun.freeze_time("2020-01-01"):
-            with dd_tracer.trace("freezegun.test") as span:
-                time.sleep(1)
-
-        assert span.duration == 0
 
     def test_freezegun_does_not_freeze_tracing(self):
         import freezegun
@@ -78,7 +63,6 @@ class TestFreezegunTestCase:
 
 
 class PytestFreezegunTestCase(PytestTestCaseBase):
-    @flaky(1759346444)
     def test_freezegun_pytest_plugin(self):
         """Tests that pytest's patching of freezegun in the v1 plugin version works"""
         import sys


### PR DESCRIPTION
PR https://github.com/DataDog/dd-trace-py/pull/14036 made the tracer report correct span durations in the presence of ddtrace even without this integration, so it can be deprecated (and fully removed in the next major version). This fixes the issues with freezegun ignoring calls from functions wrapped by ddtrace, such as unittest wrappers.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
