### PR TITLE
chore(sampling): log error when sampling rules are not applied

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
@@ -923,19 +923,19 @@ experiments:
           # samplingrules
           - name: samplingrules-average_match
             thresholds:
-              - execution_time < 0.35 ms
+              - execution_time < 0.29 ms
               - max_rss_usage < 34.00 MB
           - name: samplingrules-high_match
             thresholds:
-              - execution_time < 0.55 ms
+              - execution_time < 0.48 ms
               - max_rss_usage < 34.00 MB
           - name: samplingrules-low_match
             thresholds:
-              - execution_time < 0.19 ms
+              - execution_time < 0.12 ms
               - max_rss_usage < 450.00 MB
           - name: samplingrules-very_low_match
             thresholds:
-              - execution_time < 9.15 ms
+              - execution_time < 8.50 ms
               - max_rss_usage < 60.00 MB
 
           # sethttpmeta

--- a/ddtrace/_trace/sampler.py
+++ b/ddtrace/_trace/sampler.py
@@ -155,19 +155,17 @@ class DatadogSampler:
         json_rules = []
         try:
             json_rules = json.loads(rules)
-        except JSONDecodeError:
-            if config._raise:
-                raise ValueError("Unable to parse DD_TRACE_SAMPLING_RULES={}".format(rules))
+        except JSONDecodeError as e:
+            log.error("Unable to parse DD_TRACE_SAMPLING_RULES=%s: %s", rules, e)
+
         for rule in json_rules:
             if "sample_rate" not in rule:
-                if config._raise:
-                    raise KeyError("No sample_rate provided for sampling rule: {}".format(json.dumps(rule)))
+                log.error("No sample_rate provided for sampling rule: %s", rule)
                 continue
             try:
                 sampling_rules.append(SamplingRule(**rule))
             except ValueError as e:
-                if config._raise:
-                    raise ValueError("Error creating sampling rule {}: {}".format(json.dumps(rule), e))
+                log.error("Error creating sampling rule %s: %s", rule, e)
 
         # Sort the sampling_rules list using a lambda function as the key
         self.rules = sorted(sampling_rules, key=lambda rule: PROVENANCE_ORDER.index(rule.provenance))

--- a/ddtrace/_trace/sampler.py
+++ b/ddtrace/_trace/sampler.py
@@ -147,27 +147,16 @@ class DatadogSampler:
 
     def set_sampling_rules(self, rules: str) -> None:
         """Sets the trace sampling rules from a JSON string"""
-        if not rules:
-            self.rules = []
-            return
-
         sampling_rules = []
-        json_rules = []
         try:
             json_rules = json.loads(rules)
-        except JSONDecodeError:
-            log.error("Unable to parse DD_TRACE_SAMPLING_RULES=%s", rules, exc_info=True)
-
-        for rule in json_rules:
-            if "sample_rate" not in rule:
-                log.error("No sample_rate provided for sampling rule: %s", rule)
-                continue
-            try:
+            for rule in json_rules:
+                if "sample_rate" not in rule:
+                    log.error("No sample_rate provided for sampling rule: %s. Skipping.", rule)
+                    continue
                 sampling_rules.append(SamplingRule(**rule))
-            except ValueError:
-                log.error("Error creating sampling rule %s: %s", rule, exc_info=True)
-
-        # Sort the sampling_rules list using a lambda function as the key
+        except (JSONDecodeError, ValueError):
+            log.error("Failed to apply all sampling rules. Rules=%s, Applied=%s", rules, sampling_rules, exc_info=True)
         self.rules = sorted(sampling_rules, key=lambda rule: PROVENANCE_ORDER.index(rule.provenance))
 
     def sample(self, span: Span) -> bool:

--- a/ddtrace/_trace/sampler.py
+++ b/ddtrace/_trace/sampler.py
@@ -155,8 +155,8 @@ class DatadogSampler:
         json_rules = []
         try:
             json_rules = json.loads(rules)
-        except JSONDecodeError as e:
-            log.error("Unable to parse DD_TRACE_SAMPLING_RULES=%s: %s", rules, e)
+        except JSONDecodeError:
+            log.error("Unable to parse DD_TRACE_SAMPLING_RULES=%s", rules, exc_info=True)
 
         for rule in json_rules:
             if "sample_rate" not in rule:
@@ -164,8 +164,8 @@ class DatadogSampler:
                 continue
             try:
                 sampling_rules.append(SamplingRule(**rule))
-            except ValueError as e:
-                log.error("Error creating sampling rule %s: %s", rule, e)
+            except ValueError:
+                log.error("Error creating sampling rule %s: %s", rule, exc_info=True)
 
         # Sort the sampling_rules list using a lambda function as the key
         self.rules = sorted(sampling_rules, key=lambda rule: PROVENANCE_ORDER.index(rule.provenance))

--- a/tests/tracer/test_sampler.py
+++ b/tests/tracer/test_sampler.py
@@ -377,8 +377,8 @@ def test_sampling_rule_init_via_env():
     mock_log.error.assert_has_calls(
         [
             mock.call(
-                "No sample_rate provided for sampling rule: %s",
-                mock.ANY,
+                "No sample_rate provided for sampling rule: %s. Skipping.",
+                {"service": "xyz", "name": "abc"},
             )
         ]
     )
@@ -389,8 +389,9 @@ def test_sampling_rule_init_via_env():
     mock_log.error.assert_has_calls(
         [
             mock.call(
-                "Unable to parse DD_TRACE_SAMPLING_RULES=%s",
+                "Failed to apply all sampling rules. Rules=%s, Applied=%s",
                 '["sample_rate":1.0,"service":"xyz","name":"abc"]',
+                [],
                 exc_info=True,
             )
         ]
@@ -407,8 +408,8 @@ def test_sampling_rule_init_via_env():
     mock_log.error.assert_has_calls(
         [
             mock.call(
-                "No sample_rate provided for sampling rule: %s",
-                mock.ANY,
+                "No sample_rate provided for sampling rule: %s. Skipping.",
+                {"service": "my-service", "name": "my-name"},
             )
         ]
     )

--- a/tests/tracer/test_sampler.py
+++ b/tests/tracer/test_sampler.py
@@ -389,9 +389,9 @@ def test_sampling_rule_init_via_env():
     mock_log.error.assert_has_calls(
         [
             mock.call(
-                "Unable to parse DD_TRACE_SAMPLING_RULES=%s: %s",
+                "Unable to parse DD_TRACE_SAMPLING_RULES=%s",
                 '["sample_rate":1.0,"service":"xyz","name":"abc"]',
-                mock.ANY,
+                exc_info=True,
             )
         ]
     )


### PR DESCRIPTION
## Summary

Ensure an error log is always generated when sampling rules fail to apply.

## Context

Previously, failures to apply sampling rules were silent unless DD_TESTING_RAISE=True (which is disabled by default). This lack of visibility made debugging and observability difficult.

## Change

This PR guarantees that an error log is emitted whenever sampling rules are not applied, regardless of the DD_TESTING_RAISE setting.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
