### PR TITLE
chore(iast): context refactor II

### DIFF
--- a/benchmarks/appsec_iast_aspects/scenario.py
+++ b/benchmarks/appsec_iast_aspects/scenario.py
@@ -4,31 +4,28 @@ import bm
 from bm.utils import override_env
 
 
-with override_env({"DD_IAST_ENABLED": "True"}):
-    # from ddtrace.appsec._iast import oce
+try:
+    # 3.15+
+    from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request as end_iast_context
+    from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as iast_start_request
+    from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
+except ImportError:
     try:
         # 3.6+
-        from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as start_iast_context
-        from ddtrace.appsec._iast._iast_request_context_base import iast_finish_request as end_iast_context
+        from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
+        from ddtrace.appsec._iast._iast_request_context_base import iast_start_request
         from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
     except ImportError:
         # Pre 3.6
-        try:
-            from ddtrace.appsec._iast._iast_request_context import end_iast_context
-            from ddtrace.appsec._iast._iast_request_context import set_iast_request_enabled
-            from ddtrace.appsec._iast._iast_request_context import start_iast_context
-        except ImportError:
-            # Pre 2.15
-            from ddtrace.appsec._iast._taint_tracking._context import create_context as start_iast_context  # noqa: F401
-            from ddtrace.appsec._iast._taint_tracking._context import reset_context as end_iast_context  # noqa: F401
-
-            set_iast_request_enabled = lambda x: None  # noqa: E731
+        from ddtrace.appsec._iast._iast_request_context import end_iast_context
+        from ddtrace.appsec._iast._iast_request_context import iast_start_request
+        from ddtrace.appsec._iast._iast_request_context import set_iast_request_enabled
 
 
 def _start_iast_context_and_oce():
     # oce.reconfigure()
     # oce.acquire_request(None)
-    start_iast_context()
+    iast_start_request()
     set_iast_request_enabled(True)
 
 

--- a/benchmarks/appsec_iast_aspects/scenario.py
+++ b/benchmarks/appsec_iast_aspects/scenario.py
@@ -13,8 +13,8 @@ except ImportError:
     try:
         # 3.6+
         from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
-        from ddtrace.appsec._iast._iast_request_context_base import iast_start_request
         from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
+        from ddtrace.appsec._iast._iast_request_context_base import start_iast_context as iast_start_request
     except ImportError:
         # Pre 3.6
         from ddtrace.appsec._iast._iast_request_context import end_iast_context

--- a/benchmarks/appsec_iast_aspects/scenario.py
+++ b/benchmarks/appsec_iast_aspects/scenario.py
@@ -7,7 +7,7 @@ from bm.utils import override_env
 try:
     # 3.15+
     from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request as end_iast_context
-    from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as iast_start_request
+    from ddtrace.appsec._iast._iast_request_context_base import _iast_start_request as iast_start_request
     from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
 except ImportError:
     try:

--- a/benchmarks/appsec_iast_aspects/scenario.py
+++ b/benchmarks/appsec_iast_aspects/scenario.py
@@ -8,9 +8,9 @@ with override_env({"DD_IAST_ENABLED": "True"}):
     # from ddtrace.appsec._iast import oce
     try:
         # 3.6+
-        from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
+        from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as start_iast_context
+        from ddtrace.appsec._iast._iast_request_context_base import iast_finish_request as end_iast_context
         from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
-        from ddtrace.appsec._iast._iast_request_context_base import start_iast_context
     except ImportError:
         # Pre 3.6
         try:
@@ -19,8 +19,8 @@ with override_env({"DD_IAST_ENABLED": "True"}):
             from ddtrace.appsec._iast._iast_request_context import start_iast_context
         except ImportError:
             # Pre 2.15
-            from ddtrace.appsec._iast._taint_tracking._context import create_context as start_iast_context
-            from ddtrace.appsec._iast._taint_tracking._context import reset_context as end_iast_context
+            from ddtrace.appsec._iast._taint_tracking._context import create_context as start_iast_context  # noqa: F401
+            from ddtrace.appsec._iast._taint_tracking._context import reset_context as end_iast_context  # noqa: F401
 
             set_iast_request_enabled = lambda x: None  # noqa: E731
 

--- a/benchmarks/appsec_iast_aspects_ospath/scenario.py
+++ b/benchmarks/appsec_iast_aspects_ospath/scenario.py
@@ -6,9 +6,9 @@ with override_env({"DD_IAST_ENABLED": "True"}):
     # from ddtrace.appsec._iast import oce
     try:
         # 3.6+
-        from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
+        from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as start_iast_context
+        from ddtrace.appsec._iast._iast_request_context_base import iast_finish_request as end_iast_context
         from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
-        from ddtrace.appsec._iast._iast_request_context_base import start_iast_context
     except ImportError:
         # Pre 3.6
         try:
@@ -17,8 +17,8 @@ with override_env({"DD_IAST_ENABLED": "True"}):
             from ddtrace.appsec._iast._iast_request_context import start_iast_context
         except ImportError:
             # Pre 2.15
-            from ddtrace.appsec._iast._taint_tracking._context import create_context as start_iast_context
-            from ddtrace.appsec._iast._taint_tracking._context import reset_context as end_iast_context
+            from ddtrace.appsec._iast._taint_tracking._context import create_context as start_iast_context  # noqa: F401
+            from ddtrace.appsec._iast._taint_tracking._context import reset_context as end_iast_context  # noqa: F401
 
             set_iast_request_enabled = lambda x: None  # noqa: E731
 

--- a/benchmarks/appsec_iast_aspects_ospath/scenario.py
+++ b/benchmarks/appsec_iast_aspects_ospath/scenario.py
@@ -11,8 +11,8 @@ except ImportError:
     try:
         # 3.6+
         from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
-        from ddtrace.appsec._iast._iast_request_context_base import iast_start_request
         from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
+        from ddtrace.appsec._iast._iast_request_context_base import start_iast_context as iast_start_request
     except ImportError:
         # Pre 3.6
         from ddtrace.appsec._iast._iast_request_context import end_iast_context

--- a/benchmarks/appsec_iast_aspects_ospath/scenario.py
+++ b/benchmarks/appsec_iast_aspects_ospath/scenario.py
@@ -2,31 +2,28 @@ import bm
 from bm.utils import override_env
 
 
-with override_env({"DD_IAST_ENABLED": "True"}):
-    # from ddtrace.appsec._iast import oce
+try:
+    # 3.15+
+    from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request as end_iast_context
+    from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as iast_start_request
+    from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
+except ImportError:
     try:
         # 3.6+
-        from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as start_iast_context
-        from ddtrace.appsec._iast._iast_request_context_base import iast_finish_request as end_iast_context
+        from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
+        from ddtrace.appsec._iast._iast_request_context_base import iast_start_request
         from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
     except ImportError:
         # Pre 3.6
-        try:
-            from ddtrace.appsec._iast._iast_request_context import end_iast_context
-            from ddtrace.appsec._iast._iast_request_context import set_iast_request_enabled
-            from ddtrace.appsec._iast._iast_request_context import start_iast_context
-        except ImportError:
-            # Pre 2.15
-            from ddtrace.appsec._iast._taint_tracking._context import create_context as start_iast_context  # noqa: F401
-            from ddtrace.appsec._iast._taint_tracking._context import reset_context as end_iast_context  # noqa: F401
-
-            set_iast_request_enabled = lambda x: None  # noqa: E731
+        from ddtrace.appsec._iast._iast_request_context import end_iast_context
+        from ddtrace.appsec._iast._iast_request_context import iast_start_request
+        from ddtrace.appsec._iast._iast_request_context import set_iast_request_enabled
 
 
 def _start_iast_context_and_oce():
     # oce.reconfigure()
     # oce.acquire_request(None)
-    start_iast_context()
+    iast_start_request()
     set_iast_request_enabled(True)
 
 

--- a/benchmarks/appsec_iast_aspects_ospath/scenario.py
+++ b/benchmarks/appsec_iast_aspects_ospath/scenario.py
@@ -5,7 +5,7 @@ from bm.utils import override_env
 try:
     # 3.15+
     from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request as end_iast_context
-    from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as iast_start_request
+    from ddtrace.appsec._iast._iast_request_context_base import _iast_start_request as iast_start_request
     from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
 except ImportError:
     try:

--- a/benchmarks/appsec_iast_aspects_re_module/scenario.py
+++ b/benchmarks/appsec_iast_aspects_re_module/scenario.py
@@ -6,9 +6,9 @@ with override_env({"DD_IAST_ENABLED": "True"}):
     # from ddtrace.appsec._iast import oce
     try:
         # 3.6+
-        from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
+        from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as start_iast_context
+        from ddtrace.appsec._iast._iast_request_context_base import iast_finish_request as end_iast_context
         from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
-        from ddtrace.appsec._iast._iast_request_context_base import start_iast_context
     except ImportError:
         # Pre 3.6
         try:
@@ -17,8 +17,8 @@ with override_env({"DD_IAST_ENABLED": "True"}):
             from ddtrace.appsec._iast._iast_request_context import start_iast_context
         except ImportError:
             # Pre 2.15
-            from ddtrace.appsec._iast._taint_tracking._context import create_context as start_iast_context
-            from ddtrace.appsec._iast._taint_tracking._context import reset_context as end_iast_context
+            from ddtrace.appsec._iast._taint_tracking._context import create_context as start_iast_context  # noqa: F401
+            from ddtrace.appsec._iast._taint_tracking._context import reset_context as end_iast_context  # noqa: F401
 
             set_iast_request_enabled = lambda x: None  # noqa: E731
 

--- a/benchmarks/appsec_iast_aspects_re_module/scenario.py
+++ b/benchmarks/appsec_iast_aspects_re_module/scenario.py
@@ -11,8 +11,8 @@ except ImportError:
     try:
         # 3.6+
         from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
-        from ddtrace.appsec._iast._iast_request_context_base import iast_start_request
         from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
+        from ddtrace.appsec._iast._iast_request_context_base import start_iast_context as iast_start_request
     except ImportError:
         # Pre 3.6
         from ddtrace.appsec._iast._iast_request_context import end_iast_context

--- a/benchmarks/appsec_iast_aspects_re_module/scenario.py
+++ b/benchmarks/appsec_iast_aspects_re_module/scenario.py
@@ -2,31 +2,28 @@ import bm
 from bm.utils import override_env
 
 
-with override_env({"DD_IAST_ENABLED": "True"}):
-    # from ddtrace.appsec._iast import oce
+try:
+    # 3.15+
+    from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request as end_iast_context
+    from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as iast_start_request
+    from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
+except ImportError:
     try:
         # 3.6+
