### PR TITLE
fix(llmobs): [MLOB-3863] openai agents support reasoning messages

### DIFF
--- a/ddtrace/llmobs/_integrations/openai_agents.py
+++ b/ddtrace/llmobs/_integrations/openai_agents.py
@@ -37,6 +37,7 @@ from ddtrace.llmobs._integrations.utils import OaiTraceAdapter
 from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
 from ddtrace.llmobs._utils import _get_span_name
 from ddtrace.llmobs._utils import load_data_value
+from ddtrace.llmobs._utils import safe_json
 from ddtrace.trace import Span
 
 
@@ -232,13 +233,13 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
         if oai_span.response and oai_span.response.output:
             messages, tool_call_outputs = oai_span.llmobs_output_messages()
 
-            for tool_id, tool_name, tool_args in tool_call_outputs:
+            for tool_call_output in tool_call_outputs:
                 core.dispatch(
                     DISPATCH_ON_LLM_TOOL_CHOICE,
                     (
-                        tool_id,
-                        tool_name,
-                        tool_args,
+                        tool_call_output["tool_id"],
+                        tool_call_output["name"],
+                        safe_json(tool_call_output["arguments"]),
                         {
                             "trace_id": format_trace_id(span.trace_id),
                             "span_id": str(span.span_id),

--- a/ddtrace/llmobs/_integrations/pydantic_ai.py
+++ b/ddtrace/llmobs/_integrations/pydantic_ai.py
@@ -136,7 +136,7 @@ class PydanticAIIntegration(BaseLLMIntegration):
         span._set_ctx_items(
             {
                 NAME: tool_name,
-                METADATA: {"description": tool_description},
+                METADATA: {"description": tool_description} if tool_description else {},
                 INPUT_VALUE: tool_input,
             }
         )

--- a/ddtrace/llmobs/_integrations/pydantic_ai.py
+++ b/ddtrace/llmobs/_integrations/pydantic_ai.py
@@ -136,7 +136,7 @@ class PydanticAIIntegration(BaseLLMIntegration):
         span._set_ctx_items(
             {
                 NAME: tool_name,
-                METADATA: {"description": tool_description} if tool_description else {},
+                METADATA: {"description": tool_description},
                 INPUT_VALUE: tool_input,
             }
         )

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -1156,7 +1156,7 @@ class OaiSpanAdapter:
         for item in messages:
             message = {}
             # Handle content-based messages
-            if hasattr(item, "content"):
+            if hasattr(item, "content") and item.content:
                 text = ""
                 for content in item.content:
                     if hasattr(content, "text") or hasattr(content, "refusal"):

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -596,7 +596,7 @@ def _openai_parse_input_response_messages(
                 processed_item["role"] = item["role"]
         elif "call_id" in item and ("arguments" in item or "input" in item):
             # Process `ResponseFunctionToolCallParam` or ResponseCustomToolCallParam type from input messages
-            arguments_str = item.get("arguments", OAI_HANDOFF_TOOL_ARG) or item.get("input", OAI_HANDOFF_TOOL_ARG)
+            arguments_str = item.get("arguments", "") or item.get("input", OAI_HANDOFF_TOOL_ARG)
             arguments = safe_load_json(arguments_str)
 
             tool_call_info = ToolCall(

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -715,7 +715,7 @@ def _openai_parse_output_response_messages(messages: List[Any]) -> Tuple[List[Di
                 }
             )
         else:
-            message.update({"content": str(item)})
+            message.update({"content": str(item), "role": "assistant"})
 
         processed.append(message)
 

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -553,9 +553,12 @@ def openai_get_input_messages_from_response_input(
     processed, _ = _openai_parse_input_response_messages(messages)
     return processed
 
-def _openai_parse_input_response_messages(messages: List[Any], system_instructions: str = "") -> Tuple[List[Dict[str, Any]], List[str]]:
+
+def _openai_parse_input_response_messages(
+    messages: List[Any], system_instructions: str = ""
+) -> Tuple[List[Dict[str, Any]], List[str]]:
     """
-    Parses input messages from the openai responses api into a list of processed messages 
+    Parses input messages from the openai responses api into a list of processed messages
     and a list of tool call IDs.
 
     Args:
@@ -654,9 +657,10 @@ def openai_get_output_messages_from_response(response: Optional[Any]) -> List[Di
 
     return processed_messages
 
+
 def _openai_parse_output_response_messages(messages: List[Any]) -> Tuple[List[Dict[str, Any]], List[ToolCall]]:
     """
-    Parses output messages from the openai responses api into a list of processed messages 
+    Parses output messages from the openai responses api into a list of processed messages
     and a list of tool call outputs.
 
     Args:
@@ -675,7 +679,7 @@ def _openai_parse_output_response_messages(messages: List[Any]) -> Tuple[List[Di
 
         if message_type == "message":
             text = ""
-            for content in _get_attr(item, "content", []):
+            for content in _get_attr(item, "content", []) or []:
                 text += str(_get_attr(content, "text", "") or "")
                 text += str(_get_attr(content, "refusal", "") or "")
             message.update({"role": _get_attr(item, "role", "assistant"), "content": text})
@@ -720,9 +724,8 @@ def _openai_parse_output_response_messages(messages: List[Any]) -> Tuple[List[Di
             message.update({"content": str(item)})
 
         processed.append(message)
-    
-    return processed, tool_call_outputs
 
+    return processed, tool_call_outputs
 
 
 def openai_get_metadata_from_response(

--- a/releasenotes/notes/openai-agents-support-reasoning-a782615651107cc9.yaml
+++ b/releasenotes/notes/openai-agents-support-reasoning-a782615651107cc9.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes an issue where reasoning message types were not being handled correctly in the OpenAI Agents integration, leading to 
+    output messages being dropped on LLM spans.

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -572,7 +572,7 @@ async def test_llmobs_multiple_agent_handoffs(agents, mock_tracer, request_vcr, 
                                 "tool_id": mock.ANY,
                                 "name": "",
                                 "result": "united beat liverpool 2-1 yesterday. also a lot of other stuff happened."
-                                "like super important stuff. blah blah blah.",
+                                " like super important stuff. blah blah blah.",
                                 "type": "function_call_output",
                             }
                         ],
@@ -683,7 +683,7 @@ async def test_llmobs_single_agent_with_tool_errors(
                                 "tool_id": mock.ANY,
                                 "name": "",
                                 "result": "An error occurred while running the tool."
-                                "Please try again. Error: This is a test error",
+                                " Please try again. Error: This is a test error",
                                 "type": "function_call_output",
                             }
                         ],

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -415,7 +415,8 @@ async def test_llmobs_single_agent_with_tool_calls_llmobs(
                                 "name": "add",
                                 "type": "function_call",
                             }
-                        ]
+                        ],
+                        "role": "assistant",
                     }
                 ],
             ),
@@ -431,9 +432,10 @@ async def test_llmobs_single_agent_with_tool_calls_llmobs(
                                 "name": "add",
                                 "type": "function_call",
                             }
-                        ]
+                        ],
+                        "role": "assistant",
                     },
-                    {"role": "tool", "content": mock.ANY, "tool_id": mock.ANY},
+                    {"role": "user", "tool_results": [{"tool_id": mock.ANY, "name": "", "result": "3", "type": "function_call_output"}]},
                 ],
                 [{"role": "assistant", "content": result.final_output}],
             ),
