### PR TITLE
test(co): remove flakiness in session test

### DIFF
--- a/tests/debugging/mocking.py
+++ b/tests/debugging/mocking.py
@@ -112,6 +112,9 @@ class MockSignalUploader(SignalUploader):
 
         return self.payloads
 
+    def flush(self) -> None:
+        self.queue.clear()
+
     @property
     def collector(self):
         return self._collector

--- a/tests/debugging/origin/test_span.py
+++ b/tests/debugging/origin/test_span.py
@@ -40,8 +40,14 @@ class SpanProbeTestCase(TracerTestCase):
         ddtrace.tracer = self.backup_tracer
         super(SpanProbeTestCase, self).tearDown()
 
+        if (uploader := MockSpanCodeOriginProcessor.get_uploader()) is not None:
+            uploader.flush()
+
         MockSpanCodeOriginProcessorEntry.disable()
         MockSpanCodeOriginProcessor.disable()
+
+        assert MockSpanCodeOriginProcessor.get_uploader() is None
+
         core.reset_listeners(event_id="service_entrypoint.patch")
 
     def test_span_origin(self):


### PR DESCRIPTION
We clean up the mock uploader in between tests to reduce the chances of lingering snapshots that can pollute test runs.