### PR TITLE
chore(benchmarks): give telemetry add metric slos more headroom

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
@@ -1061,63 +1061,63 @@ experiments:
           # telemetryaddmetric
           - name: telemetryaddmetric-1-count-metric-1-times
             thresholds:
-              - execution_time < 0.01 ms
+              - execution_time < 0.02 ms
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-1-count-metrics-100-times
             thresholds:
-              - execution_time < 0.24 ms
+              - execution_time < 0.25 ms
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-1-distribution-metric-1-times
             thresholds:
-              - execution_time < 0.01 ms
+              - execution_time < 0.02 ms
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-1-distribution-metrics-100-times
             thresholds:
-              - execution_time < 0.21 ms
+              - execution_time < 0.22 ms
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-1-gauge-metric-1-times
             thresholds:
-              - execution_time < 0.01 ms
+              - execution_time < 0.02 ms
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-1-gauge-metrics-100-times
             thresholds:
-              - execution_time < 0.14 ms
+              - execution_time < 0.15 ms
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-1-rate-metric-1-times
             thresholds:
-              - execution_time < 0.01 ms
+              - execution_time < 0.02 ms
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-1-rate-metrics-100-times
             thresholds:
-              - execution_time < 0.24 ms
+              - execution_time < 0.25 ms
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-100-count-metrics-100-times
             thresholds:
-              - execution_time < 23.00 ms
+              - execution_time < 23.50 ms
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-100-distribution-metrics-100-times
             thresholds:
-              - execution_time < 2.20 ms
+              - execution_time < 2.25 ms
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-100-gauge-metrics-100-times
             thresholds:
-              - execution_time < 1.50 ms
+              - execution_time < 1.55 ms
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-100-rate-metrics-100-times
             thresholds:
-              - execution_time < 2.50 ms
+              - execution_time < 2.55 ms
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-flush-1-metric
             thresholds:
-              - execution_time < 0.01 ms
+              - execution_time < 0.02 ms
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-flush-100-metrics
             thresholds:
-              - execution_time < 0.20 ms
+              - execution_time < 0.25 ms
               - max_rss_usage < 34.00 MB
           - name: telemetryaddmetric-flush-1000-metrics
             thresholds:
-              - execution_time < 2.45 ms
+              - execution_time < 2.50 ms
               - max_rss_usage < 34.50 MB
 
           # tracer


### PR DESCRIPTION
They are still a bit flaky, and for the ones which are <0.20 ms they don't need that much more headroom.

e.g.

- telemetryaddmetric-1-distribution-metrics-100-times
    - 🟥 `execution_time` seen in benchmark [211.852µs; 214.681µs]; SLO is < 210.000µs

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
