### PR TITLE
chore(bench): fix build baseline for microbenchmarks

### DIFF
--- a/.gitlab/benchmarks/steps/build-baseline.sh
+++ b/.gitlab/benchmarks/steps/build-baseline.sh
@@ -13,7 +13,7 @@ else
   echo "Building wheel for ${BASELINE_BRANCH}:${BASELINE_COMMIT_SHA}"
   git checkout "${BASELINE_COMMIT_SHA}"
   mkdir ./tmp
-  PYO3_PYTHON=python3.9 python3.9 -m pip wheel --no-deps -w ./tmp/ ./
+  PYO3_PYTHON=python3.9 CIBW_BUILD=1 python3.9 -m pip wheel --no-deps -w ./tmp/ ./
   for wheel in ./tmp/*.whl;
   do
     auditwheel repair "$wheel" --plat "manylinux2014_x86_64" -w ./

--- a/.gitlab/benchmarks/steps/build-baseline.sh
+++ b/.gitlab/benchmarks/steps/build-baseline.sh
@@ -13,7 +13,7 @@ else
   echo "Building wheel for ${BASELINE_BRANCH}:${BASELINE_COMMIT_SHA}"
   git checkout "${BASELINE_COMMIT_SHA}"
   mkdir ./tmp
-  python3.9 -m pip wheel --no-deps -w ./tmp/ ./
+  PYO3_PYTHON=python3.9 python3.9 -m pip wheel --no-deps -w ./tmp/ ./
   for wheel in ./tmp/*.whl;
   do
     auditwheel repair "$wheel" --plat "manylinux2014_x86_64" -w ./


### PR DESCRIPTION
#13984 broke baseline:build job as 1) it upgraded in PyO3 version 2) changed how _taint_tracking is built


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
