### PR TITLE
chore(appsec): update Pin import paths

### DIFF
--- a/tests/appsec/contrib_appsec/django_app/urls.py
+++ b/tests/appsec/contrib_appsec/django_app/urls.py
@@ -14,6 +14,7 @@ from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
+from ddtrace._trace.pin import Pin
 import ddtrace.constants
 from ddtrace.trace import tracer
 
@@ -154,7 +155,7 @@ def rasp(request, endpoint: str):
             if param.startswith("cmda"):
                 cmd = query_params[param]
                 try:
-                    res.append(f'cmd stdout: {subprocess.run([cmd, "-c", "3", "localhost"], timeout=0.5)}')
+                    res.append(f"cmd stdout: {subprocess.run([cmd, '-c', '3', 'localhost'], timeout=0.5)}")
                 except Exception as e:
                     res.append(f"Error: {e}")
             elif param.startswith("cmds"):
@@ -244,7 +245,7 @@ def login_user_sdk(request):
 def new_service(request, service_name: str):
     import ddtrace
 
-    ddtrace.trace.Pin._override(django, service=service_name, tracer=ddtrace.tracer)
+    Pin._override(django, service=service_name, tracer=ddtrace.tracer)
     return HttpResponse(service_name, status=200)
 
 

--- a/tests/appsec/contrib_appsec/fastapi_app/app.py
+++ b/tests/appsec/contrib_appsec/fastapi_app/app.py
@@ -12,6 +12,7 @@ from fastapi.responses import JSONResponse
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
+from ddtrace._trace.pin import Pin
 import ddtrace.constants
 from ddtrace.trace import tracer
 
@@ -128,7 +129,7 @@ def get_app():
     async def new_service(service_name: str, request: Request):  # noqa: B008
         import ddtrace
 
-        ddtrace.trace.Pin._override(app, service=service_name, tracer=ddtrace.tracer)
+        Pin._override(app, service=service_name, tracer=ddtrace.tracer)
         return HTMLResponse(service_name, 200)
 
     async def slow_numbers(minimum, maximum):

--- a/tests/appsec/contrib_appsec/flask_app/app.py
+++ b/tests/appsec/contrib_appsec/flask_app/app.py
@@ -8,6 +8,7 @@ from flask import Flask
 from flask import request
 
 # from ddtrace.appsec.iast import ddtrace_iast_flask_patch
+from ddtrace._trace.pin import Pin
 import ddtrace.constants
 from ddtrace.trace import tracer
 from tests.webclient import PingFilter
@@ -56,7 +57,7 @@ def multi_view(param_int=0, param_str=""):
 def new_service(service_name: str):
     import ddtrace
 
-    ddtrace.trace.Pin._override(Flask, service=service_name, tracer=ddtrace.tracer)
+    Pin._override(Flask, service=service_name, tracer=ddtrace.tracer)
     return service_name
 
 

--- a/tests/appsec/contrib_appsec/test_flask.py
+++ b/tests/appsec/contrib_appsec/test_flask.py
@@ -1,8 +1,8 @@
 from flask.testing import FlaskClient
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.internal.packages import get_version_for_package
-from ddtrace.trace import Pin
 from tests.appsec.contrib_appsec import utils
 from tests.utils import TracerTestCase
 

--- a/tests/appsec/contrib_appsec/utils.py
+++ b/tests/appsec/contrib_appsec/utils.py
@@ -11,6 +11,7 @@ from urllib.parse import urlencode
 import pytest
 
 import ddtrace
+from ddtrace._trace.pin import Pin
 from ddtrace.appsec import _asm_request_context
 from ddtrace.appsec import _constants as asm_constants
 from ddtrace.appsec._utils import get_security
@@ -1980,8 +1981,8 @@ def test_tracer():
 
 @contextmanager
 def post_tracer(interface):
-    original_tracer = getattr(ddtrace.trace.Pin.get_from(interface.framework), "tracer", None)
-    ddtrace.trace.Pin._override(interface.framework, tracer=interface.tracer)
+    original_tracer = getattr(Pin.get_from(interface.framework), "tracer", None)
+    Pin._override(interface.framework, tracer=interface.tracer)
     yield
     if original_tracer is not None:
-        ddtrace.trace.Pin._override(interface.framework, tracer=original_tracer)
+        Pin._override(interface.framework, tracer=original_tracer)

--- a/tests/appsec/iast/taint_sinks/test_sql_injection_dbapi.py
+++ b/tests/appsec/iast/taint_sinks/test_sql_injection_dbapi.py
@@ -2,13 +2,13 @@ from unittest import mock
 
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.appsec._iast import load_iast
 from ddtrace.appsec._iast._overhead_control_engine import oce
 from ddtrace.contrib.dbapi import TracedCursor
 from ddtrace.settings._config import Config
 from ddtrace.settings.asm import config as asm_config
 from ddtrace.settings.integration import IntegrationConfig
-from ddtrace.trace import Pin
 from tests.appsec.iast.iast_utils import _end_iast_context_and_oce
 from tests.appsec.iast.iast_utils import _start_iast_context_and_oce
 from tests.utils import TracerTestCase

--- a/tests/appsec/integrations/django_tests/conftest.py
+++ b/tests/appsec/integrations/django_tests/conftest.py
@@ -4,13 +4,13 @@ import django
 from django.conf import settings
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.appsec._iast import enable_iast_propagation
 from ddtrace.appsec._iast import load_iast
 from ddtrace.appsec._iast.main import patch_iast
 from ddtrace.contrib.internal.django.patch import patch as django_patch
 from ddtrace.contrib.internal.requests.patch import patch as requests_patch
 from ddtrace.internal import core
-from ddtrace.trace import Pin
 from tests.appsec.iast.iast_utils import _end_iast_context_and_oce
 from tests.appsec.iast.iast_utils import _start_iast_context_and_oce
 from tests.utils import DummyTracer

--- a/tests/contrib/grpc/common.py
+++ b/tests/contrib/grpc/common.py
@@ -2,10 +2,10 @@ import grpc
 from grpc._grpcio_metadata import __version__ as _GRPC_VERSION
 from grpc.framework.foundation import logging_pool
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.grpc import constants
 from ddtrace.contrib.internal.grpc.patch import patch
 from ddtrace.contrib.internal.grpc.patch import unpatch
-from ddtrace.trace import Pin
 from tests.utils import TracerTestCase
 
 from .hello_pb2_grpc import add_HelloServicer_to_server

--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -5,6 +5,7 @@ import grpc
 from grpc.framework.foundation import logging_pool
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace._trace.span import _get_64_highest_order_bits_as_hex
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
@@ -14,7 +15,6 @@ from ddtrace.contrib.internal.grpc.patch import _unpatch_server
 from ddtrace.contrib.internal.grpc.patch import patch
 from ddtrace.contrib.internal.grpc.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.utils import TracerTestCase
 from tests.utils import snapshot
 

--- a/tests/contrib/subprocess/test_subprocess.py
+++ b/tests/contrib/subprocess/test_subprocess.py
@@ -5,13 +5,13 @@ import sys
 
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.subprocess.constants import COMMANDS
 from ddtrace.contrib.internal.subprocess.patch import SubprocessCmdLine
 from ddtrace.contrib.internal.subprocess.patch import patch
 from ddtrace.contrib.internal.subprocess.patch import unpatch
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
-from ddtrace.trace import Pin
 from tests.utils import override_config
 from tests.utils import override_global_config
 


### PR DESCRIPTION
Broken out from #14361 

`ddtrace.trace.Pin` is being deprecated

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
