### PR TITLE
chore(profiling): deflake test_memory_collector_thread_lifecycle

### DIFF
--- a/tests/profiling_v2/collector/test_memalloc.py
+++ b/tests/profiling_v2/collector/test_memalloc.py
@@ -763,7 +763,7 @@ def test_memory_collector_thread_lifecycle():
     """Test that continuously creates and destroys threads while they perform allocations,
     verifying that the collector can track allocations across changing thread contexts.
     """
-    mc = memalloc.MemoryCollector(heap_sample_size=512)
+    mc = memalloc.MemoryCollector(heap_sample_size=8)
 
     with mc:
         threads = []


### PR DESCRIPTION
The test is running with quite a high sampling interval, but is doing
allocations we mostly don't sample right now (list objects where the
backing memory allocation isn't profiled). As a result, there is a
decent chance that we don't sample allocations on the "worker" threads
in the test since they do ~560 bytes of sampleable allocations and the
interval is 512. Decrease the sample interval to 8 bytes so that we're
basically recording every allocation.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
