### PR TITLE
chore: add CPU usage and RSS SLO for macrobenchmarks

### DIFF
--- a/.gitlab/benchmarks/bp-runner.macrobenchmarks.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.macrobenchmarks.fail-on-breach.yml
@@ -42,8 +42,8 @@ experiments:
               - agg_http_req_duration_p95 < 95 ms
           - name: normal_operation/tracing-profiling-enabled/python-server-utilization
             thresholds:
-              - cpu_usage_percentage < 215 %
-              - rss < 1100 MB
+              - cpu_usage_percentage < 220 %
+              - rss < 1040 MB
           - name: high_load/tracing-profiling-enabled
             thresholds:
               - throughput > 30.0 op/s


### PR DESCRIPTION
PR #14205 introduced a significant performance regression, where the
profiler created a thread which consumed an entire CPU core spinning in
a tight loop. Our macrobenchmarks captured this increased CPU usage, but
we didn't have any SLOs defined. This commit adds an SLO for CPU usage
based on the typical CPU usage prior to that regression. This commit
also adds an RSS SLO, again based on typical usage.

<img width="1057" height="439" alt="Screenshot 2025-09-08 at 09 44 38" src="https://github.com/user-attachments/assets/ce20e03d-543f-4ec4-ac08-ac36af357e68" />

Sample run: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1118617959

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
