### PR TITLE
perf: use set_metric(_SPANS_MEASURED_KEY, 1) instead of set_tag(_SPAN_MEASURED_KEY)

### DIFF
--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -147,7 +147,8 @@ def _start_span(ctx: core.ExecutionContext, call_trace: bool = True, **kwargs) -
 def _set_web_frameworks_tags(ctx, span, int_config):
     span.set_tag_str(COMPONENT, int_config.integration_name)
     span.set_tag_str(SPAN_KIND, SpanKind.SERVER)
-    span.set_tag(_SPAN_MEASURED_KEY)
+    # PERF: avoid setting via Span.set_tag
+    span.set_metric(_SPAN_MEASURED_KEY, 1)
 
 
 def _on_web_framework_start_request(ctx, int_config):
@@ -447,7 +448,8 @@ def _on_request_span_modifier(
     # RequestContext` and possibly a url rule
     span.resource = " ".join((request.method, request.path))
 
-    span.set_tag(_SPAN_MEASURED_KEY)
+    # PERF: avoid setting via Span.set_tag
+    span.set_metric(_SPAN_MEASURED_KEY, 1)
 
     span.set_tag_str(flask_version, flask_version_str)
 

--- a/ddtrace/_trace/utils_botocore/span_tags.py
+++ b/ddtrace/_trace/utils_botocore/span_tags.py
@@ -22,7 +22,8 @@ def set_botocore_patched_api_call_span_tags(span: Span, instance, args, params, 
     span.set_tag_str(COMPONENT, config.botocore.integration_name)
     # set span.kind to the type of request being performed
     span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
-    span.set_tag(_SPAN_MEASURED_KEY)
+    # PERF: avoid setting via Span.set_tag
+    span.set_metric(_SPAN_MEASURED_KEY, 1)
 
     if args:
         # DEV: join is the fastest way of concatenating strings that is compatible

--- a/ddtrace/_trace/utils_redis.py
+++ b/ddtrace/_trace/utils_redis.py
@@ -29,7 +29,8 @@ def _set_span_tags(
     span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
     span.set_tag_str(COMPONENT, config_integration.integration_name)
     span.set_tag_str(db.SYSTEM, redisx.APP)
-    span.set_tag(_SPAN_MEASURED_KEY)
+    # PERF: avoid setting via Span.set_tag
+    span.set_metric(_SPAN_MEASURED_KEY, 1)
     if query is not None:
         span_name = schematize_cache_operation(redisx.RAWCMD, cache_provider=redisx.APP)  # type: ignore[operator]
         span.set_tag_str(span_name, query)

--- a/ddtrace/_trace/utils_valkey.py
+++ b/ddtrace/_trace/utils_valkey.py
@@ -29,7 +29,8 @@ def _set_span_tags(
     span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
     span.set_tag_str(COMPONENT, config_integration.integration_name)
     span.set_tag_str(db.SYSTEM, valkeyx.APP)
-    span.set_tag(_SPAN_MEASURED_KEY)
+    # PERF: avoid setting via Span.set_tag
+    span.set_metric(_SPAN_MEASURED_KEY, 1)
     if query is not None:
         span_name = schematize_cache_operation(valkeyx.RAWCMD, cache_provider=valkeyx.APP)  # type: ignore[operator]
         span.set_tag_str(span_name, query)

--- a/ddtrace/contrib/dbapi.py
+++ b/ddtrace/contrib/dbapi.py
@@ -88,7 +88,8 @@ class TracedCursor(wrapt.ObjectProxy):
             name, service=ext_service(pin, self._self_config), resource=resource, span_type=SpanTypes.SQL
         ) as s:
             if measured:
-                s.set_tag(_SPAN_MEASURED_KEY)
+                # PERF: avoid setting via Span.set_tag
+                s.set_metric(_SPAN_MEASURED_KEY, 1)
             # No reason to tag the query since it is set as the resource by the agent. See:
             # https://github.com/DataDog/datadog-trace-agent/blob/bda1ebbf170dd8c5879be993bdd4dbae70d10fda/obfuscate/sql.go#L232
             s.set_tags(pin.tags)

--- a/ddtrace/contrib/dbapi_async.py
+++ b/ddtrace/contrib/dbapi_async.py
@@ -63,7 +63,8 @@ class TracedAsyncCursor(TracedCursor):
             name, service=ext_service(pin, self._self_config), resource=resource, span_type=SpanTypes.SQL
         ) as s:
             if measured:
-                s.set_tag(_SPAN_MEASURED_KEY)
+                # PERF: avoid setting via Span.set_tag
+                s.set_metric(_SPAN_MEASURED_KEY, 1)
             # No reason to tag the query since it is set as the resource by the agent. See:
             # https://github.com/DataDog/datadog-trace-agent/blob/bda1ebbf170dd8c5879be993bdd4dbae70d10fda/obfuscate/sql.go#L232
             s.set_tags(pin.tags)

--- a/ddtrace/contrib/internal/aiobotocore/patch.py
+++ b/ddtrace/contrib/internal/aiobotocore/patch.py
@@ -129,7 +129,8 @@ async def _wrapped_api_call(original_func, instance, args, kwargs):
         # set span.kind tag equal to type of request
         span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
 
         try:
             operation = get_argument_value(args, kwargs, 0, "operation_name")

--- a/ddtrace/contrib/internal/aiomysql/patch.py
+++ b/ddtrace/contrib/internal/aiomysql/patch.py
@@ -87,7 +87,8 @@ class AIOTracedCursor(wrapt.ObjectProxy):
             # set span.kind to the type of request being performed
             s.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-            s.set_tag(_SPAN_MEASURED_KEY)
+            # PERF: avoid setting via Span.set_tag
+            s.set_metric(_SPAN_MEASURED_KEY, 1)
             s.set_tags(pin.tags)
             s.set_tags(extra_tags)
 

--- a/ddtrace/contrib/internal/aiopg/connection.py
+++ b/ddtrace/contrib/internal/aiopg/connection.py
@@ -46,7 +46,8 @@ class AIOTracedCursor(wrapt.ObjectProxy):
             # set span.kind to the type of request being performed
             s.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-            s.set_tag(_SPAN_MEASURED_KEY)
+            # PERF: avoid setting via Span.set_tag
+            s.set_metric(_SPAN_MEASURED_KEY, 1)
             s.set_tags(pin.tags)
             s.set_tags(extra_tags)
 

--- a/ddtrace/contrib/internal/aioredis/patch.py
+++ b/ddtrace/contrib/internal/aioredis/patch.py
@@ -153,7 +153,8 @@ def traced_13_execute_command(func, instance, args, kwargs):
 
     span.set_tag_str(COMPONENT, config.aioredis.integration_name)
     span.set_tag_str(db.SYSTEM, redisx.APP)
-    span.set_tag(_SPAN_MEASURED_KEY)
+    # PERF: avoid setting via Span.set_tag
+    span.set_metric(_SPAN_MEASURED_KEY, 1)
     span.set_tag_str(redisx.RAWCMD, query)
     if pin.tags:
         span.set_tags(pin.tags)
@@ -227,7 +228,8 @@ async def traced_13_execute_pipeline(func, instance, args, kwargs):
             }
         )
 
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
         span.set_tag_str(redisx.RAWCMD, cmds_string)
         span.set_metric(redisx.PIPELINE_LEN, len(instance._pipeline))
 

