### PR TITLE
fix(Profiling): Allow upload of profiles while requesting a local capture

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
@@ -65,10 +65,11 @@ Datadog::Uploader::upload(ddog_prof_Profile& profile)
     }
     ddog_prof_EncodedProfile* encoded = &serialize_result.ok; // NOLINT (cppcoreguidelines-pro-type-union-access)
 
+    // Export to file if output_filename is specified
+    bool file_export_success = true;
     if (!output_filename.empty()) {
-        bool ret = export_to_file(encoded);
-        ddog_prof_EncodedProfile_drop(encoded);
-        return ret;
+        file_export_success = export_to_file(encoded);
+        // Continue with network upload even if file export was requested
     }
 
     std::vector<ddog_prof_Exporter_File> to_compress_files;
@@ -135,7 +136,8 @@ Datadog::Uploader::upload(ddog_prof_Profile& profile)
         ddog_CancellationToken_drop(&cancel_for_request);
     }
 
-    return ret;
+    // Return success only if both operations succeeded (or file export wasn't requested)
+    return ret && file_export_success;
 }
 
 void


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->
Allow upload of profiles while requesting a local capture.

I find it easier to debug with both local and UI view.

## Testing

<!-- Describe your testing strategy or note what tests are included -->
This is mostly tested in prof-correctness.

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->
This option is only used in debug workflows.

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
NA