### PR TITLE
chore: remove unused core.on_all function

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
@@ -15,10 +15,6 @@ experiments:
             thresholds:
               - execution_time < 0.01 ms
               - max_rss_usage < 33.50 MB
-          - name: coreapiscenario-context_with_data_only_all_listeners
-            thresholds:
-              - execution_time < 0.02 ms
-              - max_rss_usage < 33.50 MB
           - name: coreapiscenario-get_item_exists
             thresholds:
               - execution_time < 0.01 ms

--- a/benchmarks/core_api/config.yaml
+++ b/benchmarks/core_api/config.yaml
@@ -1,75 +1,36 @@
 core_dispatch_no_listeners:
   listeners: 0
-  all_listeners: 0
   set_item_count: 0
   get_item_exists: false
 core_dispatch_listeners:
   listeners: 10
-  all_listeners: 0
-  set_item_count: 0
-  get_item_exists: false
-core_dispatch_listeners_and_all_listeners:
-  listeners: 10
-  all_listeners: 10
-  set_item_count: 0
-  get_item_exists: false
-core_dispatch_only_all_listeners:
-  listeners: 0
-  all_listeners: 10
   set_item_count: 0
   get_item_exists: false
 core_dispatch_with_results_no_listeners:
   listeners: 0
-  all_listeners: 0
   set_item_count: 0
   get_item_exists: false
 core_dispatch_with_results_listeners:
   listeners: 10
-  all_listeners: 0
-  set_item_count: 0
-  get_item_exists: false
-core_dispatch_with_results_listeners_and_all_listeners:
-  listeners: 10
-  all_listeners: 10
-  set_item_count: 0
-  get_item_exists: false
-core_dispatch_with_results_only_all_listeners:
-  listeners: 0
-  all_listeners: 10
   set_item_count: 0
   get_item_exists: false
 context_with_data_no_listeners:
   listeners: 0
-  all_listeners: 0
   set_item_count: 0
   get_item_exists: false
 context_with_data_listeners:
   listeners: 10
-  all_listeners: 0
-  set_item_count: 0
-  get_item_exists: false
-context_with_data_listeners_and_all_listeners:
-  listeners: 10
-  all_listeners: 10
-  set_item_count: 0
-  get_item_exists: false
-context_with_data_only_all_listeners:
-  listeners: 10
-  all_listeners: 0
   set_item_count: 0
   get_item_exists: false
 set_item:
   listeners: 0
-  all_listeners: 0
   set_item_count: 100
   get_item_exists: false
 get_item_missing:
   listeners: 0
-  all_listeners: 0
   set_item_count: 0
   get_item_exists: false
 get_item_exists:
   listeners: 0
-  all_listeners: 0
   set_item_count: 0
   get_item_exists: true

--- a/benchmarks/core_api/scenario.py
+++ b/benchmarks/core_api/scenario.py
@@ -11,7 +11,6 @@ if not hasattr(core, "dispatch_with_results"):
 
 class CoreAPIScenario(bm.Scenario):
     listeners: int
-    all_listeners: int
     set_item_count: int
     get_item_exists: bool
 
@@ -25,24 +24,6 @@ class CoreAPIScenario(bm.Scenario):
             core.on(CUSTOM_EVENT_NAME, listener)
             core.on("context.started.with_data", listener)
             core.on("context.ended.with_data", listener)
-
-        for _ in range(self.all_listeners):
-            if hasattr(core, "on_all"):
-
-                def all_listener(event_id, args):
-                    pass
-
-                core.on_all(all_listener)
-            else:
-
-                def listener(*_):
-                    pass
-
-                # If we don't support "core.on_all", just double up the registered listeners to try
-                # and make the comparison semi-equal
-                core.on(CUSTOM_EVENT_NAME, listener)
-                core.on("context.started.with_data", listener)
-                core.on("context.ended.with_data", listener)
 
         if self.get_item_exists:
             core.set_item("key", "value")

--- a/ddtrace/internal/core/event_hub.py
+++ b/ddtrace/internal/core/event_hub.py
@@ -11,7 +11,6 @@ from ddtrace.settings._config import config
 
 
 _listeners: Dict[str, Dict[Any, Callable[..., Any]]] = {}
-_all_listeners: List[Callable[[str, Tuple[Any, ...]], None]] = []
 
 
 class ResultType(enum.Enum):
@@ -61,44 +60,25 @@ def on(event_id: str, callback: Callable[..., Any], name: Any = None) -> None:
     _listeners[event_id][name] = callback
 
 
