### PR TITLE
chore(appsec): remove extra waf.config_errors reporting

### DIFF
--- a/ddtrace/appsec/_metrics.py
+++ b/ddtrace/appsec/_metrics.py
@@ -64,8 +64,6 @@ def _set_waf_updates_metric(info: DDWaf_info, success: bool):
         telemetry.telemetry_writer.add_count_metric(
             TELEMETRY_NAMESPACE.APPSEC, "waf.updates", 1, tags=tags + (("success", bool_str[success]),)
         )
-        if not success:
-            telemetry.telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.APPSEC, "waf.config_errors", 1, tags=tags)
     except Exception:
         extra = {"product": "appsec", "exec_limit": 6, "more_info": ":waf:updates"}
         logger.warning(WARNING_TAGS.TELEMETRY_METRICS, extra=extra, exc_info=True)


### PR DESCRIPTION
## Description

Remove unnecessary waf.config_errors reportings:
- verbatim from the RFC: 
> appsec.waf.config_errors: this metric counts the configuration errors as reported by libddwaf. Note that this tag doesn’t count the number of times a configuration failed to load but rather the count of individual elements within the configuration which failed to load with an error (as opposed to a warning), currently this may need to be extracted from the *.errors key within diagnostics.

The reporting of individual errors extracted from the diagnostics is already performed in the `DDwaf._set_info` method. The one removed is called in `AppSecSpanProcessor._update_rule` and counts the number of times a configuration failed to load which should not be done as per the RFC.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
