### PR TITLE
ci: install libenchant in base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update \
       git \
       jq \
       libbz2-dev \
+      libenchant-2-dev \
       libffi-dev \
       liblzma-dev \
       libmariadb-dev \

--- a/scripts/docs/install.sh
+++ b/scripts/docs/install.sh
@@ -5,15 +5,8 @@ set -ex
 if [[ "${READTHEDOCS}" = "True" ]]; then
     # We skip here because we do not check spelling in RTD
     echo "Skipping install"
-else
-  if [[ "$(uname)" == "Darwin" ]]; then
-    brew install enchant
-  else
-    export DEBIAN_FRONTEND="noninteractive"
-    export DEBCONF_NOWARNINGS="yes"
+elif [[ "$(uname)" == "Darwin" ]]; then
+  brew install enchant
 
-    apt-get -qq update
-    apt-get -qy install --no-install-recommends libenchant-2-dev >/dev/null ||
-        apt-get -qy install --no-install-recommends libenchant-dev >/dev/null
-  fi
+# libenchant is already installed in our base dev image docker/Dockerfile
 fi

--- a/scripts/docs/install.sh
+++ b/scripts/docs/install.sh
@@ -5,8 +5,15 @@ set -ex
 if [[ "${READTHEDOCS}" = "True" ]]; then
     # We skip here because we do not check spelling in RTD
     echo "Skipping install"
-elif [[ "$(uname)" == "Darwin" ]]; then
-  brew install enchant
+else
+  if [[ "$(uname)" == "Darwin" ]]; then
+    brew install enchant
+  else
+    export DEBIAN_FRONTEND="noninteractive"
+    export DEBCONF_NOWARNINGS="yes"
 
-# libenchant is already installed in our base dev image docker/Dockerfile
+    apt-get -qq update
+    apt-get -qy install --no-install-recommends libenchant-2-dev >/dev/null ||
+        apt-get -qy install --no-install-recommends libenchant-dev >/dev/null
+  fi
 fi


### PR DESCRIPTION
LANGPLAT-661

The new testrunner image runs as `bits` and not `root` so we cannot run `apt`/`apt-get` to install packages.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
