### PR TITLE
docs: add pre-release performance gate runbook to release doc

### DIFF
--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -141,26 +141,3 @@ Scenarios
 
 .. _viztracer: https://viztracer.readthedocs.io/en/stable/basic_usage.html#display-report
 
-PR-Level Gates
-^^^^^^^^^^^^^^
-This repository is using PR-level performance quality gates.
-Verify that the `check-slo-breaches` CI job has passed.
-If any regression happened, merging this PR will be blocked.
-
-If bypassing is necessary, see `Performance quality gates - User Guide`_ for more details.
-
-
-Pre-Release Gates
-^^^^^^^^^^^^^^^^^
-This repository is using pre-release performance quality gates.
-
-On `main`, verify that the latest CI pipeline passed the check-slo-breaches job.
-
-If any SLO is breached, the release pipeline on GitLab will be blocked.
-
-See our thresholds file(s) at `bp-runner.macrobenchmarks.fail-on-breach.yml <https://github.com/DataDog/dd-trace-py/blob/3cf3342a005c1ef9e345d2a82a631bc827c8617a/.gitlab/benchmarks/bp-runner.macrobenchmarks.fail-on-breach.yml#L4>`_ for macrobenchmarks, and `bp-runner.microbenchmarks.fail-on-breach.yml <https://github.com/DataDog/dd-trace-py/blob/3cf3342a005c1ef9e345d2a82a631bc827c8617a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml#L4>`_ for microbenchmarks.
-
-If bypassing is necessary, see `Performance quality gates - User Guide`_ for more details.
-
-
-.. _Performance quality gates - User Guide: https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/5158175217/Performance+quality+gates+-+User+Guide

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -140,3 +140,27 @@ Scenarios
 
 
 .. _viztracer: https://viztracer.readthedocs.io/en/stable/basic_usage.html#display-report
+
+PR-Level Gates
+^^^^^^^^^^^^^^
+This repository is using PR-level performance quality gates.
+Verify that the `check-slo-breaches` CI job has passed.
+If any regression happened, merging this PR will be blocked.
+
+If bypassing is necessary, see `Performance quality gates - User Guide`_ for more details.
+
+
+Pre-Release Gates
+^^^^^^^^^^^^^^^^^
+This repository is using pre-release performance quality gates.
+
+On `main`, verify that the latest CI pipeline passed the check-slo-breaches job.
+
+If any SLO is breached, the release pipeline on GitLab will be blocked.
+
+See our thresholds file(s) at `bp-runner.macrobenchmarks.fail-on-breach.yml <https://github.com/DataDog/dd-trace-py/blob/3cf3342a005c1ef9e345d2a82a631bc827c8617a/.gitlab/benchmarks/bp-runner.macrobenchmarks.fail-on-breach.yml#L4>`_ for macrobenchmarks, and `bp-runner.microbenchmarks.fail-on-breach.yml <https://github.com/DataDog/dd-trace-py/blob/3cf3342a005c1ef9e345d2a82a631bc827c8617a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml#L4>`_ for microbenchmarks.
+
+If bypassing is necessary, see `Performance quality gates - User Guide`_ for more details.
+
+
+.. _Performance quality gates - User Guide: https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/5158175217/Performance+quality+gates+-+User+Guide

--- a/docs/contributing-release.rst
+++ b/docs/contributing-release.rst
@@ -16,6 +16,22 @@ Prerequisites
 
 2. Ensure the CI is green on the branch on which the release will be based.
 
+3. Ensure the SLOs have not been breached on the release branch (`main` for new major/minor, `major.minor` branch for patch releases). See section below for details.
+
+Pre-Release Performance Gates
+-----------------------------
+
+This repository is using pre-release performance quality gates.
+
+On `main` or the `major.minor` release branch, verify that the latest CI pipeline passed the `check-slo-breaches` job.
+
+If any SLO is breached, the release pipeline on GitLab will be blocked.
+
+See our thresholds file(s) at `bp-runner.macrobenchmarks.fail-on-breach.yml <https://github.com/DataDog/dd-trace-py/blob/3cf3342a005c1ef9e345d2a82a631bc827c8617a/.gitlab/benchmarks/bp-runner.macrobenchmarks.fail-on-breach.yml#L4>`_ for macrobenchmarks, and `bp-runner.microbenchmarks.fail-on-breach.yml <https://github.com/DataDog/dd-trace-py/blob/3cf3342a005c1ef9e345d2a82a631bc827c8617a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml#L4>`_ for microbenchmarks.
+
+If bypassing is necessary, see `Performance quality gates - User Guide <https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/5158175217/Performance+quality+gates+-+User+Guide>`_ for more details.
+
+
 Instructions
 ------------
 


### PR DESCRIPTION
Adding the runbook documentation for our pre-release performance gating to the release documentation.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