-        from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as start_iast_context
-        from ddtrace.appsec._iast._iast_request_context_base import iast_finish_request as end_iast_context
+        from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
+        from ddtrace.appsec._iast._iast_request_context_base import iast_start_request
         from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
     except ImportError:
         # Pre 3.6
-        try:
-            from ddtrace.appsec._iast._iast_request_context import end_iast_context
-            from ddtrace.appsec._iast._iast_request_context import set_iast_request_enabled
-            from ddtrace.appsec._iast._iast_request_context import start_iast_context
-        except ImportError:
-            # Pre 2.15
-            from ddtrace.appsec._iast._taint_tracking._context import create_context as start_iast_context  # noqa: F401
-            from ddtrace.appsec._iast._taint_tracking._context import reset_context as end_iast_context  # noqa: F401
-
-            set_iast_request_enabled = lambda x: None  # noqa: E731
+        from ddtrace.appsec._iast._iast_request_context import end_iast_context
+        from ddtrace.appsec._iast._iast_request_context import iast_start_request
+        from ddtrace.appsec._iast._iast_request_context import set_iast_request_enabled
 
 
 def _start_iast_context_and_oce():
     # oce.reconfigure()
     # oce.acquire_request(None)
-    start_iast_context()
+    iast_start_request()
     set_iast_request_enabled(True)
 
 

--- a/benchmarks/appsec_iast_aspects_re_module/scenario.py
+++ b/benchmarks/appsec_iast_aspects_re_module/scenario.py
@@ -5,7 +5,7 @@ from bm.utils import override_env
 try:
     # 3.15+
     from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request as end_iast_context
-    from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as iast_start_request
+    from ddtrace.appsec._iast._iast_request_context_base import _iast_start_request as iast_start_request
     from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
 except ImportError:
     try:

--- a/benchmarks/appsec_iast_aspects_split/scenario.py
+++ b/benchmarks/appsec_iast_aspects_split/scenario.py
@@ -6,9 +6,9 @@ with override_env({"DD_IAST_ENABLED": "True"}):
     # from ddtrace.appsec._iast import oce
     try:
         # 3.6+
-        from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
+        from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as start_iast_context
+        from ddtrace.appsec._iast._iast_request_context_base import iast_finish_request as end_iast_context
         from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
-        from ddtrace.appsec._iast._iast_request_context_base import start_iast_context
     except ImportError:
         # Pre 3.6
         try:
@@ -17,8 +17,8 @@ with override_env({"DD_IAST_ENABLED": "True"}):
             from ddtrace.appsec._iast._iast_request_context import start_iast_context
         except ImportError:
             # Pre 2.15
-            from ddtrace.appsec._iast._taint_tracking._context import create_context as start_iast_context
-            from ddtrace.appsec._iast._taint_tracking._context import reset_context as end_iast_context
+            from ddtrace.appsec._iast._taint_tracking._context import create_context as start_iast_context  # noqa: F401
+            from ddtrace.appsec._iast._taint_tracking._context import reset_context as end_iast_context  # noqa: F401
 
             set_iast_request_enabled = lambda x: None  # noqa: E731
 

--- a/benchmarks/appsec_iast_aspects_split/scenario.py
+++ b/benchmarks/appsec_iast_aspects_split/scenario.py
@@ -11,8 +11,8 @@ except ImportError:
     try:
         # 3.6+
         from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
-        from ddtrace.appsec._iast._iast_request_context_base import iast_start_request
         from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
+        from ddtrace.appsec._iast._iast_request_context_base import start_iast_context as iast_start_request
     except ImportError:
         # Pre 3.6
         from ddtrace.appsec._iast._iast_request_context import end_iast_context

--- a/benchmarks/appsec_iast_aspects_split/scenario.py
+++ b/benchmarks/appsec_iast_aspects_split/scenario.py
@@ -2,31 +2,28 @@ import bm
 from bm.utils import override_env
 
 
-with override_env({"DD_IAST_ENABLED": "True"}):
-    # from ddtrace.appsec._iast import oce
+try:
+    # 3.15+
+    from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request as end_iast_context
+    from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as iast_start_request
+    from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
+except ImportError:
     try:
         # 3.6+
-        from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as start_iast_context
-        from ddtrace.appsec._iast._iast_request_context_base import iast_finish_request as end_iast_context
+        from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
+        from ddtrace.appsec._iast._iast_request_context_base import iast_start_request
         from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
     except ImportError:
         # Pre 3.6
-        try:
-            from ddtrace.appsec._iast._iast_request_context import end_iast_context
-            from ddtrace.appsec._iast._iast_request_context import set_iast_request_enabled
-            from ddtrace.appsec._iast._iast_request_context import start_iast_context
-        except ImportError:
-            # Pre 2.15
-            from ddtrace.appsec._iast._taint_tracking._context import create_context as start_iast_context  # noqa: F401
-            from ddtrace.appsec._iast._taint_tracking._context import reset_context as end_iast_context  # noqa: F401
-
-            set_iast_request_enabled = lambda x: None  # noqa: E731
+        from ddtrace.appsec._iast._iast_request_context import end_iast_context
+        from ddtrace.appsec._iast._iast_request_context import iast_start_request
+        from ddtrace.appsec._iast._iast_request_context import set_iast_request_enabled
 
 
 def _start_iast_context_and_oce():
     # oce.reconfigure()
     # oce.acquire_request(None)
-    start_iast_context()
+    iast_start_request()
     set_iast_request_enabled(True)
 
 

--- a/benchmarks/appsec_iast_aspects_split/scenario.py
+++ b/benchmarks/appsec_iast_aspects_split/scenario.py
@@ -5,7 +5,7 @@ from bm.utils import override_env
 try:
     # 3.15+
     from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request as end_iast_context
-    from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as iast_start_request
+    from ddtrace.appsec._iast._iast_request_context_base import _iast_start_request as iast_start_request
     from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
 except ImportError:
     try:

--- a/benchmarks/appsec_iast_propagation/scenario.py
+++ b/benchmarks/appsec_iast_propagation/scenario.py
@@ -3,19 +3,19 @@ import bm
 
 try:
     # 3.6+
-    from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
+    from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as iast_start_request
+    from ddtrace.appsec._iast._iast_request_context_base import iast_finish_request as end_iast_context
     from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
-    from ddtrace.appsec._iast._iast_request_context_base import start_iast_context
 except ImportError:
     # Pre 3.6
     try:
         from ddtrace.appsec._iast._iast_request_context import end_iast_context
+        from ddtrace.appsec._iast._iast_request_context import iast_start_request
         from ddtrace.appsec._iast._iast_request_context import set_iast_request_enabled
-        from ddtrace.appsec._iast._iast_request_context import start_iast_context
     except ImportError:
         # Pre 2.15
-        from ddtrace.appsec._iast._taint_tracking._context import create_context as start_iast_context
-        from ddtrace.appsec._iast._taint_tracking._context import reset_context as end_iast_context
+        from ddtrace.appsec._iast._taint_tracking._context import create_context as iast_start_request  # noqa: F401
+        from ddtrace.appsec._iast._taint_tracking._context import reset_context as end_iast_context  # noqa: F401
 
         set_iast_request_enabled = lambda x: None  # noqa: E731
 from ddtrace.appsec._iast._taint_tracking import OriginType
@@ -34,7 +34,7 @@ except ImportError:
 def _start_iast_context_and_oce():
     oce.reconfigure()
     oce.acquire_request(None)
-    start_iast_context()
+    iast_start_request()
     set_iast_request_enabled(True)
 
 

--- a/benchmarks/appsec_iast_propagation/scenario.py
+++ b/benchmarks/appsec_iast_propagation/scenario.py
@@ -4,7 +4,7 @@ import bm
 try:
     # 3.15+
     from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request as end_iast_context
-    from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as iast_start_request
+    from ddtrace.appsec._iast._iast_request_context_base import _iast_start_request as iast_start_request
     from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
 except ImportError:
     try:

--- a/benchmarks/appsec_iast_propagation/scenario.py
+++ b/benchmarks/appsec_iast_propagation/scenario.py
@@ -2,22 +2,22 @@ import bm
 
 
 try:
-    # 3.6+
+    # 3.15+
+    from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request as end_iast_context
     from ddtrace.appsec._iast._iast_request_context_base import _start_iast_context as iast_start_request
-    from ddtrace.appsec._iast._iast_request_context_base import iast_finish_request as end_iast_context
     from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
 except ImportError:
-    # Pre 3.6
     try:
+        # 3.6+
+        from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
+        from ddtrace.appsec._iast._iast_request_context_base import iast_start_request
+        from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
+    except ImportError:
+        # Pre 3.6
         from ddtrace.appsec._iast._iast_request_context import end_iast_context
         from ddtrace.appsec._iast._iast_request_context import iast_start_request
         from ddtrace.appsec._iast._iast_request_context import set_iast_request_enabled
-    except ImportError:
-        # Pre 2.15
-        from ddtrace.appsec._iast._taint_tracking._context import create_context as iast_start_request  # noqa: F401
-        from ddtrace.appsec._iast._taint_tracking._context import reset_context as end_iast_context  # noqa: F401
 
-        set_iast_request_enabled = lambda x: None  # noqa: E731
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect

--- a/benchmarks/appsec_iast_propagation/scenario.py
+++ b/benchmarks/appsec_iast_propagation/scenario.py
@@ -10,8 +10,8 @@ except ImportError:
     try:
         # 3.6+
         from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
-        from ddtrace.appsec._iast._iast_request_context_base import iast_start_request
         from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
+        from ddtrace.appsec._iast._iast_request_context_base import start_iast_context as iast_start_request
     except ImportError:
         # Pre 3.6
         from ddtrace.appsec._iast._iast_request_context import end_iast_context

--- a/ddtrace/appsec/_iast/_iast_request_context.py
+++ b/ddtrace/appsec/_iast/_iast_request_context.py
@@ -1,9 +1,7 @@
-from typing import TYPE_CHECKING  # noqa:F401
-from typing import Any  # noqa:F401
-from typing import Dict  # noqa:F401
-from typing import Literal  # noqa:F401
+from typing import Any
+from typing import Dict
 from typing import Optional
-from typing import Union  # noqa:F401
+from typing import Union
 
 from ddtrace._trace.span import Span
 from ddtrace.appsec._constants import APPSEC
@@ -24,8 +22,6 @@ from ddtrace.settings.asm import config as asm_config
 
 
 log = get_logger(__name__)
-
-# Stopgap module for providing ASM context for the blocking features wrapping some contextvars.
 
 
 def set_iast_reporter(iast_reporter: IastSpanReporter) -> None:
