### PR TITLE
chore(core): rename and document core APIs for clarity

### DIFF
--- a/benchmarks/core_api/scenario.py
+++ b/benchmarks/core_api/scenario.py
@@ -74,7 +74,7 @@ class CoreAPIScenario(bm.Scenario):
         def get_item(loops):
             """Measure the cost to fetch an item from the root context"""
             for _ in range(loops):
-                core.get_item("key")
+                core.find_item("key")
 
         if "core_dispatch_with_results" in self.scenario_name:
             yield core_dispatch_with_results

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -243,7 +243,7 @@ def _on_inferred_proxy_start(ctx, tracer, span_kwargs, call_trace, integration_c
 
     # some integrations like Flask / WSGI store headers from environ in 'distributed_headers'
     # and normalized headers in 'headers'
-    headers = ctx.get_item("headers", ctx.get_local_item("distributed_headers", None))
+    headers = ctx.get_item("headers", ctx.get_item("distributed_headers", None))
 
     # Inferred Proxy Spans
     if integration_config and headers is not None:

--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -544,7 +544,7 @@ def end_context(span: Span):
 
 
 def _on_context_ended(ctx, _exc_info: Tuple[Optional[type], Optional[BaseException], Optional[TracebackType]]):
-    env = ctx.get_local_item(_ASM_CONTEXT)
+    env = ctx.get_item(_ASM_CONTEXT)
     if env is not None:
         finalize_asm_env(env)
 

--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -108,11 +108,11 @@ class ASM_Environment:
 
 
 def _get_asm_context() -> Optional[ASM_Environment]:
-    return core.get_item(_ASM_CONTEXT)
+    return core.find_item(_ASM_CONTEXT)
 
 
 def in_asm_context() -> bool:
-    return core.get_item(_ASM_CONTEXT) is not None
+    return core.find_item(_ASM_CONTEXT) is not None
 
 
 def is_blocked() -> bool:
@@ -530,10 +530,10 @@ def start_context(span: Span, rc_products: str):
         # it should only be called at start of a core context, when ASM_Env is not set yet
         core.set_item(_ASM_CONTEXT, ASM_Environment(span=span, rc_products=rc_products))
         asm_request_context_set(
-            core.get_local_item("remote_addr"),
-            core.get_local_item("headers"),
-            core.get_local_item("headers_case_sensitive"),
-            core.get_local_item("block_request_callable"),
+            core.get_item("remote_addr"),
+            core.get_item("headers"),
+            core.get_item("headers_case_sensitive"),
+            core.get_item("block_request_callable"),
         )
 
 

--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -375,13 +375,13 @@ def _asgi_make_block_content(ctx, url):
 
 def _on_flask_blocked_request(span):
     span.set_tag_str(http.STATUS_CODE, "403")
-    request = core.get_item("flask_request")
+    request = core.find_item("flask_request")
     try:
         base_url = getattr(request, "base_url", None)
         query_string = getattr(request, "query_string", None)
         if base_url and query_string:
-            _set_url_tag(core.get_item("flask_config"), span, base_url, query_string)
-        if query_string and core.get_item("flask_config").trace_query_string:
+            _set_url_tag(core.find_item("flask_config"), span, base_url, query_string)
+        if query_string and core.find_item("flask_config").trace_query_string:
             span.set_tag_str(http.QUERY_STRING, query_string)
         if request.method is not None:
             span.set_tag_str(http.METHOD, request.method)

--- a/ddtrace/appsec/_iast/_handlers.py
+++ b/ddtrace/appsec/_iast/_handlers.py
@@ -190,7 +190,7 @@ def _on_django_middleware(ctx: core.ExecutionContext, call_trace: bool = True, *
     if not asm_config._iast_enabled or not asm_config.is_iast_request_enabled:
         return
 
-    request = ctx.get_item("request")
+    request = ctx.find_item("request")
     if request:
         args = (request,)
         _taint_django_func_call(request, args, {})

--- a/ddtrace/appsec/_iast/_iast_env.py
+++ b/ddtrace/appsec/_iast/_iast_env.py
@@ -44,8 +44,8 @@ class IASTEnvironment:
 
 
 def _get_iast_env() -> Optional[IASTEnvironment]:
-    return core.get_item(IAST.REQUEST_CONTEXT_KEY)
+    return core.find_item(IAST.REQUEST_CONTEXT_KEY)
 
 
 def in_iast_env() -> bool:
-    return core.get_item(IAST.REQUEST_CONTEXT_KEY) is not None
+    return core.find_item(IAST.REQUEST_CONTEXT_KEY) is not None

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -197,7 +197,7 @@ class AppSecSpanProcessor(SpanProcessor):
             return
 
         if span.span_type == SpanTypes.SERVERLESS:
-            skip_event = core.get_item("appsec_skip_next_lambda_event")
+            skip_event = core.find_item("appsec_skip_next_lambda_event")
             if skip_event:
                 core.discard_item("appsec_skip_next_lambda_event")
                 log.debug(

--- a/ddtrace/contrib/internal/botocore/services/bedrock.py
+++ b/ddtrace/contrib/internal/botocore/services/bedrock.py
@@ -332,7 +332,7 @@ def _extract_streamed_response(ctx: core.ExecutionContext, streamed_body: List[D
         elif provider == _COHERE:
             if "is_finished" in streamed_body[0]:  # streamed response
                 if "index" in streamed_body[0]:  # n >= 2
-                    num_generations = int(ctx.get_item("num_generations") or 0)
+                    num_generations = int(ctx.find_item("num_generations") or 0)
                     text = [
                         "".join([chunk["text"] for chunk in streamed_body[:-1] if chunk["index"] == i])
                         for i in range(num_generations)

--- a/ddtrace/contrib/internal/botocore/services/stepfunctions.py
+++ b/ddtrace/contrib/internal/botocore/services/stepfunctions.py
@@ -36,7 +36,7 @@ def update_stepfunction_input(ctx: core.ExecutionContext, params: Any) -> None:
 
     input_obj["_datadog"] = {}
     core.dispatch("botocore.stepfunctions.update_input", [ctx, None, None, input_obj, None])
-    updated_input_obj = ctx.get_item(BOTOCORE_STEPFUNCTIONS_INPUT_KEY)
+    updated_input_obj = ctx.find_item(BOTOCORE_STEPFUNCTIONS_INPUT_KEY)
     if updated_input_obj:
         input_json_str = json.dumps(updated_input_obj)
         params["input"] = input_json_str

--- a/ddtrace/contrib/internal/celery/app.py
+++ b/ddtrace/contrib/internal/celery/app.py
@@ -126,13 +126,13 @@ def _traced_apply_async_function(integration_config, fn_name, resource_fn=None):
             except Exception:
                 # If an internal exception occurs, record the exception in the span,
                 # then raise the Celery error as usual
-                task_span = core.get_item("task_span")
+                task_span = core.find_item("task_span")
                 if task_span:
                     task_span.set_exc_info(*sys.exc_info())
 
                 raise
             finally:
-                task_span = core.get_item("task_span")
+                task_span = core.find_item("task_span")
                 if task_span:
                     log.debug(
                         "The after_task_publish signal was not called, so manually closing span: %r",

--- a/ddtrace/contrib/internal/subprocess/patch.py
+++ b/ddtrace/contrib/internal/subprocess/patch.py
@@ -599,15 +599,15 @@ def _traced_subprocess_wait(module, pin, wrapped, instance, args, kwargs):
         the span with execution results and exit code.
     """
     if should_trace_subprocess():
-        binary = core.get_item("subprocess_popen_binary")
+        binary = core.find_item("subprocess_popen_binary")
 
         with pin.tracer.trace(COMMANDS.SPAN_NAME, resource=binary, span_type=SpanTypes.SYSTEM) as span:
-            if core.get_item(COMMANDS.CTX_SUBP_IS_SHELL):
-                span.set_tag_str(COMMANDS.SHELL, core.get_item(COMMANDS.CTX_SUBP_LINE))
+            if core.find_item(COMMANDS.CTX_SUBP_IS_SHELL):
+                span.set_tag_str(COMMANDS.SHELL, core.find_item(COMMANDS.CTX_SUBP_LINE))
             else:
-                span.set_tag(COMMANDS.EXEC, core.get_item(COMMANDS.CTX_SUBP_LINE))
+                span.set_tag(COMMANDS.EXEC, core.find_item(COMMANDS.CTX_SUBP_LINE))
 
-            truncated = core.get_item(COMMANDS.CTX_SUBP_TRUNCATED)
+            truncated = core.find_item(COMMANDS.CTX_SUBP_TRUNCATED)
             if truncated:
                 span.set_tag_str(COMMANDS.TRUNCATED, "yes")
             span.set_tag_str(COMMANDS.COMPONENT, "subprocess")

--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -455,7 +455,7 @@ def set_http_meta(
         # https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2118779066/Client+IP+addresses+resolution
         if asm_config._asm_enabled or config._retrieve_client_ip:
             # Retrieve the IP if it was calculated on AppSecProcessor.on_span_start
-            request_ip = core.get_item("http.request.remote_ip")
+            request_ip = core.find_item("http.request.remote_ip")
 
             if not request_ip:
                 # Not calculated: framework does not support IP blocking or testing env

--- a/ddtrace/contrib/internal/wsgi/wsgi.py
+++ b/ddtrace/contrib/internal/wsgi/wsgi.py
@@ -137,7 +137,7 @@ class _DDWSGIMiddlewareBase(object):
             if not_blocked:
                 core.dispatch("wsgi.request.prepare", (ctx, start_response))
                 try:
-                    closing_iterable = self.app(environ, ctx.get_item("intercept_start_response"))
+                    closing_iterable = self.app(environ, ctx.find_item("intercept_start_response"))
                 except BlockingException as e:
                     set_blocked(e.args[0])
                     content, status, headers = blocked_view()

--- a/ddtrace/internal/core/__init__.py
+++ b/ddtrace/internal/core/__init__.py
@@ -189,7 +189,8 @@ class ExecutionContext(object):
             else any(issubclass(exc_type, exc_type_) for exc_type_ in self._suppress_exceptions)
         )
 
-    def get_item(self, data_key: str, default: Optional[Any] = None) -> Any:
+    def find_item(self, data_key: str, default: Optional[Any] = None) -> Any:
+        """Traverse up the context tree to find the first occurrence of `data_key`."""
         # NB mimic the behavior of `ddtrace.internal._context` by doing lazy inheritance
         current: Optional[ExecutionContext] = self
         while current is not None:
@@ -199,16 +200,23 @@ class ExecutionContext(object):
             current = current._parent
         return default
 
-    def get_local_item(self, data_key: str, default: Optional[Any] = None) -> Any:
+    def get_item(self, data_key: str, default: Optional[Any] = None) -> Any:
+        """Get an item from the local context only, without traversing up the context tree."""
         return self._data.get(data_key, default)
 
     def __getitem__(self, key: str):
-        value = self.get_item(key)
+        """Get an item from the context, traversing up the context tree. Raises KeyError if not found."""
+        value = self.find_item(key)
         if value is None and key not in self._data:
             raise KeyError
         return value
 
+    def find_items(self, data_keys: List[str]) -> List[Optional[Any]]:
+        """Find multiple items by their keys, traversing up the context tree for each key."""
+        return [self.find_item(key) for key in data_keys]
+
     def get_items(self, data_keys: List[str]) -> List[Optional[Any]]:
+        """Return multiple items by their keys, only in the local context."""
         return [self.get_item(key) for key in data_keys]
 
     def set_item(self, data_key: str, data_value: Optional[Any]) -> None:
@@ -224,6 +232,7 @@ class ExecutionContext(object):
             self.set_item(data_key, data_value)
 
     def discard_item(self, data_key: str) -> None:
+        """Traverse up the context tree to find and delete the first occurrence of `data_key`."""
         # NB mimic the behavior of `ddtrace.internal._context` by doing lazy inheritance
         current: Optional[ExecutionContext] = self
         while current is not None:
@@ -233,6 +242,7 @@ class ExecutionContext(object):
             current = current._parent
 
     def discard_local_item(self, data_key: str) -> None:
+        """Delete an item from the local context only, without traversing up the context tree."""
         self._data.pop(data_key, None)
 
     def root(self):
@@ -283,15 +293,23 @@ def add_suppress_exception(exc_type: type) -> None:
     _CURRENT_CONTEXT.get()._suppress_exceptions.append(exc_type)
 
 
+def find_item(data_key: str, default: Optional[Any] = None) -> Any:
+    """Find an item by its key, traversing up the context tree."""
+    return _CURRENT_CONTEXT.get().find_item(data_key, default=default)
+
+
 def get_item(data_key: str, default: Optional[Any] = None) -> Any:
+    """Get an item from the local context only, without traversing up the context tree."""
     return _CURRENT_CONTEXT.get().get_item(data_key, default=default)
 
 
-def get_local_item(data_key: str, default: Optional[Any] = None) -> Any:
-    return _CURRENT_CONTEXT.get().get_local_item(data_key, default=default)
+def find_items(data_keys: List[str]) -> List[Optional[Any]]:
+    """Find multiple items by their keys, traversing up the context tree for each key."""
+    return _CURRENT_CONTEXT.get().find_items(data_keys)
 
 
 def get_items(data_keys: List[str]) -> List[Optional[Any]]:
+    """Return multiple items by their keys, only in the local context."""
     return _CURRENT_CONTEXT.get().get_items(data_keys)
 
 
@@ -309,10 +327,12 @@ def set_items(keys_values: Dict[str, Optional[Any]]) -> None:
 
 
 def discard_item(data_key: str) -> None:
+    """Traverse up the context tree to find and delete the first occurrence of `data_key`."""
     _CURRENT_CONTEXT.get().discard_item(data_key)
 
 
 def discard_local_item(data_key: str) -> None:
+    """Delete an item from the local context only, without traversing up the context tree."""
     _CURRENT_CONTEXT.get().discard_local_item(data_key)
 
 

--- a/ddtrace/internal/datastreams/kafka.py
+++ b/ddtrace/internal/datastreams/kafka.py
@@ -25,8 +25,8 @@ log = get_logger(__name__)
 def dsm_kafka_message_produce(instance, args, kwargs, is_serializing, span):
     from . import data_streams_processor as processor
 
-    topic = core.get_item("kafka_topic")
-    cluster_id = core.get_item("kafka_cluster_id")
+    topic = core.find_item("kafka_topic")
+    cluster_id = core.find_item("kafka_cluster_id")
     message = get_argument_value(args, kwargs, MESSAGE_ARG_POSITION, "value", optional=True)
     key = get_argument_value(args, kwargs, KEY_ARG_POSITION, KEY_KWARG_NAME, optional=True)
     headers = kwargs.get("headers", {})
@@ -81,8 +81,8 @@ def dsm_kafka_message_consume(instance, message, span):
     from . import data_streams_processor as processor
 
     headers = {header[0]: header[1] for header in (message.headers() or [])}
-    topic = core.get_item("kafka_topic")
-    cluster_id = core.get_item("kafka_cluster_id")
+    topic = core.find_item("kafka_topic")
+    cluster_id = core.find_item("kafka_cluster_id")
     group = instance._group_id
 
     payload_size = 0

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -385,7 +385,7 @@ class BedrockIntegration(BaseLLMIntegration):
         return str(endpoint_host) if endpoint_host else None
 
     def _tag_proxy_request(self, ctx: core.ExecutionContext) -> None:
-        base_url = self._get_base_url(instance=ctx.get_item("instance"))
+        base_url = self._get_base_url(instance=ctx.find_item("instance"))
         if self._is_instrumented_proxy_url(base_url):
             ctx.set_item(PROXY_REQUEST, True)
 

--- a/ddtrace/settings/asm.py
+++ b/ddtrace/settings/asm.py
@@ -316,7 +316,7 @@ class ASMConfig(DDConfig):
 
     @property
     def is_iast_request_enabled(self) -> bool:
-        env = core.get_item(IAST.REQUEST_CONTEXT_KEY)
+        env = core.find_item(IAST.REQUEST_CONTEXT_KEY)
         if env:
             return env.request_enabled
         return False

--- a/tests/appsec/appsec/test_processor.py
+++ b/tests/appsec/appsec/test_processor.py
@@ -664,14 +664,14 @@ def test_asm_context_registration(tracer):
 
     # For a web type span, a context manager is added, but then removed
     with asm_context(tracer=tracer, config=config_asm) as span:
-        assert core.get_item(_ASM_CONTEXT) is not None
-    assert core.get_item(_ASM_CONTEXT) is None
+        assert core.find_item(_ASM_CONTEXT) is not None
+    assert core.find_item(_ASM_CONTEXT) is None
 
     # Regression test, if the span type changes after being created, we always removed
     with asm_context(tracer=tracer, config=config_asm) as span:
         span.span_type = SpanTypes.HTTP
-        assert core.get_item(_ASM_CONTEXT) is not None
-    assert core.get_item(_ASM_CONTEXT) is None
+        assert core.find_item(_ASM_CONTEXT) is not None
+    assert core.find_item(_ASM_CONTEXT) is None
 
 
 CUSTOM_RULE_METHOD = [
@@ -799,7 +799,7 @@ def test_lambda_unsupported_event(tracer, skip_event):
     if skip_event:
         # When skip_event is True, the metric should be set and context item should be discarded
         assert span.get_metric(APPSEC.UNSUPPORTED_EVENT_TYPE) == 1.0
-        assert core.get_item("appsec_skip_next_lambda_event") is None
+        assert core.find_item("appsec_skip_next_lambda_event") is None
     else:
         # When skip_event is False, the metric should not be set
         assert span.get_metric(APPSEC.UNSUPPORTED_EVENT_TYPE) is None

--- a/tests/contrib/subprocess/test_subprocess.py
+++ b/tests/contrib/subprocess/test_subprocess.py
@@ -485,9 +485,9 @@ def test_subprocess_wait_shell_false(tracer, config):
             subp = subprocess.Popen(args=args, shell=False)
             subp.wait()
 
-            assert not core.get_item(COMMANDS.CTX_SUBP_IS_SHELL)
-            assert not core.get_item(COMMANDS.CTX_SUBP_TRUNCATED)
-            assert core.get_item(COMMANDS.CTX_SUBP_LINE) == args
+            assert not core.find_item(COMMANDS.CTX_SUBP_IS_SHELL)
+            assert not core.find_item(COMMANDS.CTX_SUBP_TRUNCATED)
+            assert core.find_item(COMMANDS.CTX_SUBP_LINE) == args
 
 
 @pytest.mark.parametrize("config", PATCH_ENABLED_CONFIGURATIONS)
@@ -499,7 +499,7 @@ def test_subprocess_wait_shell_true(tracer, config):
             subp = subprocess.Popen(args=["dir", "-li", "/"], shell=True)
             subp.wait()
 
-            assert core.get_item(COMMANDS.CTX_SUBP_IS_SHELL)
+            assert core.find_item(COMMANDS.CTX_SUBP_IS_SHELL)
 
 
 @pytest.mark.parametrize("config", PATCH_ENABLED_CONFIGURATIONS)


### PR DESCRIPTION
#14404 helped show that people should be clear/intentional over which core API is used for getting items off of an `ExecutionContext`.

This PR aims to rename and update doc strings to try and clarify further what will happen when the function is called.

- `get_item` -> `find_item`: since this API will traverse the context tree looking for the first value for the key. normally this adds the overhead of a loop instruction, but in general will return back quickly. The problem comes from cache misses where we traverse the whole tree just to return the default value.
- `get_local_item` -> `get_item`: make it so any new usage of `get_item` does the more correct thing by default
- `get_items` -> `find_items`: similar as `find_item`, making it more clear we iterate the whole context tree for each key



Main open question still is, what should `__getitem__` do? this one is harder to refactor without knowing 100% of all usages of `ctx["key"]` in the codebase, so we should handle as a follow-up since it might have higher impact. Opinion: we should remove the `__getitem__` API and force people to use `get_item` or `find_item` for clarity.. the overhead should be the same since they are all Python function calls.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
