### PR TITLE
perf(co): retrieve context from spans

### DIFF
--- a/ddtrace/debugging/_origin/span.py
+++ b/ddtrace/debugging/_origin/span.py
@@ -166,7 +166,7 @@ class EntrySpanWrappingContext(WrappingContext):
 
         # Check if we have any level 2 debugging sessions running for the
         # current trace
-        if any(s.level >= 2 for s in Session.from_trace()):
+        if any(s.level >= 2 for s in Session.from_trace(root.context or span.context)):
             # Create a snapshot
             snapshot = Snapshot(
                 probe=self.location.probe,
@@ -270,7 +270,7 @@ class SpanCodeOriginProcessorExit(SpanProcessor):
 
                 # Check if we have any level 2 debugging sessions running for
                 # the current trace
-                if any(s.level >= 2 for s in Session.from_trace()):
+                if any(s.level >= 2 for s in Session.from_trace(span.context)):
                     # Create a snapshot
                     snapshot = Snapshot(
                         probe=ExitSpanProbe.from_frame(frame),

--- a/ddtrace/debugging/_session.py
+++ b/ddtrace/debugging/_session.py
@@ -75,8 +75,8 @@ class Session:
         return self._counts.get(probe_id, 0)
 
     @classmethod
-    def from_trace(cls) -> t.List["Session"]:
-        return SessionManager.get_sessions_for_trace()
+    def from_trace(cls, trace_context: t.Optional[t.Any] = None) -> t.List["Session"]:
+        return SessionManager.get_sessions_for_trace(trace_context)
 
     @classmethod
     def lookup(cls, ident: SessionId) -> t.Optional["Session"]:
@@ -112,12 +112,12 @@ class SessionManager:
         cls._sessions_trace_map.get(context, {}).pop(session.ident, None)
 
     @classmethod
-    def get_sessions_for_trace(cls) -> t.List[Session]:
-        context = tracer.current_trace_context()
-        if context is None:
-            return []
-
-        return list(cls._sessions_trace_map.get(context, {}).values())
+    def get_sessions_for_trace(cls, trace_context: t.Optional[t.Any] = None) -> t.List[Session]:
+        return (
+            list(cls._sessions_trace_map.get(context, {}).values())
+            if cls._sessions_trace_map and (context := (trace_context or tracer.current_trace_context())) is not None
+            else []
+        )
 
     @classmethod
     def lookup_session(cls, ident: SessionId) -> t.Optional[Session]:


### PR DESCRIPTION
We retrieve the context object that we use to link sessions to traces directly from span objects to avoid triggering more expensive tracer logic by querying for the current running context from the tracer itself