### PR TITLE
chore(ci_visibility): change unexpected coverage format error logging

### DIFF
--- a/ddtrace/contrib/internal/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v2.py
@@ -824,8 +824,16 @@ def _pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
             run_coverage_report()
 
         lines_pct_value = _coverage_data.get(PCT_COVERED_KEY, None)
-        if not isinstance(lines_pct_value, float):
-            log.warning("Tried to add total covered percentage to session span but the format was unexpected")
+        if lines_pct_value is None:
+            log.debug("Unable to retrieve coverage data for the session span")
+        elif not isinstance(lines_pct_value, (float, int)):
+            t = type(lines_pct_value)
+            log.warning(
+                "Unexpected format for total covered percentage: type=%s.%s, value=%r",
+                t.__module__,
+                t.__name__,
+                lines_pct_value,
+            )
         else:
             InternalTestSession.set_covered_lines_pct(lines_pct_value)
 

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -4183,135 +4183,129 @@ class PytestTestCase(PytestTestCaseBase):
         result = self.subprocess_run("--ddtrace", file_name)
         assert result.ret == 0
 
-    def test_pytest_coverage_data_format_handling(self):
-        """Test that coverage data format issues are handled correctly with proper logging."""
-        from ddtrace.contrib.internal.coverage.constants import PCT_COVERED_KEY
-        from ddtrace.contrib.internal.pytest._plugin_v2 import _pytest_sessionfinish
 
-        # Create a mock session object
-        mock_session = mock.MagicMock()
-        mock_session.exitstatus = 0
+def test_pytest_coverage_data_format_handling_none_value():
+    """Test that coverage data format issues are handled correctly with proper logging for None value."""
+    from ddtrace.contrib.internal.coverage.constants import PCT_COVERED_KEY
+    from ddtrace.contrib.internal.pytest._plugin_v2 import _pytest_sessionfinish
 
-        ci_visibility_instance = mock.MagicMock(spec=CIVisibility)
+    # Create a mock session object
+    mock_session = mock.MagicMock()
+    mock_session.exitstatus = 0
 
-        # Test case 1: coverage data is None
-        with mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2._coverage_data",
-            {PCT_COVERED_KEY: None},
-        ), mock.patch(
-            "ddtrace.ext.test_visibility.api.require_ci_visibility_service",
-            return_value=ci_visibility_instance,
-        ), mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2.is_test_visibility_enabled",
-            return_value=True,
-        ), mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_patched",
-            return_value=True,
-        ), mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_invoked_by_coverage_run",
-            return_value=True,
-        ), mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2.run_coverage_report"
-        ), mock.patch(
-            "ddtrace.internal.test_visibility.api.InternalTestSession.set_covered_lines_pct"
-        ) as mock_set_covered_lines_pct, mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2.log"
-        ) as mock_log:
-            _pytest_sessionfinish(mock_session, 0)
+    ci_visibility_instance = mock.MagicMock(spec=CIVisibility)
 
-            mock_log.debug.assert_called_with("Unable to retrieve coverage data for the session span")
-            mock_set_covered_lines_pct.assert_not_called()
+    # Test case 1: coverage data is None
+    with mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2._coverage_data",
+        {PCT_COVERED_KEY: None},
+    ), mock.patch(
+        "ddtrace.ext.test_visibility.api.require_ci_visibility_service",
+        return_value=ci_visibility_instance,
+    ), mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2.is_test_visibility_enabled",
+        return_value=True,
+    ), mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_patched",
+        return_value=True,
+    ), mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_invoked_by_coverage_run",
+        return_value=True,
+    ), mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2.run_coverage_report"
+    ), mock.patch(
+        "ddtrace.internal.test_visibility.api.InternalTestSession.set_covered_lines_pct"
+    ) as mock_set_covered_lines_pct, mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2.log"
+    ) as mock_log:
+        _pytest_sessionfinish(mock_session, 0)
 
