### PR TITLE
chore: stricter wrapping context wrap check

### DIFF
--- a/ddtrace/internal/wrapping/context.py
+++ b/ddtrace/internal/wrapping/context.py
@@ -485,7 +485,16 @@ class _UniversalWrappingContext(BaseWrappingContext):
 
     @classmethod
     def is_wrapped(cls, f: FunctionType) -> bool:
-        return hasattr(f, "__dd_context_wrapped__")
+        try:
+            # Check that we have actual bytecode wrapping. The presence of the
+            # __dd_context_wrapped__ attribute is not enough, as this could be
+            # copied over from an object state cloning.
+            if sys.version_info >= (3, 11):
+                return f.__dd_context_wrapped__.__enter__ in f.__code__.co_consts  # type: ignore
+            else:
+                return f.__dd_context_wrapped__ in f.__code__.co_consts  # type: ignore
+        except AttributeError:
+            return False
 
     @classmethod
     def extract(cls, f: FunctionType) -> "_UniversalWrappingContext":


### PR DESCRIPTION
We make the check on whehter a function is wrapped with a universal wrapping context stricter. This will now check that we have actual bytecode wrapping, as the attribute check alone is not strict enough. There are examples of frameworks that might copy the state of wrapped functions over to closures, which would lead the current implementation to believe that a function is wrapped when in reality it is not.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
