### PR TITLE
chore(internal): remove span attributes from the core api

### DIFF
--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -1896,30 +1896,6 @@ def test_finish_span_with_ancestors(tracer):
     assert span3.finished
 
 
-def test_ctx_api(tracer):
-    from ddtrace.internal import core
-
-    assert core.get_item("key") is None
-
-    with tracer.trace("root") as span:
-        v = core.get_item("my.val")
-        assert v is None
-
-        core.set_item("appsec.key", "val", span=span)
-        core.set_items({"appsec.key2": "val2", "appsec.key3": "val3"}, span=span)
-        assert core.get_item("appsec.key", span=span) == "val"
-        assert core.get_item("appsec.key2", span=span) == "val2"
-        assert core.get_item("appsec.key3", span=span) == "val3"
-        assert core.get_items(["appsec.key"], span=span) == ["val"]
-        assert core.get_items(["appsec.key", "appsec.key2", "appsec.key3"], span=span) == ["val", "val2", "val3"]
-
-        with tracer.trace("child") as childspan:
-            assert core.get_item("appsec.key", span=childspan) == "val"
-
-    assert core.get_item("appsec.key") is None
-    assert core.get_items(["appsec.key"]) == [None]
-
-
 @pytest.mark.parametrize("sca_enabled", ["true", "false"])
 @pytest.mark.parametrize("appsec_enabled", [True, False])
 @pytest.mark.parametrize("iast_enabled", [True, False])


### PR DESCRIPTION
There did not appear to be any usage of `span=` for these functions, so we can remove the attribute and deprecation warnings now!

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
