### PR TITLE
chore(profiling): remove redundant .so extension in dd_wrapper

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/CMakeLists.txt
@@ -81,7 +81,10 @@ string(TOLOWER ${PLATFORM_SUFFIX} PLATFORM_SUFFIX)
 # but as long as it encodes the major moving parts, it's fine
 
 if(DEFINED EXTENSION_SUFFIX)
-    set(DD_WRAPPER_TARGET_NAME "dd_wrapper${EXTENSION_SUFFIX}")
+    # EXTENSION_SUFFIX already contains .so (both Linux and macOS Python extensions use .so) but CMake will add its own
+    # extension (.so on Linux, .dylib on macOS) So we need to strip the .so extension to avoid double extensions
+    string(REGEX REPLACE "\\.so$" "" EXTENSION_SUFFIX_NO_EXT "${EXTENSION_SUFFIX}")
+    set(DD_WRAPPER_TARGET_NAME "dd_wrapper${EXTENSION_SUFFIX_NO_EXT}")
 else()
     set(DD_WRAPPER_TARGET_NAME "dd_wrapper-${PLATFORM_SUFFIX}")
 endif()


### PR DESCRIPTION
ddtrace 3.12.0 wheel has `libdd_wrapper.cpython-313-x86_64-linux-gnu.so.so`, with this PR, it will be `libdd_wrapper.cpython-313-x86_64-linux-gnu.so`

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
