### PR TITLE
chore(span): remove Span._context

### DIFF
--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -149,7 +149,7 @@ class TraceSamplingProcessor(TraceProcessor):
     def process_trace(self, trace: List[Span]) -> Optional[List[Span]]:
         if trace:
             chunk_root = trace[0]
-            root_ctx = chunk_root._context
+            root_ctx = chunk_root.context
 
             if self.apm_opt_out:
                 for span in trace:
@@ -227,8 +227,8 @@ class TraceTagsProcessor(TraceProcessor):
             return trace
 
         chunk_root = trace[0]
-        ctx = chunk_root._context
-        if not ctx:
+        ctx = chunk_root.context
+        if not ctx._meta and not ctx._metrics:
             return trace
 
         chunk_root._update_tags_from_context()

--- a/tests/opentelemetry/test_span.py
+++ b/tests/opentelemetry/test_span.py
@@ -222,8 +222,8 @@ def test_otel_get_span_context(oteltracer):
 
 def test_otel_get_span_context_with_multiple_tracesates(oteltracer):
     otelspan = oteltracer.start_span("otel-server")
-    otelspan._ddspan._context._meta["_dd.p.congo"] = "t61rcWkgMzE"
-    otelspan._ddspan._context._meta["_dd.p.some_val"] = "tehehe"
+    otelspan._ddspan.context._meta["_dd.p.congo"] = "t61rcWkgMzE"
+    otelspan._ddspan.context._meta["_dd.p.some_val"] = "tehehe"
     otelspan.end()
 
     span_context = otelspan.get_span_context()


### PR DESCRIPTION
This PR removes the internal `Span,_context`  property and ensures that Span.context is never None. 

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
