### PR TITLE
perf(tracing): use get_local_item instead of get_item

### DIFF
--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -197,7 +197,7 @@ def _on_web_framework_start_request(ctx, int_config):
 def _on_web_framework_finish_request(
     span, int_config, method, url, status_code, query, req_headers, res_headers, route, finish, **kwargs
 ):
-    if core.get_item("set_resource", default=False) is True and status_code is not None:
+    if core.get_local_item("set_resource", default=False) is True and status_code is not None:
         try:
             status_code = int(status_code)
         except ValueError:
@@ -216,7 +216,7 @@ def _on_web_framework_finish_request(
         **kwargs,
     )
     _set_inferred_proxy_tags(span, status_code)
-    for tk, tv in core.get_item("additional_tags", default=dict()).items():
+    for tk, tv in core.get_local_item("additional_tags", default=dict()).items():
         span.set_tag_str(tk, tv)
 
     if finish:
@@ -246,7 +246,7 @@ def _on_inferred_proxy_start(ctx, tracer, span_kwargs, call_trace, integration_c
 
     # some integrations like Flask / WSGI store headers from environ in 'distributed_headers'
     # and normalized headers in 'headers'
-    headers = ctx.get_local_item("headers", ctx.get_item("distributed_headers", None))
+    headers = ctx.get_local_item("headers", ctx.get_local_item("distributed_headers", None))
 
     # Inferred Proxy Spans
     if integration_config and headers is not None:
@@ -914,7 +914,7 @@ def _on_azure_servicebus_send_message_modifier(ctx, azure_servicebus_config, ent
 
 
 def _on_router_match(route):
-    req_span = core.get_item("req_span")
+    req_span = core.get_local_item("req_span")
     core.set_item("set_resource", False)
     req_span.resource = "{} {}".format(
         route.method,

--- a/ddtrace/contrib/internal/botocore/patch.py
+++ b/ddtrace/contrib/internal/botocore/patch.py
@@ -180,6 +180,7 @@ def patched_lib_fn(original_func, instance, args, kwargs):
         "botocore.instrumented_lib_function",
         span_name="{}.{}".format(original_func.__module__, original_func.__name__),
         tags={COMPONENT: config.botocore.integration_name, SPAN_KIND: SpanKind.CLIENT},
+        pin=pin,
     ) as ctx, ctx.span:
         return original_func(*args, **kwargs)
 

--- a/ddtrace/internal/core/__init__.py
+++ b/ddtrace/internal/core/__init__.py
@@ -287,8 +287,8 @@ def get_item(data_key: str, default: Optional[Any] = None) -> Any:
     return _CURRENT_CONTEXT.get().get_item(data_key, default=default)
 
 
-def get_local_item(data_key: str) -> Any:
-    return _CURRENT_CONTEXT.get().get_local_item(data_key)
+def get_local_item(data_key: str, default: Optional[Any] = None) -> Any:
+    return _CURRENT_CONTEXT.get().get_local_item(data_key, default=default)
 
 
 def get_items(data_keys: List[str]) -> List[Optional[Any]]:


### PR DESCRIPTION
`core.get_item`/`ExecutionContext.get_item` will search through the hierarchy of parents until it finds the key (or cache miss on all parents and returns the default).

Most usage of context set_item/get_item are intended to be for the currently actively context only, and don't need to search for an item potentially on the parent.

When profiling `get_item` can be up to 5-6x slower than `get_local_item` especially for cache misses.

This change updates the `ddtrace/_trace/trace_handlers.py` usage to only use `get_local_item` instead.


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
