### PR TITLE
chore(contrib): update Pin import paths

### DIFF
--- a/ddtrace/contrib/internal/aiobotocore/patch.py
+++ b/ddtrace/contrib/internal/aiobotocore/patch.py
@@ -5,6 +5,7 @@ import aiobotocore.client
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace._trace.utils_botocore.span_tags import _derive_peer_hostname
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
@@ -23,7 +24,6 @@ from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import deep_getattr
 from ddtrace.internal.utils.version import parse_version
-from ddtrace.trace import Pin
 
 
 aiobotocore_version_str = getattr(aiobotocore, "__version__", "")

--- a/ddtrace/contrib/internal/aiohttp/patch.py
+++ b/ddtrace/contrib/internal/aiohttp/patch.py
@@ -6,6 +6,7 @@ import wrapt
 from yarl import URL
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib.internal.trace_utils import ext_service
 from ddtrace.contrib.internal.trace_utils import extract_netloc_and_query_info_from_url
@@ -24,7 +25,6 @@ from ddtrace.internal.telemetry import get_config as _get_config
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.propagation.http import HTTPPropagator
-from ddtrace.trace import Pin
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/internal/aiohttp_jinja2/patch.py
+++ b/ddtrace/contrib/internal/aiohttp_jinja2/patch.py
@@ -3,13 +3,13 @@ from typing import Dict
 import aiohttp_jinja2
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.trace_utils import unwrap
 from ddtrace.contrib.internal.trace_utils import with_traced_module
 from ddtrace.contrib.internal.trace_utils import wrap
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.utils import get_argument_value
-from ddtrace.trace import Pin
 
 
 config._add(

--- a/ddtrace/contrib/internal/aiomysql/patch.py
+++ b/ddtrace/contrib/internal/aiomysql/patch.py
@@ -4,6 +4,7 @@ import aiomysql
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import dbapi
@@ -19,7 +20,6 @@ from ddtrace.internal.schema import schematize_database_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.wrappers import unwrap
 from ddtrace.propagation._database_monitoring import _DBM_Propagator
-from ddtrace.trace import Pin
 
 
 config._add(

--- a/ddtrace/contrib/internal/aiopg/connection.py
+++ b/ddtrace/contrib/internal/aiopg/connection.py
@@ -3,6 +3,7 @@ from aiopg.utils import _ContextManager
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import dbapi
@@ -14,7 +15,6 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_database_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.version import parse_version
-from ddtrace.trace import Pin
 
 
 AIOPG_VERSION = parse_version(__version__)

--- a/ddtrace/contrib/internal/aioredis/patch.py
+++ b/ddtrace/contrib/internal/aioredis/patch.py
@@ -7,6 +7,7 @@ import aioredis
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace._trace.utils_redis import _instrument_redis_cmd
 from ddtrace._trace.utils_redis import _instrument_redis_execute_pipeline
 from ddtrace.constants import _SPAN_MEASURED_KEY
@@ -27,7 +28,6 @@ from ddtrace.internal.utils.formats import CMD_MAX_LEN
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import stringify_cache_args
 from ddtrace.internal.utils.wrappers import unwrap as _u
-from ddtrace.trace import Pin
 from ddtrace.vendor.packaging.version import parse as parse_version
 
 

--- a/ddtrace/contrib/internal/algoliasearch/patch.py
+++ b/ddtrace/contrib/internal/algoliasearch/patch.py
@@ -3,6 +3,7 @@ from typing import Dict
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
@@ -12,7 +13,6 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_cloud_api_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.wrappers import unwrap as _u
-from ddtrace.trace import Pin
 from ddtrace.vendor.packaging.version import parse as parse_version
 
 

--- a/ddtrace/contrib/internal/aredis/patch.py
+++ b/ddtrace/contrib/internal/aredis/patch.py
@@ -5,6 +5,7 @@ import aredis
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace._trace.utils_redis import _instrument_redis_cmd
 from ddtrace._trace.utils_redis import _instrument_redis_execute_pipeline
 from ddtrace.contrib.internal.redis_utils import _run_redis_command_async
@@ -13,7 +14,6 @@ from ddtrace.internal.utils.formats import CMD_MAX_LEN
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import stringify_cache_args
 from ddtrace.internal.utils.wrappers import unwrap
-from ddtrace.trace import Pin
 
 
 config._add(

--- a/ddtrace/contrib/internal/asyncio/patch.py
+++ b/ddtrace/contrib/internal/asyncio/patch.py
@@ -1,11 +1,11 @@
 import asyncio
 from typing import Dict
 
+from ddtrace._trace.pin import Pin
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils import set_argument_value
 from ddtrace.internal.wrapping import unwrap
 from ddtrace.internal.wrapping import wrap
-from ddtrace.trace import Pin
 
 
 def get_version():

--- a/ddtrace/contrib/internal/asyncpg/patch.py
+++ b/ddtrace/contrib/internal/asyncpg/patch.py
@@ -6,6 +6,7 @@ import asyncpg
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib.internal.trace_utils import ext_service
@@ -23,7 +24,6 @@ from ddtrace.internal.schema import schematize_database_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.propagation._database_monitoring import _DBM_Propagator
-from ddtrace.trace import Pin
 
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/ddtrace/contrib/internal/avro/patch.py
+++ b/ddtrace/contrib/internal/avro/patch.py
@@ -4,8 +4,8 @@ import avro
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.internal.utils.wrappers import unwrap
-from ddtrace.trace import Pin
 
 from .schema_iterator import SchemaExtractor
 

--- a/ddtrace/contrib/internal/azure_functions/patch.py
+++ b/ddtrace/contrib/internal/azure_functions/patch.py
@@ -5,11 +5,11 @@ import azure.functions as azure_functions
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.trace_utils import unwrap as _u
 from ddtrace.ext import SpanKind
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.formats import asbool
-from ddtrace.trace import Pin
 
 from .utils import create_context
 from .utils import message_list_has_single_context

--- a/ddtrace/contrib/internal/azure_servicebus/patch.py
+++ b/ddtrace/contrib/internal/azure_servicebus/patch.py
@@ -6,12 +6,12 @@ import azure.servicebus.aio as azure_servicebus_aio
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.trace_utils import unwrap as _u
 from ddtrace.internal import core
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import asbool
-from ddtrace.trace import Pin
 
 from .utils import create_context
 from .utils import handle_service_bus_message_arg

--- a/ddtrace/contrib/internal/boto/patch.py
+++ b/ddtrace/contrib/internal/boto/patch.py
@@ -7,6 +7,7 @@ import boto.connection
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace._trace.utils_botocore.span_tags import _derive_peer_hostname
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
@@ -21,7 +22,6 @@ from ddtrace.internal.serverless import in_aws_lambda
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.wrappers import unwrap
-from ddtrace.trace import Pin
 
 
 # Original boto client class

--- a/ddtrace/contrib/internal/botocore/patch.py
+++ b/ddtrace/contrib/internal/botocore/patch.py
@@ -16,6 +16,7 @@ import botocore.exceptions
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib.internal.trace_utils import ext_service
 from ddtrace.contrib.internal.trace_utils import unwrap
@@ -34,7 +35,6 @@ from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import deep_getattr
 from ddtrace.llmobs._integrations import BedrockIntegration
 from ddtrace.settings._config import Config
-from ddtrace.trace import Pin
 
 from .services.bedrock import patched_bedrock_api_call
 from .services.bedrock_agents import patched_bedrock_agents_api_call

--- a/ddtrace/contrib/internal/cassandra/session.py
+++ b/ddtrace/contrib/internal/cassandra/session.py
@@ -21,6 +21,7 @@ from cassandra.query import SimpleStatement
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_TYPE
@@ -37,7 +38,6 @@ from ddtrace.internal.schema import schematize_database_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import deep_getattr
-from ddtrace.trace import Pin
 from ddtrace.trace import Span
 
 

--- a/ddtrace/contrib/internal/celery/app.py
+++ b/ddtrace/contrib/internal/celery/app.py
@@ -5,6 +5,7 @@ from celery import signals
 
 from ddtrace import config
 from ddtrace._trace.pin import _DD_PIN_NAME
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
@@ -18,7 +19,6 @@ from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
-from ddtrace.trace import Pin
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/internal/celery/signals.py
+++ b/ddtrace/contrib/internal/celery/signals.py
@@ -4,6 +4,7 @@ from celery import current_app
 from celery import registry
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
@@ -22,7 +23,6 @@ from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
 from ddtrace.propagation.http import HTTPPropagator
-from ddtrace.trace import Pin
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/internal/consul/patch.py
+++ b/ddtrace/contrib/internal/consul/patch.py
@@ -4,6 +4,7 @@ import consul
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.ext import SpanKind
@@ -16,7 +17,6 @@ from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.wrappers import unwrap as _u
-from ddtrace.trace import Pin
 
 
 _KV_FUNCS = ["put", "get", "delete"]

--- a/ddtrace/contrib/internal/django/patch.py
+++ b/ddtrace/contrib/internal/django/patch.py
@@ -19,6 +19,7 @@ import wrapt
 from wrapt.importer import when_imported
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
 from ddtrace.contrib.internal.django.user import _DjangoUserInfoRetriever
@@ -44,7 +45,6 @@ from ddtrace.internal.utils.importlib import func_name
 from ddtrace.settings.asm import config as asm_config
 from ddtrace.settings.asm import endpoint_collection
 from ddtrace.settings.integration import IntegrationConfig
-from ddtrace.trace import Pin
 from ddtrace.vendor.packaging.version import parse as parse_version
 
 

--- a/ddtrace/contrib/internal/dogpile_cache/lock.py
+++ b/ddtrace/contrib/internal/dogpile_cache/lock.py
@@ -1,7 +1,7 @@
 import dogpile
 
+from ddtrace._trace.pin import Pin
 from ddtrace.internal.utils.formats import asbool
-from ddtrace.trace import Pin
 
 
 def _wrap_lock_ctor(func, instance, args, kwargs):

--- a/ddtrace/contrib/internal/dogpile_cache/patch.py
+++ b/ddtrace/contrib/internal/dogpile_cache/patch.py
@@ -11,8 +11,8 @@ from wrapt import wrap_function_wrapper as _w
 
 from ddtrace._trace.pin import _DD_PIN_NAME
 from ddtrace._trace.pin import _DD_PIN_PROXY_NAME
+from ddtrace._trace.pin import Pin
 from ddtrace.internal.schema import schematize_service_name
-from ddtrace.trace import Pin
 
 from .lock import _wrap_lock_ctor
 from .region import _wrap_get_create

--- a/ddtrace/contrib/internal/dogpile_cache/region.py
+++ b/ddtrace/contrib/internal/dogpile_cache/region.py
@@ -1,5 +1,6 @@
 import dogpile
 
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import db
@@ -7,7 +8,6 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_cache_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils import get_argument_value
-from ddtrace.trace import Pin
 
 
 def _wrap_get_create(func, instance, args, kwargs):

--- a/ddtrace/contrib/internal/elasticsearch/patch.py
+++ b/ddtrace/contrib/internal/elasticsearch/patch.py
@@ -8,6 +8,7 @@ from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
 from ddtrace._trace import _limits
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib.internal.elasticsearch.quantize import quantize
@@ -22,7 +23,6 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.wrappers import unwrap as _u
-from ddtrace.trace import Pin
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/internal/fastapi/patch.py
+++ b/ddtrace/contrib/internal/fastapi/patch.py
@@ -7,6 +7,7 @@ from wrapt import ObjectProxy
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.asgi.middleware import TraceMiddleware
 from ddtrace.contrib.internal.starlette.patch import _trace_background_tasks
 from ddtrace.contrib.internal.starlette.patch import traced_handler
@@ -17,7 +18,6 @@ from ddtrace.internal.telemetry import get_config as _get_config
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.settings.asm import config as asm_config
-from ddtrace.trace import Pin
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/internal/flask/patch.py
+++ b/ddtrace/contrib/internal/flask/patch.py
@@ -31,13 +31,13 @@ except ImportError:
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.trace_utils import unwrap as _u
 from ddtrace.contrib.internal.wsgi.wsgi import _DDWSGIMiddlewareBase
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.importlib import func_name
 from ddtrace.internal.utils.version import parse_version
-from ddtrace.trace import Pin
 
 from .wrappers import _wrap_call_with_pin_check
 from .wrappers import get_current_app

--- a/ddtrace/contrib/internal/flask/wrappers.py
+++ b/ddtrace/contrib/internal/flask/wrappers.py
@@ -2,12 +2,12 @@ import flask
 from wrapt import function_wrapper
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib import trace_utils
 from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.importlib import func_name
-from ddtrace.trace import Pin
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/internal/graphql/patch.py
+++ b/ddtrace/contrib/internal/graphql/patch.py
@@ -25,6 +25,7 @@ from graphql.execution import ExecutionResult
 from graphql.language.source import Source
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
@@ -41,7 +42,6 @@ from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.internal.wrapping import unwrap
 from ddtrace.internal.wrapping import wrap
-from ddtrace.trace import Pin
 
 
 _graphql_version_str = graphql.__version__

--- a/ddtrace/contrib/internal/grpc/aio_client_interceptor.py
+++ b/ddtrace/contrib/internal/grpc/aio_client_interceptor.py
@@ -12,6 +12,7 @@ from grpc.aio._typing import ResponseIterableType
 from grpc.aio._typing import ResponseType
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_TYPE
@@ -26,7 +27,6 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.propagation.http import HTTPPropagator
-from ddtrace.trace import Pin
 from ddtrace.trace import Span
 
 

--- a/ddtrace/contrib/internal/grpc/aio_server_interceptor.py
+++ b/ddtrace/contrib/internal/grpc/aio_server_interceptor.py
@@ -14,6 +14,7 @@ from grpc.aio._typing import ResponseType
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin  # noqa:F401
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_TYPE
@@ -26,7 +27,6 @@ from ddtrace.ext import SpanTypes
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
-from ddtrace.trace import Pin  # noqa:F401
 from ddtrace.trace import Span  # noqa:F401
 
 

--- a/ddtrace/contrib/internal/grpc/patch.py
+++ b/ddtrace/contrib/internal/grpc/patch.py
@@ -4,6 +4,7 @@ import grpc
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.grpc import constants
 from ddtrace.contrib.internal.grpc import utils
 from ddtrace.contrib.internal.grpc.client_interceptor import create_client_interceptor
@@ -14,7 +15,6 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils import set_argument_value
-from ddtrace.trace import Pin
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/internal/httplib/patch.py
+++ b/ddtrace/contrib/internal/httplib/patch.py
@@ -8,6 +8,7 @@ from urllib import parse
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
 from ddtrace.contrib.internal.trace_utils import unwrap as _u
@@ -21,7 +22,6 @@ from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.settings.asm import config as asm_config
-from ddtrace.trace import Pin
 
 
 span_name = "http.client.request"

--- a/ddtrace/contrib/internal/httpx/patch.py
+++ b/ddtrace/contrib/internal/httpx/patch.py
@@ -6,6 +6,7 @@ from wrapt import BoundFunctionWrapper
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib.internal.trace_utils import distributed_tracing_enabled
@@ -23,7 +24,6 @@ from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.propagation.http import HTTPPropagator
-from ddtrace.trace import Pin
 
 
 HTTPX_VERSION = parse_version(httpx.__version__)

--- a/ddtrace/contrib/internal/jinja2/patch.py
+++ b/ddtrace/contrib/internal/jinja2/patch.py
@@ -5,13 +5,13 @@ import jinja2
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.contrib.internal.trace_utils import unwrap as _u
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.utils import ArgumentError
 from ddtrace.internal.utils import get_argument_value
-from ddtrace.trace import Pin
 
 from .constants import DEFAULT_TEMPLATE_NAME
 

--- a/ddtrace/contrib/internal/kafka/patch.py
+++ b/ddtrace/contrib/internal/kafka/patch.py
@@ -7,6 +7,7 @@ from typing import Dict
 import confluent_kafka
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
@@ -27,7 +28,6 @@ from ddtrace.internal.utils import set_argument_value
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.propagation.http import HTTPPropagator as Propagator
-from ddtrace.trace import Pin
 
 
 _Producer = confluent_kafka.Producer

--- a/ddtrace/contrib/internal/kombu/patch.py
+++ b/ddtrace/contrib/internal/kombu/patch.py
@@ -6,6 +6,7 @@ import kombu
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 
@@ -23,7 +24,6 @@ from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.wrappers import unwrap
 from ddtrace.propagation.http import HTTPPropagator
-from ddtrace.trace import Pin
 
 from .constants import DEFAULT_SERVICE
 from .utils import HEADER_POS

--- a/ddtrace/contrib/internal/mako/patch.py
+++ b/ddtrace/contrib/internal/mako/patch.py
@@ -5,6 +5,7 @@ from mako.template import DefTemplate
 from mako.template import Template
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.contrib.internal.trace_utils import int_service
 from ddtrace.contrib.internal.trace_utils import unwrap as _u
@@ -13,7 +14,6 @@ from ddtrace.ext import SpanTypes
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.importlib import func_name
-from ddtrace.trace import Pin
 
 from .constants import DEFAULT_TEMPLATE_NAME
 

--- a/ddtrace/contrib/internal/mariadb/patch.py
+++ b/ddtrace/contrib/internal/mariadb/patch.py
@@ -5,13 +5,13 @@ import mariadb
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.dbapi import TracedConnection
 from ddtrace.ext import db
 from ddtrace.ext import net
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.wrappers import unwrap
-from ddtrace.trace import Pin
 
 
 config._add(

--- a/ddtrace/contrib/internal/molten/patch.py
+++ b/ddtrace/contrib/internal/molten/patch.py
@@ -7,6 +7,7 @@ import wrapt
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib import trace_utils
 from ddtrace.contrib.internal.trace_utils import unwrap as _u
 from ddtrace.ext import SpanTypes
@@ -17,7 +18,6 @@ from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.importlib import func_name
 from ddtrace.internal.utils.version import parse_version
-from ddtrace.trace import Pin
 
 from .wrappers import MOLTEN_ROUTE
 from .wrappers import WrapperComponent

--- a/ddtrace/contrib/internal/molten/wrappers.py
+++ b/ddtrace/contrib/internal/molten/wrappers.py
@@ -2,6 +2,7 @@ import molten
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
 from ddtrace.ext import SpanKind
@@ -9,7 +10,6 @@ from ddtrace.ext import http
 from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.utils.importlib import func_name
-from ddtrace.trace import Pin
 
 
 MOLTEN_ROUTE = "molten.route"

--- a/ddtrace/contrib/internal/mongoengine/trace.py
+++ b/ddtrace/contrib/internal/mongoengine/trace.py
@@ -2,7 +2,7 @@
 # project
 import wrapt
 
-import ddtrace
+from ddtrace._trace.pin import Pin
 
 # keep the TracedMongoClient import to avoid breaking the public api
 from ddtrace.contrib.internal.pymongo.client import TracedMongoClient  # noqa: F401
@@ -23,14 +23,14 @@ class WrappedConnect(wrapt.ObjectProxy):
 
     def __init__(self, connect):
         super(WrappedConnect, self).__init__(connect)
-        ddtrace.trace.Pin(_SERVICE).onto(self)
+        Pin(_SERVICE).onto(self)
 
     def __call__(self, *args, **kwargs):
         client = self.__wrapped__(*args, **kwargs)
-        pin = ddtrace.trace.Pin.get_from(self)
+        pin = Pin.get_from(self)
         if pin:
             tracer = pin.tracer
-            pp = ddtrace.trace.Pin(service=pin.service)
+            pp = Pin(service=pin.service)
             if tracer is not None:
                 pp._tracer = tracer
             pp.onto(client)

--- a/ddtrace/contrib/internal/mysql/patch.py
+++ b/ddtrace/contrib/internal/mysql/patch.py
@@ -5,6 +5,7 @@ import mysql.connector
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.dbapi import TracedConnection
 from ddtrace.contrib.internal.trace_utils import _convert_to_string
 from ddtrace.ext import db
@@ -14,7 +15,6 @@ from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.propagation._database_monitoring import _DBM_Propagator
 from ddtrace.settings.asm import config as asm_config
-from ddtrace.trace import Pin
 
 
 config._add(

--- a/ddtrace/contrib/internal/mysqldb/patch.py
+++ b/ddtrace/contrib/internal/mysqldb/patch.py
@@ -5,6 +5,7 @@ import MySQLdb
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib.dbapi import TracedConnection
@@ -21,7 +22,6 @@ from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.propagation._database_monitoring import _DBM_Propagator
 from ddtrace.settings.asm import config as asm_config
-from ddtrace.trace import Pin
 
 
 config._add(

--- a/ddtrace/contrib/internal/protobuf/patch.py
+++ b/ddtrace/contrib/internal/protobuf/patch.py
@@ -5,8 +5,8 @@ from google.protobuf.internal import builder
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.internal.utils.wrappers import unwrap
-from ddtrace.trace import Pin
 
 from .schema_iterator import SchemaExtractor
 

--- a/ddtrace/contrib/internal/psycopg/async_connection.py
+++ b/ddtrace/contrib/internal/psycopg/async_connection.py
@@ -1,4 +1,5 @@
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import dbapi_async
 from ddtrace.contrib.internal.psycopg.async_cursor import Psycopg3FetchTracedAsyncCursor
@@ -10,7 +11,6 @@ from ddtrace.ext import SpanTypes
 from ddtrace.ext import db
 from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
-from ddtrace.trace import Pin
 
 
 class Psycopg3TracedAsyncConnection(dbapi_async.TracedAsyncConnection):

--- a/ddtrace/contrib/internal/psycopg/connection.py
+++ b/ddtrace/contrib/internal/psycopg/connection.py
@@ -1,4 +1,5 @@
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import dbapi
 from ddtrace.contrib.internal.psycopg.cursor import Psycopg2FetchTracedCursor
@@ -14,7 +15,6 @@ from ddtrace.ext import net
 from ddtrace.ext import sql
 from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
-from ddtrace.trace import Pin
 
 
 class Psycopg3TracedConnection(dbapi.TracedConnection):

--- a/ddtrace/contrib/internal/psycopg/patch.py
+++ b/ddtrace/contrib/internal/psycopg/patch.py
@@ -7,6 +7,7 @@ from typing import List  # noqa:F401
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib import dbapi
 from ddtrace.contrib.internal.psycopg.async_connection import patched_connect_async_factory
 from ddtrace.contrib.internal.psycopg.async_cursor import Psycopg3FetchTracedAsyncCursor
@@ -23,7 +24,6 @@ from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.propagation._database_monitoring import _DBM_Propagator
 from ddtrace.propagation._database_monitoring import default_sql_injector as _default_sql_injector
-from ddtrace.trace import Pin
 
 
 # These will be initialized lazily to avoid circular imports

--- a/ddtrace/contrib/internal/pylibmc/client.py
+++ b/ddtrace/contrib/internal/pylibmc/client.py
@@ -6,8 +6,8 @@ import pylibmc
 from wrapt import ObjectProxy
 
 # project
-import ddtrace
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib.internal.pylibmc.addrs import parse_addresses
@@ -50,7 +50,7 @@ class TracedClient(ObjectProxy):
         super(TracedClient, self).__init__(client)
 
         schematized_service = schematize_service_name(service)
-        pin = ddtrace.trace.Pin(service=schematized_service)
+        pin = Pin(service=schematized_service)
         pin._tracer = tracer
         pin.onto(self)
 
@@ -64,7 +64,7 @@ class TracedClient(ObjectProxy):
         # rewrap new connections.
         cloned = self.__wrapped__.clone(*args, **kwargs)
         traced_client = TracedClient(cloned)
-        pin = ddtrace.trace.Pin.get_from(self)
+        pin = Pin.get_from(self)
         if pin:
             pin.clone().onto(traced_client)
         return traced_client
@@ -155,7 +155,7 @@ class TracedClient(ObjectProxy):
 
     def _span(self, cmd_name):
         """Return a span timing the given command."""
-        pin = ddtrace.trace.Pin.get_from(self)
+        pin = Pin.get_from(self)
         if not pin or not pin.enabled():
             return self._no_span()
 

--- a/ddtrace/contrib/internal/pymemcache/client.py
+++ b/ddtrace/contrib/internal/pymemcache/client.py
@@ -15,6 +15,7 @@ import wrapt
 
 # 3p
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 
 # project
 from ddtrace.constants import _SPAN_MEASURED_KEY
@@ -28,7 +29,6 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.schema import schematize_cache_operation
 from ddtrace.internal.utils.formats import asbool
-from ddtrace.trace import Pin
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/internal/pymemcache/patch.py
+++ b/ddtrace/contrib/internal/pymemcache/patch.py
@@ -5,9 +5,9 @@ import pymemcache.client.hash
 
 from ddtrace._trace.pin import _DD_PIN_NAME
 from ddtrace._trace.pin import _DD_PIN_PROXY_NAME
+from ddtrace._trace.pin import Pin
 from ddtrace.ext import memcached as memcachedx
 from ddtrace.internal.schema import schematize_service_name
-from ddtrace.trace import Pin
 
 from .client import WrappedClient
 from .client import WrappedHashClient

--- a/ddtrace/contrib/internal/pymongo/client.py
+++ b/ddtrace/contrib/internal/pymongo/client.py
@@ -11,8 +11,8 @@ from pymongo.message import _Query
 from wrapt import ObjectProxy
 
 # project
-import ddtrace
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
@@ -27,7 +27,6 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.schema import schematize_database_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils import get_argument_value
-from ddtrace.trace import Pin
 
 from .parse import parse_msg
 from .parse import parse_query
@@ -63,7 +62,7 @@ def _trace_mongo_client_init(func, args, kwargs):
         pin.onto(client._topology)
 
     def __getddpin__(client):
-        return ddtrace.trace.Pin.get_from(client._topology)
+        return Pin.get_from(client._topology)
 
     # Set a pin on the mongoclient pin on the topology object
     # This allows us to pass the same pin to the server objects
@@ -105,7 +104,7 @@ def _trace_topology_select_server(func, args, kwargs):
     # Ensure the pin used on the traced mongo client is passed down to the topology instance
     # This allows us to pass the same pin in traced server objects.
     topology_instance = get_argument_value(args, kwargs, 0, "self")
-    pin = ddtrace.trace.Pin.get_from(topology_instance)
+    pin = Pin.get_from(topology_instance)
 
     if pin is not None:
         pin.onto(server)
@@ -127,7 +126,7 @@ def _datadog_trace_operation(operation, wrapped):
             log.exception("error parsing query")
 
     # Gets the pin from the mogno client (through the topology object)
-    pin = ddtrace.trace.Pin.get_from(wrapped)
+    pin = Pin.get_from(wrapped)
     # if we couldn't parse or shouldn't trace the message, just go.
     if not cmd or not pin or not pin.enabled():
         return None
@@ -220,7 +219,7 @@ def _trace_socket_command(func, args, kwargs):
     except Exception:
         log.exception("error parsing spec. skipping trace")
 
-    pin = ddtrace.trace.Pin.get_from(socket_instance)
+    pin = Pin.get_from(socket_instance)
     # skip tracing if we don't have a piece of data we need
     if not dbname or not cmd or not pin or not pin.enabled():
         return func(*args, **kwargs)
@@ -241,7 +240,7 @@ def _trace_socket_write_command(func, args, kwargs):
     except Exception:
         log.exception("error parsing msg")
 
-    pin = ddtrace.trace.Pin.get_from(socket_instance)
+    pin = Pin.get_from(socket_instance)
     # if we couldn't parse it, don't try to trace it.
     if not cmd or not pin or not pin.enabled():
         return func(*args, **kwargs)
@@ -254,7 +253,7 @@ def _trace_socket_write_command(func, args, kwargs):
 
 
 def _trace_cmd(cmd, socket_instance, address):
-    pin = ddtrace.trace.Pin.get_from(socket_instance)
+    pin = Pin.get_from(socket_instance)
     s = pin.tracer.trace(
         schematize_database_operation("pymongo.cmd", database_provider="mongodb"),
         span_type=SpanTypes.MONGODB,

--- a/ddtrace/contrib/internal/pymongo/patch.py
+++ b/ddtrace/contrib/internal/pymongo/patch.py
@@ -4,6 +4,7 @@ from typing import Dict
 import pymongo
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
@@ -17,7 +18,6 @@ from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.wrapping import unwrap as _u
 from ddtrace.internal.wrapping import wrap as _w
 from ddtrace.propagation._database_monitoring import _DBM_Propagator
-from ddtrace.trace import Pin
 from ddtrace.vendor.sqlcommenter import _generate_comment_from_metadata as _generate_comment_from_metadata
 
 from ....internal.schema import schematize_service_name

--- a/ddtrace/contrib/internal/pymysql/patch.py
+++ b/ddtrace/contrib/internal/pymysql/patch.py
@@ -5,6 +5,7 @@ import pymysql
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.dbapi import TracedConnection
 from ddtrace.contrib.internal.trace_utils import _convert_to_string
 from ddtrace.ext import db
@@ -13,7 +14,6 @@ from ddtrace.internal.schema import schematize_database_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.propagation._database_monitoring import _DBM_Propagator
-from ddtrace.trace import Pin
 
 
 config._add(

--- a/ddtrace/contrib/internal/pynamodb/patch.py
+++ b/ddtrace/contrib/internal/pynamodb/patch.py
@@ -8,6 +8,7 @@ import pynamodb.connection.base
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
@@ -21,7 +22,6 @@ from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils import ArgumentError
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import deep_getattr
-from ddtrace.trace import Pin
 
 
 # Pynamodb connection class

--- a/ddtrace/contrib/internal/pyodbc/patch.py
+++ b/ddtrace/contrib/internal/pyodbc/patch.py
@@ -4,6 +4,7 @@ from typing import Dict
 import pyodbc
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.dbapi import TracedConnection
 from ddtrace.contrib.dbapi import TracedCursor
 from ddtrace.contrib.internal.trace_utils import unwrap
@@ -11,7 +12,6 @@ from ddtrace.contrib.internal.trace_utils import wrap
 from ddtrace.ext import db
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.formats import asbool
-from ddtrace.trace import Pin
 
 
 config._add(

--- a/ddtrace/contrib/internal/redis/asyncio_patch.py
+++ b/ddtrace/contrib/internal/redis/asyncio_patch.py
@@ -1,10 +1,10 @@
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace._trace.utils_redis import _instrument_redis_cmd
 from ddtrace._trace.utils_redis import _instrument_redis_execute_async_cluster_pipeline
 from ddtrace._trace.utils_redis import _instrument_redis_execute_pipeline
 from ddtrace.contrib.internal.redis_utils import _run_redis_command_async
 from ddtrace.internal.utils.formats import stringify_cache_args
-from ddtrace.trace import Pin
 
 
 async def instrumented_async_execute_command(func, instance, args, kwargs):

--- a/ddtrace/contrib/internal/redis/patch.py
+++ b/ddtrace/contrib/internal/redis/patch.py
@@ -5,6 +5,7 @@ import redis
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace._trace.utils_redis import _instrument_redis_cmd
 from ddtrace._trace.utils_redis import _instrument_redis_execute_pipeline
 from ddtrace.contrib.internal.redis_utils import ROW_RETURNING_COMMANDS
@@ -15,7 +16,6 @@ from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.formats import CMD_MAX_LEN
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import stringify_cache_args
-from ddtrace.trace import Pin
 
 
 config._add(

--- a/ddtrace/contrib/internal/rediscluster/patch.py
+++ b/ddtrace/contrib/internal/rediscluster/patch.py
@@ -7,6 +7,7 @@ import wrapt
 
 # project
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
@@ -23,7 +24,6 @@ from ddtrace.internal.utils.formats import CMD_MAX_LEN
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import stringify_cache_args
 from ddtrace.internal.utils.wrappers import unwrap
-from ddtrace.trace import Pin
 
 
 # DEV: In `2.0.0` `__version__` is a string and `VERSION` is a tuple,

--- a/ddtrace/contrib/internal/requests/connection.py
+++ b/ddtrace/contrib/internal/requests/connection.py
@@ -3,6 +3,7 @@ from urllib import parse
 
 import ddtrace
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
@@ -16,7 +17,6 @@ from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.settings.asm import config as asm_config
-from ddtrace.trace import Pin
 
 
 log = get_logger(__name__)
@@ -75,7 +75,7 @@ def _wrap_send(func, instance, args, kwargs):
     hostname, path = _extract_hostname_and_path(url)
     host_without_port = hostname.split(":")[0] if hostname is not None else None
 
-    cfg = ddtrace.trace.Pin._get_config(instance)
+    cfg = Pin._get_config(instance)
     service = None
     if cfg["split_by_domain"] and hostname:
         service = hostname

--- a/ddtrace/contrib/internal/requests/patch.py
+++ b/ddtrace/contrib/internal/requests/patch.py
@@ -5,11 +5,11 @@ import requests
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.trace_utils import unwrap as _u
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.settings.asm import config as asm_config
-from ddtrace.trace import Pin
 
 from .connection import _wrap_send
 from .session import TracedSession

--- a/ddtrace/contrib/internal/rq/patch.py
+++ b/ddtrace/contrib/internal/rq/patch.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import SPAN_KIND
 from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
@@ -9,7 +10,6 @@ from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import asbool
-from ddtrace.trace import Pin
 
 from ....ext import SpanKind
 from ....ext import SpanTypes

--- a/ddtrace/contrib/internal/sanic/patch.py
+++ b/ddtrace/contrib/internal/sanic/patch.py
@@ -6,6 +6,7 @@ import wrapt
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib import trace_utils
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
@@ -14,7 +15,6 @@ from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.utils.wrappers import unwrap as _u
-from ddtrace.trace import Pin
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/internal/snowflake/patch.py
+++ b/ddtrace/contrib/internal/snowflake/patch.py
@@ -4,6 +4,7 @@ from typing import Dict
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.dbapi import TracedConnection
 from ddtrace.contrib.dbapi import TracedCursor
 from ddtrace.contrib.internal.trace_utils import unwrap
@@ -11,7 +12,6 @@ from ddtrace.ext import db
 from ddtrace.ext import net
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.formats import asbool
-from ddtrace.trace import Pin
 
 
 config._add(

--- a/ddtrace/contrib/internal/sqlalchemy/engine.py
+++ b/ddtrace/contrib/internal/sqlalchemy/engine.py
@@ -18,6 +18,7 @@ from sqlalchemy.event import listen
 # project
 import ddtrace
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.ext import SpanKind
@@ -28,7 +29,6 @@ from ddtrace.ext import sql as sqlx
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_database_operation
 from ddtrace.internal.schema import schematize_service_name
-from ddtrace.trace import Pin
 
 
 def trace_engine(engine, tracer=None, service=None):

--- a/ddtrace/contrib/internal/sqlite3/patch.py
+++ b/ddtrace/contrib/internal/sqlite3/patch.py
@@ -6,6 +6,7 @@ from typing import Dict
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.dbapi import FetchTracedCursor
 from ddtrace.contrib.dbapi import TracedConnection
 from ddtrace.contrib.dbapi import TracedCursor
@@ -14,7 +15,6 @@ from ddtrace.internal.schema import schematize_database_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.settings.asm import config as asm_config
-from ddtrace.trace import Pin
 
 
 # Original connect method

--- a/ddtrace/contrib/internal/starlette/patch.py
+++ b/ddtrace/contrib/internal/starlette/patch.py
@@ -13,6 +13,7 @@ from wrapt import ObjectProxy
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib import trace_utils
 from ddtrace.contrib.asgi import TraceMiddleware
 from ddtrace.contrib.internal.trace_utils import with_traced_module
@@ -28,7 +29,6 @@ from ddtrace.internal.utils import set_argument_value
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.settings.asm import config as asm_config
-from ddtrace.trace import Pin
 from ddtrace.trace import Span  # noqa:F401
 from ddtrace.vendor.packaging.version import parse as parse_version
 

--- a/ddtrace/contrib/internal/tornado/application.py
+++ b/ddtrace/contrib/internal/tornado/application.py
@@ -4,6 +4,7 @@ from tornado import template
 
 import ddtrace
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.tornado import decorators
 from ddtrace.contrib.internal.tornado.constants import CONFIG_KEY
 from ddtrace.contrib.internal.tornado.stack_context import context_provider
@@ -59,6 +60,6 @@ def tracer_config(__init__, app, args, kwargs):
     if tags:
         tracer.set_tags(tags)
 
-    pin = ddtrace.trace.Pin(service=service)
+    pin = Pin(service=service)
     pin._tracer = tracer
     pin.onto(template)

--- a/ddtrace/contrib/internal/tornado/template.py
+++ b/ddtrace/contrib/internal/tornado/template.py
@@ -1,9 +1,9 @@
 from tornado import template
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.constants import COMPONENT
-from ddtrace.trace import Pin
 
 
 def generate(func, renderer, args, kwargs):

--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -21,6 +21,7 @@ from urllib import parse
 
 import wrapt
 
+from ddtrace._trace.pin import Pin
 from ddtrace._trace.span import Span
 from ddtrace.constants import _ORIGIN_KEY
 from ddtrace.contrib.internal.trace_utils_base import USER_AGENT_PATTERNS  # noqa:F401
@@ -41,7 +42,6 @@ import ddtrace.internal.utils.wrappers
 from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.settings._config import config
 from ddtrace.settings.asm import config as asm_config
-from ddtrace.trace import Pin
 
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/ddtrace/contrib/internal/trace_utils_async.py
+++ b/ddtrace/contrib/internal/trace_utils_async.py
@@ -3,8 +3,8 @@ async tracing utils
 
 Note that this module should only be imported in Python 3.5+.
 """
+from ddtrace._trace.pin import Pin
 from ddtrace.internal.logger import get_logger
-from ddtrace.trace import Pin
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/internal/urllib3/patch.py
+++ b/ddtrace/contrib/internal/urllib3/patch.py
@@ -6,6 +6,7 @@ import urllib3
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
 from ddtrace.ext import SpanKind
@@ -21,7 +22,6 @@ from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.wrappers import unwrap as _u
 from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.settings.asm import config as asm_config
-from ddtrace.trace import Pin
 
 
 # Ports which, if set, will not be used in hostnames/service names

--- a/ddtrace/contrib/internal/valkey/asyncio_patch.py
+++ b/ddtrace/contrib/internal/valkey/asyncio_patch.py
@@ -1,10 +1,10 @@
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace._trace.utils_valkey import _instrument_valkey_cmd
 from ddtrace._trace.utils_valkey import _instrument_valkey_execute_async_cluster_pipeline
 from ddtrace._trace.utils_valkey import _instrument_valkey_execute_pipeline
 from ddtrace.contrib.internal.valkey_utils import _run_valkey_command_async
 from ddtrace.internal.utils.formats import stringify_cache_args
-from ddtrace.trace import Pin
 
 
 async def instrumented_async_execute_command(func, instance, args, kwargs):

--- a/ddtrace/contrib/internal/valkey/patch.py
+++ b/ddtrace/contrib/internal/valkey/patch.py
@@ -73,6 +73,7 @@ import valkey
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace._trace.utils_valkey import _instrument_valkey_cmd
 from ddtrace._trace.utils_valkey import _instrument_valkey_execute_pipeline
 from ddtrace.contrib.internal.valkey_utils import ROW_RETURNING_COMMANDS
@@ -83,7 +84,6 @@ from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils.formats import CMD_MAX_LEN
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import stringify_cache_args
-from ddtrace.trace import Pin
 
 
 config._add(

--- a/ddtrace/contrib/internal/vertica/patch.py
+++ b/ddtrace/contrib/internal/vertica/patch.py
@@ -4,6 +4,7 @@ from typing import Dict
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
@@ -17,7 +18,6 @@ from ddtrace.internal.schema import schematize_database_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.wrappers import unwrap
-from ddtrace.trace import Pin
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/internal/wsgi/wsgi.py
+++ b/ddtrace/contrib/internal/wsgi/wsgi.py
@@ -11,8 +11,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Mapping  # noqa:F401
     from typing import Optional  # noqa:F401
 
+    from ddtrace._trace.pin import Pin  # noqa:F401
     from ddtrace.settings._config import Config  # noqa:F401
-    from ddtrace.trace import Pin  # noqa:F401
     from ddtrace.trace import Span  # noqa:F401
     from ddtrace.trace import Tracer  # noqa:F401
 

--- a/ddtrace/contrib/internal/yaaredis/patch.py
+++ b/ddtrace/contrib/internal/yaaredis/patch.py
@@ -5,6 +5,7 @@ import wrapt
 import yaaredis
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace._trace.utils_redis import _instrument_redis_cmd
 from ddtrace._trace.utils_redis import _instrument_redis_execute_pipeline
 from ddtrace.contrib.internal.redis_utils import _run_redis_command_async
@@ -14,7 +15,6 @@ from ddtrace.internal.utils.formats import CMD_MAX_LEN
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import stringify_cache_args
 from ddtrace.internal.utils.wrappers import unwrap
-from ddtrace.trace import Pin
 from ddtrace.vendor.debtcollector import deprecate
 
 

--- a/templates/integration/__init__.py
+++ b/templates/integration/__init__.py
@@ -27,18 +27,6 @@ Global Configuration
 
    Default: ``"foo"``
 
-
-Instance Configuration
-~~~~~~~~~~~~~~~~~~~~~~
-
-To configure the foo integration on an per-instance basis use the
-``Pin`` API::
-
-    import foo
-    from ddtrace.trace import Pin
-
-    myfoo = foo.Foo()
-    Pin.override(myfoo, service="myfoo")
 """
 
 from .patch import get_version

--- a/tests/commands/ddtrace_run_integration.py
+++ b/tests/commands/ddtrace_run_integration.py
@@ -5,7 +5,7 @@ that we expect to be implicitly traced via `ddtrace-run`
 
 import redis
 
-from ddtrace.trace import Pin
+from ddtrace._trace.pin import Pin
 from tests.contrib.config import REDIS_CONFIG
 from tests.utils import DummyTracer
 from tests.utils import DummyWriter

--- a/tests/contrib/aiobotocore/utils.py
+++ b/tests/contrib/aiobotocore/utils.py
@@ -3,7 +3,7 @@ from async_generator import async_generator
 from async_generator import asynccontextmanager
 from async_generator import yield_
 
-from ddtrace.trace import Pin
+from ddtrace._trace.pin import Pin
 from tests.contrib.config import MOTO_CONFIG
 
 

--- a/tests/contrib/aiohttp/test_aiohttp_client.py
+++ b/tests/contrib/aiohttp/test_aiohttp_client.py
@@ -3,10 +3,10 @@ import os
 import aiohttp
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.aiohttp.patch import extract_netloc_and_query_info_from_url
 from ddtrace.contrib.internal.aiohttp.patch import patch
 from ddtrace.contrib.internal.aiohttp.patch import unpatch
-from ddtrace.trace import Pin
 from tests.utils import override_config
 from tests.utils import override_http_config
 

--- a/tests/contrib/aiohttp_jinja2/conftest.py
+++ b/tests/contrib/aiohttp_jinja2/conftest.py
@@ -1,9 +1,9 @@
 import aiohttp_jinja2
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.aiohttp_jinja2.patch import patch
 from ddtrace.contrib.internal.aiohttp_jinja2.patch import unpatch
-from ddtrace.trace import Pin
 from tests.contrib.aiohttp.conftest import app_tracer  # noqa:F401
 from tests.contrib.aiohttp.conftest import patched_app_tracer  # noqa:F401
 from tests.contrib.aiohttp.conftest import untraced_app_tracer  # noqa:F401

--- a/tests/contrib/aiohttp_jinja2/test_aiohttp_jinja2.py
+++ b/tests/contrib/aiohttp_jinja2/test_aiohttp_jinja2.py
@@ -1,8 +1,8 @@
 import aiohttp_jinja2
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import ERROR_MSG
-from ddtrace.trace import Pin
 from ddtrace.trace import tracer
 from tests.contrib.aiohttp.app.web import set_filesystem_loader
 from tests.contrib.aiohttp.app.web import set_package_loader

--- a/tests/contrib/aiomysql/test_aiomysql.py
+++ b/tests/contrib/aiomysql/test_aiomysql.py
@@ -5,10 +5,10 @@ import mock
 import pymysql
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.aiomysql.patch import patch
 from ddtrace.contrib.internal.aiomysql.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.contrib import shared_tests_async as shared_tests
 from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.asyncio.utils import mark_asyncio

--- a/tests/contrib/aiopg/test.py
+++ b/tests/contrib/aiopg/test.py
@@ -4,12 +4,11 @@ import aiopg
 from psycopg2 import extras
 import pytest
 
+# project
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.aiopg.patch import patch
 from ddtrace.contrib.internal.aiopg.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-
-# project
-from ddtrace.trace import Pin
 from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.config import POSTGRES_CONFIG
 from tests.opentracer.utils import init_tracer

--- a/tests/contrib/algoliasearch/test.py
+++ b/tests/contrib/algoliasearch/test.py
@@ -1,9 +1,9 @@
 from ddtrace import config
 from ddtrace._monkey import _patch_all
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.algoliasearch.patch import algoliasearch_version
 from ddtrace.contrib.internal.algoliasearch.patch import patch
 from ddtrace.contrib.internal.algoliasearch.patch import unpatch
-from ddtrace.trace import Pin
 from ddtrace.vendor.packaging.version import parse as parse_version
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured

--- a/tests/contrib/aredis/test_aredis.py
+++ b/tests/contrib/aredis/test_aredis.py
@@ -5,9 +5,9 @@ import aredis
 import pytest
 from wrapt import ObjectProxy
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.aredis.patch import patch
 from ddtrace.contrib.internal.aredis.patch import unpatch
-from ddtrace.trace import Pin
 from tests.conftest import DEFAULT_DDTRACE_SUBPROCESS_TEST_SERVICE_NAME
 from tests.opentracer.utils import init_tracer
 from tests.utils import override_config

--- a/tests/contrib/asyncpg/test_asyncpg.py
+++ b/tests/contrib/asyncpg/test_asyncpg.py
@@ -5,10 +5,10 @@ import asyncpg
 import mock
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.asyncpg.patch import patch
 from ddtrace.contrib.internal.asyncpg.patch import unpatch
 from ddtrace.contrib.internal.trace_utils import iswrapped
-from ddtrace.trace import Pin
 from ddtrace.trace import tracer
 from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.asyncio.utils import mark_asyncio

--- a/tests/contrib/avro/test_avro.py
+++ b/tests/contrib/avro/test_avro.py
@@ -4,11 +4,11 @@ from avro.io import DatumReader
 from avro.io import DatumWriter
 from wrapt import ObjectProxy
 
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import AUTO_KEEP
 from ddtrace.contrib.internal.avro.patch import patch
 from ddtrace.contrib.internal.avro.patch import unpatch
 from ddtrace.ext import schema as SCHEMA_TAGS
-from ddtrace.trace import Pin
 
 
 OPENAPI_USER_SCHEMA_DEF = (

--- a/tests/contrib/boto/test.py
+++ b/tests/contrib/boto/test.py
@@ -14,13 +14,12 @@ from moto import mock_lambda
 from moto import mock_s3
 from moto import mock_sts
 
+# project
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.boto.patch import patch
 from ddtrace.contrib.internal.boto.patch import unpatch
 from ddtrace.ext import http
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-
-# project
-from ddtrace.trace import Pin
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured

--- a/tests/contrib/botocore/conftest.py
+++ b/tests/contrib/botocore/conftest.py
@@ -3,12 +3,12 @@ import os
 import botocore
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.botocore.patch import patch
 from ddtrace.contrib.internal.botocore.patch import unpatch
 from ddtrace.contrib.internal.urllib3.patch import patch as urllib3_patch
 from ddtrace.contrib.internal.urllib3.patch import unpatch as urllib3_unpatch
 from ddtrace.llmobs import LLMObs as llmobs_service
-from ddtrace.trace import Pin
 from tests.contrib.botocore.bedrock_utils import get_request_vcr
 from tests.llmobs._utils import TestLLMObsSpanWriter
 from tests.utils import DummyTracer

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -34,6 +34,7 @@ except ImportError:
     from moto import mock_kinesis as mock_firehose
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
@@ -46,7 +47,6 @@ from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
-from ddtrace.trace import Pin
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured

--- a/tests/contrib/botocore/test_stepfunctions.py
+++ b/tests/contrib/botocore/test_stepfunctions.py
@@ -1,9 +1,9 @@
 import json
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.botocore.services.stepfunctions import update_stepfunction_input
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
-from ddtrace.trace import Pin
 
 
 def test_update_stepfunction_input():

--- a/tests/contrib/cassandra/test.py
+++ b/tests/contrib/cassandra/test.py
@@ -10,6 +10,7 @@ from cassandra.query import SimpleStatement
 import mock
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.internal.cassandra.patch import patch
@@ -18,7 +19,6 @@ from ddtrace.contrib.internal.cassandra.session import SERVICE
 from ddtrace.ext import cassandra as cassx
 from ddtrace.ext import net
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.contrib.config import CASSANDRA_CONFIG
 from tests.opentracer.utils import init_tracer
 from tests.utils import DummyTracer

--- a/tests/contrib/celery/autopatch.py
+++ b/tests/contrib/celery/autopatch.py
@@ -1,4 +1,4 @@
-from ddtrace.trace import Pin
+from ddtrace._trace.pin import Pin
 
 
 if __name__ == "__main__":

--- a/tests/contrib/celery/base.py
+++ b/tests/contrib/celery/base.py
@@ -3,9 +3,9 @@ from functools import wraps
 import celery
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.celery.patch import patch
 from ddtrace.contrib.internal.celery.patch import unpatch
-from ddtrace.trace import Pin
 from tests.utils import TracerTestCase
 
 from ..config import RABBITMQ_CONFIG

--- a/tests/contrib/celery/test_app.py
+++ b/tests/contrib/celery/test_app.py
@@ -1,7 +1,7 @@
 import celery
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.celery.patch import unpatch_app
-from ddtrace.trace import Pin
 
 from .base import CeleryBaseTestCase
 

--- a/tests/contrib/celery/test_integration.py
+++ b/tests/contrib/celery/test_integration.py
@@ -8,13 +8,13 @@ from celery.exceptions import Retry
 import mock
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import ERROR_MSG
 from ddtrace.contrib.internal.celery.patch import patch
 from ddtrace.contrib.internal.celery.patch import unpatch
 import ddtrace.internal.forksafe as forksafe
 from ddtrace.propagation.http import HTTPPropagator
 from ddtrace.trace import Context
-from ddtrace.trace import Pin
 from tests.opentracer.utils import init_tracer
 
 from ...utils import override_global_config

--- a/tests/contrib/celery/test_patch.py
+++ b/tests/contrib/celery/test_patch.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ddtrace.trace import Pin
+from ddtrace._trace.pin import Pin
 from tests.contrib.patch import emit_integration_and_version_to_test_agent
 
 

--- a/tests/contrib/celery/test_tagging.py
+++ b/tests/contrib/celery/test_tagging.py
@@ -5,9 +5,9 @@ from celery import Celery
 from celery.contrib.testing.worker import start_worker
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.celery.patch import patch
 from ddtrace.contrib.internal.celery.patch import unpatch
-from ddtrace.trace import Pin
 from tests.utils import DummyTracer
 
 from .base import AMQP_BROKER_URL

--- a/tests/contrib/consul/test.py
+++ b/tests/contrib/consul/test.py
@@ -3,11 +3,11 @@ import os
 import consul
 from wrapt import BoundFunctionWrapper
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.consul.patch import patch
 from ddtrace.contrib.internal.consul.patch import unpatch
 from ddtrace.ext import consul as consulx
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 

--- a/tests/contrib/dbapi/test_dbapi.py
+++ b/tests/contrib/dbapi/test_dbapi.py
@@ -1,13 +1,13 @@
 import mock
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.dbapi import FetchTracedCursor
 from ddtrace.contrib.dbapi import TracedConnection
 from ddtrace.contrib.dbapi import TracedCursor
 from ddtrace.propagation._database_monitoring import _DBM_Propagator
 from ddtrace.settings._config import Config
 from ddtrace.settings.integration import IntegrationConfig
-from ddtrace.trace import Pin
 from ddtrace.trace import Span  # noqa:F401
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured

--- a/tests/contrib/dbapi_async/test_dbapi_async.py
+++ b/tests/contrib/dbapi_async/test_dbapi_async.py
@@ -1,13 +1,13 @@
 import mock
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.dbapi_async import FetchTracedAsyncCursor
 from ddtrace.contrib.dbapi_async import TracedAsyncConnection
 from ddtrace.contrib.dbapi_async import TracedAsyncCursor
 from ddtrace.propagation._database_monitoring import _DBM_Propagator
 from ddtrace.settings._config import Config
 from ddtrace.settings.integration import IntegrationConfig
-from ddtrace.trace import Pin
 from ddtrace.trace import Span  # noqa:F401
 from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.asyncio.utils import mark_asyncio

--- a/tests/contrib/django/conftest.py
+++ b/tests/contrib/django/conftest.py
@@ -4,8 +4,8 @@ import django
 from django.conf import settings
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.django.patch import patch
-from ddtrace.trace import Pin
 from tests.utils import DummyTracer
 from tests.utils import TracerSpanContainer
 from tests.utils import override_config

--- a/tests/contrib/django/test_django_dbm.py
+++ b/tests/contrib/django/test_django_dbm.py
@@ -1,7 +1,7 @@
 from django.db import connections
 import mock
 
-from ddtrace.trace import Pin
+from ddtrace._trace.pin import Pin
 from tests.contrib import shared_tests
 from tests.utils import DummyTracer
 from tests.utils import override_config

--- a/tests/contrib/dogpile_cache/test_tracing.py
+++ b/tests/contrib/dogpile_cache/test_tracing.py
@@ -3,9 +3,9 @@ import os
 import dogpile
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.dogpile_cache.patch import patch
 from ddtrace.contrib.internal.dogpile_cache.patch import unpatch
-from ddtrace.trace import Pin
 from tests.conftest import DEFAULT_DDTRACE_SUBPROCESS_TEST_SERVICE_NAME
 from tests.utils import DummyTracer
 from tests.utils import TracerSpanContainer

--- a/tests/contrib/dramatiq/test_integration.py
+++ b/tests/contrib/dramatiq/test_integration.py
@@ -3,9 +3,9 @@ import unittest
 import dramatiq
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.dramatiq.patch import patch
 from ddtrace.contrib.internal.dramatiq.patch import unpatch
-from ddtrace.trace import Pin
 from tests.utils import DummyTracer
 from tests.utils import snapshot
 

--- a/tests/contrib/elasticsearch/test_elasticsearch.py
+++ b/tests/contrib/elasticsearch/test_elasticsearch.py
@@ -7,13 +7,13 @@ import time
 import pytest
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.elasticsearch.patch import get_version
 from ddtrace.contrib.internal.elasticsearch.patch import get_versions
 from ddtrace.contrib.internal.elasticsearch.patch import patch
 from ddtrace.contrib.internal.elasticsearch.patch import unpatch
 from ddtrace.ext import http
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.contrib.patch import emit_integration_and_version_to_test_agent
 from tests.utils import TracerTestCase
 

--- a/tests/contrib/flask/__init__.py
+++ b/tests/contrib/flask/__init__.py
@@ -2,9 +2,9 @@ import flask
 from flask.testing import FlaskClient
 import wrapt
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.flask.patch import patch
 from ddtrace.contrib.internal.flask.patch import unpatch
-from ddtrace.trace import Pin
 from tests.utils import TracerTestCase
 
 

--- a/tests/contrib/flask/test_blueprint.py
+++ b/tests/contrib/flask/test_blueprint.py
@@ -1,7 +1,7 @@
 import flask
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.flask.patch import unpatch
-from ddtrace.trace import Pin
 
 from . import BaseFlaskTestCase
 

--- a/tests/contrib/flask/test_flask_helpers.py
+++ b/tests/contrib/flask/test_flask_helpers.py
@@ -3,9 +3,9 @@ from io import StringIO
 
 import flask
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.flask.patch import flask_version
 from ddtrace.contrib.internal.flask.patch import unpatch
-from ddtrace.trace import Pin
 
 from . import BaseFlaskTestCase
 

--- a/tests/contrib/flask/test_signals.py
+++ b/tests/contrib/flask/test_signals.py
@@ -1,9 +1,9 @@
 import flask
 import mock
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.flask.patch import flask_version
 from ddtrace.contrib.internal.flask.patch import unpatch
-from ddtrace.trace import Pin
 
 from . import BaseFlaskTestCase
 

--- a/tests/contrib/flask/test_template.py
+++ b/tests/contrib/flask/test_template.py
@@ -1,8 +1,8 @@
 import flask
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.flask.patch import flask_version
 from ddtrace.contrib.internal.flask.patch import unpatch
-from ddtrace.trace import Pin
 
 from . import BaseFlaskTestCase
 

--- a/tests/contrib/flask_autopatch/test_flask_autopatch.py
+++ b/tests/contrib/flask_autopatch/test_flask_autopatch.py
@@ -2,9 +2,9 @@
 import flask
 import wrapt
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.flask.patch import flask_version
 from ddtrace.ext import http
-from ddtrace.trace import Pin
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 from tests.utils import assert_span_http_status_code

--- a/tests/contrib/grpc_aio/test_grpc_aio.py
+++ b/tests/contrib/grpc_aio/test_grpc_aio.py
@@ -7,6 +7,7 @@ import grpc
 from grpc import aio
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
@@ -15,7 +16,6 @@ from ddtrace.contrib.internal.grpc.patch import GRPC_AIO_PIN_MODULE_SERVER
 from ddtrace.contrib.internal.grpc.patch import patch
 from ddtrace.contrib.internal.grpc.patch import unpatch
 from ddtrace.contrib.internal.grpc.utils import _parse_rpc_repr_string
-from ddtrace.trace import Pin
 import ddtrace.vendor.packaging.version as packaging_version
 from tests.contrib.grpc.hello_pb2 import HelloReply
 from tests.contrib.grpc.hello_pb2 import HelloRequest

--- a/tests/contrib/httplib/test_httplib.py
+++ b/tests/contrib/httplib/test_httplib.py
@@ -11,13 +11,13 @@ import pytest
 import wrapt
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.httplib.patch import patch
 from ddtrace.contrib.internal.httplib.patch import should_skip_request
 from ddtrace.contrib.internal.httplib.patch import unpatch
 from ddtrace.ext import http
 from ddtrace.internal.constants import _HTTPLIB_NO_TRACE_REQUEST
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
 from tests.utils import assert_span_http_status_code

--- a/tests/contrib/httplib/test_httplib_distributed.py
+++ b/tests/contrib/httplib/test_httplib_distributed.py
@@ -4,9 +4,10 @@ import http.client as httplib
 
 import wrapt
 
+from ddtrace._trace.pin import Pin
+
 # Project
 from ddtrace._trace.span import _get_64_highest_order_bits_as_hex
-from ddtrace.trace import Pin
 from tests.utils import TracerTestCase
 
 from .test_httplib import SOCKET

--- a/tests/contrib/httpx/test_httpx.py
+++ b/tests/contrib/httpx/test_httpx.py
@@ -3,11 +3,11 @@ import pytest
 from wrapt import ObjectProxy
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.httpx.patch import HTTPX_VERSION
 from ddtrace.contrib.internal.httpx.patch import patch
 from ddtrace.contrib.internal.httpx.patch import unpatch
 from ddtrace.settings.http import HttpConfig
-from ddtrace.trace import Pin
 from tests.utils import override_config
 from tests.utils import override_http_config
 

--- a/tests/contrib/httpx/test_httpx_pre_0_11.py
+++ b/tests/contrib/httpx/test_httpx_pre_0_11.py
@@ -3,11 +3,11 @@ import pytest
 from wrapt import ObjectProxy
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.httpx.patch import HTTPX_VERSION
 from ddtrace.contrib.internal.httpx.patch import patch
 from ddtrace.contrib.internal.httpx.patch import unpatch
 from ddtrace.settings.http import HttpConfig
-from ddtrace.trace import Pin
 from tests.utils import override_config
 from tests.utils import override_http_config
 

--- a/tests/contrib/jinja2/test_jinja2.py
+++ b/tests/contrib/jinja2/test_jinja2.py
@@ -4,9 +4,9 @@ import os.path
 # 3rd party
 import jinja2
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.jinja2.patch import patch
 from ddtrace.contrib.internal.jinja2.patch import unpatch
-from ddtrace.trace import Pin
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 from tests.utils import assert_is_not_measured

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -12,6 +12,7 @@ import mock
 import pytest
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.kafka.patch import TracedConsumer
 from ddtrace.contrib.internal.kafka.patch import TracedProducer
 from ddtrace.contrib.internal.kafka.patch import patch
@@ -22,7 +23,6 @@ from ddtrace.internal.datastreams.processor import ConsumerPartitionKey
 from ddtrace.internal.datastreams.processor import DataStreamsCtx
 from ddtrace.internal.datastreams.processor import PartitionKey
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
-from ddtrace.trace import Pin
 from ddtrace.trace import TraceFilter
 from ddtrace.trace import tracer as ddtracer
 from tests.contrib.config import KAFKA_CONFIG
@@ -570,8 +570,8 @@ def _generate_in_subprocess(random_topic):
             "auto.offset.reset": "earliest",
         }
     )
-    ddtrace.trace.Pin._override(producer, tracer=ddtrace.tracer)
-    ddtrace.trace.Pin._override(consumer, tracer=ddtrace.tracer)
+    Pin._override(producer, tracer=ddtrace.tracer)
+    Pin._override(consumer, tracer=ddtrace.tracer)
 
     # We run all of these commands with retry attempts because the kafka-confluent API
     # sys.exits on connection failures, which causes the test to fail. We want to retry
@@ -851,7 +851,7 @@ import pytest
 import random
 import sys
 
-from ddtrace.trace import Pin
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.kafka.patch import patch
 
 from tests.contrib.kafka.test_kafka import consumer
@@ -1091,7 +1091,7 @@ import pytest
 import random
 import sys
 
-from ddtrace.trace import Pin
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.kafka.patch import patch
 from ddtrace import config
 

--- a/tests/contrib/kombu/test.py
+++ b/tests/contrib/kombu/test.py
@@ -2,13 +2,13 @@
 import kombu
 import mock
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.kombu import utils
 from ddtrace.contrib.internal.kombu.patch import patch
 from ddtrace.contrib.internal.kombu.patch import unpatch
 from ddtrace.ext import kombu as kombux
 from ddtrace.internal.datastreams.processor import PROPAGATION_KEY_BASE_64
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 

--- a/tests/contrib/mako/test_mako.py
+++ b/tests/contrib/mako/test_mako.py
@@ -5,11 +5,11 @@ from mako.lookup import TemplateLookup
 from mako.runtime import Context
 from mako.template import Template
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.mako.constants import DEFAULT_TEMPLATE_NAME
 from ddtrace.contrib.internal.mako.patch import patch
 from ddtrace.contrib.internal.mako.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 

--- a/tests/contrib/mariadb/test_mariadb.py
+++ b/tests/contrib/mariadb/test_mariadb.py
@@ -4,9 +4,9 @@ from typing import Tuple  # noqa:F401
 import mariadb
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.mariadb.patch import patch
 from ddtrace.contrib.internal.mariadb.patch import unpatch
-from ddtrace.trace import Pin
 from tests.contrib.config import MARIADB_CONFIG
 from tests.utils import DummyTracer
 from tests.utils import assert_dict_issuperset

--- a/tests/contrib/molten/test_molten.py
+++ b/tests/contrib/molten/test_molten.py
@@ -3,6 +3,7 @@ from molten.testing import TestClient
 import pytest
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.internal.molten.patch import MOLTEN_VERSION
@@ -12,7 +13,6 @@ from ddtrace.ext import http
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
-from ddtrace.trace import Pin
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured

--- a/tests/contrib/molten/test_molten_di.py
+++ b/tests/contrib/molten/test_molten_di.py
@@ -3,9 +3,9 @@ from inspect import Parameter
 import molten
 from molten import DependencyInjector
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.molten.patch import patch
 from ddtrace.contrib.internal.molten.patch import unpatch
-from ddtrace.trace import Pin
 from tests.utils import TracerTestCase
 
 

--- a/tests/contrib/mongoengine/test.py
+++ b/tests/contrib/mongoengine/test.py
@@ -3,11 +3,11 @@ import time
 import mongoengine
 import pymongo
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.mongoengine.patch import patch
 from ddtrace.contrib.internal.mongoengine.patch import unpatch
 from ddtrace.ext import mongo as mongox
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.opentracer.utils import init_tracer
 from tests.utils import DummyTracer
 from tests.utils import TracerTestCase

--- a/tests/contrib/mysql/test_mysql.py
+++ b/tests/contrib/mysql/test_mysql.py
@@ -1,9 +1,9 @@
 import mock
 import mysql
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.mysql.patch import patch
 from ddtrace.contrib.internal.mysql.patch import unpatch
-from ddtrace.trace import Pin
 from tests.contrib import shared_tests
 from tests.contrib.config import MYSQL_CONFIG
 from tests.opentracer.utils import init_tracer

--- a/tests/contrib/mysqldb/test_mysqldb.py
+++ b/tests/contrib/mysqldb/test_mysqldb.py
@@ -2,10 +2,10 @@ import mock
 import MySQLdb
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.mysqldb.patch import patch
 from ddtrace.contrib.internal.mysqldb.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.contrib import shared_tests
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -8,11 +8,11 @@ from psycopg.sql import Composed
 from psycopg.sql import Identifier
 from psycopg.sql import Literal
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.psycopg.patch import patch
 from ddtrace.contrib.internal.psycopg.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.utils.version import parse_version
-from ddtrace.trace import Pin
 from tests.contrib.config import POSTGRES_CONFIG
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase

--- a/tests/contrib/psycopg/test_psycopg_async.py
+++ b/tests/contrib/psycopg/test_psycopg_async.py
@@ -5,9 +5,9 @@ import psycopg
 from psycopg.sql import SQL
 from psycopg.sql import Literal
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.psycopg.patch import patch
 from ddtrace.contrib.internal.psycopg.patch import unpatch
-from ddtrace.trace import Pin
 from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.config import POSTGRES_CONFIG
 from tests.opentracer.utils import init_tracer

--- a/tests/contrib/psycopg2/test_psycopg.py
+++ b/tests/contrib/psycopg2/test_psycopg.py
@@ -7,11 +7,11 @@ import psycopg2
 from psycopg2 import extensions
 from psycopg2 import extras
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.psycopg.patch import patch
 from ddtrace.contrib.internal.psycopg.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.utils.version import parse_version
-from ddtrace.trace import Pin
 from tests.contrib.config import POSTGRES_CONFIG
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase

--- a/tests/contrib/pylibmc/test.py
+++ b/tests/contrib/pylibmc/test.py
@@ -5,13 +5,12 @@ from unittest.case import SkipTest
 # 3p
 import pylibmc
 
+# project
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.pylibmc.client import TracedClient
 from ddtrace.contrib.internal.pylibmc.patch import patch
 from ddtrace.contrib.internal.pylibmc.patch import unpatch
 from ddtrace.ext import memcached
-
-# project
-from ddtrace.trace import Pin
 from tests.contrib.config import MEMCACHED_CONFIG as cfg
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase

--- a/tests/contrib/pymemcache/test_client.py
+++ b/tests/contrib/pymemcache/test_client.py
@@ -9,13 +9,12 @@ from pymemcache.exceptions import MemcacheUnknownError
 import pytest
 import wrapt
 
+# project
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.pymemcache.client import WrappedClient
 from ddtrace.contrib.internal.pymemcache.patch import patch
 from ddtrace.contrib.internal.pymemcache.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-
-# project
-from ddtrace.trace import Pin
 from tests.utils import DummyTracer
 from tests.utils import TracerTestCase
 from tests.utils import override_config

--- a/tests/contrib/pymemcache/test_client_defaults.py
+++ b/tests/contrib/pymemcache/test_client_defaults.py
@@ -2,11 +2,10 @@
 import pymemcache
 import pytest
 
+# project
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.pymemcache.patch import patch
 from ddtrace.contrib.internal.pymemcache.patch import unpatch
-
-# project
-from ddtrace.trace import Pin
 from tests.utils import override_config
 
 from .test_client_mixin import TEST_HOST

--- a/tests/contrib/pymemcache/test_client_mixin.py
+++ b/tests/contrib/pymemcache/test_client_mixin.py
@@ -2,13 +2,12 @@
 import pymemcache
 import pytest
 
+# project
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.pymemcache.patch import patch
 from ddtrace.contrib.internal.pymemcache.patch import unpatch
 from ddtrace.ext import memcached as memcachedx
 from ddtrace.ext import net
-
-# project
-from ddtrace.trace import Pin
 from tests.utils import DummyTracer
 from tests.utils import TracerTestCase
 from tests.utils import override_config

--- a/tests/contrib/pymongo/test.py
+++ b/tests/contrib/pymongo/test.py
@@ -3,14 +3,13 @@ import time
 
 import pymongo
 
+# project
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.pymongo.client import normalize_filter
 from ddtrace.contrib.internal.pymongo.patch import _CHECKOUT_FN_NAME
 from ddtrace.contrib.internal.pymongo.patch import patch
 from ddtrace.contrib.internal.pymongo.patch import unpatch
 from ddtrace.ext import SpanTypes
-
-# project
-from ddtrace.trace import Pin
 from tests.opentracer.utils import init_tracer
 from tests.utils import DummyTracer
 from tests.utils import TracerTestCase

--- a/tests/contrib/pymysql/test_pymysql.py
+++ b/tests/contrib/pymysql/test_pymysql.py
@@ -1,10 +1,10 @@
 import mock
 import pymysql
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.pymysql.patch import patch
 from ddtrace.contrib.internal.pymysql.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.contrib import shared_tests
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase

--- a/tests/contrib/pynamodb/test_pynamodb.py
+++ b/tests/contrib/pynamodb/test_pynamodb.py
@@ -4,10 +4,10 @@ import pynamodb.connection.base
 from pynamodb.connection.base import Connection
 import pytest
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.pynamodb.patch import patch
 from ddtrace.contrib.internal.pynamodb.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 

--- a/tests/contrib/pyodbc/test_pyodbc.py
+++ b/tests/contrib/pyodbc/test_pyodbc.py
@@ -1,9 +1,9 @@
 import pyodbc
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.pyodbc.patch import patch
 from ddtrace.contrib.internal.pyodbc.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 

--- a/tests/contrib/redis/test_redis.py
+++ b/tests/contrib/redis/test_redis.py
@@ -5,10 +5,10 @@ import pytest
 import redis
 
 import ddtrace
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.redis.patch import patch
 from ddtrace.contrib.internal.redis.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.opentracer.utils import init_tracer
 from tests.utils import DummyTracer
 from tests.utils import TracerTestCase

--- a/tests/contrib/redis/test_redis_asyncio.py
+++ b/tests/contrib/redis/test_redis_asyncio.py
@@ -7,9 +7,9 @@ import redis
 import redis.asyncio
 from wrapt import ObjectProxy
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.redis.patch import patch
 from ddtrace.contrib.internal.redis.patch import unpatch
-from ddtrace.trace import Pin
 from ddtrace.trace import tracer
 from tests.utils import override_config
 

--- a/tests/contrib/redis/test_redis_cluster.py
+++ b/tests/contrib/redis/test_redis_cluster.py
@@ -2,10 +2,10 @@
 import pytest
 import redis
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.redis.patch import patch
 from ddtrace.contrib.internal.redis.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.contrib.config import REDISCLUSTER_CONFIG
 from tests.utils import DummyTracer
 from tests.utils import TracerTestCase

--- a/tests/contrib/redis/test_redis_cluster_asyncio.py
+++ b/tests/contrib/redis/test_redis_cluster_asyncio.py
@@ -2,9 +2,9 @@
 import pytest
 import redis
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.redis.patch import patch
 from ddtrace.contrib.internal.redis.patch import unpatch
-from ddtrace.trace import Pin
 from tests.contrib.config import REDISCLUSTER_CONFIG
 from tests.utils import DummyTracer
 from tests.utils import assert_is_measured
@@ -164,9 +164,9 @@ def test_default_service_name_v1():
 
     import redis
 
+    from ddtrace._trace.pin import Pin
     from ddtrace.contrib.internal.redis.patch import patch
     from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-    from ddtrace.trace import Pin
     from tests.contrib.config import REDISCLUSTER_CONFIG
     from tests.utils import DummyTracer
     from tests.utils import TracerSpanContainer
@@ -211,8 +211,8 @@ def test_user_specified_service_v0():
     import redis
 
     from ddtrace import config
+    from ddtrace._trace.pin import Pin
     from ddtrace.contrib.internal.redis.patch import patch
-    from ddtrace.trace import Pin
     from tests.contrib.config import REDISCLUSTER_CONFIG
     from tests.utils import DummyTracer
     from tests.utils import TracerSpanContainer
@@ -260,8 +260,8 @@ def test_user_specified_service_v1():
     import redis
 
     from ddtrace import config
+    from ddtrace._trace.pin import Pin
     from ddtrace.contrib.internal.redis.patch import patch
-    from ddtrace.trace import Pin
     from tests.contrib.config import REDISCLUSTER_CONFIG
     from tests.utils import DummyTracer
     from tests.utils import TracerSpanContainer
@@ -304,8 +304,8 @@ def test_env_user_specified_rediscluster_service_v0():
 
     import redis
 
+    from ddtrace._trace.pin import Pin
     from ddtrace.contrib.internal.redis.patch import patch
-    from ddtrace.trace import Pin
     from tests.contrib.config import REDISCLUSTER_CONFIG
     from tests.utils import DummyTracer
     from tests.utils import TracerSpanContainer
@@ -345,8 +345,8 @@ def test_env_user_specified_rediscluster_service_v1():
 
     import redis
 
+    from ddtrace._trace.pin import Pin
     from ddtrace.contrib.internal.redis.patch import patch
-    from ddtrace.trace import Pin
     from tests.contrib.config import REDISCLUSTER_CONFIG
     from tests.utils import DummyTracer
     from tests.utils import TracerSpanContainer
@@ -391,8 +391,8 @@ def test_service_precedence_v0():
     import redis
 
     from ddtrace import config
+    from ddtrace._trace.pin import Pin
     from ddtrace.contrib.internal.redis.patch import patch
-    from ddtrace.trace import Pin
     from tests.contrib.config import REDISCLUSTER_CONFIG
     from tests.utils import DummyTracer
     from tests.utils import TracerSpanContainer
@@ -436,8 +436,8 @@ def test_service_precedence_v1():
     import redis
 
     from ddtrace import config
+    from ddtrace._trace.pin import Pin
     from ddtrace.contrib.internal.redis.patch import patch
-    from ddtrace.trace import Pin
     from tests.contrib.config import REDISCLUSTER_CONFIG
     from tests.utils import DummyTracer
     from tests.utils import TracerSpanContainer

--- a/tests/contrib/rediscluster/test.py
+++ b/tests/contrib/rediscluster/test.py
@@ -2,11 +2,11 @@
 import pytest
 import rediscluster
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.rediscluster.patch import REDISCLUSTER_VERSION
 from ddtrace.contrib.internal.rediscluster.patch import patch
 from ddtrace.contrib.internal.rediscluster.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.contrib.config import REDISCLUSTER_CONFIG
 from tests.utils import DummyTracer
 from tests.utils import TracerTestCase

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -8,6 +8,7 @@ from requests.exceptions import InvalidURL
 from requests.exceptions import MissingSchema
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
@@ -17,7 +18,6 @@ from ddtrace.contrib.internal.requests.patch import patch
 from ddtrace.contrib.internal.requests.patch import unpatch
 from ddtrace.ext import http
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured

--- a/tests/contrib/requests/test_requests_distributed.py
+++ b/tests/contrib/requests/test_requests_distributed.py
@@ -1,7 +1,7 @@
 from requests_mock import Adapter
 
+from ddtrace._trace.pin import Pin
 from ddtrace.settings.asm import config as asm_config
-from ddtrace.trace import Pin
 from tests.utils import TracerTestCase
 from tests.utils import get_128_bit_trace_id_from_headers
 

--- a/tests/contrib/rq/test_rq.py
+++ b/tests/contrib/rq/test_rq.py
@@ -6,10 +6,10 @@ import pytest
 import redis
 import rq
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.rq.patch import get_version
 from ddtrace.contrib.internal.rq.patch import patch
 from ddtrace.contrib.internal.rq.patch import unpatch
-from ddtrace.trace import Pin
 from tests.contrib.patch import emit_integration_and_version_to_test_agent
 from tests.utils import override_config
 from tests.utils import snapshot

--- a/tests/contrib/shared_tests.py
+++ b/tests/contrib/shared_tests.py
@@ -1,4 +1,4 @@
-from ddtrace.trace import Pin
+from ddtrace._trace.pin import Pin
 
 
 # DBM Shared Tests

--- a/tests/contrib/shared_tests_async.py
+++ b/tests/contrib/shared_tests_async.py
@@ -1,4 +1,4 @@
-from ddtrace.trace import Pin
+from ddtrace._trace.pin import Pin
 
 
 # DBM Shared Tests

--- a/tests/contrib/snowflake/test_snowflake.py
+++ b/tests/contrib/snowflake/test_snowflake.py
@@ -6,9 +6,9 @@ import pytest
 import responses
 import snowflake.connector
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.snowflake.patch import patch
 from ddtrace.contrib.internal.snowflake.patch import unpatch
-from ddtrace.trace import Pin
 from ddtrace.trace import tracer
 from tests.opentracer.utils import init_tracer
 from tests.utils import override_config

--- a/tests/contrib/sqlalchemy/test_patch.py
+++ b/tests/contrib/sqlalchemy/test_patch.py
@@ -1,10 +1,10 @@
 import sqlalchemy
 from sqlalchemy import text
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.sqlalchemy.patch import get_version
 from ddtrace.contrib.internal.sqlalchemy.patch import patch
 from ddtrace.contrib.internal.sqlalchemy.patch import unpatch
-from ddtrace.trace import Pin
 from tests.contrib.patch import emit_integration_and_version_to_test_agent
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured

--- a/tests/contrib/sqlite3/test_sqlite3.py
+++ b/tests/contrib/sqlite3/test_sqlite3.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING  # noqa:F401
 import pytest
 
 import ddtrace
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
@@ -20,7 +21,6 @@ from ddtrace.contrib.internal.sqlite3.patch import TracedSQLiteCursor
 from ddtrace.contrib.internal.sqlite3.patch import patch
 from ddtrace.contrib.internal.sqlite3.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured

--- a/tests/contrib/starlette/test_starlette.py
+++ b/tests/contrib/starlette/test_starlette.py
@@ -8,13 +8,13 @@ import starlette
 from starlette.testclient import TestClient
 
 import ddtrace
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import ERROR_MSG
 from ddtrace.contrib.internal.sqlalchemy.patch import patch as sql_patch
 from ddtrace.contrib.internal.sqlalchemy.patch import unpatch as sql_unpatch
 from ddtrace.contrib.internal.starlette.patch import patch as starlette_patch
 from ddtrace.contrib.internal.starlette.patch import unpatch as starlette_unpatch
 from ddtrace.propagation import http as http_propagation
-from ddtrace.trace import Pin
 from tests.contrib.starlette.app import get_app
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
 from tests.utils import DummyTracer

--- a/tests/contrib/urllib3/test_urllib3.py
+++ b/tests/contrib/urllib3/test_urllib3.py
@@ -3,6 +3,7 @@ import pytest
 import urllib3
 
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace._trace.span import _get_64_highest_order_bits_as_hex
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
@@ -12,7 +13,6 @@ from ddtrace.contrib.internal.urllib3.patch import unpatch
 from ddtrace.ext import http
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.settings.asm import config as asm_config
-from ddtrace.trace import Pin
 from tests.contrib.config import HTTPBIN_CONFIG
 from tests.opentracer.utils import init_tracer
 from tests.utils import TracerTestCase

--- a/tests/contrib/valkey/test_valkey.py
+++ b/tests/contrib/valkey/test_valkey.py
@@ -5,10 +5,10 @@ import pytest
 import valkey
 
 import ddtrace
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.valkey.patch import patch
 from ddtrace.contrib.internal.valkey.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.opentracer.utils import init_tracer
 from tests.utils import DummyTracer
 from tests.utils import TracerTestCase

--- a/tests/contrib/valkey/test_valkey_asyncio.py
+++ b/tests/contrib/valkey/test_valkey_asyncio.py
@@ -8,9 +8,9 @@ import valkey.asyncio
 from wrapt import ObjectProxy
 
 from ddtrace import tracer
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.valkey.patch import patch
 from ddtrace.contrib.internal.valkey.patch import unpatch
-from ddtrace.trace import Pin
 from tests.utils import override_config
 
 from ..config import VALKEY_CONFIG

--- a/tests/contrib/valkey/test_valkey_cluster.py
+++ b/tests/contrib/valkey/test_valkey_cluster.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import valkey
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.valkey.patch import patch
 from ddtrace.contrib.internal.valkey.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-from ddtrace.trace import Pin
 from tests.contrib.config import VALKEY_CLUSTER_CONFIG
 from tests.utils import DummyTracer
 from tests.utils import TracerTestCase

--- a/tests/contrib/valkey/test_valkey_cluster_asyncio.py
+++ b/tests/contrib/valkey/test_valkey_cluster_asyncio.py
@@ -2,9 +2,9 @@
 import pytest
 import valkey
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.valkey.patch import patch
 from ddtrace.contrib.internal.valkey.patch import unpatch
-from ddtrace.trace import Pin
 from tests.contrib.config import VALKEY_CLUSTER_CONFIG
 from tests.utils import DummyTracer
 from tests.utils import assert_is_measured
@@ -157,9 +157,9 @@ def test_default_service_name_v1():
 
     import valkey
 
+    from ddtrace._trace.pin import Pin
     from ddtrace.contrib.internal.valkey.patch import patch
     from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
-    from ddtrace.trace import Pin
     from tests.contrib.config import VALKEY_CLUSTER_CONFIG
     from tests.utils import DummyTracer
     from tests.utils import TracerSpanContainer
@@ -203,8 +203,8 @@ def test_user_specified_service_v0():
     import valkey
 
     from ddtrace import config
+    from ddtrace._trace.pin import Pin
     from ddtrace.contrib.internal.valkey.patch import patch
-    from ddtrace.trace import Pin
     from tests.contrib.config import VALKEY_CLUSTER_CONFIG
     from tests.utils import DummyTracer
     from tests.utils import TracerSpanContainer
@@ -251,8 +251,8 @@ def test_user_specified_service_v1():
     import valkey
 
     from ddtrace import config
+    from ddtrace._trace.pin import Pin
     from ddtrace.contrib.internal.valkey.patch import patch
-    from ddtrace.trace import Pin
     from tests.contrib.config import VALKEY_CLUSTER_CONFIG
     from tests.utils import DummyTracer
     from tests.utils import TracerSpanContainer
@@ -294,8 +294,8 @@ def test_env_user_specified_valkeycluster_service_v0():
 
     import valkey
 
+    from ddtrace._trace.pin import Pin
     from ddtrace.contrib.internal.valkey.patch import patch
-    from ddtrace.trace import Pin
     from tests.contrib.config import VALKEY_CLUSTER_CONFIG
     from tests.utils import DummyTracer
     from tests.utils import TracerSpanContainer
@@ -334,8 +334,8 @@ def test_env_user_specified_valkeycluster_service_v1():
 
     import valkey
 
+    from ddtrace._trace.pin import Pin
     from ddtrace.contrib.internal.valkey.patch import patch
-    from ddtrace.trace import Pin
     from tests.contrib.config import VALKEY_CLUSTER_CONFIG
     from tests.utils import DummyTracer
     from tests.utils import TracerSpanContainer
@@ -379,8 +379,8 @@ def test_service_precedence_v0():
     import valkey
 
     from ddtrace import config
+    from ddtrace._trace.pin import Pin
     from ddtrace.contrib.internal.valkey.patch import patch
-    from ddtrace.trace import Pin
     from tests.contrib.config import VALKEY_CLUSTER_CONFIG
     from tests.utils import DummyTracer
     from tests.utils import TracerSpanContainer
@@ -423,8 +423,8 @@ def test_service_precedence_v1():
     import valkey
 
     from ddtrace import config
+    from ddtrace._trace.pin import Pin
     from ddtrace.contrib.internal.valkey.patch import patch
-    from ddtrace.trace import Pin
     from tests.contrib.config import VALKEY_CLUSTER_CONFIG
     from tests.utils import DummyTracer
     from tests.utils import TracerSpanContainer

--- a/tests/contrib/vertica/test_vertica.py
+++ b/tests/contrib/vertica/test_vertica.py
@@ -3,6 +3,7 @@ import wrapt
 
 import ddtrace
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
@@ -10,7 +11,6 @@ from ddtrace.contrib.internal.vertica.patch import patch
 from ddtrace.contrib.internal.vertica.patch import unpatch
 from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.settings._config import _deepmerge
-from ddtrace.trace import Pin
 from tests.contrib.config import VERTICA_CONFIG
 from tests.opentracer.utils import init_tracer
 from tests.utils import DummyTracer

--- a/tests/contrib/yaaredis/test_yaaredis.py
+++ b/tests/contrib/yaaredis/test_yaaredis.py
@@ -6,9 +6,9 @@ import pytest
 from wrapt import ObjectProxy
 import yaaredis
 
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.yaaredis.patch import patch
 from ddtrace.contrib.internal.yaaredis.patch import unpatch
-from ddtrace.trace import Pin
 from tests.opentracer.utils import init_tracer
 from tests.utils import override_config
 


### PR DESCRIPTION
Broken out from #14361 

`ddtrace.trace.Pin` is being deprecated

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
