### PR TITLE
chore(ci): update system tests commit

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '5b6c0261d7b1cb178dcbb0688636f975e494e8db'
+          ref: 'c7c2a5a24ba5509027af3c6271e96672331ad3d0'
 
       - name: Checkout dd-trace-py
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -96,7 +96,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '5b6c0261d7b1cb178dcbb0688636f975e494e8db'
+          ref: 'c7c2a5a24ba5509027af3c6271e96672331ad3d0'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -277,7 +277,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '5b6c0261d7b1cb178dcbb0688636f975e494e8db'
+          ref: 'c7c2a5a24ba5509027af3c6271e96672331ad3d0'
       - name: Checkout dd-trace-py
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '84c09c78dbb8681799ec4682e7c575b1ca37d3c5'
+          ref: '0f90d394c7241db7cb2c3ca8d68e018a06b77384'
 
       - name: Checkout dd-trace-py
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -96,7 +96,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '84c09c78dbb8681799ec4682e7c575b1ca37d3c5'
+          ref: '0f90d394c7241db7cb2c3ca8d68e018a06b77384'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -277,7 +277,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '84c09c78dbb8681799ec4682e7c575b1ca37d3c5'
+          ref: '0f90d394c7241db7cb2c3ca8d68e018a06b77384'
       - name: Checkout dd-trace-py
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'c7c2a5a24ba5509027af3c6271e96672331ad3d0'
+          ref: '84c09c78dbb8681799ec4682e7c575b1ca37d3c5'
 
       - name: Checkout dd-trace-py
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -96,7 +96,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'c7c2a5a24ba5509027af3c6271e96672331ad3d0'
+          ref: '84c09c78dbb8681799ec4682e7c575b1ca37d3c5'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -277,7 +277,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'c7c2a5a24ba5509027af3c6271e96672331ad3d0'
+          ref: '84c09c78dbb8681799ec4682e7c575b1ca37d3c5'
       - name: Checkout dd-trace-py
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
Trying to confirm if updating to the last system-tests commit fix the protobuf error:
```
! _py***.outcomes.Exit: Unexpected error while deserialize logs_appsec_rate_limiter/interfaces/agent/00052__api_v2_series.json:
 Traceback (most recent call last):
  File "/app/utils/proxy/_deserializer.py", line 345, in deserialize
    data[key]["content"] = deserialize_http_message(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/utils/proxy/_deserializer.py", line 190, in deserialize_http_message
    return MessageToDict(MetricPayload.FromString(content))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
google.protobuf.message.DecodeError: Error parsing message !
```

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
