### PR TITLE
ci: fix scripts/run-tests issues

### DIFF
--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -44,6 +44,7 @@ class RiotVenv(NamedTuple):
     name: str
     python_version: str
     packages: str
+    suite_name: str = ""  # Track which suite this venv belongs to
 
     def _normalize_package_name(self, name: str) -> List[str]:
         """Generate possible package name variations from venv name component.
@@ -152,6 +153,18 @@ class TestRunner:
         suites = get_suites()
         matching = {}
 
+        # Expand directory paths to include glob patterns
+        expanded_files = set()
+        for file_path in files:
+            expanded_files.add(file_path)
+            # If it's a directory (ends with / or exists as dir), add wildcard patterns
+            path_obj = self.root / file_path.rstrip('/')
+            if path_obj.is_dir():
+                # Add common directory patterns
+                base = file_path.rstrip('/')
+                expanded_files.add(f"{base}/*")
+                expanded_files.add(f"{base}/**/*")
+
         for suite_name, suite_config in suites.items():
             try:
                 patterns = get_patterns(suite_name)
@@ -161,7 +174,7 @@ class TestRunner:
                 # Check if any changed files match the suite patterns
                 matches = []
                 for pattern in patterns:
-                    matches.extend(fnmatch.filter(files, pattern))
+                    matches.extend(fnmatch.filter(expanded_files, pattern))
 
                 if matches:
                     matching[suite_name] = suite_config.copy()
@@ -191,43 +204,7 @@ class TestRunner:
 
         return services
 
-    def get_riot_patterns(self, suites: Dict[str, dict]) -> List[str]:
-        """Get riot patterns for the selected suites."""
-        patterns = []
-        seen = set()
-
-        for suite_name, suite_config in suites.items():
-            if suite_config.get('runner') == 'riot':
-                pattern = suite_config.get('pattern', suite_name)
-                # Convert regex patterns to actual riot pattern names
-                riot_names = self._parse_riot_pattern(pattern)
-                for name in riot_names:
-                    if name not in seen:
-                        patterns.append(name)
-                        seen.add(name)
-
-        # Sort patterns for consistent ordering
-        return sorted(patterns)
-
-    def _parse_riot_pattern(self, pattern: str) -> List[str]:
-        """Parse a suitespec pattern to extract riot venv names.
-
-        Examples:
-            "^django$" -> ["django"]
-            "^(django|django:celery)$" -> ["django", "django:celery"]
-            "flask" -> ["flask"]
-        """
-        # Remove regex anchors if present
-        if pattern.startswith('^') and pattern.endswith('$'):
-            pattern = pattern[1:-1]
-
-        # Extract options from (option1|option2) patterns
-        if pattern.startswith('(') and pattern.endswith(')'):
-            return [opt.strip() for opt in pattern[1:-1].split('|')]
-
-        return [pattern]
-
-    def get_riot_venvs(self, pattern: str) -> List[RiotVenv]:
+    def get_riot_venvs(self, pattern: str, suite_name: str = "") -> List[RiotVenv]:
         """Get available riot venvs for a pattern by using riotfile.venv.instances()."""
         try:
             venvs = []
@@ -251,7 +228,8 @@ class TestRunner:
                     hash=inst.short_hash if hasattr(inst, 'short_hash') else f"hash{n}",
                     name=inst.name,
                     python_version=str(inst.py._hint) if hasattr(inst, 'py') and hasattr(inst.py, '_hint') else "3.10",
-                    packages=packages_info
+                    packages=packages_info,
+                    suite_name=suite_name
                 ))
 
             return venvs
@@ -273,6 +251,20 @@ class TestRunner:
         except subprocess.CalledProcessError as e:
             print(f"❌ Failed to start services: {e}")
             return False
+
+    def stop_services(self, services: Set[str]) -> bool:
+        """Stop and remove Docker services."""
+        if not services:
+            return True
+
+        print(f"\n🛑 Stopping services: {', '.join(sorted(services))}")
+        try:
+            cmd = ["docker", "compose", "down"] + list(services)
+            subprocess.run(cmd, cwd=self.root, check=True)
+            return True
+        except subprocess.CalledProcessError as e:
+            print(f"⚠️  Warning: Failed to stop services: {e}")
+            return False  # Don't fail the whole run if cleanup fails
 
     def _parse_selection(self, selection: str, max_items: int) -> Set[int]:
         """Parse user selection string into set of indices.
@@ -336,34 +328,38 @@ class TestRunner:
             except (ValueError, IndexError):
                 print(f"❌ Invalid selection. Please use format like '1,3', 'all', or 'none'")
 
