### PR TITLE
fix(pydantic_ai): fix tool call tracing in pydantic-ai-slim >= 0.4.4

### DIFF
--- a/ddtrace/contrib/internal/pydantic_ai/patch.py
+++ b/ddtrace/contrib/internal/pydantic_ai/patch.py
@@ -7,6 +7,8 @@ from ddtrace.contrib.internal.pydantic_ai.utils import TracedPydanticRunStream
 from ddtrace.contrib.internal.trace_utils import unwrap
 from ddtrace.contrib.internal.trace_utils import wrap
 from ddtrace.contrib.trace_utils import with_traced_module
+from ddtrace.internal.utils import get_argument_value
+from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._integrations.pydantic_ai import PydanticAIIntegration
 from ddtrace.trace import Pin
 
@@ -22,6 +24,8 @@ def get_version() -> str:
 
 def _supported_versions() -> Dict[str, str]:
     return {"pydantic_ai": "*"}
+
+PYDANTIC_AI_SLIM_VERSION = parse_version(get_version())
 
 
 @with_traced_module
@@ -54,21 +58,33 @@ def traced_agent_iter(pydantic_ai, pin, func, instance, args, kwargs):
     kwargs["instance"] = instance
     return TracedPydanticAsyncContextManager(result, span, instance, integration, args, kwargs)
 
+@with_traced_module
+async def traced_tool_manager_call(pydantic_ai, pin, func, instance, args, kwargs):
+    tool_call = get_argument_value(args, kwargs, 0, "tool_call", True)
+    tool_name = getattr(tool_call, "tool_name", None) or "Pydantic Tool"
+    tool_manager_tools = getattr(instance, "tools", {})
+    tool_instance = tool_manager_tools.get(tool_name) or None
+    return await traced_tool_run(pydantic_ai, pin, func, instance, args, kwargs, tool_name, tool_instance)
 
 @with_traced_module
-async def traced_tool_run(pydantic_ai, pin, func, instance, args, kwargs):
+async def traced_tool_call(pydantic_ai, pin, func, instance, args, kwargs):
+    tool_name = getattr(instance, "name", None) or "Pydantic Tool"
+    return await traced_tool_run(pydantic_ai, pin, func, instance, args, kwargs, tool_name, instance)
+
+
+async def traced_tool_run(pydantic_ai, pin, func, instance, args, kwargs, tool_name, tool_instance):
     integration = pydantic_ai._datadog_integration
     resp = None
     try:
         span = integration.trace(pin, "Pydantic Tool", submit_to_llmobs=True, kind="tool")
-        span.name = getattr(instance, "name", None) or "Pydantic Tool"
+        span.name = tool_name
         resp = await func(*args, **kwargs)
         return resp
     except Exception:
         span.set_exc_info(*sys.exc_info())
         raise
     finally:
-        kwargs["instance"] = instance
+        kwargs["instance"] = tool_instance
         integration.llmobs_set_tags(span, args=args, kwargs=kwargs, response=resp)
         span.finish()
 
@@ -85,8 +101,11 @@ def patch():
     pydantic_ai._datadog_integration = PydanticAIIntegration(integration_config=config.pydantic_ai)
 
     wrap(pydantic_ai, "agent.Agent.iter", traced_agent_iter(pydantic_ai))
-    wrap(pydantic_ai, "tools.Tool.run", traced_tool_run(pydantic_ai))
     wrap(pydantic_ai, "agent.Agent.run_stream", traced_agent_run_stream(pydantic_ai))
+    if PYDANTIC_AI_SLIM_VERSION >= (0, 4, 4):
+        wrap(pydantic_ai, "agent.ToolManager.handle_call", traced_tool_manager_call(pydantic_ai))
+    else:
+        wrap(pydantic_ai, "tools.Tool.run", traced_tool_call(pydantic_ai))
 
 
 def unpatch():
@@ -98,8 +117,11 @@ def unpatch():
     pydantic_ai._datadog_patch = False
 
     unwrap(pydantic_ai.agent.Agent, "iter")
-    unwrap(pydantic_ai.tools.Tool, "run")
     unwrap(pydantic_ai.agent.Agent, "run_stream")
+    if PYDANTIC_AI_SLIM_VERSION >= (0, 4, 4):
+        unwrap(pydantic_ai.agent.ToolManager, "handle_call")
+    else:
+        unwrap(pydantic_ai.tools.Tool, "run")
 
     delattr(pydantic_ai, "_datadog_integration")
     Pin().remove_from(pydantic_ai)

--- a/tests/contrib/pydantic_ai/test_pydantic_ai_patch.py
+++ b/tests/contrib/pydantic_ai/test_pydantic_ai_patch.py
@@ -1,7 +1,10 @@
 from ddtrace.contrib.internal.pydantic_ai.patch import get_version
 from ddtrace.contrib.internal.pydantic_ai.patch import patch
 from ddtrace.contrib.internal.pydantic_ai.patch import unpatch
+from ddtrace.internal.utils.version import parse_version
 from tests.contrib.patch import PatchTestCase
+
+PYDANTIC_AI_SLIM_VERSION = parse_version(get_version())
 
 
 class TestPydanticAIPatch(PatchTestCase.Base):
@@ -13,12 +16,24 @@ class TestPydanticAIPatch(PatchTestCase.Base):
 
     def assert_module_patched(self, pydantic_ai):
         self.assert_wrapped(pydantic_ai.agent.Agent.iter)
-        self.assert_wrapped(pydantic_ai.tools.Tool.run)
+        self.assert_wrapped(pydantic_ai.agent.Agent.run_stream)
+        if PYDANTIC_AI_SLIM_VERSION >= (0, 4, 4):
+            self.assert_wrapped(pydantic_ai.agent.ToolManager.handle_call)
+        else:
+            self.assert_wrapped(pydantic_ai.tools.Tool.run)
 
     def assert_not_module_patched(self, pydantic_ai):
         self.assert_not_wrapped(pydantic_ai.agent.Agent.iter)
-        self.assert_not_wrapped(pydantic_ai.tools.Tool.run)
+        self.assert_not_wrapped(pydantic_ai.agent.Agent.run_stream)
+        if PYDANTIC_AI_SLIM_VERSION >= (0, 4, 4):
+            self.assert_not_wrapped(pydantic_ai.agent.ToolManager.handle_call)
+        else:
+            self.assert_not_wrapped(pydantic_ai.tools.Tool.run)
 
     def assert_not_module_double_patched(self, pydantic_ai):
         self.assert_not_double_wrapped(pydantic_ai.agent.Agent.iter)
-        self.assert_not_double_wrapped(pydantic_ai.tools.Tool.run)
+        self.assert_not_double_wrapped(pydantic_ai.agent.Agent.run_stream)
+        if PYDANTIC_AI_SLIM_VERSION >= (0, 4, 4):
+            self.assert_not_double_wrapped(pydantic_ai.agent.ToolManager.handle_call)
+        else:
+            self.assert_not_double_wrapped(pydantic_ai.tools.Tool.run)


### PR DESCRIPTION
We received this issue where upgrading to `pydantic-ai-slim >= 0.4.4` breaks tool call tracing for Pydantic AI since the traced tool call method (`Tool.run`) was removed in this version. This PR fixes that issue by conditionally tracing either the `run` method of the Tool class for versions < 0.4.4 or tracing the `ToolManager.handle_call` in newer versions of Pydantic AI.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
