### PR TITLE
ci(benchmarks): bump up http propagation SLO thresholds

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
@@ -153,7 +153,7 @@ experiments:
           # httppropagationextract
           - name: httppropagationextract-all_styles_all_headers
             thresholds:
-              - execution_time < 0.084 ms
+              - execution_time < 0.10 ms
               - max_rss_usage < 31.00 MB
           - name: httppropagationextract-b3_headers
             thresholds:
@@ -161,15 +161,15 @@ experiments:
               - max_rss_usage < 31.00 MB
           - name: httppropagationextract-b3_single_headers
             thresholds:
-              - execution_time < 0.015 ms
+              - execution_time < 0.02 ms
               - max_rss_usage < 31.00 MB
           - name: httppropagationextract-datadog_tracecontext_tracestate_not_propagated_on_trace_id_no_match
             thresholds:
-              - execution_time < 0.066 ms
+              - execution_time < 0.08 ms
               - max_rss_usage < 31.00 MB
           - name: httppropagationextract-datadog_tracecontext_tracestate_propagated_on_trace_id_match
             thresholds:
-              - execution_time < 0.069 ms
+              - execution_time < 0.08 ms
               - max_rss_usage < 31.00 MB
           - name: httppropagationextract-empty_headers
             thresholds:
@@ -177,7 +177,7 @@ experiments:
               - max_rss_usage < 31.00 MB
           - name: httppropagationextract-full_t_id_datadog_headers
             thresholds:
-              - execution_time < 0.025 ms
+              - execution_time < 0.03 ms
               - max_rss_usage < 31.00 MB
           - name: httppropagationextract-invalid_priority_header
             thresholds:
@@ -217,7 +217,7 @@ experiments:
               - max_rss_usage < 31.00 MB
           - name: httppropagationextract-tracecontext_headers
             thresholds:
-              - execution_time < 0.035 ms
+              - execution_time < 0.04 ms
               - max_rss_usage < 31.00 MB
           - name: httppropagationextract-valid_headers_all
             thresholds:
@@ -275,35 +275,35 @@ experiments:
           # httppropagationinject
           - name: httppropagationinject-ids_only
             thresholds:
-              - execution_time < 0.02 ms
+              - execution_time < 0.03 ms
               - max_rss_usage < 31.00 MB
           - name: httppropagationinject-with_all
             thresholds:
-              - execution_time < 0.036 ms
+              - execution_time < 0.04 ms
               - max_rss_usage < 31.00 MB
           - name: httppropagationinject-with_dd_origin
             thresholds:
-              - execution_time < 0.027 ms
+              - execution_time < 0.03 ms
               - max_rss_usage < 31.00 MB
           - name: httppropagationinject-with_priority_and_origin
             thresholds:
-              - execution_time < 0.029 ms
+              - execution_time < 0.04 ms
               - max_rss_usage < 31.00 MB
           - name: httppropagationinject-with_sampling_priority
             thresholds:
-              - execution_time < 0.023 ms
+              - execution_time < 0.03 ms
               - max_rss_usage < 31.00 MB
           - name: httppropagationinject-with_tags
             thresholds:
-              - execution_time < 0.029 ms
+              - execution_time < 0.04 ms
               - max_rss_usage < 31.00 MB
           - name: httppropagationinject-with_tags_invalid
             thresholds:
-              - execution_time < 0.032 ms
+              - execution_time < 0.04 ms
               - max_rss_usage < 31.00 MB
           - name: httppropagationinject-with_tags_max_size
             thresholds:
-              - execution_time < 0.03 ms
+              - execution_time < 0.04 ms
               - max_rss_usage < 31.00 MB
 
           # iast_aspects


### PR DESCRIPTION
https://github.com/DataDog/dd-trace-py/pull/13992 introduced a small performance regression, and bumped the SLOs, but there were a few scenarios that still needed to be updated.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
