### PR TITLE
chore(aap): improvement to avoid warnings for typing and lint

### DIFF
--- a/ddtrace/appsec/_iast/__init__.py
+++ b/ddtrace/appsec/_iast/__init__.py
@@ -26,7 +26,7 @@ def wrapped_function(wrapped, instance, args, kwargs):
         evidence_value=evidence,
     )
     return wrapped(*args, **kwargs)
-"""  # noqa: RST201, RST213, RST210
+"""
 import os
 import sys
 import types

--- a/ddtrace/appsec/_iast/_patch_modules.py
+++ b/ddtrace/appsec/_iast/_patch_modules.py
@@ -129,7 +129,7 @@ class WrapFunctonsForIAST:
         testing (bool): Whether the instance is being used in a testing context
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize a WrapFunctonsForIAST instance."""
         self.functions: Set[IASTFunction] = set()
         self.testing: bool = asm_config._iast_is_testing

--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -1402,7 +1402,7 @@ def strip_aspect(orig_function: Optional[Callable], flag_added_args: int, *args:
     return result
 
 
-def _strip_lstrip_aspect(candidate_text, result):
+def _strip_lstrip_aspect(candidate_text, result) -> None:
     ranges_new: List[TaintRange] = []
     ranges = get_ranges(candidate_text)
     start_pos = candidate_text.index(result)

--- a/ddtrace/appsec/_utils.py
+++ b/ddtrace/appsec/_utils.py
@@ -29,24 +29,24 @@ _TRUNC_CONTAINER_SIZE = 2
 
 
 class _observator:
-    def __init__(self):
+    def __init__(self) -> None:
         self.string_length: Optional[int] = None
         self.container_size: Optional[int] = None
         self.container_depth: Optional[int] = None
 
-    def set_string_length(self, length: int):
+    def set_string_length(self, length: int) -> None:
         if self.string_length is None:
             self.string_length = length
         else:
             self.string_length = max(self.string_length, length)
 
-    def set_container_size(self, size: int):
+    def set_container_size(self, size: int) -> None:
         if self.container_size is None:
             self.container_size = size
         else:
             self.container_size = max(self.container_size, size)
 
-    def set_container_depth(self, depth: int):
+    def set_container_depth(self, depth: int) -> None:
         if self.container_depth is None:
             self.container_depth = depth
         else:
@@ -79,7 +79,7 @@ class DDWaf_result:
         truncation: _observator,
         derivatives: Dict[str, Any],
         keep: bool = False,
-    ):
+    ) -> None:
         self.return_code = return_code
         self.data = data
         self.actions = actions
@@ -115,13 +115,13 @@ Binding_error = DDWaf_result(-127, [], {}, 0.0, 0.0, False, _observator(), {})
 class DDWaf_info:
     __slots__ = ["loaded", "failed", "errors", "version"]
 
-    def __init__(self, loaded: int, failed: int, errors: str, version: str):
+    def __init__(self, loaded: int, failed: int, errors: str, version: str) -> None:
         self.loaded = loaded
         self.failed = failed
         self.errors = errors
         self.version = version
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "{loaded: %d, failed: %d, errors: %s, version: %s}" % (
             self.loaded,
             self.failed,
@@ -133,24 +133,24 @@ class DDWaf_info:
 class Truncation_result:
     __slots__ = ["string_length", "container_size", "container_depth"]
 
-    def __init__(self):
-        self.string_length = []
-        self.container_size = []
-        self.container_depth = []
+    def __init__(self) -> None:
+        self.string_length: List[int] = []
+        self.container_size: List[int] = []
+        self.container_depth: List[int] = []
 
 
 class Rasp_result:
     __slots__ = ["blocked", "sum_eval", "duration", "total_duration", "eval", "match", "timeout", "durations"]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.blocked = False
         self.sum_eval = 0
         self.duration = 0.0
         self.total_duration = 0.0
-        self.eval = collections.defaultdict(int)
-        self.match = collections.defaultdict(int)
-        self.timeout = collections.defaultdict(int)
-        self.durations = collections.defaultdict(float)
+        self.eval: Dict[str, int] = collections.defaultdict(int)
+        self.match: Dict[str, int] = collections.defaultdict(int)
+        self.timeout: Dict[str, int] = collections.defaultdict(int)
+        self.durations: Dict[str, float] = collections.defaultdict(float)
 
 
 class Telemetry_result:
@@ -167,7 +167,7 @@ class Telemetry_result:
         "error",
     ]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.blocked = False
         self.triggered = False
         self.timeout = 0

--- a/ddtrace/settings/asm.py
+++ b/ddtrace/settings/asm.py
@@ -291,9 +291,9 @@ class ASMConfig(DDConfig):
         """For testing purposes, reset the configuration to its default values given current environment variables."""
         self.__init__()
 
-    def _eval_asm_can_be_enabled(self):
+    def _eval_asm_can_be_enabled(self) -> None:
         self._asm_can_be_enabled = APPSEC_ENV not in os.environ and tracer_config._remote_config_enabled
-        self._load_modules: bool = bool(
+        self._load_modules = bool(
             self._iast_enabled or (self._ep_enabled and (self._asm_enabled or self._asm_can_be_enabled))
         )
         self._asm_rc_enabled = (self._asm_enabled and tracer_config._remote_config_enabled) or self._asm_can_be_enabled


### PR DESCRIPTION
mypy and ruff emits some warnings on aap code.
This PR fixes all those warnings.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