@@ -532,7 +534,8 @@ async def test_llmobs_multiple_agent_handoffs(agents, mock_tracer, request_vcr, 
                                 "name": "research",
                                 "type": "function_call",
                             }
-                        ]
+                        ],
+                        "role": "assistant",
                     }
                 ],
             ),
@@ -554,9 +557,10 @@ async def test_llmobs_multiple_agent_handoffs(agents, mock_tracer, request_vcr, 
                                 "name": "research",
                                 "type": "function_call",
                             }
-                        ]
+                        ],
+                        "role": "assistant",
                     },
-                    {"role": "tool", "content": mock.ANY, "tool_id": mock.ANY},
+                    {"role": "user", "tool_results": [{"tool_id": mock.ANY, "name": "", "result": "united beat liverpool 2-1 yesterday. also a lot of other stuff happened. like super important stuff. blah blah blah.", "type": "function_call_output"}]},
                 ],
                 [
                     {"role": "assistant", "content": mock.ANY},
@@ -568,7 +572,8 @@ async def test_llmobs_multiple_agent_handoffs(agents, mock_tracer, request_vcr, 
                                 "name": "transfer_to_summarizer",
                                 "type": "function_call",
                             }
-                        ]
+                        ],
+                        "role": "assistant",
                     },
                 ],
             ),