--- a/ddtrace/contrib/internal/algoliasearch/patch.py
+++ b/ddtrace/contrib/internal/algoliasearch/patch.py
@@ -134,7 +134,8 @@ def _patched_search(func, instance, wrapt_args, wrapt_kwargs):
         # set span.kind to the type of request being performed
         span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
         if span.context.sampling_priority is not None and span.context.sampling_priority <= 0:
             return func(*wrapt_args, **wrapt_kwargs)
 

--- a/ddtrace/contrib/internal/asyncpg/patch.py
+++ b/ddtrace/contrib/internal/asyncpg/patch.py
@@ -121,7 +121,8 @@ async def _traced_query(pin, method, query, args, kwargs):
 
         # set span.kind to the type of request being performed
         span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
         span.set_tags(pin.tags)
 
         # dispatch DBM

--- a/ddtrace/contrib/internal/boto/patch.py
+++ b/ddtrace/contrib/internal/boto/patch.py
@@ -97,7 +97,8 @@ def patched_query_request(original_func, instance, args, kwargs):
         # set span.kind to the type of request being performed
         span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
 
         operation_name = None
         if args:
@@ -165,7 +166,8 @@ def patched_auth_request(original_func, instance, args, kwargs):
         service=schematize_service_name("{}.{}".format(pin.service, endpoint_name)),
         span_type=SpanTypes.HTTP,
     ) as span:
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
         if args:
             http_method = get_argument_value(args, kwargs, 0, "method")
             span.resource = "%s.%s" % (endpoint_name, http_method.lower())

