### PR TITLE
[MLOB-3622] poc for linking LLM and tool spans

### DIFF
--- a/ddtrace/llmobs/_integrations/pydantic_ai.py
+++ b/ddtrace/llmobs/_integrations/pydantic_ai.py
@@ -233,25 +233,25 @@ class PydanticAIIntegration(BaseLLMIntegration):
 
     def _get_span_links(self, span: Span, span_kind: Any) -> List[Dict[str, Any]]:
         span_links = []
-        if span_kind == "agent":
-            for tool_span_id in self._running_agents.pop(span.span_id, []):
-                span_links.append(
-                    {
-                        "span_id": str(tool_span_id),
-                        "trace_id": format_trace_id(span.trace_id),
-                        "attributes": {"from": "output", "to": "output"},
-                    }
-                )
-        elif span_kind == "tool":
-            ancestor = _get_nearest_llmobs_ancestor(span)
-            if ancestor:
-                span_links.append(
-                    {
-                        "span_id": str(ancestor.span_id),
-                        "trace_id": format_trace_id(ancestor.trace_id),
-                        "attributes": {"from": "input", "to": "input"},
-                    }
-                )
+        # if span_kind == "agent":
+        #     for tool_span_id in self._running_agents.pop(span.span_id, []):
+        #         span_links.append(
+        #             {
+        #                 "span_id": str(tool_span_id),
+        #                 "trace_id": format_trace_id(span.trace_id),
+        #                 "attributes": {"from": "output", "to": "output"},
+        #             }
+        #         )
+        # elif span_kind == "tool":
+        #     ancestor = _get_nearest_llmobs_ancestor(span)
+        #     if ancestor:
+        #         span_links.append(
+        #             {
+        #                 "span_id": str(ancestor.span_id),
+        #                 "trace_id": format_trace_id(ancestor.trace_id),
+        #                 "attributes": {"from": "input", "to": "input"},
+        #             }
+        #         )
         return span_links
 
     def _register_span(self, span: Span, kind: Any) -> None:

--- a/ddtrace/llmobs/_integrations/pydantic_ai.py
+++ b/ddtrace/llmobs/_integrations/pydantic_ai.py
@@ -71,7 +71,6 @@ class PydanticAIIntegration(BaseLLMIntegration):
         operation: str = "",
     ) -> None:
         span_kind = span._get_ctx_item(SPAN_KIND)
-        span_links = self._get_span_links(span, span_kind)
 
         if span_kind == "agent":
             self._llmobs_set_tags_agent(span, args, kwargs, response)
@@ -81,7 +80,6 @@ class PydanticAIIntegration(BaseLLMIntegration):
         span._set_ctx_items(
             {
                 SPAN_KIND: span_kind,
-                SPAN_LINKS: span_links,
                 MODEL_NAME: span.get_tag("pydantic_ai.request.model") or "",
                 MODEL_PROVIDER: span.get_tag("pydantic_ai.request.provider") or "",
             }
@@ -230,29 +228,6 @@ class PydanticAIIntegration(BaseLLMIntegration):
             OUTPUT_TOKENS_METRIC_KEY: completion_tokens,
             TOTAL_TOKENS_METRIC_KEY: total_tokens or (prompt_tokens + completion_tokens),
         }
-
-    def _get_span_links(self, span: Span, span_kind: Any) -> List[Dict[str, Any]]:
-        span_links = []
-        # if span_kind == "agent":
-        #     for tool_span_id in self._running_agents.pop(span.span_id, []):
-        #         span_links.append(
-        #             {
-        #                 "span_id": str(tool_span_id),
-        #                 "trace_id": format_trace_id(span.trace_id),
-        #                 "attributes": {"from": "output", "to": "output"},
-        #             }
-        #         )
-        # elif span_kind == "tool":
-        #     ancestor = _get_nearest_llmobs_ancestor(span)
-        #     if ancestor:
-        #         span_links.append(
-        #             {
-        #                 "span_id": str(ancestor.span_id),
-        #                 "trace_id": format_trace_id(ancestor.trace_id),
-        #                 "attributes": {"from": "input", "to": "input"},
-        #             }
-        #         )
-        return span_links
 
     def _register_span(self, span: Span, kind: Any) -> None:
         if kind == "agent":

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -247,7 +247,8 @@ class LLMObs(Service):
     def _llmobs_span_event(self, span: Span) -> LLMObsSpanEvent:
         """Span event object structure."""
         span_kind = span._get_ctx_item(SPAN_KIND)
