### PR TITLE
chore(aioredis): mark deprecation

### DIFF
--- a/ddtrace/contrib/internal/aioredis/patch.py
+++ b/ddtrace/contrib/internal/aioredis/patch.py
@@ -23,11 +23,13 @@ from ddtrace.ext import redis as redisx
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_cache_operation
 from ddtrace.internal.schema import schematize_service_name
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.internal.utils.formats import CMD_MAX_LEN
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import stringify_cache_args
 from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.trace import Pin
+from ddtrace.vendor.debtcollector import deprecate
 from ddtrace.vendor.packaging.version import parse as parse_version
 
 
@@ -50,8 +52,7 @@ aioredis_version = parse_version(aioredis_version_str)
 V2 = parse_version("2.0")
 
 
-def get_version():
-    # type: () -> str
+def get_version() -> str:
     return aioredis_version_str
 
 
@@ -60,6 +61,12 @@ def _supported_versions() -> Dict[str, str]:
 
 
 def patch():
+    deprecate(
+        "The aioredis integration is deprecated.",
+        message="Use the aredis integration instead.",
+        category=DDTraceDeprecationWarning,
+        removal_version="4.0.0",
+    )
     if getattr(aioredis, "_datadog_patch", False):
         return
     aioredis._datadog_patch = True

--- a/ddtrace/contrib/internal/aioredis/patch.py
+++ b/ddtrace/contrib/internal/aioredis/patch.py
@@ -63,7 +63,7 @@ def _supported_versions() -> Dict[str, str]:
 def patch():
     deprecate(
         "The aioredis integration is deprecated.",
-        message="Use the aredis integration instead.",
+        message="Use the redis integration instead.",
         category=DDTraceDeprecationWarning,
         removal_version="4.0.0",
     )


### PR DESCRIPTION
The aioredis integration has been deprecated since [this release note](https://github.com/DataDog/dd-trace-py/blob/main/releasenotes/notes/deprecate-aioredis-e4a356f920de2cfe.yaml). This change adds a deprecation warning to its `patch()` function.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
