### PR TITLE
chore(internal): add is_wrapped and is_wrapped_with helpers

### DIFF
--- a/ddtrace/internal/wrapping/__init__.py
+++ b/ddtrace/internal/wrapping/__init__.py
@@ -269,6 +269,38 @@ def wrap(f, wrapper):
     return wf
 
 
+def is_wrapped(f: FunctionType) -> bool:
+    """Check if a function is wrapped with any wrapper."""
+    try:
+        wf = cast(WrappedFunction, f)
+        inner = cast(FunctionType, wf.__dd_wrapped__)
+
+        # Sanity check
+        assert inner.__name__ == "<wrapped>", "Wrapper has wrapped function"  # nosec
+        return True
+    except AttributeError:
+        return False
+
+
+def is_wrapped_with(f: FunctionType, wrapper: Wrapper) -> bool:
+    """Check if a function is wrapped with a specific wrapper."""
+    try:
+        wf = cast(WrappedFunction, f)
+        inner = cast(FunctionType, wf.__dd_wrapped__)
+
+        # Sanity check
+        assert inner.__name__ == "<wrapped>", "Wrapper has wrapped function"  # nosec
+
+        if wrapper in f.__code__.co_consts:
+            return True
+
+        # This is not the correct wrapping layer. Try with the next one.
+        return is_wrapped_with(inner, wrapper)
+
+    except AttributeError:
+        return False
+
+
 def unwrap(wf, wrapper):
     # type: (WrappedFunction, Wrapper) -> FunctionType
     """Unwrap a wrapped function.


### PR DESCRIPTION
Useful helpers to ensure we can check if something is already wrapped to avoid re-wrapping it, and we can check if it is already wrapped with a specific function. Useful both for testing and patching.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
