### PR TITLE
ci: increase otel-span RSS SLOs

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
@@ -799,11 +799,11 @@ experiments:
           - name: otelspan-add-metrics
             thresholds:
               - execution_time < 344.80 ms
-              - max_rss_usage < 630.00 MB
+              - max_rss_usage < 675.00 MB
           - name: otelspan-add-tags
             thresholds:
               - execution_time < 314.00 ms
-              - max_rss_usage < 630.00 MB
+              - max_rss_usage < 675.00 MB
           - name: otelspan-get-context
             thresholds:
               - execution_time < 92.35 ms


### PR DESCRIPTION
## Description

Memory usage on `main` is just above the threshold. This PR increases the SLO for now.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

The Span add metric/tag benchmarks also use a ton of memory, their SLOs are almost 1gb. We are probably not clearing spans from span aggregator or something between loops, meaning the amount of memory used is dependent on how many loops/iterations pyperf decides to run and not the actual memory usage of the library.
