### PR TITLE
test(appsec): close sqlite3 connection to remove logs

### DIFF
--- a/tests/appsec/contrib_appsec/fastapi_app/app.py
+++ b/tests/appsec/contrib_appsec/fastapi_app/app.py
@@ -3,8 +3,10 @@ import json
 import os
 import sqlite3
 import subprocess
+from typing import AsyncGenerator
 from typing import Optional
 
+from fastapi import Depends
 from fastapi import FastAPI
 from fastapi import Request
 from fastapi.responses import HTMLResponse
@@ -39,6 +41,17 @@ class User(BaseModel):
 
 def get_app():
     app = FastAPI()
+
+    async def get_db() -> AsyncGenerator[sqlite3.Connection, None]:
+        db = sqlite3.connect(":memory:")
+        db.execute("CREATE TABLE users (id TEXT PRIMARY KEY, name TEXT)")
+        db.execute("INSERT INTO users (id, name) VALUES ('1_secret_id', 'Alice')")
+        db.execute("INSERT INTO users (id, name) VALUES ('2_secret_id', 'Bob')")
+        db.execute("INSERT INTO users (id, name) VALUES ('3_secret_id', 'Christophe')")
+        try:
+            yield db
+        finally:
+            db.close()
 
     @app.middleware("http")
     async def passthrough_middleware(request: Request, call_next):
@@ -144,12 +157,7 @@ def get_app():
     @app.get("/rasp/{endpoint:str}/")
     @app.post("/rasp/{endpoint:str}/")
     @app.options("/rasp/{endpoint:str}/")
-    async def rasp(endpoint: str, request: Request):
-        DB = sqlite3.connect(":memory:")
-        DB.execute("CREATE TABLE users (id TEXT PRIMARY KEY, name TEXT)")
-        DB.execute("INSERT INTO users (id, name) VALUES ('1_secret_id', 'Alice')")
-        DB.execute("INSERT INTO users (id, name) VALUES ('2_secret_id', 'Bob')")
-        DB.execute("INSERT INTO users (id, name) VALUES ('3_secret_id', 'Christophe')")
+    async def rasp(endpoint: str, request: Request, db: sqlite3.Connection = Depends(get_db)):
         query_params = request.query_params
         if endpoint == "lfi":
             res = ["lfi endpoint"]
@@ -199,7 +207,7 @@ def get_app():
                     user_id = query_params[param]
                 try:
                     if param.startswith("user_id"):
-                        cursor = DB.execute(f"SELECT * FROM users WHERE id = {user_id}")
+                        cursor = db.execute(f"SELECT * FROM users WHERE id = {user_id}")
                         res.append(f"Url: {list(cursor)}")
                 except Exception as e:
                     res.append(f"Error: {e}")


### PR DESCRIPTION
## Description

Close the database connection in the rasp endpoint of fastapi contrib_appsec app. This removes a lot of logs when running riot tests:
```log
tests/appsec/contrib_appsec/test_fastapi.py::Test_FastAPI::test_api10[urlopen_string]
  <frozen os>:717: ResourceWarning: unclosed database in <sqlite3.Connection object at 0x112e23790>
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
```

This reduces the amount of logs from 2650 lines to 105 lines when running the appsec_threats_fastapi suite. Much easier to handle in a terminal.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
