### PR TITLE
chore(django): migrate template render wrappers to WrappingContext

### DIFF
--- a/ddtrace/contrib/internal/django/patch.py
+++ b/ddtrace/contrib/internal/django/patch.py
@@ -34,7 +34,6 @@ from ddtrace.ext import net
 from ddtrace.ext import sql as sqlx
 from ddtrace.internal import core
 from ddtrace.internal._exceptions import BlockingException
-from ddtrace.internal.compat import maybe_stringify
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.core.event_hub import ResultType
 from ddtrace.internal.logger import get_logger
@@ -568,36 +567,6 @@ def traced_get_response(django, pin, func, instance, args, kwargs):
                     return response  # noqa: B012
 
 
-@trace_utils.with_traced_module
-def traced_template_render(django, pin, wrapped, instance, args, kwargs):
-    # DEV: Check here in case this setting is configured after a template has been instrumented
-    if not config.django.instrument_templates:
-        return wrapped(*args, **kwargs)
-
-    template_name = maybe_stringify(getattr(instance, "name", None))
-    if template_name:
-        resource = template_name
-    else:
-        resource = "{0}.{1}".format(func_name(instance), wrapped.__name__)
-
-    tags = {COMPONENT: config.django.integration_name}
-    if template_name:
-        tags["django.template.name"] = template_name
-    engine = getattr(instance, "engine", None)
-    if engine:
-        tags["django.template.engine.class"] = func_name(engine)
-
-    with core.context_with_data(
-        "django.template.render",
-        span_name="django.template.render",
-        resource=resource,
-        span_type=http.TEMPLATE,
-        tags=tags,
-        pin=pin,
-    ) as ctx, ctx.span:
-        return wrapped(*args, **kwargs)
-
-
 def instrument_view(django, view):
     """
     Helper to wrap Django views.
@@ -959,9 +928,9 @@ def _patch(django):
         )
 
     if config.django.instrument_templates:
-        when_imported("django.template.base")(
-            lambda m: trace_utils.wrap(m, "Template.render", traced_template_render(django))
-        )
+        from .templates import DjangoTemplateWrappingContext
+
+        when_imported("django.template.base")(DjangoTemplateWrappingContext.instrument_module)
 
     if django.VERSION < (4, 0, 0):
         when_imported("django.conf.urls")(lambda m: trace_utils.wrap(m, "url", traced_urls_path(django)))
@@ -1033,6 +1002,11 @@ def _unpatch(django):
     for conn in django.db.connections.all():
         trace_utils.unwrap(conn, "cursor")
     trace_utils.unwrap(django.db.utils.ConnectionHandler, "__getitem__")
+
+    if config.django.instrument_templates:
+        from .templates import DjangoTemplateWrappingContext
+
+        DjangoTemplateWrappingContext.uninstrument_module(django.template.base)
 
 
 def unpatch():

--- a/ddtrace/contrib/internal/django/templates.py
+++ b/ddtrace/contrib/internal/django/templates.py
@@ -1,0 +1,128 @@
+from types import FunctionType
+from types import ModuleType
+from types import TracebackType
+import typing
+from typing import Optional
+from typing import Type
+from typing import TypeVar
+
+import ddtrace
+from ddtrace import config
+from ddtrace._trace.pin import Pin
+from ddtrace.ext import http
+from ddtrace.internal import core
+from ddtrace.internal.compat import maybe_stringify
+from ddtrace.internal.constants import COMPONENT
+from ddtrace.internal.utils.importlib import func_name
+from ddtrace.internal.wrapping.context import WrappingContext
+
+
+T = TypeVar("T")
+
+
+class DjangoTemplateWrappingContext(WrappingContext):
+    """
+    A context for wrapping django.template.base:Template.render method.
+    """
+
+    def __init__(self, f: FunctionType, django: ModuleType) -> None:
+        super().__init__(f)
+        self._django = django
+
+    @classmethod
+    def instrument_module(cls, django_template_base: ModuleType) -> None:
+        """
+        Instrument the django template base module to wrap the render method.
+        """
+        if not config.django.instrument_templates:
+            return
+
+        # Wrap the render method of the Template class
+        Template = getattr(django_template_base, "Template", None)
+        if not Template or not hasattr(Template, "render"):
+            return
+
+        import django
+
+        cls(typing.cast(FunctionType, Template.render), django).wrap()
+
+    @classmethod
+    def uninstrument_module(cls, django_template_base: ModuleType) -> None:
+        # Unwrap the render method of the Template class
+        Template = getattr(django_template_base, "Template", None)
+        if not Template or not hasattr(Template, "render"):
+            return
+
+        if cls.is_wrapped(Template.render):
+            ctx = cls.extract(Template.render)
+            ctx.unwrap()
+
+    def __enter__(self) -> "DjangoTemplateWrappingContext":
+        super().__enter__()
+
+        if not config.django.instrument_templates:
+            return
+
+        # Get the template instance (self parameter of the render method)
+        # Note: instance is a django.template.base.Template
+        instance = self.get_local("self")
+
+        # Extract template name
+        template_name = maybe_stringify(getattr(instance, "name", None))
+        if template_name:
+            resource = template_name
+        else:
+            resource = "{0}.{1}".format(func_name(instance), self.__wrapped__.__name__)
+
+        # Build tags
+        tags = {COMPONENT: config.django.integration_name}
+        if template_name:
+            tags["django.template.name"] = template_name
+
+        engine = getattr(instance, "engine", None)
+        if engine:
+            tags["django.template.engine.class"] = func_name(engine)
+
+        # Create the span context
+        pin = Pin.get_from(self._django)
+        tracer = ddtrace.tracer
+        if pin:
+            tracer = pin.tracer or tracer
+        ctx = core.context_with_data(
+            "django.template.render",
+            span_name="django.template.render",
+            resource=resource,
+            span_type=http.TEMPLATE,
+            tags=tags,
+            tracer=tracer,
+        )
+
+        # Enter the context and store it
+        ctx.__enter__()
+        self.set("ctx", ctx)
+
+        return self
+
+    def _close_ctx(
+        self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
+    ) -> None:
+        try:
+            # Close the context and any open span
+            ctx = self.get("ctx")
+            ctx.__exit__(exc_type, exc_val, exc_tb)
+            if ctx.span:
+                ctx.span.__exit__(exc_type, exc_val, exc_tb)
+        except Exception:
+            pass
+
+    def __return__(self, value: T) -> T:
+        if config.django.instrument_templates:
+            self._close_ctx(None, None, None)
+        return super().__return__(value)
+
+    def __exit__(
+        self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
+    ) -> None:
+        if config.django.instrument_templates:
+            self._close_ctx(exc_type, exc_val, exc_tb)
+        return super().__exit__(exc_type, exc_val, exc_tb)

--- a/tests/contrib/django/test_django_patch.py
+++ b/tests/contrib/django/test_django_patch.py
@@ -1,5 +1,6 @@
 from ddtrace.contrib.internal.django.patch import get_version
 from ddtrace.contrib.internal.django.patch import patch
+from ddtrace.contrib.internal.django.templates import DjangoTemplateWrappingContext
 from tests.contrib.patch import PatchTestCase
 
 
@@ -22,7 +23,7 @@ class TestDjangoPatch(PatchTestCase.Base):
 
         import django.template.base
 
-        self.assert_wrapped(django.template.base.Template.render)
+        assert DjangoTemplateWrappingContext.is_wrapped(django.template.base.Template.render)
         if django.VERSION >= (2, 0, 0):
             self.assert_wrapped(django.urls.path)
             self.assert_wrapped(django.urls.re_path)
@@ -34,7 +35,7 @@ class TestDjangoPatch(PatchTestCase.Base):
 
         self.assert_not_wrapped(django.core.handlers.base.BaseHandler.load_middleware)
         self.assert_not_wrapped(django.core.handlers.base.BaseHandler.get_response)
-        self.assert_not_wrapped(django.template.base.Template.render)
+        assert not DjangoTemplateWrappingContext.is_wrapped(django.template.base.Template.render)
         if django.VERSION >= (2, 0, 0):
             self.assert_not_wrapped(django.urls.path)
             self.assert_not_wrapped(django.urls.re_path)
@@ -46,7 +47,12 @@ class TestDjangoPatch(PatchTestCase.Base):
         self.assert_not_double_wrapped(django.apps.registry.Apps.populate)
         self.assert_not_double_wrapped(django.core.handlers.base.BaseHandler.load_middleware)
         self.assert_not_double_wrapped(django.core.handlers.base.BaseHandler.get_response)
-        self.assert_not_double_wrapped(django.template.base.Template.render)
+
+        assert DjangoTemplateWrappingContext.is_wrapped(django.template.base.Template.render)
+        ctx = DjangoTemplateWrappingContext.extract(django.template.base.Template.render)
+        ctx.unwrap()
+        assert not DjangoTemplateWrappingContext.is_wrapped(django.template.base.Template.render)
+
         if django.VERSION >= (2, 0, 0):
             self.assert_not_double_wrapped(django.urls.path)
             self.assert_not_double_wrapped(django.urls.re_path)


### PR DESCRIPTION
We will work to update the Django integration to use new wrapping patterns. Overall this should have a performance impact, but only doing template render is not having enough of an impact to call this a performance improvement for Django.

The only change to tests needed were the ones asserting that `Template.render` was wrapped, otherwise all existing tests are passing.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
