### PR TITLE
feat(appsec): enable api security for lambda

### DIFF
--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -189,7 +189,7 @@ class AppSecSpanProcessor(SpanProcessor):
             if skip_event:
                 core.discard_item("appsec_skip_next_lambda_event")
                 log.debug(
-                    "appsec: ignoring unsupported lamdba event",
+                    "appsec: ignoring unsupported lambda event",
                 )
                 span.set_metric(APPSEC.UNSUPPORTED_EVENT_TYPE, 1.0)
                 return

--- a/ddtrace/settings/asm.py
+++ b/ddtrace/settings/asm.py
@@ -246,9 +246,8 @@ class ASMConfig(DDConfig):
             self._asm_processed_span_types.add(SpanTypes.SERVERLESS)
             self._asm_http_span_types.add(SpanTypes.SERVERLESS)
 
-            # As a first step, only Threat Management in monitoring mode should be enabled in AWS Lambda
+            # Disable all features that are not supported in Lambda
             tracer_config._remote_config_enabled = False
-            self._api_security_enabled = False
             self._ep_enabled = False
             self._iast_supported = False
 


### PR DESCRIPTION
## Description

Add a handler for lambda to send a response body to parse.

Additionally fix one typo

## Additional Notes

This is enabled in datadog_lambda by this PR: https://github.com/DataDog/datadog-lambda-python/pull/636

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