@@ -67,7 +63,7 @@ def _create_and_attach_iast_report_to_span(
     _set_span_tag_iast_executed_sink(req_span)
 
     base.set_iast_request_enabled(False)
-    base.end_iast_context(req_span)
+    base._iast_finish_request(req_span)
 
     if req_span.get_tag(_ORIGIN_KEY) is None:
         req_span.set_tag_str(_ORIGIN_KEY, APPSEC.ORIGIN_VALUE)
@@ -94,7 +90,7 @@ def _iast_end_request(ctx=None, span=None, *args, **kwargs):
                 if req_span.get_metric(IAST.ENABLED) is None:
                     if not base.is_iast_request_enabled():
                         req_span.set_metric(IAST.ENABLED, 0.0)
-                        base.end_iast_context(req_span)
+                        base._iast_finish_request(req_span)
                         oce.release_request()
                         return
 

--- a/ddtrace/appsec/_iast/_iast_request_context_base.py
+++ b/ddtrace/appsec/_iast/_iast_request_context_base.py
@@ -30,20 +30,6 @@ def _set_span_tag_iast_request_tainted(span):
         span.set_tag(IAST_SPAN_TAGS.TELEMETRY_REQUEST_TAINTED, total_objects_tainted)
 
 
-def start_iast_context(span: Optional["Span"] = None):
-    if asm_config._iast_enabled:
-        create_propagation_context()
-        core.set_item(IAST.REQUEST_CONTEXT_KEY, IASTEnvironment(span))
-
-
-def end_iast_context(span: Optional["Span"] = None):
-    env = _get_iast_env()
-    if env is not None and env.span is span:
-        update_global_vulnerability_limit(env)
-        finalize_iast_env(env)
-    reset_propagation_context()
-
-
 def finalize_iast_env(env: IASTEnvironment) -> None:
     core.discard_item(IAST.REQUEST_CONTEXT_KEY)
 
@@ -69,11 +55,6 @@ def set_iast_request_enabled(request_enabled) -> None:
         log.debug("iast::propagation::context::Trying to set IAST reporter but no context is present")
 
 
-def is_iast_request_enabled() -> bool:
-    """Check whether IAST is currently operating within an active request context."""
-    return asm_config.is_iast_request_enabled
-
-
 def set_iast_request_endpoint(method, route) -> None:
     if asm_config._iast_enabled:
         env = _get_iast_env()
@@ -89,13 +70,32 @@ def set_iast_request_endpoint(method, route) -> None:
 def _iast_start_request(span=None, *args, **kwargs):
     try:
         if asm_config._iast_enabled:
-            start_iast_context(span)
+            create_propagation_context()
+            core.set_item(IAST.REQUEST_CONTEXT_KEY, IASTEnvironment(span))
             request_iast_enabled = False
             if oce.acquire_request(span):
                 request_iast_enabled = True
             set_iast_request_enabled(request_iast_enabled)
     except Exception:
         log.debug("iast::propagation::context::Error starting IAST context", exc_info=True)
+
+
+def _get_iast_context_id() -> Optional[int]:
+    """Retrieve the current IAST context identifier from the ContextVar."""
+    return IAST_CONTEXT.get()
+
+
+def _iast_finish_request(span: Optional["Span"] = None):
+    env = _get_iast_env()
+    if env is not None and env.span is span:
+        update_global_vulnerability_limit(env)
+        finalize_iast_env(env)
+    reset_propagation_context()
+
+
+def is_iast_request_enabled() -> bool:
+    """Check whether IAST is currently operating within an active request context."""
+    return asm_config.is_iast_request_enabled
 
 
 def _num_objects_tainted_in_request():

--- a/ddtrace/appsec/_iast/_patch_modules.py
+++ b/ddtrace/appsec/_iast/_patch_modules.py
@@ -162,7 +162,6 @@ class WrapFunctonsForIAST:
         """
         for module in self.functions:
             if module.patch():
-                log.debug("Wrapping %s", module)
                 if self.testing:
                     MODULES_TO_UNPATCH.add(module)
 
@@ -175,7 +174,6 @@ class WrapFunctonsForIAST:
         log.debug("Testing: %s. Unwrapping %s", self.testing, len(MODULES_TO_UNPATCH))
         if self.testing:
             for module in MODULES_TO_UNPATCH.copy():
-                log.debug("Unwrapping %s", module)
                 module.unpatch()
                 MODULES_TO_UNPATCH.remove(module)
 

--- a/ddtrace/appsec/_iast/_patches/json_tainting.py
+++ b/ddtrace/appsec/_iast/_patches/json_tainting.py
@@ -1,10 +1,10 @@
 from typing import Text
 
+from ddtrace.appsec._iast._iast_request_context_base import is_iast_request_enabled
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
 
 from ..._constants import IAST
-from .._iast_request_context_base import is_iast_request_enabled
 from .._patch_modules import WrapFunctonsForIAST
 
 

--- a/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.cpp
@@ -22,7 +22,8 @@
 //
 #include "taint_engine_context.h"
 #include "taint_tracking/tainted_object.h"
-#include <cstdint>
+#include "utils/string_utils.h"
+#include <Python.h>
 #include <cstdlib>
 #include <initializer_list>
 
@@ -32,38 +33,6 @@ namespace {
 static constexpr size_t DEFAULT_CAPACITY = 2; // safe default per guidance
 static constexpr size_t MIN_CAPACITY = 1;
 static constexpr size_t MAX_CAPACITY = 1024; // reasonable upper bound
-}
-
-// AIDEV-NOTE: Return the first taint map found when scanning a list of candidate PyObjects.
-// The map must exist and be non-empty to be considered valid.
-TaintedObjectMapTypePtr
-TaintEngineContext::get_tainted_object_map_from_list_of_pyobjects(std::initializer_list<PyObject*> objects)
-{
-    for (auto* obj : objects) {
-        if (!obj) {
-            continue;
-        }
-        auto map = get_tainted_object_map(obj);
-        if (map && !map->empty()) {
-            return map;
-        }
-    }
-    return nullptr;
-}
-
-TaintedObjectMapTypePtr
-TaintEngineContext::get_tainted_object_map_from_list_of_pyobjects(const std::vector<PyObject*>& objects)
-{
-    for (auto* obj : objects) {
-        if (!obj) {
-            continue;
-        }
-        auto map = get_tainted_object_map(obj);
-        if (map && !map->empty()) {
-            return map;
-        }
-    }
-    return nullptr;
 }
 
 size_t
@@ -100,17 +69,23 @@ TaintEngineContext::start_request_context()
             return i;
         }
     }
-    // Saturated
-    return -1;
+    return std::nullopt;
 }
 
 void
 TaintEngineContext::finish_request_context(size_t ctx_id)
 {
-    if (request_context_slots[ctx_id]) {
-        request_context_slots[ctx_id]->clear();
+    const auto cap = request_context_slots.size();
+    if (ctx_id >= cap) {
+        return;
     }
-    request_context_slots[ctx_id] = nullptr;
+
+    auto& slot = request_context_slots[ctx_id];
+    if (!slot) {
+        return;
+    }
+    slot->clear();
+    slot = nullptr;
 }
 
 void
@@ -125,15 +100,139 @@ TaintEngineContext::clear_all_request_context_slots()
 }
 
 TaintedObjectMapTypePtr
-TaintEngineContext::get_tainted_object_map(PyObject* tainted_object)
+TaintEngineContext::get_tainted_object_map(PyObject* obj)
+{
+    if (!obj) {
+        return nullptr;
+    }
+
+    // 1) Direct text objects
+    if (is_text(obj)) {
+        auto map = get_tainted_object_map_from_pyobject(obj);
+        if (map && !map->empty()) {
+            return map;
+        }
+        return nullptr;
+    }
+
+    // 2) Containers: list or tuple -> iterate each element
+    if (PyList_Check(obj)) {
+        const Py_ssize_t n = PyList_GET_SIZE(obj);
+        for (Py_ssize_t i = 0; i < n; ++i) {
+            PyObject* item = PyList_GET_ITEM(obj, i); // borrowed ref
+            if (!item) {
+                continue;
+            }
+            auto map = get_tainted_object_map_from_pyobject(item);
+            if (map && !map->empty()) {
+                return map;
+            }
+        }
+        return nullptr;
+    }
+    if (PyTuple_Check(obj)) {
+        const Py_ssize_t n = PyTuple_GET_SIZE(obj);
+        for (Py_ssize_t i = 0; i < n; ++i) {
+            PyObject* item = PyTuple_GET_ITEM(obj, i); // borrowed ref
+            if (!item) {
+                continue;
+            }
+            auto map = get_tainted_object_map_from_pyobject(item);
+            if (map && !map->empty()) {
+                return map;
+            }
+        }
+        return nullptr;
+    }
+
+    // 3) Dictionaries: iterate over values
+    if (PyDict_Check(obj)) {
+        PyObject *key, *value;
+        Py_ssize_t pos = 0;
+        while (PyDict_Next(obj, &pos, &key, &value)) { // borrowed refs
+            if (!value) {
+                continue;
+            }
+            auto map = get_tainted_object_map_from_pyobject(value);
+            if (map && !map->empty()) {
+                return map;
+            }
+        }
+        return nullptr;
+    }
+    auto map = get_tainted_object_map_from_pyobject(obj);
+    if (map) {
+        return map;
+    }
+
+    return nullptr;
+}
+
+TaintedObjectMapTypePtr
+TaintEngineContext::get_tainted_object_map_from_pyobject(PyObject* tainted_object)
 {
     for (const auto& context_map : request_context_slots) {
         if (!context_map) {
             continue;
         }
+
         const auto& to_initial = get_tainted_object(tainted_object, context_map);
         if (to_initial && !to_initial->get_ranges().empty()) {
             return context_map;
+        }
+    }
+    return nullptr;
+}
+
+TaintedObjectMapTypePtr
+TaintEngineContext::get_tainted_object_map_from_list_of_pyobjects(const std::vector<PyObject*>& objects)
+{
+    for (auto* obj : objects) {
+        if (!obj) {
+            continue;
+        }
+        if (auto map = get_tainted_object_map(obj); map && !map->empty()) {
+            return map;
+        }
+    }
+    return nullptr;
+}
+
+TaintedObjectMapTypePtr
+TaintEngineContext::get_tainted_object_map_from_ranges(const TaintRangeRefs& ranges)
+{
+    if (ranges.empty()) {
+        return nullptr;
+    }
+
+    for (const auto& context_map : request_context_slots) {
+        if (!context_map) {
+            continue;
+        }
+
+        // Iterate over all tainted objects in this context map
+        for (const auto& kv : *context_map) {
+            const auto& tainted_obj = kv.second.second;
+            if (!tainted_obj) {
+                continue;
+            }
+
+            const auto& obj_ranges = tainted_obj->get_ranges();
+            if (obj_ranges.empty()) {
+                continue;
+            }
+
+            // Check if any of the input ranges matches by pointer identity
+            for (const auto& needle : ranges) {
+                if (!needle) {
+                    continue;
+                }
+                for (const auto& r : obj_ranges) {
+                    if (r == needle) {
+                        return context_map;
+                    }
+                }
+            }
         }
     }
     return nullptr;
@@ -181,6 +280,16 @@ TaintEngineContext::debug_num_tainted_objects(size_t ctx_id)
     return 0;
 }
 
+TaintedObjectMapTypePtr
+TaintEngineContext::get_tainted_object_map_by_ctx_id(size_t ctx_id)
+{
+    const auto cap = request_context_slots.size();
+    if (ctx_id >= cap) {
+        return nullptr;
+    }
+    return request_context_slots[ctx_id];
+}
+
 void
 pyexport_taint_engine_context(py::module& m)
 {
@@ -194,6 +303,8 @@ pyexport_taint_engine_context(py::module& m)
         return map_ptr != nullptr;
     });
     m.def("debug_context_array_size", [] { return taint_engine_context->debug_context_array_size(); });
+    m.def("debug_context_array_free_slots_number",
+          [] { return taint_engine_context->debug_context_array_free_slots_number(); });
 
     m.def("debug_taint_map", [](size_t ctx_id) { return taint_engine_context->debug_taint_map(ctx_id); });
 

--- a/ddtrace/appsec/_iast/sampling/vulnerability_detection.py
+++ b/ddtrace/appsec/_iast/sampling/vulnerability_detection.py
@@ -19,11 +19,6 @@ GlobalDictType = Dict[str, RequestDictType]
 GLOBAL_VULNERABILITIES_LIMIT: GlobalDictType = collections.OrderedDict()
 
 
-def _reset_global_limit():
-    global GLOBAL_VULNERABILITIES_LIMIT
-    GLOBAL_VULNERABILITIES_LIMIT = collections.OrderedDict()
-
-
 def init_request_vulnerability_maps(context) -> RequestDictType:
     """
     Initialize vulnerability maps for a new request.
@@ -112,3 +107,8 @@ def reset_request_vulnerabilities(context=None) -> None:
     context.vulnerabilities_request_limit = {}
     context.is_first_vulnerability = True
     context.vulnerability_budget = 0
+
+
+def _reset_global_limit():
+    global GLOBAL_VULNERABILITIES_LIMIT
+    GLOBAL_VULNERABILITIES_LIMIT = collections.OrderedDict()

--- a/ddtrace/appsec/_iast/sources/ast_taint.py
+++ b/ddtrace/appsec/_iast/sources/ast_taint.py
@@ -1,12 +1,12 @@
 from typing import Any
 from typing import Callable
 
+from ddtrace.appsec._iast._iast_request_context_base import is_iast_request_enabled
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
-from .._iast_request_context_base import is_iast_request_enabled
 from ..constants import DEFAULT_SOURCE_IO_FUNCTIONS
 
 

--- a/ddtrace/appsec/_iast/taint_sinks/command_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/command_injection.py
@@ -3,6 +3,7 @@ from typing import Union
 
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._constants import IAST_SPAN_TAGS
+from ddtrace.appsec._iast._iast_request_context_base import is_iast_request_enabled
 from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
 from ddtrace.appsec._iast._metrics import _set_metric_iast_instrumented_sink
 from ddtrace.appsec._iast._span_metrics import increment_iast_span_metric
@@ -13,7 +14,6 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.settings.asm import config as asm_config
 
-from .._iast_request_context_base import is_iast_request_enabled
 from .._logs import iast_error
 from .._logs import iast_propagation_sink_point_debug_log
 from ._base import VulnerabilityBase

--- a/ddtrace/appsec/_iast/taint_sinks/weak_cipher.py
+++ b/ddtrace/appsec/_iast/taint_sinks/weak_cipher.py
@@ -5,6 +5,7 @@ from typing import Set
 from typing import Text
 
 from ddtrace.appsec._constants import IAST_SPAN_TAGS
+from ddtrace.appsec._iast._iast_request_context_base import is_iast_request_enabled
 from ddtrace.appsec._iast.constants import BLOWFISH_DEF
 from ddtrace.appsec._iast.constants import DEFAULT_WEAK_CIPHER_ALGORITHMS
 from ddtrace.appsec._iast.constants import DES_DEF
@@ -14,7 +15,6 @@ from ddtrace.appsec._iast.constants import VULN_WEAK_CIPHER_TYPE
 from ddtrace.internal.logger import get_logger
 from ddtrace.settings.asm import config as asm_config
 
-from .._iast_request_context_base import is_iast_request_enabled
 from .._metrics import _set_metric_iast_executed_sink
 from .._metrics import _set_metric_iast_instrumented_sink
 from .._patch_modules import WrapFunctonsForIAST

--- a/not_exists.txt2
+++ b/not_exists.txt2
@@ -1,1 +1,0 @@
-test content for path traversal

--- a/not_exists.txt2
+++ b/not_exists.txt2
@@ -1,0 +1,1 @@
+test content for path traversal

--- a/scripts/iast/leak_functions.py
+++ b/scripts/iast/leak_functions.py
@@ -9,21 +9,21 @@ import pytest
 
 from ddtrace.appsec._iast import disable_iast_propagation
 from ddtrace.appsec._iast import enable_iast_propagation
-from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
+from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request
+from ddtrace.appsec._iast._iast_request_context_base import _iast_start_request
 from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
-from ddtrace.appsec._iast._iast_request_context_base import start_iast_context
 from ddtrace.appsec._iast._taint_tracking import active_map_addreses_size
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from tests.utils import override_env
 
 
-def _start_iast_context_and_oce():
-    start_iast_context()
+def __iast_start_request_and_oce():
+    _iast_start_request()
     set_iast_request_enabled(True)
 
 
 def _end_iast_context_and_oce():
-    end_iast_context()
+    _iast_finish_request()
 
 
 def parse_arguments():
@@ -68,7 +68,7 @@ async def iast_leaks(iterations: int, fail_percent: float, print_every: int):
         _pre_checks(test_doit)
 
         for i in range(iterations):
-            _start_iast_context_and_oce()
+            __iast_start_request_and_oce()
             result = await test_doit()
             assert result == "DDD_III_extend", f"result is {result}"
             assert is_pyobject_tainted(result)

--- a/tests/appsec/iast/_ast/conftest.py
+++ b/tests/appsec/iast/_ast/conftest.py
@@ -11,5 +11,7 @@ def iast_create_context():
         dict(_iast_enabled=True, _iast_is_testing=True, _iast_deduplication_enabled=False, _iast_request_sampling=100.0)
     ):
         _start_iast_context_and_oce()
