### PR TITLE
link input and output guardrail spans for openai agents

### DIFF
--- a/ddtrace/contrib/internal/openai_agents/processor.py
+++ b/ddtrace/contrib/internal/openai_agents/processor.py
@@ -80,6 +80,7 @@ class LLMObsTraceProcessor(TracingProcessor):
         llmobs_span = self._integration.oai_to_llmobs_span.get(span_adapter.span_id)
         if not llmobs_span:
             return
+        self._integration.active_guardrail_llmobs_spans.discard(llmobs_span)
         self._integration.llmobs_set_tags(llmobs_span, [], {"oai_span": span_adapter})
         llmobs_span.finish()
 


### PR DESCRIPTION
This PR implements span linking for Open AI Agents guardrail spans. 

For input guardrails, a span link is created from the output of the guardrail to any LLM spans that 1) are siblings of the input guardrail (share the same parent ID) and 2) are executed concurrently with the input guardrail span.
<img width="708" height="264" alt="image" src="https://github.com/user-attachments/assets/35df597a-9d27-464e-b302-9b241e2b4f4d" />


For output guardrails, a span link is created from the last finished LLM span to the output guardrail span.
<img width="2766" height="178" alt="image" src="https://github.com/user-attachments/assets/35773ad9-d512-4be5-8db9-8a559ab29047" />



## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
