### PR TITLE
chore(django): move template wrapping away from wrapping context

### DIFF
--- a/.gitlab/benchmarks/steps/detect-baseline.sh
+++ b/.gitlab/benchmarks/steps/detect-baseline.sh
@@ -27,7 +27,7 @@ elif [[ "${UPSTREAM_BRANCH}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
   BASELINE_BRANCH=$(echo "${UPSTREAM_BRANCH:1}" | cut -d. -f1-2)
 
   # Check if a release branch exists or not
-  if git ls-remote --exit-code --heads origin "${BASELINE_BRANCH}" > /dev/null; then
+  if git ls-remote --exit-code --heads origin "refs/heads/${BASELINE_BRANCH}" > /dev/null; then
     echo "Found remote branch origin/${BASELINE_BRANCH}"
   else
     echo "Remote branch origin/${BASELINE_BRANCH} not found. Falling back to main."

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -11,6 +11,7 @@ from urllib import parse
 
 import wrapt
 
+import ddtrace
 from ddtrace import config
 from ddtrace._trace._inferred_proxy import create_inferred_proxy_span_if_headers_exist
 from ddtrace._trace._span_pointer import _SpanPointerDescription
@@ -112,7 +113,8 @@ def _start_span(ctx: core.ExecutionContext, call_trace: bool = True, **kwargs) -
     activate_distributed_headers = ctx.get_local_item("activate_distributed_headers")
     span_kwargs = _get_parameters_for_new_span_directly_from_context(ctx)
     call_trace = ctx.get_item("call_trace", call_trace)
-    tracer = ctx.get_item("tracer") or (ctx.get_item("middleware") or ctx["pin"]).tracer
+    # Look for the tracer in the context, or fallback to the global tracer
+    tracer = ctx.get_item("tracer") or (ctx.get_item("middleware") or ctx.get_item("pin") or ddtrace).tracer
     integration_config = ctx.get_item("integration_config")
     if integration_config and activate_distributed_headers:
         trace_utils.activate_distributed_headers(

--- a/ddtrace/contrib/internal/django/patch.py
+++ b/ddtrace/contrib/internal/django/patch.py
@@ -6,6 +6,7 @@ Django internals are instrumented via normal `patch()`.
 `django.apps.registry.Apps.populate` is patched to add instrumentation for any
 specific Django apps like Django Rest Framework (DRF).
 """
+
 from collections.abc import Iterable
 import functools
 from inspect import getmro
@@ -94,6 +95,8 @@ config._add(
         ),
         obfuscate_404_resource=os.getenv("DD_ASGI_OBFUSCATE_404_RESOURCE", default=False),
         views={},
+        # DEV: Used only for testing purposes, do not use in production
+        _tracer=None,
     ),
 )
 
@@ -965,9 +968,9 @@ def _patch(django):
         )
 
     if config_django.instrument_templates:
-        from .templates import DjangoTemplateWrappingContext
+        from . import templates
 
-        when_imported("django.template.base")(DjangoTemplateWrappingContext.instrument_module)
+        when_imported("django.template.base")(templates.instrument_module)
 
     if django.VERSION < (4, 0, 0):
         when_imported("django.conf.urls")(lambda m: trace_utils.wrap(m, "url", traced_urls_path(django)))

--- a/ddtrace/contrib/internal/django/templates.py
+++ b/ddtrace/contrib/internal/django/templates.py
@@ -1,21 +1,22 @@
 from types import FunctionType
 from types import ModuleType
-from types import TracebackType
 import typing
-from typing import Optional
+from typing import Any
+from typing import Dict
+from typing import Tuple
 from typing import Type
 from typing import TypeVar
 
-import ddtrace
 from ddtrace import config
-from ddtrace._trace.pin import Pin
 from ddtrace.ext import http
 from ddtrace.internal import core
 from ddtrace.internal.compat import maybe_stringify
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.importlib import func_name
-from ddtrace.internal.wrapping.context import WrappingContext
+from ddtrace.internal.wrapping import is_wrapped_with
+from ddtrace.internal.wrapping import unwrap
+from ddtrace.internal.wrapping import wrap
 from ddtrace.settings.integration import IntegrationConfig
 
 
@@ -28,107 +29,62 @@ log = get_logger(__name__)
 config_django: IntegrationConfig = typing.cast(IntegrationConfig, config.django)
 
 
-class DjangoTemplateWrappingContext(WrappingContext):
+def instrument_module(django_template_base: ModuleType) -> None:
     """
-    A context for wrapping django.template.base:Template.render method.
+    Instrument the django template base module to wrap the render method.
     """
+    if not config_django.instrument_templates:
+        return
 
-    def __init__(self, f: FunctionType, django: ModuleType) -> None:
-        super().__init__(f)
-        self._django = django
+    # Wrap the render method of the Template class
+    Template = getattr(django_template_base, "Template", None)
+    if not Template or not hasattr(Template, "render"):
+        return
 
-    @classmethod
-    def instrument_module(cls, django_template_base: ModuleType) -> None:
-        """
-        Instrument the django template base module to wrap the render method.
-        """
-        if not config_django.instrument_templates:
-            return
+    if not is_wrapped_with(Template.render, traced_render):
+        wrap(Template.render, traced_render)
 
-        # Wrap the render method of the Template class
-        Template = getattr(django_template_base, "Template", None)
-        if not Template or not hasattr(Template, "render"):
-            return
 
-        import django
+def uninstrument_module(django_template_base: ModuleType) -> None:
+    # Unwrap the render method of the Template class
+    Template = getattr(django_template_base, "Template", None)
+    if not Template or not hasattr(Template, "render"):
+        return
 
-        cls(typing.cast(FunctionType, Template.render), django).wrap()
+    unwrap(Template.render, traced_render)
 
-    @classmethod
-    def uninstrument_module(cls, django_template_base: ModuleType) -> None:
-        # Unwrap the render method of the Template class
-        Template = getattr(django_template_base, "Template", None)
-        if not Template or not hasattr(Template, "render"):
-            return
 
-        if cls.is_wrapped(Template.render):
-            ctx = cls.extract(Template.render)
-            ctx.unwrap()
+def traced_render(func: FunctionType, args: Tuple[Any], kwargs: Dict[str, Any]) -> Any:
+    if not config_django.instrument_templates:
+        return func(*args, **kwargs)
 
-    def __enter__(self) -> "DjangoTemplateWrappingContext":
-        super().__enter__()
+    # Get the template instance (self parameter of the render method)
+    # Note: instance is a django.template.base.Template
+    instance: Type[Any] = args[0]
 
-        if not config_django.instrument_templates:
-            return self
+    # Extract template name
+    template_name = maybe_stringify(getattr(instance, "name", None))
+    if template_name:
+        resource = template_name
+    else:
+        resource = f"{func_name(instance)}.render"
 
-        # Get the template instance (self parameter of the render method)
-        # Note: instance is a django.template.base.Template
-        instance = self.get_local("self")
+    # Build tags
+    tags = {COMPONENT: config_django.integration_name}
+    if template_name:
+        tags["django.template.name"] = template_name
 
-        # Extract template name
-        template_name = maybe_stringify(getattr(instance, "name", None))
-        if template_name:
-            resource = template_name
-        else:
-            resource = "{0}.{1}".format(func_name(instance), self.__wrapped__.__name__)
+    engine = getattr(instance, "engine", None)
+    if engine:
+        tags["django.template.engine.class"] = func_name(engine)
 
-        # Build tags
-        tags = {COMPONENT: config_django.integration_name}
-        if template_name:
-            tags["django.template.name"] = template_name
-
-        engine = getattr(instance, "engine", None)
-        if engine:
-            tags["django.template.engine.class"] = func_name(engine)
-
-        # Create the span context
-        pin = Pin.get_from(self._django)
-        tracer = ddtrace.tracer
-        if pin:
-            tracer = pin.tracer or tracer
-        ctx = core.context_with_data(
-            "django.template.render",
-            span_name="django.template.render",
-            resource=resource,
-            span_type=http.TEMPLATE,
-            tags=tags,
-            tracer=tracer,
-        )
-
-        # Enter the context and store it
-        ctx.__enter__()
-        self.set("ctx", ctx)
-
-        return self
-
-    def _close_ctx(
-        self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
-    ) -> None:
-        try:
-            # Close the context and any open span
-            ctx = self.get("ctx")
-            ctx.__exit__(exc_type, exc_val, exc_tb)
-        except Exception:
-            log.exception("Failed to close Django template render wrapping context")
-
-    def __return__(self, value: T) -> T:
-        if config_django.instrument_templates:
-            self._close_ctx(None, None, None)
-        return super().__return__(value)
-
-    def __exit__(
-        self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
-    ) -> None:
-        if config_django.instrument_templates:
-            self._close_ctx(exc_type, exc_val, exc_tb)
-        return super().__exit__(exc_type, exc_val, exc_tb)
+    with core.context_with_data(
+        "django.template.render",
+        span_name="django.template.render",
+        resource=resource,
+        span_type=http.TEMPLATE,
+        tags=tags,
+        # TODO: Migrate all tests to snapshot tests and remove this
+        tracer=config_django._tracer,
+    ):
+        return func(*args, **kwargs)

--- a/tests/contrib/django/conftest.py
+++ b/tests/contrib/django/conftest.py
@@ -8,6 +8,7 @@ from ddtrace.contrib.internal.django.patch import patch
 from ddtrace.trace import Pin
 from tests.utils import DummyTracer
 from tests.utils import TracerSpanContainer
+from tests.utils import override_config
 
 
 # We manually designate which settings we will be using in an environment variable
@@ -35,7 +36,8 @@ def tracer():
     Pin._override(django, tracer=tracer)
 
     # Yield to our test
-    yield tracer
+    with override_config("django", dict(_tracer=tracer)):
+        yield tracer
     tracer.pop()
 
     # Reset the tracer pinned to Django and unpatch

--- a/tests/contrib/django/test_django_patch.py
+++ b/tests/contrib/django/test_django_patch.py
@@ -1,6 +1,5 @@
 from ddtrace.contrib.internal.django.patch import get_version
 from ddtrace.contrib.internal.django.patch import patch
-from ddtrace.contrib.internal.django.templates import DjangoTemplateWrappingContext
 from tests.contrib.patch import PatchTestCase
 
 
@@ -23,7 +22,7 @@ class TestDjangoPatch(PatchTestCase.Base):
 
         import django.template.base
 
-        assert DjangoTemplateWrappingContext.is_wrapped(django.template.base.Template.render)
+        self.assert_wrapped(django.template.base.Template.render)
         if django.VERSION >= (2, 0, 0):
             self.assert_wrapped(django.urls.path)
             self.assert_wrapped(django.urls.re_path)
@@ -35,7 +34,7 @@ class TestDjangoPatch(PatchTestCase.Base):
 
         self.assert_not_wrapped(django.core.handlers.base.BaseHandler.load_middleware)
         self.assert_not_wrapped(django.core.handlers.base.BaseHandler.get_response)
-        assert not DjangoTemplateWrappingContext.is_wrapped(django.template.base.Template.render)
+        self.assert_not_wrapped(django.template.base.Template.render)
         if django.VERSION >= (2, 0, 0):
             self.assert_not_wrapped(django.urls.path)
             self.assert_not_wrapped(django.urls.re_path)
@@ -47,11 +46,7 @@ class TestDjangoPatch(PatchTestCase.Base):
         self.assert_not_double_wrapped(django.apps.registry.Apps.populate)
         self.assert_not_double_wrapped(django.core.handlers.base.BaseHandler.load_middleware)
         self.assert_not_double_wrapped(django.core.handlers.base.BaseHandler.get_response)
-
-        assert DjangoTemplateWrappingContext.is_wrapped(django.template.base.Template.render)
-        ctx = DjangoTemplateWrappingContext.extract(django.template.base.Template.render)
-        ctx.unwrap()
-        assert not DjangoTemplateWrappingContext.is_wrapped(django.template.base.Template.render)
+        self.assert_not_double_wrapped(django.template.base.Template.render)
 
         if django.VERSION >= (2, 0, 0):
             self.assert_not_double_wrapped(django.urls.path)


### PR DESCRIPTION
~Depends on #14295~

While working on #14273 I was running into some compatibility issues with middleware wrappers using WrappingContext + core api/ExecutionContext.

For now I feel it is safer to just use the regular bytecode wrappers instead until we can reproduce and debug the WrappingContext issues.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
