### PR TITLE
ci: improve GHA run detection in gitlab builds

### DIFF
--- a/.gitlab/download-wheels-from-gh-actions.sh
+++ b/.gitlab/download-wheels-from-gh-actions.sh
@@ -6,7 +6,7 @@ if [ -z "$CI_COMMIT_SHA" ]; then
   exit 1
 fi
 
-RUN_ID=$(gh run ls --repo DataDog/dd-trace-py --commit=$CI_COMMIT_SHA --workflow=build_deploy.yml --json databaseId --jq "first (.[]) | .databaseId")
+RUN_ID=$(gh run ls --repo DataDog/dd-trace-py --commit=$CI_COMMIT_SHA --event=release --workflow=build_deploy.yml --json databaseId --jq "first (.[]) | .databaseId")
 if [ -z "$RUN_ID" ]; then
   echo "No RUN_ID found waiting for job to start"
   # The job has not started yet. Give it time to start

--- a/.gitlab/download-wheels-from-gh-actions.sh
+++ b/.gitlab/download-wheels-from-gh-actions.sh
@@ -6,7 +6,19 @@ if [ -z "$CI_COMMIT_SHA" ]; then
   exit 1
 fi
 
-RUN_ID=$(gh run ls --repo DataDog/dd-trace-py --commit=$CI_COMMIT_SHA --event=release --workflow=build_deploy.yml --json databaseId --jq "first (.[]) | .databaseId")
+if [ -v "$CI_COMMIT_TAG" ]; then
+    TRIGGERING_EVENT="release"
+fi
+
+RUN_ID=$(
+    gh run ls \
+    --repo DataDog/dd-trace-py \
+    --commit="$CI_COMMIT_SHA" \
+    $([ -z "$TRIGGERING_EVENT" ] && echo "" || echo "--event=$TRIGGERING_EVENT") \
+    --workflow=build_deploy.yml \
+    --json databaseId \
+    --jq "first (.[]) | .databaseId"
+)
 if [ -z "$RUN_ID" ]; then
   echo "No RUN_ID found waiting for job to start"
   # The job has not started yet. Give it time to start


### PR DESCRIPTION
This change fixes an issue in which the gitlab pipeline for a tagged release would sometimes start with the wrong wheel. The fix involves filtering the list of wheel candidates by the event that triggered their creation. Release pipelines should only consider wheels built during **tag** github actions.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
