### PR TITLE
chore(llmobs): support other sites when printing url

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -55,6 +55,10 @@ AGENTLESS_SPAN_BASE_URL = "https://{}".format(SPAN_SUBDOMAIN_NAME)
 AGENTLESS_EVAL_BASE_URL = "https://{}".format(EVAL_SUBDOMAIN_NAME)
 AGENTLESS_EXP_BASE_URL = "https://{}".format(EXP_SUBDOMAIN_NAME)
 
+DEFAULT_DD_SITE = "datadoghq.com"
+# from https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
+DD_SITES_NEEDING_APP_SUBDOMAIN = {DEFAULT_DD_SITE, "datadoghq.eu", "ddog-gov.com"}
+
 EVP_PAYLOAD_SIZE_LIMIT = 5 << 20  # 5MB (actual limit is 5.1MB)
 EVP_EVENT_SIZE_LIMIT = (1 << 20) - 1024  # 999KB (actual limit is 1MB)
 

--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -55,9 +55,8 @@ AGENTLESS_SPAN_BASE_URL = "https://{}".format(SPAN_SUBDOMAIN_NAME)
 AGENTLESS_EVAL_BASE_URL = "https://{}".format(EVAL_SUBDOMAIN_NAME)
 AGENTLESS_EXP_BASE_URL = "https://{}".format(EXP_SUBDOMAIN_NAME)
 
-DEFAULT_DD_SITE = "datadoghq.com"
 # from https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
-DD_SITES_NEEDING_APP_SUBDOMAIN = {DEFAULT_DD_SITE, "datadoghq.eu", "ddog-gov.com"}
+DD_SITES_NEEDING_APP_SUBDOMAIN = {"datadoghq.com", "datadoghq.eu", "ddog-gov.com"}
 
 EVP_PAYLOAD_SIZE_LIMIT = 5 << 20  # 5MB (actual limit is 5.1MB)
 EVP_EVENT_SIZE_LIMIT = (1 << 20) - 1024  # 999KB (actual limit is 1MB)

--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -21,6 +21,7 @@ from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._constants import EXPERIMENT_EXPECTED_OUTPUT
+from ddtrace.llmobs._utils import _get_base_url
 from ddtrace.llmobs._utils import convert_tags_dict_to_list
 
 
@@ -156,9 +157,8 @@ class Dataset:
 
     @property
     def url(self) -> str:
-        # FIXME: need to use the user's site
-        # also will not work for subdomain orgs
-        return f"https://app.datadoghq.com/llm/datasets/{self._id}"
+        # FIXME: will not work for subdomain orgs
+        return f"{_get_base_url()}/llm/datasets/{self._id}"
 
     @overload
     def __getitem__(self, index: int) -> DatasetRecord:
@@ -299,9 +299,8 @@ class Experiment:
 
     @property
     def url(self) -> str:
-        # FIXME: need to use the user's site
-        # also will not work for subdomain orgs
-        return f"https://app.datadoghq.com/llm/experiments/{self._id}"
+        # FIXME: will not work for subdomain orgs
+        return f"{_get_base_url()}/llm/experiments/{self._id}"
 
     def _process_record(self, idx_record: Tuple[int, DatasetRecord]) -> Optional[TaskResult]:
         if not self._llmobs_instance or not self._llmobs_instance.enabled:

--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -16,12 +16,13 @@ from typing import cast
 from typing import overload
 
 import ddtrace
+from ddtrace import config
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
 from ddtrace.internal.logger import get_logger
+from ddtrace.llmobs._constants import DD_SITES_NEEDING_APP_SUBDOMAIN
 from ddtrace.llmobs._constants import EXPERIMENT_EXPECTED_OUTPUT
-from ddtrace.llmobs._utils import _get_base_url
 from ddtrace.llmobs._utils import convert_tags_dict_to_list
 
 
@@ -469,3 +470,11 @@ class Experiment:
                 )
                 eval_metrics.append(eval_metric)
         return eval_metrics
