### PR TITLE
ci(benchmarks): increase slos for telemetry add metric

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
@@ -1094,7 +1094,7 @@ experiments:
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-100-count-metrics-100-times
             thresholds:
-              - execution_time < 22.50 ms
+              - execution_time < 23.00 ms
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-100-distribution-metrics-100-times
             thresholds:
@@ -1102,11 +1102,11 @@ experiments:
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-100-gauge-metrics-100-times
             thresholds:
-              - execution_time < 1.40 ms
+              - execution_time < 1.50 ms
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-100-rate-metrics-100-times
             thresholds:
-              - execution_time < 2.40 ms
+              - execution_time < 2.50 ms
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-flush-1-metric
             thresholds:
@@ -1118,7 +1118,7 @@ experiments:
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-flush-1000-metrics
             thresholds:
-              - execution_time < 2.35 ms
+              - execution_time < 2.45 ms
               - max_rss_usage < 34.50 MB
 
           # tracer


### PR DESCRIPTION
We've seen some flakiness in a few telemetry add metric benchmarks, increasing the SLOs slightly to give some head room to try and avoid false positives.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
