### PR TITLE
ci(er): make exception endpoint comparable to index

### DIFF
--- a/benchmarks/django_simple/app.py
+++ b/benchmarks/django_simple/app.py
@@ -93,8 +93,10 @@ def index(request):
 
 
 def exception(request):
-    request.no_such_attr
-    return index(request)
+    try:
+        return index(request)
+    finally:
+        request.no_such_attr += 1
 
 
 urlpatterns = [path("", index), path("exc/", exception)]


### PR DESCRIPTION
## Description

We make the exception endpoint do work comparable to the index endpoint so that we can get benchmarking figures that can be compared amongst each other for more sensible results.