--- a/ddtrace/contrib/internal/cassandra/session.py
+++ b/ddtrace/contrib/internal/cassandra/session.py
@@ -213,7 +213,8 @@ def _start_span_and_set_tags(
     span.set_tag_str(COMPONENT, config.cassandra.integration_name)
     span.set_tag_str(db.SYSTEM, "cassandra")
     span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
-    span.set_tag(_SPAN_MEASURED_KEY)
+    # PERF: avoid setting via Span.set_tag
+    span.set_metric(_SPAN_MEASURED_KEY, 1)
     span.set_tags(additional_tags)
     if query is not None:
         span.set_tag_str("cassandra.query", query)

--- a/ddtrace/contrib/internal/celery/app.py
+++ b/ddtrace/contrib/internal/celery/app.py
@@ -98,7 +98,8 @@ def _traced_beat_function(integration_config, fn_name, resource_fn=None):
             if resource_fn:
                 span.resource = resource_fn(args)
             span.set_tag_str(SPAN_KIND, SpanKind.PRODUCER)
-            span.set_tag(_SPAN_MEASURED_KEY)
+            # PERF: avoid setting via Span.set_tag
+            span.set_metric(_SPAN_MEASURED_KEY, 1)
 
             return func(*args, **kwargs)
 

--- a/ddtrace/contrib/internal/celery/signals.py
+++ b/ddtrace/contrib/internal/celery/signals.py
@@ -59,7 +59,8 @@ def trace_prerun(*args, **kwargs):
     # set component tag equal to name of integration
     span.set_tag_str(COMPONENT, config.celery.integration_name)
 
-    span.set_tag(_SPAN_MEASURED_KEY)
+    # PERF: avoid setting via Span.set_tag
+    span.set_metric(_SPAN_MEASURED_KEY, 1)
     attach_span(task, task_id, span)
     if config.celery["distributed_tracing"]:
         attach_span_context(task, task_id, span)
@@ -128,7 +129,8 @@ def trace_before_publish(*args, **kwargs):
     # set span.kind to the type of request being performed
     span.set_tag_str(SPAN_KIND, SpanKind.PRODUCER)
 
-    span.set_tag(_SPAN_MEASURED_KEY)
+    # PERF: avoid setting via Span.set_tag
+    span.set_metric(_SPAN_MEASURED_KEY, 1)
     span.set_tag_str(c.TASK_TAG_KEY, c.TASK_APPLY_ASYNC)
     span.set_tag_str("celery.id", task_id)
     set_tags_from_context(span, kwargs)

--- a/ddtrace/contrib/internal/consul/patch.py
+++ b/ddtrace/contrib/internal/consul/patch.py
@@ -78,7 +78,8 @@ def wrap_function(name):
             # set span.kind to the type of request being performed
             span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-            span.set_tag(_SPAN_MEASURED_KEY)
+            # PERF: avoid setting via Span.set_tag
+            span.set_metric(_SPAN_MEASURED_KEY, 1)
             span.set_tag_str(consulx.KEY, path)
             span.set_tag_str(consulx.CMD, resource)
             return wrapped(*args, **kwargs)

--- a/ddtrace/contrib/internal/dogpile_cache/region.py
+++ b/ddtrace/contrib/internal/dogpile_cache/region.py
@@ -23,7 +23,8 @@ def _wrap_get_create(func, instance, args, kwargs):
         span_type=SpanTypes.CACHE,
     ) as span:
         span.set_tag_str(COMPONENT, "dogpile_cache")
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
         span.set_tag("key", key)
         span.set_tag("region", instance.name)
         span.set_tag("backend", instance.actual_backend.__class__.__name__)
