### PR TITLE
chore(debugger): simplify er/di type to snapshot

### DIFF
--- a/ddtrace/debugging/_exception/replay.py
+++ b/ddtrace/debugging/_exception/replay.py
@@ -189,7 +189,7 @@ class SpanExceptionProbe(LogLineProbe):
 
 @dataclass
 class SpanExceptionSnapshot(Snapshot):
-    __type__ = "er_snapshot"
+    __type__ = "snapshot"
 
     exc_id: t.Optional[uuid.UUID] = None
 

--- a/ddtrace/debugging/_signal/log.py
+++ b/ddtrace/debugging/_signal/log.py
@@ -17,7 +17,7 @@ class LogSignal(Signal):
     (e.g. conditions) might need to be reported.
     """
 
-    __type__ = "di_snapshot"
+    __type__ = "snapshot"
     __track__: t.ClassVar[SignalTrack] = SignalTrack.LOGS
 
     @property


### PR DESCRIPTION
Fix from https://github.com/DataDog/dd-trace-py/pull/14402 where we decided in the specification to use `type:"snapshot"` instead of differentiate between which product produced the event.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
