### PR TITLE
ci: re-enable mutli-os-tests for windows + Python 3.13

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -46,8 +46,6 @@ jobs:
           sudo apt-get install -y python3.13 python3.13-dev
 
       - name: Run tests
-        # Currently failing to build the project on Windows 3.13, but only for this job, "Build" workflow is successful
-        if: matrix.os != 'windows-latest' && matrix.python-version != '3.13'
         run: hatch run +py=${{ matrix.python-version }} multiple_os_tests:test
 
   finished:


### PR DESCRIPTION
These were disabled in the past, but the underlying issue appears to have been fixed, we should re-enable these.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
