### PR TITLE
chore(profiling): remove deprecated env var, `DD_PROFILING_API_TIMEOUT`

### DIFF
--- a/ddtrace/internal/settings/profiling.py
+++ b/ddtrace/internal/settings/profiling.py
@@ -85,27 +85,6 @@ def _parse_profiling_enabled(raw: str) -> bool:
     return False
 
 
-def _parse_api_timeout_ms(raw: str) -> int:
-    # Check if the deprecated DD_PROFILING_API_TIMEOUT is set (in seconds)
-    deprecated_timeout = os.environ.get("DD_PROFILING_API_TIMEOUT")
-    if deprecated_timeout is not None:
-        from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
-        from ddtrace.vendor.debtcollector import deprecate
-
-        deprecate(
-            "DD_PROFILING_API_TIMEOUT is deprecated",
-            message="DD_PROFILING_API_TIMEOUT (in seconds) is deprecated and will be removed in version 4.0.0. "
-            "Please use DD_PROFILING_API_TIMEOUT_MS (in milliseconds) instead.",
-            category=DDTraceDeprecationWarning,
-            removal_version="4.0.0",
-        )
-        # Convert seconds to milliseconds
-        return int(float(deprecated_timeout) * 1000)
-
-    # Otherwise, use the raw value (in milliseconds)
-    return int(raw)
-
-
 def _update_git_metadata_tags(tags):
     """
     Update profiler tags with git metadata
@@ -226,7 +205,6 @@ class ProfilingConfig(DDConfig):
     api_timeout_ms = DDConfig.v(
         int,
         "api_timeout_ms",
-        parser=_parse_api_timeout_ms,
         default=10000,
         help_type="Integer",
         help="The timeout in milliseconds before dropping events if the HTTP API does not reply",


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
