### PR TITLE
feat(packages): symlinked .runfile pkgs should not be usercode (#13474) [backport 2.21]

### DIFF
--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -123,7 +123,8 @@ def _root_module(path: Path) -> str:
     # Try the most likely prefixes first
     for parent_path in (purelib_path, platlib_path):
         try:
-            return _effective_root(path.relative_to(parent_path), parent_path)
+            # Resolve the path to use the shortest relative path.
+            return _effective_root(path.resolve().relative_to(parent_path), parent_path)
         except ValueError:
             # Not relative to this path
             pass
@@ -223,7 +224,18 @@ def filename_to_package(filename: t.Union[str, Path]) -> t.Optional[Distribution
 
     try:
         path = Path(filename) if isinstance(filename, str) else filename
-        return mapping.get(_root_module(path.resolve()))
+        # Avoid calling .resolve() on the path here to prevent breaking symlink matching in `_root_module`.
+        root_module_path = _root_module(path)
+        if root_module_path in mapping:
+            return mapping[root_module_path]
+
+        # Loop through mapping and check the distribution name, since the key isn't always the same, for example:
+        #   '__editable__.ddtrace-3.9.0.dev...pth': Distribution(name='ddtrace', version='...')
+        for distribution in mapping.values():
+            if distribution.name == root_module_path:
+                return distribution
+
+        return None
     except (ValueError, OSError):
         return None
 
@@ -252,7 +264,7 @@ def is_stdlib(path: Path) -> bool:
 
 @cached(maxsize=256)
 def is_third_party(path: Path) -> bool:
-    package = filename_to_package(str(path))
+    package = filename_to_package(path)
     if package is None:
         return False
 

--- a/tests/debugging/origin/test_span.py
+++ b/tests/debugging/origin/test_span.py
@@ -52,5 +52,5 @@ class SpanProbeTestCase(TracerTestCase):
 
         # Check for the expected tags on the exit span
         assert _exit.get_tag("_dd.code_origin.type") == "exit"
-        assert _exit.get_tag("_dd.code_origin.frames.2.file") == str(Path(__file__).resolve())
-        assert _exit.get_tag("_dd.code_origin.frames.2.line") == str(self.test_span_origin.__code__.co_firstlineno)
+        assert _exit.get_tag("_dd.code_origin.frames.0.file") == str(Path(__file__).resolve())
+        assert _exit.get_tag("_dd.code_origin.frames.0.line") == str(self.test_span_origin.__code__.co_firstlineno)

--- a/tests/internal/test_packages.py
+++ b/tests/internal/test_packages.py
@@ -108,3 +108,42 @@ def test_third_party_packages_excludes_includes():
 
     assert {"myfancypackage", "myotherfancypackage"} < _third_party_packages()
     assert "requests" not in _third_party_packages()
+
+
+def test_third_party_packages_symlinks(tmp_path):
+    """
+    Test that a symlink doesn't break our logic of detecting user code.
+    """
+    import os
+
+    from ddtrace.internal.packages import is_user_code
+
+    # Use pathlib for more pythonic directory creation
+    actual_path = tmp_path / "site-packages" / "ddtrace"
+    runfiles_path = tmp_path / "test.runfiles" / "site-packages" / "ddtrace"
+
+    # Create directories using pathlib (more pythonic)
+    actual_path.mkdir(parents=True)
+    runfiles_path.mkdir(parents=True)
+
+    # Assert that the runfiles path is considered user code when symlinked.
+    code_file = actual_path / "test.py"
+    code_file.write_bytes(b"#")
+
+    symlink_file = runfiles_path / "test.py"
+    os.symlink(code_file, symlink_file)
+
+    assert is_user_code(code_file)
+    # Symlinks with `.runfiles` in the path should not be considered user code.
+    from ddtrace.internal.compat import Path
+
+    p = Path(symlink_file)
+    p2 = Path(symlink_file).resolve()
+    print(symlink_file, p, p2)
+
+    assert not is_user_code(symlink_file)
+
+    code_file_2 = runfiles_path / "test2.py"
+    code_file_2.write_bytes(b"#")
+
+    assert not is_user_code(code_file_2)


### PR DESCRIPTION
This came up again so I'll backport to 2.21 - https://datadoghq.atlassian.net/browse/DEBUG-4257

---

While dogfooding, we noticed that code origins was still sending third-party code for bazel, e.g. this path:

```
/app/domains/dashboardsnotebooks_backend/sharing/apps/apis/shared_dd_query/shared_dd_query.runfiles/dd_source/external/pypi_linux_x86_64_ddtrace/site-packages/ddtrace/_trace/tracer.py
```

We have code specifically to handle the `*.runfiles` path, but we pass the string to a Path and call the resolve which removes the `*.runfiles` segment.

To fix this, we update the path resolution logic in `ddtrace/internal/packages.py` to improve handling of symlinks and add a new test to ensure correct behavior when symlinks are involved.

* [`ddtrace/internal/packages.py`](diffhunk://#diff-362935abfa156805410cbcdbfa453d011dbc4c77ce21a20c68402ec130c2e76fL116-R117): Updated `_root_module` to use `path` instead of `path.resolve()` to ensure symlinks are searched properly. Similarly, updated `filename_to_package` to use `path` for consistent path handling. [[1]](diffhunk://#diff-362935abfa156805410cbcdbfa453d011dbc4c77ce21a20c68402ec130c2e76fL116-R117) [[2]](diffhunk://#diff-362935abfa156805410cbcdbfa453d011dbc4c77ce21a20c68402ec130c2e76fL225-R226)

* [`tests/internal/test_packages.py`](diffhunk://#diff-bd71856276db697cbc2cd49e26c7598838b0ca0c67af35876ad8f8944014cd10R107-R136): Added `test_third_party_packages_symlinks` to verify that symlinks, particularly those with `.runfiles` in their paths, are correctly excluded from being identified as user code. This ensures the logic remains robust in environments with symlinked directories.

Refs: DEBUG-3926, DEBUG-4257

(cherry picked from commit 197dbe2aff130d7dc0e3408a94dd0403d60a87cb)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
