### PR TITLE
chore(google_genai): extract model name from resp, not kwargs

### DIFF
--- a/ddtrace/llmobs/_integrations/google_genai.py
+++ b/ddtrace/llmobs/_integrations/google_genai.py
@@ -74,6 +74,8 @@ class GoogleGenAIIntegration(BaseLLMIntegration):
         operation: str = "",
     ) -> None:
         provider_name, model_name = extract_provider_and_model_name(kwargs=kwargs)
+        if response is not None:
+            model_name = getattr(response, "model_version", "") or model_name
         span._set_ctx_items(
             {
                 SPAN_KIND: operation,


### PR DESCRIPTION
[MLOB-4058]

## Description
Changes the google genai integration to extract model name from the response, rather than from kwargs. This functionally shouldn't change the behavior since our current model parsing helper added workarounds to sanitize model paths from the kwarg model ID, but should ensure stability long term by avoiding the complexity of using kwargs to guess the model name.

<!-- Provide an overview of the change and motivation for the change -->

## Testing

Existing tests should suffice, since we expect the same model name to be returned as part of `response.model_version`.
<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->


[MLOB-4058]: https://datadoghq.atlassian.net/browse/MLOB-4058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