### PR TITLE
chore(debugger): rate-limit agent warning logs to once an hour

### DIFF
--- a/ddtrace/debugging/_uploader.py
+++ b/ddtrace/debugging/_uploader.py
@@ -20,7 +20,7 @@ from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 
 
 log = get_logger(__name__)
-UNSUPPORTED_AGENT = "debugger::unsupported_agent"
+UNSUPPORTED_AGENT = "unsupported_agent"
 logger.set_tag_rate_limit(UNSUPPORTED_AGENT, logger.HOUR)
 
 

--- a/ddtrace/debugging/_uploader.py
+++ b/ddtrace/debugging/_uploader.py
@@ -13,12 +13,17 @@ from ddtrace.debugging._metrics import metrics
 from ddtrace.debugging._signal.collector import SignalCollector
 from ddtrace.debugging._signal.model import SignalTrack
 from ddtrace.internal import agent
+from ddtrace.internal import logger
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.http import connector
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 
 
 log = get_logger(__name__)
+UNSUPPORTED_AGENT = "debugger::unsupported_agent"
+logger.set_tag_rate_limit(UNSUPPORTED_AGENT, logger.HOUR)
+
+
 meter = metrics.get_meter("uploader")
 
 
@@ -124,9 +129,15 @@ class SignalUploader(agent.AgentCheckPeriodicService):
         else:
             snapshot_track.enabled = False
             log.warning(
-                "Unsupported Datadog agent detected. "
-                "Snapshots from Dynamic Instrumentation/Exception Replay/Code Origin for Spans will not be uploaded. "
-                "Please upgrade to version 7.49.0 or later."
+                UNSUPPORTED_AGENT,
+                extra={
+                    "product": "debugger",
+                    "more_info": (
+                        ": Unsupported Datadog agent detected. Snapshots from Dynamic Instrumentation/"
+                        "Exception Replay/Code Origin for Spans will not be uploaded. "
+                        "Please upgrade to version 7.49.0 or later"
+                    ),
+                },
             )
 
         return True


### PR DESCRIPTION
Small tweak to rate-limit the number of warning logs to at most once an hour. At some point we should also do this for:

```
[DEBUG] ddtrace.internal.remoteconfig.worker: Agent is down or Remote Config is not enabled in the Agent
Check your Agent version, you need an Agent running on 7.39.1 version or above.
Check Your Remote Config environment variables on your Agent:
DD_REMOTE_CONFIGURATION_ENABLED=true
```

Since it's quite noisy as well, but it's behind a DEBUG flag so less important.