### PR TITLE
fix(aap): status code for downstream requests

### DIFF
--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -222,7 +222,7 @@ def wrapped_open_ED4CF71136E15EBF(original_open_callable, instance, args, kwargs
                     # api10 response handler for regular reponses
                     if response.__class__.__name__ == "HTTPResponse":
                         addresses = {
-                            "DOWN_RES_STATUS": response.status,
+                            "DOWN_RES_STATUS": str(response.status),
                             "DOWN_RES_HEADERS": _build_headers(response.getheaders()),
                         }
                         if use_body:
@@ -242,7 +242,7 @@ def wrapped_open_ED4CF71136E15EBF(original_open_callable, instance, args, kwargs
                             response_headers = None
                         if status_code is not None or response_headers is not None:
                             call_waf_callback(
-                                {"DOWN_RES_STATUS": status_code, "DOWN_RES_HEADERS": response_headers},
+                                {"DOWN_RES_STATUS": str(status_code), "DOWN_RES_HEADERS": response_headers},
                                 rule_type=EXPLOIT_PREVENTION.TYPE.SSRF,
                             )
                     raise

--- a/releasenotes/notes/api10_status_code-deb7bbc4c0c2a68e.yaml
+++ b/releasenotes/notes/api10_status_code-deb7bbc4c0c2a68e.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    AAP: make sure the status code for downstream requests is properly sent to libddwaf.


### PR DESCRIPTION
The implementation of api10 was sending status code for downstream requests as an unsigned integer while libddwaf is expecting a string.
This fixes that.

This will be extensively tested in system tests (problem was discovered on ST)

## Checklist
- [ ] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
