### PR TITLE
ci: add riot hash to DD_TAGS [backport 3.11]

### DIFF
--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -80,6 +80,7 @@ include:
       do
         echo "Running riot hash: ${hash}"
         riot list "${hash}"
+        export _CI_DD_TAGS="test.configuration.riot_hash:${hash}"
         ${RIOT_RUN_CMD} "${hash}" -- --ddtrace
       done
       ./scripts/check-diff ".riot/requirements/" \

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -69,8 +69,8 @@ from ddtrace.internal.service import Service
 from ddtrace.internal.test_visibility._atr_mixins import AutoTestRetriesSettings
 from ddtrace.internal.test_visibility._library_capabilities import LibraryCapabilities
 from ddtrace.internal.utils.formats import asbool
-from ddtrace.settings import IntegrationConfig
 from ddtrace.internal.utils.formats import parse_tags_str
+from ddtrace.settings import IntegrationConfig
 from ddtrace.settings._agent import config as agent_config
 from ddtrace.trace import Tracer
 

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -70,6 +70,7 @@ from ddtrace.internal.test_visibility._atr_mixins import AutoTestRetriesSettings
 from ddtrace.internal.test_visibility._library_capabilities import LibraryCapabilities
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.settings import IntegrationConfig
+from ddtrace.internal.utils.formats import parse_tags_str
 from ddtrace.settings._agent import config as agent_config
 from ddtrace.trace import Tracer
 
@@ -163,6 +164,10 @@ class CIVisibility(Service):
                 log.debug("Using DD CI context provider: test traces may be incomplete, telemetry may be inaccurate")
                 # Create a new CI tracer, using a specific URL if provided (only useful when testing the tracer itself)
                 self.tracer = CIVisibilityTracer()
+
+                if ci_dd_tags := os.getenv("_CI_DD_TAGS"):
+                    log.debug("Using _CI_DD_TAGS for CI Visibility tracer: %s", ci_dd_tags)
+                    self.tracer._tags.update(parse_tags_str(ci_dd_tags))
 
                 env_agent_url = os.getenv("_CI_DD_AGENT_URL")
                 if env_agent_url is not None:


### PR DESCRIPTION
Backport 02b1c2b74e0781e343be442169bbb7fdf1591a1d from #14296 to 3.11.

Add the riot environment hash to the tags sent with tests, so that runs of the same test in different environments get different test fingerprints in the backend. This avoids an issue where a test that passes in one environment and fails in another would end up being marked as flaky.

To avoid breaking tests that check for tags, a new `_CI_DD_TAGS` environment variable was added that only sets the tags for the CI environment, but does not affect the tracer being tested.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
