### PR TITLE
fix(llmobs): properly stringify google genai code execution results for llm call output messages

### DIFF
--- a/.gitlab/services.yml
+++ b/.gitlab/services.yml
@@ -12,7 +12,7 @@
       DD_REMOTE_CONFIGURATION_REFRESH_INTERVAL: 5s
       DD_DOGSTATSD_NON_LOCAL_TRAFFIC: true
   testagent:
-    name: registry.ddbuild.io/images/mirror/dd-apm-test-agent/ddapm-test-agent:v1.28.0
+    name: registry.ddbuild.io/images/mirror/dd-apm-test-agent/ddapm-test-agent:v1.29.1
     alias: testagent
     variables:
       LOG_LEVEL: ERROR

--- a/ddtrace/llmobs/_integrations/google_utils.py
+++ b/ddtrace/llmobs/_integrations/google_utils.py
@@ -10,6 +10,7 @@ from ddtrace.llmobs._constants import INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import OUTPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
 from ddtrace.llmobs._utils import _get_attr
+from ddtrace.llmobs._utils import safe_json
 
 
 # Google GenAI has roles "model" and "user", but in order to stay consistent with other integrations,
@@ -199,14 +200,14 @@ def extract_message_from_part_google_genai(part, role: str) -> Dict[str, Any]:
     if executable_code:
         language = _get_attr(executable_code, "language", "UNKNOWN")
         code = _get_attr(executable_code, "code", "")
-        message["content"] = {"language": str(language), "code": str(code)}
+        message["content"] = safe_json({"language": str(language), "code": str(code)})
         return message
 
     code_execution_result = _get_attr(part, "code_execution_result", None)
     if code_execution_result:
         outcome = _get_attr(code_execution_result, "outcome", "OUTCOME_UNSPECIFIED")
         output = _get_attr(code_execution_result, "output", "")
-        message["content"] = {"outcome": str(outcome), "output": str(output)}
+        message["content"] = safe_json({"outcome": str(outcome), "output": str(output)})
         return message
 
     return {"content": "Unsupported file type: {}".format(type(part)), "role": role}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
         volumes:
           - ddagent:/tmp/ddagent:rw
     testagent:
-        image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.28.0
+        image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.29.1
         ports:
             - "127.0.0.1:9126:8126"
         volumes:

--- a/releasenotes/notes/google-genai-code-execution-annotations-87f398ee698437a2.yaml
+++ b/releasenotes/notes/google-genai-code-execution-annotations-87f398ee698437a2.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes a bug where code execution outputs done through ``google-genai`` would result in no output messages on the LLM Observability ``llm`` span.

--- a/tests/contrib/google_genai/conftest.py
+++ b/tests/contrib/google_genai/conftest.py
@@ -42,6 +42,11 @@ def genai_client(request, genai):
 
 
 @pytest.fixture
+def genai_client_vcr(genai):
+    return genai.Client(http_options={"base_url": "http://127.0.0.1:9126/vcr/genai"})
+
+
+@pytest.fixture
 def mock_tracer(ddtrace_global_config, genai):
     try:
         pin = Pin.get_from(genai)

