### PR TITLE
ci: bump azure-functions-core-tools to 4.1.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update \
       && mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg \
       && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-bookworm-prod bookworm main" > /etc/apt/sources.list.d/dotnetdev.list \
       && apt-get update \
-      && apt-get install -y --no-install-recommends azure-functions-core-tools-4=4.0.6280-1; \
+      && apt-get install -y --no-install-recommends azure-functions-core-tools-4=4.1.0-1; \
     fi \
     # Google Chrome is needed for selenium contrib tests but is currently only available on amd64
     && if [ "$TARGETARCH" = "amd64" ]; \


### PR DESCRIPTION
The error below arose while working on adding [azure-eventhub](https://pypi.org/project/azure-eventhub/) instrumentation. Upgrading to the latest version of [azure-functions-core-tools](https://github.com/Azure/azure-functions-core-tools) resolves this error.

```
A host error has occurred during startup operation '6093904c-5e5b-4c98-8a0f-8a3b1c0cfccc'.
[2025-08-07T18:02:19.062Z] Microsoft.Azure.WebJobs.Extensions.EventHubs: Could not load file or assembly 'System.Memory.Data, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'. The system cannot find the file specified.
[2025-08-07T18:02:19.062Z] .
Value cannot be null. (Parameter 'provider')
```

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
