### PR TITLE
chore(llmobs): fix llm obs tests to match new API endpoint behavior

### DIFF
--- a/tests/llmobs/test_llmobs_eval_metric_agentless_writer.py
+++ b/tests/llmobs/test_llmobs_eval_metric_agentless_writer.py
@@ -73,8 +73,8 @@ def test_send_metric_bad_api_key(mock_writer_logs):
         1,
         "evaluation_metric",
         INTAKE_ENDPOINT,
-        403,
-        b'{"status":"error","code":403,"errors":["Forbidden"],"statuspage":"http://status.datadoghq.com","twitter":"http://twitter.com/datadogops","email":"support@datadoghq.com"}',  # noqa
+        401,
+        b'{"errors":["Unauthorized"]}',  # noqa
     )
 
 
@@ -163,8 +163,5 @@ llmobs_eval_metric_writer.enqueue(_score_metric_event())
     )
     assert status == 0, err
     assert out == b""
-    assert b"got response code 403" in err
-    assert (
-        b'status: b\'{"status":"error","code":403,"errors":["Forbidden"],"statuspage":"http://status.datadoghq.com","twitter":"http://twitter.com/datadogops","email":"support@datadoghq.com"}\'\n'
-        in err
-    )
+    assert b"got response code 401" in err
+    assert b'status: b\'{"errors":["Unauthorized"]}\'\n' in err

--- a/tests/llmobs/test_llmobs_evaluator_runner.py
+++ b/tests/llmobs/test_llmobs_evaluator_runner.py
@@ -115,11 +115,8 @@ LLMObs._instance._evaluator_runner.enqueue({"span_id": "123", "trace_id": "1234"
     )
     assert status == 0, err
     assert out == b""
-    assert b"got response code 403" in err
-    assert (
-        b'status: b\'{"status":"error","code":403,"errors":["Forbidden"],"statuspage":"http://status.datadoghq.com","twitter":"http://twitter.com/datadogops","email":"support@datadoghq.com"}\'\n'
-        in err
-    )
+    assert b"got response code 401" in err
+    assert b'status: b\'{"errors":["Unauthorized"]}' in err
 
 
 def test_evaluator_runner_unsupported_evaluator():


### PR DESCRIPTION
the APIs now return 401 instead of 403 on incorrect API keys, fix the tests

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
