### PR TITLE
ci(llmobs): skip flaky tests hitting faulty endpoint

### DIFF
--- a/tests/llmobs/test_llmobs_eval_metric_agentless_writer.py
+++ b/tests/llmobs/test_llmobs_eval_metric_agentless_writer.py
@@ -63,6 +63,7 @@ def test_buffer_limit(mock_writer_logs):
     )
 
 
+@pytest.mark.skip(reason="Skipping due to flakiness in hitting the staging endpoint")
 def test_send_metric_bad_api_key(mock_writer_logs):
     llmobs_eval_metric_writer = LLMObsEvalMetricWriter(1, 1, is_agentless=True, _site=DD_SITE, _api_key="<bad-api-key>")
 
@@ -142,6 +143,7 @@ def test_send_multiple_events(mock_writer_logs):
     )
 
 
+@pytest.mark.skip(reason="Skipping due to flakiness in hitting the staging endpoint")
 def test_send_on_exit(mock_writer_logs, run_python_code_in_subprocess):
     env = os.environ.copy()
     pypath = [os.path.dirname(os.path.dirname(os.path.dirname(__file__)))]

--- a/tests/llmobs/test_llmobs_evaluator_runner.py
+++ b/tests/llmobs/test_llmobs_evaluator_runner.py
@@ -92,6 +92,7 @@ def test_evaluator_runner_multiple_evaluators(llmobs, mock_llmobs_eval_metric_wr
     ]
 
 
+@pytest.mark.skip(reason="Skipping due to flakiness in hitting the staging endpoint")
 def test_evaluator_runner_on_exit(mock_writer_logs, run_python_code_in_subprocess):
     env = os.environ.copy()
     pypath = [os.path.dirname(os.path.dirname(os.path.dirname(__file__)))]


### PR DESCRIPTION
some of our tests hit our real staging endpoint, which itself could sometimes be flaky. following up soon with a real fix to record a response one time and serve it back (since these tests are just checking logging behavior).

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
