### PR TITLE
chore(asm): aap service activation origin configuration metric

### DIFF
--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -11,6 +11,7 @@ from ddtrace.appsec._asm_request_context import _call_waf
 from ddtrace.appsec._asm_request_context import _call_waf_first
 from ddtrace.appsec._asm_request_context import get_blocked
 from ddtrace.appsec._asm_request_context import set_body_response
+from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import SPAN_DATA_NAMES
 from ddtrace.appsec._http_utils import extract_cookies_from_headers
 from ddtrace.appsec._http_utils import normalize_headers
@@ -23,7 +24,6 @@ from ddtrace.internal import core
 from ddtrace.internal import telemetry
 from ddtrace.internal.constants import RESPONSE_HEADERS
 from ddtrace.internal.logger import get_logger
-from ddtrace.internal.telemetry import TELEMETRY_NAMESPACE
 from ddtrace.internal.utils import http as http_utils
 from ddtrace.internal.utils.http import parse_form_multipart
 from ddtrace.settings.asm import config as asm_config
@@ -397,10 +397,15 @@ def _on_start_response_blocked(ctx, flask_config, response_headers, status):
 
 
 def _on_telemetry_periodic():
-    if asm_config._asm_enabled:
-        telemetry.telemetry_writer.add_gauge_metric(
-            TELEMETRY_NAMESPACE.APPSEC, "enabled", 2, (("origin", asm_config.asm_enabled_origin),)
-        )
+    telemetry.telemetry_writer.add_configurations(
+        [
+            (
+                APPSEC.ENV,
+                asm_config._asm_enabled,
+                asm_config.asm_enabled_origin,
+            )
+        ]
+    )
 
 
 def listen():

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -488,7 +488,7 @@ class TelemetryWriter(PeriodicService):
             config["seq_id"] = next(self._sequence_configurations)
             self._configuration_queue.append(config)
 
-    def add_configurations(self, configuration_list):
+    def add_configurations(self, configuration_list: List[Tuple[str, str, str]]):
         """Creates and queues a list of configurations"""
         with self._service_lock:
             for name, value, origin in configuration_list:

--- a/tests/appsec/appsec/test_telemetry.py
+++ b/tests/appsec/appsec/test_telemetry.py
@@ -1,6 +1,7 @@
 import os
 from time import sleep
 from unittest import mock
+from unittest.mock import ANY
 
 import pytest
 
@@ -273,7 +274,7 @@ def test_log_metric_error_ddwaf_update_deduplication_timelapse(telemetry_writer)
 @pytest.mark.parametrize(
     "environment,appsec_enabled,rc_enabled,expected_result,expected_origin",
     (
-        ({}, False, False, 0, ""),
+        ({}, False, False, 0, APPSEC.ENABLED_ORIGIN_UNKNOWN),
         ({APPSEC_ENV: "true"}, True, False, 1, APPSEC.ENABLED_ORIGIN_ENV),
         ({}, True, False, 1, APPSEC.ENABLED_ORIGIN_UNKNOWN),
         ({}, True, True, 1, APPSEC.ENABLED_ORIGIN_UNKNOWN),
@@ -293,15 +294,10 @@ def test_appsec_enabled_metric(
 
         telemetry_writer._dispatch()
 
-        metrics_result = telemetry_writer._namespace.flush(0.1)
-        list_telemetry_metrics = metrics_result.get(TELEMETRY_TYPE_GENERATE_METRICS, {}).get(
-            TELEMETRY_NAMESPACE.APPSEC.value, {}
-        )
-        metrics = [m for m in list_telemetry_metrics if m["metric"] == "enabled"]
-        assert len(metrics) == expected_result, metrics
-        if expected_result > 0:
-            assert len(metrics[0]["tags"]) == 1
-            assert f"origin:{expected_origin}" in metrics[0]["tags"]
+        metrics_result = telemetry_writer._flush_configuration_queue()
+        assert metrics_result == [
+            {"name": "DD_APPSEC_ENABLED", "origin": expected_origin, "seq_id": ANY, "value": expected_result}
+        ]
 
         # Restore defaults
         tracer.configure(appsec_enabled=appsec_enabled, appsec_enabled_origin=APPSEC.ENABLED_ORIGIN_UNKNOWN)


### PR DESCRIPTION
There was a misunderstanding with this task: it's not a telemetry metric, it's a configuration metric

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