-    def select_riot_patterns(self, matching_suites: Dict[str, dict]) -> List[str]:
-        """Let user select which riot patterns to run."""
-        riot_patterns = self.get_riot_patterns(matching_suites)
-        if not riot_patterns:
-            print("❌ No riot patterns found in matching suites")
-            return []
+    def select_riot_suites(self, matching_suites: Dict[str, dict]) -> Dict[str, dict]:
+        """Let user select which riot suites to run."""
+        riot_suites = {name: config for name, config in matching_suites.items()
+                       if config.get('runner') == 'riot'}
 
-        print(f"\n📋 Found {len(riot_patterns)} matching riot pattern(s):")
-        print("   " + ", ".join(riot_patterns))
+        if not riot_suites:
+            print("❌ No riot suites found in matching suites")
+            return {}
 
-        selected = self._interactive_select(riot_patterns, "patterns")
+        print(f"\n📋 Found {len(riot_suites)} matching riot suite(s):")
+        suite_list = list(riot_suites.keys())
+
+        selected = self._interactive_select(suite_list, "suites")
         if selected:
-            print(f"   Selected patterns: {', '.join(selected)}")
-        return selected
+            print(f"   Selected suites: {', '.join(selected)}")
+            return {name: riot_suites[name] for name in selected}
+        return {}
 
-    def select_venvs_for_patterns(self, selected_patterns: List[str]) -> List[RiotVenv]:
-        """Let user select specific venvs for each pattern."""
+    def select_venvs_for_suites(self, selected_suites: Dict[str, dict]) -> List[RiotVenv]:
+        """Let user select specific venvs for each suite."""
         selected_venvs = []
 
-        for pattern in selected_patterns:
-            print(f"\n🔍 Getting available venvs for pattern '{pattern}'...")
-            venvs = self.get_riot_venvs(pattern)
+        for suite_name, suite_config in selected_suites.items():
+            pattern = suite_config.get('pattern', suite_name)
+            print(f"\n🔍 Getting available venvs for suite '{suite_name}' (pattern: '{pattern}')...")
+            venvs = self.get_riot_venvs(pattern, suite_name=suite_name)
 
             if not venvs:
-                print(f"   ⚠️  No venvs found for pattern '{pattern}'")
+                print(f"   ⚠️  No venvs found for suite '{suite_name}'")
                 continue
 
-            print(f"\n📋 Available venvs for '{pattern}' ({len(venvs)} total):")
+            print(f"\n📋 Available venvs for suite '{suite_name}' ({len(venvs)} total):")
             print("=" * 80)
 
             # Custom format function for venvs
@@ -374,7 +370,7 @@ class TestRunner:
 
             if selected:
                 selected_venvs.extend(selected)
-                print(f"   Selected {len(selected)} venv(s) for '{pattern}':")
+                print(f"   Selected {len(selected)} venv(s) for suite '{suite_name}':")
                 for venv in selected:
                     print(f"     • {venv.name}: {venv.display_name}")
 
@@ -386,69 +382,102 @@ class TestRunner:
             print("❌ No matching test suites found for the changed files.")
             return []
 
-        # Step 1: Select riot patterns
-        selected_patterns = self.select_riot_patterns(matching_suites)
-        if not selected_patterns:
+        # Step 1: Select riot suites
+        selected_suites = self.select_riot_suites(matching_suites)
+        if not selected_suites:
             return []
 
-        # Step 2: Select specific venvs for each pattern
-        return self.select_venvs_for_patterns(selected_patterns)
+        # Step 2: Select specific venvs for each suite
+        return self.select_venvs_for_suites(selected_suites)
 
     def run_tests(self, selected_venvs: List[RiotVenv], matching_suites: Dict[str, dict], riot_args: List[str] = None, dry_run: bool = False) -> bool:
-        """Execute the selected venvs."""
+        """Execute the selected venvs, grouped by suite with per-suite service management."""
         if not selected_venvs:
             print("ℹ️  No venvs selected for execution.")
             return True
 
-        # Extract services and start them
-        services = self.extract_required_services(matching_suites)
-        if services and not self.start_services(services):
-            return False
-
-        print(f"\n🧪 Running {len(selected_venvs)} selected venv(s):")
+        # Group venvs by suite
+        venvs_by_suite: Dict[str, List[RiotVenv]] = {}
         for venv in selected_venvs:
-            print(f"   • {venv.name} - {venv.display_name}")
+            suite_name = venv.suite_name
+            if suite_name not in venvs_by_suite:
+                venvs_by_suite[suite_name] = []
+            venvs_by_suite[suite_name].append(venv)
 
-        # Check if any selected suite needs testagent (has snapshot: true)
-        needs_testagent = any(
-            suite_config.get('snapshot', False)
-            for suite_config in matching_suites.values()
-        )
+        print(f"\n🧪 Running {len(selected_venvs)} venv(s) across {len(venvs_by_suite)} suite(s):")
+        for suite_name, venvs in venvs_by_suite.items():
+            print(f"   • Suite '{suite_name}': {len(venvs)} venv(s)")
 
