### PR TITLE
chore: regenerate the snapshots for test_aws_payload_tagging_sqs

### DIFF
--- a/tests/snapshots/tests.contrib.botocore.test.BotocoreTest.test_aws_payload_tagging_sqs.json
+++ b/tests/snapshots/tests.contrib.botocore.test.BotocoreTest.test_aws_payload_tagging_sqs.json
@@ -11,14 +11,15 @@
     "meta": {
       "_dd.base_service": "tests.contrib.botocore",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "672522b300000000",
+      "_dd.p.tid": "68dd8a3f00000000",
       "aws.agent": "botocore",
       "aws.operation": "ReceiveMessage",
+      "aws.partition": "aws",
       "aws.region": "us-east-1",
       "aws.request.body.MessageAttributeNames.0": "_datadog",
       "aws.request.body.QueueUrl": "http://localhost:4566/000000000000/Test",
       "aws.request.body.WaitTimeSeconds": "2",
-      "aws.requestid": "WJ6C1QMRXCMYSO918PTT0Y8488VH2RZHPKHZZXQZ1E3L079PE2PE",
+      "aws.requestid": "8VPDOOAWG8W4ARL4G1T283DY99ZL0DOIQS9G1MHWI1GUA6FW547W",
       "aws.response.body.HTTPHeaders.access-control-allow-headers": "authorization,cache-control,content-length,content-md5,content-type,etag,location,x-amz-acl,x-amz-content-sha256,x-amz-date,x-amz-request-id,x-amz-security-token,x-amz-tagging,x-amz-target,x-amz-user-agent,x-amz-version-id,x-amzn-requestid,x-localstack-target,amz-sdk-invocation-id,amz-sdk-request",
       "aws.response.body.HTTPHeaders.access-control-allow-methods": "HEAD,GET,PUT,POST,DELETE,OPTIONS,PATCH",
       "aws.response.body.HTTPHeaders.access-control-allow-origin": "*",
@@ -26,10 +27,10 @@
       "aws.response.body.HTTPHeaders.connection": "close",
       "aws.response.body.HTTPHeaders.content-length": "654",
       "aws.response.body.HTTPHeaders.content-type": "text/xml",
-      "aws.response.body.HTTPHeaders.date": "Fri, 01 Nov 2024 18:49:24 GMT",
+      "aws.response.body.HTTPHeaders.date": "Wed, 01 Oct 2025 20:08:31 GMT",
       "aws.response.body.HTTPHeaders.server": "hypercorn-h11",
       "aws.response.body.HTTPStatusCode": "200",
-      "aws.response.body.RequestId": "WJ6C1QMRXCMYSO918PTT0Y8488VH2RZHPKHZZXQZ1E3L079PE2PE",
+      "aws.response.body.RequestId": "8VPDOOAWG8W4ARL4G1T283DY99ZL0DOIQS9G1MHWI1GUA6FW547W",
       "aws.response.body.RetryAttempts": "0",
       "aws.sqs.queue_name": "Test",
       "aws_account": "000000000000",
@@ -39,7 +40,7 @@
       "language": "python",
       "queuename": "Test",
       "region": "us-east-1",
-      "runtime-id": "e45a6c451bfb47bfbb0f4f36bd0803a3",
+      "runtime-id": "170e664d16b94fb488fd3b267c5814eb",
       "span.kind": "client"
     },
     "metrics": {
@@ -47,11 +48,11 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 9691,
+      "process_id": 11556,
       "retry_attempts": 0
     },
