### PR TITLE
fix: use default trace agent url for tracer flare

### DIFF
--- a/ddtrace/internal/remoteconfig/products/client.py
+++ b/ddtrace/internal/remoteconfig/products/client.py
@@ -1,5 +1,6 @@
 from ddtrace import config
 from ddtrace.internal.remoteconfig.client import config as rc_config
+from ddtrace.settings._agent import config as agent_config
 
 
 # TODO: Modularize better into their own respective components
@@ -10,7 +11,7 @@ def _register_rc_products() -> None:
     from ddtrace.internal.flare.handler import _tracerFlarePubSub
     from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
 
-    flare = Flare(trace_agent_url=config._trace_agent_url, api_key=config._dd_api_key, ddconfig=config.__dict__)
+    flare = Flare(trace_agent_url=agent_config.trace_agent_url, api_key=config._dd_api_key, ddconfig=config.__dict__)
     tracerflare_pubsub = _tracerFlarePubSub()(_handle_tracer_flare, flare)
     remoteconfig_poller.register("AGENT_CONFIG", tracerflare_pubsub)
     remoteconfig_poller.register("AGENT_TASK", tracerflare_pubsub)

--- a/releasenotes/notes/fix-tracer-flare-default-url-fc1232a153f60b45.yaml
+++ b/releasenotes/notes/fix-tracer-flare-default-url-fc1232a153f60b45.yaml
@@ -1,4 +1,4 @@
 fixes:
   - |
-    This fix resolves an issue where the tracer flare was not sent when DD_TRACE_AGENT_URL was not set,
+    internal: This fix resolves an issue where the tracer flare was not sent when ``DD_TRACE_AGENT_URL`` was not set,
     as the default URL was not used.

--- a/releasenotes/notes/fix-tracer-flare-default-url-fc1232a153f60b45.yaml
+++ b/releasenotes/notes/fix-tracer-flare-default-url-fc1232a153f60b45.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    This fix resolves an issue where the tracer flare was not sent when DD_TRACE_AGENT_URL was not set,
+    as the default URL was not used.


### PR DESCRIPTION
## Description

This PR fixes the tracer flare when `DD_TRACE_AGENT_URL` is not set. `ddtrace.config._trace_agent_url` is `None` when not set, which leads to `Failed to send tracer flare to Zendesk ticket XXXXXXXXX: Unsupported protocol 'b''' in intake URL 'None'. Must be one of: http, https, unix` when sending a flare. 

This PR makes sure to use the default.

## Motivation

Making tracer flares for Python work again

## Testing strategy
- Create a VM
- Install the agent
- Install the tracer with SSI
- Create a sample Flask app
- Start it with `DD_TRACE_DEBUG=true`
- Go to the Datadog UI & trigger a flare for your host (no need to force debug logs)
- After a few minutes a Zendesk ticket should be created and contain your tracer flare
- You should see a log starting with `Successfully sent the flare to Zendesk ticket` 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
