### PR TITLE
chore(profiling): proper setup for test needing `ddup.config()`

### DIFF
--- a/tests/profiling_v2/collector/test_threading.py
+++ b/tests/profiling_v2/collector/test_threading.py
@@ -48,27 +48,6 @@ def test_repr():
     )
 
 
-def test_wrapper():
-    collector = collector_threading.ThreadingLockCollector()
-    with collector:
-
-        class Foobar(object):
-            lock_class = threading.Lock
-
-            def __init__(self):
-                lock = self.lock_class()
-                assert lock.acquire()
-                lock.release()
-
-        # Try to access the attribute
-        lock = Foobar.lock_class()
-        assert lock.acquire()
-        lock.release()
-
-        # Try this way too
-        Foobar()
-
-
 def test_patch():
     lock = threading.Lock
     collector = collector_threading.ThreadingLockCollector()
@@ -301,6 +280,22 @@ class TestThreadingLockCollector:
             except Exception as e:
                 print("Error removing file: {}".format(e))
         pass
+
+    def test_wrapper(self):
+        collector = collector_threading.ThreadingLockCollector()
+        with collector:
+
+            class Foobar(object):
+                lock_class = threading.Lock
+
+                def __init__(self):
+                    lock = self.lock_class()
+                    assert lock.acquire()
+                    lock.release()
+
+            lock = Foobar.lock_class()
+            assert lock.acquire()
+            lock.release()
 
     # Tests
     def test_lock_events(self):


### PR DESCRIPTION
## Description

`test_wrapper()` segfaults with following stack backtrace

```
#3  handle_posix_sigaction () at src/collector/crash_handler.rs:108
#4  <signal handler called>
#5  0x000075fb182a92b9 in Datadog::Sample::push_release (count=1, lock_time=3896666036706324, this=<optimized out>)
    at /home/bits/project/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp:235
#6  Datadog::Sample::push_release (this=<optimized out>, lock_time=3896666036706324, count=1)
    at /home/bits/project/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp:231
#7  0x000075fb182bec5c in __pyx_pf_7ddtrace_8internal_7datadog_9profiling_4ddup_5_ddup_12SampleHandle_10push_release (
    __pyx_v_count=<optimized out>, __pyx_v_value=0x75fb187c7250, __pyx_v_self=0x75fb187c7630)
    at /tmp/tmpxso4scef.build-lib/ddtrace.internal.datadog.profiling.ddup._ddup/_ddup.cpp:7956
#8  __pyx_pw_7ddtrace_8internal_7datadog_9profiling_4ddup_5_ddup_12SampleHandle_11push_release (
    __pyx_v_self=0x75fb187c7630, __pyx_args=<optimized out>, __pyx_nargs=<optimized out>, __pyx_kwds=<optimized out>)
    at /tmp/tmpxso4scef.build-lib/ddtrace.internal.datadog.profiling.ddup._ddup/_ddup.cpp:7907
#9  0x000075fb1c35b495 in _PyObject_VectorcallTstate (kwnames=0x0, nargsf=<optimized out>, args=0x59d0af703300,
```

As it indexes into empty `values` [vector](https://github.com/DataDog/dd-trace-py/blob/d033f37c48994b061a00748a00724b54a110de39/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp#L81). It is typically initialized by a call to `ddup.config()`. Shuffle the test code into `TestThreadingLockCollector` class to do so. 

<!-- Provide an overview of the change and motivation for the change -->

## Testing

Run `CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) DD_FAST_BUILD=1 DD_TRACE_AGENT_URL=http://localhost:8126 riot -v run 9bb19fe --pass-env -- -s -vv -k test_wrapper`

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->

[PROF-12678](https://datadoghq.atlassian.net/browse/PROF-12678)