-    "duration": 895390012,
-    "start": 1730486964009311666
+    "duration": 524059792,
+    "start": 1759349311493738094
   }],
 [
   {
@@ -66,17 +67,18 @@
     "meta": {
       "_dd.base_service": "tests.contrib.botocore",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "672522b200000000",
+      "_dd.p.tid": "68dd8a3e00000000",
       "aws.agent": "botocore",
       "aws.operation": "ListQueues",
+      "aws.partition": "aws",
       "aws.region": "us-east-1",
-      "aws.requestid": "GCXA1QNSIT8ZCO2ER8SPI6U6QPTINWZKK1J0QLJE4FV89SOAG7VY",
+      "aws.requestid": "65DY1SPVWE5T2R2DI5C475TPZEU6Y6ZH9HVRKYKYMYZ8AOYO0KMQ",
       "aws_service": "sqs",
       "component": "botocore",
       "http.status_code": "200",
       "language": "python",
       "region": "us-east-1",
-      "runtime-id": "e45a6c451bfb47bfbb0f4f36bd0803a3",
+      "runtime-id": "170e664d16b94fb488fd3b267c5814eb",
       "span.kind": "client"
     },
     "metrics": {
@@ -84,11 +86,11 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 9691,
+      "process_id": 11556,
       "retry_attempts": 0
     },
-    "duration": 9492759,
-    "start": 1730486963003404555
+    "duration": 6641833,
+    "start": 1759349310906322260
   }],
 [
   {
@@ -103,11 +105,12 @@
     "meta": {
       "_dd.base_service": "tests.contrib.botocore",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "672522b300000000",
+      "_dd.p.tid": "68dd8a3e00000000",
       "aws.agent": "botocore",
       "aws.operation": "CreateQueue",
+      "aws.partition": "aws",
       "aws.region": "us-east-1",
-      "aws.requestid": "A3R2CT5ZWO1XH9GEAT7L232IPRFJSCTBRRGO9LCSBEUX0T8KHC1O",
+      "aws.requestid": "M280N1BC88ZVKHMCP1ZZHLGVKNK090V5NS2KED6AABK36BXPCJYK",
       "aws.sqs.queue_name": "Test",
       "aws_service": "sqs",
       "component": "botocore",
@@ -115,7 +118,7 @@
       "language": "python",
       "queuename": "Test",
       "region": "us-east-1",
-      "runtime-id": "e45a6c451bfb47bfbb0f4f36bd0803a3",
+      "runtime-id": "170e664d16b94fb488fd3b267c5814eb",
       "span.kind": "client"
     },
     "metrics": {
@@ -123,11 +126,11 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 9691,
+      "process_id": 11556,
       "retry_attempts": 0
     },
-    "duration": 7553649,
-    "start": 1730486963013740697
+    "duration": 2763666,
+    "start": 1759349310913350427
   }],
 [
   {
@@ -142,9 +145,10 @@
     "meta": {
       "_dd.base_service": "tests.contrib.botocore",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "672522b300000000",
+      "_dd.p.tid": "68dd8a3e00000000",
       "aws.agent": "botocore",
       "aws.operation": "SendMessage",
+      "aws.partition": "aws",
       "aws.region": "us-east-1",
       "aws.request.body.MessageAttributes.eight.DataType": "String",
       "aws.request.body.MessageAttributes.eight.StringValue": "eight",
@@ -168,7 +172,7 @@
       "aws.request.body.MessageAttributes.two.StringValue": "two",
       "aws.request.body.MessageBody": "world",
       "aws.request.body.QueueUrl": "http://localhost:4566/000000000000/Test",
-      "aws.requestid": "NLK4TDG9YGTYRAMQ6QHN6NWC6QKRSSIZ8IBF0DS4RTY2Y3YWA7XC",
+      "aws.requestid": "AI70E7GOW9XMKWH0O86YWVEFMLUMMHDVOOCANB6IPBAZEAO86IPO",
       "aws.response.body.HTTPHeaders.access-control-allow-headers": "authorization,cache-control,content-length,content-md5,content-type,etag,location,x-amz-acl,x-amz-content-sha256,x-amz-date,x-amz-request-id,x-amz-security-token,x-amz-tagging,x-amz-target,x-amz-user-agent,x-amz-version-id,x-amzn-requestid,x-localstack-target,amz-sdk-invocation-id,amz-sdk-request",
       "aws.response.body.HTTPHeaders.access-control-allow-methods": "HEAD,GET,PUT,POST,DELETE,OPTIONS,PATCH",
       "aws.response.body.HTTPHeaders.access-control-allow-origin": "*",
@@ -176,10 +180,10 @@
       "aws.response.body.HTTPHeaders.connection": "close",
       "aws.response.body.HTTPHeaders.content-length": "493",
       "aws.response.body.HTTPHeaders.content-type": "text/xml",
-      "aws.response.body.HTTPHeaders.date": "Fri, 01 Nov 2024 18:49:23 GMT",
+      "aws.response.body.HTTPHeaders.date": "Wed, 01 Oct 2025 20:08:31 GMT",
       "aws.response.body.HTTPHeaders.server": "hypercorn-h11",
       "aws.response.body.HTTPStatusCode": "200",
-      "aws.response.body.RequestId": "NLK4TDG9YGTYRAMQ6QHN6NWC6QKRSSIZ8IBF0DS4RTY2Y3YWA7XC",
+      "aws.response.body.RequestId": "AI70E7GOW9XMKWH0O86YWVEFMLUMMHDVOOCANB6IPBAZEAO86IPO",
       "aws.response.body.RetryAttempts": "0",
       "aws.sqs.queue_name": "Test",
       "aws_account": "000000000000",
@@ -189,7 +193,7 @@
       "language": "python",
       "queuename": "Test",
       "region": "us-east-1",
-      "runtime-id": "e45a6c451bfb47bfbb0f4f36bd0803a3",
+      "runtime-id": "170e664d16b94fb488fd3b267c5814eb",
       "span.kind": "client"
     },
     "metrics": {
@@ -197,9 +201,9 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 9691,
+      "process_id": 11556,
       "retry_attempts": 0
     },
-    "duration": 964509306,
-    "start": 1730486963031752521
+    "duration": 565989959,
+    "start": 1759349310920822593
   }]]

