### PR TITLE
feat(llmobs): make `ml_app` optional by defaulting to `service`

### DIFF
--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -180,7 +180,7 @@ def _get_ml_app(span: Span) -> Optional[str]:
         if ml_app is not None:
             return ml_app
         llmobs_parent = _get_nearest_llmobs_ancestor(llmobs_parent)
-    return ml_app or span.context._meta.get(PROPAGATED_ML_APP_KEY) or config._llmobs_ml_app
+    return ml_app or span.context._meta.get(PROPAGATED_ML_APP_KEY) or config._llmobs_ml_app or config.service
 
 
 def _get_session_id(span: Span) -> Optional[str]:

--- a/releasenotes/notes/llmobs-ml-app-sensible-default-502cd05ee2af8485.yaml
+++ b/releasenotes/notes/llmobs-ml-app-sensible-default-502cd05ee2af8485.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    LLM Observability: ``ml_app`` is now entirely optional, defaulting to ``service``. while it is still recommended to set ``ml_app``, ``ddtrace.llmobs`` will no longer throw if one is not provided or propagated from an upstream service.

--- a/tests/llmobs/conftest.py
+++ b/tests/llmobs/conftest.py
@@ -289,6 +289,14 @@ def llmobs_no_ml_app(tracer):
 
 
 @pytest.fixture
+def llmobs_empty_ml_app(tracer):
+    with override_global_config(dict(_llmobs_ml_app="")):
+        llmobs_service.enable(_tracer=tracer)
+        yield llmobs_service
+        llmobs_service.disable()
+
+
+@pytest.fixture
 def llmobs_events(llmobs, llmobs_span_writer):
     return llmobs_span_writer.events
 

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -220,10 +220,18 @@ def test_service_enable_does_not_override_global_patch_config(mock_tracer_patch,
         llmobs_service.disable()
 
 
-def test_start_span_with_no_ml_app_throws(llmobs_no_ml_app):
-    with pytest.raises(ValueError):
-        with llmobs_no_ml_app.task():
-            pass
+def test_start_span_with_no_ml_app_defaults_to_service_name(llmobs_no_ml_app):
+    with llmobs_no_ml_app.task() as span:
+        pass
+
+    assert span._get_ctx_item(ML_APP) == "tests.llmobs"
+
+
+def test_start_span_empty_ml_app_defaults_to_service_name(llmobs_empty_ml_app):
+    with llmobs_empty_ml_app.task() as span:
+        pass
+
+    assert span._get_ctx_item(ML_APP) == "tests.llmobs"
 
 
 def test_start_span_without_ml_app_does_noop():


### PR DESCRIPTION
Makes the `ml_app` option for LLM Observability optional by defaulting it to `service`, with the idea that without a clear opinion on naming the `ml_app`, its directive falls largely in-line with the service it lives in (if a service does not have multiple `ml_app`s / the service _is_ the `ml_app`).

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
