### PR TITLE
chore(crashtracking): emit error output to stderr instead of stdout

### DIFF
--- a/ddtrace/internal/core/crashtracking.py
+++ b/ddtrace/internal/core/crashtracking.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import shutil
+import sys
 from typing import Dict
 from typing import Optional
 
@@ -87,7 +88,7 @@ def _get_args(additional_tags: Optional[Dict[str, str]]):
             dd_crashtracker_receiver = script_path
 
     if dd_crashtracker_receiver is None:
-        print("Failed to find _dd_crashtracker_receiver")
+        print("Failed to find _dd_crashtracker_receiver", file=sys.stderr)
         return (None, None, None)
 
     if crashtracker_config.stacktrace_resolver is None:
@@ -101,7 +102,7 @@ def _get_args(additional_tags: Optional[Dict[str, str]]):
     else:
         # This should never happen, as the value is validated in the crashtracker_config
         # module.
-        print(f"Invalid stacktrace_resolver value: {crashtracker_config.stacktrace_resolver}")
+        print(f"Invalid stacktrace_resolver value: {crashtracker_config.stacktrace_resolver}", file=sys.stderr)
         stacktrace_resolver = StacktraceCollection.EnabledWithInprocessSymbols
 
     # Create crashtracker configuration
@@ -146,7 +147,7 @@ def start(additional_tags: Optional[Dict[str, str]] = None) -> bool:
     try:
         config, receiver_config, metadata = _get_args(additional_tags)
         if config is None or receiver_config is None or metadata is None:
-            print("Failed to start crashtracker: failed to construct crashtracker configuration")
+            print("Failed to start crashtracker: failed to construct crashtracker configuration", file=sys.stderr)
             return False
 
         crashtracker_init(config, receiver_config, metadata)
@@ -156,12 +157,15 @@ def start(additional_tags: Optional[Dict[str, str]] = None) -> bool:
             # fork
             config, receiver_config, metadata = _get_args(additional_tags)
             if config is None or receiver_config is None or metadata is None:
-                print("Failed to restart crashtracker after fork: failed to construct crashtracker configuration")
+                print(
+                    "Failed to restart crashtracker after fork: failed to construct crashtracker configuration",
+                    file=sys.stderr,
+                )
                 return
             crashtracker_on_fork(config, receiver_config, metadata)
 
         forksafe.register(crashtracker_fork_handler)
     except Exception as e:
-        print(f"Failed to start crashtracker: {e}")
+        print(f"Failed to start crashtracker: {e}", file=sys.stderr)
         return False
     return True


### PR DESCRIPTION
We should emit output of errors to stderr, not stdout. This change updates all error prints to be directed to stderr in `ddtrace/internal/core/crashtracking.py`.

Ticker: [LINK](https://datadoghq.atlassian.net/jira/software/c/projects/PROF/boards/11?selectedIssue=PROF-12391)

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
