### PR TITLE
ci(aap): enable test, remove todo

### DIFF
--- a/tests/contrib/subprocess/test_subprocess.py
+++ b/tests/contrib/subprocess/test_subprocess.py
@@ -411,17 +411,10 @@ def test_osspawn_variants(tracer, function, mode, arguments):
                     ret = function(mode, arguments[0], arguments)
             else:
                 ret = function(mode, arguments[0], *arguments)
-            # TODO(APPSEC-57964): Gitlab raises at some point
-            #  Traceback (most recent call last):
-            #    File "/3.10.16/lib/python3.10/multiprocessing/util.py", line 357, in _exit_function
-            #      p.join()
-            #    File "/root/.pyenv/versions/3.10.16/lib/python3.10/multiprocessing/process.py", line 147, in join
-            #      assert self._parent_pid == os.getpid(), 'can only join a child process'
-            #  AssertionError: can only join a child process
-            # if mode == os.P_WAIT:
-            #     assert ret == 0
-            # else:
-            #     assert ret > 0  # for P_NOWAIT returned value is the pid
+            if mode == os.P_WAIT:
+                assert ret == 0
+            else:
+                assert ret > 0  # for P_NOWAIT returned value is the pid
 
         spans = tracer.pop()
         assert spans


### PR DESCRIPTION
## Description

One subprocess test was failing, probably I fixed in https://github.com/DataDog/dd-trace-py/pull/14689

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
