### PR TITLE
ci: use prebuilt wheels in system-tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -17,7 +17,8 @@ jobs:
       cibw_build: 'cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp313-manylinux_x86_64'
 
   system-tests-build-weblog:
-    needs: [build-wheels]
+    needs:
+      - build-wheels
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -264,7 +264,8 @@ jobs:
 
 
   parametric:
-    needs: [build-wheels]
+    needs:
+      - build-wheels
     runs-on: ubuntu-latest
     env:
       TEST_LIBRARY: python

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'fef0bc7c0ba5f74babbb1ac3419291dbd4b65e5e'
+          ref: 'd23bd68a15bca6d6c748edbeb1ed3fe3eed7ced1'
 
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -93,7 +93,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'fef0bc7c0ba5f74babbb1ac3419291dbd4b65e5e'
+          ref: 'd23bd68a15bca6d6c748edbeb1ed3fe3eed7ced1'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -277,7 +277,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'fef0bc7c0ba5f74babbb1ac3419291dbd4b65e5e'
+          ref: 'd23bd68a15bca6d6c748edbeb1ed3fe3eed7ced1'
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -11,7 +11,13 @@ on:
     - cron: '00 04 * * 2-6'
 
 jobs:
+  build-wheels:
+    uses: ./.github/workflows/build_python_3.yml
+    with:
+      cibw_build: 'cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp313-manylinux_x86_64'
+
   system-tests-build-weblog:
+    needs: [build-wheels]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -42,15 +48,12 @@ jobs:
           # Automatically managed, use scripts/update-system-tests-version to update
           ref: 'fef0bc7c0ba5f74babbb1ac3419291dbd4b65e5e'
 
-      - name: Checkout dd-trace-py
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Download wheels to binaries directory
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          persist-credentials: false
-          path: 'binaries/dd-trace-py'
-          fetch-depth: 0
-          # NB this ref is necessary to keep the checkout out of detached HEAD state, which setuptools_scm requires for
-          # proper version guessing
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          pattern: wheels-*
+          path: binaries/
+          merge-multiple: true
 
       - name: Build
         run: ./build.sh -i weblog
@@ -260,6 +263,7 @@ jobs:
 
 
   parametric:
+    needs: [build-wheels]
     runs-on: ubuntu-latest
     env:
       TEST_LIBRARY: python
@@ -274,13 +278,12 @@ jobs:
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
           ref: 'fef0bc7c0ba5f74babbb1ac3419291dbd4b65e5e'
-      - name: Checkout dd-trace-py
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Download wheels to binaries directory
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          persist-credentials: false
-          path: 'binaries/dd-trace-py'
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          pattern: wheels-*
+          path: binaries/
+          merge-multiple: true
 
       - name: Build runner
         id: build_runner

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "fef0bc7c0ba5f74babbb1ac3419291dbd4b65e5e"
+  SYSTEM_TESTS_REF: "d23bd68a15bca6d6c748edbeb1ed3fe3eed7ced1"
 
 default:
   interruptible: true


### PR DESCRIPTION
## Overview

  Optimizes the system tests CI workflow by building wheels once and reusing them across jobs instead of checking out and building from source multiple times.

## Motivation

  The current system tests workflow checks out the dd-trace-py repository and builds from source in each job, leading to:
  - Redundant build time across multiple jobs
  - Increased CI resource usage
  - Longer overall workflow execution time
  - Build dependencies required in system-tests

This change centralizes wheel building in a dedicated job and distributes the pre-built wheels to consuming jobs, eliminating the need for build dependencies in system test runners.

## Changes

  - Created a new build-wheels job that calls the existing build_python_3.yml reusable workflow
  - Replaced "Checkout dd-trace-py" steps with "Download wheels to binaries directory" in both system-tests-build-weblog and parametric jobs
  - Added job dependencies to ensure wheels are built before being consumed

## Testing Strategy

Only ci changes. Tested by running the system tests workflow to completion.

## Risks

  - Low risk: If wheel building fails, all dependent jobs will fail fast rather than building individually
  - Mitigation: The reusable workflow build_python_3.yml is already proven and used in other workflows

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
