### PR TITLE
ci: pin wrapt<2 in typing checker

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -15,6 +15,9 @@ dependencies = [
     "types-PyYAML==6.0.12.2",
     "types-setuptools==65.6.0.0",
     "ddapm-test-agent>=1.2.0",
+    # TODO: Remove this when we are compatible with wrapt>=2
+    #       ddapm-test-agent -> vcrpy -> wrapt
+    "wrapt<2",
     "packaging==23.1",
     "pygments==2.16.1",
     "riot==0.20.1",


### PR DESCRIPTION
## Description

ddapm-test-agent installs vcrpy which installs "wrapt" with no constraints. This meant we were still install wrapt 2.0 in our hatch lint environment causing us to type against wrapt 2 even though we updated pyproject.toml to be "wrapt>=1,<2".

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