-        # Test case 2: coverage data is not a float (e.g., string)
-        invalid_value = "not_a_float"
-        with mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2._coverage_data",
-            {PCT_COVERED_KEY: invalid_value},
-        ), mock.patch(
-            "ddtrace.ext.test_visibility.api.require_ci_visibility_service",
-            return_value=ci_visibility_instance,
-        ), mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2.is_test_visibility_enabled",
-            return_value=True,
-        ), mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_patched",
-            return_value=True,
-        ), mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_invoked_by_coverage_run",
-            return_value=True,
-        ), mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2.run_coverage_report"
-        ), mock.patch(
-            "ddtrace.internal.test_visibility.api.InternalTestSession.set_covered_lines_pct"
-        ) as mock_set_covered_lines_pct, mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2.log"
-        ) as mock_log:
-            _pytest_sessionfinish(mock_session, 0)
+        mock_log.debug.assert_called_with("Unable to retrieve coverage data for the session span")
+        mock_set_covered_lines_pct.assert_not_called()
 
-            mock_log.warning.assert_called_with(
-                "Unexpected format for total covered percentage: type=%s.%s, value=%r",
-                "builtins",
-                "str",
-                invalid_value,
-            )
-            mock_set_covered_lines_pct.assert_not_called()
 
-        # Test case 3: coverage data is an integer
-        valid_value = 75
-        with mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2._coverage_data", {PCT_COVERED_KEY: valid_value}
-        ), mock.patch(
-            "ddtrace.ext.test_visibility.api.require_ci_visibility_service",
-            return_value=ci_visibility_instance,
-        ), mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2.is_test_visibility_enabled",
-            return_value=True,
-        ), mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_patched",
-            return_value=True,
-        ), mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_invoked_by_coverage_run",
-            return_value=True,
-        ), mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2.run_coverage_report"
-        ), mock.patch(
-            "ddtrace.internal.test_visibility.api.InternalTestSession.set_covered_lines_pct"
-        ) as mock_set_covered_lines_pct, mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2.log"
-        ) as mock_log:
-            _pytest_sessionfinish(mock_session, 0)
+def test_pytest_coverage_data_format_handling_invalid_type():
+    """Test that coverage data format issues are handled correctly with proper logging for invalid value."""
+    from ddtrace.contrib.internal.coverage.constants import PCT_COVERED_KEY
+    from ddtrace.contrib.internal.pytest._plugin_v2 import _pytest_sessionfinish
 
-            # No warning or debug should be called for valid case
-            mock_log.warning.assert_not_called()
-            mock_log.debug.assert_not_called()
-            mock_set_covered_lines_pct.assert_called_once_with(valid_value)
+    # Create a mock session object
+    mock_session = mock.MagicMock()
+    mock_session.exitstatus = 0
 
-        # Test case 4: coverage data is a valid float
-        valid_value = 85.5
-        with mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2._coverage_data", {PCT_COVERED_KEY: valid_value}
-        ), mock.patch(
-            "ddtrace.ext.test_visibility.api.require_ci_visibility_service",
-            return_value=ci_visibility_instance,
-        ), mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2.is_test_visibility_enabled",
-            return_value=True,
-        ), mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_patched",
-            return_value=True,
-        ), mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_invoked_by_coverage_run",
-            return_value=True,
-        ), mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2.run_coverage_report"
-        ), mock.patch(
-            "ddtrace.internal.test_visibility.api.InternalTestSession.set_covered_lines_pct"
-        ) as mock_set_covered_lines_pct, mock.patch(
-            "ddtrace.contrib.internal.pytest._plugin_v2.log"
-        ) as mock_log:
-            _pytest_sessionfinish(mock_session, 0)
+    ci_visibility_instance = mock.MagicMock(spec=CIVisibility)
 