+
+
+def _get_base_url() -> str:
+    subdomain = ""
+    if config._dd_site in DD_SITES_NEEDING_APP_SUBDOMAIN:
+        subdomain = "app."
+
+    return f"https://{subdomain}{config._dd_site}"

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -13,6 +13,8 @@ from ddtrace.ext import SpanTypes
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._constants import CREWAI_APM_SPAN_NAME
+from ddtrace.llmobs._constants import DD_SITES_NEEDING_APP_SUBDOMAIN
+from ddtrace.llmobs._constants import DEFAULT_DD_SITE
 from ddtrace.llmobs._constants import GEMINI_APM_SPAN_NAME
 from ddtrace.llmobs._constants import INTERNAL_CONTEXT_VARIABLE_KEYS
 from ddtrace.llmobs._constants import INTERNAL_QUERY_VARIABLE_KEYS
@@ -203,6 +205,18 @@ def _unserializable_default_repr(obj):
     except Exception:
         log.warning("I/O object is neither JSON serializable nor string-able. Defaulting to placeholder value instead.")
         return "[Unserializable object: {}]".format(repr(obj))
+
+
+def _get_base_url() -> str:
+    subdomain = ""
+    site = DEFAULT_DD_SITE
+    if config._dd_site:
+        site = config._dd_site
+
+    if site in DD_SITES_NEEDING_APP_SUBDOMAIN:
+        subdomain = "app."
+
+    return f"https://{subdomain}{site}"
 
 
 def safe_json(obj, ensure_ascii=True):

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -13,8 +13,6 @@ from ddtrace.ext import SpanTypes
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._constants import CREWAI_APM_SPAN_NAME
-from ddtrace.llmobs._constants import DD_SITES_NEEDING_APP_SUBDOMAIN
-from ddtrace.llmobs._constants import DEFAULT_DD_SITE
 from ddtrace.llmobs._constants import GEMINI_APM_SPAN_NAME
 from ddtrace.llmobs._constants import INTERNAL_CONTEXT_VARIABLE_KEYS
 from ddtrace.llmobs._constants import INTERNAL_QUERY_VARIABLE_KEYS
@@ -205,18 +203,6 @@ def _unserializable_default_repr(obj):
     except Exception:
         log.warning("I/O object is neither JSON serializable nor string-able. Defaulting to placeholder value instead.")
         return "[Unserializable object: {}]".format(repr(obj))
-
-
-def _get_base_url() -> str:
-    subdomain = ""
-    site = DEFAULT_DD_SITE
-    if config._dd_site:
-        site = config._dd_site
-
-    if site in DD_SITES_NEEDING_APP_SUBDOMAIN:
-        subdomain = "app."
-
-    return f"https://{subdomain}{site}"
 
 
 def safe_json(obj, ensure_ascii=True):

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -21,6 +21,7 @@ import pytest
 
 from ddtrace.llmobs._experiment import Dataset
 from ddtrace.llmobs._experiment import DatasetRecord
+from tests.utils import override_global_config
 
 
 def wait_for_backend():
@@ -85,6 +86,18 @@ def test_dataset_create_delete(llmobs):
     assert dataset.url == f"https://app.datadoghq.com/llm/datasets/{dataset._id}"
 
     llmobs._delete_dataset(dataset_id=dataset._id)
+
+
+def test_dataset_url_diff_site(llmobs, test_dataset_one_record):
+    with override_global_config(dict(_dd_site="us3.datadoghq.com")):
+        dataset = test_dataset_one_record
+        assert dataset.url == f"https://us3.datadoghq.com/llm/datasets/{dataset._id}"
+
+
+def test_dataset_url_diff_site_eu(llmobs, test_dataset_one_record):
+    with override_global_config(dict(_dd_site="datadoghq.eu")):
+        dataset = test_dataset_one_record
+        assert dataset.url == f"https://app.datadoghq.eu/llm/datasets/{dataset._id}"
 
 
 def test_dataset_as_dataframe(llmobs, test_dataset_one_record):


### PR DESCRIPTION
previously it only printed us1 links, now it will support urls based on the configured dd_site

[tested with us3](https://us3.datadoghq.com/llm/datasets/9a23881a-71a8-45af-9259-aef0c9d5e4bf?page=1) 
<img width="652" height="134" alt="image" src="https://github.com/user-attachments/assets/30379dc3-27ef-4452-8402-5d55b8668600" />


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
