### PR TITLE
perf(profiler): don't start an extra thread for memory profiling

### DIFF
--- a/ddtrace/profiling/collector/memalloc.py
+++ b/ddtrace/profiling/collector/memalloc.py
@@ -27,26 +27,20 @@ MemorySample = namedtuple(
 )
 
 
-class MemoryCollector(collector.PeriodicCollector):
+class MemoryCollector:
     """Memory allocation collector."""
-
-    _DEFAULT_INTERVAL = 0.5
 
     def __init__(
         self,
-        _interval: float = _DEFAULT_INTERVAL,
         max_nframe: Optional[int] = None,
         heap_sample_size: Optional[int] = None,
         ignore_profiler: Optional[bool] = None,
     ):
-        super().__init__()
-        self._interval: float = _interval
-        # TODO make this dynamic based on the 1. interval and 2. the max number of events allowed in the Recorder
         self.max_nframe: int = max_nframe if max_nframe is not None else config.max_frames
         self.heap_sample_size: int = heap_sample_size if heap_sample_size is not None else config.heap.sample_size
         self.ignore_profiler: bool = ignore_profiler if ignore_profiler is not None else config.ignore_profiler
 
-    def _start_service(self):
+    def start(self):
         # type: (...) -> None
         """Start collecting memory profiles."""
         if _memalloc is None:
@@ -61,10 +55,16 @@ class MemoryCollector(collector.PeriodicCollector):
             _memalloc.stop()
             _memalloc.start(self.max_nframe, self.heap_sample_size)
 
-        super(MemoryCollector, self)._start_service()
+    def __enter__(self):
+        self.start()
 
-    @staticmethod
-    def on_shutdown():
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop()
+
+    def join(self):
+        pass
+
+    def stop(self):
         # type: () -> None
         if _memalloc is not None:
             try:

--- a/tests/profiling_v2/collector/test_memalloc.py
+++ b/tests/profiling_v2/collector/test_memalloc.py
@@ -119,7 +119,7 @@ def test_memory_collector_ignore_profiler(tmp_path):
         alloc_thread._ddtrace_profiling_ignore = True
         alloc_thread.start()
 
-        mc.periodic()
+        mc.snapshot()
 
     # We need to wait for the data collection to happen so it gets the `_ddtrace_profiling_ignore` Thread attribute from
     # the global thread list.


### PR DESCRIPTION
The MemoryCollector inherits from the PeriodicService class, which in turn
starts a thread to periodically call a given Python callback. The callback is
the periodic method, which for MemoryCollector is just the no-op method
inherited from PeriodicService.

I wasn't even aware of this behavior just looking at MemoryCollector, which
caused problems when I deleted the `_interval` member variable in a PR. After
that, the periodic thread ran in a tight loop. This is how I learned that the
thread was even there... Really we don't need the periodic thread for the
memory profiler. The main profiling thread is already responsible for setup,
teardown, and collecting periodic snapshots of the memory profile.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
