### PR TITLE
chore(tracing): update Pin import paths

### DIFF
--- a/tests/tracer/test_instance_config.py
+++ b/tests/tracer/test_instance_config.py
@@ -1,8 +1,8 @@
 from unittest import TestCase
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.settings.integration import IntegrationConfig
-from ddtrace.trace import Pin
 
 
 class InstanceConfigTestCase(TestCase):

--- a/tests/tracer/test_pin.py
+++ b/tests/tracer/test_pin.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 import pytest
 
-from ddtrace.trace import Pin
+from ddtrace._trace.pin import Pin
 
 
 class PinTestCase(TestCase):

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -14,6 +14,7 @@ import mock
 import pytest
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal import trace_utils
 from ddtrace.contrib.internal.trace_utils import _get_request_header_client_ip
 from ddtrace.ext import SpanTypes
@@ -26,7 +27,6 @@ from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.settings._config import Config
 from ddtrace.settings.integration import IntegrationConfig
 from ddtrace.trace import Context
-from ddtrace.trace import Pin
 from ddtrace.trace import Span
 from tests.appsec.utils import asm_context
 from tests.utils import override_global_config


### PR DESCRIPTION
Broken out from #14361

`ddtrace.trace.Pin` is being deprecated

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
