### PR TITLE
perf(span): deprecate Span._pprint, use repr and fstrings instead

### DIFF
--- a/ddtrace/_trace/_span_link.py
+++ b/ddtrace/_trace/_span_link.py
@@ -122,6 +122,6 @@ class SpanLink:
 
     def __str__(self) -> str:
         return (
-            f"trace_id={self.trace_id} span_id={self.span_id} attributes={self.attributes} "
+            f"trace_id={self.trace_id} span_id={self.span_id} attributes={dict(self.attributes)} "
             f"tracestate={self.tracestate} flags={self.flags} dropped_attributes={self._dropped_attributes}"
         )

--- a/ddtrace/_trace/_span_link.py
+++ b/ddtrace/_trace/_span_link.py
@@ -122,6 +122,6 @@ class SpanLink:
 
     def __repr__(self) -> str:
         return (
-            f"SpanLink(trace_id={self.trace_id}, span_id={self.span_id}, attributes={self.attributes} "
+            f"SpanLink(trace_id={self.trace_id}, span_id={self.span_id}, attributes={self.attributes}, "
             f"tracestate={self.tracestate}, flags={self.flags}, dropped_attributes={self._dropped_attributes})"
         )

--- a/ddtrace/_trace/_span_link.py
+++ b/ddtrace/_trace/_span_link.py
@@ -120,8 +120,8 @@ class SpanLink:
 
         return d
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return (
-            f"trace_id={self.trace_id} span_id={self.span_id} attributes={dict(self.attributes)} "
-            f"tracestate={self.tracestate} flags={self.flags} dropped_attributes={self._dropped_attributes}"
+            f"SpanLink(trace_id={self.trace_id}, span_id={self.span_id}, attributes={self.attributes} "
+            f"tracestate={self.tracestate}, flags={self.flags}, dropped_attributes={self._dropped_attributes})"
         )

--- a/ddtrace/_trace/_span_link.py
+++ b/ddtrace/_trace/_span_link.py
@@ -121,8 +121,7 @@ class SpanLink:
         return d
 
     def __str__(self) -> str:
-        attrs_str = ",".join([f"{k}:{v}" for k, v in self.attributes.items()])
         return (
-            f"trace_id={self.trace_id} span_id={self.span_id} attributes={attrs_str} "
+            f"trace_id={self.trace_id} span_id={self.span_id} attributes={self.attributes} "
             f"tracestate={self.tracestate} flags={self.flags} dropped_attributes={self._dropped_attributes}"
         )

--- a/ddtrace/_trace/_span_pointer.py
+++ b/ddtrace/_trace/_span_pointer.py
@@ -64,7 +64,7 @@ class _SpanPointer(SpanLink):
     def __repr__(self):
         return (
             f"SpanPointer(trace_id={self.trace_id}, span_id={self.span_id}, kind={self.kind}, "
-            f"direction={self.direction}, hash={self.hash}, attributes={dict(self.attributes)})"
+            f"direction={self.direction}, hash={self.hash}, attributes={self.attributes})"
         )
 
 

--- a/ddtrace/_trace/_span_pointer.py
+++ b/ddtrace/_trace/_span_pointer.py
@@ -64,7 +64,7 @@ class _SpanPointer(SpanLink):
     def __repr__(self):
         return (
             f"SpanPointer(trace_id={self.trace_id}, span_id={self.span_id}, kind={self.kind}, "
-            f"direction={self.direction}, hash={self.hash})"
+            f"direction={self.direction}, hash={self.hash}, attributes={dict(self.attributes)})"
         )
 
 

--- a/ddtrace/_trace/_span_pointer.py
+++ b/ddtrace/_trace/_span_pointer.py
@@ -61,6 +61,12 @@ class _SpanPointer(SpanLink):
         # Do not want to do the trace_id and span_id checks that SpanLink does.
         pass
 
+    def __repr__(self):
+        return (
+            f"SpanPointer(trace_id={self.trace_id}, span_id={self.span_id}, kind={self.kind}, "
+            f"direction={self.direction}, hash={self.hash})"
+        )
+
 
 _STANDARD_HASHING_FUNCTION_FAILURE_PREFIX = "HashingFailure"
 

