### PR TITLE
fix(er): start capturing from the leaf frame

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -47,7 +47,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '04070bed4dd644284690650abe291e632eb27cd9'
+          ref: '66e321c4a84b7d5ad0f81ad74140487252ad3da1'
 
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -94,7 +94,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '04070bed4dd644284690650abe291e632eb27cd9'
+          ref: '66e321c4a84b7d5ad0f81ad74140487252ad3da1'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -279,7 +279,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '04070bed4dd644284690650abe291e632eb27cd9'
+          ref: '66e321c4a84b7d5ad0f81ad74140487252ad3da1'
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "04070bed4dd644284690650abe291e632eb27cd9"
+  SYSTEM_TESTS_REF: "66e321c4a84b7d5ad0f81ad74140487252ad3da1"
 
 default:
   interruptible: true

--- a/ddtrace/debugging/_exception/replay.py
+++ b/ddtrace/debugging/_exception/replay.py
@@ -1,6 +1,5 @@
 from collections import deque
 from dataclasses import dataclass
-from itertools import count
 from pathlib import Path
 from threading import current_thread
 from types import FrameType
@@ -21,6 +20,7 @@ from ddtrace.internal.packages import is_user_code
 from ddtrace.internal.rate_limiter import BudgetRateLimiterWithJitter as RateLimiter
 from ddtrace.internal.rate_limiter import RateLimitExceeded
 from ddtrace.internal.utils.time import HourGlass
+from ddtrace.settings._config import config as global_config
 from ddtrace.settings.exception_replay import config
 from ddtrace.trace import Span
 
@@ -117,7 +117,7 @@ def unwind_exception_chain(
     chain: ExceptionChain = deque()
 
     while exc is not None:
-        chain.append((exc, tb))
+        chain.appendleft((exc, tb))
 
         if exc.__cause__ is not None:
             exc = exc.__cause__
@@ -132,13 +132,34 @@ def unwind_exception_chain(
     if chain:
         # If the chain is not trivial we generate an ID for the whole chain and
         # store it on the outermost exception, if not already generated.
-        exc, _ = chain[-1]
+        exc, _ = chain[0]
         try:
             exc_id = exc._dd_exc_id  # type: ignore[attr-defined]
         except AttributeError:
             exc._dd_exc_id = exc_id = uuid.uuid4()  # type: ignore[attr-defined]
 
     return chain, exc_id
+
+
+def get_tb_frames_from_exception_chain(chain: ExceptionChain) -> t.List[TracebackType]:
+    """Get the frames from the exception chain."""
+    frames: t.List[TracebackType] = []
+
+    for _, tb in chain:
+        local_frames = []
+        if tb is None or tb.tb_frame is None:
+            continue
+
+        _tb: t.Optional[TracebackType] = tb
+        while _tb is not None:
+            local_frames.append(_tb)
+            _tb = _tb.tb_next
+
+        # Get only the last N frames from the traceback, where N is the
+        # configured max size for span tracebacks.
+        frames.extend(local_frames[-global_config._span_traceback_max_size :])
+
+    return frames
 
 
 class SpanExceptionProbe(LogLineProbe):
@@ -212,8 +233,7 @@ def get_snapshot_count(span: Span) -> int:
     if root is None:
         return 0
 
-    count = root.get_metric(SNAPSHOT_COUNT_TAG)
-    if count is None:
+    if (count := root.get_metric(SNAPSHOT_COUNT_TAG)) is None:
         return 0
 
     return int(count)
@@ -224,8 +244,14 @@ class SpanExceptionHandler:
 
     _instance: t.Optional["SpanExceptionHandler"] = None
 
-    def _capture_tb_frame_for_span(
-        self, span: Span, tb: TracebackType, exc_id: uuid.UUID, seq_nr: int = 1, only_user_code: bool = True
+    def _attach_tb_frame_snapshot_to_span(
+        self,
+        span: Span,
+        tb: TracebackType,
+        exc_id: uuid.UUID,
+        seq_nr: int = 1,
+        only_user_code: bool = True,
+        cached_only: bool = False,
     ) -> bool:
         frame = tb.tb_frame
         code = frame.f_code
@@ -236,6 +262,12 @@ class SpanExceptionHandler:
         snapshot_id = frame.f_locals.get(SNAPSHOT_KEY, None)
         if snapshot_id is None:
             # We don't have a snapshot for the frame so we create one
+            if cached_only:
+                # If we only want a cached snapshot we return True as a signal
+                # that we would have captured, but we actually skip generating
+                # a new snapshot.
+                return True
+
             snapshot = SpanExceptionSnapshot(
                 probe=SpanExceptionProbe.build(exc_id, frame),
                 frame=frame,
@@ -286,28 +318,31 @@ class SpanExceptionHandler:
             # We have seen this exception recently
             return
 
-        seq = count(1)  # 1-based sequence number
-
         frames_captured = get_snapshot_count(span)
 
-        while chain and frames_captured < config.max_frames:
-            exc, _tb = chain.pop()  # LIFO: reverse the chain
+        # Capture more frames if we have budget left, otherwise set just the
+        # tags on the span for those frames that we have already captured.
+        for seq_nr, _tb in reversed(list(enumerate(get_tb_frames_from_exception_chain(chain), 1))):
+            has_snapshot_budget = frames_captured < config.max_frames
+            has_captured = self._attach_tb_frame_snapshot_to_span(
+                span, _tb, exc_id, seq_nr, cached_only=not has_snapshot_budget
+            )
+            if not has_snapshot_budget and has_captured:
+                # We would need to capture new frames at this point but we don't
+                # have budget left so we stop capturing.
+                break
 
-            if _tb is None or _tb.tb_frame is None:
-                # If we don't have a traceback there isn't much we can do
-                continue
+            frames_captured += has_captured
 
-            # DEV: We go from the handler up to the root exception
-            while _tb and frames_captured < config.max_frames:
-                frames_captured += self._capture_tb_frame_for_span(span, _tb, exc_id, next(seq))
-
-                # Move up the traceback
-                _tb = _tb.tb_next
+            if has_captured and frames_captured >= config.max_frames:
+                # The last capture has saturated the budget so we can stop
+                # capturing
+                break
 
         if not frames_captured and tb is not None:
             # Ensure we capture at least one frame if we have a traceback,
             # the one potentially closer to user code.
-            frames_captured += self._capture_tb_frame_for_span(span, tb, exc_id, only_user_code=False)
+            frames_captured += self._attach_tb_frame_snapshot_to_span(span, tb, exc_id, only_user_code=False)
 
         if frames_captured:
             span.set_tag_str(DEBUG_INFO_TAG, "true")

--- a/releasenotes/notes/fix-er-reverse-tracebacks-44a52d4f1601ca1f.yaml
+++ b/releasenotes/notes/fix-er-reverse-tracebacks-44a52d4f1601ca1f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    exception replay: ensure that value capture starts from the leaf frame of
+    the innermost exception.


### PR DESCRIPTION
The introduction of the maximum number of frames to capture in Exception Replay has caused the capture to be truncated at the outermost exception end, close to the exception handler frame. This follows the natural ordering of traceback frames in traceback objects, which go in the opposite direction of stack traces. We reverse the order of the frames in an exception chain to ensure that we start capturing from the leaf frame of the innermost exception, thus starting from the end where the exception was actually thrown. We also ensure to keep the numbering consistent with the current implementation to allow for the correct matching on the UI side.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
