### PR TITLE
chore(telemetry): improve redaction of telemetry error logs

### DIFF
--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -1089,12 +1089,14 @@ def test_otel_config_telemetry(test_agent_session, run_python_code_in_subprocess
     assert tags == [["config_opentelemetry:otel_logs_exporter"]]
 
 
-def test_add_integration_error_log(mock_time, telemetry_writer, test_agent_session):
+def test_add_error_log(mock_time, telemetry_writer, test_agent_session):
     """Test add_integration_error_log functionality with real stack trace"""
     try:
-        raise ValueError("Test exception")
-    except ValueError as e:
-        telemetry_writer.add_integration_error_log("Test error message", e)
+        import json
+
+        json.loads("{invalid: json,}")
+    except Exception as e:
+        telemetry_writer.add_error_log("Test error message", e)
         telemetry_writer.periodic(force_flush=True)
 
         log_events = test_agent_session.get_events("logs")
@@ -1110,9 +1112,14 @@ def test_add_integration_error_log(mock_time, telemetry_writer, test_agent_sessi
         stack_trace = log_entry["stack_trace"]
         expected_lines = [
             "Traceback (most recent call last):",
-            "  <REDACTED>",
-            "    <REDACTED>",
-            "builtins.ValueError: Test exception",
+            "<REDACTED>",  # User code gets redacted
+            '  File "json/__init__.py',
+            "    return _default_decoder.decode(s)",
+            '  File "json/decoder.py"',
+            "    obj, end = self.raw_decode(s, idx=_w(s, 0).end())",
+            '  File "json/decoder.py"',
+            "    obj, end = self.scan_once(s, idx)",
+            "json.decoder.JSONDecodeError: <REDACTED>",
         ]
         for expected_line in expected_lines:
             assert expected_line in stack_trace
@@ -1127,7 +1134,7 @@ def test_add_integration_error_log_with_log_collection_disabled(mock_time, telem
         try:
             raise ValueError("Test exception")
         except ValueError as e:
-            telemetry_writer.add_integration_error_log("Test error message", e)
+            telemetry_writer.add_error_log("Test error message", e)
             telemetry_writer.periodic(force_flush=True)
 
             log_events = test_agent_session.get_events("logs", subprocess=True)
@@ -1137,17 +1144,22 @@ def test_add_integration_error_log_with_log_collection_disabled(mock_time, telem
 
 
 @pytest.mark.parametrize(
-    "filename, is_redacted",
+    "filename, result",
     [
-        ("/path/to/file.py", True),
-        ("/path/to/ddtrace/contrib/flask/file.py", False),
-        ("/path/to/dd-trace-something/file.py", True),
+        ("/path/to/file.py", "<REDACTED>"),
+        ("/path/to/ddtrace/contrib/flask/file.py", "<REDACTED>"),
+        ("/path/to/lib/python3.13/site-packages/ddtrace/_trace/tracer.py", "ddtrace/_trace/tracer.py"),
+        ("/path/to/lib/python3.13/site-packages/requests/api.py", "requests/api.py"),
+        (
+            "/path/to/python@3.13/3.13.1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/json/__init__.py",
+            "json/__init__.py",
+        ),
     ],
 )
-def test_redact_filename(filename, is_redacted):
+def test_redact_filename(filename, result):
     """Test file redaction logic"""
     writer = TelemetryWriter(is_periodic=False)
-    assert writer._should_redact(filename) == is_redacted
+    assert writer._format_file_path(filename) == result
 
 
 def test_telemetry_writer_multiple_sources_config(telemetry_writer, test_agent_session):


### PR DESCRIPTION
First PR in a list of 3 PRs to achieved requirements listed [here](https://docs.google.com/document/d/16SFeOp7yxzT6dM1O0TKtWkgDsiq6SeV8P_MAYboCdOI/edit?tab=t.gho5ikpq9hed).

# Changes

Improve Stack Redaction of error telemetry logs:
- The error value is redacted
- The user code frames are fully redacted
- Paths are partially redacted for python/third party packages libraries. 

## Checklist
- [X] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [ ] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
