### PR TITLE
chore(llmobs): remove bedrock sampling tests

### DIFF
--- a/tests/contrib/botocore/test_bedrock.py
+++ b/tests/contrib/botocore/test_bedrock.py
@@ -1,98 +1,14 @@
 import json
-import os
 
 import mock
 import pytest
 
-from ddtrace.contrib.internal.botocore.patch import patch
-from ddtrace.trace import Pin
 from tests.contrib.botocore.bedrock_utils import _MODELS
 from tests.contrib.botocore.bedrock_utils import _REQUEST_BODIES
 from tests.contrib.botocore.bedrock_utils import BOTO_VERSION
 from tests.contrib.botocore.bedrock_utils import bedrock_converse_args_with_system_and_tool
 from tests.contrib.botocore.bedrock_utils import create_bedrock_converse_request
 from tests.contrib.botocore.bedrock_utils import get_request_vcr
-from tests.subprocesstest import SubprocessTestCase
-from tests.subprocesstest import run_in_subprocess
-from tests.utils import DummyTracer
-from tests.utils import DummyWriter
-from tests.utils import flaky
-
-
-class TestBedrockConfig(SubprocessTestCase):
-    def setUp(self):
-        patch()
-        import boto3
-
-        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
-        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
-        os.environ["AWS_SECURITY_TOKEN"] = "testing"
-        os.environ["AWS_SESSION_TOKEN"] = "testing"
-        os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
-
-        self.session = boto3.Session(
-            aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID", ""),
-            aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY", ""),
-            aws_session_token=os.getenv("AWS_SESSION_TOKEN", ""),
-            region_name=os.getenv("AWS_DEFAULT_REGION", "us-east-1"),
-        )
-        self.bedrock_client = self.session.client("bedrock-runtime")
-        self.mock_tracer = DummyTracer(writer=DummyWriter(trace_flush_enabled=False))
-        pin = Pin.get_from(self.bedrock_client)
-        pin._override(self.bedrock_client, tracer=self.mock_tracer)
-
-        super(TestBedrockConfig, self).setUp()
-
-    @run_in_subprocess(
-        env_overrides=dict(
-            DD_SERVICE="test-svc", DD_ENV="staging", DD_VERSION="1234", DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v1"
-        )
-    )
-    def test_global_tags(self):
-        body, model = json.dumps(_REQUEST_BODIES["meta"]), _MODELS["meta"]
-        with get_request_vcr().use_cassette("meta_invoke.yaml"):
-            response = self.bedrock_client.invoke_model(body=body, modelId=model)
-            json.loads(response.get("body").read())
-        span = self.mock_tracer.pop_traces()[0][0]
-        assert span.resource == "InvokeModel"
-        assert span.service == "test-svc"
-        assert span.get_tag("env") == "staging"
-        assert span.get_tag("version") == "1234"
-
-    def _test_span_sampling(self, rate):
-        body, model = json.dumps(_REQUEST_BODIES["meta"]), _MODELS["meta"]
-        num_completions = 200
-        for _ in range(num_completions):
-            with get_request_vcr().use_cassette("meta_invoke.yaml"):
-                response = self.bedrock_client.invoke_model(body=body, modelId=model)
-                json.loads(response.get("body").read())
-        traces = self.mock_tracer.pop_traces()
-        sampled = 0
-        for trace in traces:
-            for span in trace:
-                if span.get_tag("bedrock.response.choices.0.text"):
-                    sampled += 1
-        assert (rate * num_completions - 30) < sampled < (rate * num_completions + 30)
-
-    @flaky(until=1752686557)
-    @run_in_subprocess(env_overrides=dict(DD_BEDROCK_SPAN_PROMPT_COMPLETION_SAMPLE_RATE="0.0"))
-    def test_span_sampling_0(self):
-        self._test_span_sampling(rate=float(os.getenv("DD_BEDROCK_SPAN_PROMPT_COMPLETION_SAMPLE_RATE")))
-
-    @flaky(until=1752686557)
-    @run_in_subprocess(env_overrides=dict(DD_BEDROCK_SPAN_PROMPT_COMPLETION_SAMPLE_RATE="0.25"))
-    def test_span_sampling_25(self):
-        self._test_span_sampling(rate=float(os.getenv("DD_BEDROCK_SPAN_PROMPT_COMPLETION_SAMPLE_RATE")))
-
-    @flaky(until=1752686557)
-    @run_in_subprocess(env_overrides=dict(DD_BEDROCK_SPAN_PROMPT_COMPLETION_SAMPLE_RATE="0.75"))
-    def test_span_sampling_75(self):
-        self._test_span_sampling(rate=float(os.getenv("DD_BEDROCK_SPAN_PROMPT_COMPLETION_SAMPLE_RATE")))
-
-    @flaky(until=1752686557)
-    @run_in_subprocess(env_overrides=dict(DD_BEDROCK_SPAN_PROMPT_COMPLETION_SAMPLE_RATE="1.0"))
-    def test_span_sampling_100(self):
-        self._test_span_sampling(rate=float(os.getenv("DD_BEDROCK_SPAN_PROMPT_COMPLETION_SAMPLE_RATE")))
 
 
 @pytest.mark.snapshot


### PR DESCRIPTION
These tests are 1) super flaky and freezing merges, and 2) not needed because we're getting rid of prompt/completion sampling in APM integrations.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
