### PR TITLE
chore(llmobs): don't push records on dataset creation

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -592,8 +592,6 @@ class LLMObs(Service):
         ds = cls._instance._dne_client.dataset_create(name, description)
         for r in records:
             ds.append(r)
-        if len(records) > 0:
-            ds.push()
         return ds
 
     @classmethod

--- a/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_2397010a-906e-43c4-8a51-9cd81ecad0ad_batch_update_post_a1752fdc.yaml
+++ b/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_2397010a-906e-43c4-8a51-9cd81ecad0ad_batch_update_post_a1752fdc.yaml
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: '{"data": {"type": "datasets", "id": "2397010a-906e-43c4-8a51-9cd81ecad0ad",
+      "attributes": {"insert_records": [], "update_records": [], "delete_records":
+      []}}}'
+    headers:
+      Accept:
+      - '*/*'
+      ? !!python/object/new:multidict._multidict.istr
+      - Accept-Encoding
+      : - identity
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '158'
+      ? !!python/object/new:multidict._multidict.istr
+      - Content-Type
+      : - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://api.datadoghq.com/api/unstable/llm-obs/v1/datasets/2397010a-906e-43c4-8a51-9cd81ecad0ad/batch_update
+  response:
+    body:
+      string: '{"data":[]}'
+    headers:
+      content-length:
+      - '11'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.com
+      content-type:
+      - application/vnd.api+json
+      date:
+      - Tue, 22 Jul 2025 19:44:39 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -57,6 +57,7 @@ def test_dataset_name(request) -> str:
 @pytest.fixture
 def test_dataset(llmobs, test_dataset_records, test_dataset_name) -> Generator[Dataset, None, None]:
     ds = llmobs.create_dataset(name=test_dataset_name, description="A test dataset", records=test_dataset_records)
+    ds.push()
 
     # When recording the requests, we need to wait for the dataset to be queryable.
     wait_for_backend()
@@ -72,6 +73,7 @@ def test_dataset_one_record(llmobs):
         DatasetRecord(input_data={"prompt": "What is the capital of France?"}, expected_output={"answer": "Paris"})
     ]
     ds = llmobs.create_dataset(name="test-dataset-123", description="A test dataset", records=records)
+    ds.push()
     wait_for_backend()
 
     yield ds


### PR DESCRIPTION
We want to make explicit synchronizing a pattern in the SDK. It is also an easier change to make create push the dataset records rather than reverting it later which would be a breaking change.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
