### PR TITLE
chore(serverless): test to ensure that all imports in datadog-lambda-python still valid

### DIFF
--- a/tests/internal/test_serverless.py
+++ b/tests/internal/test_serverless.py
@@ -132,9 +132,11 @@ import {package}
         pytest.param(
             "ddtrace.profiling",
             "profiler",
+            # when 3.14 is officially supported, this xfail can be removed.
             marks=pytest.mark.xfail(
                 reason="throws AttributeError: module 'asyncio.events' has no attribute 'BaseDefaultEventLoopPolicy'",
                 condition=sys.version_info >= (3, 14),
+                strict=True,
             ),
         ),
         ("ddtrace.propagation.http", "HTTPPropagator"),

--- a/tests/internal/test_serverless.py
+++ b/tests/internal/test_serverless.py
@@ -103,3 +103,56 @@ import {package}
     assert stdout.decode() == ""
     assert stderr.decode() == ""
     assert status == 0
+
+
+@pytest.mark.parametrize(
+    "from_,import_",
+    [
+        ("ddtrace", "__version__"),
+        ("ddtrace", "patch"),
+        ("ddtrace", "patch_all"),
+        ("ddtrace._trace._span_pointer", "_SpanPointerDescription"),
+        ("ddtrace._trace._span_pointer", "_SpanPointerDirection"),
+        ("ddtrace._trace.utils_botocore.span_pointers.dynamodb", "_aws_dynamodb_item_span_pointer_description"),
+        ("ddtrace._trace.utils_botocore.span_pointers.s3", "_aws_s3_object_span_pointer_description"),
+        ("ddtrace.contrib.internal.trace_utils", "_get_request_header_client_ip"),
+        ("ddtrace.data_streams", "set_consume_checkpoint"),
+        ("ddtrace.debugging._exception.replay", "SpanExceptionHandler"),
+        ("ddtrace.debugging._uploader", "SignalUploader"),
+        ("ddtrace.internal", "core"),
+        ("ddtrace.internal._exceptions", "BlockingException"),
+        ("ddtrace.internal.appsec.product", "start"),
+        ("ddtrace.internal.telemetry", "telemetry_writer"),
+        ("ddtrace.internal.utils", "get_blocked"),
+        ("ddtrace.internal.utils", "http"),
+        ("ddtrace.llmobs", "LLMObs"),
+        ("ddtrace.opentelemetry", "TracerProvider"),
+        ("ddtrace.profiling", "profiler"),
+        ("ddtrace.propagation.http", "HTTPPropagator"),
+        ("ddtrace.trace", "Context, Span, tracer"),
+        ("ddtrace.trace", "Span"),
+        ("ddtrace.trace", "tracer"),
+    ],
+)
+def test_serverless_imports(from_, import_, run_python_code_in_subprocess):
+    # datadog-lambda-python imports a bunch of packages from ddtrace.  This
+    # test ensures that none of those imports break.  If this test fails, then
+    # either you will need to retain the import that was removed or you must
+    # update datadog-lambda-python to support the new import path.
+    import os
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "AWS_LAMBDA_FUNCTION_NAME": "foobar",
+            "DD_INSTRUMENTATION_TELEMETRY_ENABLED": "False",
+            "DD_API_SECURITY_ENABLED": "False",
+        }
+    )
+
+    code = f"from {from_} import {import_}"
+
+    stderr, stdout, status, _ = run_python_code_in_subprocess(code, env=env)
+    assert stdout.decode() == ""
+    assert stderr.decode() == ""
+    assert status == 0

--- a/tests/internal/test_serverless.py
+++ b/tests/internal/test_serverless.py
@@ -1,5 +1,6 @@
-import pytest
 import sys
+
+import pytest
 
 from ddtrace.internal.serverless import in_azure_function
 from ddtrace.internal.serverless import in_gcp_function
@@ -132,7 +133,7 @@ import {package}
             "ddtrace.profiling",
             "profiler",
             marks=pytest.mark.xfail(
-                reason="import throws error AttributeError: module 'asyncio.events' has no attribute 'BaseDefaultEventLoopPolicy'",
+                reason="throws AttributeError: module 'asyncio.events' has no attribute 'BaseDefaultEventLoopPolicy'",
                 condition=sys.version_info >= (3, 14),
             ),
         ),

--- a/tests/internal/test_serverless.py
+++ b/tests/internal/test_serverless.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 
 from ddtrace.internal.serverless import in_azure_function
 from ddtrace.internal.serverless import in_gcp_function
@@ -127,7 +128,14 @@ import {package}
         ("ddtrace.internal.utils", "http"),
         ("ddtrace.llmobs", "LLMObs"),
         ("ddtrace.opentelemetry", "TracerProvider"),
-        ("ddtrace.profiling", "profiler"),
+        pytest.param(
+            "ddtrace.profiling",
+            "profiler",
+            marks=pytest.mark.xfail(
+                reason="import throws error AttributeError: module 'asyncio.events' has no attribute 'BaseDefaultEventLoopPolicy'",
+                condition=sys.version_info >= (3, 14),
+            ),
+        ),
         ("ddtrace.propagation.http", "HTTPPropagator"),
         ("ddtrace.trace", "Context, Span, tracer"),
         ("ddtrace.trace", "Span"),


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->

Customer reported that a class name changed in the most recent version of ddtrace which was then causing errors when attempting to import `datadog_lambda`. See https://github.com/DataDog/datadog-lambda-python/pull/661 and https://github.com/DataDog/dd-trace-py/pull/14653.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

It's just some tests, so risk is low.

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->

Added additional tests on the `datadog_lambda` side as well, including running our unit tests twice a day. See https://github.com/DataDog/datadog-lambda-python/pull/662.