### PR TITLE
chore(debugger): re-route payloads thru diagnostics

### DIFF
--- a/ddtrace/debugging/_exception/replay.py
+++ b/ddtrace/debugging/_exception/replay.py
@@ -168,6 +168,8 @@ class SpanExceptionProbe(LogLineProbe):
 
 @dataclass
 class SpanExceptionSnapshot(Snapshot):
+    __type__ = "er_snapshot"
+
     exc_id: t.Optional[uuid.UUID] = None
 
     @property

--- a/ddtrace/debugging/_probe/status.py
+++ b/ddtrace/debugging/_probe/status.py
@@ -49,6 +49,7 @@ class ProbeStatusLogger:
             "timestamp": int(timestamp * 1e3),  # milliseconds
             "message": message,
             "ddsource": "dd_debugger",
+            "type": "diagnostic",
             "debugger": {
                 "diagnostics": {
                     "probeId": probe.probe_id,

--- a/ddtrace/debugging/_signal/log.py
+++ b/ddtrace/debugging/_signal/log.py
@@ -16,6 +16,8 @@ class LogSignal(Signal):
     (e.g. conditions) might need to be reported.
     """
 
+    __type__ = "di_snapshot"
+
     @property
     @abc.abstractmethod
     def message(self) -> t.Optional[str]:
@@ -61,6 +63,7 @@ class LogSignal(Signal):
             "evaluationErrors": [{"expr": e.expr, "message": e.message} for e in self.errors],
             "probe": self._probe_details(),
             "language": "python",
+            "type": self.__type__,
         }
         full_data.update(self.data)
 

--- a/ddtrace/internal/symbol_db/symbols.py
+++ b/ddtrace/internal/symbol_db/symbols.py
@@ -468,6 +468,7 @@ class ScopeContext:
             "ddsource": "python",
             "service": config.service or DEFAULT_SERVICE_NAME,
             "runtimeId": get_runtime_id(),
+            "type": "symdb",
         }
 
     def add_scope(self, scope: Scope) -> None:

--- a/ddtrace/settings/dynamic_instrumentation.py
+++ b/ddtrace/settings/dynamic_instrumentation.py
@@ -52,7 +52,7 @@ class DynamicInstrumentationConfig(DDConfig):
     max_probes = DDConfig.d(int, lambda _: DEFAULT_MAX_PROBES)
     global_rate_limit = DDConfig.d(float, lambda _: DEFAULT_GLOBAL_RATE_LIMIT)
     _tags_in_qs = DDConfig.d(bool, lambda _: True)
-    _intake_endpoint = DDConfig.d(str, lambda _: "/debugger/v1/input")
+    _intake_endpoint = DDConfig.d(str, lambda _: "/debugger/v1/diagnostics")
     tags = DDConfig.d(str, _derive_tags)
 
     enabled = DDConfig.v(

--- a/tests/debugging/probe/test_registry.py
+++ b/tests/debugging/probe/test_registry.py
@@ -67,6 +67,7 @@ def test_registry_location_error():
             "service": "test",
             "message": "Failed to instrument probe 42",
             "ddsource": "dd_debugger",
+            "type": "diagnostic",
             "debugger": {
                 "diagnostics": {
                     "probeId": 42,


### PR DESCRIPTION
We temporarily re-route all debugger payloads through the diagnostics endpoint.

Refs: [DEBUG-4338](https://datadoghq.atlassian.net/browse/DEBUG-4338)

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
