### PR TITLE
fix(asyncpg): fix _TracedConnection error when using the connect option in create_pool [backport 3.12]

### DIFF
--- a/releasenotes/notes/fix-asyncpg-pool-error-97a58b63370428bc.yaml
+++ b/releasenotes/notes/fix-asyncpg-pool-error-97a58b63370428bc.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    asyncpg: Fix the error "Error: expected pool connect callback to return an instance of 'asyncpg.connection.Connection', got 'ddtrace.contrib.internal.asyncpg.patch._TracedConnection'`" when a pool connection" due to using the custom connect option. With this fix, postgres.connect spans will be created when this option is used.

--- a/tests/contrib/asyncpg/test_asyncpg.py
+++ b/tests/contrib/asyncpg/test_asyncpg.py
@@ -8,6 +8,7 @@ import pytest
 from ddtrace.contrib.internal.asyncpg.patch import patch
 from ddtrace.contrib.internal.asyncpg.patch import unpatch
 from ddtrace.contrib.internal.trace_utils import iswrapped
+from ddtrace.internal.utils.version import parse_version
 from ddtrace.trace import Pin
 from ddtrace.trace import tracer
 from tests.contrib.asyncio.utils import AsyncioTestCase

--- a/tests/contrib/asyncpg/test_asyncpg.py
+++ b/tests/contrib/asyncpg/test_asyncpg.py
@@ -315,6 +315,58 @@ asyncio.run(test())
     assert err == b""
 
 
+@pytest.mark.skipif(
+    parse_version(getattr(asyncpg, "__version__", "0.0.0")) < (0, 30, 0),
+    reason="the custom connect parameter for create_pool requires asyncpg >= 0.30.0",
+)
+@pytest.mark.snapshot()
+@pytest.mark.asyncio
+async def test_pool_custom_connect():
+    """
+    Test that if someone uses a custom connect parameter when creating a pool,
+    the tracer doesn't cause a _TracedConnection error or throw any other errors
+    The connect option was introduced in 0.30.0
+    """
+    database_url = f"postgresql://{POSTGRES_CONFIG['user']}:{POSTGRES_CONFIG['password']}@{POSTGRES_CONFIG['host']}:{POSTGRES_CONFIG['port']}/{POSTGRES_CONFIG['dbname']}"
+
+    try:
+        # The default is 10 connection pools so the integration will create 10 spans in the snapshot
+        pool = await asyncpg.create_pool(database_url, connect=asyncpg.connect)
+
+        async with pool.acquire() as conn:
+            result = await conn.fetchval("SELECT 1")
+            assert result == 1
+
+        await pool.close()
+    except Exception as err:
+        raise err
+
+    assert True
+
+
+@pytest.mark.snapshot()
+@pytest.mark.asyncio
+async def test_pool_without_custom_connect():
+    """
+    Test that create_pool without the connect option still works
+    """
+    database_url = f"postgresql://{POSTGRES_CONFIG['user']}:{POSTGRES_CONFIG['password']}@{POSTGRES_CONFIG['host']}:{POSTGRES_CONFIG['port']}/{POSTGRES_CONFIG['dbname']}"
+
+    try:
+        # The default is 10 connection pools so the integration will create 10 spans in the snapshot
+        pool = await asyncpg.create_pool(database_url)
+
+        async with pool.acquire() as conn:
+            result = await conn.fetchval("SELECT 1")
+            assert result == 1
+
+        await pool.close()
+    except Exception as err:
+        raise err
+
+    assert True
+
+
 def test_patch_unpatch_asyncpg():
     assert iswrapped(asyncpg.connect)
     assert iswrapped(asyncpg.protocol.Protocol.execute)

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_pool_custom_connect.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_pool_custom_connect.json
@@ -1,0 +1,410 @@
+[[
+  {
+    "name": "postgres.connect",
+    "service": "postgres",
+    "resource": "postgres.connect",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.contrib.asyncpg",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "68af8e8000000000",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "1088e237bc7b4db9bc3e60089add41e3",
+      "server.address": "127.0.0.1",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 1361
+    },
+    "duration": 2679833,
+    "start": 1756335744581279013
+  }],
+[
+  {
+    "name": "postgres.connect",
+    "service": "postgres",
+    "resource": "postgres.connect",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.contrib.asyncpg",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "68af8e8000000000",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "1088e237bc7b4db9bc3e60089add41e3",
+      "server.address": "127.0.0.1",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 1361
+    },
+    "duration": 5201375,
+    "start": 1756335744587173346
+  }],
+[
+  {
+    "name": "postgres.connect",
+    "service": "postgres",
+    "resource": "postgres.connect",
+    "trace_id": 2,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.contrib.asyncpg",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "68af8e8000000000",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "1088e237bc7b4db9bc3e60089add41e3",
+      "server.address": "127.0.0.1",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 1361
+    },
+    "duration": 8095083,
+    "start": 1756335744584452263
+  }],
+[
+  {
+    "name": "postgres.connect",
+    "service": "postgres",
+    "resource": "postgres.connect",
+    "trace_id": 3,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.contrib.asyncpg",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "68af8e8000000000",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "1088e237bc7b4db9bc3e60089add41e3",
+      "server.address": "127.0.0.1",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 1361
+    },
+    "duration": 6094083,
+    "start": 1756335744586555263
+  }],
+[
+  {
+    "name": "postgres.connect",
+    "service": "postgres",
+    "resource": "postgres.connect",
+    "trace_id": 4,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.contrib.asyncpg",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "68af8e8000000000",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "1088e237bc7b4db9bc3e60089add41e3",
+      "server.address": "127.0.0.1",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 1361
+    },
+    "duration": 6859333,
+    "start": 1756335744585880763
+  }],
+[
+  {
+    "name": "postgres.connect",
+    "service": "postgres",
+    "resource": "postgres.connect",
+    "trace_id": 5,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.contrib.asyncpg",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "68af8e8000000000",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "1088e237bc7b4db9bc3e60089add41e3",
+      "server.address": "127.0.0.1",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 1361
+    },
+    "duration": 7701167,
+    "start": 1756335744585127971
+  }],
+[
+  {
+    "name": "postgres.connect",
+    "service": "postgres",
+    "resource": "postgres.connect",
+    "trace_id": 6,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.contrib.asyncpg",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "68af8e8000000000",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "1088e237bc7b4db9bc3e60089add41e3",
+      "server.address": "127.0.0.1",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 1361
+    },
+    "duration": 3808375,
+    "start": 1756335744589154179
+  }],
+[
+  {
+    "name": "postgres.connect",
+    "service": "postgres",
+    "resource": "postgres.connect",
+    "trace_id": 7,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.contrib.asyncpg",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "68af8e8000000000",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "1088e237bc7b4db9bc3e60089add41e3",
+      "server.address": "127.0.0.1",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 1361
+    },
+    "duration": 3187292,
+    "start": 1756335744589863846
+  }],
+[
+  {
+    "name": "postgres.connect",
+    "service": "postgres",
+    "resource": "postgres.connect",
+    "trace_id": 8,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.contrib.asyncpg",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "68af8e8000000000",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "1088e237bc7b4db9bc3e60089add41e3",
+      "server.address": "127.0.0.1",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 1361
+    },
+    "duration": 5375250,
+    "start": 1756335744587778263
+  }],
+[
+  {
+    "name": "postgres.connect",
+    "service": "postgres",
+    "resource": "postgres.connect",
+    "trace_id": 9,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.contrib.asyncpg",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "68af8e8000000000",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "1088e237bc7b4db9bc3e60089add41e3",
+      "server.address": "127.0.0.1",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 1361
+    },
+    "duration": 5549292,
+    "start": 1756335744588465179
+  }],
+[
+  {
+    "name": "postgres.query",
+    "service": "postgres",
+    "resource": "SELECT 1",
+    "trace_id": 10,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.contrib.asyncpg",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "68af8e8000000000",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "1088e237bc7b4db9bc3e60089add41e3",
+      "server.address": "127.0.0.1",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 1361
+    },
+    "duration": 162250,
+    "start": 1756335744594572263
+  }],
+[
+  {
+    "name": "postgres.query",
+    "service": "postgres",
+    "resource": "SELECT pg_advisory_unlock_all();\nCLOSE ALL;\nUNLISTEN *;\nRESET ALL;",
+    "trace_id": 11,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.contrib.asyncpg",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "68af8e8000000000",
+      "component": "asyncpg",
+      "db.name": "postgres",
+      "db.system": "postgresql",
+      "db.user": "postgres",
+      "language": "python",
+      "out.host": "127.0.0.1",
+      "runtime-id": "1088e237bc7b4db9bc3e60089add41e3",
+      "server.address": "127.0.0.1",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "network.destination.port": 5432,
+      "process_id": 1361
+    },
+    "duration": 151875,
+    "start": 1756335744594905179
+  }]]

