### PR TITLE
chore(llmobs): add span finished telemetry for bedrock agents integration

### DIFF
--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -13,6 +13,7 @@ from ddtrace.llmobs._constants import CACHE_READ_INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import CACHE_WRITE_INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import INPUT_MESSAGES
 from ddtrace.llmobs._constants import INPUT_VALUE
+from ddtrace.llmobs._constants import INTEGRATION
 from ddtrace.llmobs._constants import METADATA
 from ddtrace.llmobs._constants import METRICS
 from ddtrace.llmobs._constants import MODEL_NAME
@@ -30,6 +31,7 @@ from ddtrace.llmobs._integrations.bedrock_utils import normalize_input_tokens
 from ddtrace.llmobs._integrations.utils import get_final_message_converse_stream_message
 from ddtrace.llmobs._integrations.utils import get_messages_from_converse_content
 from ddtrace.llmobs._integrations.utils import update_proxy_workflow_input_output_value
+from ddtrace.llmobs._telemetry import record_bedrock_agent_span_event_created
 from ddtrace.llmobs._writer import LLMObsSpanEvent
 from ddtrace.trace import Span
 
@@ -151,6 +153,7 @@ class BedrockIntegration(BaseLLMIntegration):
                 INPUT_VALUE: str(input_value),
                 TAGS: {"session_id": session_id},
                 METADATA: {"agent_id": agent_id, "agent_alias_id": agent_alias_id},
+                INTEGRATION: "bedrock_agents",
             }
         )
         if not response:
@@ -176,6 +179,7 @@ class BedrockIntegration(BaseLLMIntegration):
             )
         for _, span_event in self._spans.items():
             LLMObs._instance._llmobs_span_writer.enqueue(span_event)
+            record_bedrock_agent_span_event_created(span_event)
         self._spans.clear()
         self._active_span_by_step_id.clear()
 

--- a/ddtrace/llmobs/_integrations/bedrock_agents.py
+++ b/ddtrace/llmobs/_integrations/bedrock_agents.py
@@ -15,6 +15,7 @@ from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._constants import LLMOBS_TRACE_ID
 from ddtrace.llmobs._integrations.bedrock_utils import parse_model_id
 from ddtrace.llmobs._utils import _get_ml_app
+from ddtrace.llmobs._utils import _get_session_id
 from ddtrace.llmobs._utils import safe_json
 
 
@@ -57,12 +58,15 @@ def _build_span_event(
     llmobs_trace_id = root_span._get_ctx_item(LLMOBS_TRACE_ID)
     if llmobs_trace_id is None:
         llmobs_trace_id = root_span.trace_id
+    session_id = _get_session_id(root_span)
+    ml_app = _get_ml_app(root_span)
+    tags = [f"ml_app:{ml_app}", f"session_id:{session_id}", "integration:bedrock_agents"]
     span_event = {
         "name": span_name,
         "span_id": str(span_id),
         "trace_id": format_trace_id(llmobs_trace_id),
         "parent_id": str(parent_id or root_span.span_id),
-        "tags": ["ml_app:{}".format(_get_ml_app(root_span))],
+        "tags": tags,
         "start_ns": int(start_ns or root_span.start_ns),
         "duration": int(duration_ns or DEFAULT_SPAN_DURATION),
         "status": "error" if error else "ok",

--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -36,16 +36,17 @@ class LLMObsTelemetryMetrics:
     USER_PROCESSOR_CALLED = "user_processor_called"
 
 
-def _find_integration_from_tags(tags):
-    integration_tag = next((tag for tag in tags if tag.startswith("integration:")), None)
-    if not integration_tag:
+def _find_tag_value_from_tags(tags, tag_key):
+    tag_string = next((tag for tag in tags if tag.startswith(f"{tag_key}:")), None)
+    if not tag_string:
         return None
-    return integration_tag.split("integration:")[-1]
+    return tag_string.split(f"{tag_key}:")[-1]
 
 
 def _get_tags_from_span_event(event: LLMObsSpanEvent):
     span_kind = event.get("meta", {}).get("span.kind", "")
-    integration = _find_integration_from_tags(event.get("tags", []))
+    integration = _find_tag_value_from_tags(event.get("tags", []), "integration")
+    ml_app = _find_tag_value_from_tags(event.get("tags", []), "ml_app")
     autoinstrumented = integration is not None
     error = event.get("status") == "error"
     return [
@@ -53,6 +54,7 @@ def _get_tags_from_span_event(event: LLMObsSpanEvent):
         ("autoinstrumented", str(int(autoinstrumented))),
         ("error", str(int(error))),
         ("integration", integration if integration else "N/A"),
+        ("ml_app", ml_app if ml_app else "N/A"),
     ]
 
 
@@ -119,6 +121,19 @@ def record_span_created(span: Span):
     if not autoinstrumented:
         tags.append(("decorator", str(int(decorator))))
     if model_provider:
+        tags.append(("model_provider", model_provider))
+    telemetry_writer.add_count_metric(
+        namespace=TELEMETRY_NAMESPACE.MLOBS, name=LLMObsTelemetryMetrics.SPAN_FINISHED, value=1, tags=tuple(tags)
+    )
+
+
+def record_bedrock_agent_span_event_created(span_event: LLMObsSpanEvent):
+    is_root_span = span_event["parent_id"] == ROOT_PARENT_ID
+    has_session_id = any("session_id" in tag for tag in span_event["tags"])
+    tags = _get_tags_from_span_event(span_event)
+    tags.extend([("has_session_id", str(int(has_session_id))), ("is_root_span", str(int(is_root_span)))])
+    model_provider = span_event["meta"]["metadata"].get("model_provider")
+    if model_provider is not None:
         tags.append(("model_provider", model_provider))
     telemetry_writer.add_count_metric(
         namespace=TELEMETRY_NAMESPACE.MLOBS, name=LLMObsTelemetryMetrics.SPAN_FINISHED, value=1, tags=tuple(tags)


### PR DESCRIPTION
Adds span.finished telemetry metric for bedrock agent spans. This was missed in the original PR because bedrock agent spans are not actual spans (that are created/finished) and are instead translated directly into span events from bedrock trace data. The integration name was also manually added in bedrock agent span tags because it is technically from the bedrock integration (so automatically would be set to "bedrock" instead of "bedrock_agents").

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
