### PR TITLE
chore(ci): removes APPSEC_BLOCKING from system-tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -217,10 +217,6 @@ jobs:
         if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'appsec-1'
         run: ./run.sh APPSEC_BLOCKING_FULL_DENYLIST
 
-      - name: Run APPSEC_REQUEST_BLOCKING
-        if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'appsec-1'
-        run: ./run.sh APPSEC_REQUEST_BLOCKING
-
       - name: Run APPSEC_RASP
         if: always() && steps.docker_load.outcome == 'success' && matrix.scenario == 'appsec-1'
         run: ./run.sh APPSEC_RASP

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -47,7 +47,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'da285213e99805433b99f8ea9d1e57f68e2b8e3d'
+          ref: '0eadeeae3a7c2fddb61ed55b692580ad6cd852f9'
 
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -94,7 +94,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'da285213e99805433b99f8ea9d1e57f68e2b8e3d'
+          ref: '0eadeeae3a7c2fddb61ed55b692580ad6cd852f9'
 
       - name: Build runner
         uses: ./.github/actions/install_runner
@@ -279,7 +279,7 @@ jobs:
           persist-credentials: false
           repository: 'DataDog/system-tests'
           # Automatically managed, use scripts/update-system-tests-version to update
-          ref: 'da285213e99805433b99f8ea9d1e57f68e2b8e3d'
+          ref: '0eadeeae3a7c2fddb61ed55b692580ad6cd852f9'
       - name: Download wheels to binaries directory
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "da285213e99805433b99f8ea9d1e57f68e2b8e3d"
+  SYSTEM_TESTS_REF: "0eadeeae3a7c2fddb61ed55b692580ad6cd852f9"
 
 default:
   interruptible: true


### PR DESCRIPTION
## Description

The scenario APPSEC_REQUEST_BLOCKING has been merged into APPSEC_BLOCKING_FULL_DENYLIST in the system-tests project. This means tests that were previously run under APPSEC_REQUEST_BLOCKING will now execute using APPSEC_BLOCKING_FULL_DENYLIST (https://github.com/DataDog/system-tests/pull/5277)

This PR just cleans up the pipeline by removing the reference to the no-longer-existing scenario and updates ST version

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
