### PR TITLE
chore(string): replace format by f-string in ddtrace/contrib

### DIFF
--- a/ddtrace/contrib/dbapi.py
+++ b/ddtrace/contrib/dbapi.py
@@ -54,7 +54,7 @@ class TracedCursor(wrapt.ObjectProxy):
         span_name = (
             cfg["_dbapi_span_operation_name"]
             if cfg and "_dbapi_span_operation_name" in cfg
-            else "{}.query".format(span_name_prefix)
+            else f"{span_name_prefix}.query"
         )
         self._self_datadog_name = span_name
         self._self_last_execute_operation = None
@@ -196,21 +196,21 @@ class FetchTracedCursor(TracedCursor):
 
     def fetchone(self, *args, **kwargs):
         """Wraps the cursor.fetchone method"""
-        span_name = "{}.{}".format(self._self_datadog_name, "fetchone")
+        span_name = f"{self._self_datadog_name}.fetchone"
         return self._trace_method(
             self.__wrapped__.fetchone, span_name, self._self_last_execute_operation, {}, None, *args, **kwargs
         )
 
     def fetchall(self, *args, **kwargs):
         """Wraps the cursor.fetchall method"""
-        span_name = "{}.{}".format(self._self_datadog_name, "fetchall")
+        span_name = f"{self._self_datadog_name}.fetchall"
         return self._trace_method(
             self.__wrapped__.fetchall, span_name, self._self_last_execute_operation, {}, None, *args, **kwargs
         )
 
     def fetchmany(self, *args, **kwargs):
         """Wraps the cursor.fetchmany method"""
-        span_name = "{}.{}".format(self._self_datadog_name, "fetchmany")
+        span_name = f"{self._self_datadog_name}.fetchmany"
         # We want to trace the information about how many rows were requested. Note that this number may be larger
         # the number of rows actually returned if less then requested are available from the query.
         size_tag_key = "db.fetch.size"
@@ -239,7 +239,7 @@ class TracedConnection(wrapt.ObjectProxy):
 
         super(TracedConnection, self).__init__(conn)
         name = _get_vendor(conn)
-        self._self_datadog_name = "{}.connection".format(name)
+        self._self_datadog_name = f"{name}.connection"
         db_pin = pin or Pin(service=name)
         db_pin.onto(self)
         # wrapt requires prefix of `_self` for attributes that are only in the
@@ -313,11 +313,11 @@ class TracedConnection(wrapt.ObjectProxy):
         return self._self_cursor_cls(cursor=cursor, pin=pin, cfg=self._self_config)
 
     def commit(self, *args, **kwargs):
-        span_name = "{}.{}".format(self._self_datadog_name, "commit")
+        span_name = f"{self._self_datadog_name}.commit"
         return self._trace_method(self.__wrapped__.commit, span_name, {}, *args, **kwargs)
 
     def rollback(self, *args, **kwargs):
-        span_name = "{}.{}".format(self._self_datadog_name, "rollback")
+        span_name = f"{self._self_datadog_name}.rollback"
         return self._trace_method(self.__wrapped__.rollback, span_name, {}, *args, **kwargs)
 
 

--- a/ddtrace/contrib/dbapi_async.py
+++ b/ddtrace/contrib/dbapi_async.py
@@ -136,21 +136,21 @@ class FetchTracedAsyncCursor(TracedAsyncCursor):
 
     async def fetchone(self, *args, **kwargs):
         """Wraps the cursor.fetchone method"""
-        span_name = "{}.{}".format(self._self_datadog_name, "fetchone")
+        span_name = f"{self._self_datadog_name}.fetchone"
         return await self._trace_method(
             self.__wrapped__.fetchone, span_name, self._self_last_execute_operation, {}, None, *args, **kwargs
         )
 
     async def fetchall(self, *args, **kwargs):
         """Wraps the cursor.fetchall method"""
-        span_name = "{}.{}".format(self._self_datadog_name, "fetchall")
+        span_name = f"{self._self_datadog_name}.fetchall"
         return await self._trace_method(
             self.__wrapped__.fetchall, span_name, self._self_last_execute_operation, {}, None, *args, **kwargs
         )
 
     async def fetchmany(self, *args, **kwargs):
         """Wraps the cursor.fetchmany method"""
