### PR TITLE
ci: pin Microsoft.Azure.Functions.ExtensionBundle to latest stable version

### DIFF
--- a/tests/contrib/azure_functions/azure_function_app/host.json
+++ b/tests/contrib/azure_functions/azure_function_app/host.json
@@ -1,15 +1,7 @@
 {
   "version": "2.0",
-  "logging": {
-    "applicationInsights": {
-      "samplingSettings": {
-        "isEnabled": true,
-        "excludedTypes": "Request"
-      }
-    }
-  },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[4.*, 5.0.0)"
+    "version": "[4.0.0, 4.22.0)"
   }
 }


### PR DESCRIPTION
The most recent [Azure Extension Bundle](https://learn.microsoft.com/en-us/azure/azure-functions/extension-bundles) release, [4.23.1](https://github.com/Azure/azure-functions-extension-bundles/releases/tag/4.23.1), introduced a breaking change (see below). Currently, the Azure Functions tests use the latest available version of this bundle between version 4 and 5 so this new version was picked up automatically. This PR pins the Azure Extension Bundle to the most recent stable version, `4.22.0` in addition to removing some other unnecessary configuration in `host.json`.

```
Looking for extension bundle Microsoft.Azure.Functions.ExtensionBundle at /root/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle
[2025-07-18T03:23:01.168Z] Found a matching extension bundle at /root/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/4.23.1
[2025-07-18T03:23:01.169Z] Fetching information on versions of extension bundle Microsoft.Azure.Functions.ExtensionBundle available on https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/index.json
[2025-07-18T03:23:01.289Z] Skipping bundle download since it already exists at path /root/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/4.23.1
[2025-07-18T03:23:01.294Z] Loading extension bundle from /root/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/4.23.1/bin
[2025-07-18T03:23:01.295Z] Script Startup resetting load context with base path: '/root/.azure-functions-core-tools/Functions/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/4.23.1/bin'.
[2025-07-18T03:23:01.303Z] Loading startup extension 'ServiceBus'
[2025-07-18T03:23:01.371Z] Loaded extension 'ServiceBus' (5.16.5.0)
[2025-07-18T03:23:01.400Z] Reading host configuration file '/root/project/tests/contrib/azure_functions/azure_function_app/host.json'
[2025-07-18T03:23:01.400Z] Host configuration file read:
[2025-07-18T03:23:01.400Z] {
[2025-07-18T03:23:01.400Z]   "version": "2.0",
[2025-07-18T03:23:01.401Z]   "extensionBundle": {
[2025-07-18T03:23:01.401Z]     "id": "Microsoft.Azure.Functions.ExtensionBundle",
[2025-07-18T03:23:01.401Z]     "version": "[4.*, 5.0.0)"
[2025-07-18T03:23:01.401Z]   }
[2025-07-18T03:23:01.401Z] }
[2025-07-18T03:23:01.432Z] Error configuring services in an external startup class.
[2025-07-18T03:23:01.433Z] Error configuring services in an external startup class. Microsoft.Azure.WebJobs.Extensions.ServiceBus: Could not load file or assembly 'Microsoft.Extensions.Configuration.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'. The system cannot find the file specified.
[2025-07-18T03:23:01.433Z] .
[2025-07-18T03:23:01.507Z] A host error has occurred during startup operation 'af05ca43-cfb8-4191-8373-9f67a5242695'.
[2025-07-18T03:23:01.508Z] Microsoft.Azure.WebJobs.Script: Error configuring services in an external startup class. Microsoft.Azure.WebJobs.Extensions.ServiceBus: Could not load file or assembly 'Microsoft.Extensions.Configuration.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'. The system cannot find the file specified.
[2025-07-18T03:23:01.508Z] .
Value cannot be null. (Parameter 'provider')
[2025-07-18T03:23:01.588Z] Host startup operation has been canceled
[2025-07-18T03:23:01.588Z] Initialization cancellation requested by runtime.
[2025-07-18T03:23:01.592Z] Stopping host...
[2025-07-18T03:23:01.594Z] Host shutdown completed.
[2025-07-18T03:23:01.597Z] Shutting down language worker channels for runtime:python
```

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
