### PR TITLE
ci: avoid GITHUB_TOKEN for PR creation

### DIFF
--- a/.github/chainguard/self.backport.create-pr.sts.yaml
+++ b/.github/chainguard/self.backport.create-pr.sts.yaml
@@ -1,0 +1,14 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-py:pull_request
+
+claim_pattern:
+  event_name: pull_request_target
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/dd-trace-py/\.github/workflows/backport\.yml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write
+

--- a/.github/chainguard/self.generate-package-versions.create-pr.sts.yaml
+++ b/.github/chainguard/self.generate-package-versions.create-pr.sts.yaml
@@ -1,0 +1,14 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-py:ref:refs/heads/main
+
+claim_pattern:
+  event_name: (workflow_dispatch|schedule)
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/dd-trace-py/\.github/workflows/generate-package-versions\.yml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write
+

--- a/.github/chainguard/self.generate-supported-versions.create-pr.sts.yaml
+++ b/.github/chainguard/self.generate-supported-versions.create-pr.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-py:ref:refs/heads/main
+
+claim_pattern:
+  event_name: workflow_dispatch
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/dd-trace-py/\.github/workflows/generate-supported-versions\.yml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
+      id-token: write
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >
@@ -24,9 +24,15 @@ jobs:
         )
       )
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/dd-trace-py
+          policy: self.backport.create-pr
+
       - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.octo-sts.outputs.token }}
           body_template: "Backport <%= mergeCommitSha %> from #<%= number %> to <%= base %>.\n\n<%= body %>"
           label_pattern: "^backport (?<base>([0-9]+\\.[0-9]+))$"
           # Include the original labels from the merged PR (minus any matching label_pattern)

--- a/.github/workflows/generate-package-versions.yml
+++ b/.github/workflows/generate-package-versions.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       actions: read
       contents: write
-      pull-requests: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -95,11 +95,17 @@ jobs:
           NEW_LATEST=$(python scripts/get_latest_version.py ${{ env.VENV_NAME }})
           echo "NEW_LATEST=$NEW_LATEST" >> $GITHUB_ENV
 
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/dd-trace-py
+          policy: self.generate-package-versions.create-pr
+
       - name: Create Pull Request
         id: pr
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.octo-sts.outputs.token }}
           branch: "upgrade-latest-${{ env.VENV_NAME }}-version"
           commit-message: "Update package version"
           delete-branch: true

--- a/.github/workflows/generate-supported-versions.yml
+++ b/.github/workflows/generate-supported-versions.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       actions: read
       contents: write
-      pull-requests: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -77,11 +77,17 @@ jobs:
 
       - run: git diff
 
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/dd-trace-py
+          policy: self.generate-supported-versions.create-pr
+
       - name: Create Pull Request
         id: pr
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.octo-sts.outputs.token }}
           branch: "update-supported-versions"
           commit-message: "Update supported versions table"
           delete-branch: true


### PR DESCRIPTION
Using the workflow-native `GITHUB_TOKEN` for creation/approval of PRs requires an insecure workflow permissions setting: 
<img width="750" height="336" alt="image" src="https://github.com/user-attachments/assets/bba5c179-99c8-4e2c-925d-c553deddaffe" />

This creates a risk of branch protection bypass. Therefore, this PR migrates away from using the GITHUB_TOKEN for PR creation. It replaces the native GITHUB_TOKEN with a technical token generated via dd-octo-sts.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