-        self._span_linker.add_span_links(span, span_kind)
+        parent_id = span._get_ctx_item(PARENT_ID_KEY) or ROOT_PARENT_ID
+        self._span_linker.add_span_links(span, span_kind, parent_id)
         if not span_kind:
             raise KeyError("Span kind not found in span context")
 
@@ -359,7 +360,6 @@ class LLMObs(Service):
             )
 
         span._set_ctx_item(ML_APP, ml_app)
-        parent_id = span._get_ctx_item(PARENT_ID_KEY) or ROOT_PARENT_ID
 
         llmobs_trace_id = span._get_ctx_item(LLMOBS_TRACE_ID)
         if llmobs_trace_id is None:

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -247,11 +247,7 @@ class LLMObs(Service):
     def _llmobs_span_event(self, span: Span) -> LLMObsSpanEvent:
         """Span event object structure."""
         span_kind = span._get_ctx_item(SPAN_KIND)
-        llmobs_trace_id = span._get_ctx_item(LLMOBS_TRACE_ID)
-        if llmobs_trace_id is None:
-            raise ValueError("Failed to extract LLMObs trace ID from span context.")
-        formatted_trace_id = format_trace_id(llmobs_trace_id)
-        self._span_linker.add_span_links(span, span_kind, formatted_trace_id)
+        self._span_linker.add_span_links(span, span_kind)
         if not span_kind:
             raise KeyError("Span kind not found in span context")
 
@@ -365,8 +361,12 @@ class LLMObs(Service):
         span._set_ctx_item(ML_APP, ml_app)
         parent_id = span._get_ctx_item(PARENT_ID_KEY) or ROOT_PARENT_ID
 
