### PR TITLE
chore(llmobs): make prompt type failure less noisy

### DIFF
--- a/ddtrace/llmobs/_integrations/langchain.py
+++ b/ddtrace/llmobs/_integrations/langchain.py
@@ -848,7 +848,7 @@ class LangChainIntegration(BaseLLMIntegration):
             template = instance.template
         variables = get_argument_value(args, kwargs, 0, "input", optional=True)
 
-        if not template or not variables:
+        if not template or not variables or not isinstance(variables, dict):
             return
 
         prompt_id = self._get_prompt_variable_name(instance)
@@ -888,4 +888,4 @@ class LangChainIntegration(BaseLLMIntegration):
                 prompt = validate_prompt(prompt)
                 span._set_ctx_item(INPUT_PROMPT, prompt)
             except Exception as e:
-                log.warning("Failed to validate langchain prompt", e)
+                log.debug("Failed to validate langchain prompt", e)


### PR DESCRIPTION
In this first version, we only allow a small subset of prompt template types. Right now, valid templates that we don't support are logging a warning, which seems very noisy. I've stopped logging on more cases we know we don't support, and dropped the log from warning to debug for the rest.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
