### PR TITLE
fix(tracing): fix HTTPPropagator sampling the wrong span when the span_context is not active [CLONE]

### DIFF
--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -1124,6 +1124,15 @@ class HTTPPropagator(object):
             else:
                 root_span = core.tracer.current_root_span()
 
+                if root_span is not None and root_span.context is not span_context:
+                    log.error(
+                        "The passed in span_context is not the active context. The span must be passed in with"
+                        "non_active_span in order to be sampled. span_context: {}, non_active_span.context: {}",
+                        span_context,
+                        root_span.context,
+                    )
+                    root_span = None
+
             if root_span is not None and root_span.context.sampling_priority is None:
                 core.tracer.sample(root_span)
         else:


### PR DESCRIPTION
Clone of #14085

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
