### PR TITLE
chore: ignore .worktrees when running linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,8 @@ write_to = "ddtrace/_version.py"
 max-line-length = 120
 exclude = '''
 (
-  .venv*
+  \.worktrees/
+  | .venv*
   | \.riot
   | ddtrace/profiling/
   | test_ci_visibility_api_client_skippable_real_world_responses\.py
@@ -107,7 +108,8 @@ target_version = ['py37', 'py38', 'py39', 'py310', 'py311', 'py312']
 include = '''\.py[ix]?$'''
 exclude = '''
 (
-  .venv*
+  \.worktrees/
+  | .venv*
   | \.riot/
   | ddtrace/appsec/_ddwaf.pyx$
   | ddtrace/internal/_encoding.pyx$
@@ -149,6 +151,7 @@ exclude = [
   ".riot",
   ".tox",
   ".venv",
+  ".worktrees",
 ]
 
 [tool.slotscheck]
@@ -216,6 +219,7 @@ exclude = [
     ".ddriot",
     ".venv*",
     ".git",
+    ".worktrees",
     "__pycache__",
     ".eggs",
     "*.egg",


### PR DESCRIPTION
For anyone using git worktrees until .worktrees running `hatch run lint:checks`/`hatch run lint:typing`, etc will take a long time since the tools will traverse all the worktrees as well.

This ignores those for those tools.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