@@ -632,7 +637,8 @@ async def test_llmobs_single_agent_with_tool_errors(
                                 "name": "add",
                                 "type": "function_call",
                             }
-                        ]
+                        ],
+                        "role": "assistant",
                     }
                 ],
             ),
@@ -651,9 +657,10 @@ async def test_llmobs_single_agent_with_tool_errors(
                                 "name": "add",
                                 "type": "function_call",
                             }
-                        ]
+                        ],
+                        "role": "assistant",
                     },
-                    {"role": "tool", "content": mock.ANY, "tool_id": mock.ANY},
+                    {"role": "user", "tool_results": [{"tool_id": mock.ANY, "name": "", "result": "An error occurred while running the tool. Please try again. Error: This is a test error", "type": "function_call_output"}]},
                 ],
                 [{"role": "assistant", "content": result.final_output}],
             ),

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -483,7 +483,7 @@ async def test_llmobs_single_agent_with_ootb_tools(agents, mock_tracer, request_
                         "content": "ResponseFunctionWebSearch(id='ws_68814fa4582081989a0bc4a33dc197cc026575ca32f194ce',"
                         " status='completed', type='web_search_call', action={'type': 'search', 'query': 'current "
                         "weather in New York'})",
-                        "role": "",
+                        "role": "assistant",
                     },
                     {"role": "assistant", "content": result.final_output},
                 ],

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -571,7 +571,8 @@ async def test_llmobs_multiple_agent_handoffs(agents, mock_tracer, request_vcr, 
                             {
                                 "tool_id": mock.ANY,
                                 "name": "",
-                                "result": "united beat liverpool 2-1 yesterday. also a lot of other stuff happened. like super important stuff. blah blah blah.",
+                                "result": "united beat liverpool 2-1 yesterday. also a lot of other stuff happened."
+                                "like super important stuff. blah blah blah.",
                                 "type": "function_call_output",
                             }
                         ],
@@ -681,7 +682,8 @@ async def test_llmobs_single_agent_with_tool_errors(
                             {
                                 "tool_id": mock.ANY,
                                 "name": "",
-                                "result": "An error occurred while running the tool. Please try again. Error: This is a test error",
+                                "result": "An error occurred while running the tool."
+                                "Please try again. Error: This is a test error",
                                 "type": "function_call_output",
                             }
                         ],

--- a/tests/contrib/openai_agents/test_openai_agents_llmobs.py
+++ b/tests/contrib/openai_agents/test_openai_agents_llmobs.py
@@ -435,7 +435,12 @@ async def test_llmobs_single_agent_with_tool_calls_llmobs(
                         ],
                         "role": "assistant",
                     },
-                    {"role": "user", "tool_results": [{"tool_id": mock.ANY, "name": "", "result": "3", "type": "function_call_output"}]},
+                    {
+                        "role": "user",
+                        "tool_results": [
+                            {"tool_id": mock.ANY, "name": "", "result": "3", "type": "function_call_output"}
+                        ],
+                    },
                 ],
                 [{"role": "assistant", "content": result.final_output}],
             ),
@@ -560,7 +565,17 @@ async def test_llmobs_multiple_agent_handoffs(agents, mock_tracer, request_vcr, 
                         ],
                         "role": "assistant",
                     },
-                    {"role": "user", "tool_results": [{"tool_id": mock.ANY, "name": "", "result": "united beat liverpool 2-1 yesterday. also a lot of other stuff happened. like super important stuff. blah blah blah.", "type": "function_call_output"}]},
+                    {
+                        "role": "user",
+                        "tool_results": [
+                            {
+                                "tool_id": mock.ANY,
+                                "name": "",
+                                "result": "united beat liverpool 2-1 yesterday. also a lot of other stuff happened. like super important stuff. blah blah blah.",
+                                "type": "function_call_output",
+                            }
+                        ],
+                    },
                 ],
                 [
                     {"role": "assistant", "content": mock.ANY},
@@ -660,7 +675,17 @@ async def test_llmobs_single_agent_with_tool_errors(
                         ],
                         "role": "assistant",
                     },
