### PR TITLE
chore(llmobs): use upload endpoint for CSV's and large pushes

### DIFF
--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -101,6 +101,8 @@ class Dataset:
     _updated_record_ids_to_new_fields: Dict[str, UpdatableDatasetRecord]
     _deleted_record_ids: List[str]
 
+    BATCH_UPDATE_THRESHOLD = 5 * 1024 * 1024  # 5MB
+
     def __init__(
         self,
         name: str,
@@ -136,17 +138,24 @@ class Dataset:
                 )
             )
 
-        updated_records = list(self._updated_record_ids_to_new_fields.values())
-        new_version, new_record_ids = self._dne_client.dataset_batch_update(
-            self._id, list(self._new_records_by_record_id.values()), updated_records, self._deleted_record_ids
-        )
+        delta_size = self._estimate_delta_size()
+        if delta_size > self.BATCH_UPDATE_THRESHOLD:
+            logger.debug("dataset delta is %d, using bulk upload", delta_size)
+            # TODO must return version too
+            self._dne_client.dataset_bulk_upload(self._id, self)
+        else:
+            logger.debug("dataset delta is %d, using batch update", delta_size)
+            updated_records = list(self._updated_record_ids_to_new_fields.values())
+            new_version, new_record_ids = self._dne_client.dataset_batch_update(
+                self._id, list(self._new_records_by_record_id.values()), updated_records, self._deleted_record_ids
+            )
 
-        # attach record ids to newly created records
-        for record, record_id in zip(self._new_records_by_record_id.values(), new_record_ids):
-            record["record_id"] = record_id  # type: ignore
+            # attach record ids to newly created records
+            for record, record_id in zip(self._new_records_by_record_id.values(), new_record_ids):
+                record["record_id"] = record_id  # type: ignore
 
-        # FIXME: we don't get version numbers in responses to deletion requests
-        self._version = new_version if new_version != -1 else self._version + 1
+            # FIXME: we don't get version numbers in responses to deletion requests
+            self._version = new_version if new_version != -1 else self._version + 1
         self._new_records_by_record_id = {}
         self._deleted_record_ids = []
         self._updated_record_ids_to_new_fields = {}
@@ -198,6 +207,30 @@ class Dataset:
     def url(self) -> str:
         # FIXME: will not work for subdomain orgs
         return f"{_get_base_url()}/llm/datasets/{self._id}"
+
+    # very rough estimate of the size of the next batch update call if it happens, will likely overestimate
+    def _estimate_delta_size(self) -> int:
+        num_bytes = 0
+        for r_id, insert_rec in self._new_records_by_record_id.items():
+            num_bytes += (
+                len(r_id)
+                + sys.getsizeof(insert_rec.get("input_data", ""))
+                + sys.getsizeof(insert_rec.get("expected_output", ""))
+                + sys.getsizeof(insert_rec.get("metadata", ""))
+            )
+        for r_id, update_rec in self._updated_record_ids_to_new_fields.items():
+            num_bytes += (
+                len(r_id)
+                + sys.getsizeof(update_rec.get("input_data", ""))
+                + sys.getsizeof(update_rec.get("expected_output", ""))
+                + sys.getsizeof(update_rec.get("metadata", ""))
+            )
+        logger.debug(
+            "estimated size is %d, naive estimation is %d",
+            num_bytes,
+            sys.getsizeof(self._new_records_by_record_id) + sys.getsizeof(self._updated_record_ids_to_new_fields),
+        )
+        return num_bytes
 
     @overload
     def __getitem__(self, index: int) -> DatasetRecord:

--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -1,6 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
-import json
 import sys
 import traceback
 from typing import TYPE_CHECKING

--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -209,8 +209,8 @@ class Dataset:
         # FIXME: will not work for subdomain orgs
         return f"{_get_base_url()}/llm/datasets/{self._id}"
 
-    # rough estimate (in bytes) of the size of the next batch update call if it happens
     def _estimate_delta_size(self) -> int:
+        """rough estimate (in bytes) of the size of the next batch update call if it happens"""
         size = len(json.dumps(self._new_records_by_record_id)) + len(json.dumps(self._updated_record_ids_to_new_fields))
         logger.debug("estimated delta size %d", size)
         return size

--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -211,7 +211,7 @@ class Dataset:
 
     def _estimate_delta_size(self) -> int:
         """rough estimate (in bytes) of the size of the next batch update call if it happens"""
-        size = len(json.dumps(self._new_records_by_record_id)) + len(json.dumps(self._updated_record_ids_to_new_fields))
+        size = len(safe_json(self._new_records_by_record_id)) + len(safe_json(self._updated_record_ids_to_new_fields))
         logger.debug("estimated delta size %d", size)
         return size
 

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -720,7 +720,7 @@ class LLMObs(Service):
             csv.field_size_limit(original_field_size_limit)
 
         if len(ds) > 0:
