### PR TITLE
chore(iast): ci_visibility interaction

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -47,7 +47,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'e13ccb562e9e060317b173e25b1e638d89f9df3b'
+          ref: '8f2c3d3fff7719d4d84cce0ea99304a8a5e1d4bd'
 
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -94,7 +94,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'e13ccb562e9e060317b173e25b1e638d89f9df3b'
+          ref: '8f2c3d3fff7719d4d84cce0ea99304a8a5e1d4bd'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -279,7 +279,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'e13ccb562e9e060317b173e25b1e638d89f9df3b'
+          ref: '8f2c3d3fff7719d4d84cce0ea99304a8a5e1d4bd'
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -47,7 +47,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '8f2c3d3fff7719d4d84cce0ea99304a8a5e1d4bd'
+          ref: '53608020d1f5cc57eb8c86f302d41c156bce091d'
 
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -94,7 +94,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '8f2c3d3fff7719d4d84cce0ea99304a8a5e1d4bd'
+          ref: '53608020d1f5cc57eb8c86f302d41c156bce091d'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -279,7 +279,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: '8f2c3d3fff7719d4d84cce0ea99304a8a5e1d4bd'
+          ref: '53608020d1f5cc57eb8c86f302d41c156bce091d'
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "e13ccb562e9e060317b173e25b1e638d89f9df3b"
+  SYSTEM_TESTS_REF: "8f2c3d3fff7719d4d84cce0ea99304a8a5e1d4bd"
 
 default:
   interruptible: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "8f2c3d3fff7719d4d84cce0ea99304a8a5e1d4bd"
+  SYSTEM_TESTS_REF: "53608020d1f5cc57eb8c86f302d41c156bce091d"
 
 default:
   interruptible: true

--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
@@ -726,11 +726,11 @@ experiments:
               - max_rss_usage < 39.00 MB
           - name: iastpropagation-propagation_enabled_100
             thresholds:
-              - execution_time < 1.90 ms
+              - execution_time < 2.30 ms
               - max_rss_usage < 39.00 MB
           - name: iastpropagation-propagation_enabled_1000
             thresholds:
-              - execution_time < 35.55 ms
+              - execution_time < 34.55 ms
               - max_rss_usage < 39.00 MB
 
           # otelsdkspan

--- a/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.cpp
@@ -59,6 +59,15 @@ TaintEngineContext::TaintEngineContext()
 {
 }
 
