### PR TITLE
fix(aap): fix flask patch for none methods

### DIFF
--- a/ddtrace/contrib/internal/flask/patch.py
+++ b/ddtrace/contrib/internal/flask/patch.py
@@ -455,7 +455,7 @@ def patched_add_url_rule(wrapped, instance, args, kwargs):
             #   should we do something special with these views? Change the name/resource? Add tags?
             core.dispatch("service_entrypoint.patch", (unwrap(view_func),))
             wrapped_view = wrap_view(instance, view_func, name=endpoint, resource=rule)
-        for method in kwargs.get("methods", []):
+        for method in kwargs.get("methods", []) or []:
             endpoint_collection.add_endpoint(method, rule, operation_name="flask.request")
         return wrapped(
             rule,

--- a/ddtrace/contrib/internal/flask/patch.py
+++ b/ddtrace/contrib/internal/flask/patch.py
@@ -455,11 +455,11 @@ def patched_add_url_rule(wrapped, instance, args, kwargs):
             #   should we do something special with these views? Change the name/resource? Add tags?
             core.dispatch("service_entrypoint.patch", (unwrap(view_func),))
             wrapped_view = wrap_view(instance, view_func, name=endpoint, resource=rule)
-        methods = kwargs.get("methods", [])
+        methods = kwargs.get("methods", ["GET"])
         try:
             methods = iter(methods)
         except Exception:  # nosec
-            methods = []
+            methods = ["GET"]
         for method in methods:
             endpoint_collection.add_endpoint(method, rule, operation_name="flask.request")
         return wrapped(

--- a/ddtrace/contrib/internal/flask/patch.py
+++ b/ddtrace/contrib/internal/flask/patch.py
@@ -455,7 +455,12 @@ def patched_add_url_rule(wrapped, instance, args, kwargs):
             #   should we do something special with these views? Change the name/resource? Add tags?
             core.dispatch("service_entrypoint.patch", (unwrap(view_func),))
             wrapped_view = wrap_view(instance, view_func, name=endpoint, resource=rule)
-        for method in kwargs.get("methods", []) or []:
+        methods = kwargs.get("methods", [])
+        try:
+            methods = iter(methods)
+        except Exception:  # nosec
+            methods = []
+        for method in methods:
             endpoint_collection.add_endpoint(method, rule, operation_name="flask.request")
         return wrapped(
             rule,

--- a/releasenotes/notes/flask_endpoint_discovery_fix-7f98200c2fa342c4.yaml
+++ b/releasenotes/notes/flask_endpoint_discovery_fix-7f98200c2fa342c4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    AAP: This fix resolves an issue where the endpoint discovery feature could generate a crash for flask at startup.

--- a/tests/appsec/contrib_appsec/flask_app/app.py
+++ b/tests/appsec/contrib_appsec/flask_app/app.py
@@ -307,9 +307,11 @@ def login_user_sdk():
         return "OK"
     return "login failure", 401
 
+
 @app.route("/buggy_endpoint/", methods=None)
 def buggy_endpoint():
     return ""
+
 
 @app.before_request
 def service_renaming():

--- a/tests/appsec/contrib_appsec/flask_app/app.py
+++ b/tests/appsec/contrib_appsec/flask_app/app.py
@@ -307,6 +307,9 @@ def login_user_sdk():
         return "OK"
     return "login failure", 401
 
+@app.route("/buggy_endpoint/", methods=None)
+def buggy_endpoint():
+    return ""
 
 @app.before_request
 def service_renaming():

--- a/tests/appsec/contrib_appsec/utils.py
+++ b/tests/appsec/contrib_appsec/utils.py
@@ -235,7 +235,10 @@ class Contrib_TestClass_For_Threats:
                     if ep.method == "POST"
                     else interface.client.get(path)
                 )
-                assert self.status(response) in (200, 401), f"ep.path failed: [{self.status(response)}] {ep.path} -> {path}"
+                assert self.status(response) in (
+                    200,
+                    401,
+                ), f"ep.path failed: [{self.status(response)}] {ep.path} -> {path}"
                 resource = "GET" + ep.resource_name[1:] if ep.resource_name.startswith("* ") else ep.resource_name
                 assert find_resource(resource)
         assert must_found <= found

--- a/tests/appsec/contrib_appsec/utils.py
+++ b/tests/appsec/contrib_appsec/utils.py
@@ -226,7 +226,7 @@ class Contrib_TestClass_For_Threats:
                 assert isinstance(ep.path, str)
                 assert ep.resource_name
                 assert ep.operation_name
-                if ep.method not in ("GET", "*", "POST"):
+                if ep.method not in ("GET", "*", "POST") or ep.path.startswith("/static"):
                     continue
                 path = parse(ep.path)
                 found.add(path.rstrip("/"))
@@ -235,7 +235,7 @@ class Contrib_TestClass_For_Threats:
                     if ep.method == "POST"
                     else interface.client.get(path)
                 )
-                assert self.status(response) in (200, 401), f"ep.path failed: {ep.path} -> {path}"
+                assert self.status(response) in (200, 401), f"ep.path failed: [{self.status(response)}] {ep.path} -> {path}"
                 resource = "GET" + ep.resource_name[1:] if ep.resource_name.startswith("* ") else ep.resource_name
                 assert find_resource(resource)
         assert must_found <= found


### PR DESCRIPTION
## Description

Some problems were found on dogweb with flask.
This fix ensures the `methods` value is properly iterable.

Also: use the default "GET" method as specified in the Flask documentation in case no methods have been defined.

## Testing

Add a specific endpoint with methods=None to the flask application for appsec_threats test as a regression test, triggering the bug in previous versions of the tracer.

APPSEC-59242
