### PR TITLE
fix: guard against potential pkg_resources race

### DIFF
--- a/releasenotes/notes/fix-pkg_resources-race-9e50201791f4cb98.yaml
+++ b/releasenotes/notes/fix-pkg_resources-race-9e50201791f4cb98.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed an issue that could have caused some products to fail to start
+    properly in applications that use ``pkg_resources``, either directly or
+    indirectly.


### PR DESCRIPTION
We handle a potential race condition with the import of pkg_resources that can happen when a module watchdog is enabled while the import of said module is in progress.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
