### PR TITLE
chore(llmobs): add underlying support for tool definitions

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -18,6 +18,7 @@ INPUT_DOCUMENTS = "_ml_obs.meta.input.documents"
 INPUT_MESSAGES = "_ml_obs.meta.input.messages"
 INPUT_VALUE = "_ml_obs.meta.input.value"
 INPUT_PROMPT = "_ml_obs.meta.input.prompt"
+TOOLS = "_ml_obs.meta.tool_definitions"
 
 OUTPUT_DOCUMENTS = "_ml_obs.meta.output.documents"
 OUTPUT_MESSAGES = "_ml_obs.meta.output.messages"

--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -18,7 +18,7 @@ INPUT_DOCUMENTS = "_ml_obs.meta.input.documents"
 INPUT_MESSAGES = "_ml_obs.meta.input.messages"
 INPUT_VALUE = "_ml_obs.meta.input.value"
 INPUT_PROMPT = "_ml_obs.meta.input.prompt"
-TOOLS = "_ml_obs.meta.tool_definitions"
+TOOL_DEFINITIONS = "_ml_obs.meta.tool_definitions"
 
 OUTPUT_DOCUMENTS = "_ml_obs.meta.output.documents"
 OUTPUT_MESSAGES = "_ml_obs.meta.output.messages"

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -78,6 +78,7 @@ from ddtrace.llmobs._constants import SPAN_KIND
 from ddtrace.llmobs._constants import SPAN_LINKS
 from ddtrace.llmobs._constants import SPAN_START_WHILE_DISABLED_WARNING
 from ddtrace.llmobs._constants import TAGS
+from ddtrace.llmobs._constants import TOOLS
 from ddtrace.llmobs._context import LLMObsContextProvider
 from ddtrace.llmobs._evaluators.runner import EvaluatorRunner
 from ddtrace.llmobs._experiment import Dataset
@@ -304,6 +305,8 @@ class LLMObs(Service):
                 )
             else:
                 meta["input"]["prompt"] = prompt_json_str
+        if span._get_ctx_item(TOOLS) is not None:
+            meta["tool_definitions"] = span._get_ctx_item(TOOLS)
         if span.error:
             meta.update(
                 {

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -78,7 +78,7 @@ from ddtrace.llmobs._constants import SPAN_KIND
 from ddtrace.llmobs._constants import SPAN_LINKS
 from ddtrace.llmobs._constants import SPAN_START_WHILE_DISABLED_WARNING
 from ddtrace.llmobs._constants import TAGS
-from ddtrace.llmobs._constants import TOOLS
+from ddtrace.llmobs._constants import TOOL_DEFINITIONS
 from ddtrace.llmobs._context import LLMObsContextProvider
 from ddtrace.llmobs._evaluators.runner import EvaluatorRunner
 from ddtrace.llmobs._experiment import Dataset
@@ -305,8 +305,8 @@ class LLMObs(Service):
                 )
             else:
                 meta["input"]["prompt"] = prompt_json_str
-        if span._get_ctx_item(TOOLS) is not None:
-            meta["tool_definitions"] = span._get_ctx_item(TOOLS)
+        if span._get_ctx_item(TOOL_DEFINITIONS) is not None:
+            meta["tool_definitions"] = span._get_ctx_item(TOOL_DEFINITIONS)
         if span.error:
             meta.update(
                 {

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -85,7 +85,7 @@ def _expected_llmobs_llm_span_event(
     error_message=None,
     error_stack=None,
     span_links=False,
-    tools=None,
+    tool_definitions=None,
 ):
     """
     Helper function to create an expected LLM span event.
@@ -102,7 +102,7 @@ def _expected_llmobs_llm_span_event(
     error_message: error message
     error_stack: error stack
     span_links: whether there are span links present on this span.
-    tools: list of tool definitions that were available to the LLM
+    tool_definitions: list of tool definitions that were available to the LLM
     """
     span_event = _llmobs_base_span_event(
         span, span_kind, tags, session_id, error, error_message, error_stack, span_links
@@ -144,8 +144,8 @@ def _expected_llmobs_llm_span_event(
         meta_dict.update({"model_name": model_name})
     if model_provider is not None:
         meta_dict.update({"model_provider": model_provider})
-    if tools is not None:
-        meta_dict["tool_definitions"] = tools
+    if tool_definitions is not None:
+        meta_dict["tool_definitions"] = tool_definitions
     meta_dict.update({"metadata": metadata or {}})
     span_event["meta"].update(meta_dict)
     if token_metrics is not None:

--- a/tests/llmobs/_utils.py
+++ b/tests/llmobs/_utils.py
@@ -85,6 +85,7 @@ def _expected_llmobs_llm_span_event(
     error_message=None,
     error_stack=None,
     span_links=False,
+    tools=None,
 ):
     """
     Helper function to create an expected LLM span event.
@@ -101,6 +102,7 @@ def _expected_llmobs_llm_span_event(
     error_message: error message
     error_stack: error stack
     span_links: whether there are span links present on this span.
+    tools: list of tool definitions that were available to the LLM
     """
     span_event = _llmobs_base_span_event(
         span, span_kind, tags, session_id, error, error_message, error_stack, span_links
@@ -142,6 +144,8 @@ def _expected_llmobs_llm_span_event(
         meta_dict.update({"model_name": model_name})
     if model_provider is not None:
         meta_dict.update({"model_provider": model_provider})
+    if tools is not None:
+        meta_dict["tool_definitions"] = tools
     meta_dict.update({"metadata": metadata or {}})
     span_event["meta"].update(meta_dict)
     if token_metrics is not None:


### PR DESCRIPTION
This PR adds underlying support to tracking tool definitions, which will soon be added integrations.

Changes made include adding a TOOL_DEFINITIONS constant for span context, setting a meta field for tools (accounted for in dd-source go structs) and adding a tools field to _expected_llmobs_llm_span_event.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
