### PR TITLE
chore(otel): remove useless metric

### DIFF
--- a/ddtrace/internal/opentelemetry/logs.py
+++ b/ddtrace/internal/opentelemetry/logs.py
@@ -43,7 +43,6 @@ def set_otel_logs_provider() -> None:
     if not _initialize_logging(exporter_class, protocol, resource):
         return
 
-    telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.TRACERS, "logging_provider_configured", 1, (("type", "dd"),))
     global DD_LOGS_PROVIDER_CONFIGURED
     DD_LOGS_PROVIDER_CONFIGURED = True
     # Disable log injection to prevent duplicate log attributes from being sent.


### PR DESCRIPTION
## Description

Removing useless metric. We can use telemetry configurations to track when/where opentelemetry logs are enabled.

## Testing

This metric isnt tested 

## Risks

No risk. This metric is already rejected by telemetry intake

## Additional Notes

Writing this PR description took longer than making this change. 
