### PR TITLE
chore: ensure lib-injection telemetry forwarder uses bash process

### DIFF
--- a/lib-injection/sources/sitecustomize.py
+++ b/lib-injection/sources/sitecustomize.py
@@ -185,9 +185,6 @@ def _send_telemetry(event):
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         universal_newlines=True,
-        env={
-            "DD_TRACE_ENABLED": "false",
-        },
     )
     # Mimic Popen.__exit__ which was added in Python 3.3
     try:

--- a/lib-injection/sources/sitecustomize.py
+++ b/lib-injection/sources/sitecustomize.py
@@ -185,6 +185,9 @@ def _send_telemetry(event):
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         universal_newlines=True,
+        env={
+            "DD_TRACE_ENABLED": "false",
+        },
     )
     # Mimic Popen.__exit__ which was added in Python 3.3
     try:

--- a/tests/lib_injection/conftest.py
+++ b/tests/lib_injection/conftest.py
@@ -182,18 +182,12 @@ def test_venv(ddtrace_injection_artifact):
 def mock_telemetry_forwarder(tmp_path):
     def _setup(env, python_executable):
         telemetry_output_file = tmp_path / "telemetry.json"
-        forwarder_script_file = tmp_path / "forwarder.py"
-        # Create a mock forwarder script. This script will be executed by sitecustomize.py
+        forwarder_script_file = tmp_path / "forwarder.sh"
+        # Create a mock forwarder shell script. This script will be executed by sitecustomize.py
         # and will write the telemetry payload to a file that we can inspect.
         forwarder_script_file.write_text(
-            f"""#!{python_executable}
-import sys
-import os
-
-telemetry_output_file = r'{telemetry_output_file}'
-if telemetry_output_file:
-    with open(telemetry_output_file, "w", encoding="utf-8") as f:
-        f.write(sys.stdin.read())
+            f"""#!/bin/sh
+cat > "{telemetry_output_file}"
 """
         )
         os.chmod(forwarder_script_file, 0o755)

--- a/tests/lib_injection/test_guardrails.py
+++ b/tests/lib_injection/test_guardrails.py
@@ -162,15 +162,12 @@ def test_core_dependency_conflict_guardrail(test_venv, mock_telemetry_forwarder)
 
     script_to_run_conflict = """
 import sys
-import time
 try:
     import ddtrace
     print("ddtrace was imported successfully, which is an error.")
     sys.exit(1)
 except ImportError:
     print("ddtrace import failed as expected.")
-    # Give telemetry a moment to send
-    time.sleep(2)
 """
 
     try:


### PR DESCRIPTION
The previous lib injection telemetry forwarder for tests was a python process, which `ddtrace` would try to trace on startup, causing the telemetry forwarder to time out and telemetry events to not get written. This PR changes the script to be a bash script, so that no test failures are hit due to timeouts.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
