### PR TITLE
fix(wrapt): do not use wrapt 2.x yet (#14955) [backport 3.15]

### DIFF
--- a/lib-injection/sources/requirements.csv
+++ b/lib-injection/sources/requirements.csv
@@ -7,7 +7,7 @@ envier,~=0.6.1,
 legacy-cgi,>=2.0.0,python_version>='3.13.0'
 opentelemetry-api,>=1,
 protobuf,>=3,
-wrapt,>=1,
+wrapt,">=1,<2",
 opentracing,>=2.0.0,
 opentelemetry-exporter-otlp,>=1.0.0,
 tiktoken,,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "legacy-cgi>=2.0.0; python_version>='3.13.0'",
     "opentelemetry-api>=1",
     "protobuf>=3",
-    "wrapt>=1",
+    "wrapt>=1,<2",
 ]
 
 [project.optional-dependencies]

--- a/releasenotes/notes/avoid-wrapt-two-fd3b8ad3057343ba.yaml
+++ b/releasenotes/notes/avoid-wrapt-two-fd3b8ad3057343ba.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Pin to ``wrapt<2`` until we can ensure full compatibility with the breaking changes.

--- a/requirements.csv
+++ b/requirements.csv
@@ -7,7 +7,7 @@ envier,~=0.6.1,
 legacy-cgi,>=2.0.0,python_version>='3.13.0'
 opentelemetry-api,>=1,
 protobuf,>=3,
-wrapt,>=1,
+wrapt,">=1,<2",
 opentracing,>=2.0.0,
 opentelemetry-exporter-otlp,>=1.0.0,
 tiktoken,,


### PR DESCRIPTION
## Description

We have a bug report that there are recursion errors with wrapt 2.x on our psycopg integration. I'd still like to study if we can recreate the error in a test but don't want this investigation to block this known issue.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
