### PR TITLE
ci: add pip cache to download dependency wheels job

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -28,7 +28,7 @@ download_dependency_wheels:
   stage: package
   needs: [ download_ddtrace_artifacts ]
   variables:
-    - PIP_CACHE_DIR=${CI_PROJECT_DIR}/.cache/pip
+    PIP_CACHE_DIR: "${CI_PROJECT_DIR}/.cache/pip"
   parallel:
     matrix: # The image tags that are mirrored are in: https://github.com/DataDog/images/blob/master/mirror.yaml
       - PYTHON_IMAGE_TAG: "3.8"


### PR DESCRIPTION
No reason to constantly be downloading the same packages over and over again.

Not sure if we should add current month into the key or not, or something to make sure it doesn't just grow forever? but should take awhile before it is a problem, and manually bumping the key should be an easy fix?

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
