### PR TITLE
chore(mlobs): set a special flag to distinguish AI Obs spans from DJM

### DIFF
--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -29,7 +29,7 @@ _KEEP_SPANS_RATE_KEY = "_dd.tracer_kr"
 _MULTIPLE_IP_HEADERS = "_dd.multiple-ip-headers"
 _DJM_ENABLED_KEY = "_dd.djm.enabled"
 _FILTER_KEPT_KEY = "_dd.filter.kept"
-_AI_OBS_KEY = "_dd.is_ai_obs"
+_AI_OBS_ENABLED_KEY = "_dd.ai_obs.enabled"
 
 APPSEC_ENV = "DD_APPSEC_ENABLED"
 _CONFIG_ENDPOINT_ENV = "_DD_CONFIG_ENDPOINT"

--- a/ddtrace/constants.py
+++ b/ddtrace/constants.py
@@ -3,6 +3,7 @@ This module contains constants used across ddtrace products.
 
 Constants that should NOT be referenced by ddtrace users are marked with a leading underscore.
 """
+
 _SAMPLING_PRIORITY_KEY = "_sampling_priority_v1"
 _SAMPLING_AGENT_DECISION = "_dd.agent_psr"
 _SAMPLING_RULE_DECISION = "_dd.rule_psr"
@@ -28,6 +29,7 @@ _KEEP_SPANS_RATE_KEY = "_dd.tracer_kr"
 _MULTIPLE_IP_HEADERS = "_dd.multiple-ip-headers"
 _DJM_ENABLED_KEY = "_dd.djm.enabled"
 _FILTER_KEPT_KEY = "_dd.filter.kept"
+_AI_OBS_KEY = "_dd.is_ai_obs"
 
 APPSEC_ENV = "DD_APPSEC_ENABLED"
 _CONFIG_ENDPOINT_ENV = "_DD_CONFIG_ENDPOINT"

--- a/ddtrace/contrib/internal/ray/utils.py
+++ b/ddtrace/contrib/internal/ray/utils.py
@@ -18,7 +18,7 @@ from ray.runtime_context import get_runtime_context
 from ddtrace._trace._limits import MAX_SPAN_META_VALUE_LEN
 from ddtrace._trace.context import Context
 from ddtrace._trace.span import Span
-from ddtrace.constants import _AI_OBS_KEY
+from ddtrace.constants import _AI_OBS_ENABLED_KEY
 from ddtrace.constants import _DJM_ENABLED_KEY
 from ddtrace.constants import _FILTER_KEPT_KEY
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
@@ -89,7 +89,7 @@ def _extract_tracing_context_from_env() -> Optional[Context]:
 def _inject_ray_span_tags_and_metrics(span: Span) -> None:
     span.set_tag_str("component", RAY_COMPONENT)
     span.set_tag_str(RAY_HOSTNAME, socket.gethostname())
-    span.set_metric(_AI_OBS_KEY, 1)
+    span.set_metric(_AI_OBS_ENABLED_KEY, 1)
     span.set_metric(_DJM_ENABLED_KEY, 1)
     span.set_metric(_FILTER_KEPT_KEY, 1)
     span.set_metric(_SPAN_MEASURED_KEY, 1)

--- a/ddtrace/contrib/internal/ray/utils.py
+++ b/ddtrace/contrib/internal/ray/utils.py
@@ -89,7 +89,7 @@ def _extract_tracing_context_from_env() -> Optional[Context]:
 def _inject_ray_span_tags_and_metrics(span: Span) -> None:
     span.set_tag_str("component", RAY_COMPONENT)
     span.set_tag_str(RAY_HOSTNAME, socket.gethostname())
-    span.set_tag_str(_AI_OBS_KEY, 1)
+    span.set_metric(_AI_OBS_KEY, 1)
     span.set_metric(_DJM_ENABLED_KEY, 1)
     span.set_metric(_FILTER_KEPT_KEY, 1)
     span.set_metric(_SPAN_MEASURED_KEY, 1)

--- a/ddtrace/contrib/internal/ray/utils.py
+++ b/ddtrace/contrib/internal/ray/utils.py
@@ -18,6 +18,7 @@ from ray.runtime_context import get_runtime_context
 from ddtrace._trace._limits import MAX_SPAN_META_VALUE_LEN
 from ddtrace._trace.context import Context
 from ddtrace._trace.span import Span
+from ddtrace.constants import _AI_OBS_KEY
 from ddtrace.constants import _DJM_ENABLED_KEY
 from ddtrace.constants import _FILTER_KEPT_KEY
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
@@ -88,6 +89,7 @@ def _extract_tracing_context_from_env() -> Optional[Context]:
 def _inject_ray_span_tags_and_metrics(span: Span) -> None:
     span.set_tag_str("component", RAY_COMPONENT)
     span.set_tag_str(RAY_HOSTNAME, socket.gethostname())
+    span.set_tag_str(_AI_OBS_KEY, 1)
     span.set_metric(_DJM_ENABLED_KEY, 1)
     span.set_metric(_FILTER_KEPT_KEY, 1)
     span.set_metric(_SPAN_MEASURED_KEY, 1)

--- a/tests/snapshots/tests.contrib.ray.test_ray.test_actor_and_task.json
+++ b/tests/snapshots/tests.contrib.ray.test_ray.test_actor_and_task.json
@@ -23,6 +23,7 @@
       "span.kind": "producer"
     },
     "metrics": {
+      "_dd.ai_obs.enabled": 1,
       "_dd.djm.enabled": 1,
       "_dd.filter.kept": 1,
       "_dd.measured": 1,
@@ -54,6 +55,7 @@
          "span.kind": "consumer"
        },
        "metrics": {
+         "_dd.ai_obs.enabled": 1,
          "_dd.djm.enabled": 1,
          "_dd.filter.kept": 1,
          "_dd.measured": 1,
@@ -89,6 +91,7 @@
       "span.kind": "producer"
     },
     "metrics": {
+      "_dd.ai_obs.enabled": 1,
       "_dd.djm.enabled": 1,
       "_dd.filter.kept": 1,
       "_dd.measured": 1,
@@ -120,6 +123,7 @@
          "span.kind": "consumer"
        },
        "metrics": {
+         "_dd.ai_obs.enabled": 1,
          "_dd.djm.enabled": 1,
          "_dd.filter.kept": 1,
          "_dd.measured": 1,
@@ -154,6 +158,7 @@
       "span.kind": "producer"
     },
     "metrics": {
+      "_dd.ai_obs.enabled": 1,
       "_dd.djm.enabled": 1,
       "_dd.filter.kept": 1,
       "_dd.measured": 1,
@@ -183,6 +188,7 @@
          "span.kind": "consumer"
        },
        "metrics": {
+         "_dd.ai_obs.enabled": 1,
          "_dd.djm.enabled": 1,
          "_dd.filter.kept": 1,
          "_dd.measured": 1,
@@ -209,6 +215,7 @@
             "span.kind": "consumer"
           },
           "metrics": {
+            "_dd.ai_obs.enabled": 1,
             "_dd.djm.enabled": 1,
             "_dd.filter.kept": 1,
             "_dd.measured": 1,
@@ -236,6 +243,7 @@
             "span.kind": "producer"
           },
           "metrics": {
+            "_dd.ai_obs.enabled": 1,
             "_dd.djm.enabled": 1,
             "_dd.filter.kept": 1,
             "_dd.measured": 1,
@@ -264,6 +272,7 @@
                "span.kind": "consumer"
              },
              "metrics": {
+               "_dd.ai_obs.enabled": 1,
                "_dd.djm.enabled": 1,
                "_dd.filter.kept": 1,
                "_dd.measured": 1,
@@ -293,6 +302,7 @@
                   "span.kind": "producer"
                 },
                 "metrics": {
+                  "_dd.ai_obs.enabled": 1,
                   "_dd.djm.enabled": 1,
                   "_dd.filter.kept": 1,
                   "_dd.measured": 1,
@@ -321,6 +331,7 @@
                      "span.kind": "consumer"
                    },
                    "metrics": {
+                     "_dd.ai_obs.enabled": 1,
                      "_dd.djm.enabled": 1,
                      "_dd.filter.kept": 1,
                      "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.ray.test_ray.test_actor_interactions.json
+++ b/tests/snapshots/tests.contrib.ray.test_ray.test_actor_interactions.json
@@ -23,6 +23,7 @@
       "span.kind": "producer"
     },
     "metrics": {
+      "_dd.ai_obs.enabled": 1,
       "_dd.djm.enabled": 1,
       "_dd.filter.kept": 1,
       "_dd.measured": 1,
@@ -54,6 +55,7 @@
          "span.kind": "consumer"
        },
        "metrics": {
+         "_dd.ai_obs.enabled": 1,
          "_dd.djm.enabled": 1,
          "_dd.filter.kept": 1,
          "_dd.measured": 1,
@@ -82,6 +84,7 @@
             "span.kind": "consumer"
           },
           "metrics": {
+            "_dd.ai_obs.enabled": 1,
             "_dd.djm.enabled": 1,
             "_dd.filter.kept": 1,
             "_dd.measured": 1,
@@ -108,6 +111,7 @@
             "span.kind": "consumer"
           },
           "metrics": {
+            "_dd.ai_obs.enabled": 1,
             "_dd.djm.enabled": 1,
             "_dd.filter.kept": 1,
             "_dd.measured": 1,
@@ -134,6 +138,7 @@
             "span.kind": "producer"
           },
           "metrics": {
+            "_dd.ai_obs.enabled": 1,
             "_dd.djm.enabled": 1,
             "_dd.filter.kept": 1,
             "_dd.measured": 1,
@@ -160,6 +165,7 @@
                "span.kind": "consumer"
              },
              "metrics": {
+               "_dd.ai_obs.enabled": 1,
                "_dd.djm.enabled": 1,
                "_dd.filter.kept": 1,
                "_dd.measured": 1,
@@ -186,6 +192,7 @@
                   "span.kind": "producer"
                 },
                 "metrics": {
+                  "_dd.ai_obs.enabled": 1,
                   "_dd.djm.enabled": 1,
                   "_dd.filter.kept": 1,
                   "_dd.measured": 1,
@@ -212,6 +219,7 @@
                      "span.kind": "consumer"
                    },
                    "metrics": {
+                     "_dd.ai_obs.enabled": 1,
                      "_dd.djm.enabled": 1,
                      "_dd.filter.kept": 1,
                      "_dd.measured": 1,
@@ -238,6 +246,7 @@
             "span.kind": "producer"
           },
           "metrics": {
+            "_dd.ai_obs.enabled": 1,
             "_dd.djm.enabled": 1,
             "_dd.filter.kept": 1,
             "_dd.measured": 1,
@@ -264,6 +273,7 @@
                "span.kind": "consumer"
              },
              "metrics": {
+               "_dd.ai_obs.enabled": 1,
                "_dd.djm.enabled": 1,
                "_dd.filter.kept": 1,
                "_dd.measured": 1,
@@ -290,6 +300,7 @@
             "span.kind": "producer"
           },
           "metrics": {
+            "_dd.ai_obs.enabled": 1,
             "_dd.djm.enabled": 1,
             "_dd.filter.kept": 1,
             "_dd.measured": 1,
@@ -316,6 +327,7 @@
                "span.kind": "consumer"
              },
              "metrics": {
+               "_dd.ai_obs.enabled": 1,
                "_dd.djm.enabled": 1,
                "_dd.filter.kept": 1,
                "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.ray.test_ray.test_args_kwargs.json
+++ b/tests/snapshots/tests.contrib.ray.test_ray.test_args_kwargs.json
@@ -25,6 +25,7 @@
       "span.kind": "producer"
     },
     "metrics": {
+      "_dd.ai_obs.enabled": 1,
       "_dd.djm.enabled": 1,
       "_dd.filter.kept": 1,
       "_dd.measured": 1,
@@ -58,6 +59,7 @@
          "span.kind": "consumer"
        },
        "metrics": {
+         "_dd.ai_obs.enabled": 1,
          "_dd.djm.enabled": 1,
          "_dd.filter.kept": 1,
          "_dd.measured": 1,
@@ -94,6 +96,7 @@
       "span.kind": "producer"
     },
     "metrics": {
+      "_dd.ai_obs.enabled": 1,
       "_dd.djm.enabled": 1,
       "_dd.filter.kept": 1,
       "_dd.measured": 1,
@@ -125,6 +128,7 @@
          "span.kind": "consumer"
        },
        "metrics": {
+         "_dd.ai_obs.enabled": 1,
          "_dd.djm.enabled": 1,
          "_dd.filter.kept": 1,
          "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.ray.test_ray.test_core_api_deactivated.json
+++ b/tests/snapshots/tests.contrib.ray.test_ray.test_core_api_deactivated.json
@@ -22,6 +22,7 @@
       "span.kind": "producer"
     },
     "metrics": {
+      "_dd.ai_obs.enabled": 1,
       "_dd.djm.enabled": 1,
       "_dd.filter.kept": 1,
       "_dd.measured": 1,
@@ -53,6 +54,7 @@
          "span.kind": "consumer"
        },
        "metrics": {
+         "_dd.ai_obs.enabled": 1,
          "_dd.djm.enabled": 1,
          "_dd.filter.kept": 1,
          "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.ray.test_ray.test_nested_tasks.json
+++ b/tests/snapshots/tests.contrib.ray.test_ray.test_nested_tasks.json
@@ -23,6 +23,7 @@
       "span.kind": "producer"
     },
     "metrics": {
+      "_dd.ai_obs.enabled": 1,
       "_dd.djm.enabled": 1,
       "_dd.filter.kept": 1,
       "_dd.measured": 1,
@@ -54,6 +55,7 @@
          "span.kind": "consumer"
        },
        "metrics": {
+         "_dd.ai_obs.enabled": 1,
          "_dd.djm.enabled": 1,
          "_dd.filter.kept": 1,
          "_dd.measured": 1,
@@ -83,6 +85,7 @@
             "span.kind": "producer"
           },
           "metrics": {
+            "_dd.ai_obs.enabled": 1,
             "_dd.djm.enabled": 1,
             "_dd.filter.kept": 1,
             "_dd.measured": 1,
@@ -111,6 +114,7 @@
                "span.kind": "consumer"
              },
              "metrics": {
+               "_dd.ai_obs.enabled": 1,
                "_dd.djm.enabled": 1,
                "_dd.filter.kept": 1,
                "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.ray.test_ray.test_simple_actor.json
+++ b/tests/snapshots/tests.contrib.ray.test_ray.test_simple_actor.json
@@ -22,6 +22,7 @@
       "span.kind": "producer"
     },
     "metrics": {
+      "_dd.ai_obs.enabled": 1,
       "_dd.djm.enabled": 1,
       "_dd.filter.kept": 1,
       "_dd.measured": 1,
@@ -51,6 +52,7 @@
          "span.kind": "consumer"
        },
        "metrics": {
+         "_dd.ai_obs.enabled": 1,
          "_dd.djm.enabled": 1,
          "_dd.filter.kept": 1,
          "_dd.measured": 1,
@@ -77,6 +79,7 @@
             "span.kind": "consumer"
           },
           "metrics": {
+            "_dd.ai_obs.enabled": 1,
             "_dd.djm.enabled": 1,
             "_dd.filter.kept": 1,
             "_dd.measured": 1,
@@ -103,6 +106,7 @@
                "span.kind": "consumer"
              },
              "metrics": {
+               "_dd.ai_obs.enabled": 1,
                "_dd.djm.enabled": 1,
                "_dd.filter.kept": 1,
                "_dd.measured": 1,
@@ -129,6 +133,7 @@
                "span.kind": "consumer"
              },
              "metrics": {
+               "_dd.ai_obs.enabled": 1,
                "_dd.djm.enabled": 1,
                "_dd.filter.kept": 1,
                "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.ray.test_ray.test_simple_get.json
+++ b/tests/snapshots/tests.contrib.ray.test_ray.test_simple_get.json
@@ -23,6 +23,7 @@
       "span.kind": "producer"
     },
     "metrics": {
+      "_dd.ai_obs.enabled": 1,
       "_dd.djm.enabled": 1,
       "_dd.filter.kept": 1,
       "_dd.measured": 1,
@@ -54,6 +55,7 @@
          "span.kind": "consumer"
        },
        "metrics": {
+         "_dd.ai_obs.enabled": 1,
          "_dd.djm.enabled": 1,
          "_dd.filter.kept": 1,
          "_dd.measured": 1,
@@ -90,6 +92,7 @@
       "span.kind": "producer"
     },
     "metrics": {
+      "_dd.ai_obs.enabled": 1,
       "_dd.djm.enabled": 1,
       "_dd.filter.kept": 1,
       "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.ray.test_ray.test_simple_put.json
+++ b/tests/snapshots/tests.contrib.ray.test_ray.test_simple_put.json
@@ -25,6 +25,7 @@
       "span.kind": "producer"
     },
     "metrics": {
+      "_dd.ai_obs.enabled": 1,
       "_dd.djm.enabled": 1,
       "_dd.filter.kept": 1,
       "_dd.measured": 1,
@@ -61,6 +62,7 @@
       "span.kind": "producer"
     },
     "metrics": {
+      "_dd.ai_obs.enabled": 1,
       "_dd.djm.enabled": 1,
       "_dd.filter.kept": 1,
       "_dd.measured": 1,
@@ -92,6 +94,7 @@
          "span.kind": "consumer"
        },
        "metrics": {
+         "_dd.ai_obs.enabled": 1,
          "_dd.djm.enabled": 1,
          "_dd.filter.kept": 1,
          "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.ray.test_ray.test_simple_task.json
+++ b/tests/snapshots/tests.contrib.ray.test_ray.test_simple_task.json
@@ -23,6 +23,7 @@
       "span.kind": "producer"
     },
     "metrics": {
+      "_dd.ai_obs.enabled": 1,
       "_dd.djm.enabled": 1,
       "_dd.filter.kept": 1,
       "_dd.measured": 1,
@@ -54,6 +55,7 @@
          "span.kind": "consumer"
        },
        "metrics": {
+        "_dd.ai_obs.enabled": 1,
          "_dd.djm.enabled": 1,
          "_dd.filter.kept": 1,
          "_dd.measured": 1,
@@ -89,6 +91,7 @@
       "span.kind": "producer"
     },
     "metrics": {
+      "_dd.ai_obs.enabled": 1,
       "_dd.djm.enabled": 1,
       "_dd.filter.kept": 1,
       "_dd.measured": 1,
@@ -120,6 +123,7 @@
          "span.kind": "consumer"
        },
        "metrics": {
+         "_dd.ai_obs.enabled": 1,
          "_dd.djm.enabled": 1,
          "_dd.filter.kept": 1,
          "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.ray.test_ray.test_simple_task.json
+++ b/tests/snapshots/tests.contrib.ray.test_ray.test_simple_task.json
@@ -55,7 +55,7 @@
          "span.kind": "consumer"
        },
        "metrics": {
-        "_dd.ai_obs.enabled": 1,
+         "_dd.ai_obs.enabled": 1,
          "_dd.djm.enabled": 1,
          "_dd.filter.kept": 1,
          "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.ray.test_ray.test_simple_wait.json
+++ b/tests/snapshots/tests.contrib.ray.test_ray.test_simple_wait.json
@@ -23,6 +23,7 @@
       "span.kind": "producer"
     },
     "metrics": {
+      "_dd.ai_obs.enabled": 1,
       "_dd.djm.enabled": 1,
       "_dd.filter.kept": 1,
       "_dd.measured": 1,
@@ -54,6 +55,7 @@
          "span.kind": "consumer"
        },
        "metrics": {
+        "_dd.ai_obs.enabled": 1,
          "_dd.djm.enabled": 1,
          "_dd.filter.kept": 1,
          "_dd.measured": 1,
@@ -90,6 +92,7 @@
       "span.kind": "producer"
     },
     "metrics": {
+      "_dd.ai_obs.enabled": 1,
       "_dd.djm.enabled": 1,
       "_dd.filter.kept": 1,
       "_dd.measured": 1,

--- a/tests/snapshots/tests.contrib.ray.test_ray.test_simple_wait.json
+++ b/tests/snapshots/tests.contrib.ray.test_ray.test_simple_wait.json
@@ -55,7 +55,7 @@
          "span.kind": "consumer"
        },
        "metrics": {
-        "_dd.ai_obs.enabled": 1,
+         "_dd.ai_obs.enabled": 1,
          "_dd.djm.enabled": 1,
          "_dd.filter.kept": 1,
          "_dd.measured": 1,


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->
This micro will enable our backend to differentiate AI Obs spans from other DJM spans, so that customers are not billed for AI Observability spans as part of their APM bill.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

After installing ddtrace from local, run Ray locally, run a sample job and [make sure the new spans get tagged with the new _dd.ai_obs.enabled metric](https://dd.datad0g.com/apm/traces?query=%40component%3Aray&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=waterfall&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=desc&spanID=2509930093327428234&spanType=all&storage=hot&timeHint=1759854974570&trace=AwAAAZm_h9ZqCDBU7wAAABhBWm1faDktREFBQkJQSC0yTlhVeF8tcmsAAAAkZjE5OWJmODctZjU2My00ODA0LTk4MGEtZTMwMmMyYmVjNDlmAAAB7A&traceID=68e5417b00000000e4ea1f535629f63a&traceQuery=&view=spans&start=1759854151303&end=1759855051303&paused=true)

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
