### PR TITLE
chore(string): replace format by f-string in ddtrace/llmobs

### DIFF
--- a/ddtrace/llmobs/_evaluators/sampler.py
+++ b/ddtrace/llmobs/_evaluators/sampler.py
@@ -39,8 +39,11 @@ class EvaluatorRunnerSamplingRule(SamplingRule):
         return True
 
     def __repr__(self):
-        return "EvaluatorRunnerSamplingRule(sample_rate={}, evaluator_label={}, span_name={})".format(
-            self.sample_rate, self.evaluator_label, self.span_name
+        return (
+            f"EvaluatorRunnerSamplingRule("
+            f"sample_rate={self.sample_rate}, "
+            f"evaluator_label={self.evaluator_label}, "
+            f"span_name={self.span_name})"
         )
 
     __str__ = __repr__
@@ -66,7 +69,7 @@ class EvaluatorRunnerSampler:
 
         def parsing_failed_because(msg, maybe_throw_this):
             telemetry_writer.add_log(
-                TELEMETRY_LOG_LEVEL.ERROR, message="Evaluator sampling parsing failure because: {}".format(msg)
+                TELEMETRY_LOG_LEVEL.ERROR, message=f"Evaluator sampling parsing failure because: {msg}"
             )
             telemetry_writer.add_count_metric(
                 namespace=TELEMETRY_NAMESPACE.MLOBS,
@@ -83,9 +86,7 @@ class EvaluatorRunnerSampler:
         try:
             json_rules = json.loads(sampling_rules_str)
         except JSONDecodeError:
-            parsing_failed_because(
-                "Failed to parse evaluator sampling rules of: `{}`".format(sampling_rules_str), ValueError
-            )
+            parsing_failed_because(f"Failed to parse evaluator sampling rules of: `{sampling_rules_str}`", ValueError)
             return []
 
         if not isinstance(json_rules, list):
@@ -94,14 +95,12 @@ class EvaluatorRunnerSampler:
 
         for rule in json_rules:
             if "sample_rate" not in rule:
-                parsing_failed_because(
-                    "No sample_rate provided for sampling rule: {}".format(json.dumps(rule)), KeyError
-                )
+                parsing_failed_because(f"No sample_rate provided for sampling rule: {json.dumps(rule)}", KeyError)
                 continue
             try:
                 sample_rate = float(rule[EvaluatorRunnerSamplingRule.SAMPLE_RATE_KEY])
             except ValueError:
-                parsing_failed_because("sample_rate is not a float for rule: {}".format(json.dumps(rule)), KeyError)
+                parsing_failed_because(f"sample_rate is not a float for rule: {json.dumps(rule)}", KeyError)
                 continue
             span_name = rule.get(EvaluatorRunnerSamplingRule.SPAN_NAME_KEY, EvaluatorRunnerSamplingRule.NO_RULE)
             evaluator_label = rule.get(

--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -427,7 +427,7 @@ class Experiment:
             return []
         if sample_size is not None and sample_size < len(self._dataset):
             subset_records = [deepcopy(record) for record in self._dataset._records[:sample_size]]
-            subset_name = "[Test subset of {} records] {}".format(sample_size, self._dataset.name)
+            subset_name = f"[Test subset of {sample_size} records] {self._dataset.name}"
             subset_dataset = Dataset(
                 name=subset_name,
                 project=self._dataset.project,
@@ -451,9 +451,7 @@ class Experiment:
                     err_stack = err_dict.get("stack")
                     err_type = err_dict.get("type")
                 if raise_errors and err_msg:
-                    raise RuntimeError(
-                        "Error on record {}: {}\n{}\n{}".format(result["idx"], err_msg, err_type, err_stack)
-                    )
+                    raise RuntimeError(f"Error on record {result['idx']}: {err_msg}\n{err_type}\n{err_stack}")
         self._llmobs_instance.flush()  # Ensure spans get submitted in serverless environments
         return task_results
 

--- a/ddtrace/llmobs/_integrations/base.py
+++ b/ddtrace/llmobs/_integrations/base.py
@@ -58,7 +58,7 @@ class BaseLLMIntegration:
         Reuse the service of the application since we'll tag downstream request spans with the LLM name.
         Eventually those should also be internal service spans once peer.service is implemented.
         """
-        span_name = kwargs.get("span_name", None) or "{}.request".format(self._integration_name)
+        span_name = kwargs.get("span_name", None) or f"{self._integration_name}.request"
         span = pin.tracer.trace(
             span_name,
             resource=operation_id,

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -273,8 +273,8 @@ class BedrockIntegration(BaseLLMIntegration):
             if "metadata" in chunk and "usage" in chunk["metadata"]:
                 usage = chunk["metadata"]["usage"]
                 for token_type in ("input", "output", "total"):
-                    if "{}Tokens".format(token_type) in usage:
-                        usage_metrics["{}_tokens".format(token_type)] = usage["{}Tokens".format(token_type)]
+                    if f"{token_type}Tokens" in usage:
+                        usage_metrics[f"{token_type}_tokens"] = usage[f"{token_type}Tokens"]
 
                 cache_read_tokens = usage.get("cacheReadInputTokenCount", None) or usage.get(
                     "cacheReadInputTokens", None

--- a/ddtrace/llmobs/_integrations/bedrock_agents.py
+++ b/ddtrace/llmobs/_integrations/bedrock_agents.py
@@ -161,7 +161,7 @@ def _create_or_update_bedrock_trace_step_span(trace, trace_step_id, inner_span_e
     if not span_event:
         start_ns = root_span.start_ns if not inner_span_event else inner_span_event.get("start_ns", root_span.start_ns)
         span_event = _build_span_event(
-            span_name="{} Step".format(trace_type),
+            span_name=f"{trace_type} Step",
             root_span=root_span,
             parent_id=root_span.span_id,
             span_kind="workflow",

--- a/ddtrace/llmobs/_integrations/gemini.py
+++ b/ddtrace/llmobs/_integrations/gemini.py
@@ -81,7 +81,7 @@ class GeminiIntegration(BaseLLMIntegration):
             messages.append(message)
             return messages
         if not isinstance(contents, list):
-            messages.append(Message(content="[Non-text content object: {}]".format(repr(contents))))
+            messages.append(Message(content=f"[Non-text content object: {repr(contents)}]"))
             return messages
         for content in contents:
             if isinstance(content, str):
@@ -90,7 +90,7 @@ class GeminiIntegration(BaseLLMIntegration):
             role = _get_attr(content, "role", None)
             parts = _get_attr(content, "parts", [])
             if not parts or not isinstance(parts, Iterable):
-                message = Message(content="[Non-text content object: {}]".format(repr(content)))
+                message = Message(content=f"[Non-text content object: {repr(content)}]")
                 if role:
                     message["role"] = role
                 messages.append(message)

--- a/ddtrace/llmobs/_integrations/google_genai.py
+++ b/ddtrace/llmobs/_integrations/google_genai.py
@@ -153,7 +153,7 @@ class GoogleGenAIIntegration(BaseLLMIntegration):
         embeddings = _get_attr(response, "embeddings", [])
         if embeddings:
             embedding_dim = len(embeddings[0].values)
-            return "[{} embedding(s) returned with size {}]".format(len(embeddings), embedding_dim)
+            return f"[{len(embeddings)} embedding(s) returned with size {embedding_dim}]"
         return ""
 
     def _extract_embedding_input_documents(self, args, kwargs, config) -> List[Document]:

--- a/ddtrace/llmobs/_integrations/google_utils.py
+++ b/ddtrace/llmobs/_integrations/google_utils.py
@@ -234,7 +234,7 @@ def extract_message_from_part_google_genai(part, role: str) -> Message:
         message["content"] = safe_json({"outcome": str(outcome), "output": str(output)}) or ""
         return message
 
-    return Message(content="Unsupported file type: {}".format(type(part)), role=role)
+    return Message(content=f"Unsupported file type: {type(part)}", role=role)
 
 
 def llmobs_get_metadata_gemini_vertexai(kwargs, instance):

--- a/ddtrace/llmobs/_integrations/langchain.py
+++ b/ddtrace/llmobs/_integrations/langchain.py
@@ -699,7 +699,7 @@ class LangChainIntegration(BaseLLMIntegration):
             embedding_dim = len(output_values[0])
             span._set_ctx_item(
                 output_tag_key,
-                "[{} embedding(s) returned with size {}]".format(embeddings_count, embedding_dim),
+                f"[{embeddings_count} embedding(s) returned with size {embedding_dim}]",
             )
         except (TypeError, IndexError):
             log.warning("Failed to write output vectors", output_embedding)
@@ -727,7 +727,7 @@ class LangChainIntegration(BaseLLMIntegration):
             span._set_ctx_item(OUTPUT_VALUE, "")
             return
         if is_workflow:
-            span._set_ctx_item(OUTPUT_VALUE, "[{} document(s) retrieved]".format(len(output_documents)))
+            span._set_ctx_item(OUTPUT_VALUE, f"[{len(output_documents)} document(s) retrieved]")
             return
         documents: List[Document] = []
         for d in output_documents:
@@ -738,7 +738,7 @@ class LangChainIntegration(BaseLLMIntegration):
             documents.append(doc)
         span._set_ctx_item(OUTPUT_DOCUMENTS, format_langchain_io(documents))
         # we set the value as well to ensure that the UI would display it in case the span was the root
-        span._set_ctx_item(OUTPUT_VALUE, "[{} document(s) retrieved]".format(len(documents)))
+        span._set_ctx_item(OUTPUT_VALUE, f"[{len(documents)} document(s) retrieved]")
 
     def _llmobs_set_meta_tags_from_tool(self, span: Span, tool_inputs: Dict[str, Any], tool_output: object) -> None:
         metadata = json.loads(str(span.get_tag(METADATA))) if span.get_tag(METADATA) else {}

--- a/ddtrace/llmobs/_integrations/mcp.py
+++ b/ddtrace/llmobs/_integrations/mcp.py
@@ -59,7 +59,7 @@ class MCPIntegration(BaseLLMIntegration):
     def _llmobs_set_tags_client(self, span: Span, args: List[Any], kwargs: Dict[str, Any], response: Any) -> None:
         tool_arguments = get_argument_value(args, kwargs, 1, "arguments", optional=True) or {}
         tool_name = args[0] if len(args) > 0 else kwargs.get("name", "unknown_tool")
-        span_name = "MCP Client Tool Call: {}".format(tool_name)
+        span_name = f"MCP Client Tool Call: {tool_name}"
 
         span._set_ctx_items(
             {
@@ -84,7 +84,7 @@ class MCPIntegration(BaseLLMIntegration):
     def _llmobs_set_tags_server(self, span: Span, args: List[Any], kwargs: Dict[str, Any], response: Any) -> None:
         tool_arguments = get_argument_value(args, kwargs, 1, "arguments", optional=True) or {}
         tool_name = args[0] if len(args) > 0 else "unknown_tool"
-        span_name = "MCP Server Tool Execute: {}".format(tool_name)
+        span_name = f"MCP Server Tool Execute: {tool_name}"
 
         span._set_ctx_items(
             {

--- a/ddtrace/llmobs/_integrations/openai.py
+++ b/ddtrace/llmobs/_integrations/openai.py
@@ -147,11 +147,9 @@ class OpenAIIntegration(BaseLLMIntegration):
             return
         if encoding_format == "float":
             embedding_dim = len(resp.data[0].embedding)
-            span._set_ctx_item(
-                OUTPUT_VALUE, "[{} embedding(s) returned with size {}]".format(len(resp.data), embedding_dim)
-            )
+            span._set_ctx_item(OUTPUT_VALUE, f"[{len(resp.data)} embedding(s) returned with size {embedding_dim}]")
             return
-        span._set_ctx_item(OUTPUT_VALUE, "[{} embedding(s) returned]".format(len(resp.data)))
+        span._set_ctx_item(OUTPUT_VALUE, f"[{len(resp.data)} embedding(s) returned]")
 
     @staticmethod
     def _extract_llmobs_metrics_tags(

--- a/ddtrace/llmobs/_integrations/openai_agents.py
+++ b/ddtrace/llmobs/_integrations/openai_agents.py
@@ -266,7 +266,7 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
         )
 
     def _llmobs_set_handoff_attributes(self, span: Span, oai_span: OaiSpanAdapter) -> None:
-        handoff_tool_name = "transfer_to_{}".format("_".join(oai_span.to_agent.split(" ")).lower())
+        handoff_tool_name = f"transfer_to_{'_'.join(oai_span.to_agent.split(' ')).lower()}"
         span.name = handoff_tool_name
         span._set_ctx_item("input_value", oai_span.from_agent or "")
         span._set_ctx_item("output_value", oai_span.to_agent or "")

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -282,7 +282,7 @@ def get_messages_from_converse_content(role: str, content: List[Dict[str, Any]])
         else:
             content_type = ",".join(content_block.keys())
             unsupported_content_messages.append(
-                Message(content="[Unsupported content type: {}]".format(content_type), role=role)
+                Message(content=f"[Unsupported content type: {content_type}]", role=role)
             )
     message: Message = Message()
     if tool_calls_info:
@@ -932,7 +932,7 @@ class OaiSpanAdapter:
         """Get the span name."""
         if hasattr(self._raw_oai_span, "span_data") and hasattr(self._raw_oai_span.span_data, "name"):
             return self._raw_oai_span.span_data.name
-        return "openai_agents.{}".format(self.span_type.lower())
+        return f"openai_agents.{self.span_type.lower()}"
 
     @property
     def span_type(self) -> str:

--- a/ddtrace/llmobs/_integrations/vertexai.py
+++ b/ddtrace/llmobs/_integrations/vertexai.py
@@ -127,7 +127,7 @@ class VertexAIIntegration(BaseLLMIntegration):
             messages.append(message)
             return messages
         if not isinstance(contents, list):
-            messages.append(Message(content="[Non-text content object: {}]".format(repr(contents))))
+            messages.append(Message(content=f"[Non-text content object: {repr(contents)}]"))
             return messages
         for content in contents:
             if isinstance(content, str):
@@ -170,7 +170,7 @@ class VertexAIIntegration(BaseLLMIntegration):
         role = _get_attr(content, "role", "")
         parts = _get_attr(content, "parts", [])
         if not parts or not isinstance(parts, Iterable):
-            message = Message(content="[Non-text content object: {}]".format(repr(content)))
+            message = Message(content=f"[Non-text content object: {repr(content)}]")
             if role:
                 message["role"] = str(role)
             messages.append(message)

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -449,7 +449,7 @@ class LLMObs(Service):
         existing_tags = span._get_ctx_item(TAGS)
         if existing_tags is not None:
             tags.update(existing_tags)
-        return ["{}:{}".format(k, v) for k, v in tags.items()]
+        return [f"{k}:{v}" for k, v in tags.items()]
 
     def _do_annotations(self, span: Span) -> None:
         # get the current span context
@@ -791,7 +791,7 @@ class LLMObs(Service):
             params = sig.parameters
             evaluator_required_params = ("input_data", "output_data", "expected_output")
             if not all(param in params for param in evaluator_required_params):
-                raise TypeError("Evaluator function must have parameters {}.".format(evaluator_required_params))
+                raise TypeError(f"Evaluator function must have parameters {evaluator_required_params}.")
 
         if summary_evaluators and not all(callable(summary_evaluator) for summary_evaluator in summary_evaluators):
             raise TypeError("Summary evaluators must be a list of callable functions.")
@@ -802,7 +802,7 @@ class LLMObs(Service):
                 summary_evaluator_required_params = ("inputs", "outputs", "expected_outputs", "evaluators_results")
                 if not all(param in params for param in summary_evaluator_required_params):
                     raise TypeError(
-                        "Summary evaluator function must have parameters {}.".format(summary_evaluator_required_params)
+                        f"Summary evaluator function must have parameters {summary_evaluator_required_params}."
                     )
         return Experiment(
             name,
@@ -1668,9 +1668,9 @@ class LLMObs(Service):
                 "label": str(label),
                 "metric_type": metric_type,
                 "timestamp_ms": timestamp_ms,
-                "{}_value".format(metric_type): value,  # type: ignore
+                f"{metric_type}_value": value,  # type: ignore
                 "ml_app": ml_app,
-                "tags": ["{}:{}".format(k, v) for k, v in evaluation_tags.items()],
+                "tags": [f"{k}:{v}" for k, v in evaluation_tags.items()],
             }
 
             if metadata:
@@ -1806,9 +1806,9 @@ class LLMObs(Service):
                 "label": str(label),
                 "metric_type": metric_type.lower(),
                 "timestamp_ms": timestamp_ms,
-                "{}_value".format(metric_type): value,  # type: ignore
+                f"{metric_type}_value": value,  # type: ignore
                 "ml_app": ml_app,
-                "tags": ["{}:{}".format(k, v) for k, v in evaluation_tags.items()],
+                "tags": [f"{k}:{v}" for k, v in evaluation_tags.items()],
             }
 
             if metadata:

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -185,7 +185,7 @@ def _get_span_name(span: Span) -> str:
         return span.resource
     elif span.name == OPENAI_APM_SPAN_NAME and span.resource != "":
         client_name = span.get_tag("openai.request.provider") or "OpenAI"
-        return "{}.{}".format(client_name, span.resource)
+        return f"{client_name}.{span.resource}"
     return span._get_ctx_item(NAME) or span.name
 
 
@@ -242,7 +242,7 @@ def _unserializable_default_repr(obj):
         return str(obj)
     except Exception:
         log.warning("I/O object is neither JSON serializable nor string-able. Defaulting to placeholder value instead.")
-        return "[Unserializable object: {}]".format(repr(obj))
+        return f"[Unserializable object: {repr(obj)}]"
 
 
 def safe_json(obj, ensure_ascii=True):


### PR DESCRIPTION
This PR is a follow up to #14867.

It appears that f string are significantly more performant than using `.format()`. Therefore every format call is replaced by an f-string 