### PR TITLE
chore: relax suffix cond `site-packages` search for modules

### DIFF
--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -142,11 +142,11 @@ def _root_module(path: Path) -> str:
             pass
 
     # Bazel runfiles support: we assume that these paths look like
-    # /some/path.runfiles/.../site-packages/<root_module>/...
-    if any(p.suffix == ".runfiles" for p in path.parents):
-        for s in path.parents:
-            if s.parent.name == "site-packages":
-                return s.name
+    # /some/path.runfiles/<distribution_name>/site-packages/<root_module>/...
+    # /usr/local/runfiles/<distribution_name>/site-packages/<root_module>/...
+    for s in path.parents:
+        if s.parent.name == "site-packages":
+            return s.name
 
     msg = f"Could not find root module for path {path}"
     raise ValueError(msg)

--- a/tests/internal/test_packages.py
+++ b/tests/internal/test_packages.py
@@ -129,7 +129,7 @@ def test_third_party_packages_symlinks(tmp_path):
     symlink_file = runfiles_path / "test.py"
     os.symlink(code_file, symlink_file)
 
-    assert is_user_code(code_file)
+    assert not is_user_code(code_file)
     # Symlinks with `.runfiles` in the path should not be considered user code.
     from ddtrace.internal.compat import Path
 


### PR DESCRIPTION
## Description

This came up reviewing some Exception Replay snapshots where the paths took the form:

> /usr/local/runfiles/pypi_linux_x86_64_parsimonious/site-packages/parsimonious/expressions.py

Rather than add another case for this, we can remove the suffix check since we're looping over `path.parents` anyways.

This should improve the third-party detection for more unconvential build environments beyond bazel.

## Testing

Manual QA and unittests

## Risks

None

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
