### PR TITLE
docs: fix failing doc builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ class VersionTagFilter(Filter):
 
 # append the ddtrace path to syspath
 # this is required when building the docs manually
-if os.getenv("READTHEDOCS") == "True":
+if not os.getenv("READTHEDOCS") == "True":
     sys.path.insert(0, os.path.abspath(".."))
 
 


### PR DESCRIPTION
Looks like we accidentally removed a `not` from the check for whether or not we append the `ddtrace` path to syspath (see PR [here](https://github.com/DataDog/dd-trace-py/pull/14105/files)). This should have been for cases where `READTHEDOCS` is NOT TRUE. With this set to true, the builds have been failing due to:
```
autodoc: failed to import module 'contrib.internal.logging' from module 'ddtrace'; the following exception was raised:
--
  | No module named 'ddtrace.internal.native._native'
```

See passing build for this branch [here](https://app.readthedocs.org/projects/ddtrace/builds/29005040/).

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
