### PR TITLE
chore: enable  telemetry only on Linux platforms

### DIFF
--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -16,6 +16,7 @@ from typing import TextIO
 import ddtrace
 from ddtrace import config
 import ddtrace.internal.native as native
+from ddtrace.internal.runtime import get_runtime_id
 import ddtrace.internal.utils.http
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from ddtrace.settings._agent import config as agent_config
@@ -809,6 +810,13 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
             stats_interval = float(os.getenv("_DD_TRACE_STATS_WRITER_INTERVAL") or 10.0)
             bucket_size_ns: int = int(stats_interval * 1e9)
             builder.enable_stats(bucket_size_ns)
+
+        # TODO (APMSP-2204): Enable telemetry for all platforms, currently only enabled for Linux.
+        if config._telemetry_enabled and sys.platform.startswith("linux"):
+            heartbeat_ms = int(
+                config._telemetry_heartbeat_interval * 1000
+            )  # Convert DD_TELEMETRY_HEARTBEAT_INTERVAL to milliseconds
+            builder.enable_telemetry(heartbeat_ms, get_runtime_id())
 
         return builder.build()
 

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -639,96 +639,6 @@ class NativeWriterTests(AgentWriterTests):
     def test_gzip_compression_exception_logging_and_metrics(self):
         pytest.skip()
 
-    @mock.patch("ddtrace.internal.native.TraceExporterBuilder")
-    def test_telemetry_enabled_on_linux(self, mock_builder_class):
-        """Test that telemetry is enabled for native writer on Linux platforms."""
-
-        mock_builder = mock.Mock()
-        mock_builder_class.return_value = mock_builder
-        mock_exporter = mock.Mock()
-        mock_builder.build.return_value = mock_exporter
-
-        for method_name in [
-            "set_url",
-            "set_language",
-            "set_language_version",
-            "set_language_interpreter",
-            "set_tracer_version",
-            "set_git_commit_sha",
-            "set_client_computed_top_level",
-            "set_input_format",
-            "set_output_format",
-            "enable_telemetry",
-        ]:
-            getattr(mock_builder, method_name).return_value = mock_builder
-
-        with mock_sys_platform("linux"):
-            with override_global_config(dict(_telemetry_enabled=True)):
-                _writer = self.WRITER_CLASS("http://localhost:8126/v0.5/traces", sync_mode=True)
-
-                mock_builder.enable_telemetry.assert_called_once()
-                mock_builder.enable_telemetry.assert_called_once_with(60000, get_runtime_id())
-
-    @mock.patch("ddtrace.internal.native.TraceExporterBuilder")
-    def test_telemetry_disabled_on_non_linux(self, mock_builder_class):
-        """Test that telemetry is not enabled for native writer on non-Linux platforms."""
-        mock_builder = mock.Mock()
-        mock_builder_class.return_value = mock_builder
-        mock_exporter = mock.Mock()
-        mock_builder.build.return_value = mock_exporter
-
-        for method_name in [
-            "set_url",
-            "set_language",
-            "set_language_version",
-            "set_language_interpreter",
-            "set_tracer_version",
-            "set_git_commit_sha",
-            "set_client_computed_top_level",
-            "set_input_format",
-            "set_output_format",
-            "enable_telemetry",
-        ]:
-            getattr(mock_builder, method_name).return_value = mock_builder
-
-        platforms = ["win32", "darwin"]
-        for platform in platforms:
-            with mock_sys_platform(platform):
-                with override_global_config(dict(_telemetry_enabled=True)):
-                    _writer = self.WRITER_CLASS("http://localhost:8126/v0.5/traces", sync_mode=True)
-
-                    mock_builder.enable_telemetry.assert_not_called()
-
-            mock_builder.enable_telemetry.reset_mock()
-
-    @mock.patch("ddtrace.internal.native.TraceExporterBuilder")
-    def test_telemetry_disabled_when_config_disabled(self, mock_builder_class):
-        """Test that telemetry is not enabled when DD_INSTRUMENTATION_TELEMETRY_ENABLED=false."""
-        mock_builder = mock.Mock()
-        mock_builder_class.return_value = mock_builder
-        mock_exporter = mock.Mock()
-        mock_builder.build.return_value = mock_exporter
-
-        for method_name in [
-            "set_url",
-            "set_language",
-            "set_language_version",
-            "set_language_interpreter",
-            "set_tracer_version",
-            "set_git_commit_sha",
-            "set_client_computed_top_level",
-            "set_input_format",
-            "set_output_format",
-            "enable_telemetry",
-        ]:
-            getattr(mock_builder, method_name).return_value = mock_builder
-
-        with mock_sys_platform("linux"):
-            with override_global_config(dict(_telemetry_enabled=False)):
-                _writer = self.WRITER_CLASS("http://localhost:8126/v0.5/traces", sync_mode=True)
-
-                mock_builder.enable_telemetry.assert_not_called()
-
 
 class CIVisibilityWriterTests(AgentWriterTests):
     WRITER_CLASS = CIVisibilityWriter
@@ -1234,3 +1144,50 @@ def test_trace_with_128bit_trace_ids():
     chunk_root = spans[0]
     assert chunk_root.trace_id >= 2**64
     assert chunk_root._meta[HIGHER_ORDER_TRACE_ID_BITS] == "{:016x}".format(parent.trace_id >> 64)
+
+
+@pytest.mark.parametrize(
+    "platform,config_value,expected_enabled",
+    [
+        ("linux", True, True),
+        ("linux", False, False),
+        # Only supported on Linux for now
+        ("darwin", True, False),
+        ("darwin", False, False),
+        ("win32", True, False),
+        ("win32", False, False),
+    ],
+)
+@mock.patch("ddtrace.internal.native.TraceExporterBuilder")
+def test_writer_telemetry_enabled_on_linux(
+    mock_builder_class, platform: str, config_value: bool, expected_enabled: bool
+):
+    """Test that telemetry is enabled for native writer on Linux platforms."""
+
+    mock_builder = mock.Mock()
+    mock_builder_class.return_value = mock_builder
+    mock_exporter = mock.Mock()
+    mock_builder.build.return_value = mock_exporter
+
+    for method_name in [
+        "set_url",
+        "set_language",
+        "set_language_version",
+        "set_language_interpreter",
+        "set_tracer_version",
+        "set_git_commit_sha",
+        "set_client_computed_top_level",
+        "set_input_format",
+        "set_output_format",
+        "enable_telemetry",
+    ]:
+        getattr(mock_builder, method_name).return_value = mock_builder
+
+    with mock_sys_platform(platform):
+        with override_global_config(dict(_telemetry_enabled=config_value)):
+            _writer = NativeWriter("http://localhost:8126/v0.5/traces", sync_mode=True)
+
+            if expected_enabled:
+                mock_builder.enable_telemetry.assert_called_once_with(60000, get_runtime_id())
+            else:
+                mock_builder.enable_telemetry.assert_not_called()


### PR DESCRIPTION
## TLDR
This PR enables `NativeWriter` telemetry only on Linux platforms.

## Description
The `NativeWriter` will only call enable_telemetry if `DD_INSTRUMENTATION_TELEMETRY_ENABLED` is True and the platform is linux.

## Motivation
This PR will allow to monitor `NativeWriter` metrics during the dogfooding phase while APMSP-2204 is investigated.

## Testing
Tests have been added to `NativeWriterTests` to check the telemetry is enabled based on the aforementioned conditions.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