-        yield
-        _end_iast_context_and_oce()
+        try:
+            yield
+        finally:
+            _end_iast_context_and_oce()

--- a/tests/appsec/iast/aspects/conftest.py
+++ b/tests/appsec/iast/aspects/conftest.py
@@ -6,10 +6,18 @@ from tests.utils import override_global_config
 
 
 @pytest.fixture(autouse=True)
-def iast_create_context():
+def iast_request():
     with override_global_config(
-        dict(_iast_enabled=True, _iast_is_testing=True, _iast_deduplication_enabled=False, _iast_request_sampling=100.0)
+        dict(
+            _iast_enabled=True,
+            _iast_is_testing=True,
+            _iast_deduplication_enabled=False,
+            _iast_request_sampling=100.0,
+            _iast_max_concurrent_requests=100,
+        )
     ):
         _start_iast_context_and_oce()
-        yield
-        _end_iast_context_and_oce()
+        try:
+            yield
+        finally:
+            _end_iast_context_and_oce()

--- a/tests/appsec/iast/aspects/test_add_aspect.py
+++ b/tests/appsec/iast/aspects/test_add_aspect.py
@@ -7,8 +7,6 @@ from hypothesis.strategies import from_type
 import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._context import create_context
-from ddtrace.appsec._iast._taint_tracking._context import reset_context
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import TaintRange_
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
@@ -275,8 +273,6 @@ def test_add_aspect_tainting_add_left_twice(obj1, obj2):
 def test_taint_object_error_with_no_context(log_level, iast_debug, caplog):
     """Test taint_pyobject without context. This test is to ensure that the function does not raise an exception."""
     string_to_taint = "my_string"
-    _end_iast_context_and_oce()
-    _start_iast_context_and_oce()
     result = taint_pyobject(
         pyobject=string_to_taint,
         source_name="test_add_aspect_tainting_left_hand",
@@ -301,7 +297,7 @@ def test_taint_object_error_with_no_context(log_level, iast_debug, caplog):
 
         assert not any("iast::propagation::native::error::" in record.message for record in caplog.records)
 
-        _start_iast_context_and_oce()
+        _end_iast_context_and_oce()
         result = taint_pyobject(
             pyobject=string_to_taint,
             source_name="test_add_aspect_tainting_left_hand",
@@ -310,14 +306,13 @@ def test_taint_object_error_with_no_context(log_level, iast_debug, caplog):
         )
 
         ranges_result = get_tainted_ranges(result)
-        assert len(ranges_result) == 1
+        assert len(ranges_result) == 0
 
 
 @pytest.mark.skip_iast_check_logs
 def test_get_ranges_from_object_with_no_context():
     """Test taint_pyobject without context. This test is to ensure that the function does not raise an exception."""
     string_to_taint = "my_string"
-    create_context()
     result = taint_pyobject(
         pyobject=string_to_taint,
         source_name="test_add_aspect_tainting_left_hand",
@@ -325,7 +320,7 @@ def test_get_ranges_from_object_with_no_context():
         source_origin=OriginType.PARAMETER,
     )
 
-    reset_context()
+    _end_iast_context_and_oce()
     ranges_result = get_tainted_ranges(result)
     assert len(ranges_result) == 0
 
@@ -334,7 +329,6 @@ def test_get_ranges_from_object_with_no_context():
 def test_propagate_ranges_with_no_context(caplog):
     """Test taint_pyobject without context. This test is to ensure that the function does not raise an exception."""
     string_to_taint = "my_string"
-    create_context()
     result = taint_pyobject(
         pyobject=string_to_taint,
         source_name="test_add_aspect_tainting_left_hand",
@@ -342,11 +336,11 @@ def test_propagate_ranges_with_no_context(caplog):
         source_origin=OriginType.PARAMETER,
     )
 
-    reset_context()
+    _end_iast_context_and_oce()
     with override_global_config(dict(_iast_debug=True)), caplog.at_level(logging.DEBUG):
         result_2 = add_aspect(result, "another_string")
 
-    create_context()
+    _start_iast_context_and_oce()
     ranges_result = get_tainted_ranges(result_2)
     log_messages = [record.message for record in caplog.get_records("call")]
     assert not any("iast::" in message for message in log_messages), log_messages

--- a/tests/appsec/iast/aspects/test_add_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_add_aspect_fixtures.py
@@ -13,10 +13,9 @@ mod = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods")
 
 class TestOperatorAddReplacement(unittest.TestCase):
     def test_nostring_operator_add(self):
-        # type: () -> None
         assert mod.do_operator_add_params(2, 3) == 5
 
-    def test_regression_operator_add_re_compile(self):  # type: () -> None
+    def test_regression_operator_add_re_compile(self):
         try:
             mod.do_add_re_compile()
         except Exception as e:
@@ -24,7 +23,7 @@ class TestOperatorAddReplacement(unittest.TestCase):
 
     def test_string_operator_add_none_tainted(
         self,
-    ):  # type: () -> None
+    ):
         string_input = "foo"
         bar = "bar"
         result = mod.do_operator_add_params(string_input, bar)
