### PR TITLE
feat(api-security): use simplified endpoint for API Security Sampling when route is missing

### DIFF
--- a/ddtrace/_trace/processor/resource_renaming.py
+++ b/ddtrace/_trace/processor/resource_renaming.py
@@ -4,6 +4,7 @@ from typing import Optional
 from urllib.parse import urlparse
 
 from ddtrace._trace.processor import SpanProcessor
+from ddtrace._trace.span import Span
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import http
 from ddtrace.internal.logger import get_logger
@@ -13,7 +14,7 @@ from ddtrace.settings._config import config
 log = get_logger(__name__)
 
 
-class ResourceRenamingProcessor(SpanProcessor):
+class SimplifiedEndpointComputer:
     def __init__(self):
         self._INT_RE = re.compile(r"^[1-9][0-9]+$")
         self._INT_ID_RE = re.compile(r"^(?=.*[0-9].*)[0-9._-]{3,}$")
@@ -35,7 +36,7 @@ class ResourceRenamingProcessor(SpanProcessor):
             return "{param:str}"
         return elem
 
-    def _compute_simplified_endpoint(self, url: Optional[str]) -> str:
+    def from_url(self, url: Optional[str]) -> str:
         """Extracts and simplifies the path from an HTTP URL."""
         if not url:
             return "/"
@@ -62,16 +63,24 @@ class ResourceRenamingProcessor(SpanProcessor):
         elements = [self._compute_simplified_endpoint_path_element(elem) for elem in elements]
         return "/" + "/".join(elements)
 
-    def on_span_start(self, span):
+
+class ResourceRenamingProcessor(SpanProcessor):
+    def __init__(self):
+        self.simplified_endpoint_computer = SimplifiedEndpointComputer()
+
+    def on_span_start(self, span: Span):
         pass
 
-    def on_span_finish(self, span):
+    def on_span_finish(self, span: Span):
         if not span._is_top_level or span.span_type not in (SpanTypes.WEB, SpanTypes.HTTP, SpanTypes.SERVERLESS):
             return
 
+        status = span.get_tag(http.STATUS_CODE)
+        is_404 = status == "404" or status == 404
+
         route = span.get_tag(http.ROUTE)
 
-        if not route or config._trace_resource_renaming_always_simplified_endpoint:
+        if not is_404 and (not route or config._trace_resource_renaming_always_simplified_endpoint):
             url = span.get_tag(http.URL)
-            endpoint = self._compute_simplified_endpoint(url)
-            span._set_tag_str(http.ENDPOINT, endpoint)
+            endpoint = self.simplified_endpoint_computer.from_url(url)
+            span.set_tag_str(http.ENDPOINT, endpoint)

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
@@ -29,7 +29,6 @@
       "django.response.class": "django.http.response.HttpResponseNotFound",
       "django.user.is_authenticated": "False",
       "http.client_ip": "127.0.0.1",
-      "http.endpoint": "/.git",
       "http.method": "GET",
       "http.request.headers.accept": "*/*",
       "http.request.headers.accept-encoding": "gzip, deflate",

--- a/tests/tracer/test_resource_renaming.py
+++ b/tests/tracer/test_resource_renaming.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ddtrace._trace.processor.resource_renaming import ResourceRenamingProcessor
+from ddtrace._trace.processor.resource_renaming import SimplifiedEndpointComputer
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import http
 from ddtrace.trace import Context
@@ -44,8 +45,7 @@ class TestResourceRenaming:
         ],
     )
     def test_compute_simplified_endpoint_path_element(self, elem, expected):
-        processor = ResourceRenamingProcessor()
-        result = processor._compute_simplified_endpoint_path_element(elem)
+        result = SimplifiedEndpointComputer()._compute_simplified_endpoint_path_element(elem)
         assert result == expected
 
     @pytest.mark.parametrize(
@@ -89,8 +89,7 @@ class TestResourceRenaming:
         ],
     )
     def test_compute_simplified_endpoint(self, url, expected):
-        processor = ResourceRenamingProcessor()
-        result = processor._compute_simplified_endpoint(url)
+        result = SimplifiedEndpointComputer().from_url(url)
         assert result == expected
 
     def test_processor_with_route(self):


### PR DESCRIPTION
## Description

In some instrumented setups, the REQUEST_ROUTE waf address might not be available. This is the case with:
- lambda function behind Application Load Balancer
- lambda function behind lambda function url services

To still compute and tag API Schemas in this case, we can sample using the simplified endpoint computed by trace resource renaming or compute it if trace resource renaming is disabled.

To avoid unnecessarily computing the endpoint on spans that correctly miss the route, we keep the route empty when:
- the request is a 404
- the request has been blocked

## Testing

- Added unit tests in API Security Manager

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
