### PR TITLE
fix(ci_visibility): do not hold references to test exceptions [backport 3.11]

### DIFF
--- a/ddtrace/contrib/internal/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v2.py
@@ -487,7 +487,7 @@ def _pytest_runtest_protocol_post_yield(item, nextitem, coverage_collector):
 
     if not InternalTest.is_finished(test_id):
         log.debug("Test %s was not finished normally during pytest_runtest_protocol, finishing it now", test_id)
-        reports_dict = reports_by_item.get(item)
+        reports_dict = reports_by_item.pop(item, None)
         if reports_dict:
             test_outcome = _process_reports_dict(item, reports_dict)
             InternalTest.finish(test_id, test_outcome.status, test_outcome.skip_reason, test_outcome.exc_info)
@@ -633,7 +633,7 @@ def _process_reports_dict(item, reports) -> _TestOutcome:
 def _process_result(item, result) -> _TestOutcome:
     test_id = _get_test_id_from_item(item)
 
-    report_excinfo = excinfo_by_report.get(result)
+    report_excinfo = excinfo_by_report.pop(result, None)
     has_exception = report_excinfo is not None
 
     # In cases where a test was marked as XFAIL, the reason is only available during when call.when == "call", so we

--- a/releasenotes/notes/ci_visibility-fix-exception-memory-usage-46bffde9569ff4df.yaml
+++ b/releasenotes/notes/ci_visibility-fix-exception-memory-usage-46bffde9569ff4df.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    CI Visibility: This fix resolves an issue where the ``pytest`` plugin would hold a reference to test exceptions
+    beyond the end of the test, preventing them from being garbage-collected and increasing memory usage.


### PR DESCRIPTION
Backport 40d2bdb9306266b4080af50bdc01ada70266086f from #14328 to 3.11.

PR #13448 introduced a dictionary mapping test reports to their exception information. This dictionary prevents the exceptions from being garbage collected, which may lead to excessive memory usage. This PR removes the items from the dictionary after they are consumed.
 
## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)