@@ -32,14 +31,14 @@ class TestOperatorAddReplacement(unittest.TestCase):
 
     def test_operator_add_dis(
         self,
-    ):  # type: () -> None
+    ):
         import dis
 
         bytecode = dis.Bytecode(mod.do_operator_add_params)
         dis.dis(mod.do_operator_add_params)
         assert bytecode.codeobj.co_names == ("_ddtrace_aspects", "add_aspect")
 
-    def test_string_operator_add_one_tainted(self):  # type: () -> None
+    def test_string_operator_add_one_tainted(self):
         string_input = taint_pyobject(
             pyobject="foo",
             source_name="test_add_aspect_tainting_left_hand",
@@ -51,7 +50,7 @@ class TestOperatorAddReplacement(unittest.TestCase):
         result = mod.do_operator_add_params(string_input, bar)
         assert len(get_tainted_ranges(result)) == 1
 
-    def test_string_operator_add_two(self):  # type: () -> None
+    def test_string_operator_add_two(self):
         string_input = taint_pyobject(
             pyobject="foo",
             source_name="test_string_operator_add_two",
@@ -70,7 +69,7 @@ class TestOperatorAddReplacement(unittest.TestCase):
 
     def test_decoration_when_function_and_decorator_modify_texts_then_tainted(
         self,
-    ):  # type: () -> None
+    ):
         prefix = taint_pyobject(pyobject="a", source_name="a", source_value="a", source_origin=OriginType.PARAMETER)
         suffix = taint_pyobject(pyobject="b", source_name="b", source_value="b", source_origin=OriginType.PARAMETER)
 
@@ -79,7 +78,7 @@ class TestOperatorAddReplacement(unittest.TestCase):
         assert result == "AB"
         assert len(get_tainted_ranges(result)) == 2
 
-    def test_string_operator_add_one_tainted_mixed_bytearray_bytes(self):  # type: () -> None
+    def test_string_operator_add_one_tainted_mixed_bytearray_bytes(self):
         string_input = taint_pyobject(
             pyobject=b"foo", source_name="foo", source_value="foo", source_origin=OriginType.PARAMETER
         )
@@ -89,7 +88,7 @@ class TestOperatorAddReplacement(unittest.TestCase):
         assert result == b"foobar"
         assert len(get_tainted_ranges(result)) == 0
 
-    def test_string_operator_add_two_mixed_bytearray_bytes(self):  # type: () -> None
+    def test_string_operator_add_two_mixed_bytearray_bytes(self):
         string_input = taint_pyobject(
             pyobject=bytearray(b"foo"), source_name="foo", source_value="foo", source_origin=OriginType.PARAMETER
         )
@@ -99,14 +98,15 @@ class TestOperatorAddReplacement(unittest.TestCase):
         assert result == bytearray(b"foobar")
         assert len(get_tainted_ranges(result)) == 0
 
-    def test_string_operator_add_bytearrays(self):  # type: () -> None
+    def test_string_operator_add_bytearrays(self):
         string_input = taint_pyobject(
             pyobject=bytearray(b"foo"), source_name="foo", source_value="foo", source_origin=OriginType.PARAMETER
         )
+        assert get_tainted_ranges(string_input)
         bar = taint_pyobject(
             pyobject=bytearray(b"bar"), source_name="bar", source_value="bar", source_origin=OriginType.PARAMETER
         )
-
+        assert get_tainted_ranges(bar)
         result = mod.do_operator_add_params(string_input, bar)
         assert result == bytearray(b"foobar")
         assert get_tainted_ranges(result)

--- a/tests/appsec/iast/aspects/test_bytearray_extend_aspect.py
+++ b/tests/appsec/iast/aspects/test_bytearray_extend_aspect.py
@@ -6,10 +6,9 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
-from ddtrace.appsec._iast._taint_tracking._context import create_context
-from ddtrace.appsec._iast._taint_tracking._context import reset_context
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from tests.appsec.iast.iast_utils import _end_iast_context_and_oce
 from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.utils import override_global_config
 
@@ -112,12 +111,11 @@ class TestByteArrayExtendAspect(object):
 
 @pytest.mark.skip_iast_check_logs
 def test_propagate_ranges_with_no_context(caplog):
-    create_context()
     ba1 = bytearray(b"123")
     ba2 = taint_pyobject(
         pyobject=bytearray(b"456"), source_name="test", source_value="foo", source_origin=OriginType.PARAMETER
     )
-    reset_context()
+    _end_iast_context_and_oce()
     with override_global_config(dict(_iast_debug=True)), caplog.at_level(logging.DEBUG):
         result = mod.do_bytearray_extend(ba1, ba2)
         assert result == bytearray(b"123456")

--- a/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_format_aspect_fixtures.py
@@ -11,13 +11,12 @@ import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
-from ddtrace.appsec._iast._taint_tracking._context import create_context
-from ddtrace.appsec._iast._taint_tracking._context import reset_context
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
 from tests.appsec.iast.aspects.aspect_utils import BaseReplacement
 from tests.appsec.iast.aspects.aspect_utils import create_taint_range_with_format
+from tests.appsec.iast.iast_utils import _end_iast_context_and_oce
 from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.utils import override_global_config
 
@@ -245,14 +244,13 @@ class TestOperatorFormatReplacement(BaseReplacement):
 def test_propagate_ranges_with_no_context(caplog):
     """Test taint_pyobject without context. This test is to ensure that the function does not raise an exception."""
     string_to_taint = "-1234 {} {} {} {test_kwarg} {test_var}"
-    create_context()
     string_input = taint_pyobject(
         pyobject=string_to_taint,
         source_name="test_add_aspect_tainting_left_hand",
         source_value=string_to_taint,
         source_origin=OriginType.PARAMETER,
     )
-    reset_context()
+    _end_iast_context_and_oce()
     with override_global_config(dict(_iast_debug=True)), caplog.at_level(logging.DEBUG):
         result_2 = mod.do_args_kwargs_4(string_input, 6, test_var=1)
 

--- a/tests/appsec/iast/aspects/test_index_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_index_aspect_fixtures.py
@@ -4,10 +4,9 @@ import sys
 import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._context import create_context
-from ddtrace.appsec._iast._taint_tracking._context import reset_context
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from tests.appsec.iast.iast_utils import _end_iast_context_and_oce
 from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.utils import override_global_config
 
@@ -103,7 +102,6 @@ def test_index_error_with_tainted_gives_one_log_metric(telemetry_writer):
 def test_propagate_ranges_with_no_context(caplog):
     """Test taint_pyobject without context. This test is to ensure that the function does not raise an exception."""
     input_str = "abcde"
-    create_context()
     string_input = taint_pyobject(
         pyobject=input_str,
         source_name="test_add_aspect_tainting_left_hand",
@@ -112,7 +110,7 @@ def test_propagate_ranges_with_no_context(caplog):
     )
     assert get_tainted_ranges(string_input)
 
-    reset_context()
+    _end_iast_context_and_oce()
     with override_global_config(dict(_iast_debug=True)), caplog.at_level(logging.DEBUG):
         result = mod.do_index(string_input, 3)
         assert result == "d"

--- a/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_join_aspect_fixtures.py
@@ -5,10 +5,9 @@ import logging
 import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._context import create_context
-from ddtrace.appsec._iast._taint_tracking._context import reset_context
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from tests.appsec.iast.iast_utils import _end_iast_context_and_oce
 from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.utils import override_global_config
 
@@ -528,12 +527,11 @@ class TestOperatorJoinReplacement(object):
 
 @pytest.mark.skip_iast_check_logs
 def test_propagate_ranges_with_no_context(caplog):
-    create_context()
     string_input = taint_pyobject(
         pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
     )
     it = ["a", "b", "c"]
-    reset_context()
+    _end_iast_context_and_oce()
     with override_global_config(dict(_iast_debug=True)), caplog.at_level(logging.DEBUG):
         result = mod.do_join(string_input, it)
         assert result == "a-joiner-b-joiner-c"
@@ -543,7 +541,6 @@ def test_propagate_ranges_with_no_context(caplog):
 
 @pytest.mark.skip_iast_check_logs
 def test_propagate_ranges_with_no_context_with_var(caplog):
-    create_context()
     string_input = taint_pyobject(
         pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
     )
@@ -552,7 +549,7 @@ def test_propagate_ranges_with_no_context_with_var(caplog):
         "b",
         "c",
     ]
-    reset_context()
+    _end_iast_context_and_oce()
     with override_global_config(dict(_iast_debug=True)), caplog.at_level(logging.DEBUG):
         result = mod.do_join(string_input, it)
         assert result == "a-joiner-b-joiner-c"
@@ -562,7 +559,6 @@ def test_propagate_ranges_with_no_context_with_var(caplog):
 
 @pytest.mark.skip_iast_check_logs
 def test_propagate_ranges_with_no_context_with_equal_var(caplog):
-    create_context()
     string_input = taint_pyobject(
         pyobject="-joiner-", source_name="joiner", source_value="foo", source_origin=OriginType.PARAMETER
     )
@@ -570,7 +566,7 @@ def test_propagate_ranges_with_no_context_with_equal_var(caplog):
         pyobject="abcdef", source_name="joined", source_value="abcdef", source_origin=OriginType.PARAMETER
     )
 
-    reset_context()
+    _end_iast_context_and_oce()
     with override_global_config(dict(_iast_debug=True)), caplog.at_level(logging.DEBUG):
         result = mod.do_join(string_input, [a_tainted, a_tainted, a_tainted])
         assert result == "abcdef-joiner-abcdef-joiner-abcdef"