--- a/ddtrace/_trace/context.py
+++ b/ddtrace/_trace/context.py
@@ -286,14 +286,10 @@ class Context(object):
         return False
 
     def __repr__(self) -> str:
-        return "Context(trace_id=%s, span_id=%s, _meta=%s, _metrics=%s, _span_links=%s, _baggage=%s, _is_remote=%s)" % (
-            self.trace_id,
-            self.span_id,
-            self._meta,
-            self._metrics,
-            self._span_links,
-            self._baggage,
-            self._is_remote,
+        return (
+            f"Context(trace_id={self.trace_id}, span_id={self.span_id}, _meta={self._meta}, "
+            f"_metrics={self._metrics}, _span_links={self._span_links}, _baggage={self._baggage}, "
+            f"_is_remote={self._is_remote})"
         )
 
     def __hash__(self) -> int:

--- a/ddtrace/_trace/context.py
+++ b/ddtrace/_trace/context.py
@@ -294,5 +294,3 @@ class Context(object):
 
     def __hash__(self) -> int:
         return hash(self.trace_id)
-
-    __str__ = __repr__

--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -1,6 +1,7 @@
 import abc
 from collections import defaultdict
 from itertools import chain
+import logging
 from threading import RLock
 from typing import Any
 from typing import DefaultDict
@@ -414,18 +415,19 @@ class SpanAggregator(SpanProcessor):
         # This ensures all remaining counts are sent before the tracer is shutdown.
         self._queue_span_count_metrics("spans_finished", "integration_name", 1)
         # Log a warning if the tracer is shutdown before spans are finished
-        unfinished_spans = [
-            f"trace_id={s.trace_id} parent_id={s.parent_id} span_id={s.span_id} name={s.name} resource={s.resource} started={s.start} sampling_priority={s.context.sampling_priority}"  # noqa: E501
-            for t in self._traces.values()
-            for s in t.spans
-            if not s.finished
-        ]
-        if unfinished_spans:
-            log.warning(
-                "Shutting down tracer with %d unfinished spans. Unfinished spans will not be sent to Datadog: %s",
-                len(unfinished_spans),
-                ", ".join(unfinished_spans),
-            )
+        if log.isEnabledFor(logging.WARNING):
+            unfinished_spans = [
+                f"trace_id={s.trace_id} parent_id={s.parent_id} span_id={s.span_id} name={s.name} resource={s.resource} started={s.start} sampling_priority={s.context.sampling_priority}"  # noqa: E501
+                for t in self._traces.values()
+                for s in t.spans
+                if not s.finished
+            ]
+            if unfinished_spans:
+                log.warning(
+                    "Shutting down tracer with %d unfinished spans. Unfinished spans will not be sent to Datadog: %s",
+                    len(unfinished_spans),
+                    ", ".join(unfinished_spans),
+                )
 
         try:
             self._traces.clear()

--- a/ddtrace/_trace/sampling_rule.py
+++ b/ddtrace/_trace/sampling_rule.py
@@ -190,8 +190,6 @@ class SamplingRule(object):
             self.provenance,
         )
 
-    __str__ = __repr__
-
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, SamplingRule):
             return False

--- a/ddtrace/_trace/sampling_rule.py
+++ b/ddtrace/_trace/sampling_rule.py
@@ -180,14 +180,9 @@ class SamplingRule(object):
         return GlobMatcher(prop)
 
     def __repr__(self):
