### PR TITLE
ci(iast): skip test_gevent_sensitive_greenlet test for python 3.8

### DIFF
--- a/tests/appsec/integrations/flask_tests/test_iast_flask_testagent.py
+++ b/tests/appsec/integrations/flask_tests/test_iast_flask_testagent.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import json
+import sys
 
 import pytest
 
@@ -519,6 +520,7 @@ def test_gevent_sensitive_socketpair(server, config, iast_enabled, iast_test_tok
         assert response.text == "OK:True"
 
 
+@pytest.mark.skipif(sys.version_info < (3, 9, 0), reason="Test not compatible with Python 3.8")
 @pytest.mark.parametrize("server, config", _GEVENT_SERVERS_SCENARIOS)
 @pytest.mark.parametrize("iast_enabled", ("true", "false"))
 def test_gevent_sensitive_greenlet(server, config, iast_enabled, iast_test_token):


### PR DESCRIPTION
## Description

Skip flaky test on python 3.8

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
