### PR TITLE
ci: increase build_docs timeout

### DIFF
--- a/scripts/gen_gitlab_config.py
+++ b/scripts/gen_gitlab_config.py
@@ -218,6 +218,7 @@ def gen_build_docs() -> None:
             print("  artifacts:", file=f)
             print("    paths:", file=f)
             print("      - 'docs/'", file=f)
+            print("  timeout: 25m", file=f)
 
 
 def gen_pre_checks() -> None:


### PR DESCRIPTION
## Description

Increase build_docs job timeout as it is frequently timing out.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