--- a/tests/snapshots/tests.contrib.botocore.test.BotocoreTest.test_aws_payload_tagging_sqs_invalid_config.json
+++ b/tests/snapshots/tests.contrib.botocore.test.BotocoreTest.test_aws_payload_tagging_sqs_invalid_config.json
@@ -11,17 +11,18 @@
     "meta": {
       "_dd.base_service": "tests.contrib.botocore",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "686be1a100000000",
+      "_dd.p.tid": "68dd8a4000000000",
       "aws.agent": "botocore",
       "aws.operation": "ListQueues",
+      "aws.partition": "aws",
       "aws.region": "us-east-1",
-      "aws.requestid": "0VVK8P7HYGMWNR72ZOMDKVN5YWBEMTQB06KZ8UIJFXZCTWB8EOE7",
+      "aws.requestid": "5JJXRQW6OHVKDW3601221IXGR8F1ALLVG4FDD6YMRENYMTLFU6CR",
       "aws_service": "sqs",
       "component": "botocore",
       "http.status_code": "200",
       "language": "python",
       "region": "us-east-1",
-      "runtime-id": "7455813a717c4f2db67e4941325daca2",
+      "runtime-id": "170e664d16b94fb488fd3b267c5814eb",
       "span.kind": "client"
     },
     "metrics": {
@@ -29,11 +30,11 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 46598,
+      "process_id": 11556,
       "retry_attempts": 0
     },
