### PR TITLE
[WIP] Add metadata and entrypoint to Ray job root span

### DIFF
--- a/ddtrace/contrib/internal/ray/constants.py
+++ b/ddtrace/contrib/internal/ray/constants.py
@@ -12,6 +12,8 @@ RAY_TASK_ID = "ray.task_id"
 RAY_ACTOR_ID = "ray.actor_id"
 RAY_SUBMISSION_ID_TAG = "ray.submission_id"
 RAY_HOSTNAME = "ray.hostname"
+RAY_ENTRYPOINT = "ray.entrypoint"
+RAY_ENTRYPOINT_SCRIPT = "ray.entrypoint_script"
 
 # Default job name if not set by the user
 DEFAULT_JOB_NAME = "unnamed.ray.job"
@@ -39,6 +41,7 @@ RAY_JOB_MESSAGE = "ray.job.message"
 RAY_WAIT_TIMEOUT = "ray.wait.timeout_s"
 RAY_WAIT_NUM_RETURNS = "ray.wait.num_returns"
 RAY_WAIT_FETCH_LOCAL = "ray.wait.fetch_local"
+RAY_METADATA_PREFIX = "ray.job.metadata"
 
 # Error tag names
 ERROR_MESSAGE = "error.message"


### PR DESCRIPTION
## Description

[MLOB-3969] Add user metadata to root span tags  
[MLOB-3980] Tag the entry point on the root span

## Testing

`pip install .`
`RAY_LOGGING_CONFIG_ENCODING=JSON DD_ENV=dev ray start --head --dashboard-host=127.0.0.1 --tracing-startup-hook=ddtrace.contrib.internal.ray.hook:setup_tracing`
`ray job submit --submission-id="imran-ray-get-test-006" -- python /Users/imran.hendley/go/src/github.com/DataDog/dd-trace-py/tests/contrib/ray/jobs/simple_task.py --metadata_json '{"job_name": "train_my_model", "pets": ["cat", "rabbit"], {"a":{"b":"c"}, "d":["e","f"]}}'`

- [ ] Debug test jobs currently not showing up on staging

## Risks

None

## Additional Notes

Do we need to support recreating these tags in `RaySpanManager._recreate_job_span`?
