### PR TITLE
chore(profiling): small typing improvements

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack_v2/__init__.pyi
+++ b/ddtrace/internal/datadog/profiling/stack_v2/__init__.pyi
@@ -1,0 +1,5 @@
+def register_thread(id: int, native_id: int, name: str) -> None: ...  # noqa: A002
+def unregister_thread(name: str) -> None: ...
+
+is_available: bool
+failure_msg: str

--- a/ddtrace/profiling/collector/__init__.py
+++ b/ddtrace/profiling/collector/__init__.py
@@ -1,4 +1,6 @@
 # -*- encoding: utf-8 -*-
+import typing
+
 from ddtrace.internal import periodic
 from ddtrace.internal import service
 from ddtrace.settings.profiling import config
@@ -15,11 +17,11 @@ class CollectorUnavailable(CollectorError):
 class Collector(service.Service):
     """A profile collector."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         super().__init__(*args, **kwargs)
 
     @staticmethod
-    def snapshot():
+    def snapshot() -> None:
         """Take a snapshot of collected data, to be exported."""
 
 
@@ -28,11 +30,11 @@ class PeriodicCollector(Collector, periodic.PeriodicService):
 
     __slots__ = ()
 
-    def periodic(self):
+    def periodic(self) -> None:
         # This is to simply override periodic.PeriodicService.periodic()
         self.collect()
 
-    def collect(self):
+    def collect(self) -> None:
         """Collect the actual data."""
         raise NotImplementedError
 
@@ -44,15 +46,15 @@ class CaptureSampler(object):
         if capture_pct < 0 or capture_pct > 100:
             raise ValueError("Capture percentage should be between 0 and 100 included")
         self.capture_pct: float = capture_pct
-        self._counter: int = 0
+        self._counter: float = 0
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         class_name = self.__class__.__name__
         attrs = {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
         attrs_str = ", ".join(f"{k}={v!r}" for k, v in attrs.items())
         return f"{class_name}({attrs_str})"
 
-    def capture(self):
+    def capture(self) -> bool:
         self._counter += self.capture_pct
         if self._counter >= 100:
             self._counter -= 100
@@ -61,7 +63,7 @@ class CaptureSampler(object):
 
 
 class CaptureSamplerCollector(Collector):
-    def __init__(self, capture_pct=config.capture_pct, *args, **kwargs):
+    def __init__(self, capture_pct: float = config.capture_pct, *args: typing.Any, **kwargs: typing.Any) -> None:
         super().__init__(*args, **kwargs)
         self.capture_pct = capture_pct
         self._capture_sampler = CaptureSampler(self.capture_pct)

--- a/ddtrace/profiling/collector/_lock.py
+++ b/ddtrace/profiling/collector/_lock.py
@@ -19,8 +19,10 @@ from ddtrace.settings.profiling import config
 from ddtrace.trace import Tracer
 
 
-def _current_thread():
-    # type: (...) -> typing.Tuple[int, str]
+T = typing.TypeVar("T")
+
+
+def _current_thread() -> typing.Tuple[int, str]:
     thread_id = _thread.get_ident()
     return thread_id, _threading.get_thread_name(thread_id)
 
@@ -58,13 +60,13 @@ class _ProfiledLock(wrapt.ObjectProxy):
         self._self_init_loc = "%s:%d" % (os.path.basename(code.co_filename), frame.f_lineno)
         self._self_name: typing.Optional[str] = None
 
-    def __aenter__(self, *args, **kwargs):
+    def __aenter__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any:
         return self._acquire(self.__wrapped__.__aenter__, *args, **kwargs)
 
-    def __aexit__(self, *args, **kwargs):
+    def __aexit__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         return self._release(self.__wrapped__.__aexit__, *args, **kwargs)
 
-    def _acquire(self, inner_func, *args, **kwargs):
+    def _acquire(self, inner_func: typing.Callable[..., T], *args: typing.Any, **kwargs: typing.Any) -> T:
         if not self._self_capture_sampler.capture():
             return inner_func(*args, **kwargs)
 
@@ -100,16 +102,18 @@ class _ProfiledLock(wrapt.ObjectProxy):
 
                 if self._self_tracer is not None:
                     handle.push_span(self._self_tracer.current_span())
-                for frame in frames:
-                    handle.push_frame(frame.function_name, frame.file_name, 0, frame.lineno)
+
+                for f in frames:
+                    handle.push_frame(f.function_name, f.file_name, 0, f.lineno)
+
                 handle.flush_sample()
             except Exception:
                 pass  # nosec
 
-    def acquire(self, *args, **kwargs):
+    def acquire(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any:
         return self._acquire(self.__wrapped__.acquire, *args, **kwargs)
 
-    def _release(self, inner_func, *args, **kwargs):
+    def _release(self, inner_func: typing.Callable[..., typing.Any], *args: typing.Any, **kwargs: typing.Any) -> None:
         # type (typing.Any, typing.Any) -> None
 
         # The underlying threading.Lock class is implemented using C code, and
@@ -158,22 +162,23 @@ class _ProfiledLock(wrapt.ObjectProxy):
 
                 if self._self_tracer is not None:
                     handle.push_span(self._self_tracer.current_span())
-                for frame in frames:
-                    handle.push_frame(frame.function_name, frame.file_name, 0, frame.lineno)
+
+                for f in frames:
+                    handle.push_frame(f.function_name, f.file_name, 0, f.lineno)
                 handle.flush_sample()
 
-    def release(self, *args, **kwargs):
+    def release(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         return self._release(self.__wrapped__.release, *args, **kwargs)
 
     acquire_lock = acquire
 
-    def __enter__(self, *args, **kwargs):
+    def __enter__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any:
         return self._acquire(self.__wrapped__.__enter__, *args, **kwargs)
 
-    def __exit__(self, *args, **kwargs):
+    def __exit__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         self._release(self.__wrapped__.__exit__, *args, **kwargs)
 
-    def _find_self_name(self, var_dict: typing.Dict):
+    def _find_self_name(self, var_dict: typing.Dict) -> typing.Optional[str]:
         for name, value in var_dict.items():
             if name.startswith("__") or isinstance(value, types.ModuleType):
                 continue
@@ -188,7 +193,7 @@ class _ProfiledLock(wrapt.ObjectProxy):
 
     # Get lock acquire/release call location and variable name the lock is assigned to
     # This function propagates ValueError if the frame depth is <= 3.
-    def _maybe_update_self_name(self):
+    def _maybe_update_self_name(self) -> None:
         if self._self_name is not None:
             return
         # We expect the call stack to be like this:
@@ -223,60 +228,66 @@ class FunctionWrapper(wrapt.FunctionWrapper):
     # Override the __get__ method: whatever happens, _allocate_lock is always considered by Python like a "static"
     # method, even when used as a class attribute. Python never tried to "bind" it to a method, because it sees it is a
     # builtin function. Override default wrapt behavior here that tries to detect bound method.
-    def __get__(self, instance, owner=None):
+    def __get__(
+        self,
+        instance: typing.Optional[typing.Any],
+        owner: typing.Optional[typing.Any] = None,
+    ) -> "FunctionWrapper":
         return self
 
 
 class LockCollector(collector.CaptureSamplerCollector):
     """Record lock usage."""
 
+    PROFILED_LOCK_CLASS: typing.Type[typing.Any]
+
     def __init__(
         self,
-        nframes=config.max_frames,
-        endpoint_collection_enabled=config.endpoint_collection,
-        tracer=None,
-        *args,
-        **kwargs,
-    ):
+        nframes: int = config.max_frames,
+        endpoint_collection_enabled: bool = config.endpoint_collection,
+        tracer: typing.Optional[Tracer] = None,
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.nframes = nframes
         self.endpoint_collection_enabled = endpoint_collection_enabled
         self.tracer = tracer
-        self._original = None
+        self._original: typing.Optional[typing.Any] = None
 
     @abc.abstractmethod
-    def _get_patch_target(self):
-        # type: (...) -> typing.Any
-        pass
+    def _get_patch_target(self) -> typing.Type[typing.Any]:
+        raise NotImplementedError
 
     @abc.abstractmethod
     def _set_patch_target(
         self,
-        value,  # type: typing.Any
-    ):
-        # type: (...) -> None
-        pass
+        value: typing.Any,
+    ) -> None:
+        raise NotImplementedError
 
-    def _start_service(self):
-        # type: (...) -> None
+    def _start_service(self) -> None:
         """Start collecting lock usage."""
         self.patch()
         super(LockCollector, self)._start_service()  # type: ignore[safe-super]
 
-    def _stop_service(self):
-        # type: (...) -> None
+    def _stop_service(self) -> None:
         """Stop collecting lock usage."""
         super(LockCollector, self)._stop_service()  # type: ignore[safe-super]
         self.unpatch()
 
-    def patch(self):
-        # type: (...) -> None
+    def patch(self) -> None:
         """Patch the module for tracking lock allocation."""
         # We only patch the lock from the `threading` module.
         # Nobody should use locks from `_thread`; if they do so, then it's deliberate and we don't profile.
         self._original = self._get_patch_target()
 
-        def _allocate_lock(wrapped, instance, args, kwargs):
+        def _allocate_lock(
+            wrapped: typing.Any,
+            instance: typing.Any,
+            args: typing.Tuple[typing.Any, ...],
+            kwargs: typing.Dict[str, typing.Any],
+        ) -> typing.Any:
             lock = wrapped(*args, **kwargs)
             return self.PROFILED_LOCK_CLASS(
                 lock,
@@ -288,7 +299,6 @@ class LockCollector(collector.CaptureSamplerCollector):
 
         self._set_patch_target(FunctionWrapper(self._original, _allocate_lock))
 
-    def unpatch(self):
-        # type: (...) -> None
+    def unpatch(self) -> None:
         """Unpatch the threading module for tracking lock allocation."""
         self._set_patch_target(self._original)

--- a/ddtrace/profiling/collector/asyncio.py
+++ b/ddtrace/profiling/collector/asyncio.py
@@ -1,4 +1,5 @@
-import typing  # noqa:F401
+from asyncio.locks import Lock
+import typing
 
 from .. import collector
 from . import _lock
@@ -13,8 +14,7 @@ class AsyncioLockCollector(_lock.LockCollector):
 
     PROFILED_LOCK_CLASS = _ProfiledAsyncioLock
 
-    def _start_service(self):
-        # type: (...) -> None
+    def _start_service(self) -> None:
         """Start collecting lock usage."""
         try:
             import asyncio
@@ -23,12 +23,11 @@ class AsyncioLockCollector(_lock.LockCollector):
         self._asyncio_module = asyncio
         return super(AsyncioLockCollector, self)._start_service()
 
-    def _get_patch_target(self):
-        # type: (...) -> typing.Any
+    def _get_patch_target(self) -> typing.Type[Lock]:
         return self._asyncio_module.Lock
 
     def _set_patch_target(
-        self, value  # type: typing.Any
-    ):
-        # type: (...) -> None
+        self,
+        value: typing.Any,
+    ) -> None:
         self._asyncio_module.Lock = value  # type: ignore[misc]

--- a/ddtrace/profiling/collector/memalloc.py
+++ b/ddtrace/profiling/collector/memalloc.py
@@ -1,10 +1,17 @@
 # -*- encoding: utf-8 -*-
-from collections import namedtuple
 import logging
 import os
 import threading
-import typing  # noqa:F401
+from types import TracebackType
+from typing import List
+from typing import NamedTuple
 from typing import Optional
+from typing import Set
+from typing import Tuple
+from typing import Type
+from typing import cast
+
+from ddtrace.profiling.event import DDFrame
 
 
 try:
@@ -21,10 +28,16 @@ from ddtrace.settings.profiling import config
 
 LOG = logging.getLogger(__name__)
 
-MemorySample = namedtuple(
-    "MemorySample",
-    ("frames", "size", "count", "in_use_size", "alloc_size", "thread_id"),
-)
+
+class MemorySample(NamedTuple):
+    frames: List[DDFrame]
+    size: int
+    count: (  # pyright: ignore[reportIncompatibleMethodOverride] (count is a method of tuple)
+        int  # type: ignore[assignment]
+    )
+    in_use_size: int
+    alloc_size: int
+    thread_id: int
 
 
 class MemoryCollector:
@@ -35,13 +48,15 @@ class MemoryCollector:
         max_nframe: Optional[int] = None,
         heap_sample_size: Optional[int] = None,
         ignore_profiler: Optional[bool] = None,
-    ):
-        self.max_nframe: int = max_nframe if max_nframe is not None else config.max_frames
-        self.heap_sample_size: int = heap_sample_size if heap_sample_size is not None else config.heap.sample_size
-        self.ignore_profiler: bool = ignore_profiler if ignore_profiler is not None else config.ignore_profiler
+    ) -> None:
+        self.max_nframe = cast(int, max_nframe if max_nframe is not None else config.max_frames)
+        self.heap_sample_size = cast(
+            int,
+            heap_sample_size if heap_sample_size is not None else config.heap.sample_size,  # pyright: ignore
+        )
+        self.ignore_profiler = cast(bool, ignore_profiler if ignore_profiler is not None else config.ignore_profiler)
 
-    def start(self):
-        # type: (...) -> None
+    def start(self) -> None:
         """Start collecting memory profiles."""
         if _memalloc is None:
             raise collector.CollectorUnavailable
@@ -55,25 +70,28 @@ class MemoryCollector:
             _memalloc.stop()
             _memalloc.start(self.max_nframe, self.heap_sample_size)
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         self.start()
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
         self.stop()
 
-    def join(self):
+    def join(self) -> None:
         pass
 
-    def stop(self):
-        # type: () -> None
+    def stop(self) -> None:
         if _memalloc is not None:
             try:
                 _memalloc.stop()
             except RuntimeError:
                 LOG.debug("Failed to stop memalloc profiling on shutdown", exc_info=True)
 
-    def _get_thread_id_ignore_set(self):
-        # type: () -> typing.Set[int]
+    def _get_thread_id_ignore_set(self) -> Set[int]:
         # This method is not perfect and prone to race condition in theory, but very little in practice.
         # Anyhow it's not a big deal — it's a best effort feature.
         return {
@@ -82,12 +100,14 @@ class MemoryCollector:
             if getattr(thread, "_ddtrace_profiling_ignore", False) and thread.ident is not None
         }
 
-    def snapshot(self):
+    def snapshot(self) -> Tuple[MemorySample, ...]:
         thread_id_ignore_set = self._get_thread_id_ignore_set()
 
         try:
+            if _memalloc is None:
+                raise ValueError("Memalloc is not initialized")
             events = _memalloc.heap()
-        except RuntimeError:
+        except (RuntimeError, ValueError):
             # DEV: This can happen if either _memalloc has not been started or has been stopped.
             LOG.debug("Unable to collect heap events from process %d", os.getpid(), exc_info=True)
             return tuple()
@@ -116,19 +136,22 @@ class MemoryCollector:
                     # DEV: This might happen if the memalloc sofile is unlinked and relinked without module
                     #      re-initialization.
                     LOG.debug("Invalid state detected in memalloc module, suppressing profile")
+
         return tuple()
 
-    def test_snapshot(self):
+    def test_snapshot(self) -> Tuple[MemorySample, ...]:
         thread_id_ignore_set = self._get_thread_id_ignore_set()
 
         try:
+            if _memalloc is None:
+                raise ValueError("Memalloc is not initialized")
             events = _memalloc.heap()
-        except RuntimeError:
+        except (RuntimeError, ValueError):
             # DEV: This can happen if either _memalloc has not been started or has been stopped.
             LOG.debug("Unable to collect heap events from process %d", os.getpid(), exc_info=True)
             return tuple()
 
-        samples = []
+        samples: List[MemorySample] = []
         for event in events:
             (frames, thread_id), in_use_size, alloc_size, count = event
 
@@ -139,5 +162,5 @@ class MemoryCollector:
 
         return tuple(samples)
 
-    def collect(self):
+    def collect(self) -> Tuple[MemorySample, ...]:
         return tuple()

--- a/ddtrace/profiling/collector/stack.pyi
+++ b/ddtrace/profiling/collector/stack.pyi
@@ -1,7 +1,7 @@
 import typing
 
-import ddtrace
+from ddtrace.trace import Tracer
 from ddtrace.profiling import collector
 
 class StackCollector(collector.PeriodicCollector):
-    tracer: typing.Optional[ddtrace.trace.Tracer]
+    tracer: typing.Optional[Tracer]

--- a/ddtrace/profiling/collector/threading.py
+++ b/ddtrace/profiling/collector/threading.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import threading
-import typing  # noqa:F401
+import typing
 
 from ddtrace.internal._unpatched import _threading as ddtrace_threading
 from ddtrace.internal.datadog.profiling import stack_v2
@@ -19,35 +19,33 @@ class ThreadingLockCollector(_lock.LockCollector):
 
     PROFILED_LOCK_CLASS = _ProfiledThreadingLock
 
-    def _get_patch_target(self):
-        # type: (...) -> typing.Any
+    def _get_patch_target(self) -> typing.Type[threading.Lock]:
         return threading.Lock
 
     def _set_patch_target(
         self,
-        value,  # type: typing.Any
-    ):
-        # type: (...) -> None
+        value: typing.Any,
+    ) -> None:
         threading.Lock = value
 
 
 # Also patch threading.Thread so echion can track thread lifetimes
-def init_stack_v2():
+def init_stack_v2() -> None:
     if config.stack.v2_enabled and stack_v2.is_available:
-        _thread_set_native_id = ddtrace_threading.Thread._set_native_id
-        _thread_bootstrap_inner = ddtrace_threading.Thread._bootstrap_inner
+        _thread_set_native_id = ddtrace_threading.Thread._set_native_id  # type: ignore[attr-defined]
+        _thread_bootstrap_inner = ddtrace_threading.Thread._bootstrap_inner  # type: ignore[attr-defined]
 
-        def thread_set_native_id(self, *args, **kswargs):
-            _thread_set_native_id(self, *args, **kswargs)
+        def thread_set_native_id(self, *args, **kwargs):
+            _thread_set_native_id(self, *args, **kwargs)
             stack_v2.register_thread(self.ident, self.native_id, self.name)
 
         def thread_bootstrap_inner(self, *args, **kwargs):
             _thread_bootstrap_inner(self, *args, **kwargs)
             stack_v2.unregister_thread(self.ident)
 
-        ddtrace_threading.Thread._set_native_id = thread_set_native_id
-        ddtrace_threading.Thread._bootstrap_inner = thread_bootstrap_inner
+        ddtrace_threading.Thread._set_native_id = thread_set_native_id  # type: ignore[attr-defined]
+        ddtrace_threading.Thread._bootstrap_inner = thread_bootstrap_inner  # type: ignore[attr-defined]
 
         # Instrument any living threads
-        for thread_id, thread in ddtrace_threading._active.items():
+        for thread_id, thread in ddtrace_threading._active.items():  # type: ignore[attr-defined]
             stack_v2.register_thread(thread_id, thread.native_id, thread.name)


### PR DESCRIPTION
## What does this PR do?

This PR improves typing in the profiling codebase:
- It fixes it by replacing certain type annotations with the actual type where there were mismatches
- It makes it more specific in several places by replacing catch-all inferred types with the right ones 
- It makes it more modern by using actual type hints instead of typing comments

Note that due to how certain things work (namely, `envier`) and the many uses of untyped C extensions,  `getattr` and patching here and there, typing is still far from perfect. 

The rationale for this change is to make it easier to understand how the code works, as well as spot possible bugs early in the development cycle.

Notes
- This is not a functional change and as such, does not have a dedicated testing strategy 
- There are no known risks, as the code changes are not on code that is run 

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