@@ -45,7 +46,8 @@ def _wrap_get_create_multi(func, instance, args, kwargs):
         span_type="cache",
     ) as span:
         span.set_tag_str(COMPONENT, "dogpile_cache")
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
         span.set_tag("keys", keys)
         span.set_tag("region", instance.name)
         span.set_tag("backend", instance.actual_backend.__class__.__name__)

--- a/ddtrace/contrib/internal/elasticsearch/patch.py
+++ b/ddtrace/contrib/internal/elasticsearch/patch.py
@@ -156,7 +156,8 @@ def _get_perform_request_coro(transport):
             # set span.kind to the type of request being performed
             span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-            span.set_tag(_SPAN_MEASURED_KEY)
+            # PERF: avoid setting via Span.set_tag
+            span.set_metric(_SPAN_MEASURED_KEY, 1)
 
             method, target = args
             params = kwargs.get("params")

--- a/ddtrace/contrib/internal/flask_cache/patch.py
+++ b/ddtrace/contrib/internal/flask_cache/patch.py
@@ -92,7 +92,8 @@ def get_traced_cache(ddtracer, service=DEFAULT_SERVICE, meta=None, cache_cls=Non
 
             s.set_tag_str(COMPONENT, config.flask_cache.integration_name)
 
-            s.set_tag(_SPAN_MEASURED_KEY)
+            # PERF: avoid setting via Span.set_tag
+            s.set_metric(_SPAN_MEASURED_KEY, 1)
             # set span tags
             s.set_tag_str(CACHE_BACKEND, self.config.get("CACHE_TYPE"))
             s.set_tags(self._datadog_meta)

--- a/ddtrace/contrib/internal/graphql/patch.py
+++ b/ddtrace/contrib/internal/graphql/patch.py
@@ -193,7 +193,8 @@ def _traced_execute(func, args, kwargs):
     ) as span:
         span.set_tag_str(COMPONENT, config.graphql.integration_name)
 
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
 
         _set_span_operation_tags(span, document)
         span.set_tag_str(_GRAPHQL_SOURCE, source_str)
@@ -223,7 +224,8 @@ def _traced_query(func, args, kwargs):
         span.set_tag_str(COMPONENT, config.graphql.integration_name)
 
         # mark span as measured and set sample rate
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
 
         result = func(*args, **kwargs)
         if isinstance(result, ExecutionResult):

--- a/ddtrace/contrib/internal/grpc/aio_client_interceptor.py
+++ b/ddtrace/contrib/internal/grpc/aio_client_interceptor.py
@@ -150,7 +150,8 @@ class _ClientInterceptor:
         # set span.kind to the type of operation being performed
         span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
 
         utils.set_grpc_method_meta(span, method_as_str, method_kind)
         utils.set_grpc_client_meta(span, self._host, self._port)

--- a/ddtrace/contrib/internal/grpc/aio_server_interceptor.py
+++ b/ddtrace/contrib/internal/grpc/aio_server_interceptor.py
@@ -190,7 +190,8 @@ def _create_span(pin, method, invocation_metadata, method_kind):
     # set span.kind to the type of operation being performed
     span.set_tag_str(SPAN_KIND, SpanKind.SERVER)
 
-    span.set_tag(_SPAN_MEASURED_KEY)
+    # PERF: avoid setting via Span.set_tag
+    span.set_metric(_SPAN_MEASURED_KEY, 1)
 
     set_grpc_method_meta(span, method, method_kind)
     span.set_tag_str(constants.GRPC_SPAN_KIND_KEY, constants.GRPC_SPAN_KIND_VALUE_SERVER)

