### PR TITLE
fix(er): prioritize tb from exception object

### DIFF
--- a/releasenotes/notes/fix-er-tb-priority-77dc656bdb2c4802.yaml
+++ b/releasenotes/notes/fix-er-tb-priority-77dc656bdb2c4802.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    exception replay: fixed an issue that prevented snapshots from retrieving
+    local variables from traceback frames from exception thrown by Celery tasks.


### PR DESCRIPTION
We retrieve the traceback object from the exception object itself, if available and prioritize it over the traceback component of the exception info tuple. Some frameworks, such as Celery, might modify the exception info tuple by passing around a custom traceback object that might not have all the information required by Exception Replay.

## Testing Strategy

We tested that we can retrieve local variables in ER when Celery tasks throw exceptions with this change.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
