### PR TITLE
chore(llmobs): include stack trace and error type if possible when raising error

### DIFF
--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -408,9 +408,14 @@ class Experiment:
                     continue
                 task_results.append(result)
                 err_dict = result.get("error") or {}
-                err_msg = err_dict.get("message") if isinstance(err_dict, dict) else None
+                if isinstance(err_dict, dict):
+                    err_msg = err_dict.get("message")
+                    err_stack = err_dict.get("stack")
+                    err_type = err_dict.get("type")
                 if raise_errors and err_msg:
-                    raise RuntimeError("Error on record {}: {}".format(result["idx"], err_msg))
+                    raise RuntimeError(
+                        "Error on record {}: {}\n{}\n{}".format(result["idx"], err_msg, err_type, err_stack)
+                    )
         self._llmobs_instance.flush()  # Ensure spans get submitted in serverless environments
         return task_results
 

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -997,6 +997,15 @@ def test_experiment_run_task_error(llmobs, test_dataset_one_record):
     assert task_results[0]["error"]["type"] == "builtins.ValueError"
 
 
+def test_experiment_run_task_error_raises(llmobs, test_dataset_one_record):
+    exp = llmobs.experiment("test_experiment", faulty_task, test_dataset_one_record, [dummy_evaluator])
+    with pytest.raises(
+        RuntimeError,
+        match=re.compile("Error on record 0: This is a test error\n.*ValueError.*in faulty_task.*", flags=re.DOTALL),
+    ):
+        exp._run_task(1, raise_errors=True)
+
+
 def test_experiment_run_evaluators(llmobs, test_dataset_one_record):
     exp = llmobs.experiment("test_experiment", dummy_task, test_dataset_one_record, [dummy_evaluator])
     task_results = exp._run_task(1, raise_errors=False)


### PR DESCRIPTION
given a snippet like this
```
def divide(n1, n2):
    return n1/n2

def print_divide(n1, n2):
    print(divide(n1, n2))

def generate_capital_name_one_word(input_data: Dict[str, Any], config: Dict[str, Any]) -> str:
    print_divide(1, 0)
    output = oai_client.chat.completions.create(
        model=config["model"],
        messages=[
            {"role": "system", "content": "You will respond only with the name of the capital of the country, nothing else."},
            {"role": "user", "content": "What is the capital of France?"},
            {"role": "assistant", "content": "Paris"},
            {"role": "user", "content": input_data["question"]}],
        temperature=config["temperature"]
    )

    return output.choices[0].message.content

def exact_match(input_data, output_data, expected_output):
    raise ValueError("BBB")
    return expected_output == output_data

def contains_answer(input_data, output_data, expected_output):
    return expected_output in output_data

experiment = LLMObs.experiment(
    name="generate-one-word-capital-with-config",
    dataset=dataset,
    task=generate_capital_name_one_word,
    evaluators=[exact_match, contains_answer],
    config={"model": "gpt-4.1-nano", "temperature": 0},
    description="a cool basic experiment with config",
)
```

we get an error message like so:
```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In[8], line 1
----> 1 experiment.run(jobs=1,raise_errors=True)
      3 experiment.url

File ~/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/.venv/lib/python3.12/site-packages/ddtrace/llmobs/_experiment.py:330, in Experiment.run(self, jobs, raise_errors, sample_size)
    328 self._tags["experiment_id"] = str(experiment_id)
    329 self._run_name = experiment_run_name
--> 330 task_results = self._run_task(jobs, raise_errors, sample_size)
    331 evaluations = self._run_evaluators(task_results, raise_errors=raise_errors)
    332 experiment_results = self._merge_results(task_results, evaluations)

File ~/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/.venv/lib/python3.12/site-packages/ddtrace/llmobs/_experiment.py:413, in Experiment._run_task(self, jobs, raise_errors, sample_size)
    411         err_msg = err_dict.get("message") if isinstance(err_dict, dict) else None
    412         if raise_errors and err_msg:
--> 413             raise RuntimeError("Error on record {}: {}".format(result["idx"], err_msg))
    414 self._llmobs_instance.flush()  # Ensure spans get submitted in serverless environments
    415 return task_results

RuntimeError: Error on record 0: division by zero
```

after this change the error will look more verbose with the stack trace on the original error
```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In[12], line 1
----> 1 experiment.run(jobs=1,raise_errors=True)
      3 experiment.url

File ~/go/src/github.com/DataDog/dd-trace-py/ddtrace/llmobs/_experiment.py:330, in Experiment.run(self, jobs, raise_errors, sample_size)
    328 self._tags["experiment_id"] = str(experiment_id)
    329 self._run_name = experiment_run_name
--> 330 task_results = self._run_task(jobs, raise_errors, sample_size)
    331 evaluations = self._run_evaluators(task_results, raise_errors=raise_errors)
    332 experiment_results = self._merge_results(task_results, evaluations)

File ~/go/src/github.com/DataDog/dd-trace-py/ddtrace/llmobs/_experiment.py:415, in Experiment._run_task(self, jobs, raise_errors, sample_size)
    413         err_type = err_dict.get("type") if isinstance(err_dict, dict) else None
    414         if raise_errors and err_msg:
--> 415             raise RuntimeError(
    416                 "Error on record {}: {}\n{}\n{}".format(result["idx"], err_msg, err_type, err_stack)
    417             )
    418 self._llmobs_instance.flush()  # Ensure spans get submitted in serverless environments
    419 return task_results

RuntimeError: Error on record 0: division by zero
builtins.ZeroDivisionError
Traceback (most recent call last):
  File "/Users/gary.huang/go/src/github.com/DataDog/dd-trace-py/ddtrace/llmobs/_experiment.py", line 365, in _process_record
    output_data = self._task(input_data, self._config)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/folders/lv/k26fs55j1dl8p2jq5n8jwdnc0000gq/T/ipykernel_77428/3580111335.py", line 8, in generate_capital_name_one_word
    print_divide(1, 0)
  File "/var/folders/lv/k26fs55j1dl8p2jq5n8jwdnc0000gq/T/ipykernel_77428/3580111335.py", line 5, in print_divide
    print(divide(n1, n2))
          ^^^^^^^^^^^^^^
  File "/var/folders/lv/k26fs55j1dl8p2jq5n8jwdnc0000gq/T/ipykernel_77428/3580111335.py", line 2, in divide
    return n1/n2
           ~~^~~
ZeroDivisionError: division by zero
```

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
