### PR TITLE
ci: pin system-tests ref in one-pipeline

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'cc0f0a64853f98d0248b682d633d227fa41f4a6e'
+          ref: '4ea4c419151062ab3c2e4131962f24f73c8f3f5d'
 
       - name: Checkout dd-trace-py
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -90,7 +90,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'cc0f0a64853f98d0248b682d633d227fa41f4a6e'
+          ref: '4ea4c419151062ab3c2e4131962f24f73c8f3f5d'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -273,7 +273,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'cc0f0a64853f98d0248b682d633d227fa41f4a6e'
+          ref: '4ea4c419151062ab3c2e4131962f24f73c8f3f5d'
       - name: Checkout dd-trace-py
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,8 @@ variables:
   # VPA Template configuration
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
+  # Automatically managed, use scripts/update-system-tests-version to update
+  SYSTEM_TESTS_REF: "cc0f0a64853f98d0248b682d633d227fa41f4a6e"
 
 default:
   interruptible: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "cc0f0a64853f98d0248b682d633d227fa41f4a6e"
+  SYSTEM_TESTS_REF: "4ea4c419151062ab3c2e4131962f24f73c8f3f5d"
 
 default:
   interruptible: true

--- a/scripts/update-system-tests-version.py
+++ b/scripts/update-system-tests-version.py
@@ -8,6 +8,7 @@ import subprocess
 
 system_tests_repo = "https://github.com/DataDog/system-tests.git"
 system_tests_workflows_path = ".github/workflows/system-tests.yml"
+gitlab_ci_path = ".gitlab-ci.yml"
 
 
 def get_latest_system_tests_version() -> str:
@@ -32,6 +33,7 @@ def get_current_system_tests_version() -> str:
 
 
 def update_system_tests_version(latest_version: str):
+    # Update GitHub workflow file
     with open(system_tests_workflows_path, "r") as file:
         content = file.read()
 
@@ -49,6 +51,22 @@ def update_system_tests_version(latest_version: str):
     with open(system_tests_workflows_path, "w") as file:
         file.write("\n".join(lines))
 
+    # Update GitLab CI file
+    with open(gitlab_ci_path, "r") as file:
+        content = file.read()
+
+    lines = content.splitlines()
+    for i in range(len(lines)):
+        # Look for the SYSTEM_TESTS_REF variable
+        if lines[i].strip().startswith("SYSTEM_TESTS_REF:"):
+            # Replace the entire line with the new commit hash
+            indent = len(lines[i]) - len(lines[i].lstrip())
+            lines[i] = f"{' ' * indent}SYSTEM_TESTS_REF: \"{latest_version}\""
+            break
+
+    with open(gitlab_ci_path, "w") as file:
+        file.write("\n".join(lines))
+
 
 if __name__ == "__main__":
     current_version = get_current_system_tests_version()
@@ -56,4 +74,4 @@ if __name__ == "__main__":
     latest_version = get_latest_system_tests_version()
     print(f"Latest system-tests version: {latest_version}")
     update_system_tests_version(latest_version)
-    print(f"Updated {system_tests_workflows_path} with the latest version.")
+    print(f"Updated {system_tests_workflows_path} and {gitlab_ci_path} with the latest version.")


### PR DESCRIPTION
Also update `scripts/update-system-tsts-version.py` to also update `.gitlab-ci.yml`

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
