### PR TITLE
chore(app): add failsafe for python 3.8 for now

### DIFF
--- a/tests/contrib/django/test_django_appsec_snapshots.py
+++ b/tests/contrib/django/test_django_appsec_snapshots.py
@@ -56,7 +56,7 @@ def daphne_client(django_asgi, additional_env=None):
             assert resp.status_code == 200
         except ConnectionRefusedError:
             # current mitigation for python 3.8
-            if sys.version_info[:2] == (3,8):
+            if sys.version_info[:2] == (3, 8):
                 pass
             else:
                 raise


### PR DESCRIPTION
## Description

Fixing django appsec tests failing on main

## Additional Notes

APPSEC-59097
