### PR TITLE
chore(telemetry): fix protocol in otel metrics

### DIFF
--- a/ddtrace/internal/opentelemetry/logs.py
+++ b/ddtrace/internal/opentelemetry/logs.py
@@ -157,7 +157,7 @@ def _import_exporter(protocol):
             )
             return None
 
-        return _dd_logs_exporter(OTLPLogExporter, protocol, "protobuf")
+        return _dd_logs_exporter(OTLPLogExporter, protocol.split("/")[0], "protobuf")
 
     except ImportError as e:
         log.warning(


### PR DESCRIPTION
## Description

Protocol is currently set as "http/protobuf", it should be sent as "http". This PR fixes this.

## Testing

This regression was found via system tests. We do not need additional testing.
