### PR TITLE
chore(llmobs): missed updates in span kind key changes

### DIFF
--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -44,7 +44,7 @@ def _find_tag_value_from_tags(tags, tag_key):
 
 
 def _get_tags_from_span_event(event: LLMObsSpanEvent):
-    span_kind = event.get("meta", {}).get("span.kind", "")
+    span_kind = event.get("meta", {}).get("span", {}).get("kind", "")
     integration = _find_tag_value_from_tags(event.get("tags", []), "integration")
     ml_app = _find_tag_value_from_tags(event.get("tags", []), "ml_app")
     autoinstrumented = integration is not None

--- a/tests/llmobs/test_llmobs.py
+++ b/tests/llmobs/test_llmobs.py
@@ -678,5 +678,5 @@ def test_apm_traces_dropped_when_disabled(llmobs, llmobs_events, tracer, llmobs_
     # But LLMObs events should still be sent
     assert len(llmobs_events) == 1
     llm_event = llmobs_events[0]
-    assert llm_event["meta"]["span.kind"] == "llm"
+    assert llm_event["meta"]["span"]["kind"] == "llm"
     assert llm_event["meta"]["model_name"] == "test-model"


### PR DESCRIPTION
## Description

Fixes a broken test blocking CI. Additionally, one of telemetry tags was incorrect. doing a grep for `span.kind` now in `ddtrace/llmobs` and `tests/llmobs` only reveals one instance, in defining our span context item key, which is fine.

## Testing

Fixes the test blocking CI

## Risks

None