### PR TITLE
chore(django): remove django.process_exception event/handler

### DIFF
--- a/ddtrace/contrib/internal/django/patch.py
+++ b/ddtrace/contrib/internal/django/patch.py
@@ -360,11 +360,11 @@ def traced_process_exception(django, name, resource=None):
         tags = {COMPONENT: config_django.integration_name}
         with core.context_with_data(
             "django.process_exception", span_name=name, resource=resource, tags=tags, pin=pin
-        ) as ctx, ctx.span:
+        ) as ctx:
             resp = func(*args, **kwargs)
-            core.dispatch(
-                "django.process_exception", (ctx, hasattr(resp, "status_code") and 500 <= resp.status_code < 600)
-            )
+
+            # Tell finish span that we should collect the traceback
+            ctx.set_item("should_set_traceback", hasattr(resp, "status_code") and 500 <= resp.status_code < 600)
             return resp
 
     return trace_utils.with_traced_module(wrapped)(django)


### PR DESCRIPTION
We can remove the need for `with ctx.span` and calling an additional `django.process_exception` event by adding support for `should_set_traceback` to the `_finish_span` trace handler.

This will help to further remove span references/usage in the django integration.


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
