### PR TITLE
ci: increase otelspan-add-metrics/tags RSS thresholds

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
@@ -799,11 +799,11 @@ experiments:
           - name: otelspan-add-metrics
             thresholds:
               - execution_time < 344.80 ms
-              - max_rss_usage < 600.00 MB
+              - max_rss_usage < 630.00 MB
           - name: otelspan-add-tags
             thresholds:
               - execution_time < 314.00 ms
-              - max_rss_usage < 600.00 MB
+              - max_rss_usage < 630.00 MB
           - name: otelspan-get-context
             thresholds:
               - execution_time < 92.35 ms


### PR DESCRIPTION
## Description

These two scenarios are consistently being flaky on RSS.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

The RSS usage for these two scenarios is _really_ high >600mb when the others are <50mb.

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
