### PR TITLE
chore(propagation): deprecate non_active_span parameter in HTTPPropagator.inject

### DIFF
--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -1124,6 +1124,15 @@ class HTTPPropagator(object):
             else:
                 root_span = core.tracer.current_root_span()
 
+                if root_span is not None and root_span.context is not span_context:
+                    log.error(
+                        "The passed in span_context is not the active context. The span must be passed in with"
+                        "non_active_span in order to be sampled. span_context: {}, non_active_span.context: {}",
+                        span_context,
+                        root_span.context,
+                    )
+                    root_span = None
+
             if root_span is not None and root_span.context.sampling_priority is None:
                 core.tracer.sample(root_span)
         else:

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -1028,7 +1028,7 @@ class HTTPPropagator(object):
             span_context = trace_info.context
         else:
             span_context = trace_info
-            current_root_span = core.tracer.current_root_span()
+            current_root_span = core.tracer and core.tracer.current_root_span()
             if current_root_span is not None and current_root_span.trace_id == trace_info.trace_id:
                 root_span = current_root_span
             else:
@@ -1160,10 +1160,9 @@ class HTTPPropagator(object):
         if not config._propagation_style_inject:
             return
         # Sample the local root span before injecting headers.
-        if span_to_sample is not None:
-            if span_to_sample.context.sampling_priority is None:
-                core.tracer.sample(span_to_sample)
-                log.debug("%s sampled before propagating trace: span_context=%s", span_to_sample, span_context)
+        if span_to_sample and core.tracer and span_to_sample.context.sampling_priority is None:
+            core.tracer.sample(span_to_sample)
+            log.debug("%s sampled before propagating trace: span_context=%s", span_to_sample, span_context)
         # Log a warning if we cannot determine a sampling decision before injecting headers.
         if span_context.span_id and span_context.trace_id and span_context.sampling_priority is None:
             log.debug(

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -1127,7 +1127,17 @@ class HTTPPropagator(object):
                     url = '<some RPC endpoint>'
                     r = requests.get(url, headers=headers)
 
-        :param Union[Span, Context] context: A re
+                with tracer.start_span('child_span2') as span:
+                    headers = {}
+                    # Inject headers using the span object instead of the span context
+                    # since the span is NOT active.
+                    HTTPPropagator.inject(span, headers)
+                    url = '<some RPC endpoint>'
+                    r = requests.get(url, headers=headers)
+
+        :param Union[Span, Context] context: A reference to the span or span context to use to inject headers. In most
+            cases, the span context should be used. However, if the span is not active, the span object should be used
+            to inject headers. This ensures that a sampling decision is made before injecting headers.
         :param dict headers: HTTP headers to extend with tracing attributes.
         :param Span non_active_span: deprecated, use the context parameter instead.
         """

--- a/releasenotes/notes/deprecate-non_active_span-http-prop-dc0cf2cd7a033e08.yaml
+++ b/releasenotes/notes/deprecate-non_active_span-http-prop-dc0cf2cd7a033e08.yaml
@@ -1,0 +1,8 @@
+---
+deprecations:
+  - |
+    tracing: Deprecate the non_active_span parameter in the ``HTTPPropagator.inject`` method. ``HTTPPropagator.inject(context=...)``
+    should be used to inject headers instead.
+other:
+  - |
+    tracing: Improves debug logging in ``HTTPPropagator.inject`` method to help diagnose issues with sampling decisions.


### PR DESCRIPTION
Deprecates support for calling ``HTTPPropagator.inject(...)`` with both a Context and Span object. This can introduce unintended conflicts. This PR updates the type of the required `context` parameter to support both a Span and Context object. The `non_active_span` parameter is now deprecated. 

The PR also introduces debug logging for when an distributed trace is generated before a sampling decision is made. This should never occur and when a sampling decision is triggered by the http propagator. By default spans are sampled when the root span is encoded. This allows us to lazily sample spans.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