--- a/ddtrace/contrib/internal/grpc/client_interceptor.py
+++ b/ddtrace/contrib/internal/grpc/client_interceptor.py
@@ -195,7 +195,8 @@ class _ClientInterceptor(
         # set span.kind to the type of operation being performed
         span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
 
         utils.set_grpc_method_meta(span, client_call_details.method, method_kind)
         utils.set_grpc_client_meta(span, self._host, self._port)

--- a/ddtrace/contrib/internal/grpc/server_interceptor.py
+++ b/ddtrace/contrib/internal/grpc/server_interceptor.py
@@ -99,7 +99,8 @@ class _TracedRpcMethodHandler(wrapt.ObjectProxy):
         # set span.kind tag equal to type of span
         span.set_tag_str(SPAN_KIND, SpanKind.SERVER)
 
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
 
         set_grpc_method_meta(span, self._handler_call_details.method, method_kind)
         span.set_tag_str(constants.GRPC_SPAN_KIND_KEY, constants.GRPC_SPAN_KIND_VALUE_SERVER)

--- a/ddtrace/contrib/internal/httpx/patch.py
+++ b/ddtrace/contrib/internal/httpx/patch.py
@@ -90,7 +90,8 @@ def _get_service_name(pin, request):
 
 def _init_span(span, request):
     # type: (Span, httpx.Request) -> None
-    span.set_tag(_SPAN_MEASURED_KEY)
+    # PERF: avoid setting via Span.set_tag
+    span.set_metric(_SPAN_MEASURED_KEY, 1)
 
     if distributed_tracing_enabled(config.httpx):
         HTTPPropagator.inject(span.context, request.headers)

--- a/ddtrace/contrib/internal/jinja2/patch.py
+++ b/ddtrace/contrib/internal/jinja2/patch.py
@@ -69,7 +69,8 @@ def _wrap_render(wrapped, instance, args, kwargs):
     with pin.tracer.trace("jinja2.render", pin.service, span_type=SpanTypes.TEMPLATE) as span:
         span.set_tag_str(COMPONENT, config.jinja2.integration_name)
 
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
         try:
             return wrapped(*args, **kwargs)
         finally:

--- a/ddtrace/contrib/internal/kafka/patch.py
+++ b/ddtrace/contrib/internal/kafka/patch.py
@@ -204,7 +204,8 @@ def traced_produce(func, instance, args, kwargs):
 
         span.set_tag(kafkax.PARTITION, partition)
         span.set_tag_str(kafkax.TOMBSTONE, str(value is None))
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
         if instance._dd_bootstrap_servers is not None:
             span.set_tag_str(kafkax.HOST_LIST, instance._dd_bootstrap_servers)
 
@@ -300,7 +301,8 @@ def _instrument_message(messages, pin, start_ns, instance, err):
                 pass
             span.set_tag_str(kafkax.TOMBSTONE, str(is_tombstone))
             span.set_tag(kafkax.MESSAGE_OFFSET, message_offset)
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
 
         if err is not None:
             span.set_exc_info(*sys.exc_info())

--- a/ddtrace/contrib/internal/kombu/patch.py
+++ b/ddtrace/contrib/internal/kombu/patch.py
@@ -121,7 +121,8 @@ def traced_receive(func, instance, args, kwargs):
         # set span.kind to the type of operation being performed
         s.set_tag_str(SPAN_KIND, SpanKind.CONSUMER)
 
-        s.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        s.set_metric(_SPAN_MEASURED_KEY, 1)
         # run the command
         exchange = message.delivery_info["exchange"]
         s.resource = exchange
@@ -149,7 +150,8 @@ def traced_publish(func, instance, args, kwargs):
         # set span.kind to the type of operation being performed
         s.set_tag_str(SPAN_KIND, SpanKind.PRODUCER)
 
-        s.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        s.set_metric(_SPAN_MEASURED_KEY, 1)
         exchange_name = get_exchange_from_args(args)
         s.resource = exchange_name
         s.set_tag_str(kombux.EXCHANGE, exchange_name)

--- a/ddtrace/contrib/internal/mako/patch.py
+++ b/ddtrace/contrib/internal/mako/patch.py
@@ -69,7 +69,8 @@ def _wrap_render(wrapped, instance, args, kwargs):
     ) as span:
         span.set_tag_str(COMPONENT, "mako")
 
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
         try:
             return wrapped(*args, **kwargs)
         finally:

--- a/ddtrace/contrib/internal/mysqldb/patch.py
+++ b/ddtrace/contrib/internal/mysqldb/patch.py
@@ -107,7 +107,8 @@ def _connect(func, instance, args, kwargs):
             # set span.kind to the type of operation being performed
             span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-            span.set_tag(_SPAN_MEASURED_KEY)
