### PR TITLE
chore(crashtracking): fix flaky test around receiving crash messages

### DIFF
--- a/tests/internal/crashtracker/test_crashtracker.py
+++ b/tests/internal/crashtracker/test_crashtracker.py
@@ -330,7 +330,7 @@ def test_crashtracker_preload_disabled(ddtrace_run_python_code_in_subprocess):
         assert exitcode == -11
 
         # No crash reports should be sent
-        assert client.crash_reports() == []
+        assert client.crash_messages() == []
 
 
 auto_code = """
@@ -389,7 +389,7 @@ def test_crashtracker_auto_disabled(run_python_code_in_subprocess):
         assert exitcode == -11
 
         # No crash reports should be sent
-        assert client.crash_reports() == []
+        assert client.crash_messages() == []
 
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")

--- a/tests/internal/crashtracker/utils.py
+++ b/tests/internal/crashtracker/utils.py
@@ -112,35 +112,44 @@ class CrashtrackerWrapper:
         return read_files([self.stdout, self.stderr])
 
 
-def wait_for_crash_reports(test_agent_client: TestAgentClient) -> List[TestAgentRequest]:
-    crash_reports = []
-    for _ in range(10):  # 10 iterations * 0.1 second = 1 second total
-        incoming_reports = test_agent_client.crash_reports()
-        if incoming_reports:
-            crash_reports.extend(incoming_reports)
-            # If we have both crash ping and crash report (2 reports), we can return early
-            if len(crash_reports) >= 2:
-                return crash_reports
-        time.sleep(0.1)
+def wait_for_crash_messages(test_agent_client: TestAgentClient) -> List[TestAgentRequest]:
+    seen_report_ids = set()
+    crash_messages = []
+    # 5 iterations * 0.2 second = 1 second total should be enough to get ping + report
+    for _ in range(5):
+        incoming_messages = test_agent_client.crash_messages()
+        for message in incoming_messages:
+            body = message.get("body", b"")
+            if isinstance(body, str):
+                body = body.encode("utf-8")
+            report_id = (hash(body), frozenset(message.get("headers", {}).items()))
+            if report_id not in seen_report_ids:
+                seen_report_ids.add(report_id)
+                crash_messages.append(message)
 
-    return crash_reports
+            # If we have both crash ping and crash report (2 reports), we can return early
+            if len(crash_messages) >= 2:
+                return crash_messages
+        time.sleep(0.2)
+
+    return crash_messages
 
 
 def get_crash_report(test_agent_client: TestAgentClient) -> TestAgentRequest:
     """Wait for a crash report from the crashtracker listener socket."""
-    crash_reports = wait_for_crash_reports(test_agent_client)
+    crash_messages = wait_for_crash_messages(test_agent_client)
     # We want at least the crash report
-    assert len(crash_reports) == 2, f"Expected at 2 messages; one ping and one report, got {len(crash_reports)}"
+    assert len(crash_messages) == 2, f"Expected at least 2 messages; got {len(crash_messages)}"
 
-    # Find the actual crash report (the one with "is_crash":"true")
-    actual_crash_report = None
-    for report in crash_reports:
-        if b"is_crash:true" in report["body"]:
-            actual_crash_report = report
+    # Find the crash report (the one with "is_crash":"true")
+    crash_report = None
+    for message in crash_messages:
+        if b"is_crash:true" in message["body"]:
+            crash_report = message
             break
 
-    assert actual_crash_report is not None, "Could not find crash report with 'is_crash:true' tag"
-    return actual_crash_report
+    assert crash_report is not None, "Could not find crash report with 'is_crash:true' tag"
+    return crash_report
 
 
 @contextmanager

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1162,7 +1162,7 @@ class TestAgentClient:
                 reqs.append(req)
         return reqs
 
-    def crash_reports(self) -> List[TestAgentRequest]:
+    def crash_messages(self) -> List[TestAgentRequest]:
         reqs = []
         for req in self.telemetry_requests(telemetry_type="logs"):
             # Parse the json data in order to filter based on "origin" key,


### PR DESCRIPTION
## Description

[Ticket](https://datadoghq.atlassian.net/jira/software/c/projects/PROF/boards/11?selectedIssue=PROF-12582)

This PR renames the function `wait_for_crash_reports` to `wait_for_crash_messages` and other uses of `reports` to `messages` where necessary. This is because the crashtracker emits two types of messages, crash reports and crash pings, so it is misleading to call both as crash reports. 

This PR also does a bit of updating of logic around how we set up our mock client to handle crash messages. Now, the crash tracker sends two messages, `crash_ping` and `crash_report`. The `wait_for_crash_reports` used to work by spinning for `N` cycles and each time, calling `TestAgentClient.crash_reports()`, which was a function that returned all the requests originated from crashtracker within that test session. The previous logic would then accumulate all the requests returned by the `TestAgentClient`. However, this logic was flawed. Consider this case


---------- Cycle 1 ---------- 
`crash_ping` arrives to client
TestAgentClient.crash_reports() -> [`crash_ping`]
accumulated requests = [`crash_ping`]
---------- Cycle 2 ---------- 
`crash_report` arrives to client
TestAgentClient.crash_reports() -> [`crash_ping`, `crash_report`]
accumulated requests = [`crash_ping`, `crash_ping`, `crash_report`]

We just duplicated `crash_ping`! This is not a problem if both `crash_ping` and `crash_report` arrive in the same cycle of waiting for crash reports, as then, we would have >=2 messages and exit early. However, if we receive `crash_ping` and `crash_report` in different cycles, we end up duplicating one of them.


This issue was identified by noticing many failures of the crashtracking tests, [because we got 3 messages instead of 2.](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1137159305)
<img width="760" height="209" alt="Screenshot 2025-09-19 at 3 04 58 PM" src="https://github.com/user-attachments/assets/b7678023-0219-412b-ada9-33e708d10159" />




## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
