### PR TITLE
chore(ci): update system tests version on 3.11

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -27,10 +27,6 @@ jobs:
     env:
       TEST_LIBRARY: python
       WEBLOG_VARIANT: ${{ matrix.weblog-variant }}
-      # system-tests requires an API_KEY, but it does not have to be a valid key, as long as we don't run a scenario
-      # that make assertion on backend data. Using a fake key allow to run system tests on PR originating from forks.
-      # If ever it's needed, a valid key exists in the repo, using ${{ secrets.DD_API_KEY }}
-      DD_API_KEY: ${{ secrets.FAKE_DD_API_KEY }}
       CMAKE_BUILD_PARALLEL_LEVEL: 12
       SYSTEM_TESTS_AWS_ACCESS_KEY_ID: ${{ secrets.IDM_AWS_ACCESS_KEY_ID }}
       SYSTEM_TESTS_AWS_SECRET_ACCESS_KEY: ${{ secrets.IDM_AWS_SECRET_ACCESS_KEY }}
@@ -81,10 +77,6 @@ jobs:
     env:
       TEST_LIBRARY: python
       WEBLOG_VARIANT: ${{ matrix.weblog-variant }}
-      # system-tests requires an API_KEY, but it does not have to be a valid key, as long as we don't run a scenario
-      # that make assertion on backend data. Using a fake key allow to run system tests on PR originating from forks.
-      # If ever it's needed, a valid key exists in the repo, using ${{ secrets.DD_API_KEY }}
-      DD_API_KEY: ${{ secrets.FAKE_DD_API_KEY }}
       CMAKE_BUILD_PARALLEL_LEVEL: 12
       SYSTEM_TESTS_AWS_ACCESS_KEY_ID: ${{ secrets.IDM_AWS_ACCESS_KEY_ID }}
       SYSTEM_TESTS_AWS_SECRET_ACCESS_KEY: ${{ secrets.IDM_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '19028ef64b7932526448f04f9a3bc5b33223c12f'
+          ref: '58ae96efe5d7a1d4b76c443bbca379d21d4d59b2'
 
       - name: Checkout dd-trace-py
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -96,7 +96,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '19028ef64b7932526448f04f9a3bc5b33223c12f'
+          ref: '58ae96efe5d7a1d4b76c443bbca379d21d4d59b2'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -277,7 +277,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '19028ef64b7932526448f04f9a3bc5b33223c12f'
+          ref: '58ae96efe5d7a1d4b76c443bbca379d21d4d59b2'
       - name: Checkout dd-trace-py
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
backport of https://github.com/DataDog/dd-trace-py/pull/14233/files to unlock 3.11 CI

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing
strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note
guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if
[applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking
[API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces)
changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance
implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
