### PR TITLE
chore(vertica): deprecate the vertica integration

### DIFF
--- a/ddtrace/contrib/internal/vertica/patch.py
+++ b/ddtrace/contrib/internal/vertica/patch.py
@@ -16,8 +16,10 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.schema import schematize_database_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils import get_argument_value
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.internal.utils.wrappers import unwrap
 from ddtrace.trace import Pin
+from ddtrace.vendor.debtcollector import deprecate
 
 
 log = get_logger(__name__)
@@ -131,6 +133,11 @@ def _supported_versions() -> Dict[str, str]:
 
 
 def patch():
+    deprecate(
+        "The vertica integration is deprecated and will be removed in a future version.",
+        category=DDTraceDeprecationWarning,
+        removal_version="5.0.0",
+    )
     global _PATCHED
     if _PATCHED:
         return


### PR DESCRIPTION
This change deprecates the Vertica integration, which only works with Python <=3.9 and has had its test suite disabled for a long time. Removal version set to 5.0.0 because that's probably when ddtrace will drop 3.9 support.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