+            # PERF: avoid setting via Span.set_tag
+            span.set_metric(_SPAN_MEASURED_KEY, 1)
             conn = func(*args, **kwargs)
     return patch_conn(conn, *args, **kwargs)
 

--- a/ddtrace/contrib/internal/psycopg/async_connection.py
+++ b/ddtrace/contrib/internal/psycopg/async_connection.py
@@ -58,7 +58,8 @@ def patched_connect_async_factory(psycopg_module):
                 if span.get_tag(db.SYSTEM) is None:
                     span.set_tag_str(db.SYSTEM, pin._config.dbms_name)
 
-                span.set_tag(_SPAN_MEASURED_KEY)
+                # PERF: avoid setting via Span.set_tag
+                span.set_metric(_SPAN_MEASURED_KEY, 1)
                 conn = await connect_func(*args, **kwargs)
 
         return patch_conn(conn, pin=pin, traced_conn_cls=traced_conn_cls)

--- a/ddtrace/contrib/internal/psycopg/connection.py
+++ b/ddtrace/contrib/internal/psycopg/connection.py
@@ -102,7 +102,8 @@ def patched_connect_factory(psycopg_module):
                 if span.get_tag(db.SYSTEM) is None:
                     span.set_tag_str(db.SYSTEM, pin._config.dbms_name)
 
-                span.set_tag(_SPAN_MEASURED_KEY)
+                # PERF: avoid setting via Span.set_tag
+                span.set_metric(_SPAN_MEASURED_KEY, 1)
                 conn = connect_func(*args, **kwargs)
 
         return patch_conn(conn, pin=pin, traced_conn_cls=traced_conn_cls)

--- a/ddtrace/contrib/internal/psycopg/extensions.py
+++ b/ddtrace/contrib/internal/psycopg/extensions.py
@@ -42,7 +42,8 @@ def get_psycopg2_extensions(psycopg_module):
                 # set span.kind to the type of operation being performed
                 s.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-                s.set_tag(_SPAN_MEASURED_KEY)
+                # PERF: avoid setting via Span.set_tag
+                s.set_metric(_SPAN_MEASURED_KEY, 1)
                 if s.context.sampling_priority is None or s.context.sampling_priority <= 0:
                     return super(TracedCursor, self).execute(query, vars)
 

--- a/ddtrace/contrib/internal/pylibmc/client.py
+++ b/ddtrace/contrib/internal/pylibmc/client.py
@@ -172,7 +172,8 @@ class TracedClient(ObjectProxy):
         # set span.kind to the type of operation being performed
         span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
 
         try:
             self._tag_span(span)

--- a/ddtrace/contrib/internal/pymemcache/client.py
+++ b/ddtrace/contrib/internal/pymemcache/client.py
@@ -318,7 +318,8 @@ def _trace(func, p, method_name, *args, **kwargs):
         # set span.kind to the type of operation being performed
         span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
 
         # try to set relevant tags, catch any exceptions so we don't mess
         # with the application

--- a/ddtrace/contrib/internal/pymongo/client.py
+++ b/ddtrace/contrib/internal/pymongo/client.py
@@ -143,7 +143,8 @@ def _datadog_trace_operation(operation, wrapped):
     # set span.kind to the operation type being performed
     span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-    span.set_tag(_SPAN_MEASURED_KEY)
+    # PERF: avoid setting via Span.set_tag
+    span.set_metric(_SPAN_MEASURED_KEY, 1)
     span.set_tag_str(mongox.DB, cmd.db)
     span.set_tag_str(mongox.COLLECTION, cmd.coll)
     span.set_tag_str(db.SYSTEM, mongox.SERVICE)
@@ -266,7 +267,8 @@ def _trace_cmd(cmd, socket_instance, address):
     # set span.kind to the type of operation being performed
     s.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-    s.set_tag(_SPAN_MEASURED_KEY)
+    # PERF: avoid setting via Span.set_tag
+    s.set_metric(_SPAN_MEASURED_KEY, 1)
     if cmd.db:
         s.set_tag_str(mongox.DB, cmd.db)
     if cmd:

