### PR TITLE
fix(appsec): unpatch close to open libddwaf

### DIFF
--- a/ddtrace/appsec/_utils.py
+++ b/ddtrace/appsec/_utils.py
@@ -367,10 +367,14 @@ def unpatching_popen():
     Context manager to temporarily unpatch `subprocess.Popen` for testing purposes.
     This is useful to ensure that the original `Popen` behavior is restored after the context.
     """
+    import os
     import subprocess  # nosec B404
 
+    from ddtrace.internal._unpatched import unpatched_close
     from ddtrace.internal._unpatched import unpatched_Popen
 
+    original_os_close = os.close
+    os.close = unpatched_close
     original_popen = subprocess.Popen
     subprocess.Popen = unpatched_Popen
     asm_config._bypass_instrumentation_for_waf = True
@@ -378,4 +382,5 @@ def unpatching_popen():
         yield
     finally:
         subprocess.Popen = original_popen
+        os.close = original_os_close
         asm_config._bypass_instrumentation_for_waf = False

--- a/ddtrace/internal/_unpatched.py
+++ b/ddtrace/internal/_unpatched.py
@@ -15,6 +15,7 @@ import sys
 
 previous_loaded_modules = frozenset(sys.modules.keys())
 from subprocess import Popen as unpatched_Popen  # noqa # nosec B404
+from os import close as unpatched_close  # noqa: F401, E402
 
 loaded_modules = frozenset(sys.modules.keys())
 for module in previous_loaded_modules - loaded_modules:

--- a/releasenotes/notes/fix-incompatibility-with-last-gevent-13d45f7b8ab18bdf.yaml
+++ b/releasenotes/notes/fix-incompatibility-with-last-gevent-13d45f7b8ab18bdf.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    AAP: Resolves an incompatibility with gevent>=25.8.1 that would cause a deadlock when starting the waf via remote config.


### PR DESCRIPTION
## Description

Follow up on https://github.com/DataDog/system-tests/pull/5180/files.
gevent started to patch `os.close` with `25.8.1`. This causes a problem in the libddwaf loading process where we are using unpatched `subprocess.Popen` that calls the gevent patched `os.close`, this causes a deadlock.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