-            # No warning or debug should be called for valid case
-            mock_log.warning.assert_not_called()
-            mock_log.debug.assert_not_called()
-            mock_set_covered_lines_pct.assert_called_once_with(valid_value)
+    # Test case 2: coverage data is not a float (e.g., string)
+    invalid_value = "not_a_float"
+    with mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2._coverage_data",
+        {PCT_COVERED_KEY: invalid_value},
+    ), mock.patch(
+        "ddtrace.ext.test_visibility.api.require_ci_visibility_service",
+        return_value=ci_visibility_instance,
+    ), mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2.is_test_visibility_enabled",
+        return_value=True,
+    ), mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_patched",
+        return_value=True,
+    ), mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_invoked_by_coverage_run",
+        return_value=True,
+    ), mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2.run_coverage_report"
+    ), mock.patch(
+        "ddtrace.internal.test_visibility.api.InternalTestSession.set_covered_lines_pct"
+    ) as mock_set_covered_lines_pct, mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2.log"
+    ) as mock_log:
+        _pytest_sessionfinish(mock_session, 0)
+
+        mock_log.warning.assert_called_with(
+            "Unexpected format for total covered percentage: type=%s.%s, value=%r",
+            "builtins",
+            "str",
+            invalid_value,
+        )
+        mock_set_covered_lines_pct.assert_not_called()
+
+
+@pytest.mark.parametrize("valid_value", [75, 86.01])
+def test_pytest_coverage_data_format_handling_valid_values(valid_value):
+    """Test that coverage data format issues are handled correctly with proper logging."""
+    from ddtrace.contrib.internal.coverage.constants import PCT_COVERED_KEY
+    from ddtrace.contrib.internal.pytest._plugin_v2 import _pytest_sessionfinish
+
+    # Create a mock session object
+    mock_session = mock.MagicMock()
+    mock_session.exitstatus = 0
+
+    ci_visibility_instance = mock.MagicMock(spec=CIVisibility)
+
+    with mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2._coverage_data", {PCT_COVERED_KEY: valid_value}
+    ), mock.patch(
+        "ddtrace.ext.test_visibility.api.require_ci_visibility_service",
+        return_value=ci_visibility_instance,
+    ), mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2.is_test_visibility_enabled",
+        return_value=True,
+    ), mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_patched",
+        return_value=True,
+    ), mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_invoked_by_coverage_run",
+        return_value=True,
+    ), mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2.run_coverage_report"
+    ), mock.patch(
+        "ddtrace.internal.test_visibility.api.InternalTestSession.set_covered_lines_pct"
+    ) as mock_set_covered_lines_pct, mock.patch(
+        "ddtrace.contrib.internal.pytest._plugin_v2.log"
+    ) as mock_log:
+        _pytest_sessionfinish(mock_session, 0)
+
+        # No warning or debug should be called for valid case
+        mock_log.warning.assert_not_called()
+        mock_log.debug.assert_not_called()
+        mock_set_covered_lines_pct.assert_called_once_with(valid_value)

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -4182,3 +4182,136 @@ class PytestTestCase(PytestTestCaseBase):
 
         result = self.subprocess_run("--ddtrace", file_name)
         assert result.ret == 0
