### PR TITLE
perf(profiling): do not copy Span object

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack_v2/include/thread_span_links.hpp
+++ b/ddtrace/internal/datadog/profiling/stack_v2/include/thread_span_links.hpp
@@ -44,7 +44,7 @@ class ThreadSpanLinks
     ThreadSpanLinks& operator=(ThreadSpanLinks const&) = delete;
 
     void link_span(uint64_t thread_id, uint64_t span_id, uint64_t local_root_span_id, std::string span_type);
-    const std::optional<Span> get_active_span_from_thread_id(uint64_t thread_id);
+    const std::optional<std::reference_wrapper<Span>> get_active_span_from_thread_id(uint64_t thread_id);
     void unlink_span(uint64_t thread_id);
     void reset();
 

--- a/ddtrace/internal/datadog/profiling/stack_v2/src/thread_span_links.cpp
+++ b/ddtrace/internal/datadog/profiling/stack_v2/src/thread_span_links.cpp
@@ -21,15 +21,15 @@ ThreadSpanLinks::link_span(uint64_t thread_id, uint64_t span_id, uint64_t local_
     }
 }
 
-const std::optional<Span>
+const std::optional<std::reference_wrapper<Span>>
 ThreadSpanLinks::get_active_span_from_thread_id(uint64_t thread_id)
 {
     std::lock_guard<std::mutex> lock(mtx);
 
-    std::optional<Span> span;
+    std::optional<std::reference_wrapper<Span>> span;
     auto it = thread_id_to_span.find(thread_id);
     if (it != thread_id_to_span.end()) {
-        span = *(it->second);
+        span = std::ref(*(it->second));
     }
     return span;
 }

--- a/ddtrace/internal/datadog/profiling/stack_v2/test/test_thread_span_links.cpp
+++ b/ddtrace/internal/datadog/profiling/stack_v2/test/test_thread_span_links.cpp
@@ -30,7 +30,7 @@ set()
         if (!thing) {
             continue;
         }
-        s = thing->span_type;
+        s = thing->get().span_type;
     }
     return s;
 }


### PR DESCRIPTION
## Description

As title says. Currently, we copy the `Span` object every time we return it. Instead, we can wrap it into a `reference_wrapper` to return an optional reference to the item that exists within the `unordered_map`. Since we do not mutate it, it should be fine to do so. 