### PR TITLE
chore(profiling): re-accept interval for memory profile collector

### DIFF
--- a/ddtrace/profiling/collector/memalloc.py
+++ b/ddtrace/profiling/collector/memalloc.py
@@ -30,13 +30,17 @@ MemorySample = namedtuple(
 class MemoryCollector(collector.PeriodicCollector):
     """Memory allocation collector."""
 
+    _DEFAULT_INTERVAL = 0.5
+
     def __init__(
         self,
+        _interval: float = _DEFAULT_INTERVAL,
         max_nframe: Optional[int] = None,
         heap_sample_size: Optional[int] = None,
         ignore_profiler: Optional[bool] = None,
     ):
         super().__init__()
+        self._interval: float = _interval
         # TODO make this dynamic based on the 1. interval and 2. the max number of events allowed in the Recorder
         self.max_nframe: int = max_nframe if max_nframe is not None else config.max_frames
         self.heap_sample_size: int = heap_sample_size if heap_sample_size is not None else config.heap.sample_size


### PR DESCRIPTION
In #14205 we removed the `_interval` parameter for the `MemoryCollector`.
This was a mistake. Now the memory profile collector thread basically
spins in a tight loop because the interval is 0. Add that parameter
back.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
