### PR TITLE
perf(starlette): avoid unnecessary version comparison

### DIFF
--- a/ddtrace/contrib/internal/starlette/patch.py
+++ b/ddtrace/contrib/internal/starlette/patch.py
@@ -62,6 +62,7 @@ def get_version():
 
 
 _STARLETTE_VERSION = parse_version(get_version())
+_STARLETTE_VERSION_LTE_0_33_0 = _STARLETTE_VERSION <= parse_version("0.33.0")
 
 
 def _supported_versions() -> Dict[str, str]:
@@ -202,7 +203,7 @@ def traced_handler(wrapped, instance, args, kwargs):
         raise BlockingException(blocked)
 
     # https://github.com/encode/starlette/issues/1336
-    if _STARLETTE_VERSION <= parse_version("0.33.0") and len(request_spans) > 1:
+    if _STARLETTE_VERSION_LTE_0_33_0 and len(request_spans) > 1:
         request_spans[-1].set_tag(http.URL, request_spans[0].get_tag(http.URL))
 
     return wrapped(*args, **kwargs)


### PR DESCRIPTION
Minor refactor for performance improvement in starlette integration to reduce number of unnecessary function calls.
In the future, could be good to add starlette/ fastapi microbenchmarks / benchmarks.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