-        span_name = "{}.{}".format(self._self_datadog_name, "fetchmany")
+        span_name = f"{self._self_datadog_name}.fetchmany"
         # We want to trace the information about how many rows were requested. Note that this number may be larger
         # the number of rows actually returned if less then requested are available from the query.
         size_tag_key = "db.fetch.size"
@@ -246,9 +246,9 @@ class TracedAsyncConnection(TracedConnection):
             return await method(*args, **kwargs)
 
     async def commit(self, *args, **kwargs):
-        span_name = "{}.{}".format(self._self_datadog_name, "commit")
+        span_name = f"{self._self_datadog_name}.commit"
         return await self._trace_method(self.__wrapped__.commit, span_name, {}, *args, **kwargs)
 
     async def rollback(self, *args, **kwargs):
-        span_name = "{}.{}".format(self._self_datadog_name, "rollback")
+        span_name = f"{self._self_datadog_name}.rollback"
         return await self._trace_method(self.__wrapped__.rollback, span_name, {}, *args, **kwargs)

--- a/ddtrace/contrib/internal/asgi/middleware.py
+++ b/ddtrace/contrib/internal/asgi/middleware.py
@@ -245,12 +245,12 @@ class TraceMiddleware:
             parsed_query = parse.parse_qs(bytes_to_str(scope.get("query_string", b"")))
             full_path = scope.get("path", "")
             if host_header:
-                url = "{}://{}{}".format(scheme, host_header, full_path)
+                url = f"{scheme}://{host_header}{full_path}"
             elif server and len(server) == 2:
                 port = server[1]
                 default_port = self.default_ports.get(scheme, None)
                 server_host = server[0] + (":" + str(port) if port is not None and port != default_port else "")
-                url = "{}://{}{}".format(scheme, server_host, full_path)
+                url = f"{scheme}://{server_host}{full_path}"
             else:
                 url = None
             query_string = scope.get("query_string")

