### PR TITLE
feat(debugger): require agent v7.49.0+ for debugger, update snapshot endpoint

### DIFF
--- a/ddtrace/debugging/_uploader.py
+++ b/ddtrace/debugging/_uploader.py
@@ -96,7 +96,7 @@ class LogsIntakeUploaderV1(ForksafeAwakeablePeriodicService):
         finally:
             self._agent_endpoints_cache.turn()
 
-        snapshot_track = "/debugger/v1/input"
+        snapshot_track = "/debugger/v1/diagnostics"
         if "/debugger/v2/input" in self._agent_endpoints:
             snapshot_track = "/debugger/v2/input"
         elif "/debugger/v1/diagnostics" in self._agent_endpoints:
@@ -106,6 +106,12 @@ class LogsIntakeUploaderV1(ForksafeAwakeablePeriodicService):
 
         # Only create the tracks if they don't exist to preserve the track queue metadata.
         if not self._tracks:
+            if snapshot_track not in self._agent_endpoints:
+                log.warning(
+                    "Live Debugger and Exception Replay could not verify if the snapshot endpoint is available. "
+                    "You may need to update the agent to v7.49.0 or later for these features to work.",
+                )
+
             self._tracks = {
                 SignalTrack.LOGS: UploaderTrack(
                     endpoint=f"/debugger/v1/input{endpoint_suffix}",

--- a/releasenotes/notes/debugger-minimum-agent-version-e65ad7987cd2491f.yaml
+++ b/releasenotes/notes/debugger-minimum-agent-version-e65ad7987cd2491f.yaml
@@ -1,0 +1,6 @@
+---
+prelude: >
+    **Breaking change** for Dynamic Instrumentation and Exception Replay: the minimum required agent version for these products is now v7.49.0.
+features:
+  - |
+    dynamic instrumentation: snapshots are now uploaded to a new debugger endpoint.


### PR DESCRIPTION
## Description

Dynamic Instrumentation and Exception Replay now require agent version v7.49.0 or later. The debugger snapshot endpoint has been updated to use `/debugger/v1/diagnostics` as the default instead of `/debugger/v1/input`, with fallback logic and warning messages for unsupported agent versions.


## Testing

System-tests and debugger-demo-python on staging

## Risks

Exception Replay and DI will stop working for folks who haven't upgraded their agent since Sept 2023.

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