-        # Set up base environment
-        env = os.environ.copy()
-        if needs_testagent:
-            env['DD_TRACE_AGENT_URL'] = TESTAGENT_URL
-            print(f"🔧 Setting DD_TRACE_AGENT_URL={TESTAGENT_URL} for snapshot tests")
+        # Execute each suite with its own service lifecycle
+        for suite_name, venvs in venvs_by_suite.items():
+            print(f"\n{'='*80}")
+            print(f"🎯 Suite: {suite_name}")
+            print(f"{'='*80}")
 
-        # Execute each venv
-        for venv in selected_venvs:
+            # Get suite config
+            suite_config = matching_suites.get(suite_name, {})
 
-            # Execute using ddtest with the specific venv hash
-            cmd = [str(self.root / "scripts" / "ddtest"), "riot", "-v", "run", "--pass-env", venv.hash]
+            # Extract services for this suite only
+            suite_services = set(suite_config.get('services', []))
+            needs_testagent = suite_config.get('snapshot', False)
+            if needs_testagent:
+                suite_services.add('testagent')
 
-            # Add riot args if provided
-            if riot_args:
-                cmd.extend(["--"] + riot_args)
-
-            if dry_run:
-                print(f"[DRY RUN] Would execute: {' '.join(cmd)}")
-                if needs_testagent:
-                    print(f"[DRY RUN] With env: DD_TRACE_AGENT_URL={env.get('DD_TRACE_AGENT_URL')}")
-            else:
-                print(f"\n▶️  Executing ({venv.display_name}): {' '.join(cmd)}")
-                try:
-                    result = subprocess.run(cmd, env=env, cwd=self.root)
-                    if result.returncode != 0:
-                        print(f"❌ {venv.display_name} failed with exit code {result.returncode}")
-                        return False
-                    else:
-                        print(f"✅ {venv.display_name} completed successfully")
-                except subprocess.CalledProcessError as e:
-                    print(f"❌ Failed to run {venv.display_name}: {e}")
+            # Start services for this suite
+            if suite_services:
+                if not self.start_services(suite_services):
+                    print(f"❌ Failed to start services for suite '{suite_name}'")
                     return False
+            else:
+                print(f"ℹ️  No services required for suite '{suite_name}'")
 
-        print("\n🎉 All selected venvs completed successfully!")
+            # Set up environment for this suite
+            env = os.environ.copy()
+            if needs_testagent:
+                env['DD_TRACE_AGENT_URL'] = TESTAGENT_URL
+                print(f"🔧 Setting DD_TRACE_AGENT_URL={TESTAGENT_URL} for snapshot tests")
+
+            # Execute each venv in this suite
+            suite_success = True
+            for venv in venvs:
+                # Execute using ddtest with the specific venv hash
+                cmd = [str(self.root / "scripts" / "ddtest"), "riot", "-v", "run", "--pass-env", venv.hash]
+
+                # Add riot args if provided
+                if riot_args:
+                    cmd.extend(["--"] + riot_args)
+
+                if dry_run:
+                    print(f"[DRY RUN] Would execute: {' '.join(cmd)}")
+                    if needs_testagent:
+                        print(f"[DRY RUN] With env: DD_TRACE_AGENT_URL={env.get('DD_TRACE_AGENT_URL')}")
+                else:
+                    print(f"\n▶️  Executing ({venv.display_name}): {' '.join(cmd)}")
+                    try:
+                        result = subprocess.run(cmd, env=env, cwd=self.root)
+                        if result.returncode != 0:
+                            print(f"❌ {venv.display_name} failed with exit code {result.returncode}")
+                            suite_success = False
+                            break  # Stop running venvs for this suite on first failure
+                        else:
+                            print(f"✅ {venv.display_name} completed successfully")
+                    except subprocess.CalledProcessError as e:
+                        print(f"❌ Failed to run {venv.display_name}: {e}")
+                        suite_success = False
+                        break
+
+            # Stop services for this suite
+            if suite_services:
+                self.stop_services(suite_services)
+
+            # If this suite failed, stop processing further suites
+            if not suite_success:
+                print(f"\n❌ Suite '{suite_name}' failed. Stopping execution.")
+                return False
+
+            print(f"\n✅ Suite '{suite_name}' completed successfully!")
+
+        print("\n🎉 All selected suites completed successfully!")
         return True
 
 


### PR DESCRIPTION
## Description

This PR fixes a few small issues with the scripts/run-tests helper.

1. No long requires trailing slash when selecting from a directory
2. Service selection
    a. Previously would collect all possible services needed from all possible test suites, not will limit to only the services needed for the selected venvs, and will start only the necessary services before each venv run, then tear them down when it is done, before starting the services needed for the next venv run, and so on.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
