### PR TITLE
chore(docs): update opentelemetry doc for span events support

### DIFF
--- a/ddtrace/opentelemetry/__init__.py
+++ b/ddtrace/opentelemetry/__init__.py
@@ -101,7 +101,7 @@ The OpenTelemetry API support implementation maps OpenTelemetry spans to Datadog
       - Derived from status
     * - ``events[]``
       - ``meta["events"]``
-      -
+      - Note: span events are stored as ``Span.span_events`` if v0.4 API is used
 
 
 """  # noqa: E501

--- a/ddtrace/opentelemetry/__init__.py
+++ b/ddtrace/opentelemetry/__init__.py
@@ -100,7 +100,7 @@ The OpenTelemetry API support implementation maps OpenTelemetry spans to Datadog
       - ``error``
       - Derived from status
     * - ``events[]``
-      - ``_events[]``
+      - ``meta["events"]``
       -
 
 

--- a/ddtrace/opentelemetry/__init__.py
+++ b/ddtrace/opentelemetry/__init__.py
@@ -100,8 +100,8 @@ The OpenTelemetry API support implementation maps OpenTelemetry spans to Datadog
       - ``error``
       - Derived from status
     * - ``events[]``
-      - N/A
-      - Span events not supported on the Datadog platform
+      - ``_events[]``
+      -
 
 
 """  # noqa: E501


### PR DESCRIPTION
Update the outdated opentelemetry ddtrace docs, which (now incorrectly) stated that span events are not supported. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