--- a/ddtrace/contrib/internal/pymongo/patch.py
+++ b/ddtrace/contrib/internal/pymongo/patch.py
@@ -146,7 +146,8 @@ def traced_get_socket(func, args, kwargs):
 
         with func(*args, **kwargs) as sock_info:
             set_address_tags(span, sock_info.address)
-            span.set_tag(_SPAN_MEASURED_KEY)
+            # PERF: avoid setting via Span.set_tag
+            span.set_metric(_SPAN_MEASURED_KEY, 1)
             # Ensure the pin used on the traced mongo client is passed down to the socket instance
             # (via the server instance)
             Pin.get_from(instance).onto(sock_info)

--- a/ddtrace/contrib/internal/pynamodb/patch.py
+++ b/ddtrace/contrib/internal/pynamodb/patch.py
@@ -75,7 +75,8 @@ def patched_api_call(original_func, instance, args, kwargs):
         # set span.kind to the type of operation being performed
         span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
 
         try:
             operation = get_argument_value(args, kwargs, 0, "operation_name")

--- a/ddtrace/contrib/internal/rediscluster/patch.py
+++ b/ddtrace/contrib/internal/rediscluster/patch.py
@@ -106,7 +106,8 @@ def traced_execute_pipeline(func, instance, args, kwargs):
         s.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
         s.set_tag_str(COMPONENT, config.rediscluster.integration_name)
         s.set_tag_str(db.SYSTEM, redisx.APP)
-        s.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        s.set_metric(_SPAN_MEASURED_KEY, 1)
         s.set_tag_str(redisx.RAWCMD, resource)
         s.set_metric(redisx.PIPELINE_LEN, len(instance.command_stack))
 

--- a/ddtrace/contrib/internal/requests/connection.py
+++ b/ddtrace/contrib/internal/requests/connection.py
@@ -93,7 +93,8 @@ def _wrap_send(func, instance, args, kwargs):
         # set span.kind to the type of operation being performed
         span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
 
         # Configure trace search sample rate
         # DEV: analytics enabled on per-session basis

--- a/ddtrace/contrib/internal/sqlalchemy/engine.py
+++ b/ddtrace/contrib/internal/sqlalchemy/engine.py
@@ -98,7 +98,8 @@ class EngineTracer(object):
         # set span.kind to the type of operation being performed
         span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
 
         if not _set_tags_from_url(span, conn.engine.url):
             _set_tags_from_cursor(span, self.vendor, cursor)

--- a/ddtrace/contrib/internal/vertica/patch.py
+++ b/ddtrace/contrib/internal/vertica/patch.py
@@ -235,7 +235,8 @@ def _install_routine(patch_routine, patch_class, patch_mod, config):
                 span.set_tag_str(SPAN_KIND, SpanKind.CLIENT)
 
                 if conf.get("measured", False):
-                    span.set_tag(_SPAN_MEASURED_KEY)
+                    # PERF: avoid setting via Span.set_tag
+                    span.set_metric(_SPAN_MEASURED_KEY, 1)
                 span.set_tags(pin.tags)
 
                 if "span_start" in conf:

--- a/ddtrace/llmobs/_integrations/base.py
+++ b/ddtrace/llmobs/_integrations/base.py
@@ -70,7 +70,8 @@ class BaseLLMIntegration:
         if self._is_instrumented_proxy_url(base_url):
             span._set_ctx_item(PROXY_REQUEST, True)
         # Enable trace metrics for these spans so users can see per-service openai usage in APM.
-        span.set_tag(_SPAN_MEASURED_KEY)
+        # PERF: avoid setting via Span.set_tag
+        span.set_metric(_SPAN_MEASURED_KEY, 1)
         self._set_base_span_tags(span, **kwargs)
         if self.llmobs_enabled:
             span._set_ctx_item(INTEGRATION, self._integration_name)


### PR DESCRIPTION
Span.set_tag does a bunch of type/value checking on the key/values set, and ultimately this ends up with just calling `Span.set_metric(_SPAN_MEASURED_KEY, 1)` anyways, so let's avoid the overhead of `Span.set_tag`.



The main optimization here is removing unnecessary `isinstance` checks and function calls, when really all we want is `Span._metrics[_SPAN_MEASURED_KEY] = 1`

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
