### PR TITLE
ci: replace @flaky with @pytest.mark.skip

### DIFF
--- a/tests/appsec/integrations/django_tests/test_iast_django.py
+++ b/tests/appsec/integrations/django_tests/test_iast_django.py
@@ -22,7 +22,6 @@ from tests.appsec.iast.iast_utils import get_line_and_hash
 from tests.appsec.iast.iast_utils import load_iast_report
 from tests.appsec.integrations.django_tests.utils import _aux_appsec_get_root_span
 from tests.utils import TracerSpanContainer
-from tests.utils import flaky
 from tests.utils import override_global_config
 
 
@@ -1304,7 +1303,7 @@ def test_django_stacktrace_leak(client, iast_span, tracer):
     assert vulnerability["hash"]
 
 
-@flaky(until=1767220930, reason="This test fails on Python 3.10 and below, and on Django versions below 4.2")
+@pytest.mark.skip(reason="This test fails on Python 3.10 and below, and on Django versions below 4.2")
 def test_django_stacktrace_from_technical_500_response(client, iast_span, tracer, debug_mode):
     root_span, response = _aux_appsec_get_root_span(
         client,

--- a/tests/contrib/botocore/test_bedrock.py
+++ b/tests/contrib/botocore/test_bedrock.py
@@ -16,7 +16,6 @@ from tests.subprocesstest import SubprocessTestCase
 from tests.subprocesstest import run_in_subprocess
 from tests.utils import DummyTracer
 from tests.utils import DummyWriter
-from tests.utils import flaky
 
 
 class TestBedrockConfig(SubprocessTestCase):
@@ -74,22 +73,22 @@ class TestBedrockConfig(SubprocessTestCase):
                     sampled += 1
         assert (rate * num_completions - 30) < sampled < (rate * num_completions + 30)
 
-    @flaky(until=1752686557)
+    @pytest.mark.skip(reason="Flaky test")
     @run_in_subprocess(env_overrides=dict(DD_BEDROCK_SPAN_PROMPT_COMPLETION_SAMPLE_RATE="0.0"))
     def test_span_sampling_0(self):
         self._test_span_sampling(rate=float(os.getenv("DD_BEDROCK_SPAN_PROMPT_COMPLETION_SAMPLE_RATE")))
 
-    @flaky(until=1752686557)
+    @pytest.mark.skip(reason="Flaky test")
     @run_in_subprocess(env_overrides=dict(DD_BEDROCK_SPAN_PROMPT_COMPLETION_SAMPLE_RATE="0.25"))
     def test_span_sampling_25(self):
         self._test_span_sampling(rate=float(os.getenv("DD_BEDROCK_SPAN_PROMPT_COMPLETION_SAMPLE_RATE")))
 
-    @flaky(until=1752686557)
+    @pytest.mark.skip(reason="Flaky test")
     @run_in_subprocess(env_overrides=dict(DD_BEDROCK_SPAN_PROMPT_COMPLETION_SAMPLE_RATE="0.75"))
     def test_span_sampling_75(self):
         self._test_span_sampling(rate=float(os.getenv("DD_BEDROCK_SPAN_PROMPT_COMPLETION_SAMPLE_RATE")))
 
-    @flaky(until=1752686557)
+    @pytest.mark.skip(reason="Flaky test")
     @run_in_subprocess(env_overrides=dict(DD_BEDROCK_SPAN_PROMPT_COMPLETION_SAMPLE_RATE="1.0"))
     def test_span_sampling_100(self):
         self._test_span_sampling(rate=float(os.getenv("DD_BEDROCK_SPAN_PROMPT_COMPLETION_SAMPLE_RATE")))

--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -16,7 +16,6 @@ from ddtrace.contrib.internal.grpc.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.trace import Pin
 from tests.utils import TracerTestCase
-from tests.utils import flaky
 from tests.utils import snapshot
 
 from .common import _GRPC_PORT
@@ -669,7 +668,7 @@ class _UnaryUnaryRpcHandler(grpc.GenericRpcHandler):
 
 
 @snapshot(ignores=["meta.network.destination.port"], wait_for_num_traces=2)
-@flaky(until=1767220930, reason="GitLab CI does not support ipv6 at this time")
+@pytest.mark.skip(reason="GitLab CI does not support ipv6 at this time")
 def test_method_service(patch_grpc):
     def handler(request, context):
         return b""

--- a/tests/contrib/gunicorn/test_gunicorn.py
+++ b/tests/contrib/gunicorn/test_gunicorn.py
@@ -11,7 +11,6 @@ from typing import Optional  # noqa:F401
 import pytest
 
 from ddtrace.internal.utils.retry import RetryError  # noqa:F401
-from tests.utils import flaky
 from tests.utils import snapshot_context
 from tests.webclient import Client
 
@@ -166,7 +165,7 @@ SETTINGS_GEVENT_DDTRACERUN_DEBUGMODE_MODULE_CLONE = _gunicorn_settings_factory(
 )
 
 
-@flaky(1759346444, reason="Server startup is flaky in CI. It is unclear whether the server fails to start or shutdown.")
+@pytest.mark.skip(reason="Server startup is flaky in CI. It is unclear whether the server fails to start or shutdown.")
 @pytest.mark.skipif(sys.version_info >= (3, 11), reason="Gunicorn is only supported up to 3.10")
 def test_no_known_errors_occur(tmp_path):
     for gunicorn_server_settings in [

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1450,43 +1450,6 @@ def get_128_bit_trace_id_from_headers(headers):
     )
 
 
-def _get_skipped_item(item, skip_reason):
-    if not inspect.isfunction(item) and not inspect.isclass(item):
-        raise ValueError(f"Unexpected skipped object: {item}")
-
-    if not hasattr(item, "pytestmark"):
-        item.pytestmark = []
-
-    item.pytestmark.append(pytest.mark.xfail(reason=skip_reason))
-
-    return item
-
-
-def _should_skip(until: int, condition=None):
-    until = dt.datetime.fromtimestamp(until)
-    if until and dt.datetime.now(dt.timezone.utc).replace(tzinfo=None) < until.replace(tzinfo=None):
-        return True
-    return condition is not None and condition
-
-
-def flaky(until: int, condition: bool = None, reason: str = None):
-    return skip_if_until(until, condition=condition, reason=reason)
-
-
-def skip_if_until(until: int, condition=None, reason=None):
-    """Conditionally skip the test until the given epoch timestamp"""
-    skip = _should_skip(until=until, condition=condition)
-
-    def decorator(function_or_class):
-        if not skip:
-            return function_or_class
-
-        full_reason = f"known bug, skipping until epoch time {until} - {reason or ''}"
-        return _get_skipped_item(function_or_class, full_reason)
-
-    return decorator
-
-
 def _build_env(env=None, file_path=FILE_PATH):
     """When a script runs in a subprocess, there are times in the CI or locally when it's assigned a different
     path than expected. Even worse, we've seen scripts that worked for months suddenly stop working because of this.


### PR DESCRIPTION
Flaky skips with a timestamp just end up disrupting CI in the future, we are going to replace them with an explicit skip, we can still search and find skipped tests for reporting without the deadline.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