-    "duration": 13548000,
-    "start": 1751900577380009000
+    "duration": 3675500,
+    "start": 1759349312201901844
   }],
 [
   {
@@ -48,11 +49,12 @@
     "meta": {
       "_dd.base_service": "tests.contrib.botocore",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "686be1a100000000",
+      "_dd.p.tid": "68dd8a4000000000",
       "aws.agent": "botocore",
       "aws.operation": "CreateQueue",
+      "aws.partition": "aws",
       "aws.region": "us-east-1",
-      "aws.requestid": "K4YVEQB22VBV7J7O70UXR6OJ2UJIOHP75492EF9JZ2TWGB8B7YRX",
+      "aws.requestid": "JV198VJWKRC4WZ4VAOLB6R4ITBEQLDROZOEAD0Z7EGRW7ZFBLF9B",
       "aws.sqs.queue_name": "Test",
       "aws_service": "sqs",
       "component": "botocore",
@@ -60,7 +62,7 @@
       "language": "python",
       "queuename": "Test",
       "region": "us-east-1",
-      "runtime-id": "7455813a717c4f2db67e4941325daca2",
+      "runtime-id": "170e664d16b94fb488fd3b267c5814eb",
       "span.kind": "client"
     },
     "metrics": {
@@ -68,11 +70,11 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 46598,
+      "process_id": 11556,
       "retry_attempts": 0
     },
-    "duration": 5525000,
-    "start": 1751900577393879000
+    "duration": 3296541,
+    "start": 1759349312205775761
   }],
 [
   {
@@ -87,11 +89,12 @@
     "meta": {
       "_dd.base_service": "tests.contrib.botocore",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "686be1a100000000",
+      "_dd.p.tid": "68dd8a4000000000",
       "aws.agent": "botocore",
       "aws.operation": "SendMessage",
+      "aws.partition": "aws",
       "aws.region": "us-east-1",
-      "aws.requestid": "IJFLTU6W4ECLHWB7LW92UT17VYSEKQ08GBSJD7N5U6TQ1AD9Q22Y",
+      "aws.requestid": "OHTGED9PC9JY5C8ZJIPOWJUYNVCXU4QA5Y1DJ7N05AXRRB1ZOEOL",
       "aws.sqs.queue_name": "Test",
       "aws_account": "000000000000",
       "aws_service": "sqs",
@@ -100,7 +103,7 @@
       "language": "python",
       "queuename": "Test",
       "region": "us-east-1",
-      "runtime-id": "7455813a717c4f2db67e4941325daca2",
+      "runtime-id": "170e664d16b94fb488fd3b267c5814eb",
       "span.kind": "client"
     },
     "metrics": {
@@ -108,11 +111,11 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 46598,
+      "process_id": 11556,
       "retry_attempts": 0
     },
-    "duration": 15291000,
-    "start": 1751900577404725000
+    "duration": 11393000,
+    "start": 1759349312213523927
   }],
 [
   {
@@ -127,11 +130,12 @@
     "meta": {
       "_dd.base_service": "tests.contrib.botocore",
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "686be1a100000000",
+      "_dd.p.tid": "68dd8a4000000000",
       "aws.agent": "botocore",
       "aws.operation": "ReceiveMessage",
+      "aws.partition": "aws",
       "aws.region": "us-east-1",
-      "aws.requestid": "KU9VQAAZ4ZJP5SEV02OTOAUX89HMHSP63ND7QTFBG7EMDCA28W0D",
+      "aws.requestid": "QRK192IFIDNBIKNLR949299LEWE2T9G4AE8NKEPWLUCTSEMVYPI9",
       "aws.sqs.queue_name": "Test",
       "aws_account": "000000000000",
       "aws_service": "sqs",
@@ -140,7 +144,7 @@
       "language": "python",
       "queuename": "Test",
       "region": "us-east-1",
-      "runtime-id": "7455813a717c4f2db67e4941325daca2",
+      "runtime-id": "170e664d16b94fb488fd3b267c5814eb",
       "span.kind": "client"
     },
     "metrics": {
@@ -148,9 +152,9 @@
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 46598,
+      "process_id": 11556,
       "retry_attempts": 0
     },
-    "duration": 103000,
-    "start": 1751900577427944000
+    "duration": 164500,
+    "start": 1759349312232757761
   }]]


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->

There are Gitlab errors about aws.parition being missing from snapshots: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1156455189 , which https://github.com/DataDog/dd-trace-py/pull/14577/ originally added.

This PR regenerates the snapshot with the new tag in test_aws_payload_tagging_sqs.

I don't have a preference between https://github.com/DataDog/dd-trace-py/pull/14740 or this PR. I'm just opening this to see if this triggers the botocore/aiobotocore/boto suites.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

I tested this locally with the `testagent` container running then rerunning this specific test:
```
DD_TRACE_AGENT_PORT=9126 riot -v run --pass-env -s 2f7da3e -- -k test_aws_payload_tagging_sqs
```

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