-def on_all(callback: Callable[..., Any]) -> None:
-    """Register a listener for all events emitted"""
-    global _all_listeners
-    if callback not in _all_listeners:
-        _all_listeners.insert(0, callback)
-
-
 def reset(event_id: Optional[str] = None, callback: Optional[Callable[..., Any]] = None) -> None:
     """Remove all registered listeners. If an event_id is provided, only clear those
     event listeners. If a callback is provided, then only the listeners for that callback are removed.
     """
     global _listeners
-    global _all_listeners
 
     if callback:
-        if not event_id:
-            _all_listeners = [cb for cb in _all_listeners if cb != callback]
-        elif event_id in _listeners:
+        if event_id in _listeners:
             _listeners[event_id] = {name: cb for name, cb in _listeners[event_id].items() if cb != callback}
     else:
         if not event_id:
             _listeners.clear()
-            _all_listeners.clear()
         elif event_id in _listeners:
             del _listeners[event_id]
 
 
 def dispatch(event_id: str, args: Tuple[Any, ...] = ()) -> None:
     """Call all hooks for the provided event_id with the provided args"""
-    global _all_listeners
     global _listeners
-
-    for hook in _all_listeners:
-        try:
-            hook(event_id, args)
-        except Exception:
-            if config._raise:
-                raise
 
     if event_id not in _listeners:
         return
@@ -116,14 +96,6 @@ def dispatch_with_results(event_id: str, args: Tuple[Any, ...] = ()) -> EventRes
     returning the results and exceptions from the called hooks
     """
     global _listeners
-    global _all_listeners
-
-    for hook in _all_listeners:
-        try:
-            hook(event_id, args)
-        except Exception:
-            if config._raise:
-                raise
 
     if event_id not in _listeners:
         return _MissingEventDict

--- a/ddtrace/internal/core/event_hub.py
+++ b/ddtrace/internal/core/event_hub.py
@@ -3,7 +3,6 @@ import enum
 from typing import Any
 from typing import Callable
 from typing import Dict
-from typing import List
 from typing import Optional
 from typing import Tuple
 

--- a/tests/internal/test_context_events_api.py
+++ b/tests/internal/test_context_events_api.py
@@ -226,11 +226,11 @@ class TestContextEventsApi(unittest.TestCase):
 
         # We stop after the first exception is raised, on_type_error listeners get called first
         with pytest.raises(TypeError):
-            core.dispatch_with_results("my.cool.event", (1, 2, 3))
+            core.dispatch_with_results("context.started.my.cool.context", (1, 2, 3))
 
         # We stop after the first exception is raised, on_runtime_error listeners get called first
         with pytest.raises(RuntimeError):
-            with core.context_with_data("my.cool.context"):
+            with core.context_with_data("context.ended.my.cool.context"):
                 pass
 
     def test_core_dispatch_context_ended(self):

--- a/tests/internal/test_context_events_api.py
+++ b/tests/internal/test_context_events_api.py
@@ -215,22 +215,24 @@ class TestContextEventsApi(unittest.TestCase):
         def on_type_error(*_):
             raise TypeError("OH NO!")
 
+        # Register 2 listeners for 1 event, the first one gets called first
         core.on("my.cool.event", on_runtime_error)
+        core.on("my.cool.event", on_type_error)
+
         core.on("context.started.my.cool.context", on_type_error)
-        core.on("context.started.my.cool.context", on_runtime_error)
         core.on("context.ended.my.cool.context", on_runtime_error)
-        core.on("context.ended.my.cool.context", on_type_error)
-
-        with pytest.raises(RuntimeError):
-            core.dispatch("my.cool.event", (1, 2, 3))
-
-        # We stop after the first exception is raised, on_type_error listeners get called first
-        with pytest.raises(TypeError):
-            core.dispatch_with_results("context.started.my.cool.context", (1, 2, 3))
 
         # We stop after the first exception is raised, on_runtime_error listeners get called first
         with pytest.raises(RuntimeError):
-            with core.context_with_data("context.ended.my.cool.context"):
+            core.dispatch("my.cool.event", (1, 2, 3))
+
+        # We stop after the first exception is raised, on_runtime_error listeners get called first
+        with pytest.raises(RuntimeError):
+            core.dispatch_with_results("my.cool.event", (1, 2, 3))
+
+        # We stop after the first exception raised, which is the context started event
+        with pytest.raises(TypeError):
+            with core.context_with_data("my.cool.context"):
                 pass
 
     def test_core_dispatch_context_ended(self):

--- a/tests/internal/test_context_events_api.py
+++ b/tests/internal/test_context_events_api.py
@@ -1,7 +1,6 @@
 import threading
 from time import sleep
 from typing import Any
-from typing import List
 import unittest
 
 import mock


### PR DESCRIPTION
## Description

No one is actively using this feature, so let's remove to save on API footprint + overhead until we do actually need it.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
