### PR TITLE
fix(sampling): skip _dd.p.dm tag when sampling priority is propagated

### DIFF
--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -363,7 +363,8 @@ class _DatadogMultiHeader:
         if not meta:
             meta = {}
 
-        if not meta.get(SAMPLING_DECISION_TRACE_TAG_KEY):
+        # Only set sampling decision tag if there's no head sampling decision (no sampling_priority header)
+        if not meta.get(SAMPLING_DECISION_TRACE_TAG_KEY) and sampling_priority is None:
             meta[SAMPLING_DECISION_TRACE_TAG_KEY] = f"-{SamplingMechanism.LOCAL_USER_TRACE_SAMPLING_RULE}"
 
         # Try to parse values into their expected types

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -52,8 +52,6 @@ from ..internal.constants import PROPAGATION_STYLE_DATADOG
 from ..internal.constants import W3C_TRACEPARENT_KEY
 from ..internal.constants import W3C_TRACESTATE_KEY
 from ..internal.logger import get_logger
-from ..internal.sampling import SAMPLING_DECISION_TRACE_TAG_KEY
-from ..internal.sampling import SamplingMechanism
 from ..internal.sampling import validate_sampling_decision
 from ..internal.utils.http import w3c_tracestate_add_p
 from ._utils import get_wsgi_header
@@ -1240,13 +1238,6 @@ class HTTPPropagator(object):
                     style = prop_style
                     if context:
                         _record_http_telemetry("context_header_style.extracted", prop_style)
-                        
-                        # If the context has a head sampling decision, remove LOCAL_USER_TRACE_SAMPLING_RULE _dd.p.dm tag
-                        if (context.sampling_priority is not None and 
-                            SAMPLING_DECISION_TRACE_TAG_KEY in context._meta and
-                            context._meta[SAMPLING_DECISION_TRACE_TAG_KEY] == f"-{SamplingMechanism.LOCAL_USER_TRACE_SAMPLING_RULE}"):
-                            del context._meta[SAMPLING_DECISION_TRACE_TAG_KEY]
-                            
                     if config._propagation_http_baggage_enabled is True:
                         _attach_baggage_to_context(normalized_headers, context)
                     break
@@ -1260,13 +1251,6 @@ class HTTPPropagator(object):
 
                 if contexts:
                     context = HTTPPropagator._resolve_contexts(contexts, styles_w_ctx, normalized_headers)
-                    
-                    # If the final context has a head sampling decision, remove LOCAL_USER_TRACE_SAMPLING_RULE _dd.p.dm tag
-                    if (context and context.sampling_priority is not None and 
-                        SAMPLING_DECISION_TRACE_TAG_KEY in context._meta and
-                        context._meta[SAMPLING_DECISION_TRACE_TAG_KEY] == f"-{SamplingMechanism.LOCAL_USER_TRACE_SAMPLING_RULE}"):
-                        del context._meta[SAMPLING_DECISION_TRACE_TAG_KEY]
-                    
                     if config._propagation_http_baggage_enabled is True:
                         _attach_baggage_to_context(normalized_headers, context)
 

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -1240,7 +1240,13 @@ class HTTPPropagator(object):
                     style = prop_style
                     if context:
                         _record_http_telemetry("context_header_style.extracted", prop_style)
-
+                        
+                        # If the context has a head sampling decision, remove LOCAL_USER_TRACE_SAMPLING_RULE _dd.p.dm tag
+                        if (context.sampling_priority is not None and 
+                            SAMPLING_DECISION_TRACE_TAG_KEY in context._meta and
+                            context._meta[SAMPLING_DECISION_TRACE_TAG_KEY] == f"-{SamplingMechanism.LOCAL_USER_TRACE_SAMPLING_RULE}"):
+                            del context._meta[SAMPLING_DECISION_TRACE_TAG_KEY]
+                            
                     if config._propagation_http_baggage_enabled is True:
                         _attach_baggage_to_context(normalized_headers, context)
                     break
@@ -1254,7 +1260,13 @@ class HTTPPropagator(object):
 
                 if contexts:
                     context = HTTPPropagator._resolve_contexts(contexts, styles_w_ctx, normalized_headers)
-
+                    
+                    # If the final context has a head sampling decision, remove LOCAL_USER_TRACE_SAMPLING_RULE _dd.p.dm tag
+                    if (context and context.sampling_priority is not None and 
+                        SAMPLING_DECISION_TRACE_TAG_KEY in context._meta and
+                        context._meta[SAMPLING_DECISION_TRACE_TAG_KEY] == f"-{SamplingMechanism.LOCAL_USER_TRACE_SAMPLING_RULE}"):
+                        del context._meta[SAMPLING_DECISION_TRACE_TAG_KEY]
+                    
                     if config._propagation_http_baggage_enabled is True:
                         _attach_baggage_to_context(normalized_headers, context)
 

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -363,9 +363,6 @@ class _DatadogMultiHeader:
         if not meta:
             meta = {}
 
