### PR TITLE
chore(ci_visibility): restore log level for Test Optimization log messages

### DIFF
--- a/ddtrace/internal/ci_visibility/utils.py
+++ b/ddtrace/internal/ci_visibility/utils.py
@@ -131,6 +131,7 @@ def take_over_logger_stream_handler(remove_ddtrace_stream_handlers=True):
 
     try:
         ci_visibility_handler.setLevel(level.upper())
+        ddtrace_logger.setLevel(level.upper())
     except ValueError:
         log.warning("Invalid log level: %s", level)
         return


### PR DESCRIPTION
With PR #14121, we stopped propagating logs to the root logger, so the root logging level is not used by Test Optimization messages anymore; we need to explicitly set the log level for the ddtrace logger as well.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
