### PR TITLE
ci: actually validate the ast-grep rules against the repo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,12 +75,20 @@ run-tests-trigger:
    strategy: depend
 
 # Validate the ast-grep rule's test suite in .sg/tests
-"test ast-grep rules":
+"ast-grep rules":
   extends: .testrunner
   stage: tests
   needs: []
   script:
-    - hatch run lint:sg-test
+  script:
+    - |
+      echo -e "\e[0Ksection_start:`date +%s`:sg_test[collapsed=true]\r\e[0KValidate ast-grep rules"
+      hatch run lint:sg-test
+      echo -e "\e[0Ksection_end:`date +%s`:sg_test\r\e[0K"
+    - |
+      echo -e "\e[0Ksection_start:`date +%s`:sg_scan[collapsed=true]\r\e[0Kast-grep scan"
+      hatch run lint:sg
+      echo -e "\e[0Ksection_end:`date +%s`:sg_scan\r\e[0K"
 
 microbenchmarks:
   stage: benchmarks

--- a/ddtrace/contrib/internal/django/database.py
+++ b/ddtrace/contrib/internal/django/database.py
@@ -11,6 +11,7 @@ from typing import cast
 import wrapt
 
 import ddtrace
+from ddtrace._trace.pin import Pin
 from ddtrace import config
 from ddtrace.contrib import dbapi
 from ddtrace.contrib.internal.trace_utils import _convert_to_string
@@ -24,7 +25,6 @@ from ddtrace.internal.wrapping import is_wrapped_with
 from ddtrace.internal.wrapping import wrap
 from ddtrace.propagation._database_monitoring import _DBM_Propagator
 from ddtrace.settings.integration import IntegrationConfig
-from ddtrace.trace import Pin
 
 
 log = get_logger(__name__)

--- a/ddtrace/contrib/internal/django/database.py
+++ b/ddtrace/contrib/internal/django/database.py
@@ -11,8 +11,8 @@ from typing import cast
 import wrapt
 
 import ddtrace
-from ddtrace._trace.pin import Pin
 from ddtrace import config
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib import dbapi
 from ddtrace.contrib.internal.trace_utils import _convert_to_string
 from ddtrace.ext import db


### PR DESCRIPTION
## Description

We added ast-grep and a custom rule for checking `ddtrace.trace.Pin` usage and warning that it is deprecated.

We updated CI to run our ast-grep pattern test suite (tests that our rules work), but we never actually ran the "scan" which validates the repo for the rules.

## Testing

There is 1 known violation in the codebase, I opened the draft PR first with adding the `hatch run lint:sg` to ensure it caught the issue first before fixing the violation.

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