--- a/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_pool_without_custom_connect.json
+++ b/tests/snapshots/tests.contrib.asyncpg.test_asyncpg.test_pool_without_custom_connect.json
@@ -1,0 +1,60 @@
+[[
+  {
+    "name": "postgres.query",
+    "service": "postgres",
+    "resource": "SELECT 1",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.contrib.asyncpg",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "68b05c4c00000000",
+      "component": "asyncpg",
+      "db.system": "postgresql",
+      "language": "python",
+      "runtime-id": "affe257e588347a08dc9aba7c5237c9f",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 5029
+    },
+    "duration": 225917,
+    "start": 1756388428735309501
+  }],
+[
+  {
+    "name": "postgres.query",
+    "service": "postgres",
+    "resource": "SELECT pg_advisory_unlock_all();\nCLOSE ALL;\nUNLISTEN *;\nRESET ALL;",
+    "trace_id": 1,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "sql",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.contrib.asyncpg",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "68b05c4c00000000",
+      "component": "asyncpg",
+      "db.system": "postgresql",
+      "language": "python",
+      "runtime-id": "affe257e588347a08dc9aba7c5237c9f",
+      "span.kind": "client"
+    },
+    "metrics": {
+      "_dd.measured": 1,
+      "_dd.top_level": 1,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1,
+      "process_id": 5029
+    },
+    "duration": 152500,
+    "start": 1756388428735899668
+  }]]


### PR DESCRIPTION
Backports https://github.com/DataDog/dd-trace-py/pull/14436 to 3.12
## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
