### PR TITLE
feat(appsec): enable urllib3 patches by default

### DIFF
--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -49,6 +49,11 @@ def patch_common_modules():
     if _is_patched:
         return
 
+    try_wrap_function_wrapper(
+        "urllib3.connectionpool", "HTTPConnectionPool._make_request", wrapped_urllib3_make_request
+    )
+    try_wrap_function_wrapper("urllib3._request_methods", "RequestMethods.request", wrapped_request_D8CB81E472AF98A2)
+    try_wrap_function_wrapper("urllib3.request", "RequestMethods.request", wrapped_request_D8CB81E472AF98A2)
     try_wrap_function_wrapper("builtins", "open", wrapped_open_CFDDB7ABBA9081B6)
     try_wrap_function_wrapper("urllib.request", "OpenerDirector.open", wrapped_open_ED4CF71136E15EBF)
     try_wrap_function_wrapper("http.client", "HTTPConnection.request", wrapped_request)
@@ -62,6 +67,9 @@ def unpatch_common_modules():
     if not _is_patched:
         return
 
+    try_unwrap("urllib3.connectionpool", "HTTPConnectionPool._make_request")
+    try_unwrap("urllib3._request_methods", "RequestMethods.request")
+    try_unwrap("urllib3.request", "RequestMethods.request")
     try_unwrap("builtins", "open")
     try_unwrap("urllib.request", "OpenerDirector.open")
     try_unwrap("_io", "BytesIO.read")

--- a/releasenotes/notes/aap-patch-urllib3-by-default-df1177d7852727ac.yaml
+++ b/releasenotes/notes/aap-patch-urllib3-by-default-df1177d7852727ac.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    AAP: AppSec instrumentation for downstream request is now enabled by default for `urllib3` and `requests`. It does not require enabling APM instrumentation for `urllib3` anymore.

--- a/riotfile.py
+++ b/riotfile.py
@@ -3694,7 +3694,7 @@ venv = Venv(
                 "AGENT_VERSION": "testagent",
                 "DD_REMOTE_CONFIGURATION_ENABLED": "true",
                 "DD_API_SECURITY_SAMPLE_DELAY": "0",
-                "DD_PATCH_MODULES": "unittest:false,urllib3:true",
+                "DD_PATCH_MODULES": "unittest:false",
             },
             venvs=[
                 Venv(
@@ -3748,7 +3748,7 @@ venv = Venv(
                 "AGENT_VERSION": "testagent",
                 "DD_REMOTE_CONFIGURATION_ENABLED": "true",
                 "DD_API_SECURITY_SAMPLE_DELAY": "0",
-                "DD_PATCH_MODULES": "unittest:false,urllib3:true",
+                "DD_PATCH_MODULES": "unittest:false",
             },
             venvs=[
                 Venv(
@@ -3799,7 +3799,7 @@ venv = Venv(
                 "DD_REMOTE_CONFIGURATION_ENABLED": "true",
                 "DD_IAST_DEDUPLICATION_ENABLED": "false",
                 "DD_API_SECURITY_SAMPLE_DELAY": "0",
-                "DD_PATCH_MODULES": "unittest:false,urllib3:true",
+                "DD_PATCH_MODULES": "unittest:false",
             },
             venvs=[
                 Venv(


### PR DESCRIPTION
## Description

Apply AppSec patches for urllib3 when AppSec is enabled regardless of wether urllib3 is patched or not.

## Testing

- removed explicit urllib3 patching from riotfiles

## Risks

None

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
