### PR TITLE
chore(codeowners): assign contrib, test, and snapshot files apm-serverless codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -224,25 +224,25 @@ tests/tracer/test_ci.py                            @DataDog/ci-app-libraries
 
 # Serverless
 ddtrace/contrib/internal/aws_lambda                         @DataDog/apm-serverless
-ddtrace/contrib/internal/azure_eventhubs                    @DataDog/apm-serverless
-ddtrace/contrib/internal/azure_functions                    @DataDog/apm-serverless
-ddtrace/contrib/internal/azure_servicebus                   @DataDog/apm-serverless
+ddtrace/contrib/internal/azure_eventhubs                    @DataDog/serverless @DataDog/apm-serverless
+ddtrace/contrib/internal/azure_functions                    @DataDog/serverless @DataDog/apm-serverless
+ddtrace/contrib/internal/azure_servicebus                   @DataDog/serverless @DataDog/apm-serverless
 ddtrace/ext/aws.py                                          @DataDog/apm-serverless @DataDog/apm-idm-python
-ddtrace/ext/azure_eventhubs.py                              @DataDog/apm-serverless
-ddtrace/ext/azure_servicebus.py                             @DataDog/apm-serverless
+ddtrace/ext/azure_eventhubs.py                              @DataDog/serverless @DataDog/apm-serverless
+ddtrace/ext/azure_servicebus.py                             @DataDog/serverless @DataDog/apm-serverless
 tests/contrib/aws_lambda                                    @DataDog/apm-serverless
-tests/contrib/azure_eventhubs                               @DataDog/apm-serverless
-tests/contrib/azure_functions                               @DataDog/apm-serverless
-tests/contrib/azure_functions_eventhubs                     @DataDog/apm-serverless
-tests/contrib/azure_functions_servicebus                    @DataDog/apm-serverless
-tests/contrib/azure_servicebus                              @DataDog/apm-serverless
+tests/contrib/azure_eventhubs                               @DataDog/serverless @DataDog/apm-serverless
+tests/contrib/azure_functions                               @DataDog/serverless @DataDog/apm-serverless
+tests/contrib/azure_functions_eventhubs                     @DataDog/serverless @DataDog/apm-serverless
+tests/contrib/azure_functions_servicebus                    @DataDog/serverless @DataDog/apm-serverless
+tests/contrib/azure_servicebus                              @DataDog/serverless @DataDog/apm-serverless
 tests/internal/test_serverless.py                           @DataDog/apm-core-python @DataDog/apm-serverless
 tests/snapshots/tests.contrib.aws_lambda.*.                 @DataDog/apm-serverless
-tests/snapshots/tests.contrib.azure_eventhubs.*             @DataDog/apm-serverless
-tests/snapshots/tests.contrib.azure_functions.*             @DataDog/apm-serverless
-tests/snapshots/tests.contrib.azure_functions_eventhubs.*   @DataDog/apm-serverless
-tests/snapshots/tests.contrib.azure_functions_servicebus.*  @DataDog/apm-serverless
-tests/snapshots/tests.contrib.azure_servicebus.*            @DataDog/apm-serverless
+tests/snapshots/tests.contrib.azure_eventhubs.*             @DataDog/serverless @DataDog/apm-serverless
+tests/snapshots/tests.contrib.azure_functions.*             @DataDog/serverless @DataDog/apm-serverless
+tests/snapshots/tests.contrib.azure_functions_eventhubs.*   @DataDog/serverless @DataDog/apm-serverless
+tests/snapshots/tests.contrib.azure_functions_servicebus.*  @DataDog/serverless @DataDog/apm-serverless
+tests/snapshots/tests.contrib.azure_servicebus.*            @DataDog/serverless @DataDog/apm-serverless
 
 # Data Streams Monitoring
 ddtrace/internal/datastreams        @DataDog/data-streams-monitoring


### PR DESCRIPTION
## Description

Add codeowners for files that should be reviewed by `apm-serverless`. Also add `serverless` as a codeowner temporarily while `apm-serverless` gets up to speed on supporting the Azure Integrations.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

Relevant integrations owned by apm-serverless
- aws_lambda
- azure_eventhubs
- azure_functions
- azure_servicebus
