### PR TITLE
fix(er): proactively remove exception fields

### DIFF
--- a/ddtrace/debugging/_signal/utils.py
+++ b/ddtrace/debugging/_signal/utils.py
@@ -359,4 +359,11 @@ def capture_value(
     elif len(fields) > maxfields:
         data["notCapturedReason"] = "fieldCount"
 
+    if _isinstance(value, BaseException):
+        # DEV: Celery doesn't like that we store references to these objects so we
+        # delete them as soon as we're done with them.
+        for attr in ("args", "__cause__", "__context__", "__suppress_context__"):
+            if attr in fields:
+                del fields[attr]
+
     return data

--- a/releasenotes/notes/fix-di-celery-exception-capturing-93e54eb0214ece66.yaml
+++ b/releasenotes/notes/fix-di-celery-exception-capturing-93e54eb0214ece66.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    exception replay: prevent Celery from crashing when a task raises a custom
+    exception with mandatory arguments.


### PR DESCRIPTION
## Description

Exception Replay introduces an unexpected interaction with Celery when tasks raise custom exceptions with mandatory arguments. It seems that holding on to exception fields, such as __cause__, for longer than necessary causes Celery to produce bad pickled responses that are not handled by the framework. We therefore proactively clear up our tracking of the exception fields that we want to capture to prevent Celery tasks from crashing the application.