### PR TITLE
fix: cleanup_loaded_modules: dont clean up modules that have not finished loading [backport 3.14]

### DIFF
--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -45,6 +45,20 @@ if "gevent" in sys.modules or "gevent.monkey" in sys.modules:
 def cleanup_loaded_modules():
     def drop(module_name):
         # type: (str) -> None
+        module = sys.modules.get(module_name)
+        # Don't delete modules that are currently being imported (they might be None or incomplete)
+        # or that don't exist. This can happen when pytest's assertion rewriter is importing modules
+        # that themselves import ddtrace.auto, which triggers this cleanup during the import process.
+        if module is None:
+            return
+        # Skip modules that don't have a __spec__ attribute yet (still being imported)
+        if not hasattr(module, "__spec__"):
+            return
+        # Check if the module is currently being initialized
+        # During import, __spec__._initializing is True
+        spec = getattr(module, "__spec__", None)
+        if spec is not None and getattr(spec, "_initializing", False):
+            return
         del sys.modules[module_name]
 
     MODULES_REQUIRING_CLEANUP = ("gevent",)

--- a/releasenotes/notes/pytest-ddtrace-auto-e6c09074a4b0af3d.yaml
+++ b/releasenotes/notes/pytest-ddtrace-auto-e6c09074a4b0af3d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix some modules being unloaded too soon when using pytest + ddtrace + gevent.

--- a/tests/internal/test_auto.py
+++ b/tests/internal/test_auto.py
@@ -1,18 +1,105 @@
+from pathlib import Path
+import subprocess
 import sys
+import tempfile
 
 import pytest
 
 
-@pytest.mark.skipif(sys.version_info < (3, 12, 5), reason="Python < 3.12.5 eagerly loads the threading module")
+# DEV: This test must pass ALWAYS. If this test fails, it means that something
+# needs to be fixed somewhere. Please DO NOT skip this test under any
+# circumstance!
 @pytest.mark.subprocess(
     env=dict(
         DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE="true",
-        DD_REMOTE_CONFIGURATION_ENABLED="1",
-    )
+    ),
+    parametrize={
+        "DD_REMOTE_CONFIGURATION_ENABLED": ("1", "0"),
+    },
 )
 def test_auto():
+    import os
     import sys
 
     import ddtrace.auto  # noqa:F401
 
     assert "threading" not in sys.modules
+    assert "socket" not in sys.modules
+    assert "subprocess" not in sys.modules
+
+    if os.getenv("DD_REMOTE_CONFIGURATION_ENABLED") == "0":
+        # When unloading modules we must have the HTTP clients imported already
+        assert "ddtrace.internal.http" in sys.modules
+
+        # emulate socket patching (e.g. by gevent)
+        import socket  # noqa:F401
+
+        socket.create_connection = None
+        socket.socket = None
+
+        from ddtrace.internal.http import HTTPConnection  # noqa:F401
+        import ddtrace.internal.uds as uds
+
+        assert HTTPConnection("localhost")._create_connection is not None
+        assert uds.socket.socket is not None
+
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="Test requires Python 3.8+")
+def test_pytest_with_gevent_and_ddtrace_auto():
+    """
+    Test that pytest works when a module imports ddtrace.auto and gevent is installed.
+
+    This is a regression test for an issue where cleanup_loaded_modules() would delete
+    modules from sys.modules while they were still being imported by pytest's assertion
+    rewriter, causing a KeyError during import.
+
+    The fix checks if a module's __spec__._initializing is True before deleting it.
+    """
+    pytest.importorskip("pytest")
+    pytest.importorskip("gevent")
+
+    # Create a temporary directory with test files
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+
+        # Create a module that imports ddtrace.auto
+        foo_module = tmpdir_path / "foo.py"
+        foo_module.write_text(
+            """import ddtrace.auto
+A = 1
+"""
+        )
+
+        # Create a test file that imports the module
+        test_file = tmpdir_path / "test_foo.py"
+        test_file.write_text(
+            """from foo import A
+
+def test_foo():
+    assert A == 1
+"""
+        )
+
+        # Run pytest as a subprocess with the current ddtrace on PYTHONPATH
+        import os
+
+        import ddtrace
+
+        ddtrace_path = str(Path(ddtrace.__file__).parent.parent)
+        env = os.environ.copy()
+        # Prepend ddtrace path to PYTHONPATH to ensure we use the local version
+        env["PYTHONPATH"] = ddtrace_path + os.pathsep + env.get("PYTHONPATH", "")
+
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", str(test_file), "-v"],
+            cwd=tmpdir,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        # The test should pass without KeyError
+        assert result.returncode == 0, f"pytest failed:\nSTDOUT:\n{result.stdout}\n\nSTDERR:\n{result.stderr}"
+        assert "KeyError" not in result.stdout
+        assert "KeyError" not in result.stderr
+        assert "1 passed" in result.stdout


### PR DESCRIPTION

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing
strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note
guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if
[applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist
- [x] Reviewer has checked that all the criteria below are met 
- Title is accurate
- All changes are related to the pull request's stated goal
- Avoids breaking
[API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces)
changes
- Testing strategy adequately addresses listed risks
- Newly-added code is easy to change
- Release note makes sense to a user of the library
- If necessary, author has acknowledged and discussed the performance
implications of this PR as reported in the benchmarks PR comment
- Backport labels are set in a manner that is consistent with the
[release branch maintenance
policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)
