### PR TITLE
refactor: integration plugin interface

### DIFF
--- a/ddtrace/internal/compat.py
+++ b/ddtrace/internal/compat.py
@@ -1,7 +1,10 @@
+from importlib.metadata import EntryPoint
+from importlib.metadata import entry_points as _entry_points
 import ipaddress
 import sys
 from types import TracebackType
 from typing import Any
+from typing import List
 from typing import Optional  # noqa:F401
 from typing import Text  # noqa:F401
 from typing import Tuple  # noqa:F401
@@ -126,3 +129,14 @@ def __getattr__(name: str) -> Any:
         return globals()[name]
     except KeyError:
         raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+if PYTHON_VERSION_INFO >= (3, 10):
+
+    def entry_points(group: str) -> List[EntryPoint]:
+        return list(_entry_points(group=group))
+
+else:
+
+    def entry_points(group: str) -> List[EntryPoint]:
+        return [ep for _, eps in _entry_points().items() for ep in eps if ep.group == group]

--- a/ddtrace/internal/products.py
+++ b/ddtrace/internal/products.py
@@ -1,13 +1,12 @@
 import atexit
 from collections import defaultdict
 from collections import deque
-from importlib.metadata import entry_points
 from itertools import chain
-import sys
 import typing as t
 from typing import Protocol  # noqa:F401
 
 from ddtrace.internal import forksafe
+from ddtrace.internal.compat import entry_points
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.telemetry import report_configuration
 from ddtrace.internal.telemetry import telemetry_writer
@@ -19,17 +18,6 @@ from ddtrace.settings._core import DDConfig
 
 
 log = get_logger(__name__)
-
-
-if sys.version_info >= (3, 10):
-
-    def get_product_entry_points() -> t.List[t.Any]:
-        return list(entry_points(group="ddtrace.products"))
-
-else:
-
-    def get_product_entry_points() -> t.List[t.Any]:
-        return [ep for _, eps in entry_points().items() for ep in eps if ep.group == "ddtrace.products"]
 
 
 class Product(Protocol):
@@ -59,7 +47,7 @@ class ProductManager:
         self._failed: t.Set[str] = set()
 
     def _load_products(self) -> None:
-        for product_plugin in get_product_entry_points():
+        for product_plugin in entry_points("ddtrace.products"):
             name = product_plugin.name
             log.debug("Discovered product plugin '%s'", name)
 

--- a/ddtrace/internal/utils/wrappers.py
+++ b/ddtrace/internal/utils/wrappers.py
@@ -9,6 +9,10 @@ import wrapt
 F = TypeVar("F", bound=Callable[..., Any])
 
 
+class NotWrappedError(Exception):
+    pass
+
+
 def iswrapped(obj, attr=None):
     # type: (Any, Optional[str]) -> bool
     """Returns whether an attribute is wrapped or not."""
@@ -17,7 +21,8 @@ def iswrapped(obj, attr=None):
     return (hasattr(obj, "__wrapped__") and isinstance(obj, wrapt.ObjectProxy)) or hasattr(obj, "__dd_wrapped__")
 
 
-def unwrap(obj, attr):
-    # type: (Any, str) -> None
-    f = getattr(obj, attr)
-    setattr(obj, attr, f.__wrapped__)
+def unwrap(obj: Any, attr: str) -> None:
+    try:
+        setattr(obj, attr, getattr(obj, attr).__wrapped__)
+    except AttributeError:
+        raise NotWrappedError("{}.{} is not wrapped".format(obj, attr))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ ddtrace = "ddtrace.contrib.internal.pytest.plugin"
 "iast" = "ddtrace.internal.iast.product"
 "tracer" = "ddtrace._trace.product"
 
+[project.entry-points.'ddtrace.contrib.extra']
+"urllib3" = "ddtrace.contrib.internal.urllib3.patch"
+
 [project.urls]
 "Bug Tracker" = "https://github.com/DataDog/dd-trace-py/issues"
 Changelog = "https://github.com/DataDog/dd-trace-py/releases"


### PR DESCRIPTION
We refactor the tracer integration loading system to be based on entry points. This makes the tracer integrations more modular by defining an interface that an integration module has to follow. This allows to remove integration-specific information from core sources and completely automate the integration lifecycle management.

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
