### PR TITLE
ci: fix inaccurate detect baseline script for benchmarks

### DIFF
--- a/.gitlab/benchmarks/steps/detect-baseline.sh
+++ b/.gitlab/benchmarks/steps/detect-baseline.sh
@@ -27,7 +27,7 @@ elif [[ "${UPSTREAM_BRANCH}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
   BASELINE_BRANCH=$(echo "${UPSTREAM_BRANCH:1}" | cut -d. -f1-2)
 
   # Check if a release branch exists or not
-  if git ls-remote --exit-code --heads origin "${BASELINE_BRANCH}" > /dev/null; then
+  if git ls-remote --exit-code --heads origin "refs/heads/${BASELINE_BRANCH}" > /dev/null; then
     echo "Found remote branch origin/${BASELINE_BRANCH}"
   else
     echo "Remote branch origin/${BASELINE_BRANCH} not found. Falling back to main."


### PR DESCRIPTION
ls-remote will use the provided string as a pattern, so when checking if the '3.12' branch exists, it'll allow anything that contains '3.12' in the name.

this change is more exacting by checking for a specific ref instead


```
UPSTREAM_BRANCH=v3.12.0rc1
+ '[' v3.12.0rc1 == main ']'
+ [[ v3.12.0rc1 =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]
++ echo 3.12.0rc1
++ cut -d. -f1-2
+ BASELINE_BRANCH=3.12
+ git ls-remote --exit-code --heads origin 3.12
+ echo 'Found remote branch origin/3.12'
Found remote branch origin/3.12
++ git describe --tags --abbrev=0 --exclude '*rc*' --exclude v3.12.0rc1 origin/3.12
fatal: Not a valid object name origin/3.12
```

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
