### PR TITLE
docs: fix release note formatting

### DIFF
--- a/releasenotes/notes/profiling-main-package-my-code-f650101b736c412e.yaml
+++ b/releasenotes/notes/profiling-main-package-my-code-f650101b736c412e.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
-  - profiling: |
-      Fix a bug where profile frames from the package specified by DD_MAIN_PACKAGE
-      were marked as "library" code in the profiler UI
+  - |
+    profiling: Fix a bug where profile frames from the package specified by DD_MAIN_PACKAGE
+    were marked as "library" code in the profiler UI


### PR DESCRIPTION
Fixes an incorrectly-formatted release note that causes `reno` to fail

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