-            cls._instance._dne_client.dataset_bulk_upload(ds._id, ds)
+            cls._instance._dne_client.dataset_bulk_upload(ds._id, ds._records)
         return ds
 
     @classmethod

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -720,7 +720,7 @@ class LLMObs(Service):
             csv.field_size_limit(original_field_size_limit)
 
         if len(ds) > 0:
-            ds.push()
+            cls._instance._dne_client.dataset_bulk_upload(ds._id, ds)
         return ds
 
     @classmethod

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -328,12 +328,9 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
     def multipart_request(self, method: str, path: str, content_type: str, body: bytes = b"") -> Response:
         headers = {
             "Content-Type": content_type,
-            # "Content-Type": "multipart/form-data", this one maybe?
             "DD-API-KEY": self._api_key,
             "DD-APPLICATION-KEY": self._app_key,
         }
-        if not self._agentless:
-            headers[EVP_SUBDOMAIN_HEADER_NAME] = self.EVP_SUBDOMAIN_HEADER_VALUE
 
         conn = get_connection(url=self._intake, timeout=self.BULK_UPLOAD_TIMEOUT)
         try:
@@ -472,7 +469,7 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
             )
         return Dataset(name, dataset_id, class_records, dataset_description, curr_version, _dne_client=self)
 
-    def dataset_bulk_upload(self, dataset_id: str, dataset: Dataset):
+    def dataset_bulk_upload(self, dataset_id: str, records: List[DatasetRecord]):
         with tempfile.NamedTemporaryFile(suffix=".csv") as tmp:
             file_name = os.path.basename(tmp.name)
             file_name_parts = file_name.rsplit(".", 1)
@@ -488,7 +485,7 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
                 field_names = ["input", "expected_output", "metadata"]
                 writer = csv.writer(csv_file)
                 writer.writerow(field_names)
