### PR TITLE
chore(llmobs): raise prompt import to ddtrace.llmobs

### DIFF
--- a/ddtrace/llmobs/__init__.py
+++ b/ddtrace/llmobs/__init__.py
@@ -10,6 +10,7 @@ from ._experiment import Dataset
 from ._experiment import DatasetRecord
 from ._llmobs import LLMObs
 from ._llmobs import LLMObsSpan
+from .types import Prompt
 
 
-__all__ = ["LLMObs", "LLMObsSpan", "Dataset", "DatasetRecord"]
+__all__ = ["LLMObs", "LLMObsSpan", "Dataset", "DatasetRecord", "Prompt"]


### PR DESCRIPTION
## Description
from recent prompt bugbash, was suggested that the Prompt type be importable directly from ddtrace.llmobs instead of from ddtrace.llmobs.utils
since then, the type has already been moved to ddtrace.llmobs.types, so not totally sure this is still wanted, but throwing this up here anyway.
we just want to re-export like this right? not actually move it?

i dont think this needs changelog? 

## Testing
```
 from ddtrace.llmobs import LLMObs, Prompt
 LLMObs.enable(...)
 with LLMObs.annotation_context(name="prompt_test", prompt=Prompt(template="test_template")):
     with LLMObs.llm(name="prompt_test") as span:
         pass
```
should succeed and show up in ui

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