-        if not meta.get(SAMPLING_DECISION_TRACE_TAG_KEY):
-            meta[SAMPLING_DECISION_TRACE_TAG_KEY] = f"-{SamplingMechanism.LOCAL_USER_TRACE_SAMPLING_RULE}"
-
         # Try to parse values into their expected types
         try:
             if sampling_priority is not None:
@@ -1244,15 +1241,6 @@ class HTTPPropagator(object):
                     if context:
                         _record_http_telemetry("context_header_style.extracted", prop_style)
 
-                        # If context has a head sampling decision, remove LOCAL_USER_TRACE_SAMPLING_RULE _dd.p.dm tag
-                        if (
-                            context.sampling_priority is not None
-                            and SAMPLING_DECISION_TRACE_TAG_KEY in context._meta
-                            and context._meta[SAMPLING_DECISION_TRACE_TAG_KEY]
-                            == f"-{SamplingMechanism.LOCAL_USER_TRACE_SAMPLING_RULE}"
-                        ):
-                            del context._meta[SAMPLING_DECISION_TRACE_TAG_KEY]
-
                     if config._propagation_http_baggage_enabled is True:
                         _attach_baggage_to_context(normalized_headers, context)
                     break
@@ -1266,16 +1254,6 @@ class HTTPPropagator(object):
 
                 if contexts:
                     context = HTTPPropagator._resolve_contexts(contexts, styles_w_ctx, normalized_headers)
-
-                    # If context has a head sampling decision, remove LOCAL_USER_TRACE_SAMPLING_RULE _dd.p.dm tag
-                    if (
-                        context
-                        and context.sampling_priority is not None
-                        and SAMPLING_DECISION_TRACE_TAG_KEY in context._meta
-                        and context._meta[SAMPLING_DECISION_TRACE_TAG_KEY]
-                        == f"-{SamplingMechanism.LOCAL_USER_TRACE_SAMPLING_RULE}"
-                    ):
-                        del context._meta[SAMPLING_DECISION_TRACE_TAG_KEY]
 
                     if config._propagation_http_baggage_enabled is True:
                         _attach_baggage_to_context(normalized_headers, context)

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -363,7 +363,6 @@ class _DatadogMultiHeader:
         if not meta:
             meta = {}
 
-        # Only set LOCAL_USER_TRACE_SAMPLING_RULE sampling decision tag if there's no head sampling decision
         if not meta.get(SAMPLING_DECISION_TRACE_TAG_KEY):
             meta[SAMPLING_DECISION_TRACE_TAG_KEY] = f"-{SamplingMechanism.LOCAL_USER_TRACE_SAMPLING_RULE}"
 

--- a/releasenotes/notes/single-span-sampling-tags-95f5f0723403ca75.yaml
+++ b/releasenotes/notes/single-span-sampling-tags-95f5f0723403ca75.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    sampling: Fix trace sampling decision tag (_dd.p.dm) interference with head sampling.
+    When sampling priority is propagated via distributed tracing headers (head sampling decision),
+    local trace sampling rules no longer override the upstream decision by setting sampling decision tags.

--- a/releasenotes/notes/single-span-sampling-tags-95f5f0723403ca75.yaml
+++ b/releasenotes/notes/single-span-sampling-tags-95f5f0723403ca75.yaml
@@ -1,6 +1,5 @@
 ---
 fixes:
   - |
-    sampling: Fix trace sampling decision tag (_dd.p.dm) interference with head sampling.
-    When sampling priority is propagated via distributed tracing headers (head sampling decision),
-    local trace sampling rules no longer override the upstream decision by setting sampling decision tags.
+    sampling: Removed automatic setting of local trace sampling rule tag (_dd.p.dm=-3) during
+    distributed tracing header extraction.

--- a/releasenotes/notes/single-span-sampling-tags-95f5f0723403ca75.yaml
+++ b/releasenotes/notes/single-span-sampling-tags-95f5f0723403ca75.yaml
@@ -1,5 +1,4 @@
 ---
 fixes:
   - |
-    sampling: Removed automatic setting of local trace sampling rule tag (_dd.p.dm=-3) during
-    distributed tracing header extraction.
+    sampling: Removed automatic setting of local trace sampling rule tag (_dd.p.dm=-3) during distributed tracing header extraction.

