### PR TITLE
fix(bedrock): check list length before access to prevent IndexError

### DIFF
--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -373,7 +373,7 @@ class BedrockIntegration(BaseLLMIntegration):
         """
         if isinstance(response["text"], str):
             return [Message(content=response["text"])]
-        if isinstance(response["text"], list):
+        if isinstance(response["text"], list) and len(response["text"]) > 0:
             if isinstance(response["text"][0], str):
                 return [Message(content=str(content)) for content in response["text"]]
             if isinstance(response["text"][0], dict):


### PR DESCRIPTION
## Description

Trivial fix for IndexError reported in #14575

## Testing

N/A

## Risks

None (simply checking for a positive `len` on a value that's already been narrowed to `list`, and the existing default return value is the one callers expect in this situation)