-        return "{}(sample_rate={!r}, service={!r}, name={!r}, resource={!r}, tags={!r}, provenance={!r})".format(
-            self.__class__.__name__,
-            self.sample_rate,
-            self._no_rule_or_self(self.service),
-            self._no_rule_or_self(self.name),
-            self._no_rule_or_self(self.resource),
-            self._no_rule_or_self(self.tags),
-            self.provenance,
+        return (
+            f"SamplingRule(sample_rate={self.sample_rate}, service={self.service}, "
+            f"name={self.name}, resource={self.resource}, tags={self.tags}, provenance={self.provenance})"
         )
 
     def __eq__(self, other: Any) -> bool:

--- a/ddtrace/_trace/sampling_rule.py
+++ b/ddtrace/_trace/sampling_rule.py
@@ -147,7 +147,7 @@ class SamplingRule(object):
     def __repr__(self):
         return (
             f"SamplingRule(sample_rate={self.sample_rate}, service={self.service}, "
-            f"name={self.name}, resource={self.resource}, tags={dict(self.tags)}, provenance={self.provenance})"
+            f"name={self.name}, resource={self.resource}, tags={self.tags}, provenance={self.provenance})"
         )
 
     def __eq__(self, other: Any) -> bool:

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -853,7 +853,7 @@ class Span(object):
             f"resource='{self.resource}', "
             f"type='{self.span_type}', "
             f"start={self.start_ns}, "
-            f"end={self.duration_ns and self.start_ns + self.duration_ns}, "
+            f"end={self.duration_ns and self.start_ns and self.start_ns + self.duration_ns}, "
             f"duration={self.duration_ns}, "
             f"error={self.error}, "
             f"tags={dict(self._meta)}, "

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -1,6 +1,5 @@
 from io import StringIO
 import math
-import pprint
 import sys
 import traceback
 from types import TracebackType
@@ -80,14 +79,13 @@ class SpanEvent:
             d["attributes"] = self.attributes
         return d
 
-    def __str__(self):
+    def __repr__(self):
         """
         Stringify and return value.
         Attribute value can be either str, bool, int, float, or a list of these.
         """
-
         attrs_str = ",".join(f"{k}:{v}" for k, v in self.attributes.items())
-        return f"name={self.name} time={self.time_unix_nano} attributes={attrs_str}"
+        return f"SpanEvent(name='{self.name}', time={self.time_unix_nano}, attributes={attrs_str})"
 
     def __iter__(self):
         yield "name", self.name
@@ -704,31 +702,6 @@ class Span(object):
 
         return False
 
-    def _pprint(self) -> str:
-        """Return a human readable version of the span."""
-        data = [
-            ("name", self.name),
-            ("id", self.span_id),
-            ("trace_id", self.trace_id),
-            ("parent_id", self.parent_id),
-            ("service", self.service),
-            ("resource", self.resource),
-            ("type", self.span_type),
-            ("start", self.start),
-            ("end", None if not self.duration else self.start + self.duration),
-            ("duration", self.duration),
-            ("error", self.error),
-            ("tags", dict(sorted(self._meta.items()))),
-            ("metrics", dict(sorted(self._metrics.items()))),
-            ("links", ", ".join([str(link) for link in self._links])),
-            ("events", ", ".join([str(e) for e in self._events])),
-        ]
-        return " ".join(
-            # use a large column width to keep pprint output on one line
-            "%s=%s" % (k, pprint.pformat(v, width=1024**2).strip())
-            for (k, v) in data
-        )
-
     @property
     def context(self) -> Context:
         """Return the trace context for this span."""
@@ -857,7 +830,38 @@ class Span(object):
         except Exception:
             log.exception("error closing trace")
 
+    def _pprint(self) -> str:
+        deprecate(
+            prefix="The _pprint method is deprecated for __repr__",
+            message="""Use __repr__ instead.""",
+            category=DDTraceDeprecationWarning,
+            removal_version="4.0.0",
+        )
+        return self.__repr__()
+
     def __repr__(self) -> str:
+        """Return a detailed string representation of a span."""
+        return (
+            f"Span(name='{self.name}', "
+            f"span_id={self.span_id}, "
+            f"parent_id={self.parent_id}, "
+            f"trace_id={self.trace_id}, "
+            f"service='{self.service}', "
+            f"resource='{self.resource}', "
+            f"type='{self.span_type}', "
+            f"start={self.start_ns}, "
+            f"end={self.duration_ns and self.start_ns + self.duration_ns}, "
+            f"duration={self.duration_ns}, "
+            f"error={self.error}, "
+            f"tags={dict(self._meta)}, "
+            f"metrics={dict(self._metrics)}, "
+            f"links={self._links}, "
+            f"events={self._events}, "
+            f"context={self._context})"
+        )
+
+    def __str__(self) -> str:
+        """Return a concise string representation of a span."""
         return "<Span(id=%s,trace_id=%s,parent_id=%s,name=%s)>" % (
             self.span_id,
             self.trace_id,

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -84,8 +84,7 @@ class SpanEvent:
         Stringify and return value.
         Attribute value can be either str, bool, int, float, or a list of these.
         """
-        attrs_str = ",".join(f"{k}:{v}" for k, v in self.attributes.items())
-        return f"SpanEvent(name='{self.name}', time={self.time_unix_nano}, attributes={attrs_str})"
+        return f"SpanEvent(name='{self.name}', time={self.time_unix_nano}, attributes={dict(self.attributes)})"
 
     def __iter__(self):
         yield "name", self.name

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -831,6 +831,9 @@ class Span(object):
             log.exception("error closing trace")
 
     def _pprint(self) -> str:
+        # Although Span._pprint has been internal to ddtrace since v1.0.0, it is still
+        # used to debug spans in the wild. Introducing a deprecation warning here to
+        # give users a chance to migrate to __repr__ before we remove it.
         deprecate(
             prefix="The _pprint method is deprecated for __repr__",
             message="""Use __repr__ instead.""",

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -84,7 +84,7 @@ class SpanEvent:
         Stringify and return value.
         Attribute value can be either str, bool, int, float, or a list of these.
         """
-        return f"SpanEvent(name='{self.name}', time={self.time_unix_nano}, attributes={dict(self.attributes)})"
+        return f"SpanEvent(name='{self.name}', time={self.time_unix_nano}, attributes={self.attributes})"
 
     def __iter__(self):
         yield "name", self.name
@@ -855,8 +855,8 @@ class Span(object):
             f"end={self.duration_ns and self.start_ns and self.start_ns + self.duration_ns}, "
             f"duration={self.duration_ns}, "
             f"error={self.error}, "
-            f"tags={dict(self._meta)}, "
-            f"metrics={dict(self._metrics)}, "
+            f"tags={self._meta}, "
+            f"metrics={self._metrics}, "
             f"links={self._links}, "
             f"events={self._events}, "
             f"context={self._context})"

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -627,7 +627,7 @@ class Tracer(object):
                     p.on_span_finish(span)
 
         core.dispatch("trace.span_finish", (span,))
-        log.debug("finishing span %r (enabled:%s)", span, self.enabled)
+        log.debug("finishing span - %r (enabled:%s)", span, self.enabled)
 
     def _log_compat(self, level, msg):
         """Logs a message for the given level.

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -627,9 +627,7 @@ class Tracer(object):
                     p.on_span_finish(span)
 
         core.dispatch("trace.span_finish", (span,))
-
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug("finishing span %s (enabled:%s)", span.__repr__(), self.enabled)
+        log.debug("finishing span %r (enabled:%s)", span, self.enabled)
 
     def _log_compat(self, level, msg):
         """Logs a message for the given level.

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -629,7 +629,7 @@ class Tracer(object):
         core.dispatch("trace.span_finish", (span,))
 
         if log.isEnabledFor(logging.DEBUG):
-            log.debug("finishing span %s (enabled:%s)", span._pprint(), self.enabled)
+            log.debug("finishing span %s (enabled:%s)", span.__repr__(), self.enabled)
 
     def _log_compat(self, level, msg):
         """Logs a message for the given level.

--- a/ddtrace/contrib/internal/celery/app.py
+++ b/ddtrace/contrib/internal/celery/app.py
@@ -135,7 +135,7 @@ def _traced_apply_async_function(integration_config, fn_name, resource_fn=None):
                 if task_span:
                     log.debug(
                         "The after_task_publish signal was not called, so manually closing span: %s",
-                        task_span._pprint(),
+                        task_span.__repr__(),
                     )
                     task_span.finish()
 

--- a/ddtrace/contrib/internal/celery/app.py
+++ b/ddtrace/contrib/internal/celery/app.py
@@ -134,8 +134,8 @@ def _traced_apply_async_function(integration_config, fn_name, resource_fn=None):
                 task_span = core.get_item("task_span")
                 if task_span:
                     log.debug(
-                        "The after_task_publish signal was not called, so manually closing span: %s",
-                        task_span.__repr__(),
+                        "The after_task_publish signal was not called, so manually closing span: %r",
+                        task_span,
                     )
                     task_span.finish()
 

--- a/ddtrace/internal/glob_matching.py
+++ b/ddtrace/internal/glob_matching.py
@@ -52,7 +52,7 @@ class GlobMatcher(object):
             return False
         return True
 
-    def __str__(self):
+    def __repr__(self):
         return f"GlobMatcher(pattern={self.pattern})"
 
     def __eq__(self, other):

--- a/ddtrace/internal/rate_limiter.py
+++ b/ddtrace/internal/rate_limiter.py
@@ -163,8 +163,6 @@ class RateLimiter(object):
             self.effective_rate,
         )
 
-    __str__ = __repr__
-
 
 class RateLimitExceeded(Exception):
     pass

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -295,7 +295,7 @@ def test_startup_logs_sampling_rules():
     f = debug.collect(tracer)
 
     assert f.get("sampling_rules") == [
-        "SamplingRule(sample_rate=1.0, service=None, name=None, resource=None, tags={}, provenance='default')"
+        "SamplingRule(sample_rate=1.0, service=None, name=None, resource=None, tags={}, provenance=default)"
     ], f.get("sampling_rules")
 
 

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -363,7 +363,7 @@ def test_debug_span_log():
     )
     p.wait()
     stderr = p.stderr.read()
-    assert b"finishing span name='span'" in stderr
+    assert b"finishing span - Span(name='span'" in stderr
 
 
 @pytest.mark.subprocess(

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -871,8 +871,8 @@ def _value():
         {"service": True},
         {"resource": 50},
         {"name": [1, 2, 3]},
-        {"start_ns": "start_time"},
-        {"duration_ns": "duration_time"},
+        {"start_ns": []},
+        {"duration_ns": {}},
         {"span_type": 100},
         {"_meta": {"num": 100}},
         # Validating behavior with a context manager is a customer regression
@@ -891,7 +891,7 @@ def test_encoding_invalid_data(data):
     with pytest.raises(RuntimeError) as e:
         encoder.put(trace)
 
-    assert e.match(r"failed to pack span: <Span\(id="), e
+    assert e.match(r"failed to pack span: Span\(name="), e
     encoded_traces = encoder.encode()
     assert (not encoded_traces) or (encoded_traces[0][0] is None)
 

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from functools import partial
-import re
 import sys
 import time
 import traceback
@@ -11,6 +10,7 @@ import pytest
 
 from ddtrace._trace._span_link import SpanLink
 from ddtrace._trace._span_pointer import _SpanPointerDirection
+from ddtrace._trace.context import Context
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import ENV_KEY
 from ddtrace.constants import ERROR_MSG
@@ -850,7 +850,7 @@ def test_span_preconditions(arg):
 
 
 def test_span_pprint():
-    root = Span("test.span", service="s", resource="r", span_type=SpanTypes.WEB)
+    root = Span("test.span", service="s", resource="r", span_type=SpanTypes.WEB, context=Context(trace_id=1, span_id=2))
     root.set_tag("t", "v")
     root.set_metric("m", 1.0)
     root._add_event("message", {"importance": 10}, 16789898242)
@@ -865,36 +865,32 @@ def test_span_pprint():
     assert "error=0" in actual
     assert "tags={'t': 'v'}" in actual
     assert "metrics={'m': 1.0}" in actual
-    assert "events='name=message time=16789898242 attributes=importance:10'" in actual
+    assert "events=[SpanEvent(name='message', time=16789898242, attributes=importance:10)]" in actual
     assert (
-        "links='trace_id=99 span_id=10 attributes=link.name:s1_to_s2,link.kind:scheduled_by "
-        "tracestate=None flags=None dropped_attributes=0'" in actual
+        "links=[SpanLink(trace_id=99, span_id=10, tracestate=None, flags=None, "
+        "attributes={'link.name': 's1_to_s2', 'link.kind': 'scheduled_by'}, "
+        "_dropped_attributes=0)]" in actual
     )
-    assert re.search("id=[0-9]+", actual) is not None
-    assert re.search("trace_id=[0-9]+", actual) is not None
-    assert "parent_id=None" in actual
-    assert re.search("duration=[0-9.]+", actual) is not None
-    assert re.search("start=[0-9.]+", actual) is not None
-    assert re.search("end=[0-9.]+", actual) is not None
-
-    root = Span("test.span", service="s", resource="r", span_type=SpanTypes.WEB)
-    actual = root._pprint()
-    assert "duration=None" in actual
-    assert "end=None" in actual
+    assert (
+        f"context=Context(trace_id={root.trace_id}, span_id={root.span_id}, _meta={{}}, "
+        "_metrics={}, _span_links=[], _baggage={}, _is_remote=False)"
+    ) in actual
+    assert f"span_id={root.span_id}" in actual
+    assert f"trace_id={root.trace_id}" in actual
+    assert f"parent_id={root.parent_id}" in actual
+    assert f"start={root.start_ns}" in actual
+    assert f"duration={root.duration_ns}" in actual
+    assert f"end={root.start_ns + root.duration_ns}" in actual
 
     root = Span("test.span", service="s", resource="r", span_type=SpanTypes.WEB)
     root.error = 1
+    kv = {f"😌{i}": "😌" for i in range(100)}
+    root.set_tags(kv)
     actual = root._pprint()
+    assert "duration=None" in actual
+    assert "end=None" in actual
     assert "error=1" in actual
-
-    root = Span("test.span", service="s", resource="r", span_type=SpanTypes.WEB)
-    root.set_tag("😌", "😌")
-    actual = root._pprint()
-    assert "tags={'😌': '😌'}" in actual
-
-    root = Span("test.span", service=object())
-    actual = root._pprint()
-    assert "service=<object object at" in actual
+    assert f"tags={kv}" in actual
 
 
 def test_manual_context_usage():

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -865,12 +865,11 @@ def test_span_pprint():
     assert "error=0" in actual
     assert "tags={'t': 'v'}" in actual
     assert "metrics={'m': 1.0}" in actual
-    assert "events=[SpanEvent(name='message', time=16789898242, attributes=importance:10)]" in actual
+    assert "events=[SpanEvent(name='message', time=16789898242, attributes={'importance': 10})]" in actual
     assert (
-        "links=[SpanLink(trace_id=99, span_id=10, tracestate=None, flags=None, "
-        "attributes={'link.name': 's1_to_s2', 'link.kind': 'scheduled_by'}, "
-        "_dropped_attributes=0)]" in actual
-    )
+        "[SpanLink(trace_id=99, span_id=10, attributes={'link.name': 's1_to_s2', 'link.kind': 'scheduled_by'}, "
+        "tracestate=None, flags=None, dropped_attributes=0)]"
+    ) in actual
     assert (
         f"context=Context(trace_id={root.trace_id}, span_id={root.span_id}, _meta={{}}, "
         "_metrics={}, _span_links=[], _baggage={}, _is_remote=False)"


### PR DESCRIPTION
## Description

This PR removes all internal usages of `Span._pprint()`, which is deprecated and will be removed in ddtrace v4.0.0, while delivering significant performance improvements to span formatting.

## Changes

API Migration
- Replace all internal calls to `Span._pprint()` with `Span.__repr__()` across:
  - Span finish debug logs
  - Celery integration
  - Internal debugging utilities
- Performance Optimizations
  - Rewrite `Span.__repr__()` to use f-strings instead of the slow pprint module (5-10x faster)
  - Remove unnecessary sorting and formatting operations from span representation
  - Eliminate redundant `__str__ = __repr__` assignments in classes that already define `__repr__()`
- Enhanced Debugging
   - Add `__repr__` methods to SpanEvent, SpanPointer, and SpanLink objects for better span representations
   - Add Span.context property to `Span.__repr__()` for improved debugging of trace-level tags and distributed tracing

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
