### PR TITLE
chore(ray): env variable unitialized && atexit during shutdown

### DIFF
--- a/ddtrace/contrib/internal/ray/patch.py
+++ b/ddtrace/contrib/internal/ray/patch.py
@@ -304,7 +304,7 @@ def _job_supervisor_run_wrapper(method: Callable[..., Any]) -> Any:
         with long_running_ray_span(
             "actor_method.execute",
             resource=f"{self.__class__.__name__}.{method.__name__}",
-            service=RAY_SERVICE_NAME,
+            service=os.environ.get(RAY_JOB_NAME, DEFAULT_JOB_NAME),
             span_type=SpanTypes.RAY,
             child_of=context,
             activate=True,
@@ -342,7 +342,7 @@ def _exec_entrypoint_wrapper(method: Callable[..., Any]) -> Any:
         with tracer.trace(
             "exec entrypoint",
             resource=f"exec {entrypoint_name}",
-            service=RAY_SERVICE_NAME,
+            service=os.environ.get(RAY_JOB_NAME, DEFAULT_JOB_NAME),
             span_type=SpanTypes.RAY,
         ) as span:
             span.set_tag_str(SPAN_KIND, SpanKind.CONSUMER)

--- a/ddtrace/contrib/internal/ray/span_manager.py
+++ b/ddtrace/contrib/internal/ray/span_manager.py
@@ -18,6 +18,7 @@ from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import SPAN_KIND
 from ddtrace.ext import SpanKind
 from ddtrace.internal.forksafe import Lock
+from ddtrace.internal.logger import get_logger
 
 from .constants import DD_PARTIAL_VERSION
 from .constants import DD_WAS_LONG_RUNNING
@@ -29,6 +30,9 @@ from .constants import RAY_STATUS_FINISHED
 from .constants import RAY_STATUS_RUNNING
 from .constants import RAY_SUBMISSION_ID_TAG
 from .utils import _inject_ray_span_tags_and_metrics
+
+
+log = get_logger(__name__)
 
 
 @contextmanager
@@ -67,7 +71,11 @@ class RaySpanManager:
         self._is_shutting_down: bool = False
 
         # Register cleanup on process exit
-        atexit.register(self.cleanup_on_exit)
+        try:
+            atexit.register(self.cleanup_on_exit)
+        except BaseException:
+            log.debug("SpanManager initializing during shutdown", exc_info=True)
+            pass
 
     def _get_submission_id(self, span: Span) -> Optional[str]:
         return span.get_tag(RAY_SUBMISSION_ID_TAG)


### PR DESCRIPTION
Add two small fixes:

In some process, the RAY_SERVICE_NAME constant was not initialized, causing spans with no service names
When stopping ray just after a job sometimes, a message was appearing because of the registration of the at exit.
No changelog as it will be included with the release of ray