+        llmobs_trace_id = span._get_ctx_item(LLMOBS_TRACE_ID)
+        if llmobs_trace_id is None:
+            raise ValueError("Failed to extract LLMObs trace ID from span context.")
+
         llmobs_span_event: LLMObsSpanEvent = {
-            "trace_id": formatted_trace_id,
+            "trace_id": format_trace_id(llmobs_trace_id),
             "span_id": str(span.span_id),
             "parent_id": parent_id,
             "name": _get_span_name(span),

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -973,7 +973,6 @@ class LLMObs(Service):
 
     def _activate_llmobs_span(self, span: Span) -> None:
         """Propagate the llmobs parent span's ID as the new span's parent ID and activate the new span."""
-        self._span_linker.register_span(span)
         llmobs_parent = self._llmobs_context_provider.active()
         if llmobs_parent:
             span._set_ctx_item(PARENT_ID_KEY, str(llmobs_parent.span_id))

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -372,19 +372,18 @@ class SpanLinker:
         """Removes the children spans of the given parent span."""
         self._parent_to_children_spans.pop(parent.span_id, None)
     
-    def _register_span_metadata(self, span: Span, span_kind: str, formatted_trace_id: str) -> None:
+    def _register_span_metadata(self, span: Span, span_kind: str) -> None:
         """Registers the kind of a span upon submitting the span event."""
         children = self._parent_to_children_spans.setdefault(span.parent_id, {})
         children[span.span_id]["kind"] = span_kind
-        children[span.span_id]["llmobs_trace_id"] = formatted_trace_id
     
-    def add_span_links(self, span: Span, span_kind: str, formatted_trace_id: str) -> None:
+    def add_span_links(self, span: Span, span_kind: str) -> None:
         """
         Called when a span finishes. This is used to add span links to the span before it is finished.
         
         Currently, this only works for adding span links between adjacent LLM and tool spans.
         """
-        self._register_span_metadata(span, span_kind, formatted_trace_id)
+        self._register_span_metadata(span, span_kind)
         children = self._parent_to_children_spans.get(span.parent_id, {})
         span_entry = children[span.span_id]
         try:
@@ -409,7 +408,7 @@ class SpanLinker:
                     add_span_link(
                         span,
                         str(previous_child["span"].span_id),
-                        previous_child["llmobs_trace_id"],
+                        format_trace_id(previous_child["span"].trace_id),
                         "output",
                         "input",
                     )

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -366,7 +366,7 @@ class SpanLinker:
         """Removes the children spans of the given parent span."""
         self._parent_to_children_spans.pop(parent.span_id, None)
     
-    def _register_span(self, span: Span, span_kind: str) -> Tuple[Dict[str, any], Dict[str, any]]:
+    def _register_span(self, span: Span, span_kind: str, parent_id: str) -> Tuple[Dict[str, any], Dict[str, any]]:
         """
         Registers the span in the _parent_to_children_spans dict.
 
@@ -376,19 +376,18 @@ class SpanLinker:
 
         Returns the children spans and the span entry for the registered span.
         """
-        parent_id = span.parent_id
         children = self._parent_to_children_spans.setdefault(parent_id, {})
         span_entry = {"span": span, "index": len(children), "kind": span_kind}
         children[span.span_id] = span_entry
         return children, span_entry
     
-    def add_span_links(self, span: Span, span_kind: str) -> None:
+    def add_span_links(self, span: Span, span_kind: str, parent_id: str) -> None:
         """
         Called when a span finishes. This is used to add span links to the span before it is finished.
         
         Currently, this only works for adding span links between adjacent LLM and tool spans.
         """
-        children, span_entry = self._register_span(span, span_kind)
+        children, span_entry = self._register_span(span, span_kind, parent_id)
         try:
             span_index = span_entry["index"]
             if span_index > 0:

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -388,31 +388,28 @@ class SpanLinker:
         Currently, this only works for adding span links between adjacent LLM and tool spans.
         """
         children, span_entry = self._register_span(span, span_kind, parent_id)
-        try:
-            span_index = span_entry["index"]
-            if span_index > 0:
-                previous_child = None
-                for child in children.values():
-                    if child["index"] == span_index - 1:
-                        previous_child = child
-                        break
-                if (
-                    previous_child is not None and (
-                        (
-                            previous_child["kind"] == "llm"
-                            and span_entry["kind"] == "tool"
-                        ) or (
-                            previous_child["kind"] == "tool"
-                            and span_entry["kind"] == "llm"
-                        )
+        span_index = span_entry["index"]
+        if span_index > 0:
+            previous_child = None
+            for child in children.values():
+                if child["index"] == span_index - 1:
+                    previous_child = child
+                    break
+            if (
+                previous_child is not None and (
+                    (
+                        previous_child["kind"] == "llm"
+                        and span_entry["kind"] == "tool"
+                    ) or (
+                        previous_child["kind"] == "tool"
+                        and span_entry["kind"] == "llm"
                     )
-                ):
-                    add_span_link(
-                        span,
-                        str(previous_child["span"].span_id),
-                        format_trace_id(previous_child["span"].trace_id),
-                        "output",
-                        "input",
-                    )
-        except ValueError:
-            return
+                )
+            ):
+                add_span_link(
+                    span,
+                    str(previous_child["span"].span_id),
+                    format_trace_id(previous_child["span"].trace_id),
+                    "output",
+                    "input",
+                )


### PR DESCRIPTION
This PR adds global span linking logic to our LLM Obs SDK, specifically for linking cases of LLM --> Tool --> LLM spans across integrations. We use a best effort approach (i.e. add span links for adjacent LLM --> Tool or Tool --> LLM siblings). 

Note that the Open AI Agents integration already had support for this kind of span linking which relies on a common tool ID shared across LLM and Tool calls. This is a slightly more general approach which will work for other frameworks as well.

[example trace w/ Pydantic AI](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&llmPanels=%5B%7B%22t%22%3A%22sampleDetailPanel%22%2C%22rEID%22%3A%22AwAAAZiBJag9x8WjYAAAABhBWmlCSmFnOUFBQnpQeXRTR2NaUUFBQUEAAAAkZjE5ODgxMjUtYzIxMS00Y2FlLWE5ODMtNjMyYjIzMThlNWZmAAACJQ%22%7D%5D&spanId=15028984867987085480&start=1754512501688&end=1754513401688&paused=false)

[example trace w/ Crew AI](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&llmPanels=%5B%7B%22t%22%3A%22sampleDetailPanel%22%2C%22rEID%22%3A%22AwAAAZiFFYNvX822NQAAABhBWmlGRllOdkFBRE1lUmJ2Z0lrYkFBQUEAAAAkZjE5ODg1MTUtYTA4YS00ZDc5LTgzZTMtZTNkYTYwNWU3M2VjAAAC4w%22%7D%5D&spanId=17738418626473279227&start=1754575858968&end=1754579458968&paused=false)

<img width="410" height="706" alt="image" src="https://github.com/user-attachments/assets/50f62e0f-3776-47a5-b276-732e6ab6385e" />


## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
