### PR TITLE
fix(er): use correct Path type in exception replay (and code origin)

### DIFF
--- a/ddtrace/debugging/_exception/replay.py
+++ b/ddtrace/debugging/_exception/replay.py
@@ -1,6 +1,5 @@
 from collections import deque
 from dataclasses import dataclass
-from pathlib import Path
 from threading import current_thread
 from types import FrameType
 from types import TracebackType
@@ -15,6 +14,7 @@ from ddtrace.debugging._signal.snapshot import Snapshot
 from ddtrace.debugging._uploader import SignalUploader
 from ddtrace.debugging._uploader import UploaderProduct
 from ddtrace.internal import core
+from ddtrace.internal.compat import Path
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.packages import is_user_code
 from ddtrace.internal.rate_limiter import BudgetRateLimiterWithJitter as RateLimiter
@@ -255,49 +255,49 @@ class SpanExceptionHandler:
         only_user_code: bool = True,
         cached_only: bool = False,
     ) -> bool:
-        frame = tb.tb_frame
-        code = frame.f_code
-        if only_user_code and not is_user_code(Path(code.co_filename)):
-            return False
-
-        snapshot = None
-        snapshot_id = frame.f_locals.get(SNAPSHOT_KEY, None)
-        if snapshot_id is None:
-            # We don't have a snapshot for the frame so we create one
-            if cached_only:
-                # If we only want a cached snapshot we return True as a signal
-                # that we would have captured, but we actually skip generating
-                # a new snapshot.
-                return True
-
-            snapshot = SpanExceptionSnapshot(
-                probe=SpanExceptionProbe.build(exc_id, frame),
-                frame=frame,
-                thread=current_thread(),
-                trace_context=span,
-                exc_id=exc_id,
-            )
-
-            # Capture
-            try:
-                snapshot.do_line()
-            except Exception:
-                log.exception("Error capturing exception replay snapshot %r", snapshot)
+        try:
+            frame = tb.tb_frame
+            code = frame.f_code
+            if only_user_code and not is_user_code(Path(code.co_filename)):
                 return False
 
-            # Collect
-            self.__uploader__.get_collector().push(snapshot)
+            snapshot = None
+            snapshot_id = frame.f_locals.get(SNAPSHOT_KEY, None)
+            if snapshot_id is None:
+                # We don't have a snapshot for the frame so we create one
+                if cached_only:
+                    # If we only want a cached snapshot we return True as a signal
+                    # that we would have captured, but we actually skip generating
+                    # a new snapshot.
+                    return True
 
-            # Memoize
-            frame.f_locals[SNAPSHOT_KEY] = snapshot_id = snapshot.uuid
+                snapshot = SpanExceptionSnapshot(
+                    probe=SpanExceptionProbe.build(exc_id, frame),
+                    frame=frame,
+                    thread=current_thread(),
+                    trace_context=span,
+                    exc_id=exc_id,
+                )
 
-        # Add correlation tags on the span
-        span.set_tag_str(FRAME_SNAPSHOT_ID_TAG % seq_nr, snapshot_id)
-        span.set_tag_str(FRAME_FUNCTION_TAG % seq_nr, code.co_name)
-        span.set_tag_str(FRAME_FILE_TAG % seq_nr, code.co_filename)
-        span.set_tag_str(FRAME_LINE_TAG % seq_nr, str(tb.tb_lineno))
+                # Capture
+                snapshot.do_line()
 
-        return snapshot is not None
+                # Collect
+                self.__uploader__.get_collector().push(snapshot)
+
+                # Memoize
+                frame.f_locals[SNAPSHOT_KEY] = snapshot_id = snapshot.uuid
+
+            # Add correlation tags on the span
+            span.set_tag_str(FRAME_SNAPSHOT_ID_TAG % seq_nr, snapshot_id)
+            span.set_tag_str(FRAME_FUNCTION_TAG % seq_nr, code.co_name)
+            span.set_tag_str(FRAME_FILE_TAG % seq_nr, code.co_filename)
+            span.set_tag_str(FRAME_LINE_TAG % seq_nr, str(tb.tb_lineno))
+
+            return snapshot is not None
+        except Exception:  # noqa: F841
+            log.exception("Error capturing exception replay snapshot")
+            return False
 
     def on_span_exception(
         self, span: Span, _exc_type: t.Type[BaseException], exc: BaseException, traceback: t.Optional[TracebackType]

--- a/ddtrace/debugging/_origin/span.py
+++ b/ddtrace/debugging/_origin/span.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from functools import partial
 from itertools import count
-from pathlib import Path
 import sys
 from threading import current_thread
 from time import monotonic_ns
@@ -24,6 +23,7 @@ from ddtrace.debugging._uploader import SignalUploader
 from ddtrace.debugging._uploader import UploaderProduct
 from ddtrace.ext import EXIT_SPAN_TYPES
 from ddtrace.internal import core
+from ddtrace.internal.compat import Path
 from ddtrace.internal.packages import is_user_code
 from ddtrace.internal.safety import _isinstance
 from ddtrace.internal.wrapping.context import WrappingContext

--- a/releasenotes/notes/fix-debugger-exception-replay-path-type-5180b5cf0d482e9e.yaml
+++ b/releasenotes/notes/fix-debugger-exception-replay-path-type-5180b5cf0d482e9e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: Fixes an issue where Exception Replay would sometimes
+    fail to capture snapshots when enabled via remote configuration.


### PR DESCRIPTION
## Description

Exception replay was failing when enabled via remote configuration due to using `pathlib.Path` instead of `ddtrace.internal.compat.Path`. The `is_user_code()` function uses `@singledispatch` and is only registered for the `compat.Path` type, causing `Unsupported type <class 'pathlib.PosixPath'>` errors that silently prevented snapshot capture.

This issue only manifested when enabled via RC (vs environment variable) due to module initialization timing differences.

Changes:
- Replace `pathlib.Path` import with `ddtrace.internal.compat.Path` in replay.py
- Replace `pathlib.Path` import with `ddtrace.internal.compat.Path` in origin/span.py
- Add exception logging in `_attach_tb_frame_snapshot_to_span` for debugging

Fixes exception replay not capturing snapshots when enabled through remote configuration.

The system-tests pass with these changes here: https://github.com/DataDog/system-tests/pull/5140

## Testing

Tested against the failing test defined here: https://github.com/DataDog/system-tests/pull/5140

## Risks

Low risk: new debug log could be too verbose?

## Additional Notes

Files are [best reviewed with the `?w=1` query param](https://github.com/DataDog/dd-trace-py/pull/14781/files?w=1) to reduce the noise of indenting a section of code. Also worth noting that this **does not** fix https://github.com/DataDog/system-tests/pull/5143 unfortunately. There's still an unknown there.