--- a/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_distributed_tracing_nested.json
+++ b/tests/snapshots/tests.contrib.wsgi.test_wsgi.test_distributed_tracing_nested.json
@@ -10,7 +10,7 @@
     "error": 0,
     "meta": {
       "_dd.base_service": "tests.contrib.wsgi",
-      "_dd.p.dm": "-3",
+      "_dd.p.dm": "-0",
       "_dd.p.tid": "654a694400000000",
       "component": "wsgi",
       "http.method": "GET",

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -1612,7 +1612,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": None,
             "dd_origin": "synthetics",
-            "meta": {"_dd.p.dm": "-3"},
+            "meta": {},
         },
     ),
     (
@@ -2249,7 +2249,7 @@ EXTRACT_FIXTURES = [
             "trace_id": 9291375655657946024,
             "span_id": 10,
             "sampling_priority": None,
-            "meta": {"_dd.p.dm": "-3", LAST_DD_PARENT_ID_KEY: "000000000000000f"},
+            "meta": {LAST_DD_PARENT_ID_KEY: "000000000000000f"},
         },
     ),
     (
@@ -3797,6 +3797,5 @@ def test_datadog_extract_sampling_decision_tag_with_head_sampling():
     assert context_without_priority.span_id == 98765432103
     assert context_without_priority.sampling_priority is None
     assert context_without_priority.dd_origin == "rum"
-    # The key assertion: _dd.p.dm SHOULD be present when no sampling priority is propagated
-    assert SAMPLING_DECISION_TRACE_TAG_KEY in context_without_priority._meta
-    assert context_without_priority._meta[SAMPLING_DECISION_TRACE_TAG_KEY] == "-3"
+    # The key assertion: _dd.p.dm should NOT be present during extraction
+    assert SAMPLING_DECISION_TRACE_TAG_KEY not in context_without_priority._meta

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -303,7 +303,6 @@ def test_extract(tracer):  # noqa: F811
         assert span.context.dd_origin == "synthetics"
         assert span.context._meta == {
             "_dd.origin": "synthetics",
-            "_dd.p.dm": "-3",
             "_dd.p.test": "value",
         }
         with tracer.trace("child_span") as child_span:
@@ -313,7 +312,6 @@ def test_extract(tracer):  # noqa: F811
             assert child_span.context.dd_origin == "synthetics"
             assert child_span.context._meta == {
                 "_dd.origin": "synthetics",
-                "_dd.p.dm": "-3",
                 "_dd.p.test": "value",
             }
         assert context.get_baggage_item("foo") == "bar"
@@ -605,7 +603,6 @@ def test_asm_standalone_present_appsec_tag_no_appsec_event_propagation_set_to_us
                 assert span.context.dd_origin == "synthetics"
                 assert span.context._meta == {
                     "_dd.origin": "synthetics",
-                    "_dd.p.dm": "-3",
                     "_dd.p.ts": "02",
                 }
                 with tracer.trace("child_span") as child_span:
@@ -615,7 +612,6 @@ def test_asm_standalone_present_appsec_tag_no_appsec_event_propagation_set_to_us
                     assert child_span.context.dd_origin == "synthetics"
                     assert child_span.context._meta == {
                         "_dd.origin": "synthetics",
-                        "_dd.p.dm": "-3",
                         "_dd.p.ts": "02",
                     }
 
@@ -624,7 +620,8 @@ def test_asm_standalone_present_appsec_tag_no_appsec_event_propagation_set_to_us
                 assert next_headers["x-datadog-origin"] == "synthetics"
                 assert next_headers["x-datadog-sampling-priority"] == str(USER_KEEP)
                 assert next_headers["x-datadog-trace-id"] == "1234"
-                assert next_headers["x-datadog-tags"].startswith("_dd.p.ts=02,")
+                # With head sampling decision, only _dd.p.ts should be present (no _dd.p.dm)
+                assert next_headers["x-datadog-tags"] == "_dd.p.ts=02"
 
             # Ensure span sets user keep regardless of received priority (appsec event upstream)
             assert span._metrics["_sampling_priority_v1"] == USER_KEEP
@@ -904,7 +901,6 @@ def test_extract_unicode(tracer):  # noqa: F811
 
         assert span.context._meta == {
             "_dd.origin": "synthetics",
-            "_dd.p.dm": "-3",
             "_dd.p.test": "value",
         }
         with tracer.trace("child_span") as child_span:
@@ -914,7 +910,6 @@ def test_extract_unicode(tracer):  # noqa: F811
             assert child_span.context.dd_origin == "synthetics"
             assert child_span.context._meta == {
                 "_dd.origin": "synthetics",
-                "_dd.p.dm": "-3",
                 "_dd.p.test": "value",
             }
 
@@ -968,7 +963,6 @@ def test_WSGI_extract(tracer):  # noqa: F811
         assert span.context._meta == {
             "_dd.origin": "synthetics",
             "_dd.p.test": "value",
-            "_dd.p.dm": "-3",
         }
 
 
@@ -992,7 +986,6 @@ def test_extract_invalid_tags(tracer):  # noqa: F811
         assert span.context.dd_origin == "synthetics"
         assert span.context._meta == {
             "_dd.origin": "synthetics",
-            "_dd.p.dm": "-3",
             "_dd.propagation_error": "decoding_error",
         }
 
@@ -1017,7 +1010,6 @@ def test_extract_tags_large(tracer):  # noqa: F811
         assert span.context.dd_origin == "synthetics"
         assert span.context._meta == {
             "_dd.origin": "synthetics",
-            "_dd.p.dm": "-3",
             "_dd.propagation_error": "extract_max_size",
         }
 
@@ -1594,7 +1586,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
-            "meta": {"_dd.p.dm": "-3"},
+            "meta": {"_dd.origin": "synthetics"},
         },
     ),
     (
@@ -1607,7 +1599,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
-            "meta": {"_dd.p.dm": "-3"},
+            "meta": {"_dd.origin": "synthetics"},
         },
     ),
     (
@@ -1640,7 +1632,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
-            "meta": {"_dd.p.dm": "-3"},
+            "meta": {"_dd.origin": "synthetics"},
         },
     ),
     (
@@ -1665,7 +1657,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
-            "meta": {"_dd.p.dm": "-3"},
+            "meta": {"_dd.origin": "synthetics"},
         },
     ),
     (
@@ -1678,7 +1670,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
-            "meta": {"_dd.p.dm": "-3"},
+            "meta": {"_dd.origin": "synthetics"},
         },
     ),
     (
@@ -1698,7 +1690,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
-            "meta": {"_dd.p.dm": "-3"},
+            "meta": {"_dd.origin": "synthetics"},
             "baggage": {"key1": "val1", "key2": "val2"},
         },
     ),
