### PR TITLE
fix(openai): catch and propagate asyncio.CancelledError

### DIFF
--- a/ddtrace/contrib/internal/openai/patch.py
+++ b/ddtrace/contrib/internal/openai/patch.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import sys
 from typing import Dict
@@ -296,7 +297,7 @@ def _patched_endpoint_async(openai, patch_hook):
         try:
             resp = await func(*args, **kwargs)
             return resp
-        except Exception as e:
+        except (Exception, asyncio.CancelledError) as e:
             err = e
             raise
         finally:

--- a/ddtrace/contrib/internal/openai/patch.py
+++ b/ddtrace/contrib/internal/openai/patch.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import sys
 from typing import Dict
@@ -263,7 +262,7 @@ def _patched_endpoint(openai, patch_hook):
         resp, err = None, None
         try:
             resp = func(*args, **kwargs)
-        except Exception as e:
+        except BaseException as e:
             err = e
             raise
         finally:
@@ -297,7 +296,7 @@ def _patched_endpoint_async(openai, patch_hook):
         try:
             resp = await func(*args, **kwargs)
             return resp
-        except (Exception, asyncio.CancelledError) as e:
+        except BaseException as e:
             err = e
             raise
         finally:

--- a/releasenotes/notes/fix-openai-catch-base-exception-a59c36fa8b0f40a0.yaml
+++ b/releasenotes/notes/fix-openai-catch-base-exception-a59c36fa8b0f40a0.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    openai: Resolves an issue in the OpenAI integration where ``asyncio.CancelledError`` was not caught or re-raised.


### PR DESCRIPTION
Resolves an issue where our openai integration did not catch/propagate asyncio CancelledError cases.

In OpenAI Agents SDK, the OpenAI library is used internally to make LLM calls. However in a somewhat convoluted scenario, OpenAI Agents makes two LLM calls concurrently via `asyncio.gather(...)`, in which the first one can raise an error, which results in the second LLM call being cancelled sometime later. Our OpenAI integration did not catch this and continued executing and returning the underlying LLM call instead of raising, which caused an exception in the OpenAI Agents SDK which did not expect a None response (this should've cancelled and raised before it got to this point).

This fix addresses this by directly raising if we notice the asyncio task has been cancelled.

We're avoiding a repro here because it's 1) difficult to simulate a non-standard exception, and 2) the repro case involves using asyncio to simulate a cancelled task, which is not trivial. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