--- a/ddtrace/contrib/internal/botocore/services/bedrock.py
+++ b/ddtrace/contrib/internal/botocore/services/bedrock.py
@@ -467,7 +467,7 @@ def patched_bedrock_api_call(original_func, instance, args, kwargs, function_var
         pin=pin,
         span_name=function_vars.get("trace_operation"),
         service=schematize_service_name(
-            "{}.{}".format(ext_service(pin, int_config=config.botocore), function_vars.get("endpoint_name"))
+            f'{ext_service(pin, int_config=config.botocore)}.{function_vars.get("endpoint_name")}'
         ),
         resource=function_vars.get("operation"),
         span_type=SpanTypes.LLM if submit_to_llmobs else None,

--- a/ddtrace/contrib/internal/botocore/services/bedrock_agents.py
+++ b/ddtrace/contrib/internal/botocore/services/bedrock_agents.py
@@ -83,10 +83,8 @@ def patched_bedrock_agents_api_call(original_func, instance, args, kwargs, funct
     result = None
     span = integration.trace(
         pin,
-        schematize_service_name(
-            "{}.{}".format(ext_service(pin, int_config=config.botocore), function_vars.get("endpoint_name"))
-        ),
-        span_name="Bedrock Agent {}".format(agent_id),
+        schematize_service_name(f'{ext_service(pin, int_config=config.botocore)}.{function_vars.get("endpoint_name")}'),
+        span_name=f"Bedrock Agent {agent_id}",
         submit_to_llmobs=True,
         interface_type="agent",
     )

--- a/ddtrace/contrib/internal/langchain/patch.py
+++ b/ddtrace/contrib/internal/langchain/patch.py
@@ -61,7 +61,7 @@ def traced_llm_generate(langchain_core, pin, func, instance, args, kwargs):
     prompts = get_argument_value(args, kwargs, 0, "prompts")
     span = integration.trace(
         pin,
-        "%s.%s" % (instance.__module__, instance.__class__.__name__),
+        f"{instance.__module__}.{instance.__class__.__name__}",
         submit_to_llmobs=True,
         interface_type="llm",
         provider=llm_provider,
@@ -95,7 +95,7 @@ async def traced_llm_agenerate(langchain_core, pin, func, instance, args, kwargs
     model = _extract_model_name(instance)
     span = integration.trace(
         pin,
-        "%s.%s" % (instance.__module__, instance.__class__.__name__),
+        f"{instance.__module__}.{instance.__class__.__name__}",
         submit_to_llmobs=True,
         interface_type="llm",
         provider=llm_provider,
@@ -128,7 +128,7 @@ def traced_chat_model_generate(langchain_core, pin, func, instance, args, kwargs
     integration: LangChainIntegration = langchain_core._datadog_integration
     span = integration.trace(
         pin,
-        "%s.%s" % (instance.__module__, instance.__class__.__name__),
+        f"{instance.__module__}.{instance.__class__.__name__}",
         submit_to_llmobs=True,
         interface_type="chat_model",
         provider=llm_provider,
@@ -161,7 +161,7 @@ async def traced_chat_model_agenerate(langchain_core, pin, func, instance, args,
     integration: LangChainIntegration = langchain_core._datadog_integration
     span = integration.trace(
         pin,
-        "%s.%s" % (instance.__module__, instance.__class__.__name__),
+        f"{instance.__module__}.{instance.__class__.__name__}",
         submit_to_llmobs=True,
         interface_type="chat_model",
         provider=llm_provider,
@@ -204,7 +204,7 @@ def traced_lcel_runnable_sequence(langchain_core, pin, func, instance, args, kwa
     integration: LangChainIntegration = langchain_core._datadog_integration
     span = integration.trace(
         pin,
-        "{}.{}".format(instance.__module__, instance.__class__.__name__),
+        f"{instance.__module__}.{instance.__class__.__name__}",
         submit_to_llmobs=True,
         interface_type="chain",
         instance=instance,
@@ -239,7 +239,7 @@ async def traced_lcel_runnable_sequence_async(langchain_core, pin, func, instanc
     integration: LangChainIntegration = langchain_core._datadog_integration
     span = integration.trace(
         pin,
-        "{}.{}".format(instance.__module__, instance.__class__.__name__),
+        f"{instance.__module__}.{instance.__class__.__name__}",
         submit_to_llmobs=True,
         interface_type="chain",
         instance=instance,
@@ -387,7 +387,7 @@ def traced_base_tool_invoke(langchain_core, pin, func, instance, args, kwargs):
 
     span = integration.trace(
         pin,
-        "%s" % func.__self__.name,
+        f"{func.__self__.name}",
         interface_type="tool",
         submit_to_llmobs=True,
         instance=instance,
@@ -428,7 +428,7 @@ async def traced_base_tool_ainvoke(langchain_core, pin, func, instance, args, kw
 
     span = integration.trace(
         pin,
-        "%s" % func.__self__.name,
+        f"{func.__self__.name}",
         interface_type="tool",
         submit_to_llmobs=True,
         instance=instance,
@@ -532,7 +532,7 @@ def traced_embedding(langchain_core, pin, func, instance, args, kwargs):
     integration: LangChainIntegration = langchain_core._datadog_integration
     span = integration.trace(
         pin,
-        "%s.%s" % (instance.__module__, instance.__class__.__name__),
+        f"{instance.__module__}.{instance.__class__.__name__}",
         submit_to_llmobs=True,
         interface_type="embedding",
         provider=provider,
@@ -560,7 +560,7 @@ def traced_similarity_search(langchain_core, pin, func, instance, args, kwargs):
     provider = instance.__class__.__name__.lower()
     span = integration.trace(
         pin,
-        "%s.%s" % (instance.__module__, instance.__class__.__name__),
+        f"{instance.__module__}.{instance.__class__.__name__}",
         submit_to_llmobs=True,
         interface_type="similarity_search",
         provider=provider,

--- a/ddtrace/contrib/internal/molten/wrappers.py
+++ b/ddtrace/contrib/internal/molten/wrappers.py
@@ -40,7 +40,7 @@ class WrapperComponent(wrapt.ObjectProxy):
     def can_handle_parameter(self, *args, **kwargs):
         func = self.__wrapped__.can_handle_parameter
         cname = func_name(self.__wrapped__)
-        resource = "{}.{}".format(cname, func.__name__)
+        resource = f"{cname}.{func.__name__}"
         return trace_wrapped(resource, func, *args, **kwargs)
 
 
@@ -48,7 +48,7 @@ class WrapperRenderer(wrapt.ObjectProxy):
     def render(self, *args, **kwargs):
         func = self.__wrapped__.render
         cname = func_name(self.__wrapped__)
-        resource = "{}.{}".format(cname, func.__name__)
+        resource = f"{cname}.{func.__name__}"
         return trace_wrapped(resource, func, *args, **kwargs)
 
 

--- a/ddtrace/contrib/internal/openai/patch.py
+++ b/ddtrace/contrib/internal/openai/patch.py
@@ -135,8 +135,8 @@ def patch():
             log.debug("WARNING: resource %s is not found", resource)
             continue
         for method_name, endpoint_hook in method_hook_dict.items():
-            sync_method = "resources.{}.{}".format(resource, method_name)
-            async_method = "resources.{}.{}".format(".Async".join(resource.split(".")), method_name)
+            sync_method = f"resources.{resource}.{method_name}"
+            async_method = f"resources.{".Async".join(resource.split("."))}.{method_name}"
             if deep_getattr(openai, sync_method) is not None:
                 wrap(openai, sync_method, _patched_endpoint(openai, endpoint_hook))
             if deep_getattr(openai, async_method) is not None:

--- a/ddtrace/contrib/internal/psycopg/async_connection.py
+++ b/ddtrace/contrib/internal/psycopg/async_connection.py
@@ -25,7 +25,7 @@ class Psycopg3TracedAsyncConnection(dbapi_async.TracedAsyncConnection):
 
     async def execute(self, *args, **kwargs):
         """Execute a query and return a cursor to read its results."""
-        span_name = "{}.{}".format(self._self_datadog_name, "execute")
+        span_name = f"{self._self_datadog_name}.execute"
 
         async def patched_execute(*args, **kwargs):
             try:
@@ -50,7 +50,7 @@ def patched_connect_async_factory(psycopg_module):
         else:
             with core.context_with_data(
                 "psycopg.patched_connect",
-                span_name="{}.{}".format(connect_func.__module__, connect_func.__name__),
+                span_name=f"{connect_func.__module__}.{connect_func.__name__}",
                 service=ext_service(pin, pin._config),
                 span_type=SpanTypes.SQL,
                 pin=pin,

--- a/ddtrace/contrib/internal/psycopg/connection.py
+++ b/ddtrace/contrib/internal/psycopg/connection.py
@@ -94,7 +94,7 @@ def patched_connect_factory(psycopg_module):
         else:
             with core.context_with_data(
                 "psycopg.patched_connect",
-                span_name="{}.{}".format(connect_func.__module__, connect_func.__name__),
+                span_name=f"{connect_func.__module__}.{connect_func.__name__}",
                 service=ext_service(pin, pin._config),
                 span_type=SpanTypes.SQL,
                 pin=pin,

--- a/ddtrace/contrib/internal/pymemcache/client.py
+++ b/ddtrace/contrib/internal/pymemcache/client.py
@@ -327,7 +327,7 @@ def _trace(func, p, method_name, *args, **kwargs):
             span.set_tags(p.tags)
             if config.pymemcache.command_enabled:
                 vals = _get_query_string(args)
-                query = "{}{}{}".format(method_name, " " if vals else "", vals)
+                query = f'{method_name}{" " if vals else ""}{vals}'
                 span.set_tag_str(memcachedx.QUERY, query)
         except Exception:
             log.debug("Error setting relevant pymemcache tags")

--- a/ddtrace/contrib/internal/pymongo/client.py
+++ b/ddtrace/contrib/internal/pymongo/client.py
@@ -327,9 +327,9 @@ def _set_query_metadata(span, cmd):
         # dict keys like {u'foo':'bar'}
         q = json.dumps(nq)
         span.set_tag("mongodb.query", q)
-        span.resource = "{} {} {}".format(cmd.name, cmd.coll, q)
+        span.resource = f"{cmd.name} {cmd.coll} {q}"
     else:
-        span.resource = "{} {}".format(cmd.name, cmd.coll)
+        span.resource = f"{cmd.name} {cmd.coll}"
 
 
 def set_query_rowcount(docs, span):

--- a/ddtrace/contrib/internal/pyramid/trace.py
+++ b/ddtrace/contrib/internal/pyramid/trace.py
@@ -103,7 +103,7 @@ def trace_tween_factory(handler, registry):
                 finally:
                     # set request tags
                     if request.matched_route:
-                        req_span.resource = "{} {}".format(request.method, request.matched_route.name)
+                        req_span.resource = f"{request.method} {request.matched_route.name}"
                         req_span.set_tag_str("pyramid.route.name", request.matched_route.name)
                     # set response tags
                     if response:

--- a/ddtrace/contrib/internal/pytest/_report_links.py
+++ b/ddtrace/contrib/internal/pytest/_report_links.py
@@ -68,7 +68,7 @@ def _build_test_commit_redirect_url(base_url, ci_tags, service, env):
     url_format = "/ci/redirect/tests/{repo_url}/-/{service}/-/{branch}/-/{commit_sha}"
     url = base_url + url_format.format(**{k: quote(v, safe="") for k, v in params.items()})
     if env:
-        url += f"?env={env}".format(env=quote(env, safe=""))
+        url += f"?env={quote(env, safe='')}"
 
     return url
 
@@ -88,7 +88,7 @@ def _build_test_runs_url(base_url, ci_tags):
     if not (ci_job_name and ci_pipeline_id):
         return None
 
-    query = "@ci.job.name:{} @ci.pipeline.id:{}".format(_quote_for_query(ci_job_name), _quote_for_query(ci_pipeline_id))
+    query = f"@ci.job.name:{_quote_for_query(ci_job_name)} @ci.pipeline.id:{_quote_for_query(ci_pipeline_id)}"
 
     url_format = "/ci/test-runs?query={query}&index=citest"
     url = base_url + url_format.format(query=quote(query, safe=""))

--- a/ddtrace/contrib/internal/pytest/_retry_utils.py
+++ b/ddtrace/contrib/internal/pytest/_retry_utils.py
@@ -51,7 +51,7 @@ def set_retry_num(item: pytest.Item, retry_num: int):
 
 def _get_retry_attempt_string(report: pytest_TestReport) -> str:
     retry_number = get_retry_num(report)
-    return "ATTEMPT {} ".format(retry_number) if retry_number else "INITIAL ATTEMPT "
+    return f"ATTEMPT {retry_number} " if retry_number else "INITIAL ATTEMPT "
 
 
 def _get_outcome_from_retry(

--- a/ddtrace/contrib/internal/pytest/_utils.py
+++ b/ddtrace/contrib/internal/pytest/_utils.py
@@ -132,9 +132,9 @@ def _get_session_command(session: pytest.Session):
     """Extract and re-create pytest session command from pytest config."""
     command = "pytest"
     if getattr(session.config, "invocation_params", None):
-        command += " {}".format(" ".join(session.config.invocation_params.args))
+        command += f' {" ".join(session.config.invocation_params.args)}'
     if _get_config("PYTEST_ADDOPTS", False, asbool):
-        command += " {}".format(_get_config("PYTEST_ADDOPTS", False, asbool))
+        command += f' {_get_config("PYTEST_ADDOPTS", False, asbool)}'
     return command
 
 

--- a/ddtrace/contrib/internal/sanic/patch.py
+++ b/ddtrace/contrib/internal/sanic/patch.py
@@ -118,7 +118,7 @@ async def patch_run_request_middleware(wrapped, instance, args, kwargs):
     request = args[0]
     span = _get_current_span(request)
     if span is not None:
-        span.resource = "{} {}".format(request.method, _get_path(request))
+        span.resource = f"{request.method} {_get_path(request)}"
     return await wrapped(*args, **kwargs)
 
 
@@ -196,7 +196,7 @@ def _create_sanic_request_span(request):
 
     if SANIC_VERSION < (21, 0, 0):
         # Set span resource from the framework request
-        resource = "{} {}".format(request.method, _get_path(request))
+        resource = f"{request.method} {_get_path(request)}"
     else:
         # The path is not available anymore in 21.x. Get it from
         # the _run_request_middleware instrumented method.
@@ -223,7 +223,7 @@ def _create_sanic_request_span(request):
         core.dispatch("web.request.start", (ctx, config.sanic))
 
         method = request.method
-        url = "{scheme}://{host}{path}".format(scheme=request.scheme, host=request.host, path=request.path)
+        url = f"{request.scheme}://{request.host}{request.path}"
         query_string = request.query_string
         if isinstance(query_string, bytes):
             query_string = query_string.decode()
@@ -249,11 +249,11 @@ async def sanic_http_routing_after(request, route, kwargs, handler):
     pattern = route.raw_path
     # Sanic 21.9.0 and newer strip the leading slash from `route.raw_path`
     if not pattern.startswith("/"):
-        pattern = "/{}".format(pattern)
+        pattern = f"/{pattern}"
     if route.regex:
         pattern = route.pattern
 
-    span.resource = "{} {}".format(request.method, pattern)
+    span.resource = f"{request.method} {pattern}"
     span.set_tag_str("sanic.route.name", route.name)
 
 

--- a/ddtrace/contrib/internal/starlette/patch.py
+++ b/ddtrace/contrib/internal/starlette/patch.py
@@ -171,7 +171,7 @@ def traced_handler(wrapped, instance, args, kwargs):
             path = "".join(resource_paths[index:])
 
             if scope.get("method"):
-                span.resource = "{} {}".format(scope["method"], path)
+                span.resource = f'{scope["method"]} {path}'
             else:
                 span.resource = path
             # route should only be in the root span
@@ -181,7 +181,7 @@ def traced_handler(wrapped, instance, args, kwargs):
     elif request_spans and resource_paths:
         route = "".join(resource_paths)
         if scope.get("method"):
-            request_spans[0].resource = "{} {}".format(scope["method"], route)
+            request_spans[0].resource = f'{scope["method"]} {route}'
         else:
             request_spans[0].resource = route
         request_spans[0].set_tag_str(http.ROUTE, route)

--- a/ddtrace/contrib/internal/tornado/handlers.py
+++ b/ddtrace/contrib/internal/tornado/handlers.py
@@ -87,7 +87,7 @@ def on_finish(func, handler, args, kwargs):
         # default handler class will be used so we don't pollute the resource
         # space here
         klass = handler.__class__
-        request_span.resource = "{}.{}".format(klass.__module__, klass.__name__)
+        request_span.resource = f"{klass.__module__}.{klass.__name__}"
         core.dispatch(
             "web.request.finish",
             (

--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -627,7 +627,7 @@ def extract_netloc_and_query_info_from_url(url):
 
     # Relative URLs don't have a netloc, so we force them
     if not parse_result.netloc:
-        parse_result = parse.urlparse("//{url}".format(url=url))
+        parse_result = parse.urlparse(f"//{url}")
 
     netloc = parse_result.netloc.split("@", 1)[-1]  # Discard auth info
     netloc = netloc.split(":", 1)[0]  # Discard port information

--- a/ddtrace/contrib/internal/trace_utils_base.py
+++ b/ddtrace/contrib/internal/trace_utils_base.py
@@ -48,7 +48,7 @@ def _normalize_tag_name(request_or_response: str, header_name: str) -> str:
     #   - any digit is left unchanged
     #   - any block of any length of different ASCII chars is converted to a single underscore '_'
     normalized_name = _normalized_header_name(header_name)
-    return "http.{}.headers.{}".format(request_or_response, normalized_name)
+    return f"http.{request_or_response}.headers.{normalized_name}"
 
 
 def _get_header_value_case_insensitive(headers: Mapping[str, str], keyname: str) -> Optional[str]:

--- a/ddtrace/contrib/internal/unittest/patch.py
+++ b/ddtrace/contrib/internal/unittest/patch.py
@@ -268,19 +268,19 @@ def _extract_module_file_path(item) -> str:
 
 
 def _generate_test_resource(suite_name: str, test_name: str) -> str:
-    return "{}.{}".format(suite_name, test_name)
+    return f"{suite_name}.{test_name}"
 
 
 def _generate_suite_resource(test_suite: str) -> str:
-    return "{}".format(test_suite)
+    return f"{test_suite}"
 
 
 def _generate_module_resource(test_module: str) -> str:
-    return "{}".format(test_module)
+    return f"{test_module}"
 
 
 def _generate_session_resource(test_command: str) -> str:
-    return "{}".format(test_command)
+    return f"{test_command}"
 
 
 def _set_test_skipping_tags_to_span(span: ddtrace.trace.Span):
@@ -336,7 +336,7 @@ def _is_invoked_by_text_test_runner() -> bool:
 
 
 def _generate_module_suite_path(test_module_path: str, test_suite_name: str) -> str:
-    return "{}.{}".format(test_module_path, test_suite_name)
+    return f"{test_module_path}.{test_suite_name}"
 
 
 def _populate_suites_and_modules(test_objects: list, seen_suites: dict, seen_modules: dict):
@@ -584,9 +584,7 @@ def handle_test_wrapper(func, instance, args: tuple, kwargs: dict):
                     span.set_tag_str(test.ITR_UNSKIPPABLE, "true")
                     test_module_span.set_tag_str(test.ITR_UNSKIPPABLE, "true")
                     test_session_span.set_tag_str(test.ITR_UNSKIPPABLE, "true")
-                test_module_suite_path_without_extension = "{}/{}".format(
-                    os.path.splitext(test_module_path)[0], test_suite_name
-                )
+                test_module_suite_path_without_extension = f"{os.path.splitext(test_module_path)[0]}/{test_suite_name}"
                 if _should_be_skipped_by_itr(args, test_module_suite_path_without_extension, test_name, instance):
                     if _is_marked_as_unskippable(instance):
                         span.set_tag_str(test.ITR_FORCED_RUN, "true")

--- a/ddtrace/contrib/internal/urllib3/patch.py
+++ b/ddtrace/contrib/internal/urllib3/patch.py
@@ -102,7 +102,7 @@ def _wrap_urlopen(func, instance, args, kwargs):
         request_url = parse.urlunparse(
             (
                 instance.scheme,
-                "{}:{}".format(instance.host, instance.port)
+                f"{instance.host}:{instance.port}"
                 if instance.port and instance.port not in DROP_PORTS
                 else str(instance.host),
                 request_url,

--- a/ddtrace/contrib/internal/vertica/patch.py
+++ b/ddtrace/contrib/internal/vertica/patch.py
@@ -178,7 +178,7 @@ def _find_routine_config(config, instance, routine_name):
     """
     bases = instance.__class__.__mro__
     for base in bases:
-        full_name = "{}.{}".format(base.__module__, base.__name__)
+        full_name = f"{base.__module__}.{base.__name__}"
         if full_name not in config["patch"]:
             continue
 
@@ -190,7 +190,7 @@ def _find_routine_config(config, instance, routine_name):
 
 
 def _install_init(patch_item, patch_class, patch_mod, config):
-    patch_class_routine = "{}.{}".format(patch_class, "__init__")
+    patch_class_routine = f"{patch_class}.__init__"
 
     # patch the __init__ of the class with a Pin instance containing the defaults
     @wrapt.patch_function_wrapper(patch_mod, patch_class_routine)
@@ -206,7 +206,7 @@ def _install_init(patch_item, patch_class, patch_mod, config):
 
 
 def _install_routine(patch_routine, patch_class, patch_mod, config):
-    patch_class_routine = "{}.{}".format(patch_class, patch_routine)
+    patch_class_routine = f"{patch_class}.{patch_routine}"
 
     @wrapt.patch_function_wrapper(patch_mod, patch_class_routine)
     def wrapper(wrapped, instance, args, kwargs):

--- a/ddtrace/contrib/internal/wsgi/wsgi.py
+++ b/ddtrace/contrib/internal/wsgi/wsgi.py
@@ -261,7 +261,7 @@ def get_request_headers(environ):
 
 
 def default_wsgi_span_modifier(span, environ):
-    span.resource = "{} {}".format(environ["REQUEST_METHOD"], environ["PATH_INFO"])
+    span.resource = f'{environ["REQUEST_METHOD"]} {environ["PATH_INFO"]}'
 
 
 class DDWSGIMiddleware(_DDWSGIMiddlewareBase):


### PR DESCRIPTION
This PR is a follow up to https://github.com/DataDog/dd-trace-py/pull/14867.

It appears that f string are significantly more performant than using .format(). Therefore every format call is replaced by an f-string