### PR TITLE
chore(profiling): move events.py definitions into _memalloc.pyi file

### DIFF
--- a/ddtrace/profiling/collector/_memalloc.pyi
+++ b/ddtrace/profiling/collector/_memalloc.pyi
@@ -1,13 +1,12 @@
 import typing
+from collections import namedtuple
 
-from .. import event
-
-# (filename, line number, function name)
-FrameType = event.DDFrame
-StackType = event.StackTraceType
+# (filename, line number, function name, class name)
+DDFrame = namedtuple("DDFrame", ["file_name", "lineno", "function_name", "class_name"])
+StackTraceType = typing.List[DDFrame]
 
 # (stack, thread_id)
-TracebackType = typing.Tuple[StackType, int]
+TracebackType = typing.Tuple[StackTraceType, int]
 
 def start(max_nframe: int, heap_sample_interval: int) -> None: ...
 def stop() -> None: ...

--- a/ddtrace/profiling/event.py
+++ b/ddtrace/profiling/event.py
@@ -1,6 +1,0 @@
-from collections import namedtuple
-import typing
-
-
-DDFrame = namedtuple("DDFrame", ["file_name", "lineno", "function_name", "class_name"])
-StackTraceType = typing.List[DDFrame]


### PR DESCRIPTION
The type definitions in `events.py` are only used in `_memalloc.pyi`. This PR moves the definitions into the only file that uses it.

ticket: [LINK](https://datadoghq.atlassian.net/jira/software/c/projects/PROF/boards/11?selectedIssue=PROF-12237)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