+// Lifecycle guard. Prevent access during interpreter/module teardown.
+std::atomic<bool> TaintEngineContext::shutting_down{ false };
+
+void
+TaintEngineContext::set_shutting_down(bool v)
+{
+    shutting_down.store(v, std::memory_order_release);
+}
+
 std::optional<size_t>
 TaintEngineContext::start_request_context()
 {
@@ -171,6 +180,9 @@ TaintEngineContext::get_tainted_object_map(PyObject* obj)
 TaintedObjectMapTypePtr
 TaintEngineContext::get_tainted_object_map_from_pyobject(PyObject* tainted_object)
 {
+    if (shutting_down.load(std::memory_order_acquire)) {
+        return nullptr;
+    }
     for (const auto& context_map : request_context_slots) {
         if (!context_map) {
             continue;

--- a/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.h
@@ -49,8 +49,14 @@ class TaintEngineContext
     // Parse and clamp capacity from environment
     static size_t assign_request_context_slots_size();
 
+    // Global lifecycle flag to avoid use-after-destruction during interpreter/module teardown.
+    static std::atomic<bool> shutting_down;
+
   public:
     TaintEngineContext();
+
+    // Lifecycle control: mark the context as shutting down to prevent further access.
+    static void set_shutting_down(bool v);
 
     // Fast-path: get the taint map for a known context_id (slot index).
     // Returns nullptr if the slot is empty or out of lifecycle.

--- a/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.h
@@ -32,6 +32,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include <atomic>
 #include <memory>
 #include <optional>
 #include <string>

--- a/ddtrace/appsec/_iast/_taint_tracking/native.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/native.cpp
@@ -75,7 +75,8 @@ PYBIND11_MODULE(_native, m)
         py::gil_scoped_acquire acquire;
         // Ensure native context stops serving requests before teardown to avoid races.
         if (Py_IsFinalizing()) {
-            TaintEngineContext::set_shutting_down(true) initializer.reset();
+            TaintEngineContext::set_shutting_down(true);
+            initializer.reset();
             if (taint_engine_context) {
                 taint_engine_context->clear_all_request_context_slots();
                 taint_engine_context.reset();

--- a/ddtrace/appsec/_iast/_taint_tracking/native.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/native.cpp
@@ -5,7 +5,6 @@
  * - Aspects: common string operations are replaced by functions that propagate the taint variables.
  * - Taint ranges: Information related to tainted values.
  */
-#include <Python.h>
 #include <memory>
 #include <pybind11/pybind11.h>
 
@@ -78,9 +77,6 @@ PYBIND11_MODULE(_native, m)
         // always quiesce the native layer first, then skip heavy cleanup if Python is
         // already finalizing. Only perform cleanup while the runtime is alive.
         TaintEngineContext::set_shutting_down(true);
-        if (Py_IsFinalizing()) {
-            return; // skip heavy cleanup; OS will reclaim memory safely
-        }
         py::gil_scoped_acquire gil; // safe to touch Python-adjacent state
         initializer.reset();
         if (taint_engine_context) {

--- a/ddtrace/appsec/_iast/_taint_tracking/native.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/native.cpp
@@ -72,7 +72,6 @@ PYBIND11_MODULE(_native, m)
     // Create a atexit callback to cleanup the Initializer before the interpreter finishes
     auto atexit_register = safe_import("atexit", "register");
     atexit_register(py::cpp_function([]() {
-        py::gil_scoped_acquire gil; // safe to touch Python-adjacent state
         // During interpreter shutdown (esp. with gevent), heavy cleanup can
         // trigger refcounting or Python API calls without a valid runtime.
         // If gevent monkey-patching is active, skip setting the shutdown flag
@@ -88,6 +87,7 @@ PYBIND11_MODULE(_native, m)
         }
 
         if (!gevent_active) {
+            py::gil_scoped_acquire gil; // safe to touch Python-adjacent state
             TaintEngineContext::set_shutting_down(true);
         }
 

--- a/ddtrace/appsec/_iast/_taint_tracking/native.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/native.cpp
@@ -72,12 +72,12 @@ PYBIND11_MODULE(_native, m)
     // Create a atexit callback to cleanup the Initializer before the interpreter finishes
     auto atexit_register = safe_import("atexit", "register");
     atexit_register(py::cpp_function([]() {
+        py::gil_scoped_acquire gil; // safe to touch Python-adjacent state
         // During interpreter shutdown (esp. with gevent), heavy cleanup can
         // trigger refcounting or Python API calls without a valid runtime. We therefore
         // always quiesce the native layer first, then skip heavy cleanup if Python is
         // already finalizing. Only perform cleanup while the runtime is alive.
         TaintEngineContext::set_shutting_down(true);
-        py::gil_scoped_acquire gil; // safe to touch Python-adjacent state
         initializer.reset();
         if (taint_engine_context) {
             taint_engine_context->clear_all_request_context_slots();

--- a/ddtrace/appsec/_iast/_taint_tracking/native.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/native.cpp
@@ -81,7 +81,8 @@ PYBIND11_MODULE(_native, m)
         bool gevent_active = false;
         try {
             auto is_patched = safe_import("gevent.monkey", "is_module_patched");
-            gevent_active = asbool(is_patched("threading")) || asbool(is_patched("socket")) || asbool(is_patched("ssl"));
+            gevent_active =
+              asbool(is_patched("threading")) || asbool(is_patched("socket")) || asbool(is_patched("ssl"));
         } catch (const py::error_already_set&) {
             PyErr_Clear();
         }

--- a/ddtrace/appsec/_iast/_taint_tracking/native.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/native.cpp
@@ -72,6 +72,8 @@ PYBIND11_MODULE(_native, m)
     // Create a atexit callback to cleanup the Initializer before the interpreter finishes
     auto atexit_register = safe_import("atexit", "register");
     atexit_register(py::cpp_function([]() {
+        // Ensure native context stops serving requests before teardown to avoid races.
+        TaintEngineContext::set_shutting_down(true);
         initializer.reset();
         if (taint_engine_context) {
             taint_engine_context->clear_all_request_context_slots();

--- a/ddtrace/appsec/_iast/_taint_tracking/native.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/native.cpp
@@ -73,7 +73,7 @@ PYBIND11_MODULE(_native, m)
     auto atexit_register = safe_import("atexit", "register");
     atexit_register(py::cpp_function([]() {
         // Ensure native context stops serving requests before teardown to avoid races.
-        TaintEngineContext::set_shutting_down(true);
+        // TaintEngineContext::set_shutting_down(true);
         initializer.reset();
         if (taint_engine_context) {
             taint_engine_context->clear_all_request_context_slots();

--- a/riotfile.py
+++ b/riotfile.py
@@ -319,8 +319,7 @@ venv = Venv(
         ),
         Venv(
             name="appsec_iast_default",
-            # TODO(avara1986): remove "-vvv --no-ddtrace --no-cov" when CI visibility errors were fixed in #14581
-            command="pytest -vvv --no-ddtrace --no-cov {cmdargs} tests/appsec/iast/",
+            command="pytest -v {cmdargs} tests/appsec/iast/",
             pys=select_pys(),
             pkgs={
                 "requests": latest,


### PR DESCRIPTION
Following https://github.com/DataDog/dd-trace-py/pull/14513 that PR introduces a potencial conflict when a application shutdown exiting with a bad status code. the traceback suggests the vector’s internal state is invalid so the crash happens when constructing an iterator. I'm adding extra validations and a safe shutting down
```
#4  0x000077f0263304d7 in std::vector<std::shared_ptr<std::unordered_map<unsigned long, std::pair<long, std::shared_ptr<TaintedObject> >, std::hash<unsigned long>, std::equal_to<unsigned long>, std::allocator<std::pair<unsigned long const, std::pair<long, std::shared_ptr<TaintedObject> > > > > >, std::allocator<std::shared_ptr<std::unordered_map<unsigned long, std::pair<long, std::shared_ptr<TaintedObject> >, std::hash<unsigned long>, std::equal_to<unsigned long>, std::allocator<std::pair<unsigned long const, std::pair<long, std::shared_ptr<TaintedObject> > > > > > > >::begin() ()
   from /home/bits/project/ddtrace/appsec/_iast/_taint_tracking/_native.cpython-310-x86_64-linux-gnu.so
#5  0x000077f02632bf3f in TaintEngineContext::get_tainted_object_map_from_pyobject(_object*) () from /home/bits/project/ddtrace/appsec/_iast/_taint_tracking/_native.cpython-310-x86_64-linux-gnu.so
```
NOTE: We tryied with a mutex or shared_mutex but that approach creates conflicts with gevent in IAST_STANDALONE tests

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
