### PR TITLE
perf: reduce calls to Path.resolve

### DIFF
--- a/ddtrace/internal/module.py
+++ b/ddtrace/internal/module.py
@@ -111,21 +111,33 @@ def unregister_post_run_module_hook(hook: ModuleHookType) -> None:
 def origin(module: ModuleType) -> t.Optional[Path]:
     """Get the origin source file of the module."""
     try:
-        # DEV: Use object.__getattribute__ to avoid potential side-effects.
-        orig = Path(object.__getattribute__(module, "__file__")).resolve()
-    except (AttributeError, TypeError):
-        # Module is probably only partially initialised, so we look at its
-        # spec instead
+        return module.__dd_origin__
+    except AttributeError:
         try:
             # DEV: Use object.__getattribute__ to avoid potential side-effects.
-            orig = Path(object.__getattribute__(module, "__spec__").origin).resolve()
-        except (AttributeError, ValueError, TypeError):
-            orig = None
+            orig = Path(object.__getattribute__(module, "__file__"))
+            if not orig.is_absolute() or orig.is_symlink():
+                orig = orig.resolve()
+        except (AttributeError, TypeError):
+            # Module is probably only partially initialised, so we look at its
+            # spec instead
+            try:
+                # DEV: Use object.__getattribute__ to avoid potential side-effects.
+                orig = Path(object.__getattribute__(module, "__spec__").origin)
+                if not orig.is_absolute() or orig.is_symlink():
+                    orig = orig.resolve()
+            except (AttributeError, ValueError, TypeError):
+                orig = None
 
-    if orig is not None and orig.is_file():
-        return orig.with_suffix(".py") if orig.suffix == ".pyc" else orig
+        if orig is not None and orig.suffix == "pyc":
+            orig = orig.with_suffix(".py")
 
-    return None
+        try:
+            module.__dd_origin__ = orig  # type: ignore[attr-defined]
+        except AttributeError:
+            pass
+
+        return orig
 
 
 def _resolve(path: Path) -> t.Optional[Path]:


### PR DESCRIPTION
Calls to `Path.resolve` turn out to be quite expensive. We try to avoid them by checking whether a Path object actually needs to be resolved. In many cases, we just need to check whether the path is absolute or a link and then only resolve when necessary.

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
