### PR TITLE
chore: add debug log for when tracing is disabled due to app key and DD_TRACE_ENABLED

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -547,6 +547,11 @@ class LLMObs(Service):
 
         # FIXME: workaround to prevent noisy logs when using the experiments feature
         if config._dd_api_key and cls._app_key and os.environ.get("DD_TRACE_ENABLED", "").lower() not in ["true", "1"]:
+            log.debug(
+                "Tracing has been disabled: app key detected and DD_TRACE_ENABLED is not set to 'true' "
+                "(current value: DD_TRACE_ENABLED='%s')",
+                os.environ.get("DD_TRACE_ENABLED", ""),
+            )
             ddtrace.tracer.enabled = False
 
         error = None


### PR DESCRIPTION
Adds a debug-level log message to clarify when tracing is disabled because:
- An app key is present
- The DD_TRACE_ENABLED environment variable is not explicitly set to 'true'

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