-                for r in dataset._records:
+                for r in records:
                     writer.writerow(
                         [
                             json.dumps(r.get("input_data", "")),

--- a/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_7ebcf701-2bd3-42d4-9dbd-01bb1169e66f_records_upload_post_36936c02.yaml
+++ b/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_7ebcf701-2bd3-42d4-9dbd-01bb1169e66f_records_upload_post_36936c02.yaml
@@ -1,0 +1,49 @@
+interactions:
+- request:
+    body: "------------boundary------\r\nContent-Disposition: form-data; name=\"file\";
+      filename=\"tmp.csv\"\r\nContent-Type: text/csv\r\n\r\ninput,expected_output,metadata\r\n\"{\"\"in0\"\":
+      \"\"r0v1\"\", \"\"in1\"\": \"\"r0v2\"\", \"\"in2\"\": \"\"r0v3\"\"}\",\"{\"\"out0\"\":
+      \"\"r0v4\"\", \"\"out1\"\": \"\"r0v5\"\"}\",\"{\"\"m0\"\": \"\"r0v6\"\"}\"\r\n\"{\"\"in0\"\":
+      \"\"r1v1\"\", \"\"in1\"\": \"\"r1v2\"\", \"\"in2\"\": \"\"r1v3\"\"}\",\"{\"\"out0\"\":
+      \"\"r1v4\"\", \"\"out1\"\": \"\"r1v5\"\"}\",\"{\"\"m0\"\": \"\"r1v6\"\"}\"\r\n\r\n------------boundary--------\r\n"
+    headers:
+      Accept:
+      - '*/*'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept-Encoding
+      : - identity
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '433'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - multipart/form-data; boundary=----------boundary------
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://api.datadoghq.com/api/unstable/llm-obs/v1/datasets/7ebcf701-2bd3-42d4-9dbd-01bb1169e66f/records/upload
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.com
+      content-type:
+      - application/vnd.api+json
+      date:
+      - Tue, 02 Sep 2025 22:41:52 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_delete_post_0134f05d.yaml
+++ b/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_delete_post_0134f05d.yaml
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: '{"data": {"type": "datasets", "attributes": {"type": "soft", "dataset_ids":
+      ["ed2f83c9-dd94-41d7-ac2b-544bbdbb5584"]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept-Encoding
+      : - identity
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '119'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://api.datadoghq.com/api/unstable/llm-obs/v1/datasets/delete
+  response:
+    body:
+      string: '{"data":[{"id":"ed2f83c9-dd94-41d7-ac2b-544bbdbb5584","type":"datasets","attributes":{"author":{"id":"de473b30-eb9f-11e9-a77a-c7405862b8bd"},"created_at":"2025-09-03T23:16:13.87366Z","current_version":0,"deleted_at":"2025-09-03T23:16:14.119761Z","description":"A
+        test dataset","name":"test-dataset-test_dataset_estimate_size","updated_at":"2025-09-03T23:16:13.87366Z"}}]}'
+    headers:
+      content-length:
+      - '371'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.com
+      content-type:
+      - application/vnd.api+json
+      date:
+      - Wed, 03 Sep 2025 23:16:14 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_e03e6dcc-1a71-49ed-82b0-0042d0f7e117_records_upload_post_1d3054f1.yaml
+++ b/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_e03e6dcc-1a71-49ed-82b0-0042d0f7e117_records_upload_post_1d3054f1.yaml
@@ -1,0 +1,49 @@
+interactions:
+- request:
+    body: "------------boundary------\r\nContent-Disposition: form-data; name=\"file\";
+      filename=\"tmp.csv\"\r\nContent-Type: text/csv\r\n\r\ninput,expected_output,metadata\r\n\"{\"\"in0\"\":
+      \"\"r0v1\"\", \"\"in1\"\": \"\"r0v2\"\", \"\"in2\"\": \"\"r0v3\"\"}\",\"{\"\"out0\"\":
+      \"\"r0v4\"\", \"\"out1\"\": \"\"r0v5\"\"}\",{}\r\n\"{\"\"in0\"\": \"\"r1v1\"\",
+      \"\"in1\"\": \"\"r1v2\"\", \"\"in2\"\": \"\"r1v3\"\"}\",\"{\"\"out0\"\": \"\"r1v4\"\",
+      \"\"out1\"\": \"\"r1v5\"\"}\",{}\r\n\r\n------------boundary--------\r\n"
+    headers:
+      Accept:
+      - '*/*'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept-Encoding
+      : - identity
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '397'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - multipart/form-data; boundary=----------boundary------
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://api.datadoghq.com/api/unstable/llm-obs/v1/datasets/e03e6dcc-1a71-49ed-82b0-0042d0f7e117/records/upload
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.com
+      content-type:
+      - application/vnd.api+json
+      date:
+      - Tue, 02 Sep 2025 22:41:49 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_e03e6dcc-1a71-49ed-82b0-0042d0f7e117_records_upload_post_ca121309.yaml
+++ b/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_e03e6dcc-1a71-49ed-82b0-0042d0f7e117_records_upload_post_ca121309.yaml
@@ -1,0 +1,49 @@
+interactions:
+- request:
+    body: "------------boundary------\r\nContent-Disposition: form-data; name=\"file\";
+      filename=\"tmp.csv\"\r\nContent-Type: text/csv\r\n\r\ninput,expected_output,metadata\r\n\"{\"\"in0\"\":
+      \"\"r0v1\"\", \"\"in1\"\": \"\"r0v2\"\", \"\"in2\"\": \"\"r0v3\"\"}\",\"{\"\"out0\"\":
+      \"\"r0v4\"\", \"\"out1\"\": \"\"r0v5\"\"}\",\"{\"\"m0\"\": \"\"r0v6\"\"}\"\r\n\"{\"\"in0\"\":
+      \"\"r1v1\"\", \"\"in1\"\": \"\"r1v2\"\", \"\"in2\"\": \"\"r1v3\"\"}\",\"{\"\"out0\"\":
+      \"\"r1v4\"\", \"\"out1\"\": \"\"r1v5\"\"}\",\"{\"\"m0\"\": \"\"r1v6\"\"}\"\r\n\r\n------------boundary--------\r\n"
+    headers:
+      Accept:
+      - '*/*'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept-Encoding
+      : - identity
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '433'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - multipart/form-data; boundary=----------boundary------
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://api.datadoghq.com/api/unstable/llm-obs/v1/datasets/e03e6dcc-1a71-49ed-82b0-0042d0f7e117/records/upload
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.com
+      content-type:
+      - application/vnd.api+json
+      date:
+      - Tue, 02 Sep 2025 22:41:41 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_ee7fe7e8-e947-4d0e-be54-be22314ca561_records_upload_post_6b357ece.yaml
+++ b/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_ee7fe7e8-e947-4d0e-be54-be22314ca561_records_upload_post_6b357ece.yaml
@@ -1,0 +1,47 @@
+interactions:
+- request:
+    body: "------------boundary------\r\nContent-Disposition: form-data; name=\"file\";
+      filename=\"tmp.csv\"\r\nContent-Type: text/csv\r\n\r\ninput,expected_output,metadata\r\n\"{\"\"in0\"\":
+      \"\"r0v1\"\", \"\"in1\"\": \"\"r0v2\"\", \"\"in2\"\": \"\"r0v3\"\"}\",{},{}\r\n\"{\"\"in0\"\":
+      \"\"r1v1\"\", \"\"in1\"\": \"\"r1v2\"\", \"\"in2\"\": \"\"r1v3\"\"}\",{},{}\r\n\r\n------------boundary--------\r\n"
+    headers:
+      Accept:
+      - '*/*'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept-Encoding
+      : - identity
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '317'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - multipart/form-data; boundary=----------boundary------
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://api.datadoghq.com/api/unstable/llm-obs/v1/datasets/ee7fe7e8-e947-4d0e-be54-be22314ca561/records/upload
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.com
+      content-type:
+      - application/vnd.api+json
+      date:
+      - Tue, 02 Sep 2025 22:41:44 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_post_fd975cd7.yaml
+++ b/tests/llmobs/llmobs_cassettes/datadog/datadog_api_unstable_llm-obs_v1_datasets_post_fd975cd7.yaml
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: '{"data": {"type": "datasets", "attributes": {"name": "test-dataset-test_dataset_estimate_size",
+      "description": "A test dataset"}}}'
+    headers:
+      Accept:
+      - '*/*'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept-Encoding
+      : - identity
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '130'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://api.datadoghq.com/api/unstable/llm-obs/v1/datasets
+  response:
+    body:
+      string: '{"data":{"id":"ed2f83c9-dd94-41d7-ac2b-544bbdbb5584","type":"datasets","attributes":{"author":{"id":"de473b30-eb9f-11e9-a77a-c7405862b8bd"},"created_at":"2025-09-03T23:16:13.873660522Z","current_version":0,"description":"A
+        test dataset","name":"test-dataset-test_dataset_estimate_size","updated_at":"2025-09-03T23:16:13.873660522Z"}}}'
+    headers:
+      content-length:
+      - '334'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.com
+      content-type:
+      - application/vnd.api+json
+      date:
+      - Wed, 03 Sep 2025 23:16:13 GMT
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -497,6 +497,13 @@ def test_dataset_modify_single_record_empty_record(llmobs, test_dataset, test_da
         test_dataset.update(0, {})
 
 
+def test_dataset_estimate_size(llmobs, test_dataset):
+    test_dataset.append(
+        {"input_data": {"prompt": "What is the capital of France?"}, "expected_output": {"answer": "Paris"}}
+    )
+    assert 170 <= test_dataset._estimate_delta_size() <= 200
+
+
 @pytest.mark.parametrize(
     "test_dataset_records",
     [[DatasetRecord(input_data={"prompt": "What is the capital of France?"}, expected_output={"answer": "Paris"})]],

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -12,9 +12,11 @@ eg. VCR_CASSETTES_DIRECTORY=tests/cassettes ddapm-test-agent ...
 
 import os
 import re
+import tempfile
 import time
 from typing import Generator
 from typing import List
+from unittest.mock import MagicMock
 
 import mock
 import pytest
@@ -22,6 +24,9 @@ import pytest
 from ddtrace.llmobs._experiment import Dataset
 from ddtrace.llmobs._experiment import DatasetRecord
 from tests.utils import override_global_config
+
+
+TMP_CSV_FILE = "tmp.csv"
 
 
 def wait_for_backend(sleep_dur=2):
@@ -80,6 +85,25 @@ def test_dataset_one_record(llmobs):
     llmobs._delete_dataset(dataset_id=ds._id)
 
 
+# this fixture is needed because the tmp file call in _writer.py's dataset_bulk_upload
+# will result in random names, causing a new POST request every time to the upload endpoint
+# leading to repeated CI test failures
+@pytest.fixture
+def tmp_csv_file_for_upload(llmobs) -> Generator[MagicMock, None, None]:
+    stable_dir = tempfile.gettempdir()
+    stable_path = os.path.join(stable_dir, TMP_CSV_FILE)
+    with open(stable_path, "w"):
+        pass
+
+    fake_tmp = MagicMock()
+    fake_tmp.__enter__.return_value.name = stable_path
+
+    yield fake_tmp
+
+    if not os.path.exists(stable_path):
+        os.remove(stable_path)
+
+
 def test_dataset_create_delete(llmobs):
     dataset = llmobs.create_dataset(name="test-dataset-2", description="A second test dataset")
     assert dataset._id is not None
@@ -107,35 +131,37 @@ def test_dataset_as_dataframe(llmobs, test_dataset_one_record):
     assert df.size == 2  # size is num elements in a series
 
 
-def test_csv_dataset_as_dataframe(llmobs):
+def test_csv_dataset_as_dataframe(llmobs, tmp_csv_file_for_upload):
     test_path = os.path.dirname(__file__)
     csv_path = os.path.join(test_path, "static_files/good_dataset.csv")
     dataset_id = None
-    try:
-        dataset = llmobs.create_dataset_from_csv(
-            csv_path=csv_path,
-            dataset_name="test-dataset-good-csv",
-            description="A good csv dataset",
-            input_data_columns=["in0", "in1", "in2"],
-            expected_output_columns=["out0", "out1"],
-            metadata_columns=["m0"],
-        )
-        dataset_id = dataset._id
-        assert len(dataset) == 2
 
-        df = dataset.as_dataframe()
-        assert len(df.columns) == 6
-        assert sorted(df.columns) == [
-            ("expected_output", "out0"),
-            ("expected_output", "out1"),
-            ("input_data", "in0"),
-            ("input_data", "in1"),
-            ("input_data", "in2"),
-            ("metadata", "m0"),
-        ]
-    finally:
-        if dataset_id:
-            llmobs._delete_dataset(dataset_id=dataset_id)
+    with mock.patch("ddtrace.llmobs._writer.tempfile.NamedTemporaryFile", return_value=tmp_csv_file_for_upload):
+        try:
+            dataset = llmobs.create_dataset_from_csv(
+                csv_path=csv_path,
+                dataset_name="test-dataset-good-csv",
+                description="A good csv dataset",
+                input_data_columns=["in0", "in1", "in2"],
+                expected_output_columns=["out0", "out1"],
+                metadata_columns=["m0"],
+            )
+            dataset_id = dataset._id
+            assert len(dataset) == 2
+
+            df = dataset.as_dataframe()
+            assert len(df.columns) == 6
+            assert sorted(df.columns) == [
+                ("expected_output", "out0"),
+                ("expected_output", "out1"),
+                ("input_data", "in0"),
+                ("input_data", "in1"),
+                ("input_data", "in2"),
+                ("metadata", "m0"),
+            ]
+        finally:
+            if dataset_id:
+                llmobs._delete_dataset(dataset_id=dataset_id)
 
 
 def test_dataset_csv_missing_input_col(llmobs):
@@ -177,137 +203,140 @@ def test_dataset_csv_empty_csv(llmobs):
         )
 
 
-def test_dataset_csv_no_expected_output(llmobs):
+def test_dataset_csv_no_expected_output(llmobs, tmp_csv_file_for_upload):
     test_path = os.path.dirname(__file__)
     csv_path = os.path.join(test_path, "static_files/good_dataset.csv")
     dataset_id = None
-    try:
-        dataset = llmobs.create_dataset_from_csv(
-            csv_path=csv_path,
-            dataset_name="test-dataset-good-csv-without-expected-output",
-            description="A good csv dataset without expected_output columns",
-            input_data_columns=["in0", "in1", "in2"],
-        )
-        dataset_id = dataset._id
-        assert len(dataset) == 2
-        assert len(dataset[0]["input_data"]) == 3
-        assert dataset[0]["input_data"]["in0"] == "r0v1"
-        assert dataset[0]["input_data"]["in1"] == "r0v2"
-        assert dataset[0]["input_data"]["in2"] == "r0v3"
-        assert dataset[1]["input_data"]["in0"] == "r1v1"
-        assert dataset[1]["input_data"]["in1"] == "r1v2"
-        assert dataset[1]["input_data"]["in2"] == "r1v3"
+    with mock.patch("ddtrace.llmobs._writer.tempfile.NamedTemporaryFile", return_value=tmp_csv_file_for_upload):
+        try:
+            dataset = llmobs.create_dataset_from_csv(
+                csv_path=csv_path,
+                dataset_name="test-dataset-good-csv-without-expected-output",
+                description="A good csv dataset without expected_output columns",
+                input_data_columns=["in0", "in1", "in2"],
+            )
+            dataset_id = dataset._id
+            assert len(dataset) == 2
+            assert len(dataset[0]["input_data"]) == 3
+            assert dataset[0]["input_data"]["in0"] == "r0v1"
+            assert dataset[0]["input_data"]["in1"] == "r0v2"
+            assert dataset[0]["input_data"]["in2"] == "r0v3"
+            assert dataset[1]["input_data"]["in0"] == "r1v1"
+            assert dataset[1]["input_data"]["in1"] == "r1v2"
+            assert dataset[1]["input_data"]["in2"] == "r1v3"
 
-        assert len(dataset[0]["expected_output"]) == 0
+            assert len(dataset[0]["expected_output"]) == 0
 
-        assert dataset.description == "A good csv dataset without expected_output columns"
+            assert dataset.description == "A good csv dataset without expected_output columns"
 
-        assert dataset._id is not None
+            assert dataset._id is not None
 
-        wait_for_backend(4)
-        ds = llmobs.pull_dataset(name=dataset.name)
+            wait_for_backend(4)
+            ds = llmobs.pull_dataset(name=dataset.name)
 
-        assert len(ds) == len(dataset)
-        assert ds.name == dataset.name
-        assert ds.description == dataset.description
-        assert ds._version == 1
-    finally:
-        if dataset_id:
-            llmobs._delete_dataset(dataset_id=dataset_id)
+            assert len(ds) == len(dataset)
+            assert ds.name == dataset.name
+            assert ds.description == dataset.description
+            assert ds._version == 1
+        finally:
+            if dataset_id:
+                llmobs._delete_dataset(dataset_id=dataset_id)
 
 
-def test_dataset_csv(llmobs):
+def test_dataset_csv(llmobs, tmp_csv_file_for_upload):
     test_path = os.path.dirname(__file__)
     csv_path = os.path.join(test_path, "static_files/good_dataset.csv")
     dataset_id = None
-    try:
-        dataset = llmobs.create_dataset_from_csv(
-            csv_path=csv_path,
-            dataset_name="test-dataset-good-csv",
-            description="A good csv dataset",
-            input_data_columns=["in0", "in1", "in2"],
-            expected_output_columns=["out0", "out1"],
-        )
-        dataset_id = dataset._id
-        assert len(dataset) == 2
-        assert len(dataset[0]["input_data"]) == 3
-        assert dataset[0]["input_data"]["in0"] == "r0v1"
-        assert dataset[0]["input_data"]["in1"] == "r0v2"
-        assert dataset[0]["input_data"]["in2"] == "r0v3"
-        assert dataset[1]["input_data"]["in0"] == "r1v1"
-        assert dataset[1]["input_data"]["in1"] == "r1v2"
-        assert dataset[1]["input_data"]["in2"] == "r1v3"
+    with mock.patch("ddtrace.llmobs._writer.tempfile.NamedTemporaryFile", return_value=tmp_csv_file_for_upload):
+        try:
+            dataset = llmobs.create_dataset_from_csv(
+                csv_path=csv_path,
+                dataset_name="test-dataset-good-csv",
+                description="A good csv dataset",
+                input_data_columns=["in0", "in1", "in2"],
+                expected_output_columns=["out0", "out1"],
+            )
+            dataset_id = dataset._id
+            assert len(dataset) == 2
+            assert len(dataset[0]["input_data"]) == 3
+            assert dataset[0]["input_data"]["in0"] == "r0v1"
+            assert dataset[0]["input_data"]["in1"] == "r0v2"
+            assert dataset[0]["input_data"]["in2"] == "r0v3"
+            assert dataset[1]["input_data"]["in0"] == "r1v1"
+            assert dataset[1]["input_data"]["in1"] == "r1v2"
+            assert dataset[1]["input_data"]["in2"] == "r1v3"
 
-        assert len(dataset[0]["expected_output"]) == 2
-        assert dataset[0]["expected_output"]["out0"] == "r0v4"
-        assert dataset[0]["expected_output"]["out1"] == "r0v5"
-        assert dataset[1]["expected_output"]["out0"] == "r1v4"
-        assert dataset[1]["expected_output"]["out1"] == "r1v5"
+            assert len(dataset[0]["expected_output"]) == 2
+            assert dataset[0]["expected_output"]["out0"] == "r0v4"
+            assert dataset[0]["expected_output"]["out1"] == "r0v5"
+            assert dataset[1]["expected_output"]["out0"] == "r1v4"
+            assert dataset[1]["expected_output"]["out1"] == "r1v5"
 
-        assert dataset.description == "A good csv dataset"
+            assert dataset.description == "A good csv dataset"
 
-        assert dataset._id is not None
+            assert dataset._id is not None
 
-        wait_for_backend()
-        ds = llmobs.pull_dataset(name=dataset.name)
+            wait_for_backend()
+            ds = llmobs.pull_dataset(name=dataset.name)
 
-        assert len(ds) == len(dataset)
-        assert ds.name == dataset.name
-        assert ds.description == dataset.description
-        assert ds._version == 1
-    finally:
-        if dataset_id:
-            llmobs._delete_dataset(dataset_id=dataset_id)
+            assert len(ds) == len(dataset)
+            assert ds.name == dataset.name
+            assert ds.description == dataset.description
+            assert ds._version == 1
+        finally:
+            if dataset_id:
+                llmobs._delete_dataset(dataset_id=dataset_id)
 
 
-def test_dataset_csv_pipe_separated(llmobs):
+def test_dataset_csv_pipe_separated(llmobs, tmp_csv_file_for_upload):
     test_path = os.path.dirname(__file__)
     csv_path = os.path.join(test_path, "static_files/good_dataset_pipe_separated.csv")
     dataset_id = None
-    try:
-        dataset = llmobs.create_dataset_from_csv(
-            csv_path=csv_path,
-            dataset_name="test-dataset-good-csv-pipe",
-            description="A good pipe separated csv dataset",
-            input_data_columns=["in0", "in1", "in2"],
-            expected_output_columns=["out0", "out1"],
-            metadata_columns=["m0"],
-            csv_delimiter="|",
-        )
-        dataset_id = dataset._id
-        assert len(dataset) == 2
-        assert len(dataset[0]["input_data"]) == 3
-        assert dataset[0]["input_data"]["in0"] == "r0v1"
-        assert dataset[0]["input_data"]["in1"] == "r0v2"
-        assert dataset[0]["input_data"]["in2"] == "r0v3"
-        assert dataset[1]["input_data"]["in0"] == "r1v1"
-        assert dataset[1]["input_data"]["in1"] == "r1v2"
-        assert dataset[1]["input_data"]["in2"] == "r1v3"
+    with mock.patch("ddtrace.llmobs._writer.tempfile.NamedTemporaryFile", return_value=tmp_csv_file_for_upload):
+        try:
+            dataset = llmobs.create_dataset_from_csv(
+                csv_path=csv_path,
+                dataset_name="test-dataset-good-csv-pipe",
+                description="A good pipe separated csv dataset",
+                input_data_columns=["in0", "in1", "in2"],
+                expected_output_columns=["out0", "out1"],
+                metadata_columns=["m0"],
+                csv_delimiter="|",
+            )
+            dataset_id = dataset._id
+            assert len(dataset) == 2
+            assert len(dataset[0]["input_data"]) == 3
+            assert dataset[0]["input_data"]["in0"] == "r0v1"
+            assert dataset[0]["input_data"]["in1"] == "r0v2"
+            assert dataset[0]["input_data"]["in2"] == "r0v3"
+            assert dataset[1]["input_data"]["in0"] == "r1v1"
+            assert dataset[1]["input_data"]["in1"] == "r1v2"
+            assert dataset[1]["input_data"]["in2"] == "r1v3"
 
-        assert len(dataset[0]["expected_output"]) == 2
-        assert dataset[0]["expected_output"]["out0"] == "r0v4"
-        assert dataset[0]["expected_output"]["out1"] == "r0v5"
-        assert dataset[1]["expected_output"]["out0"] == "r1v4"
-        assert dataset[1]["expected_output"]["out1"] == "r1v5"
+            assert len(dataset[0]["expected_output"]) == 2
+            assert dataset[0]["expected_output"]["out0"] == "r0v4"
+            assert dataset[0]["expected_output"]["out1"] == "r0v5"
+            assert dataset[1]["expected_output"]["out0"] == "r1v4"
+            assert dataset[1]["expected_output"]["out1"] == "r1v5"
 
-        assert len(dataset[0]["metadata"]) == 1
-        assert dataset[0]["metadata"]["m0"] == "r0v6"
-        assert dataset[1]["metadata"]["m0"] == "r1v6"
+            assert len(dataset[0]["metadata"]) == 1
+            assert dataset[0]["metadata"]["m0"] == "r0v6"
+            assert dataset[1]["metadata"]["m0"] == "r1v6"
 
-        assert dataset.description == "A good pipe separated csv dataset"
+            assert dataset.description == "A good pipe separated csv dataset"
 
-        assert dataset._id is not None
+            assert dataset._id is not None
 
-        wait_for_backend()
-        ds = llmobs.pull_dataset(name=dataset.name)
+            wait_for_backend()
+            ds = llmobs.pull_dataset(name=dataset.name)
 
-        assert len(ds) == len(dataset)
-        assert ds.name == dataset.name
-        assert ds.description == dataset.description
-        assert ds._version == 1
-    finally:
-        if dataset_id:
-            llmobs._delete_dataset(dataset_id=dataset._id)
+            assert len(ds) == len(dataset)
+            assert ds.name == dataset.name
+            assert ds.description == dataset.description
+            assert ds._version == 1
+        finally:
+            if dataset_id:
+                llmobs._delete_dataset(dataset_id=dataset._id)
 
 
 def test_dataset_pull_non_existent(llmobs):


### PR DESCRIPTION
**case 1: create dataset from CSVs**
with big datasets / big CSVs, we will run into timeout errors 

```
Traceback (most recent call last):
  File "/Users/gary.huang/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/test.py", line 23, in <module>
    dataset = LLMObs.create_dataset_from_csv(csv_path="/Users/gary.huang/Downloads/weatherAUS.csv", dataset_name="weatheraus-2", input_data_columns=["Date", "input", "Evaporation", "Sunshine"], expected_output_columns=["RainTomorrow"])
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gary.huang/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/.venv/lib/python3.12/site-packages/ddtrace/llmobs/_llmobs.py", line 722, in create_dataset_from_csv
    ds.push()
  File "/Users/gary.huang/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/.venv/lib/python3.12/site-packages/ddtrace/llmobs/_experiment.py", line 140, in push
    new_version, new_record_ids = self._dne_client.dataset_batch_update(
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gary.huang/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/.venv/lib/python3.12/site-packages/ddtrace/llmobs/_writer.py", line 404, in dataset_batch_update
    resp = self.request("POST", path, body)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gary.huang/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/.venv/lib/python3.12/site-packages/ddtrace/llmobs/_writer.py", line 319, in request
    resp = conn.getresponse()
           ^^^^^^^^^^^^^^^^^^
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/http/client.py", line 1428, in getresponse
    response.begin()
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/http/client.py", line 331, in begin
    version, status, reason = self._read_status()
                              ^^^^^^^^^^^^^^^^^^^
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/http/client.py", line 292, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/socket.py", line 720, in readinto
    return self._sock.recv_into(b)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/ssl.py", line 1251, in recv_into
    return self.read(nbytes, buffer)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/ssl.py", line 1103, in read
    return self._sslobj.read(len, buffer)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TimeoutError: The read operation timed out
```

now it succeeds
https://dddev.datadoghq.com/llm/datasets/1e794d07-8b77-4a08-8363-e7236432f262

**case 2: large push after dataset is created**
in cases where a push is extremely big, it used to fail before 
for example with this snippet
```
dataset = LLMObs.create_dataset("1-then-big-gh-09021126", "", [{"input_data": "first", "expected_output": "1"}])

print(dataset.as_dataframe())

print(dataset.url)

for i in range(0, 25000):
    dataset.append({"input_data": "a"*5000, "expected_output": "b"*100})

dataset.push()
```
results in something like
```
3.13.0rc1
  input_data expected_output
                            
0      first               1
https://app.datadoghq.com/llm/datasets/f9a2b6a7-9690-4e3d-98ff-e11b7832c344
Traceback (most recent call last):
  File "/Users/gary.huang/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/test.py", line 33, in <module>
    dataset.push()
  File "/Users/gary.huang/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/.venv/lib/python3.12/site-packages/ddtrace/llmobs/_experiment.py", line 140, in push
    new_version, new_record_ids = self._dne_client.dataset_batch_update(
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gary.huang/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/.venv/lib/python3.12/site-packages/ddtrace/llmobs/_writer.py", line 404, in dataset_batch_update
    resp = self.request("POST", path, body)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gary.huang/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/.venv/lib/python3.12/site-packages/ddtrace/llmobs/_writer.py", line 318, in request
    conn.request(method, url, encoded_body, headers)
  File "/Users/gary.huang/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/.venv/lib/python3.12/site-packages/ddtrace/internal/http.py", line 37, in request
    return super().request(method, url, body=body, headers=_headers, encode_chunked=encode_chunked)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/http/client.py", line 1336, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/http/client.py", line 1382, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/http/client.py", line 1331, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/http/client.py", line 1130, in _send_output
    self.send(chunk)
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/http/client.py", line 1055, in send
    self.sock.sendall(data)
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/ssl.py", line 1210, in sendall
    v = self.send(byte_view[count:])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/ssl.py", line 1179, in send
    return self._sslobj.write(data)
           ^^^^^^^^^^^^^^^^^^^^^^^^
TimeoutError: The write operation timed out
```
but with this change this succeeds by estimating the size of the dataset to upload and using the bulk endpoint if the dataset gets large enough
https://dddev.datadoghq.com/llm/datasets/f9a2b6a7-9690-4e3d-98ff-e11b7832c344

**case 3: create dataset with a large list of records**
```
3.13.0rc1
Traceback (most recent call last):
  File "/Users/gary.huang/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/test.py", line 27, in <module>
    dataset = LLMObs.create_dataset("1-then-big-gh-09021127", "", recs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gary.huang/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/.venv/lib/python3.12/site-packages/ddtrace/llmobs/_llmobs.py", line 657, in create_dataset
    ds.push()
  File "/Users/gary.huang/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/.venv/lib/python3.12/site-packages/ddtrace/llmobs/_experiment.py", line 140, in push
    new_version, new_record_ids = self._dne_client.dataset_batch_update(
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gary.huang/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/.venv/lib/python3.12/site-packages/ddtrace/llmobs/_writer.py", line 404, in dataset_batch_update
    resp = self.request("POST", path, body)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gary.huang/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/.venv/lib/python3.12/site-packages/ddtrace/llmobs/_writer.py", line 318, in request
    conn.request(method, url, encoded_body, headers)
  File "/Users/gary.huang/go/src/github.com/DataDog/llm-observability/preview/experiments/notebooks/.venv/lib/python3.12/site-packages/ddtrace/internal/http.py", line 37, in request
    return super().request(method, url, body=body, headers=_headers, encode_chunked=encode_chunked)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/http/client.py", line 1336, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/http/client.py", line 1382, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/http/client.py", line 1331, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/http/client.py", line 1130, in _send_output
    self.send(chunk)
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/http/client.py", line 1055, in send
    self.sock.sendall(data)
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/ssl.py", line 1210, in sendall
    v = self.send(byte_view[count:])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gary.huang/.pyenv/versions/3.12.7/lib/python3.12/ssl.py", line 1179, in send
    return self._sslobj.write(data)
           ^^^^^^^^^^^^^^^^^^^^^^^^
TimeoutError: The write operation timed out
```
it now succeeds
https://dddev.datadoghq.com/llm/datasets/4b4af632-a51b-4a18-9393-f0a5dfe8a2b5

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
