### PR TITLE
fix(ddtrace_api): avoid clobbering ddtrace_api's stored tracer instance

### DIFF
--- a/ddtrace/contrib/internal/ddtrace_api/patch.py
+++ b/ddtrace/contrib/internal/ddtrace_api/patch.py
@@ -91,7 +91,8 @@ def _supported_versions() -> Dict[str, str]:
 def patch(tracer=None):
     if getattr(ddtrace_api, "__datadog_patch", False):
         return
-    _STUB_TO_REAL[ddtrace_api.tracer] = tracer
+    if tracer is not None:
+        _STUB_TO_REAL[ddtrace_api.tracer] = tracer
 
     DDTraceAPIWrappingContextBase(ddtrace_api.Tracer.start_span).wrap()
     DDTraceAPIWrappingContextBase(ddtrace_api.Tracer.trace).wrap()

--- a/releasenotes/notes/ddtraceapi-clobber-809a4d88df9a29dc.yaml
+++ b/releasenotes/notes/ddtraceapi-clobber-809a4d88df9a29dc.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    ddtrace_api: Fixes a bug in the ddtrace_api integration in which `patch()` with no arguments, and
-    thus `patch_all()`, breaks the integration.
+    ddtrace_api: Fixes a bug in the ddtrace_api integration in which ``patch()`` with no arguments, and
+    thus ``patch_all()``, breaks the integration.

--- a/releasenotes/notes/ddtraceapi-clobber-809a4d88df9a29dc.yaml
+++ b/releasenotes/notes/ddtraceapi-clobber-809a4d88df9a29dc.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    ddtrace_api: Fixes a bug in the ddtrace_api integration in which `patch()` with no arguments, and
+    thus `patch_all()`, breaks the integration.


### PR DESCRIPTION
Fixes a bug in the ddtrace_api integration in which `patch()` with no arguments, and thus `patch_all()`, breaks the integration.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