--- a/tests/appsec/iast/aspects/test_modulo_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_modulo_aspect_fixtures.py
@@ -40,7 +40,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
 
         result = mod.do_modulo(template, parameter)
 
-        assert result == expected_result
+        assert result == expected_result, f"Expected  {expected_result}. RESULT: {result}"
         assert as_formatted_evidence(result, tag_mapping_function=None) == escaped_expected_result
 
     def test_modulo_when_template_is_none_then_raises_attribute_error(self):  # type: () -> None

--- a/tests/appsec/iast/aspects/test_ospath_aspects_fixtures.py
+++ b/tests/appsec/iast/aspects/test_ospath_aspects_fixtures.py
@@ -8,10 +8,9 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
-from ddtrace.appsec._iast._taint_tracking._context import create_context
-from ddtrace.appsec._iast._taint_tracking._context import reset_context
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from tests.appsec.iast.iast_utils import _end_iast_context_and_oce
 from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.utils import override_global_config
 
@@ -151,7 +150,6 @@ def test_ospathsplitdrive_tainted():
 def test_propagate_ranges_with_no_context(caplog):
     """Test taint_pyobject without context. This test is to ensure that the function does not raise an exception."""
     input_str = "abcde"
-    create_context()
     string_input = taint_pyobject(
         pyobject=input_str,
         source_name="test_add_aspect_tainting_left_hand",
@@ -160,12 +158,9 @@ def test_propagate_ranges_with_no_context(caplog):
     )
     assert get_tainted_ranges(string_input)
 
-    reset_context()
+    _end_iast_context_and_oce()
     with override_global_config(dict(_iast_debug=True)), caplog.at_level(logging.DEBUG):
         result = mod.do_os_path_join(string_input, "bar")
         assert result == "abcde/bar"
     log_messages = [record.message for record in caplog.get_records("call")]
     assert not any("iast::" in message for message in log_messages), log_messages
-
-
-# TODO: add tests for os.path.splitdrive and os.path.normcase under Windows

--- a/tests/appsec/iast/aspects/test_replace_aspect.py
+++ b/tests/appsec/iast/aspects/test_replace_aspect.py
@@ -8,9 +8,9 @@ from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
 from ddtrace.appsec._iast._taint_tracking import as_formatted_evidence
-from ddtrace.appsec._iast._taint_tracking import set_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import taint_pyobject_with_ranges
 import ddtrace.appsec._iast._taint_tracking.aspects as ddtrace_aspects
 from ddtrace.internal.compat import PYTHON_VERSION_INFO
 
@@ -669,7 +669,7 @@ def test_replace_tainted_orig_and_repl(origstr, substr, replstr, maxcount, forma
     ],
 )
 def test_replace_tainted_results_in_no_tainted(origstr, substr, replstr, maxcount, formatted):
-    set_ranges(
+    taint_pyobject_with_ranges(
         origstr,
         (_build_sample_range(0, 1, "name"), _build_sample_range(2, 2, "name"), _build_sample_range(6, 3, "name")),
     )
@@ -736,7 +736,7 @@ def test_replace_tainted_results_in_no_tainted_django(origstr, formatted):
     ],
 )
 def test_replace_tainted_shrinking_ranges(origstr, substr, replstr, maxcount, formatted):
