### PR TITLE
chore(string): replace format by f-string in ddtrace/internal

### DIFF
--- a/ddtrace/_logger.py
+++ b/ddtrace/_logger.py
@@ -9,9 +9,11 @@ from ddtrace.internal.utils.formats import asbool
 
 log = get_logger(__name__)
 
-DD_LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] {}- %(message)s".format(
+DD_LOG_FORMAT = (
+    "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] "
     "[dd.service=%(dd.service)s dd.env=%(dd.env)s dd.version=%(dd.version)s"
     " dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] "
+    "- %(message)s"
 )
 
 DEFAULT_FILE_SIZE_BYTES = 15 << 20  # 15 MB

--- a/ddtrace/internal/codeowners.py
+++ b/ddtrace/internal/codeowners.py
@@ -102,7 +102,7 @@ def path_to_regex(pattern: str) -> re.Pattern:
             regex += re.escape(ch)
 
     if in_char_class:
-        raise ValueError("unterminated character class in pattern {pattern}".format(pattern=pattern))
+        raise ValueError(f"unterminated character class in pattern {pattern}")
 
     regex += "/" if matches_dir else r"(?:\Z|/)"
     return re.compile(regex)

--- a/ddtrace/internal/datastreams/botocore.py
+++ b/ddtrace/internal/datastreams/botocore.py
@@ -57,7 +57,7 @@ def inject_context(trace_data, endpoint_service, dsm_identifier, message):
     """
     from . import data_streams_processor as processor
 
-    path_type = "type:{}".format(endpoint_service)
+    path_type = f"type:{endpoint_service}"
 
     payload_size = None
     if endpoint_service == "sqs":
@@ -69,9 +69,7 @@ def inject_context(trace_data, endpoint_service, dsm_identifier, message):
 
     if not dsm_identifier:
         log.debug("pathway being generated with unrecognized service: ", dsm_identifier)
-    ctx = processor().set_checkpoint(
-        ["direction:out", "topic:{}".format(dsm_identifier), path_type], payload_size=payload_size
-    )
+    ctx = processor().set_checkpoint(["direction:out", f"topic:{dsm_identifier}", path_type], payload_size=payload_size)
     DsmPathwayCodec.encode(ctx, trace_data)
 
 

--- a/ddtrace/internal/debug.py
+++ b/ddtrace/internal/debug.py
@@ -178,83 +178,61 @@ def pretty_collect(tracer, color=True):
 
     info = collect(tracer)
 
-    info_pretty = """{blue}{bold}Tracer Configurations:{end}
-    Tracer enabled: {tracer_enabled}
-    Application Security enabled: {appsec_enabled}
-    Remote Configuration enabled: {remote_config_enabled}
-    IAST enabled (experimental): {iast_enabled}
-    Debug logging: {debug}
-    Writing traces to: {agent_url}
-    Agent error: {agent_error}
-    Log injection enabled: {log_injection_enabled}
-    Health metrics enabled: {health_metrics_enabled}
-    Priority sampling enabled: {priority_sampling_enabled}
-    Partial flushing enabled: {partial_flush_enabled}
-    Partial flush minimum number of spans: {partial_flush_min_spans}
-    WAF timeout: {waf_timeout} msecs
-    {green}{bold}Tagging:{end}
-    DD Service: {service}
-    DD Env: {env}
-    DD Version: {dd_version}
-    Global Tags: {global_tags}
-    Tracer Tags: {tracer_tags}""".format(
-        tracer_enabled=info.get("ddtrace_enabled"),
-        appsec_enabled=info.get("asm_enabled"),
-        remote_config_enabled=info.get("remote_config_enabled"),
-        iast_enabled=info.get("iast_enabled"),
-        debug=info.get("debug"),
-        agent_url=info.get("agent_url") or "Not writing at the moment, is your tracer running?",
-        agent_error=info.get("agent_error") or "None",
-        log_injection_enabled=info.get("log_injection_enabled"),
-        health_metrics_enabled=info.get("health_metrics_enabled"),
-        priority_sampling_enabled=info.get("priority_sampling_enabled"),
-        partial_flush_enabled=info.get("partial_flush_enabled"),
-        partial_flush_min_spans=info.get("partial_flush_min_spans") or "Not set",
-        service=info.get("service") or "None",
-        env=info.get("env") or "None",
-        dd_version=info.get("dd_version") or "None",
-        global_tags=info.get("global_tags") or "None",
-        waf_timeout=info.get("waf_timeout"),
-        tracer_tags=info.get("tracer_tags") or "None",
-        blue=bcolors.OKBLUE,
-        green=bcolors.OKGREEN,
-        bold=bcolors.BOLD,
-        end=bcolors.ENDC,
-    )
+    info_pretty = f"""{bcolors.OKBLUE}{bcolors.BOLD}Tracer Configurations:{bcolors.ENDC}
+    Tracer enabled: {info.get('ddtrace_enabled')}
+    Application Security enabled: {info.get('asm_enabled')}
+    Remote Configuration enabled: {info.get('remote_config_enabled')}
+    IAST enabled (experimental): {info.get('iast_enabled')}
+    Debug logging: {info.get('debug')}
+    Writing traces to: {info.get('agent_url') or 'Not writing at the moment, is your tracer running?'}
+    Agent error: {info.get('agent_error') or 'None'}
+    Log injection enabled: {info.get('log_injection_enabled')}
+    Health metrics enabled: {info.get('health_metrics_enabled')}
+    Priority sampling enabled: {info.get('priority_sampling_enabled')}
+    Partial flushing enabled: {info.get('partial_flush_enabled')}
+    Partial flush minimum number of spans: {info.get('partial_flush_min_spans') or 'Not set'}
+    WAF timeout: {info.get('waf_timeout')} msecs
+    {bcolors.OKGREEN}{bcolors.BOLD}Tagging:{bcolors.ENDC}
+    DD Service: {info.get('service') or 'None'}
+    DD Env: {info.get('env') or 'None'}
+    DD Version: {info.get('dd_version') or 'None'}
+    Global Tags: {info.get('global_tags') or 'None'}
+    Tracer Tags: {info.get('tracer_tags') or 'None'}"""
 
-    summary = "{0}{1}Summary{2}".format(bcolors.OKCYAN, bcolors.BOLD, bcolors.ENDC)
+    summary = f"{bcolors.OKCYAN}{bcolors.BOLD}Summary{bcolors.ENDC}"
 
     if info.get("agent_error"):
         summary += (
-            "\n\n{fail}ERROR: It looks like you have an agent error: '{agent_error}'\n If you're experiencing"
+            f"\n\n{bcolors.FAIL}ERROR: It looks like you have an agent error: "
+            f"'{info.get('agent_error')}'\n If you're experiencing"
             " a connection error, please make sure you've followed the setup for your particular environment so that "
             "the tracer and Datadog agent are configured properly to connect, and that the Datadog agent is running: "
             "https://ddtrace.readthedocs.io/en/stable/troubleshooting.html#failed-to-send-traces-connectionrefused"
             "error"
             "\nIf your issue is not a connection error then please reach out to support for further assistance:"
-            " https://docs.datadoghq.com/help/{end}"
-        ).format(fail=bcolors.FAIL, agent_error=info.get("agent_error"), end=bcolors.ENDC)
+            f" https://docs.datadoghq.com/help/{bcolors.ENDC}"
+        )
 
     if not info.get("service"):
         summary += (
-            "\n\n{warning}WARNING SERVICE NOT SET: It is recommended that a service tag be set for all traced"
+            f"\n\n{bcolors.WARNING}WARNING SERVICE NOT SET: It is recommended that a service tag be set for all traced"
             " applications. For more information please see"
-            " https://ddtrace.readthedocs.io/en/stable/troubleshooting.html{end}"
-        ).format(warning=bcolors.WARNING, end=bcolors.ENDC)
+            f" https://ddtrace.readthedocs.io/en/stable/troubleshooting.html{bcolors.ENDC}"
+        )
 
     if not info.get("env"):
         summary += (
-            "\n\n{warning}WARNING ENV NOT SET: It is recommended that an env tag be set for all traced"
+            f"\n\n{bcolors.WARNING}WARNING ENV NOT SET: It is recommended that an env tag be set for all traced"
             " applications. For more information please see "
-            "https://ddtrace.readthedocs.io/en/stable/troubleshooting.html{end}"
-        ).format(warning=bcolors.WARNING, end=bcolors.ENDC)
+            f"https://ddtrace.readthedocs.io/en/stable/troubleshooting.html{bcolors.ENDC}"
+        )
 
     if not info.get("dd_version"):
         summary += (
-            "\n\n{warning}WARNING VERSION NOT SET: It is recommended that a version tag be set for all traced"
+            f"\n\n{bcolors.WARNING}WARNING VERSION NOT SET: It is recommended that a version tag be set for all traced"
             " applications. For more information please see"
-            " https://ddtrace.readthedocs.io/en/stable/troubleshooting.html{end}"
-        ).format(warning=bcolors.WARNING, end=bcolors.ENDC)
+            f" https://ddtrace.readthedocs.io/en/stable/troubleshooting.html{bcolors.ENDC}"
+        )
 
     info_pretty += "\n\n" + summary
 

--- a/ddtrace/internal/dogstatsd.py
+++ b/ddtrace/internal/dogstatsd.py
@@ -26,4 +26,4 @@ def get_dogstatsd_client(url: str, namespace: Optional[str] = None, tags: Option
             constant_tags=tags,
         )
 
-    raise ValueError("Unknown scheme `%s` for DogStatsD URL `{}`".format(parsed.scheme))
+    raise ValueError(f"Unknown scheme `{parsed.scheme}` for DogStatsD URL `{url}`")

--- a/ddtrace/internal/rate_limiter.py
+++ b/ddtrace/internal/rate_limiter.py
@@ -155,12 +155,9 @@ class RateLimiter(object):
         return (self._current_window_rate() + self.prev_window_rate) / 2.0
 
     def __repr__(self):
-        return "{}(rate_limit={!r}, tokens={!r}, last_update_ns={!r}, effective_rate={!r})".format(
-            self.__class__.__name__,
-            self.rate_limit,
-            self.tokens,
-            self.last_update_ns,
-            self.effective_rate,
+        return (
+            f"{self.__class__.__name__}(rate_limit={self.rate_limit!r}, tokens={self.tokens!r}, "
+            f"last_update_ns={self.last_update_ns!r}, effective_rate={self.effective_rate!r})"
         )
 
 

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -338,18 +338,18 @@ class RemoteConfigClient:
         try:
             raw = base64.b64decode(candidates[0])
         except Exception:
-            raise RemoteConfigError("invalid base64 target_files for {!r}".format(target))
+            raise RemoteConfigError(f"invalid base64 target_files for {target!r}")
 
         computed_hash = hashlib.sha256(raw).hexdigest()
         if computed_hash != config.sha256_hash:
             raise RemoteConfigError(
-                "mismatch between target {!r} hashes {!r} != {!r}".format(target, computed_hash, config.sha256_hash)
+                f"mismatch between target {target!r} hashes {computed_hash!r} != {config.sha256_hash!r}"
             )
 
         try:
             return json.loads(raw)
         except Exception:
-            raise RemoteConfigError("invalid JSON content for target {!r}".format(target))
+            raise RemoteConfigError(f"invalid JSON content for target {target!r}")
 
     def _build_payload(self, state: Mapping[str, Any]) -> Mapping[str, Any]:
         self._client_tracer["extra_services"] = list(ddtrace.config._get_extra_services())
@@ -517,7 +517,7 @@ class RemoteConfigClient:
         for target, metadata in signed.targets.items():
             m = TARGET_FORMAT.match(target)
             if m is None:
-                raise RemoteConfigError("unexpected target format {!r}".format(target))
+                raise RemoteConfigError(f"unexpected target format {target!r}")
             _, product_name, config_id, _ = m.groups()
             targets[target] = ConfigMetadata(
                 id=config_id,

--- a/ddtrace/internal/runtime/collector.py
+++ b/ddtrace/internal/runtime/collector.py
@@ -81,9 +81,7 @@ class ValueCollector(object):
         return self.value
 
     def __repr__(self):
-        return "<{}(enabled={},periodic={},required_modules={})>".format(
-            self.__class__.__name__,
-            self.enabled,
-            self.periodic,
-            self.required_modules,
+        return (
+            f"<{self.__class__.__name__}(enabled={self.enabled},periodic={self.periodic},"
+            f"required_modules={self.required_modules})>"
         )

--- a/ddtrace/internal/runtime/container.py
+++ b/ddtrace/internal/runtime/container.py
@@ -37,10 +37,8 @@ class CGroupInfo:
     TASK_PATTERN = r"[0-9a-f]{32}-\d+"
 
     LINE_RE = re.compile(r"^(\d+):([^:]*):(.+)$")
-    POD_RE = re.compile(r"pod({0})(?:\.slice)?$".format(UUID_SOURCE_PATTERN))
-    CONTAINER_RE = re.compile(
-        r"(?:.+)?({0}|{1}|{2})(?:\.scope)?$".format(UUID_SOURCE_PATTERN, CONTAINER_SOURCE_PATTERN, TASK_PATTERN)
-    )
+    POD_RE = re.compile(rf"pod({UUID_SOURCE_PATTERN})(?:\.slice)?$")
+    CONTAINER_RE = re.compile(rf"(?:.+)?({UUID_SOURCE_PATTERN}|{CONTAINER_SOURCE_PATTERN}|{TASK_PATTERN})(?:\.scope)?$")
 
     def __init__(
         self,

--- a/ddtrace/internal/runtime/runtime_metrics.py
+++ b/ddtrace/internal/runtime/runtime_metrics.py
@@ -36,10 +36,7 @@ class RuntimeCollectorsIterable(object):
         return itertools.chain.from_iterable(collected)
 
     def __repr__(self):
-        return "{}(enabled={})".format(
-            self.__class__.__name__,
-            self._enabled,
-        )
+        return f"{self.__class__.__name__}(enabled={self._enabled})"
 
 
 class PlatformTags(RuntimeCollectorsIterable):
@@ -169,7 +166,7 @@ class RuntimeWorker(periodic.PeriodicService):
 
     def _format_tags(self, tags: RuntimeCollectorsIterable) -> List[str]:
         # DEV: ddstatsd expects tags in the form ['key1:value1', 'key2:value2', ...]
-        return ["{}:{}".format(k, v) for k, v in tags]
+        return [f"{k}:{v}" for k, v in tags]
 
     periodic = flush
     on_shutdown = flush

--- a/ddtrace/internal/sampling.py
+++ b/ddtrace/internal/sampling.py
@@ -42,9 +42,7 @@ class PriorityCategory(object):
     RULE_DYNAMIC = "rule_dynamic"
 
 
-SAMPLING_MECHANISM_CONSTANTS = {
-    "-{}".format(value) for name, value in vars(SamplingMechanism).items() if name.isupper()
-}
+SAMPLING_MECHANISM_CONSTANTS = {f"-{value}" for name, value in vars(SamplingMechanism).items() if name.isupper()}
 
 KNUTH_SAMPLE_RATE_KEY = "_dd.p.ksr"
 

--- a/ddtrace/internal/schema/__init__.py
+++ b/ddtrace/internal/schema/__init__.py
@@ -14,10 +14,8 @@ log = logging.getLogger(__name__)
 # Span attribute schema
 def _validate_schema(version):
     error_message = (
-        "You have specified an invalid span attribute schema version: '{}'.".format(version),
-        "Valid options are: {}. You can change the specified value by updating".format(
-            _SPAN_ATTRIBUTE_TO_FUNCTION.keys()
-        ),
+        f"You have specified an invalid span attribute schema version: '{version}'.",
+        f"Valid options are: {_SPAN_ATTRIBUTE_TO_FUNCTION.keys()}. You can change the specified value by updating",
         "the value exported in the 'DD_TRACE_SPAN_ATTRIBUTE_SCHEMA' environment variable.",
     )
 

--- a/ddtrace/internal/schema/span_attribute_schema.py
+++ b/ddtrace/internal/schema/span_attribute_schema.py
@@ -29,7 +29,7 @@ def database_operation_v0(v0_operation, database_provider=None):
 
 def database_operation_v1(v0_operation, database_provider=None):
     operation = "query"
-    return "{}.{}".format(database_provider, operation)
+    return f"{database_provider}.{operation}"
 
 
 def cache_operation_v0(v0_operation, cache_provider=None):
@@ -38,7 +38,7 @@ def cache_operation_v0(v0_operation, cache_provider=None):
 
 def cache_operation_v1(v0_operation, cache_provider=None):
     operation = "command"
-    return "{}.{}".format(cache_provider, operation)
+    return f"{cache_provider}.{operation}"
 
 
 def cloud_api_operation_v0(v0_operation, cloud_provider=None, cloud_service=None):
@@ -46,7 +46,7 @@ def cloud_api_operation_v0(v0_operation, cloud_provider=None, cloud_service=None
 
 
 def cloud_api_operation_v1(v0_operation, cloud_provider=None, cloud_service=None):
-    return "{}.{}.request".format(cloud_provider, cloud_service)
+    return f"{cloud_provider}.{cloud_service}.request"
 
 
 def cloud_faas_operation_v0(v0_operation, cloud_provider=None, cloud_service=None):
@@ -54,7 +54,7 @@ def cloud_faas_operation_v0(v0_operation, cloud_provider=None, cloud_service=Non
 
 
 def cloud_faas_operation_v1(v0_operation, cloud_provider=None, cloud_service=None):
-    return "{}.{}.invoke".format(cloud_provider, cloud_service)
+    return f"{cloud_provider}.{cloud_service}.invoke"
 
 
 def cloud_messaging_operation_v0(v0_operation, cloud_provider=None, cloud_service=None, direction=None):
@@ -63,11 +63,11 @@ def cloud_messaging_operation_v0(v0_operation, cloud_provider=None, cloud_servic
 
 def cloud_messaging_operation_v1(v0_operation, cloud_provider=None, cloud_service=None, direction=None):
     if direction == SpanDirection.INBOUND:
-        return "{}.{}.receive".format(cloud_provider, cloud_service)
+        return f"{cloud_provider}.{cloud_service}.receive"
     elif direction == SpanDirection.OUTBOUND:
-        return "{}.{}.send".format(cloud_provider, cloud_service)
+        return f"{cloud_provider}.{cloud_service}.send"
     elif direction == SpanDirection.PROCESSING:
-        return "{}.{}.process".format(cloud_provider, cloud_service)
+        return f"{cloud_provider}.{cloud_service}.process"
 
 
 def messaging_operation_v0(v0_operation, provider=None, service=None, direction=None):
@@ -76,11 +76,11 @@ def messaging_operation_v0(v0_operation, provider=None, service=None, direction=
 
 def messaging_operation_v1(v0_operation, provider=None, direction=None):
     if direction == SpanDirection.INBOUND:
-        return "{}.receive".format(provider)
+        return f"{provider}.receive"
     elif direction == SpanDirection.OUTBOUND:
-        return "{}.send".format(provider)
+        return f"{provider}.send"
     elif direction == SpanDirection.PROCESSING:
-        return "{}.process".format(provider)
+        return f"{provider}.process"
 
 
 def url_operation_v0(v0_operation, protocol=None, direction=None):
@@ -89,7 +89,7 @@ def url_operation_v0(v0_operation, protocol=None, direction=None):
 
 def url_operation_v1(v0_operation, protocol=None, direction=None):
     server_or_client = {SpanDirection.INBOUND: "server", SpanDirection.OUTBOUND: "client"}[direction]
-    return "{}.{}.request".format(protocol, server_or_client)
+    return f"{protocol}.{server_or_client}.request"
 
 
 _SPAN_ATTRIBUTE_TO_FUNCTION = {

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -820,7 +820,7 @@ class TelemetryWriter(PeriodicService):
                         1,
                         (("integration_name", integration_name), ("error_type", tp.__name__)),
                     )
-                    error_msg = "{}:{} {}".format(filename, lineno, str(value))
+                    error_msg = f"{filename}:{lineno} {str(value)}"
                     self.add_integration(integration_name, True, error_msg=error_msg)
 
             if self._enabled and not self.started and (app_started := self._app_started()):

--- a/ddtrace/internal/utils/formats.py
+++ b/ddtrace/internal/utils/formats.py
@@ -159,4 +159,4 @@ def flatten_key_value(root_key, value):
 
 def format_trace_id(trace_id: int) -> str:
     """Translate a trace ID to a string format supported by the backend."""
-    return "{:032x}".format(trace_id) if trace_id > MAX_UINT_64BITS else str(trace_id)
+    return f"{trace_id:032x}" if trace_id > MAX_UINT_64BITS else str(trace_id)

--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -151,24 +151,20 @@ def w3c_get_dd_list_member(context):
     # Context -> str
     tags = []
     if context.sampling_priority is not None:
-        tags.append("{}:{}".format(W3C_TRACESTATE_SAMPLING_PRIORITY_KEY, context.sampling_priority))
+        tags.append(f"{W3C_TRACESTATE_SAMPLING_PRIORITY_KEY}:{context.sampling_priority}")
     if context.dd_origin:
         tags.append(
-            "{}:{}".format(
-                W3C_TRACESTATE_ORIGIN_KEY,
-                w3c_encode_tag((_W3C_TRACESTATE_INVALID_CHARS_REGEX_VALUE, "_", context.dd_origin)),
-            )
+            f"{W3C_TRACESTATE_ORIGIN_KEY}:"
+            f"{w3c_encode_tag((_W3C_TRACESTATE_INVALID_CHARS_REGEX_VALUE, '_', context.dd_origin))}"
         )
 
     sampling_decision = context._meta.get(SAMPLING_DECISION_TRACE_TAG_KEY)
     if sampling_decision:
-        tags.append(
-            "t.dm:{}".format((w3c_encode_tag((_W3C_TRACESTATE_INVALID_CHARS_REGEX_VALUE, "_", sampling_decision))))
-        )
+        tags.append(f"t.dm:{w3c_encode_tag((_W3C_TRACESTATE_INVALID_CHARS_REGEX_VALUE, '_', sampling_decision))}")
     # since this can change, we need to grab the value off the current span
     usr_id = context._meta.get(_USER_ID_KEY)
     if usr_id:
-        tags.append("t.usr.id:{}".format(w3c_encode_tag((_W3C_TRACESTATE_INVALID_CHARS_REGEX_VALUE, "_", usr_id))))
+        tags.append(f"t.usr.id:{w3c_encode_tag((_W3C_TRACESTATE_INVALID_CHARS_REGEX_VALUE, '_', usr_id))}")
 
     current_tags_len = sum(len(i) for i in tags)
     for k, v in _get_metas_to_propagate(context):
@@ -176,9 +172,9 @@ def w3c_get_dd_list_member(context):
             # for key replace ",", "=", and characters outside the ASCII range 0x20 to 0x7E
             # for value replace ",", ";", "~" and characters outside the ASCII range 0x20 to 0x7E
             k = k.replace("_dd.p.", "t.")
-            next_tag = "{}:{}".format(
-                w3c_encode_tag((_W3C_TRACESTATE_INVALID_CHARS_REGEX_KEY, "_", k)),
-                w3c_encode_tag((_W3C_TRACESTATE_INVALID_CHARS_REGEX_VALUE, "_", v)),
+            next_tag = (
+                f"{w3c_encode_tag((_W3C_TRACESTATE_INVALID_CHARS_REGEX_KEY, '_', k))}:"
+                f"{w3c_encode_tag((_W3C_TRACESTATE_INVALID_CHARS_REGEX_VALUE, '_', v))}"
             )
             # we need to keep the total length under 256 char
             potential_current_tags_len = current_tags_len + len(next_tag)
@@ -202,7 +198,7 @@ def w3c_encode_tag(args):
 
 def w3c_tracestate_add_p(tracestate, span_id):
     # Adds last datadog parent_id to tracestate. This tag is used to reconnect a trace with non-datadog spans
-    p_member = "{}:{:016x}".format(W3C_TRACESTATE_PARENT_ID_KEY, span_id)
+    p_member = f"{W3C_TRACESTATE_PARENT_ID_KEY}:{span_id:016x}"
     if "dd=" in tracestate:
         return tracestate.replace("dd=", f"dd={p_member};")
     elif tracestate:
@@ -269,12 +265,9 @@ class Response(object):
             log.debug("Unable to parse Datadog Agent JSON response: %r", body, exc_info=True)
 
     def __repr__(self):
-        return "{0}(status={1!r}, body={2!r}, reason={3!r}, msg={4!r})".format(
-            self.__class__.__name__,
-            self.status,
-            self.body,
-            self.reason,
-            self.msg,
+        return (
+            f"{self.__class__.__name__}(status={self.status!r}, body={self.body!r}, "
+            f"reason={self.reason!r}, msg={self.msg!r})"
         )
 
 

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -203,7 +203,7 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
         )
 
     def _intake_endpoint(self, client=None):
-        return "{}/{}".format(self._intake_url(client), client.ENDPOINT if client else self._endpoint)
+        return f"{self._intake_url(client)}/{client.ENDPOINT if client else self._endpoint}"
 
     @property
     def _endpoint(self):
@@ -898,7 +898,7 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
             )
 
     def _intake_endpoint(self, client=None):
-        return "{}/{}".format(self.intake_url, client.ENDPOINT if client else self._endpoint)
+        return f"{self.intake_url}/{client.ENDPOINT if client else self._endpoint}"
 
     @property
     def _endpoint(self):


### PR DESCRIPTION
This PR is a follow up to https://github.com/DataDog/dd-trace-py/pull/14867.

It appears that f string are significantly more performant than using `.format()`. Therefore every format call is replaced by an f-string