### PR TITLE
chore(appsec): add action tag on waf.config_errors

### DIFF
--- a/ddtrace/appsec/_ddwaf/waf.py
+++ b/ddtrace/appsec/_ddwaf/waf.py
@@ -97,13 +97,11 @@ class DDWaf(WAF):
         self._cached_version = version
         for key, value in info_struct.items():
             if isinstance(value, dict):
-                if value.get("error", False):
+                if error := value.get("error", False):
+                    self.report_error(f"appsec.waf.error::{action}::{key}::{error}", self._cached_version, action)
+                elif errors := value.get("errors", False):
                     self.report_error(
-                        f"appsec.waf.error::{action}::{key}::{value['error']}", self._cached_version, action
-                    )
-                elif value.get("errors", False):
-                    self.report_error(
-                        f"appsec.waf.error::{action}::{key}::{str(value['errors'])}",
+                        f"appsec.waf.error::{action}::{key}::{str(errors)}",
                         self._cached_version,
                         action,
                         False,

--- a/ddtrace/appsec/_ddwaf/waf.py
+++ b/ddtrace/appsec/_ddwaf/waf.py
@@ -98,10 +98,15 @@ class DDWaf(WAF):
         for key, value in info_struct.items():
             if isinstance(value, dict):
                 if value.get("error", False):
-                    self.report_error(f"appsec.waf.error::{action}::{key}::{value['error']}", self._cached_version)
+                    self.report_error(
+                        f"appsec.waf.error::{action}::{key}::{value['error']}", self._cached_version, action
+                    )
                 elif value.get("errors", False):
                     self.report_error(
-                        f"appsec.waf.error::{action}::{key}::{str(value['errors'])}", self._cached_version, False
+                        f"appsec.waf.error::{action}::{key}::{str(value['errors'])}",
+                        self._cached_version,
+                        action,
+                        False,
                     )
         self._info = DDWaf_info(
             len(rules.get("loaded", [])),

--- a/ddtrace/appsec/_metrics.py
+++ b/ddtrace/appsec/_metrics.py
@@ -31,7 +31,7 @@ log_extra = {"product": "appsec", "stack_limit": 4, "exec_limit": 4}
 
 
 @deduplication
-def _set_waf_error_log(msg: str, version: str, error_level: bool = True) -> None:
+def _set_waf_error_log(msg: str, version: str, action: str, error_level: bool = True) -> None:
     """used for waf configuration errors"""
     try:
         log_tags = {
@@ -47,6 +47,7 @@ def _set_waf_error_log(msg: str, version: str, error_level: bool = True) -> None
         tags = (
             ("waf_version", ddwaf_version),
             ("event_rules_version", version or UNKNOWN_VERSION),
+            ("action", action),
         )
         telemetry.telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.APPSEC, "waf.config_errors", 1, tags=tags)
     except Exception:
@@ -80,7 +81,9 @@ def _set_waf_init_metric(info: DDWaf_info, success: bool):
             TELEMETRY_NAMESPACE.APPSEC, "waf.init", 1, tags=tags + (("success", bool_str[success]),)
         )
         if not success:
-            telemetry.telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.APPSEC, "waf.config_errors", 1, tags=tags)
+            telemetry.telemetry_writer.add_count_metric(
+                TELEMETRY_NAMESPACE.APPSEC, "waf.config_errors", 1, tags=tags + (("action", "init"),)
+            )
     except Exception:
         extra = {"product": "appsec", "exec_limit": 6, "more_info": ":waf:init"}
         logger.warning(WARNING_TAGS.TELEMETRY_METRICS, extra=extra, exc_info=True)


### PR DESCRIPTION
## Description

Add the `action` tag with value `init` or `update` on the `waf.config_errors` telemetry event to be in accordance with RFC-1051.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