-    set_ranges(
+    taint_pyobject_with_ranges(
         origstr,
         (_build_sample_range(0, 3, "name"), _build_sample_range(4, 3, "name"), _build_sample_range(10, 3, "name")),
     )
@@ -793,7 +793,7 @@ def test_replace_tainted_shrinking_ranges(origstr, substr, replstr, maxcount, fo
 )
 def test_replace_aspect_more(origstr, taint_len, substr, replstr, maxcount, formatted):
     if taint_len > 0:
-        set_ranges(
+        taint_pyobject_with_ranges(
             origstr,
             (_build_sample_range(0, taint_len, "name"),),
         )

--- a/tests/appsec/iast/aspects/test_slice_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_slice_aspect_fixtures.py
@@ -5,10 +5,9 @@ import sys
 import pytest
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._context import create_context
-from ddtrace.appsec._iast._taint_tracking._context import reset_context
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from tests.appsec.iast.iast_utils import _end_iast_context_and_oce
 from tests.appsec.iast.iast_utils import _iast_patched_module
 from tests.utils import override_global_config
 
@@ -309,7 +308,6 @@ def test_string_slice_negative():
 
 @pytest.mark.skip_iast_check_logs
 def test_propagate_ranges_with_no_context(caplog):
-    create_context()
     tainted_input = taint_pyobject(
         pyobject="abcde",
         source_name="input_str",
@@ -317,7 +315,7 @@ def test_propagate_ranges_with_no_context(caplog):
         source_origin=OriginType.PARAMETER,
     )
 
-    reset_context()
+    _end_iast_context_and_oce()
     with override_global_config(dict(_iast_debug=True)), caplog.at_level(logging.DEBUG):
         result = mod.do_slice(tainted_input, 0, 3, None)
         assert result == "abc"

--- a/tests/appsec/iast/aspects/test_split_aspect.py
+++ b/tests/appsec/iast/aspects/test_split_aspect.py
@@ -12,11 +12,10 @@ from ddtrace.appsec._iast._taint_tracking import _aspect_rsplit
 from ddtrace.appsec._iast._taint_tracking import _aspect_split
 from ddtrace.appsec._iast._taint_tracking import _aspect_splitlines
 from ddtrace.appsec._iast._taint_tracking import get_ranges
-from ddtrace.appsec._iast._taint_tracking import set_ranges
-from ddtrace.appsec._iast._taint_tracking._context import create_context
-from ddtrace.appsec._iast._taint_tracking._context import reset_context
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import taint_pyobject_with_ranges
 from tests.appsec.iast.aspects.test_aspect_helpers import _build_sample_range
+from tests.appsec.iast.iast_utils import _end_iast_context_and_oce
 from tests.appsec.iast.iast_utils import non_empty_text
 from tests.utils import override_global_config
 
@@ -36,13 +35,13 @@ def test_aspect_split(text):
 
 
 # These tests are simple ones testing the calls and replacements since most of the
-# actual testing is in test_aspect_helpers' test for set_ranges_on_splitted which these
+# actual testing is in test_aspect_helpers' test for taint_pyobject_with_ranges_on_splitted which these
 # functions call internally.
 def test_aspect_split_simple():
     s = "abc def"
     range1 = _build_sample_range(0, 3, "abc")
     range2 = _build_sample_range(3, 4, " def")
-    set_ranges(s, (range1, range2))
+    taint_pyobject_with_ranges(s, (range1, range2))
     ranges = get_ranges(s)
     assert ranges
     res = wrap_somesplit(_aspect_split, s)
@@ -55,7 +54,7 @@ def test_aspect_rsplit_simple():
     s = "abc def"
     range1 = _build_sample_range(0, 3, "abc")
     range2 = _build_sample_range(3, 4, " def")
-    set_ranges(s, (range1, range2))
+    taint_pyobject_with_ranges(s, (range1, range2))
     ranges = get_ranges(s)
     assert ranges
     res = wrap_somesplit(_aspect_rsplit, s)
@@ -68,7 +67,7 @@ def test_aspect_split_with_separator():
     s = "abc:def"
     range1 = _build_sample_range(0, 3, "abc")
     range2 = _build_sample_range(3, 4, ":def")
-    set_ranges(s, (range1, range2))
+    taint_pyobject_with_ranges(s, (range1, range2))
     ranges = get_ranges(s)
     assert ranges
     res = wrap_somesplit(_aspect_split, s, ":")
@@ -81,7 +80,7 @@ def test_aspect_rsplit_with_separator():
     s = "abc:def"
     range1 = _build_sample_range(0, 3, "abc")
     range2 = _build_sample_range(3, 4, ":def")
-    set_ranges(s, (range1, range2))
+    taint_pyobject_with_ranges(s, (range1, range2))
     ranges = get_ranges(s)
     assert ranges
     res = wrap_somesplit(_aspect_rsplit, s, ":")
@@ -95,7 +94,7 @@ def test_aspect_split_with_maxsplit():
     range1 = _build_sample_range(0, 3, "abc")
     range2 = _build_sample_range(3, 4, " def")
     range3 = _build_sample_range(7, 4, " ghi")
-    set_ranges(s, (range1, range2, range3))
+    taint_pyobject_with_ranges(s, (range1, range2, range3))
     ranges = get_ranges(s)
     assert ranges
     res = wrap_somesplit(_aspect_split, s, maxsplit=1)
@@ -122,7 +121,7 @@ def test_aspect_rsplit_with_maxsplit():
     range1 = _build_sample_range(0, 3, "abc")
     range2 = _build_sample_range(3, 4, " def")
     range3 = _build_sample_range(7, 4, " ghi")
-    set_ranges(s, (range1, range2, range3))
+    taint_pyobject_with_ranges(s, (range1, range2, range3))
     ranges = get_ranges(s)
     assert ranges
     res = wrap_somesplit(_aspect_rsplit, s, maxsplit=1)
@@ -147,7 +146,7 @@ def test_aspect_splitlines_simple():
     s = "abc\ndef"
     range1 = _build_sample_range(0, 3, "abc")
     range2 = _build_sample_range(3, 4, " def")
-    set_ranges(s, (range1, range2))
+    taint_pyobject_with_ranges(s, (range1, range2))
     ranges = get_ranges(s)
     assert ranges
     res = wrap_somesplit(_aspect_splitlines, s)
@@ -161,7 +160,7 @@ def test_aspect_splitlines_keepend_true():
     range1 = _build_sample_range(0, 4, "abc\n")
     range2 = _build_sample_range(4, 4, "def\n")
     range3 = _build_sample_range(8, 4, "hij\n")
-    set_ranges(s, (range1, range2, range3))
+    taint_pyobject_with_ranges(s, (range1, range2, range3))
     ranges = get_ranges(s)
     assert ranges
     res = wrap_somesplit(_aspect_splitlines, s, keepends=True)
@@ -176,7 +175,6 @@ def test_aspect_splitlines_keepend_true():
 def test_propagate_ranges_with_no_context(caplog):
     """Test taint_pyobject without context. This test is to ensure that the function does not raise an exception."""
     input_str = "abc|def"
-    create_context()
     string_input = taint_pyobject(
         pyobject=input_str,
         source_name="test_add_aspect_tainting_left_hand",
@@ -185,7 +183,7 @@ def test_propagate_ranges_with_no_context(caplog):
     )
     assert get_ranges(string_input)
 
-    reset_context()
+    _end_iast_context_and_oce()
     with override_global_config(dict(_iast_debug=True)), caplog.at_level(logging.DEBUG):
         result = wrap_somesplit(_aspect_split, string_input, "|")
         assert result == ["abc", "def"]

--- a/tests/appsec/iast/conftest.py
+++ b/tests/appsec/iast/conftest.py
@@ -120,9 +120,6 @@ def check_native_code_exception_in_each_python_aspect_test(request, caplog):
 
                 formatted_trace = "".join(traceback.format_exception(*record.exc_info))
                 pytest.fail(f"{record.message}:\n{formatted_trace}")
-        # TODO(avara1986): iast tests throw a timeout in gitlab
-        #   list_metrics_logs = list(telemetry_writer._logs)
-        #   assert len(list_metrics_logs) == 0
 
 
 @pytest.fixture(scope="session")

--- a/tests/appsec/iast/fixtures/entrypoint/views.py
+++ b/tests/appsec/iast/fixtures/entrypoint/views.py
@@ -1,14 +1,12 @@
 from flask import Flask
 
 from ddtrace.appsec._iast._taint_tracking import OriginType
-from ddtrace.appsec._iast._taint_tracking._context import create_context
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 
 
 def add_test():
     string_to_taint = "abc"
-    create_context()
     result = taint_pyobject(
         pyobject=string_to_taint,
         source_name="test_add_aspect_tainting_left_hand",

--- a/tests/appsec/iast/iast_utils.py
+++ b/tests/appsec/iast/iast_utils.py
@@ -23,9 +23,8 @@ from ddtrace.appsec._iast._ast.ast_patching import astpatch_module
 from ddtrace.appsec._iast._ast.ast_patching import iastpatch
 from ddtrace.appsec._iast._ast.ast_patching import initialize_iast_lists
 from ddtrace.appsec._iast._iast_request_context import get_iast_reporter
-from ddtrace.appsec._iast._iast_request_context_base import end_iast_context
-from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
-from ddtrace.appsec._iast._iast_request_context_base import start_iast_context
+from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request
+from ddtrace.appsec._iast._iast_request_context_base import _iast_start_request
 from ddtrace.appsec._iast.main import patch_iast
 from ddtrace.appsec._iast.sampling.vulnerability_detection import _reset_global_limit
 
@@ -130,18 +129,14 @@ def _get_iast_data():
 
 def _start_iast_context_and_oce(span=None):
     oce.reconfigure()
-    request_iast_enabled = False
-    if oce.acquire_request(span):
-        start_iast_context()
-        request_iast_enabled = True
-
-    set_iast_request_enabled(request_iast_enabled)
+    return _iast_start_request(span)
 
 
 def _end_iast_context_and_oce(span=None):
-    end_iast_context(span)
+    result = _iast_finish_request(span)
     oce.release_request()
     _reset_global_limit()
+    return result
 
 
 def load_iast_report(span):

--- a/tests/appsec/iast/secure_marks/conftest.py
+++ b/tests/appsec/iast/secure_marks/conftest.py
@@ -14,6 +14,8 @@ def iast_create_context():
     ):
         patch_iast()
         _start_iast_context_and_oce()
-        yield
-        _end_iast_context_and_oce()
-        _testing_unpatch_iast()
+        try:
+            yield
+        finally:
+            _end_iast_context_and_oce()
+            _testing_unpatch_iast()

--- a/tests/appsec/iast/taint_sinks/_taint_sinks_utils.py
+++ b/tests/appsec/iast/taint_sinks/_taint_sinks_utils.py
@@ -6,7 +6,7 @@ from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import Source as RangeSource
 from ddtrace.appsec._iast._taint_tracking import TaintRange
 from ddtrace.appsec._iast._taint_tracking import new_pyobject_id
-from ddtrace.appsec._iast._taint_tracking import set_ranges
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import taint_pyobject_with_ranges
 
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -99,5 +99,5 @@ def _taint_pyobject_multiranges(pyobject, elements):
         pyobject_range = TaintRange(start, len_range, source)
         pyobject_ranges.append(pyobject_range)
 
-    set_ranges(pyobject_newid, pyobject_ranges)
+    taint_pyobject_with_ranges(pyobject_newid, pyobject_ranges)
     return pyobject_newid

--- a/tests/appsec/iast/taint_sinks/test_insecure_cookie.py
+++ b/tests/appsec/iast/taint_sinks/test_insecure_cookie.py
@@ -34,6 +34,7 @@ def test_insecure_cookie_deduplication(iast_context_deduplication_enabled):
 
 def test_no_httponly_cookie_deduplication(iast_context_deduplication_enabled):
     _end_iast_context_and_oce()
+
     for num_vuln_expected in [1, 0, 0]:
         _start_iast_context_and_oce()
         for _ in range(0, 5):
@@ -59,6 +60,7 @@ def test_no_httponly_cookie_deduplication(iast_context_deduplication_enabled):
 
 def test_no_samesite_cookie_deduplication(iast_context_deduplication_enabled):
     _end_iast_context_and_oce()
+
     for num_vuln_expected in [1, 0, 0]:
         _start_iast_context_and_oce()
         for _ in range(0, 5):
@@ -84,6 +86,7 @@ def test_no_samesite_cookie_deduplication(iast_context_deduplication_enabled):
 
 def test_all_cookies_deduplication(iast_context_deduplication_enabled):
     _end_iast_context_and_oce()
+
     for num_vuln_expected in [3, 0, 0]:
         _start_iast_context_and_oce()
         for _ in range(0, 5):
@@ -111,6 +114,7 @@ def test_all_cookies_deduplication(iast_context_deduplication_enabled):
 
 def test_all_cookies_two_different_sinks_deduplication(iast_context_deduplication_enabled):
     _end_iast_context_and_oce()
+
     for num_vuln_expected in [6, 0, 0]:
         _start_iast_context_and_oce()
         for _ in range(0, 5):
@@ -144,6 +148,7 @@ def test_all_cookies_two_different_sinks_deduplication(iast_context_deduplicatio
 
 def test_all_cookies_three_different_sinks_deduplication(iast_context_deduplication_enabled):
     _end_iast_context_and_oce()
+
     for num_vuln_expected in [6, 0, 0]:
         _start_iast_context_and_oce()
         for _ in range(0, 5):

--- a/tests/appsec/iast/taint_sinks/test_sql_injection_dbapi.py
+++ b/tests/appsec/iast/taint_sinks/test_sql_injection_dbapi.py
@@ -27,8 +27,8 @@ class TestTracedCursor(TracerTestCase):
             )
         ):
             _start_iast_context_and_oce()
-        self.cursor = mock.Mock()
-        self.cursor.execute.__name__ = "execute"
+            self.cursor = mock.Mock()
+            self.cursor.execute.__name__ = "execute"
 
     def tearDown(self):
         with override_global_config(

--- a/tests/appsec/iast/taint_sinks/test_sql_injection_redacted.py
+++ b/tests/appsec/iast/taint_sinks/test_sql_injection_redacted.py
@@ -25,7 +25,7 @@ from tests.utils import override_global_config
 def test_sqli_redaction_suite(
     evidence_input, sources_expected, vulnerabilities_expected, iast_context_defaults, element
 ):
-    with override_global_config(dict(_iast_deduplication_enabled=False)):
+    with override_global_config(dict(_iast_deduplication_enabled=False, _iast_max_vulnerabilities_per_requests=1000)):
         tainted_object = _taint_pyobject_multiranges(
             evidence_input["value"],
             [
@@ -42,7 +42,7 @@ def test_sqli_redaction_suite(
 
         assert is_pyobject_tainted(tainted_object)
 
-        SqlInjection.report(tainted_object)
+        assert SqlInjection.report(tainted_object)
 
         data = _get_iast_data()
         vulnerability = list(data["vulnerabilities"])[0]

--- a/tests/appsec/iast/taint_sinks/test_stacktrace_leak.py
+++ b/tests/appsec/iast/taint_sinks/test_stacktrace_leak.py
@@ -42,10 +42,10 @@ def test_check_stacktrace_leak_text(iast_context_defaults):
         vulnerabilities[0].evidence.value
         == 'Module: ".usr.local.lib.python3.9.site-packages.constraints.py"\nException: ValueError'
     )
-    VulnerabilityBase._prepare_report._reset_cache()
 
 
 def test_stacktrace_leak_deduplication(iast_context_deduplication_enabled):
+    _end_iast_context_and_oce()
     for num_vuln_expected in [1, 0, 0]:
         _start_iast_context_and_oce()
         for _ in range(0, 5):

--- a/tests/appsec/iast/taint_sinks/test_stacktrace_leak.py
+++ b/tests/appsec/iast/taint_sinks/test_stacktrace_leak.py
@@ -65,7 +65,6 @@ def test_stacktrace_leak_deduplication(iast_context_deduplication_enabled):
         _end_iast_context_and_oce()
 
 
-
 def test_check_stacktrace_leak_text_outside_context(iast_context_deduplication_enabled):
     _end_iast_context_and_oce()
 

--- a/tests/appsec/iast/taint_sinks/test_stacktrace_leak.py
+++ b/tests/appsec/iast/taint_sinks/test_stacktrace_leak.py
@@ -1,6 +1,7 @@
 import os
 
 from ddtrace.appsec._iast._iast_request_context import get_iast_reporter
+from ddtrace.appsec._iast._iast_request_context_base import set_iast_request_enabled
 from ddtrace.appsec._iast.constants import VULN_STACKTRACE_LEAK
 from ddtrace.appsec._iast.taint_sinks._base import VulnerabilityBase
 from ddtrace.appsec._iast.taint_sinks.stacktrace_leak import check_and_report_stacktrace_leak
@@ -42,10 +43,10 @@ def test_check_stacktrace_leak_text(iast_context_defaults):
         vulnerabilities[0].evidence.value
         == 'Module: ".usr.local.lib.python3.9.site-packages.constraints.py"\nException: ValueError'
     )
+    VulnerabilityBase._prepare_report._reset_cache()
 
 
 def test_stacktrace_leak_deduplication(iast_context_deduplication_enabled):
-    _end_iast_context_and_oce()
     VulnerabilityBase._prepare_report._reset_cache()
     for num_vuln_expected in [1, 0, 0]:
         _start_iast_context_and_oce()
@@ -66,8 +67,8 @@ def test_stacktrace_leak_deduplication(iast_context_deduplication_enabled):
 
 
 def test_check_stacktrace_leak_text_outside_context(iast_context_deduplication_enabled):
-    _end_iast_context_and_oce()
-
+    VulnerabilityBase._prepare_report._reset_cache()
+    set_iast_request_enabled(False)
     # Report stacktrace outside the context
     iast_check_stacktrace_leak(_load_text_stacktrace())
     assert get_report_stacktrace_later() is not None

--- a/tests/appsec/iast/taint_sinks/test_stacktrace_leak.py
+++ b/tests/appsec/iast/taint_sinks/test_stacktrace_leak.py
@@ -46,6 +46,7 @@ def test_check_stacktrace_leak_text(iast_context_defaults):
 
 def test_stacktrace_leak_deduplication(iast_context_deduplication_enabled):
     _end_iast_context_and_oce()
+    VulnerabilityBase._prepare_report._reset_cache()
     for num_vuln_expected in [1, 0, 0]:
         _start_iast_context_and_oce()
         for _ in range(0, 5):
@@ -62,7 +63,7 @@ def test_stacktrace_leak_deduplication(iast_context_deduplication_enabled):
             vulnerability = list(span_report.vulnerabilities)[0]
             assert vulnerability.type == VULN_STACKTRACE_LEAK
         _end_iast_context_and_oce()
-    VulnerabilityBase._prepare_report._reset_cache()
+
 
 
 def test_check_stacktrace_leak_text_outside_context(iast_context_deduplication_enabled):

--- a/tests/appsec/iast/taint_sinks/test_unvalidated_redirect_redacted.py
+++ b/tests/appsec/iast/taint_sinks/test_unvalidated_redirect_redacted.py
@@ -3,6 +3,7 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import origin_to_str
 from ddtrace.appsec._iast._taint_tracking import str_to_origin
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_tracking.aspects import add_aspect
 from ddtrace.appsec._iast.constants import VULN_UNVALIDATED_REDIRECT
 from ddtrace.appsec._iast.reporter import Evidence
@@ -37,7 +38,9 @@ def test_unvalidated_redirect_redaction_suite(
             ],
         )
 
-    UnvalidatedRedirect.report(tainted_object)
+    assert is_pyobject_tainted(tainted_object)
+
+    assert UnvalidatedRedirect.report(tainted_object)
 
     data = _get_iast_data()
     vulnerability = list(data["vulnerabilities"])[0]

--- a/tests/appsec/iast/taint_sinks/test_vulnerability_detection.py
+++ b/tests/appsec/iast/taint_sinks/test_vulnerability_detection.py
@@ -9,7 +9,6 @@ from ddtrace.appsec._iast.constants import VULN_PATH_TRAVERSAL
 from ddtrace.appsec._iast.constants import VULN_SQL_INJECTION
 from ddtrace.appsec._iast.constants import VULN_SSRF
 from ddtrace.appsec._iast.constants import VULN_XSS
-from ddtrace.appsec._iast.sampling.vulnerability_detection import _reset_global_limit
 from ddtrace.appsec._iast.sampling.vulnerability_detection import init_request_vulnerability_maps
 from ddtrace.appsec._iast.sampling.vulnerability_detection import reset_request_vulnerabilities
 from ddtrace.appsec._iast.sampling.vulnerability_detection import should_process_vulnerability
@@ -29,14 +28,16 @@ def _get_global_limit():
 def iast_create_context():
     with override_global_config(dict(_iast_enabled=True, _iast_deduplication_enabled=True, _iast_request_sampling=100)):
         _start_iast_context_and_oce()
-        yield
-        _end_iast_context_and_oce()
-        _reset_global_limit()
-        reset_request_vulnerabilities()
+        try:
+            yield
+        finally:
+            _end_iast_context_and_oce()
+            reset_request_vulnerabilities()
 
 
 def test_request_1_endpoint_with_6_vuln():
     """Test that higher occurrences of vulnerabilities are processed."""
+
     # First request - detect SQL injection once
     assert _get_global_limit() == {}
     set_iast_request_endpoint("GET", "/users")

--- a/tests/appsec/iast/taint_tracking/conftest.py
+++ b/tests/appsec/iast/taint_tracking/conftest.py
@@ -6,10 +6,18 @@ from tests.utils import override_global_config
 
 
 @pytest.fixture(autouse=True)
-def iast_create_context():
+def iast_request():
     with override_global_config(
-        dict(_iast_enabled=True, _iast_is_testing=True, _iast_deduplication_enabled=False, _iast_request_sampling=100.0)
+        dict(
+            _iast_enabled=True,
+            _iast_is_testing=True,
+            _iast_deduplication_enabled=False,
+            _iast_request_sampling=100.0,
+            _iast_max_concurrent_requests=100,
+        )
     ):
         _start_iast_context_and_oce()
-        yield
-        _end_iast_context_and_oce()
+        try:
+            yield
+        finally:
+            _end_iast_context_and_oce()

--- a/tests/appsec/iast/test_processor.py
+++ b/tests/appsec/iast/test_processor.py
@@ -59,8 +59,7 @@ def test_appsec_iast_processor_ensure_span_is_manual_keep(iast_context_defaults,
         assert span.get_metric(_SAMPLING_PRIORITY_KEY) is USER_KEEP
 
 
-@pytest.mark.skip_iast_check_logs
-@pytest.mark.parametrize("sampling_rate", [0.0, "100"])
+@pytest.mark.parametrize("sampling_rate", ["0.0", "100"])
 def test_appsec_iast_processor_ensure_span_is_sampled(iast_context_defaults, sampling_rate):
     """
     test_appsec_iast_processor_ensure_span_is_manual_keep.

--- a/tests/appsec/iast/test_processor.py
+++ b/tests/appsec/iast/test_processor.py
@@ -59,6 +59,7 @@ def test_appsec_iast_processor_ensure_span_is_manual_keep(iast_context_defaults,
         assert span.get_metric(_SAMPLING_PRIORITY_KEY) is USER_KEEP
 
 
+@pytest.mark.skip_iast_check_logs
 @pytest.mark.parametrize("sampling_rate", ["0.0", "100"])
 def test_appsec_iast_processor_ensure_span_is_sampled(iast_context_defaults, sampling_rate):
     """

--- a/tests/appsec/iast/test_processor.py
+++ b/tests/appsec/iast/test_processor.py
@@ -59,7 +59,6 @@ def test_appsec_iast_processor_ensure_span_is_manual_keep(iast_context_defaults,
         assert span.get_metric(_SAMPLING_PRIORITY_KEY) is USER_KEEP
 
 
-@pytest.mark.skip_iast_check_logs
 @pytest.mark.parametrize("sampling_rate", ["0.0", "100"])
 def test_appsec_iast_processor_ensure_span_is_sampled(iast_context_defaults, sampling_rate):
     """
@@ -80,7 +79,7 @@ def test_appsec_iast_processor_ensure_span_is_sampled(iast_context_defaults, sam
         tracer._on_span_finish(span)
 
         result = load_iast_report(span)
-        if sampling_rate == 0.0:
+        if sampling_rate == "0.0":
             assert result is None
             assert span.get_metric(_SAMPLING_PRIORITY_KEY) is AUTO_KEEP
             assert span.get_metric(IAST.ENABLED) == 0.0

--- a/tests/appsec/iast_memcheck/test_iast_mem_check.py
+++ b/tests/appsec/iast_memcheck/test_iast_mem_check.py
@@ -136,7 +136,7 @@ async def test_propagation_memory_check_async(origin1, origin2, iast_context_def
         span_report = get_iast_reporter()
         assert len(span_report.sources) > 0
         assert len(span_report.vulnerabilities) > 0
-        assert len(get_tainted_ranges(result)) == 6
+        assert len(get_tainted_ranges(result)) == 1
 
         if _num_objects_tainted == 0:
             _num_objects_tainted = num_objects_tainted()

--- a/tests/appsec/integrations/django_tests/conftest.py
+++ b/tests/appsec/integrations/django_tests/conftest.py
@@ -12,8 +12,6 @@ from ddtrace.appsec._iast.main import patch_iast
 from ddtrace.contrib.internal.django.patch import patch as django_patch
 from ddtrace.contrib.internal.requests.patch import patch as requests_patch
 from ddtrace.internal import core
-from tests.appsec.iast.iast_utils import _end_iast_context_and_oce
-from tests.appsec.iast.iast_utils import _start_iast_context_and_oce
 from tests.utils import DummyTracer
 from tests.utils import TracerSpanContainer
 from tests.utils import override_config
@@ -91,9 +89,7 @@ def iast_span(tracer):
     ):
         oce.reconfigure()
         container = TracerSpanContainer(tracer)
-        _start_iast_context_and_oce()
         yield container
-        _end_iast_context_and_oce()
         container.reset()
 
 
@@ -108,9 +104,7 @@ def iast_span_disabled(tracer):
     ):
         oce.reconfigure()
         container = TracerSpanContainer(tracer)
-        _start_iast_context_and_oce()
         yield container
-        _end_iast_context_and_oce()
         container.reset()
 
 
@@ -126,9 +120,7 @@ def test_spans_2_vuln_per_request_deduplication(tracer):
     ):
         oce.reconfigure()
         container = TracerSpanContainer(tracer)
-        _start_iast_context_and_oce()
         yield container
-        _end_iast_context_and_oce()
         container.reset()
 
 
@@ -158,7 +150,5 @@ def iast_spans_with_zero_sampling(tracer):
     ):
         oce.reconfigure()
         container = TracerSpanContainer(tracer)
-        _start_iast_context_and_oce()
         yield container
-        _end_iast_context_and_oce()
         container.reset()

--- a/tests/appsec/integrations/packages_tests/conftest.py
+++ b/tests/appsec/integrations/packages_tests/conftest.py
@@ -22,8 +22,10 @@ def iast_create_context():
         sqli_sqlite_patch()
         code_injection_patch()
         _start_iast_context_and_oce()
-        yield
-        _end_iast_context_and_oce()
-        psycopg_unpatch()
-        sqlalchemy_unpatch()
-        sqli_sqlite_unpatch()
+        try:
+            yield
+        finally:
+            _end_iast_context_and_oce()
+            psycopg_unpatch()
+            sqlalchemy_unpatch()
+            sqli_sqlite_unpatch()


### PR DESCRIPTION
This PR doesn't modify the logic, it's only to simplify and reduce the number of modification of the main PR IAST Context refactor https://github.com/DataDog/dd-trace-py/pull/14513:

- rename `end_iast_context` to `_iast_finish_request`.
- merge `start_iast_context` and `_start_iast_context` logic.
- remove noisy logs in `ddtrace/appsec/_iast/_patch_modules.py`.
- Update the TaintEngineContext class and methods.
- standardized the usage of create_context and.
- wrap from `ddtrace.appsec._iast._taint_tracking import num_objects_tainted`  in `from ddtrace.appsec._iast._iast_request_context_base import _num_objects_tainted_in_request` (we need that in #14513)

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
