### PR TITLE
chore: improve the coding of ddtrace._monkey

### DIFF
--- a/ddtrace/_monkey.py
+++ b/ddtrace/_monkey.py
@@ -1,13 +1,14 @@
 import importlib
 import os
-import threading
 from types import ModuleType
 from typing import TYPE_CHECKING  # noqa:F401
+from typing import Set
 from typing import Union
 
 from wrapt.importer import when_imported
 
 from ddtrace.appsec._listeners import load_common_appsec_modules
+from ddtrace.internal.compat import Path
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.settings._config import config
 from ddtrace.settings.asm import config as asm_config
@@ -130,7 +131,6 @@ CONTRIB_DEPENDENCIES = {
 }
 
 
-_LOCK = threading.Lock()
 _PATCHED_MODULES = set()
 
 # Module names that need to be patched for a given integration. If the module
@@ -379,7 +379,7 @@ def patch(raise_errors=True, **patch_modules):
     contribs = {c: patch_indicator for c, patch_indicator in patch_modules.items() if patch_indicator}
     for contrib, patch_indicator in contribs.items():
         # Check if we have the requested contrib.
-        if not os.path.isfile(os.path.join(os.path.dirname(__file__), "contrib", "internal", contrib, "patch.py")):
+        if not (Path(__file__).parent / "contrib" / "internal" / contrib / "patch.py").exists():
             if raise_errors:
                 raise ModuleNotFoundException(f"{contrib} does not have automatic instrumentation")
         modules_to_patch = _MODULES_FOR_CONTRIB.get(contrib, (contrib,))
@@ -395,8 +395,7 @@ def patch(raise_errors=True, **patch_modules):
             )
 
         # manually add module to patched modules
-        with _LOCK:
-            _PATCHED_MODULES.add(contrib)
+        _PATCHED_MODULES.add(contrib)
 
     log.info(
         "Configured ddtrace instrumentation for %s integration(s). The following modules have been patched: %s",
@@ -405,8 +404,6 @@ def patch(raise_errors=True, **patch_modules):
     )
 
 
-def _get_patched_modules():
-    # type: () -> List[str]
+def _get_patched_modules() -> Set[str]:
     """Get the list of patched modules"""
-    with _LOCK:
-        return sorted(_PATCHED_MODULES)
+    return _PATCHED_MODULES


### PR DESCRIPTION
We improve the coding of the ddtrace._monkey module by using Path instead of os.path and by removing an unnecessary lock.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
