### PR TITLE
chore(string): replace format by f-string in ddtrace/settings

### DIFF
--- a/ddtrace/settings/_agent.py
+++ b/ddtrace/settings/_agent.py
@@ -39,12 +39,12 @@ def _derive_trace_url(config: "AgentConfig") -> str:
             host = user_supplied_host or DEFAULT_HOSTNAME
             port = user_supplied_port or DEFAULT_TRACE_PORT
             if is_ipv6_hostname(host):
-                host = "[{}]".format(host)
+                host = f"[{host}]"
             url = "http://%s:%s" % (host, port)
         elif os.path.exists("/var/run/datadog/apm.socket"):
             url = "unix://%s" % (DEFAULT_UNIX_TRACE_PATH)
         else:
-            url = "http://{}:{}".format(DEFAULT_HOSTNAME, DEFAULT_TRACE_PORT)
+            url = f"http://{DEFAULT_HOSTNAME}:{DEFAULT_TRACE_PORT}"
 
     return url
 
@@ -59,12 +59,12 @@ def _derive_stats_url(config: "AgentConfig") -> str:
             port = user_supplied_port or DEFAULT_STATS_PORT
             host = user_supplied_host or DEFAULT_HOSTNAME
             if is_ipv6_hostname(host):
-                host = "[{}]".format(host)
-            url = "udp://{}:{}".format(host, port)
+                host = f"[{host}]"
+            url = f"udp://{host}:{port}"
         elif os.path.exists("/var/run/datadog/dsd.socket"):
             url = "unix://%s" % (DEFAULT_UNIX_DSD_PATH)
         else:
-            url = "udp://{}:{}".format(DEFAULT_HOSTNAME, DEFAULT_STATS_PORT)
+            url = f"udp://{DEFAULT_HOSTNAME}:{DEFAULT_STATS_PORT}"
     return url
 
 

--- a/ddtrace/settings/_config.py
+++ b/ddtrace/settings/_config.py
@@ -345,13 +345,9 @@ class _ConfigItem:
         return "default"
 
     def __repr__(self):
-        return "<{} name={} default={} env_value={} user_value={} remote_config_value={}>".format(
-            self.__class__.__name__,
-            self._name,
-            self._default_value,
-            self._env_value,
-            self._code_value,
-            self._rc_value,
+        return (
+            f"<{self.__class__.__name__} name={self._name} default={self._default_value} "
+            f"env_value={self._env_value} user_value={self._code_value} remote_config_value={self._rc_value}>"
         )
 
 

--- a/ddtrace/settings/http.py
+++ b/ddtrace/settings/http.py
@@ -78,6 +78,8 @@ class HttpConfig(object):
         return self._header_tag_name(header_name) is not None
 
     def __repr__(self):
-        return "<{} traced_headers={} trace_query_string={}>".format(
-            self.__class__.__name__, self._header_tags.keys(), self.trace_query_string
+        return (
+            f"<{self.__class__.__name__} "
+            f"traced_headers={self._header_tags.keys()} "
+            f"trace_query_string={self.trace_query_string}>"
         )

--- a/ddtrace/settings/integration.py
+++ b/ddtrace/settings/integration.py
@@ -134,7 +134,7 @@ class IntegrationConfig(AttrDict):
     def __repr__(self):
         cls = self.__class__
         keys = ", ".join(self.keys())
-        return "{}.{}({})".format(cls.__module__, cls.__name__, keys)
+        return f"{cls.__module__}.{cls.__name__}({keys})"
 
     def copy(self):
         new_instance = self.__class__(self.global_config, self.integration_name)


### PR DESCRIPTION
This PR is a follow up to https://github.com/DataDog/dd-trace-py/pull/14867.

It appears that f string are significantly more performant than using .format(). Therefore every format call is replaced by an f-string