### PR TITLE
fix(otel): disable log injection when otlp logs are used

### DIFF
--- a/ddtrace/internal/opentelemetry/logs.py
+++ b/ddtrace/internal/opentelemetry/logs.py
@@ -47,6 +47,8 @@ def set_otel_logs_provider() -> None:
     telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.TRACERS, "logging_provider_configured", 1, (("type", "dd"),))
     global DD_LOGS_PROVIDER_CONFIGURED
     DD_LOGS_PROVIDER_CONFIGURED = True
+    # Disable log injection to prevent duplicate log attributes from being sent.
+    config._logs_injection = False
 
 
 def _should_configure_logs_exporter() -> bool:

--- a/releasenotes/notes/disable-log-injection-on-otlp-logs-deefa7c4d68c08de.yaml
+++ b/releasenotes/notes/disable-log-injection-on-otlp-logs-deefa7c4d68c08de.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    fix: Ensures that ddtrace log injection is disabled when OpenTelemetry logs are enabled (DD_LOGS_OTEL_ENABLED=true).


### PR DESCRIPTION
## Changes
- Set config._logs_injection = False in set_otel_logs_provider() to prevent duplicate log attributes
- Added test test_ddtrace_log_injection_otlp_enabled() to verify log injection is properly disabled
- Test covers both DD_LOGS_INJECTION=None and DD_LOGS_INJECTION=true scenarios

## Motivation
- Prevents duplicate log correlation attributes when both ddtrace and OpenTelemetry logs are active
- Ensures clean, non-redundant log data is sent to OpenTelemetry endpoints
- Maintains consistent behavior regardless of ddtrace log injection configuration
- Provides test coverage to verify the log injection disabling behavior works correctly

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
