### PR TITLE
fix(tracing): span pointer __repr__

### DIFF
--- a/ddtrace/_trace/_span_pointer.py
+++ b/ddtrace/_trace/_span_pointer.py
@@ -64,7 +64,8 @@ class _SpanPointer(SpanLink):
     def __repr__(self):
         return (
             f"SpanPointer(trace_id={self.trace_id}, span_id={self.span_id}, kind={self.kind}, "
-            f"direction={self.attributes.get('ptr.dir')}, hash={self.attributes.get('ptr.hash')}, attributes={self.attributes})"
+            f"direction={self.attributes.get('ptr.dir')}, hash={self.attributes.get('ptr.hash')}, "
+            f"attributes={self.attributes})"
         )
 
 

--- a/ddtrace/_trace/_span_pointer.py
+++ b/ddtrace/_trace/_span_pointer.py
@@ -64,7 +64,7 @@ class _SpanPointer(SpanLink):
     def __repr__(self):
         return (
             f"SpanPointer(trace_id={self.trace_id}, span_id={self.span_id}, kind={self.kind}, "
-            f"direction={self.direction}, hash={self.hash}, attributes={self.attributes})"
+            f"direction={self.attributes.get('ptr.dir')}, hash={self.attributes.get('ptr.hash')}, attributes={self.attributes})"
         )
 
 

--- a/releasenotes/notes/fix-spanpointer-repr-565ebb8e6679ebde.yaml
+++ b/releasenotes/notes/fix-spanpointer-repr-565ebb8e6679ebde.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    span pointer: This fix resolves an issue where the __repr__ method is trying to access non-existent direction and hash attributes directly
+    tracing: Fixes a bug where calling __repr__ on SpanPointer objected raised an AttributeError. This caused aws_lambdas to crash when debug logs were enabled.

--- a/releasenotes/notes/fix-spanpointer-repr-565ebb8e6679ebde.yaml
+++ b/releasenotes/notes/fix-spanpointer-repr-565ebb8e6679ebde.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    span pointer: This fix resolves an issue where the __repr__ method is trying to access non-existent direction and hash attributes directly

--- a/releasenotes/notes/fix-spanpointer-repr-565ebb8e6679ebde.yaml
+++ b/releasenotes/notes/fix-spanpointer-repr-565ebb8e6679ebde.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    tracing: Fixes a bug where calling __repr__ on SpanPointer objected raised an AttributeError. This caused aws_lambdas to crash when debug logs were enabled.
+    tracing: Fixes a bug where calling __repr__ on SpanPointer objected raised an AttributeError. This caused aws_lambdas to crash when debug logging was enabled.

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -9,7 +9,6 @@ import mock
 import pytest
 
 from ddtrace._trace._span_link import SpanLink
-from ddtrace._trace._span_pointer import _SpanPointer
 from ddtrace._trace._span_pointer import _SpanPointerDirection
 from ddtrace._trace.context import Context
 from ddtrace.constants import _SPAN_MEASURED_KEY

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -9,6 +9,7 @@ import mock
 import pytest
 
 from ddtrace._trace._span_link import SpanLink
+from ddtrace._trace._span_pointer import _SpanPointer
 from ddtrace._trace._span_pointer import _SpanPointerDirection
 from ddtrace._trace.context import Context
 from ddtrace.constants import _SPAN_MEASURED_KEY
@@ -872,6 +873,7 @@ def test_span_pprint():
     root.set_metric("m", 1.0)
     root._add_event("message", {"importance": 10}, 16789898242)
     root.set_link(trace_id=99, span_id=10, attributes={"link.name": "s1_to_s2", "link.kind": "scheduled_by"})
+    root._add_span_pointer("test_kind", _SpanPointerDirection.DOWNSTREAM, "test_hash_123", {"extra": "attr"})
 
     root.finish()
     actual = root._pprint()
@@ -887,6 +889,8 @@ def test_span_pprint():
         "[SpanLink(trace_id=99, span_id=10, attributes={'link.name': 's1_to_s2', 'link.kind': 'scheduled_by'}, "
         "tracestate=None, flags=None, dropped_attributes=0)]"
     ) in actual
+    assert "SpanPointer(trace_id=0, span_id=0, kind=span-pointer" in actual
+    assert "direction=d, hash=test_hash_123" in actual
     assert (
         f"context=Context(trace_id={root.trace_id}, span_id={root.span_id}, _meta={{}}, "
         "_metrics={}, _span_links=[], _baggage={}, _is_remote=False)"

--- a/tests/tracer/test_span.py
+++ b/tests/tracer/test_span.py
@@ -885,8 +885,8 @@ def test_span_pprint():
     assert "metrics={'m': 1.0}" in actual
     assert "events=[SpanEvent(name='message', time=16789898242, attributes={'importance': 10})]" in actual
     assert (
-        "[SpanLink(trace_id=99, span_id=10, attributes={'link.name': 's1_to_s2', 'link.kind': 'scheduled_by'}, "
-        "tracestate=None, flags=None, dropped_attributes=0)]"
+        "SpanLink(trace_id=99, span_id=10, attributes={'link.name': 's1_to_s2', 'link.kind': 'scheduled_by'}, "
+        "tracestate=None, flags=None, dropped_attributes=0)"
     ) in actual
     assert "SpanPointer(trace_id=0, span_id=0, kind=span-pointer" in actual
     assert "direction=d, hash=test_hash_123" in actual


### PR DESCRIPTION
## What's the issue
In the _SpanPointer.__repr__ method, it's trying to access self.direction and self.hash, but these attributes don't exist on the object. The _SpanPointer class:
  1. It inherits from SpanLink
  2. The direction and hash information are stored in the attributes dictionary as "ptr.dir" and "ptr.hash"
Therefore the fix.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