+
+    def test_pytest_coverage_data_format_handling(self):
+        """Test that coverage data format issues are handled correctly with proper logging."""
+        from ddtrace.contrib.internal.coverage.constants import PCT_COVERED_KEY
+        from ddtrace.contrib.internal.pytest._plugin_v2 import _pytest_sessionfinish
+
+        # Create a mock session object
+        mock_session = mock.MagicMock()
+        mock_session.exitstatus = 0
+
+        ci_visibility_instance = mock.MagicMock(spec=CIVisibility)
+
+        # Test case 1: coverage data is None
+        with mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2._coverage_data",
+            {PCT_COVERED_KEY: None},
+        ), mock.patch(
+            "ddtrace.ext.test_visibility.api.require_ci_visibility_service",
+            return_value=ci_visibility_instance,
+        ), mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2.is_test_visibility_enabled",
+            return_value=True,
+        ), mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_patched",
+            return_value=True,
+        ), mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_invoked_by_coverage_run",
+            return_value=True,
+        ), mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2.run_coverage_report"
+        ), mock.patch(
+            "ddtrace.internal.test_visibility.api.InternalTestSession.set_covered_lines_pct"
+        ) as mock_set_covered_lines_pct, mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2.log"
+        ) as mock_log:
+            _pytest_sessionfinish(mock_session, 0)
+
+            mock_log.debug.assert_called_with("Unable to retrieve coverage data for the session span")
+            mock_set_covered_lines_pct.assert_not_called()
+
+        # Test case 2: coverage data is not a float (e.g., string)
+        invalid_value = "not_a_float"
+        with mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2._coverage_data",
+            {PCT_COVERED_KEY: invalid_value},
+        ), mock.patch(
+            "ddtrace.ext.test_visibility.api.require_ci_visibility_service",
+            return_value=ci_visibility_instance,
+        ), mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2.is_test_visibility_enabled",
+            return_value=True,
+        ), mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_patched",
+            return_value=True,
+        ), mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_invoked_by_coverage_run",
+            return_value=True,
+        ), mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2.run_coverage_report"
+        ), mock.patch(
+            "ddtrace.internal.test_visibility.api.InternalTestSession.set_covered_lines_pct"
+        ) as mock_set_covered_lines_pct, mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2.log"
+        ) as mock_log:
+            _pytest_sessionfinish(mock_session, 0)
+
+            mock_log.warning.assert_called_with(
+                "Unexpected format for total covered percentage: type=%s.%s, value=%r",
+                "builtins",
+                "str",
+                invalid_value,
+            )
+            mock_set_covered_lines_pct.assert_not_called()
+
+        # Test case 3: coverage data is an integer
+        valid_value = 75
+        with mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2._coverage_data", {PCT_COVERED_KEY: valid_value}
+        ), mock.patch(
+            "ddtrace.ext.test_visibility.api.require_ci_visibility_service",
+            return_value=ci_visibility_instance,
+        ), mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2.is_test_visibility_enabled",
+            return_value=True,
+        ), mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_patched",
+            return_value=True,
+        ), mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_invoked_by_coverage_run",
+            return_value=True,
+        ), mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2.run_coverage_report"
+        ), mock.patch(
+            "ddtrace.internal.test_visibility.api.InternalTestSession.set_covered_lines_pct"
+        ) as mock_set_covered_lines_pct, mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2.log"
+        ) as mock_log:
+            _pytest_sessionfinish(mock_session, 0)
+
+            # No warning or debug should be called for valid case
+            mock_log.warning.assert_not_called()
+            mock_log.debug.assert_not_called()
+            mock_set_covered_lines_pct.assert_called_once_with(valid_value)
+
+        # Test case 4: coverage data is a valid float
+        valid_value = 85.5
+        with mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2._coverage_data", {PCT_COVERED_KEY: valid_value}
+        ), mock.patch(
+            "ddtrace.ext.test_visibility.api.require_ci_visibility_service",
+            return_value=ci_visibility_instance,
+        ), mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2.is_test_visibility_enabled",
+            return_value=True,
+        ), mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_patched",
+            return_value=True,
+        ), mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2._is_coverage_invoked_by_coverage_run",
+            return_value=True,
+        ), mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2.run_coverage_report"
+        ), mock.patch(
+            "ddtrace.internal.test_visibility.api.InternalTestSession.set_covered_lines_pct"
+        ) as mock_set_covered_lines_pct, mock.patch(
+            "ddtrace.contrib.internal.pytest._plugin_v2.log"
+        ) as mock_log:
+            _pytest_sessionfinish(mock_session, 0)
+
+            # No warning or debug should be called for valid case
+            mock_log.warning.assert_not_called()
+            mock_log.debug.assert_not_called()
+            mock_set_covered_lines_pct.assert_called_once_with(valid_value)


### PR DESCRIPTION
CI Visibility: Improve logging on unexpected coverage format with two different cases.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
