### PR TITLE
ci: use testrunner for microbenchmark build jobs

### DIFF
--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -4,10 +4,12 @@ stages:
   - gate
   - report
 
+include:
+  - .gitlab/testrunner.yml
+
 variables:
   BENCHMARKING_IMAGE_REGISTRY: 486234852809.dkr.ecr.us-east-1.amazonaws.com
   MICROBENCHMARKS_CI_IMAGE: $BENCHMARKING_IMAGE_REGISTRY/ci/benchmarking-platform:dd-trace-py
-  PACKAGE_IMAGE: registry.ddbuild.io/images/mirror/pypa/manylinux2014_x86_64:2024-08-12-7fde9b1
   GITHUB_CLI_IMAGE: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1
   BENCHMARKING_BRANCH: dd-trace-py
 
@@ -92,10 +94,11 @@ baseline:detect:
       - "baseline.env"
 
 baseline:build:
-  image: $PACKAGE_IMAGE
-  tags: [ "arch:amd64" ]
+  extends: .testrunner
   needs: [ "baseline:detect" ]
   stage: build
+  # .testrunner sets a default `retry: 2`
+  retry: 1
   variables:
     CMAKE_BUILD_PARALLEL_LEVEL: 12
     CARGO_BUILD_JOBS: 12
@@ -120,9 +123,10 @@ baseline:build:
       - "*.whl"
 
 candidate:
-  image: $PACKAGE_IMAGE
+  extends: .testrunner
   stage: build
-  tags: [ "arch:amd64" ]
+  # .testrunner sets a default `retry: 2`
+  retry: 1
   needs:
     - pipeline: $PARENT_PIPELINE_ID
       job: download_ddtrace_artifacts

--- a/.gitlab/benchmarks/steps/build-baseline.sh
+++ b/.gitlab/benchmarks/steps/build-baseline.sh
@@ -7,9 +7,6 @@ if [[ -n "${BASELINE_TAG}" ]];
 then
   python3.9 -m pip download --no-deps "ddtrace==${BASELINE_TAG:1}"
 else
-  ulimit -c unlimited
-  curl -sSf https://sh.rustup.rs | sh -s -- -y;
-  export PATH="$HOME/.cargo/bin:$PATH"
   echo "Building wheel for ${BASELINE_BRANCH}:${BASELINE_COMMIT_SHA}"
   git checkout "${BASELINE_COMMIT_SHA}"
   mkdir ./tmp


### PR DESCRIPTION
LANGPLAT-716

We started having issues with the manylinux package image we were using since last week.

> error: no Python 3.x interpreter found

There do not appear to have been any clear changes to the system causing this to happen, but switching to our testrunner image resolves the issue.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
