### PR TITLE
chore(ci_visibility): replace weak dicts with regular dicts

### DIFF
--- a/ddtrace/contrib/internal/pytest/_utils.py
+++ b/ddtrace/contrib/internal/pytest/_utils.py
@@ -253,5 +253,5 @@ def get_user_property(report, key, default=None):
     return default
 
 
-excinfo_by_report = weakref.WeakKeyDictionary()
-reports_by_item = weakref.WeakKeyDictionary()
+excinfo_by_report = {}
+reports_by_item = {}

--- a/ddtrace/contrib/internal/pytest/_utils.py
+++ b/ddtrace/contrib/internal/pytest/_utils.py
@@ -3,7 +3,6 @@ import json
 from pathlib import Path
 import re
 import typing as t
-import weakref
 
 import pytest
 


### PR DESCRIPTION
After changes from PRs #14328 and #14344, the dictionaries of test exceptions and reports are cleaned up manually, so they don't have to be `WeakKeyDictionary` anymore. The dictionaries being weak not only don't help, they also cause flakiness in one of the tests (`test_pytest_clears_excinfo_dict_after_use`) because the number of elements in the dicts is not reliable.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