-                    {"role": "user", "tool_results": [{"tool_id": mock.ANY, "name": "", "result": "An error occurred while running the tool. Please try again. Error: This is a test error", "type": "function_call_output"}]},
+                    {
+                        "role": "user",
+                        "tool_results": [
+                            {
+                                "tool_id": mock.ANY,
+                                "name": "",
+                                "result": "An error occurred while running the tool. Please try again. Error: This is a test error",
+                                "type": "function_call_output",
+                            }
+                        ],
+                    },
                 ],
                 [{"role": "assistant", "content": result.final_output}],
             ),


### PR DESCRIPTION
While QA-ing our agentic integrations, I noticed a bug in the current Open AI Agent's output message parsing. The content field on OpenAI's `ResponseReasoningItem` is optional ([ref](https://github.com/openai/openai-python/blob/2adf11112988e998fcf5adb805bae38501d22318/src/openai/types/responses/response_reasoning_item.py#L27-L51)) which we were not handling properly leading to potential `NoneType` errors like the one below:

```
  File "/Users/nicole.cybul/go/src/github.com/DataDog/dd-trace-py/ddtrace/llmobs/_integrations/utils.py", line 1161, in llmobs_output_messages
    for content in item.content:
                   ^^^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```

While investigating this issue, I noticed that our OpenAI integration had a nearly identical implementation for parsing input and output messages, so I decided to extract the common logic into a helper function that could be reused across the OpenAI and OpenAI Agents integrations. This fixed the `NoneType` error since now we do not try to iterate over `item.content` for reasoning message types.

## Manual Testing
Here is a [trace](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&sp=%5B%7B%22sp%22%3A%7B%22width%22%3A%22min%28100%25%2C%20max%28calc%28100%25%20-%20var%28--ui-page-left-offset%29%20-%2016px%29%2C%20900px%29%29%22%7D%2C%22p%22%3A%7B%22eventId%22%3A%22AwAAAZkvInhdwYmtigAAABhBWmt2SW5oZEFBRExtZktfRkZzZEFBQUEAAAAkMDE5OTJmMjMtOTQxOC00OTliLTg1ZWYtYjc5ZjBmNGU5YjkzAABCrQ%22%7D%2C%22i%22%3A%22llm-obs-panel%22%7D%5D&spanId=9743349247239047563&start=1757431678372&end=1757432578372&paused=false) that I created with this feature branch which can be compared with this [trace](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&sp=%5B%7B%22sp%22%3A%7B%22width%22%3A%22min%28100%25%2C%20max%28calc%28100%25%20-%20var%28--ui-page-left-offset%29%20-%2016px%29%2C%20900px%29%29%22%7D%2C%22p%22%3A%7B%22eventId%22%3A%22AwAAAZkvJpU3H4D3EQAAABhBWmt2SnBVM0FBQlh3NUdHTDY2SEFBQUEAAAAkZjE5OTJmMjYtY2MyMy00YTQxLThlZWQtZWJlNmZlNWYyOTE4AAAI6g%22%7D%2C%22i%22%3A%22llm-obs-panel%22%7D%5D&spanId=10719453409381675278&start=1757431833983&end=1757432733983&paused=false) from the main branch.

|  | Before | After |
|---|---|---|
| OpenAI Agents LLM spans were missing output messages due to the `NoneType` error). | <img width="1056" height="992" alt="image" src="https://github.com/user-attachments/assets/3e94b71f-6d39-4044-af4d-bba901e3f850" /> | <img width="1236" height="994" alt="image" src="https://github.com/user-attachments/assets/266b4085-14d4-487e-946d-a5ea0af990f6" /> |
| Tool Results for OpenAI Agents LLM spans were not being captured | <img width="542" height="116" alt="image" src="https://github.com/user-attachments/assets/8829ae88-add1-415c-964e-c2253478a595" /> | <img width="1206" height="104" alt="image" src="https://github.com/user-attachments/assets/26e829ff-efc8-4228-a289-1c1f316411f9" /> |
| Spans were not being linked properly due to missing output messages | <img width="1690" height="864" alt="image" src="https://github.com/user-attachments/assets/b7c290a1-7474-4b7a-8cab-fca1e75732f5" /> | <img width="548" height="1104" alt="image" src="https://github.com/user-attachments/assets/b5542829-784d-4780-b33c-3a9843753bcb" /> |


## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
