### PR TITLE
perf(string): replace format by f-string in ddtrace/_trace

### DIFF
--- a/ddtrace/_trace/_span_link.py
+++ b/ddtrace/_trace/_span_link.py
@@ -94,8 +94,8 @@ class SpanLink:
 
     def to_dict(self):
         d = {
-            "trace_id": "{:032x}".format(self.trace_id),
-            "span_id": "{:016x}".format(self.span_id),
+            "trace_id": f"{self.trace_id:032x}",
+            "span_id": f"{self.span_id:016x}",
         }
         if self.attributes:
             d["attributes"] = {}

--- a/ddtrace/_trace/context.py
+++ b/ddtrace/_trace/context.py
@@ -157,9 +157,9 @@ class Context(object):
             # grab the original traceparent trace id, not the converted value
             trace_id = tp.split("-")[1]
         else:
-            trace_id = "{:032x}".format(self.trace_id)
+            trace_id = f"{self.trace_id:032x}"
 
-        return "00-{}-{:016x}-{}".format(trace_id, self.span_id, self._traceflags)
+        return f"00-{trace_id}-{self.span_id:016x}-{self._traceflags}"
 
     @property
     def _traceflags(self) -> str:
@@ -175,12 +175,12 @@ class Context(object):
             # cut out the original dd list member from tracestate so we can replace it with the new one we created
             ts_w_out_dd = re.sub("dd=(.+?)(?:,|$)", "", ts)
             if ts_w_out_dd:
-                ts = "dd={},{}".format(dd_list_member, ts_w_out_dd)
+                ts = f"dd={dd_list_member},{ts_w_out_dd}"
             else:
-                ts = "dd={}".format(dd_list_member)
+                ts = f"dd={dd_list_member}"
         # if there is no original tracestate value then tracestate is just the dd list member we created
         elif dd_list_member:
-            ts = "dd={}".format(dd_list_member)
+            ts = f"dd={dd_list_member}"
         return ts
 
     @property

--- a/ddtrace/_trace/sampler.py
+++ b/ddtrace/_trace/sampler.py
@@ -132,12 +132,9 @@ class DatadogSampler:
 
     def __str__(self):
         rates = {key: sampler.sample_rate for key, sampler in self._agent_based_samplers.items()}
-        return "{}(agent_rates={!r}, limiter={!r}, rules={!r}), rate_limit_always_on={!r}".format(
-            self.__class__.__name__,
-            rates,
-            self.limiter,
-            self.rules,
-            self._rate_limit_always_on,
+        return (
+            f"{self.__class__.__name__}(agent_rates={rates!r}, limiter={self.limiter!r}, "
+            f"rules={self.rules!r}), rate_limit_always_on={self._rate_limit_always_on!r}"
         )
 
     __repr__ = __str__

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -103,7 +103,7 @@ def _get_64_lowest_order_bits_as_int(large_int: int) -> int:
 
 def _get_64_highest_order_bits_as_hex(large_int: int) -> str:
     """Get the 64 highest order bits from a 128bit integer"""
-    return "{:032x}".format(large_int)[:16]
+    return f"{large_int:032x}"[:16]
 
 
 class Span(object):

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -208,7 +208,7 @@ def _on_web_framework_finish_request(
             status_code = int(status_code)
         except ValueError:
             pass
-        span.resource = "{} {}".format(method, status_code)
+        span.resource = f"{method} {status_code}"
     trace_utils.set_http_meta(
         span=span,
         integration_config=int_config,
@@ -952,10 +952,7 @@ def _on_azure_message_modifier(
 def _on_router_match(route):
     req_span = core.get_item("req_span")
     core.set_item("set_resource", False)
-    req_span.resource = "{} {}".format(
-        route.method,
-        route.template,
-    )
+    req_span.resource = f"{route.method} {route.template}"
 
     MOLTEN_ROUTE = "molten.route"
 


### PR DESCRIPTION
This PR is a follow up to https://github.com/DataDog/dd-trace-py/pull/14867.

It appears that f string are significantly more performant than using `.format()`. Therefore every format call is replaced by an f-string