### PR TITLE
ci: allow octo-sts to make ddtracepy tokens from apm-sdks-benchmarks

### DIFF
--- a/.github/chainguard/gitlab.github-access.read.sts.yaml
+++ b/.github/chainguard/gitlab.github-access.read.sts.yaml
@@ -1,6 +1,6 @@
 issuer: https://gitlab.ddbuild.io
 
-subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-py:ref_type:(branch|tag):ref:.*"
+subject_pattern: "project_path:DataDog/apm-reliability/(dd-trace-py|apm-sdks-benchmarks):ref_type:(branch|tag):ref:.*"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

This change aims to facilitate https://github.com/DataDog/apm-sdks-benchmarks/pull/13 by granting permission from that gitlab repo to make dd-octo-sts tokens for dd-trace-py.
