### PR TITLE
chore: fix up scripts/run-tests missing riot dep

### DIFF
--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -1,7 +1,9 @@
 #!/usr/bin/env uv run --script
+# -*- mode: python -*-
 # /// script
 # requires-python = ">=3.8"
 # dependencies = [
+#     "riot>=0.20.1",
 #     "ruamel.yaml>=0.17.21",
 # ]
 # ///
@@ -21,8 +23,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, List, Set, Optional, Tuple, NamedTuple
-import tempfile
+from typing import Dict, List, Set, NamedTuple
 
 # Add project root and tests to Python path to import suitespec and riotfile
 ROOT = Path(__file__).parents[1]


### PR DESCRIPTION
## Description

When I was developing locally I had `riot` installed globally, so I missed the missing dependency here.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
