### PR TITLE
fix(rc): switch from type to typecode for mp reliability

### DIFF
--- a/ddtrace/internal/remoteconfig/_connectors.py
+++ b/ddtrace/internal/remoteconfig/_connectors.py
@@ -1,4 +1,3 @@
-from ctypes import c_char
 from dataclasses import asdict
 import json
 import os
@@ -46,7 +45,7 @@ class PublisherSubscriberConnector:
 
     def __init__(self):
         try:
-            self.data = get_mp_context().Array(c_char, SHARED_MEMORY_SIZE, lock=False)
+            self.data = get_mp_context().Array("c", SHARED_MEMORY_SIZE, lock=False)
         except FileNotFoundError:
             log.warning(
                 "Unable to create shared memory. Features relying on remote configuration will not work as expected."

--- a/releasenotes/notes/rc_switch_to_typecode-9409c92e8a07a8be.yaml
+++ b/releasenotes/notes/rc_switch_to_typecode-9409c92e8a07a8be.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    RemoteConfig: Fixes an issue introduced in Python 3.13 where creating a shared
+    array with the c_char type raised a TypeError, this now uses the 'c' typecode
+    for better compatibility across versions.


### PR DESCRIPTION
This switches the shared data for the remote configuration PublisherSubscriberConnector to use a typecode instead of an explicit type to take advantage of an internal mapping. This should be more reliable across Python versions and fix an issue with Python3.13:

```
get_mp_context().Array(c_char, SHARED_MEMORY_SIZE, lock=False): TypeError: this type has no size
```

This change should be identical, and for more information, see the docs here:

- https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Array
- https://docs.python.org/3/library/array.html#module-array
- https://docs.python.org/3/library/ctypes.html

Refs: DEBUG-4453

Relevant stacktrace:

```
    self.data = get_mp_context().Array(c_char, SHARED_MEMORY_SIZE, lock=False)
                ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/multiprocessing/context.py", line 141, in Array
    return Array(typecode_or_type, size_or_initializer, lock=lock,
                 ctx=self.get_context())
  File "/usr/local/lib/python3.13/multiprocessing/sharedctypes.py", line 88, in Array
    obj = RawArray(typecode_or_type, size_or_initializer)
  File "/usr/local/lib/python3.13/multiprocessing/sharedctypes.py", line 61, in RawArray
    obj = _new_value(type_)
  File "/usr/local/lib/python3.13/multiprocessing/sharedctypes.py", line 40, in _new_value
    size = ctypes.sizeof(type_)
TypeError: this type has no size
```

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