--- a/tests/llmobs/llmobs_cassettes/genai/genai_v1beta_models_gemini-2.5-flash_generateContent_post_459b74a0.yaml
+++ b/tests/llmobs/llmobs_cassettes/genai/genai_v1beta_models_gemini-2.5-flash_generateContent_post_459b74a0.yaml
@@ -1,0 +1,97 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "What is the sum of the first 50 prime
+      numbers? Generate and run code for the calculation, and make sure you get all
+      50."}], "role": "user"}], "tools": [{"codeExecution": {}}], "generationConfig":
+      {}}'
+    headers:
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept
+      : - '*/*'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept-Encoding
+      : - gzip, deflate
+      ? !!python/object/apply:multidict._multidict.istr
+      - Connection
+      : - keep-alive
+      Content-Length:
+      - '234'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - application/json
+      ? !!python/object/apply:multidict._multidict.istr
+      - User-Agent
+      : - google-genai-sdk/1.21.1 gl-python/3.10.13
+      ? !!python/object/apply:multidict._multidict.istr
+      - x-goog-api-client
+      : - google-genai-sdk/1.21.1 gl-python/3.10.13
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"To find the sum of the first 50 prime
+        numbers, I will first generate the prime numbers and then sum them up using
+        Python.\\n\\n**1. Strategy to find prime numbers:**\\nI will use a function
+        `is_prime(n)` to check if a number `n` is prime. A number `n` is prime if
+        it is greater than 1 and is not divisible by any number from 2 up to the square
+        root of `n`.\\nThen, I will iterate through numbers, check if they are prime,
+        and add them to a list until I have 50 prime numbers.\\n\\n**2. Calculation:**\\n\\n\"\n
+        \         },\n          {\n            \"executableCode\": {\n              \"language\":
+        \"PYTHON\",\n              \"code\": \"import math\\n\\ndef is_prime(n):\\n
+        \   \\\"\\\"\\\"Checks if a number is prime.\\\"\\\"\\\"\\n    if n \\u003c
+        2:\\n        return False\\n    for i in range(2, int(math.sqrt(n)) + 1):\\n
+        \       if n % i == 0:\\n            return False\\n    return True\\n\\nprime_numbers
+        = []\\nnum = 2\\nwhile len(prime_numbers) \\u003c 50:\\n    if is_prime(num):\\n
+        \       prime_numbers.append(num)\\n    num += 1\\n\\nsum_of_primes = sum(prime_numbers)\\n\\nprint(f\\\"The
+        first 50 prime numbers are: {prime_numbers}\\\")\\nprint(f\\\"The count of
+        prime numbers found: {len(prime_numbers)}\\\")\\nprint(f\\\"The sum of the
+        first 50 prime numbers is: {sum_of_primes}\\\")\"\n            }\n          },\n
+        \         {\n            \"codeExecutionResult\": {\n              \"outcome\":
+        \"OUTCOME_OK\",\n              \"output\": \"The first 50 prime numbers are:
+        [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71,
+        73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151,
+        157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229]\\nThe
+        count of prime numbers found: 50\\nThe sum of the first 50 prime numbers is:
+        5117\\n\"\n            }\n          },\n          {\n            \"text\":
+        \"The sum of the first 50 prime numbers is **5117**.\\n\\nHere are the first
+        50 prime numbers:\\n2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47,
+        53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131,
+        137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211,
+        223, 227, 229.\"\n          }\n        ],\n        \"role\": \"model\"\n      },\n
+        \     \"finishReason\": \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\":
+        {\n    \"promptTokenCount\": 32,\n    \"candidatesTokenCount\": 575,\n    \"totalTokenCount\":
+        1425,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
+        \       \"tokenCount\": 32\n      }\n    ],\n    \"toolUsePromptTokenCount\":
+        619,\n    \"toolUsePromptTokensDetails\": [\n      {\n        \"modality\":
+        \"TEXT\",\n        \"tokenCount\": 619\n      }\n    ],\n    \"thoughtsTokenCount\":
+        199\n  },\n  \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"1A-JaPr5Bt-wqtsPlZiayQs\"\n}\n"
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 29 Jul 2025 18:15:48 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=10062
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
Previously, we were setting code execution LLM output messages as raw objects instead of as strings. Since LLM Observability intake expects these to be strings (and are then parsed correctly as JSON in the UI), we should `safe_json` these so they show up in the UI.

Added a test, but for a visual verification as well:

1. Before fix
<img width="1346" height="267" alt="Screenshot 2025-07-29 at 2 28 08 PM" src="https://github.com/user-attachments/assets/2319498d-e389-49fe-b9bc-7ff699430b7f" />
2. After fix
<img width="1328" height="694" alt="Screenshot 2025-07-29 at 2 28 59 PM" src="https://github.com/user-attachments/assets/4a21e46f-f8d4-413c-accb-a8f0c2d3a657" />

Both the test and these images are based on [this example](https://ai.google.dev/gemini-api/docs/code-execution#enable-code-execution).

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
