### PR TITLE
test: remove checks for no error logs from many tests

### DIFF
--- a/tests/contrib/aiohttp/test_aiohttp_client.py
+++ b/tests/contrib/aiohttp/test_aiohttp_client.py
@@ -120,7 +120,6 @@ asyncio.run(test())
         env["DD_AIOHTTP_CLIENT_DISTRIBUTED_TRACING"] = "false"
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, err
-    assert err == b""
 
 
 @pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
@@ -148,7 +147,6 @@ asyncio.run(test())
         env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, err
-    assert err == b""
 
 
 @pytest.mark.parametrize("schema_version", [None, "v0", "v1"])
@@ -175,7 +173,6 @@ asyncio.run(test())
         env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, err
-    assert err == b""
 
 
 @pytest.mark.snapshot()
@@ -197,7 +194,6 @@ asyncio.run(test())
     """
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=os.environ.copy())
     assert status == 0, err
-    assert err == b""
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -101,7 +101,6 @@ if __name__ == "__main__":
         env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, (err.decode(), out.decode())
-    assert err == b""
 
 
 @pytest.mark.parametrize(

--- a/tests/contrib/aiomysql/test_aiomysql.py
+++ b/tests/contrib/aiomysql/test_aiomysql.py
@@ -135,7 +135,6 @@ asyncio.run(test())""",
         env=env,
     )
     assert status == 0, err
-    assert out == err == b""
 
 
 @pytest.mark.asyncio
@@ -164,7 +163,6 @@ asyncio.run(test())""",
         env=env,
     )
     assert status == 0, err
-    assert out == err == b""
 
 
 @pytest.mark.asyncio
@@ -191,7 +189,6 @@ asyncio.run(test())""",
         env=env,
     )
     assert status == 0, err
-    assert out == err == b""
 
 
 @pytest.mark.asyncio
@@ -218,7 +215,6 @@ asyncio.run(test())""",
         env=env,
     )
     assert status == 0, err
-    assert out == err == b""
 
 
 class AioMySQLTestCase(AsyncioTestCase):

--- a/tests/contrib/aredis/test_aredis.py
+++ b/tests/contrib/aredis/test_aredis.py
@@ -182,7 +182,6 @@ if __name__ == "__main__":
         env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema
     out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, (err.decode(), out.decode())
-    assert err == b"", err.decode()
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/asgi/test_asgi.py
+++ b/tests/contrib/asgi/test_asgi.py
@@ -237,7 +237,6 @@ if __name__ == "__main__":
         env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, (err, out)
-    assert err == b"", f"STDOUT\n{out.decode()}\nSTDERR\n{err.decode()}"
 
 
 @pytest.mark.parametrize(
@@ -298,7 +297,6 @@ if __name__ == "__main__":
         env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, (err, out)
-    assert err == b""
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/asyncio/test_lazyimport.py
+++ b/tests/contrib/asyncio/test_lazyimport.py
@@ -1,7 +1,7 @@
 import pytest  # noqa: I001
 
 
-@pytest.mark.subprocess()
+@pytest.mark.subprocess(err=lambda _: True)
 def test_lazy_import():
     import ddtrace.auto  # noqa: F401,I001
     from ddtrace.trace import tracer  # noqa: I001
@@ -18,7 +18,7 @@ def test_lazy_import():
     assert tracer.context_provider.active() is None
 
 
-@pytest.mark.subprocess()
+@pytest.mark.subprocess(err=lambda _: True)
 def test_asyncio_not_imported_by_auto_instrumentation():
     # Module unloading is not supported for asyncio, a simple workaround
     # is to ensure asyncio is not imported by ddtrace.auto or ddtrace-run.

--- a/tests/contrib/asyncpg/test_asyncpg.py
+++ b/tests/contrib/asyncpg/test_asyncpg.py
@@ -199,7 +199,6 @@ asyncio.run(test())
     env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v0"
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, err
-    assert err == b""
 
 
 @pytest.mark.snapshot()
@@ -228,7 +227,6 @@ asyncio.run(test())
     env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v1"
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, err
-    assert err == b""
 
 
 @pytest.mark.snapshot()
@@ -256,7 +254,6 @@ asyncio.run(test())
     env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v0"
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, err
-    assert err == b""
 
 
 @pytest.mark.snapshot()
@@ -284,7 +281,6 @@ asyncio.run(test())
     env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = "v1"
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, err
-    assert err == b""
 
 
 @pytest.mark.snapshot()
@@ -313,7 +309,6 @@ asyncio.run(test())
     env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = version
     out, err, status, pid = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, err
-    assert err == b""
 
 
 @pytest.mark.skipif(

--- a/tests/contrib/azure_servicebus/test_azure_servicebus_snapshot.py
+++ b/tests/contrib/azure_servicebus/test_azure_servicebus_snapshot.py
@@ -68,4 +68,3 @@ async def test_producer(ddtrace_run_python_code_in_subprocess, env_vars):
     out, err, status, _ = ddtrace_run_python_code_in_subprocess(helper_path.read_text(), env=env)
 
     assert status == 0, (err.decode(), out.decode())
-    assert err == b"", err.decode()

--- a/tests/contrib/dogpile_cache/test_tracing.py
+++ b/tests/contrib/dogpile_cache/test_tracing.py
@@ -282,4 +282,3 @@ if __name__ == "__main__":
         env["DD_TRACE_SPAN_ATTRIBUTE_SCHEMA"] = schema_version
     out, err, status, _ = ddtrace_run_python_code_in_subprocess(code, env=env)
     assert status == 0, out.decode()
-    assert err == b"", err.decode()

--- a/tests/contrib/elasticsearch/test_async.py
+++ b/tests/contrib/elasticsearch/test_async.py
@@ -59,9 +59,7 @@ def do_test(tmpdir, es_module, async_class):
         env=env,
     )
     p.wait()
-    stderr = p.stderr.read()
     stdout = p.stdout.read()
-    assert stderr == b"", stderr
     assert stdout == b"", stdout
     assert p.returncode == 0
 


### PR DESCRIPTION
## Description

This change removes checks for the lack of error logs from many tests that run ddtrace in a subprocess. There are some tests in the suite that directly validate the contents of stderr. The ones changed here are primarily checking other behaviors and break when unrelated code writes to stderr.