### PR TITLE
chore: add traceback info to the failed to send message (#14299) [backport 3.11]

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
@@ -1089,8 +1089,8 @@ experiments:
               - max_rss_usage < 31.00 MB
           - name: telemetryaddmetric-1-rate-metrics-100-times
             thresholds:
-              - execution_time < 0.23 ms
-              - max_rss_usage < 31.00 MB
+              - execution_time < 0.24 ms
+              - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-100-count-metrics-100-times
             thresholds:
               - execution_time < 22.50 ms

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -433,6 +433,7 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
                     n_traces,
                     self._intake_endpoint(client),
                     self.RETRY_ATTEMPTS,
+                    exc_info=True,
                 )
         finally:
             self._metrics_dist("http.sent.bytes", len(encoded))

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -94,6 +94,7 @@ def test_uds_wrong_socket_path():
             1,
             "unix:///tmp/ddagent/nosockethere/{}/traces".format(encoding if encoding else "v0.5"),
             3,
+            exc_info=True,
         )
     ]
     log.error.assert_has_calls(calls)
@@ -340,6 +341,7 @@ def test_trace_generates_error_logs_when_trace_agent_url_invalid():
             1,
             "http://localhost:8125/{}/traces".format(encoding if encoding else "v0.5"),
             3,
+            exc_info=True,
         )
     ]
     log.error.assert_has_calls(calls)


### PR DESCRIPTION
## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
