### PR TITLE
chore(build): use differetn extension cache venv for each python version

### DIFF
--- a/.gitlab/templates/cached-testrunner.yml
+++ b/.gitlab/templates/cached-testrunner.yml
@@ -3,7 +3,7 @@
   variables:
     PIP_CACHE_DIR: '${{CI_PROJECT_DIR}}/.cache/pip'
     SCCACHE_DIR: '${{CI_PROJECT_DIR}}/.cache/sccache'
-    EXT_CACHE_VENV: '${{CI_PROJECT_DIR}}/.cache/ext_cache_venv'
+    EXT_CACHE_VENV: '${{CI_PROJECT_DIR}}/.cache/ext_cache_venv${{PYTHON_VERSION}}'
   before_script: |
     ulimit -c unlimited
     pyenv global 3.12 3.8 3.9 3.10 3.11 3.13


### PR DESCRIPTION
Each venv should be associated with only one single Python version. 

Running `python$PYTHON_VERSION -m venv $EXT_CACHE_VENV` for same `$EXT_CACHE_VENV` for different `$PYTHON_VERSION`s results in the following. 

This is what I get after running
`python3.8 -m venv $EXT_CACHE_VENV` and then `python3.12 -m venv $EXT_CACHE_VENV` in my local `scripts/ddtest` with `export EXT_CACHE_VENV=.cache/ext_cache_venv`
```
root@docker-desktop:~/project/.cache/ext_cache_venv/bin# ls -la
total 40
drwxr-xr-x 14 root root  448 Jul 31 13:42 .
drwxr-xr-x  7 root root  224 Jul 31 13:40 ..
-rw-r--r--  1 root root 9033 Jul 31 13:42 Activate.ps1
-rw-r--r--  1 root root 2160 Jul 31 13:42 activate
-rw-r--r--  1 root root  951 Jul 31 13:42 activate.csh
-rw-r--r--  1 root root 2226 Jul 31 13:42 activate.fish
-rwxr-xr-x  1 root root  255 Jul 31 13:42 pip
-rwxr-xr-x  1 root root  255 Jul 31 13:42 pip3
-rwxr-xr-x  1 root root  255 Jul 31 13:42 pip3.12
-rwxr-xr-x  1 root root  254 Jul 31 13:40 pip3.8
lrwxr-xr-x  1 root root    9 Jul 31 13:40 python -> python3.8
lrwxr-xr-x  1 root root    9 Jul 31 13:40 python3 -> python3.8
lrwxr-xr-x  1 root root   43 Jul 31 13:42 python3.12 -> /root/.pyenv/versions/3.12.8/bin/python3.12
lrwxr-xr-x  1 root root   42 Jul 31 13:40 python3.8 -> /root/.pyenv/versions/3.8.20/bin/python3.8
```
So then `source $EXT_CACHE_VENV/bin/activate` could point to a wrong python version I guess.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
