### PR TITLE
chore(llmobs): update Pin import paths

### DIFF
--- a/ddtrace/contrib/internal/anthropic/patch.py
+++ b/ddtrace/contrib/internal/anthropic/patch.py
@@ -5,6 +5,7 @@ from typing import Dict
 import anthropic
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.anthropic._streaming import handle_streamed_response
 from ddtrace.contrib.internal.anthropic._streaming import is_streaming_operation
 from ddtrace.contrib.internal.trace_utils import unwrap
@@ -12,7 +13,6 @@ from ddtrace.contrib.internal.trace_utils import with_traced_module
 from ddtrace.contrib.internal.trace_utils import wrap
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._integrations import AnthropicIntegration
-from ddtrace.trace import Pin
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/internal/crewai/patch.py
+++ b/ddtrace/contrib/internal/crewai/patch.py
@@ -4,13 +4,13 @@ from typing import Dict
 import crewai
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.trace_utils import unwrap
 from ddtrace.contrib.internal.trace_utils import with_traced_module
 from ddtrace.contrib.internal.trace_utils import wrap
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.llmobs._integrations.crewai import CrewAIIntegration
-from ddtrace.trace import Pin
 
 
 def get_version() -> str:

--- a/ddtrace/contrib/internal/google_genai/patch.py
+++ b/ddtrace/contrib/internal/google_genai/patch.py
@@ -3,6 +3,7 @@ import sys
 from google import genai
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.google_genai._utils import GoogleGenAIAsyncStreamHandler
 from ddtrace.contrib.internal.google_genai._utils import GoogleGenAIStreamHandler
 from ddtrace.contrib.internal.trace_utils import unwrap
@@ -11,7 +12,6 @@ from ddtrace.contrib.internal.trace_utils import wrap
 from ddtrace.llmobs._integrations import GoogleGenAIIntegration
 from ddtrace.llmobs._integrations.base_stream_handler import make_traced_stream
 from ddtrace.llmobs._integrations.google_utils import extract_provider_and_model_name
-from ddtrace.trace import Pin
 
 
 config._add("google_genai", {})

--- a/ddtrace/contrib/internal/google_generativeai/patch.py
+++ b/ddtrace/contrib/internal/google_generativeai/patch.py
@@ -5,6 +5,7 @@ from typing import Dict
 import google.generativeai as genai
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.google_generativeai._utils import GoogleGenerativeAIAsyncStreamHandler
 from ddtrace.contrib.internal.google_generativeai._utils import GoogleGenerativeAIStramHandler
 from ddtrace.contrib.internal.trace_utils import unwrap
@@ -13,7 +14,6 @@ from ddtrace.contrib.internal.trace_utils import wrap
 from ddtrace.llmobs._integrations import GeminiIntegration
 from ddtrace.llmobs._integrations.base_stream_handler import make_traced_stream
 from ddtrace.llmobs._integrations.google_utils import extract_provider_and_model_name
