### PR TITLE
chore(llmobs): add url origin env var

### DIFF
--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -1,5 +1,6 @@
 import atexit
 import json
+import os
 from typing import Any
 from typing import Dict
 from typing import List
@@ -146,10 +147,10 @@ class BaseLLMObsWriter(PeriodicService):
         self._api_key: str = _api_key or config._dd_api_key
         self._site: str = _site or config._dd_site
         self._app_key: str = _app_key
-        self._override_url: str = _override_url
+        self._override_url: str = _override_url or os.environ.get("DD_LLMOBS_OVERRIDE_ORIGIN", "")
 
         self._agentless: bool = is_agentless
-        self._intake: str = _override_url or (
+        self._intake: str = self._override_url or (
             f"{self.AGENTLESS_BASE_URL}.{self._site}" if is_agentless else agent_config.trace_agent_url
         )
         self._endpoint: str = self.ENDPOINT if is_agentless else f"{EVP_PROXY_AGENT_BASE_PATH}{self.ENDPOINT}"

--- a/releasenotes/notes/llmobs-url-override-5d791534021f66a9.yaml
+++ b/releasenotes/notes/llmobs-url-override-5d791534021f66a9.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    LLM Observability: add ability to override the URL origin.


### PR DESCRIPTION
Enable users to override the origin of the url to allow users to send the data to a different local endpoint than APM.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