@@ -1947,7 +1939,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
-            "meta": {"_dd.p.dm": "-3"},
+            "meta": {"_dd.origin": "synthetics"},
             "span_links": [
                 SpanLink(
                     trace_id=TRACE_ID,
@@ -1976,7 +1968,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
-            "meta": {"_dd.p.dm": "-3"},
+            "meta": {"_dd.origin": "synthetics"},
             "span_links": [
                 SpanLink(
                     trace_id=TRACE_ID,
@@ -2017,7 +2009,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
-            "meta": {"_dd.p.dm": "-3"},
+            "meta": {"_dd.origin": "synthetics"},
             "span_links": [
                 SpanLink(
                     trace_id=TRACE_ID,
@@ -2053,7 +2045,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
-            "meta": {"_dd.p.dm": "-3"},
+            "meta": {"_dd.origin": "synthetics"},
         },
     ),
     (
@@ -2066,7 +2058,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
-            "meta": {"_dd.p.dm": "-3"},
+            "meta": {"_dd.origin": "synthetics"},
         },
     ),
     (
@@ -2203,7 +2195,6 @@ EXTRACT_FIXTURES = [
             "dd_origin": "synthetics",
             "meta": {
                 "tracestate": TRACECONTEXT_HEADERS_VALID[_HTTP_HEADER_TRACESTATE],
-                "_dd.p.dm": "-3",
                 LAST_DD_PARENT_ID_KEY: "000000000000162e",
             },
         },
@@ -2219,7 +2210,7 @@ EXTRACT_FIXTURES = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
-            "meta": {"_dd.p.dm": "-3"},
+            "meta": {"_dd.origin": "synthetics"},
             "span_links": [
                 SpanLink(
                     trace_id=TRACE_ID,
@@ -2448,7 +2439,7 @@ EXTRACT_FIXTURES_ENV_ONLY = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
-            "meta": {"_dd.p.dm": "-3"},
+            "meta": {"_dd.origin": "synthetics"},
         },
     ),
     # Only works for env since config is modified at startup to set
@@ -2471,7 +2462,7 @@ EXTRACT_FIXTURES_ENV_ONLY = [
             "span_id": 5678,
             "sampling_priority": 1,
             "dd_origin": "synthetics",
-            "meta": {"_dd.p.dm": "-3"},
+            "meta": {"_dd.origin": "synthetics"},
         },
     ),
 ]
@@ -2720,7 +2711,7 @@ FULL_CONTEXT_EXTRACT_FIXTURES = [
         Context(
             trace_id=13088165645273925489,
             span_id=5678,
-            meta={"_dd.origin": "synthetics", "_dd.p.dm": "-3"},
+            meta={"_dd.origin": "synthetics"},
             metrics={"_sampling_priority_v1": 1},
             span_links=[
                 SpanLink(
@@ -2767,7 +2758,6 @@ FULL_CONTEXT_EXTRACT_FIXTURES = [
             # behavior for this chaotic set of headers, specifically when STYLE_DATADOG precedes STYLE_W3C_TRACECONTEXT
             # in the styles configuration
             meta={
-                "_dd.p.dm": "-3",
                 "_dd.origin": "synthetics",
                 "tracestate": "dd=s:2;o:rum;t.dm:-4;t.usr.id:baz64,congo=t61rcWkgMzE",
                 LAST_DD_PARENT_ID_KEY: "000000000000162e",
@@ -3753,3 +3743,60 @@ def test_inject_span_without_sampling_priority():
     assert headers.get("x-datadog-sampling-priority") == str(
         parent.context.sampling_priority
     )  # Root span priority used
+
+
+def test_datadog_extract_sampling_decision_tag_with_head_sampling():
+    """Test that _dd.p.dm tag is not set when sampling priority is propagated via headers."""
+    from ddtrace.internal.constants import SAMPLING_DECISION_TRACE_TAG_KEY
+    from ddtrace.propagation.http import HTTPPropagator
+
+    # Test case 1: Headers with sampling priority should NOT have _dd.p.dm tag
+    headers_with_priority = {
+        "x-datadog-trace-id": "12345678901",
+        "x-datadog-parent-id": "98765432101",
+        "x-datadog-sampling-priority": "1",
+        "x-datadog-origin": "rum",
+    }
+
+    context_with_priority = HTTPPropagator.extract(headers_with_priority)
+
+    assert context_with_priority.trace_id == 12345678901
+    assert context_with_priority.span_id == 98765432101
+    assert context_with_priority.sampling_priority == 1
+    assert context_with_priority.dd_origin == "rum"
+    # The key assertion: _dd.p.dm should NOT be present when sampling priority is propagated
+    assert SAMPLING_DECISION_TRACE_TAG_KEY not in context_with_priority._meta
+
+    # Test case 2: Headers with sampling priority = 0 should also NOT have _dd.p.dm tag
+    headers_with_priority_drop = {
+        "x-datadog-trace-id": "12345678902",
+        "x-datadog-parent-id": "98765432102",
+        "x-datadog-sampling-priority": "0",
+        "x-datadog-origin": "rum",
+    }
+
+    context_with_priority_drop = HTTPPropagator.extract(headers_with_priority_drop)
+
+    assert context_with_priority_drop.trace_id == 12345678902
+    assert context_with_priority_drop.span_id == 98765432102
+    assert context_with_priority_drop.sampling_priority == 0
+    assert context_with_priority_drop.dd_origin == "rum"
+    # The key assertion: _dd.p.dm should NOT be present when sampling priority is propagated
+    assert SAMPLING_DECISION_TRACE_TAG_KEY not in context_with_priority_drop._meta
+
+    # Test case 3: Headers without sampling priority should have _dd.p.dm tag
+    headers_without_priority = {
+        "x-datadog-trace-id": "12345678903",
+        "x-datadog-parent-id": "98765432103",
+        "x-datadog-origin": "rum",
+    }
+
+    context_without_priority = HTTPPropagator.extract(headers_without_priority)
+
+    assert context_without_priority.trace_id == 12345678903
+    assert context_without_priority.span_id == 98765432103
+    assert context_without_priority.sampling_priority is None
+    assert context_without_priority.dd_origin == "rum"
+    # The key assertion: _dd.p.dm SHOULD be present when no sampling priority is propagated
+    assert SAMPLING_DECISION_TRACE_TAG_KEY in context_without_priority._meta
+    assert context_without_priority._meta[SAMPLING_DECISION_TRACE_TAG_KEY] == "-3"


### PR DESCRIPTION
Fixes an issue where the trace sampling decision tag (_dd.p.dm) was being incorrectly set during header extraction even when a sampling priority was already propagated.

This issue was discovered when [new system-tests ](https://github.com/DataDog/system-tests/pull/5014) were introduced. 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