-from ddtrace.trace import Pin
 
 
 config._add(

--- a/ddtrace/contrib/internal/langchain/patch.py
+++ b/ddtrace/contrib/internal/langchain/patch.py
@@ -36,6 +36,7 @@ except ImportError:
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.langchain.constants import text_embedding_models
 from ddtrace.contrib.internal.langchain.constants import vectorstore_classes
 from ddtrace.contrib.internal.langchain.utils import shared_stream
@@ -50,7 +51,6 @@ from ddtrace.internal.utils.formats import deep_getattr
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._integrations import LangChainIntegration
 from ddtrace.llmobs._utils import safe_json
-from ddtrace.trace import Pin
 from ddtrace.trace import Span
 
 

--- a/ddtrace/contrib/internal/langgraph/patch.py
+++ b/ddtrace/contrib/internal/langgraph/patch.py
@@ -4,6 +4,7 @@ from typing import Dict
 import langgraph
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.trace_utils import unwrap
 from ddtrace.contrib.trace_utils import with_traced_module
 from ddtrace.contrib.trace_utils import wrap
@@ -12,7 +13,6 @@ from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._integrations.constants import LANGGRAPH_ASTREAM_OUTPUT
 from ddtrace.llmobs._integrations.constants import LANGGRAPH_SPAN_TRACES_ASTREAM
 from ddtrace.llmobs._integrations.langgraph import LangGraphIntegration
-from ddtrace.trace import Pin
 
 
 def get_version():

--- a/ddtrace/contrib/internal/litellm/patch.py
+++ b/ddtrace/contrib/internal/litellm/patch.py
@@ -4,6 +4,7 @@ from typing import Dict
 import litellm
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.litellm.utils import LiteLLMAsyncStreamHandler
 from ddtrace.contrib.internal.litellm.utils import LiteLLMStreamHandler
 from ddtrace.contrib.internal.litellm.utils import extract_host_tag
@@ -14,7 +15,6 @@ from ddtrace.internal.utils import get_argument_value
 from ddtrace.llmobs._constants import LITELLM_ROUTER_INSTANCE_KEY
 from ddtrace.llmobs._integrations import LiteLLMIntegration
 from ddtrace.llmobs._integrations.base_stream_handler import make_traced_stream
-from ddtrace.trace import Pin
 
 
 config._add("litellm", {})

--- a/ddtrace/contrib/internal/mcp/patch.py
+++ b/ddtrace/contrib/internal/mcp/patch.py
@@ -7,6 +7,7 @@ from typing import Optional
 import mcp
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.trace_utils import activate_distributed_headers
 from ddtrace.contrib.trace_utils import unwrap
 from ddtrace.contrib.trace_utils import with_traced_module
@@ -18,7 +19,6 @@ from ddtrace.llmobs._integrations.mcp import SERVER_TOOL_CALL_OPERATION_NAME
 from ddtrace.llmobs._integrations.mcp import MCPIntegration
 from ddtrace.llmobs._utils import _get_attr
 from ddtrace.propagation.http import HTTPPropagator
-from ddtrace.trace import Pin
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/internal/openai/patch.py
+++ b/ddtrace/contrib/internal/openai/patch.py
@@ -5,6 +5,7 @@ from typing import Dict
 from openai import version
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.openai import _endpoint_hooks
 from ddtrace.contrib.trace_utils import unwrap
 from ddtrace.contrib.trace_utils import with_traced_module
@@ -13,7 +14,6 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import deep_getattr
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._integrations import OpenAIIntegration
-from ddtrace.trace import Pin
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/internal/openai_agents/patch.py
+++ b/ddtrace/contrib/internal/openai_agents/patch.py
@@ -4,13 +4,13 @@ import agents
 from agents.tracing import add_trace_processor
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.openai_agents.processor import LLMObsTraceProcessor
 from ddtrace.contrib.trace_utils import unwrap
 from ddtrace.contrib.trace_utils import with_traced_module_async
 from ddtrace.contrib.trace_utils import wrap
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._integrations.openai_agents import OpenAIAgentsIntegration
-from ddtrace.trace import Pin
 
 
 config._add("openai_agents", {})

--- a/ddtrace/contrib/internal/openai_agents/processor.py
+++ b/ddtrace/contrib/internal/openai_agents/processor.py
@@ -5,11 +5,11 @@ from agents.tracing.processor_interface import TracingProcessor
 from agents.tracing.spans import Span as OaiSpan
 from agents.tracing.traces import Trace as OaiTrace
 
+from ddtrace._trace.pin import Pin
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._integrations.utils import OaiSpanAdapter
 from ddtrace.llmobs._integrations.utils import OaiTraceAdapter
-from ddtrace.trace import Pin
 
 
 logger = get_logger(__name__)

--- a/ddtrace/contrib/internal/pydantic_ai/patch.py
+++ b/ddtrace/contrib/internal/pydantic_ai/patch.py
@@ -2,6 +2,7 @@ import sys
 from typing import Dict
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.pydantic_ai.utils import TracedPydanticAsyncContextManager
 from ddtrace.contrib.internal.pydantic_ai.utils import TracedPydanticRunStream
 from ddtrace.contrib.internal.trace_utils import unwrap
@@ -10,7 +11,6 @@ from ddtrace.contrib.trace_utils import with_traced_module
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._integrations.pydantic_ai import PydanticAIIntegration
-from ddtrace.trace import Pin
 
 
 config._add("pydantic_ai", {})

--- a/ddtrace/contrib/internal/vertexai/patch.py
+++ b/ddtrace/contrib/internal/vertexai/patch.py
@@ -8,6 +8,7 @@ import vertexai
 from vertexai.generative_models import GenerativeModel  # noqa:F401
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.trace_utils import unwrap
 from ddtrace.contrib.internal.trace_utils import with_traced_module
 from ddtrace.contrib.internal.trace_utils import wrap
@@ -16,7 +17,6 @@ from ddtrace.contrib.internal.vertexai._utils import VertexAIStreamHandler
 from ddtrace.llmobs._integrations import VertexAIIntegration
 from ddtrace.llmobs._integrations.base_stream_handler import make_traced_stream
 from ddtrace.llmobs._integrations.google_utils import extract_provider_and_model_name
-from ddtrace.trace import Pin
 
 
 config._add(

--- a/ddtrace/llmobs/_integrations/base.py
+++ b/ddtrace/llmobs/_integrations/base.py
@@ -5,6 +5,7 @@ from typing import List  # noqa:F401
 from typing import Optional  # noqa:F401
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace._trace.sampler import RateSampler
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.contrib.internal.trace_utils import int_service
@@ -14,7 +15,6 @@ from ddtrace.llmobs._constants import INTEGRATION
 from ddtrace.llmobs._constants import PROXY_REQUEST
 from ddtrace.llmobs._llmobs import LLMObs
 from ddtrace.settings.integration import IntegrationConfig
-from ddtrace.trace import Pin
 from ddtrace.trace import Span
 
 

--- a/ddtrace/llmobs/_integrations/crewai.py
+++ b/ddtrace/llmobs/_integrations/crewai.py
@@ -5,6 +5,7 @@ from typing import List
 from typing import Optional
 from weakref import WeakKeyDictionary
 
+from ddtrace._trace.pin import Pin
 from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import get_argument_value
@@ -21,7 +22,6 @@ from ddtrace.llmobs._constants import SPAN_LINKS
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
 from ddtrace.llmobs._utils import safe_json
-from ddtrace.trace import Pin
 from ddtrace.trace import Span
 
 

--- a/ddtrace/llmobs/_integrations/openai.py
+++ b/ddtrace/llmobs/_integrations/openai.py
@@ -3,6 +3,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
+from ddtrace._trace.pin import Pin
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._constants import CACHE_READ_INPUT_TOKENS_METRIC_KEY
@@ -26,7 +27,6 @@ from ddtrace.llmobs._integrations.utils import openai_set_meta_tags_from_respons
 from ddtrace.llmobs._integrations.utils import update_proxy_workflow_input_output_value
 from ddtrace.llmobs._utils import _get_attr
 from ddtrace.llmobs.utils import Document
-from ddtrace.trace import Pin
 from ddtrace.trace import Span
 
 

--- a/ddtrace/llmobs/_integrations/openai_agents.py
+++ b/ddtrace/llmobs/_integrations/openai_agents.py
@@ -6,6 +6,7 @@ from typing import Optional
 from typing import Union
 import weakref
 
+from ddtrace._trace.pin import Pin
 from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import get_argument_value
@@ -34,7 +35,6 @@ from ddtrace.llmobs._integrations.utils import OaiTraceAdapter
 from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
 from ddtrace.llmobs._utils import _get_span_name
 from ddtrace.llmobs._utils import load_data_value
-from ddtrace.trace import Pin
 from ddtrace.trace import Span
 
 

--- a/ddtrace/llmobs/_integrations/pydantic_ai.py
+++ b/ddtrace/llmobs/_integrations/pydantic_ai.py
@@ -5,6 +5,7 @@ from typing import Optional
 from typing import Sequence
 from typing import Tuple
 
+from ddtrace._trace.pin import Pin
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._constants import AGENT_MANIFEST
@@ -23,7 +24,6 @@ from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._utils import _get_attr
 from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
-from ddtrace.trace import Pin
 from ddtrace.trace import Span
 
 

--- a/tests/contrib/anthropic/conftest.py
+++ b/tests/contrib/anthropic/conftest.py
@@ -3,10 +3,10 @@ import os
 import mock
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.anthropic.patch import patch
 from ddtrace.contrib.internal.anthropic.patch import unpatch
 from ddtrace.llmobs import LLMObs
-from ddtrace.trace import Pin
 from tests.contrib.anthropic.utils import get_request_vcr
 from tests.utils import DummyTracer
 from tests.utils import DummyWriter

--- a/tests/contrib/botocore/test_bedrock_llmobs.py
+++ b/tests/contrib/botocore/test_bedrock_llmobs.py
@@ -4,9 +4,9 @@ import mock
 from mock import patch as mock_patch
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs import LLMObs as llmobs_service
-from ddtrace.trace import Pin
 from tests.contrib.botocore.bedrock_utils import _MODELS
 from tests.contrib.botocore.bedrock_utils import _REQUEST_BODIES
 from tests.contrib.botocore.bedrock_utils import BOTO_VERSION

--- a/tests/contrib/crewai/conftest.py
+++ b/tests/contrib/crewai/conftest.py
@@ -15,10 +15,10 @@ from crewai.tools import tool
 import pytest
 import vcr
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.crewai.patch import patch
 from ddtrace.contrib.internal.crewai.patch import unpatch
 from ddtrace.llmobs import LLMObs as llmobs_service
-from ddtrace.trace import Pin
 from tests.contrib.crewai.utils import budget_text
 from tests.contrib.crewai.utils import fun_fact_text
 from tests.contrib.crewai.utils import itinerary_text

--- a/tests/contrib/google_genai/conftest.py
+++ b/tests/contrib/google_genai/conftest.py
@@ -6,10 +6,10 @@ from unittest.mock import patch as mock_patch
 
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.google_genai.patch import patch
 from ddtrace.contrib.internal.google_genai.patch import unpatch
 from ddtrace.llmobs import LLMObs
-from ddtrace.trace import Pin
 from tests.contrib.google_genai.utils import MOCK_EMBED_CONTENT_RESPONSE
 from tests.contrib.google_genai.utils import MOCK_GENERATE_CONTENT_RESPONSE
 from tests.contrib.google_genai.utils import MOCK_GENERATE_CONTENT_RESPONSE_STREAM

--- a/tests/contrib/google_generativeai/conftest.py
+++ b/tests/contrib/google_generativeai/conftest.py
@@ -3,10 +3,10 @@ import os
 import mock
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.google_generativeai.patch import patch
 from ddtrace.contrib.internal.google_generativeai.patch import unpatch
 from ddtrace.llmobs import LLMObs
-from ddtrace.trace import Pin
 from tests.contrib.google_generativeai.utils import MockGenerativeModelAsyncClient
 from tests.contrib.google_generativeai.utils import MockGenerativeModelClient
 from tests.utils import DummyTracer

--- a/tests/contrib/langchain/conftest.py
+++ b/tests/contrib/langchain/conftest.py
@@ -3,11 +3,11 @@ import os
 
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.langchain.patch import patch
 from ddtrace.contrib.internal.langchain.patch import unpatch
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs import LLMObs as llmobs_service
-from ddtrace.trace import Pin
 from tests.llmobs._utils import TestLLMObsSpanWriter
 from tests.utils import DummyTracer
 from tests.utils import override_env

--- a/tests/contrib/langgraph/conftest.py
+++ b/tests/contrib/langgraph/conftest.py
@@ -11,10 +11,10 @@ from langgraph.graph import START
 from langgraph.graph import StateGraph
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.langgraph.patch import patch
 from ddtrace.contrib.internal.langgraph.patch import unpatch
 from ddtrace.llmobs import LLMObs as llmobs_service
-from ddtrace.trace import Pin
 from tests.llmobs._utils import TestLLMObsSpanWriter
 from tests.utils import DummyTracer
 from tests.utils import override_global_config

--- a/tests/contrib/litellm/conftest.py
+++ b/tests/contrib/litellm/conftest.py
@@ -1,10 +1,10 @@
 from litellm import Router
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.litellm.patch import patch
 from ddtrace.contrib.internal.litellm.patch import unpatch
 from ddtrace.llmobs import LLMObs as llmobs_service
-from ddtrace.trace import Pin
 from tests.contrib.litellm.utils import get_request_vcr
 from tests.contrib.litellm.utils import model_list
 from tests.llmobs._utils import TestLLMObsSpanWriter

--- a/tests/contrib/mcp/conftest.py
+++ b/tests/contrib/mcp/conftest.py
@@ -8,10 +8,10 @@ from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import create_connected_server_and_client_session
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.mcp.patch import patch
 from ddtrace.contrib.internal.mcp.patch import unpatch
 from ddtrace.llmobs import LLMObs as llmobs_service
-from ddtrace.trace import Pin
 from tests.llmobs._utils import TestLLMObsSpanWriter
 from tests.utils import DummyTracer
 from tests.utils import DummyWriter

--- a/tests/contrib/openai/conftest.py
+++ b/tests/contrib/openai/conftest.py
@@ -7,10 +7,10 @@ from typing import Optional  # noqa:F401
 import mock
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.openai.patch import patch
 from ddtrace.contrib.internal.openai.patch import unpatch
 from ddtrace.llmobs import LLMObs
-from ddtrace.trace import Pin
 from ddtrace.trace import TraceFilter
 from tests.utils import DummyTracer
 from tests.utils import DummyWriter

--- a/tests/contrib/openai_agents/conftest.py
+++ b/tests/contrib/openai_agents/conftest.py
@@ -9,10 +9,10 @@ from openai.types.responses.web_search_tool_param import UserLocation
 import pytest
 import vcr
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.openai_agents.patch import patch
 from ddtrace.contrib.internal.openai_agents.patch import unpatch
 from ddtrace.llmobs import LLMObs as llmobs_service
-from ddtrace.trace import Pin
 from tests.llmobs._utils import TestLLMObsSpanWriter
 from tests.utils import DummyTracer
 from tests.utils import override_global_config

--- a/tests/contrib/pydantic_ai/conftest.py
+++ b/tests/contrib/pydantic_ai/conftest.py
@@ -3,10 +3,10 @@ import os
 import pytest
 import vcr
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.pydantic_ai.patch import patch
 from ddtrace.contrib.internal.pydantic_ai.patch import unpatch
 from ddtrace.llmobs import LLMObs as llmobs_service
-from ddtrace.trace import Pin
 from tests.llmobs._utils import TestLLMObsSpanWriter
 from tests.utils import DummyTracer
 from tests.utils import override_global_config

--- a/tests/contrib/vertexai/conftest.py
+++ b/tests/contrib/vertexai/conftest.py
@@ -2,10 +2,10 @@ import mock
 from mock import PropertyMock
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.vertexai.patch import patch
 from ddtrace.contrib.internal.vertexai.patch import unpatch
 from ddtrace.llmobs import LLMObs
-from ddtrace.trace import Pin
 from tests.contrib.vertexai.utils import MockAsyncPredictionServiceClient
 from tests.contrib.vertexai.utils import MockPredictionServiceClient
 from tests.utils import DummyTracer


### PR DESCRIPTION
Broken out from #14361 

`ddtrace.trace.Pin` is being deprecated

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
