### PR TITLE
[WIP] Add Ray log handler with json formatter

### DIFF
--- a/ddtrace/contrib/internal/ray/tracer.py
+++ b/ddtrace/contrib/internal/ray/tracer.py
@@ -1,5 +1,9 @@
+import contextvars
+import json
 import logging
 import os
+
+from ddtrace._trace.processor import SpanProcessor
 
 
 os.environ["DD_TRACE_OTEL_ENABLED"] = "True"
@@ -12,7 +16,7 @@ from ddtrace.constants import _DJM_ENABLED_KEY
 from ddtrace.constants import _FILTER_KEPT_KEY
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
 from ddtrace.constants import _SPAN_MEASURED_KEY
-from ddtrace.trace import TraceFilter
+from ddtrace.trace import TraceFilter, Span
 from ddtrace.trace import tracer
 
 
@@ -20,15 +24,48 @@ RAY_PREFIX = "ray."
 RAY_JOB_ID_TAG_KEY = "ray.job_id"
 DEFAULT_SERVICE_NAME = "unspecified-ray-job"
 DEFAULT_SPAN_NAME = "ray.job"
+DEFAULT_OUTPUT_LOG_DIR = "/tmp/ray/session_latest/logs/"
+OUTPUT_LOG_FILENAME = "ddtracepy.log"
 
 FORMAT = (
     "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] "
     "[dd.service=%(dd.service)s dd.env=%(dd.env)s "
     "dd.version=%(dd.version)s "
-    "dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] "
     "- %(message)s"
 )
 
+dd_ray_trace_id = contextvars.ContextVar("dd_ray_trace_id")
+dd_ray_span_id = contextvars.ContextVar("dd_ray_span_id")
+dd_ray_parent_id = contextvars.ContextVar("dd_ray_parent_id")
+dd_ray_job_submission_id = contextvars.ContextVar("dd_ray_job_submission_id")
+
+
+def get_job_submission_id():
+    try:
+        ray_env_str = os.environ.get("RAY_JOB_CONFIG_JSON_ENV_VAR", "")
+        ray_env = json.loads(ray_env_str)
+        job_submission_id = ray_env.get("metadata").get("job_submission_id")
+        return job_submission_id
+    except (json.decoder.JSONDecodeError, KeyError, AttributeError) as e:
+        return None
+    
+def on_start_span(span: Span):
+    dd_ray_span_id.set(span.span_id)
+    dd_ray_trace_id.set(span.trace_id)
+    if span.parent_id == 0 and span.name != "ray.job.submit":
+        span.parent_id = dd_ray_parent_id.get()
+    
+# class RaySpanProcessor(SpanProcessor):
+#     def on_span_start(self, span):
+#         dd_ray_span_id.set(span.span_id)
+#         dd_ray_trace_id.set(span.trace_id)
+#         dd_ray_parent_id.set(span.parent_id)
+#         return super().on_span_start(span)
+#     def on_span_finish(self, span):
+#         dd_ray_span_id.set(None)
+#         dd_ray_trace_id.set(None)
+#         dd_ray_parent_id.set(None)
+#         return super().on_span_finish(span)
 
 class RayTraceFilter(TraceFilter):
     def process_trace(self, trace):
@@ -42,16 +79,48 @@ class RayTraceFilter(TraceFilter):
                 span.set_metric(_SPAN_MEASURED_KEY, 1)
                 span.set_metric(_SAMPLING_PRIORITY_KEY, 2)
 
+                span.set_tag("job_name", dd_ray_job_submission_id.get())
+                span.set_tag("operation_name", "ray.job")
+
         return trace
+    
+class ContextAwareJsonFormatter(jsonlogger.JsonFormatter): # type: ignore
+    def add_fields(self, log_record, record, message_dict):
+        super().add_fields(log_record, record, message_dict)
+        
+        # print(f"Log record trace_id={dd_ray_trace_id.get()}, span_id = {dd_ray_span_id.get()}, job_submission_id={dd_ray_job_submission_id.get()}")
+        
+        log_record['dd.trace_id'] = dd_ray_trace_id.get()
+        log_record['dd.span_id'] = dd_ray_span_id.get()
+        log_record['ray.job_submission_id'] = dd_ray_job_submission_id.get()
 
 
 def setup_tracing() -> None:
+
     tracer.configure(trace_processors=[RayTraceFilter()])
+
+    tracer.on_start_span(on_start_span)
+
+    with tracer.trace("ray.job.setup_tracing") as span:
+        span.parent_id = 0
+        dd_ray_span_id.set(span.span_id)
+        dd_ray_parent_id.set(span.span_id)
+        dd_ray_trace_id.set(span.trace_id)
+
+    # ray_span_processor = RaySpanProcessor()
+    # tracer._span_processors.append(ray_span_processor)
+
+    job_submission_id = get_job_submission_id()
+    if job_submission_id is not None:
+        dd_ray_job_submission_id.set(job_submission_id)
 
     for name in logging.root.manager.loggerDict.keys():
         logger = logging.getLogger(name)
         if name.startswith(RAY_PREFIX):
-            json_formatter = jsonlogger.JsonFormatter(fmt=FORMAT)  # type: ignore
-            stream_handler = logging.StreamHandler()
-            stream_handler.setFormatter(json_formatter)
-            logger.addHandler(stream_handler)
+            json_formatter = ContextAwareJsonFormatter(fmt=FORMAT)  # type: ignore
+            out_log_dir = os.environ.get("DD_RAY_TMP_DIR", DEFAULT_OUTPUT_LOG_DIR)
+            os.makedirs(out_log_dir, exist_ok=True)
+            out_log_path = os.path.join(out_log_dir, OUTPUT_LOG_FILENAME)            
+            file_handler = logging.FileHandler(out_log_path)
+            file_handler.setFormatter(json_formatter)
+            logger.addHandler(file_handler)


### PR DESCRIPTION
As part of [MLOB-2993](https://datadoghq.atlassian.net/browse/MLOB-2993), this PR adds a Ray log handler with json formatting to the Ray setup_tracing hook. This will cause Ray to write json log lines, which can be ingested by the Datadog agent. Later we can add fields by subclassing jsonlogger.CustomJsonFormatter as described [in the repo README](https://github.com/madzak/python-json-logger?tab=readme-ov-file#customizing-fields).

This does not solve the problem of "one job one trace" or of associated logs with traces, because as of now we do not have a way to get a unique trace id out of the Ray runtime context either when a span is being generated or when a log line is being written. Later when [MLOB-3320](https://datadoghq.atlassian.net/browse/MLOB-3320) is complete we should have a trace id available everywhere, and we can insert it in the trace filter and in the CustomJsonFormatter as described in the paragraph above.

This PR is up for early to review to validate the approach. Also possible would be outputting the transformed logs to a separate file and ingesting through the Datadog agent from there.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)


[MLOB-2993]: https://datadoghq.atlassian.net/browse/MLOB-2993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MLOB-3320]: https://datadoghq.atlassian.net/browse/MLOB-3320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