### PR TITLE
chore(ai_guard): move the meta element under attributes

### DIFF
--- a/ddtrace/appsec/ai_guard/_api_client.py
+++ b/ddtrace/appsec/ai_guard/_api_client.py
@@ -280,9 +280,10 @@ class AIGuardClient:
                 if history is None:
                     history = []
 
-                payload = {"data": {"attributes": {"history": history, "current": current}}}
+                attributes: dict[str, Any] = {"history": history, "current": current}
                 if config.service and config.env:
-                    payload["meta"] = {"service": config.service, "env": config.env}
+                    attributes["meta"] = {"service": config.service, "env": config.env}
+                payload = {"data": {"attributes": attributes}}
 
                 try:
                     response = self._execute_request(f"{self._endpoint.rstrip('/')}/evaluate", payload)

--- a/tests/appsec/ai_guard/utils.py
+++ b/tests/appsec/ai_guard/utils.py
@@ -57,16 +57,15 @@ def assert_mock_execute_request_call(
     current: Evaluation,
     meta: Optional[Dict[str, Any]] = None,
 ):
-    expected_payload = {
-        "data": {
-            "attributes": {
-                "history": history,
-                "current": current,
-            }
-        }
+    expected_attributes = {
+        "history": history,
+        "current": current,
     }
+
     if meta is not None:
-        expected_payload["meta"] = meta
+        expected_attributes["meta"] = meta
+
+    expected_payload = {"data": {"attributes": expected_attributes}}
 
     mock_execute_request.assert_called_once_with(
         f"{ai_guard_client._endpoint}/evaluate",


### PR DESCRIPTION
Move the meta element under attributes in the AI Guard payload ([schema](https://github.com/DataDog/dd-source/tree/main/domains/appsec/apps/apis/ai-guard#api-reference))

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
