### PR TITLE
chore: avoid building profiling extension under 3.14

### DIFF
--- a/.github/workflows/requirements-locks.yml
+++ b/.github/workflows/requirements-locks.yml
@@ -25,7 +25,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Set python interpreters
-        run: pyenv global 3.10 3.8 3.9 3.11 3.12 3.13
+        run: pyenv global 3.10 3.8 3.9 3.11 3.12 3.13 3.14.0rc1
 
       - name: Install Dependencies
         run: pip install --upgrade pip && pip install riot==0.20.1 && pip install toml==0.10.2

--- a/.gitlab/templates/cached-testrunner.yml
+++ b/.gitlab/templates/cached-testrunner.yml
@@ -5,7 +5,7 @@
     EXT_CACHE_VENV: '${{CI_PROJECT_DIR}}/.cache/ext_cache_venv${{PYTHON_VERSION}}'
   before_script: |
     ulimit -c unlimited
-    pyenv global 3.12 3.8 3.9 3.10 3.11 3.13
+    pyenv global 3.12 3.8 3.9 3.10 3.11 3.13 3.14.0rc1
     export _CI_DD_AGENT_URL=http://${{HOST_IP}}:8126/
     set -e -o pipefail
     if [ ! -d $EXT_CACHE_VENV ]; then

--- a/.gitlab/testrunner.yml
+++ b/.gitlab/testrunner.yml
@@ -12,7 +12,7 @@ variables:
   before_script:
     - ulimit -c unlimited
     - git config --global --add safe.directory ${CI_PROJECT_DIR}
-    - pyenv global 3.12 3.8 3.9 3.10 3.11 3.13
+    - pyenv global 3.12 3.8 3.9 3.10 3.11 3.13 3.14.0rc1
     - export _CI_DD_AGENT_URL=http://${HOST_IP}:8126/
   retry: 2
   artifacts:


### PR DESCRIPTION
This change adds Python 3.14 to the list of runtime versions available in the shell for some gitlab and github workflows. It also skips building of the profiling extension under 3.14, since the profiling product currently doesn't work with this version.

Behavior under 3.14 isn't validated in tests - for now it's enough to know that this change doesn't break any existing tests.
This was pulled out of https://github.com/DataDog/dd-trace-py/pull/14264, which will include automated testing of this change under 3.14.