### PR TITLE
feat(langchain): added support for tool results

### DIFF
--- a/ddtrace/llmobs/_integrations/langchain.py
+++ b/ddtrace/llmobs/_integrations/langchain.py
@@ -34,13 +34,12 @@ from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._integrations.utils import extract_instance_metadata_from_stack
 from ddtrace.llmobs._integrations.utils import format_langchain_io
 from ddtrace.llmobs._integrations.utils import update_proxy_workflow_input_output_value
+from ddtrace.llmobs._utils import _get_attr
 from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
 from ddtrace.llmobs._utils import validate_prompt
-from ddtrace.llmobs._utils import _get_attr
 from ddtrace.llmobs.utils import Document
 from ddtrace.llmobs.utils import ToolCall
 from ddtrace.llmobs.utils import ToolResult
-from ddtrace.llmobs.utils import ToolDefinition
 from ddtrace.trace import Span
 
 

--- a/ddtrace/llmobs/_integrations/langchain.py
+++ b/ddtrace/llmobs/_integrations/langchain.py
@@ -504,7 +504,10 @@ class LangChainIntegration(BaseLLMIntegration):
                         message.get("content", "") if isinstance(message, dict) else getattr(message, "content", "")
                     )
                     role = getattr(message, "role", ROLE_MAPPING.get(getattr(message, "type", ""), ""))
-                    message_item = {"content": str(content), "role": str(role)}
+                    message_item: Dict[str, Union[str, List[ToolCall], List[ToolResult]]] = {
+                        "content": str(content),
+                        "role": str(role),
+                    }
                     tool_calls_info = self._extract_tool_calls(message)
                     if tool_calls_info:
                         message_item["tool_calls"] = tool_calls_info
@@ -574,7 +577,7 @@ class LangChainIntegration(BaseLLMIntegration):
             }
             span._set_ctx_item(METRICS, metrics)
 
-    def _extract_tool_calls(self, chat_completion_msg: Any) -> List[Dict[str, Any]]:
+    def _extract_tool_calls(self, chat_completion_msg: Any) -> List[ToolCall]:
         """Extracts tool calls from a langchain chat completion."""
         tool_calls = _get_attr(chat_completion_msg, "tool_calls", None)
         tool_calls_info = []
@@ -591,7 +594,7 @@ class LangChainIntegration(BaseLLMIntegration):
                 tool_calls_info.append(tool_call_info)
         return tool_calls_info
 
-    def _extract_tool_results(self, chat_completion_msg: Any) -> List[Dict[str, Any]]:
+    def _extract_tool_results(self, chat_completion_msg: Any) -> List[ToolResult]:
         """Extracts tool results from a langchain chat completion."""
         content = _get_attr(chat_completion_msg, "content", "") or ""
         tool_call_id = _get_attr(chat_completion_msg, "tool_call_id", "") or ""
@@ -601,7 +604,7 @@ class LangChainIntegration(BaseLLMIntegration):
                 type="tool",
                 name=_get_attr(chat_completion_msg, "name", "") or "",
                 result=content,
-                tool_call_id=tool_call_id,
+                tool_id=tool_call_id,
             )
             tool_results.append(tool_result_info)
         return tool_results

--- a/ddtrace/llmobs/_integrations/langchain.py
+++ b/ddtrace/llmobs/_integrations/langchain.py
@@ -583,7 +583,7 @@ class LangChainIntegration(BaseLLMIntegration):
                 tool_calls = [tool_calls]
             for tool_call in tool_calls:
                 tool_call_info = ToolCall(
-                    type=tool_call.get("type", ""),
+                    type=tool_call.get("type", "tool_call"),
                     name=tool_call.get("name", ""),
                     arguments=tool_call.get("args", {}),  # this is already a dict
                     tool_id=tool_call.get("id", ""),

--- a/releasenotes/notes/langchain-tool-results-73d5d80d63db21ca.yaml
+++ b/releasenotes/notes/langchain-tool-results-73d5d80d63db21ca.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    LLM Observability: Adds support for collecting tool results in the LangChain integration.

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -487,6 +487,7 @@ def test_llmobs_chat_model_tool_calls(langchain_openai, llmobs_events, tracer, o
                         "name": "add",
                         "arguments": {"a": 1, "b": 2},
                         "tool_id": mock.ANY,
+                        "type": "tool_call",
                     }
                 ],
             }


### PR DESCRIPTION
[MLOB-3410]

This PR adds improved tracking of tool results to the LLMObs OpenAI integration.

right now this PR only adds tool result support to chat operation.
one improvement could be to add  better calls/results for tool invocations.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)


[MLOB-3410]: https://datadoghq.atlassian.net/browse/MLOB-3410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