### PR TITLE
feat(ci): push wheels to S3

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -82,3 +82,76 @@ download_dependency_wheels:
   artifacts:
     paths:
       - "pywheels-dep/"
+
+publish-wheels-to-s3:
+  tags: ["arch:amd64"]
+  image: registry.ddbuild.io/images/mirror/amazon/aws-cli:2.4.29
+  stage: package
+  rules:
+    - when: always
+  needs:
+    - job: download_ddtrace_artifacts
+      artifacts: true
+    - job: compute_library_version
+      artifacts: true
+  variables:
+    BUCKET: dd-trace-py-builds
+  script:
+    - set -euo pipefail
+    - shopt -s nullglob
+    # Find wheels
+    - WHEELS=(pywheels/*.whl)
+    - |
+      if [ ${#WHEELS[@]} -eq 0 ]; then
+        echo "No wheels found in pywheels/"; exit 1
+      fi
+    - echo "Found ${#WHEELS[@]} wheel(s):"
+    - printf ' - %s\n' "${WHEELS[@]}"
+
+    - |
+      if [ -f library-version/version.txt ]; then
+        VERSION="$(tr -d '\r\n' < library-version/version.txt)"
+      fi
+
+      if [ -z "${VERSION:-}" ]; then
+        echo "ERROR: VERSION is not defined or library-version/version.txt missing!"
+        exit 1
+      fi
+
+    - printf 'Detected version %s\n' ${VERSION}
+
+    # Upload all wheels to versioned prefix and pipeline-id prefix
+    - aws s3 cp --recursive --exclude "*" --include "*.whl" pywheels "s3://${BUCKET}/${VERSION}/"
+    - aws s3 cp --recursive --exclude "*" --include "*.whl" pywheels "s3://${BUCKET}/${CI_PIPELINE_ID}/"
+
+    - |
+      VERSION_ENC="${VERSION//+/%2B}"
+      S3_BASE_VER="https://${BUCKET}.s3.amazonaws.com/${VERSION_ENC}"
+      S3_BASE_PIPE="https://${BUCKET}.s3.amazonaws.com/${CI_PIPELINE_ID}"
+
+      generate_index_html() {
+        local outfile="$1"
+        {
+          echo "<html><body>"
+          for w in "${WHEELS[@]}"; do
+            fname="$(basename "$w")"
+            enc_fname="${fname//+/%2B}"
+            echo "<a href=\"${enc_fname}\">${fname}</a><br>"
+          done
+          echo "</body></html>"
+        } > "${outfile}"
+      }
+
+      # Generate both minimal indexes
+      generate_index_html "index.version.html"
+      generate_index_html "index.pipeline.html"
+
+      # Upload to each S3 prefix
+      aws s3 cp "index.version.html" "s3://${BUCKET}/${VERSION}/index.html" --content-type text/html
+      aws s3 cp "index.pipeline.html" "s3://${BUCKET}/${CI_PIPELINE_ID}/index.html" --content-type text/html
+
+      # Print the clickable URLs
+      VER_INDEX_URL="${S3_BASE_VER}/index.html"
+      PIPE_INDEX_URL="${S3_BASE_PIPE}/index.html"
+      echo "S3 index (version):  ${VER_INDEX_URL}"
+      echo "S3 index (pipeline): ${PIPE_INDEX_URL}"


### PR DESCRIPTION
## Description

This PR updates the `dd-trace-py` CI to push the wheels it built to S3. The goal is to make it possible to easily distribute those wheels for internal (and potentially external) testing of changes or bug fixes before they are merged and released more widely. 

The implementation is loosely based on this code: https://github.com/DataDog/dd-trace-java/blob/57e4640efd92ff855d29c549656644f24fb80c0e/.gitlab-ci.yml#L321-L350 

✅  The following is a prerequisite for that to work: [Add public S3 bucket for dd-trace-py builds](https://github.com/DataDog/cloud-inventory/pull/44908)

Thanks a lot @brettlangdon for all the help setting this up 🙇 

## Testing

I have seen successful CI runs that correctly pushed wheel files to S3. Artifacts (JSON files with URLs to download) were uploaded as well. Everything is working as expected, as far as I can tell. 
