### PR TITLE
feat(profiling): add sample count to internal payload

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/CMakeLists.txt
@@ -54,6 +54,8 @@ add_library(
     src/code_provenance_interface.cpp
     src/ddup_interface.cpp
     src/profile.cpp
+    src/profile_borrow.cpp
+    src/profiler_stats.cpp
     src/sample.cpp
     src/sample_manager.cpp
     src/static_sample_pool.cpp

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/ddup_interface.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstdint>
 #include <string_view>
 #include <unordered_map>
 
 // Forward decl of the return pointer
 namespace Datadog {
 class Sample;
-}
+} // namespace Datadog
 
 #ifdef __cplusplus
 extern "C"
@@ -68,6 +67,10 @@ extern "C"
                          int64_t line);
     void ddup_push_absolute_ns(Datadog::Sample* sample, int64_t timestamp_ns);
     void ddup_push_monotonic_ns(Datadog::Sample* sample, int64_t monotonic_ns);
+
+    void ddup_increment_sampling_event_count();
+    void ddup_increment_sample_count();
+
     void ddup_flush_sample(Datadog::Sample* sample);
     // Stack v2 specific flush, which reverses the locations
     void ddup_flush_sample_v2(Datadog::Sample* sample);

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profile_borrow.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profile_borrow.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "profile.hpp"
+
+namespace Datadog {
+
+// Forward declaration
+class Profile;
+
+// RAII wrapper for borrowing both profile and stats under a single lock
+class ProfileBorrow
+{
+  private:
+    Profile* profile_ptr;
+
+  public:
+    explicit ProfileBorrow(Profile& profile);
+    ~ProfileBorrow();
+
+    // Disable copy
+    ProfileBorrow(const ProfileBorrow&) = delete;
+    ProfileBorrow& operator=(const ProfileBorrow&) = delete;
+
+    // Enable move
+    ProfileBorrow(ProfileBorrow&& other) noexcept;
+    ProfileBorrow& operator=(ProfileBorrow&& other) noexcept;
+
+    // Accessors
+    ddog_prof_Profile& profile();
+    ProfilerStats& stats();
+};
+
+} // namespace Datadog

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cstddef>
+
+#include <string>
+#include <string_view>
+
+namespace Datadog {
+
+/*
+ProfilerStats holds statistics around Profiling to be sent along
+with the actual Profiles.
+
+None of its methods are thread-safe and it should typically used with
+a mutex to protect access to the data.
+*/
+class ProfilerStats
+{
+  private:
+    std::string internal_metadata_json;
+
+    // Number of samples collected (one per thread)
+    size_t sample_count = 0;
+
+    // Number of sampling events (one per collection cycle)
+    size_t sampling_event_count = 0;
+
+  public:
+    ProfilerStats() = default;
+    ~ProfilerStats() = default;
+
+    void increment_sample_count(size_t k_sample_count = 1);
+    size_t get_sample_count();
+
+    void increment_sampling_event_count(size_t k_sampling_event_count = 1);
+    size_t get_sampling_event_count();
+
+    // Returns a JSON string containing relevant Profiler Stats to be included
+    // in the libdatadog payload.
+    // The function returned a string_view to a statically allocated string that
+    // is updated every time the function is called.
+    std::string_view get_internal_metadata_json();
+
+    void reset_state();
+};
+
+} // namespace Datadog

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/sample.hpp
@@ -2,6 +2,7 @@
 
 #include "libdatadog_helpers.hpp"
 #include "profile.hpp"
+#include "profile_borrow.hpp"
 #include "types.hpp"
 
 #include <string>
@@ -134,8 +135,7 @@ class Sample
     // Flushes the current buffer, clearing it
     bool flush_sample(bool reverse_locations = false);
 
-    static ddog_prof_Profile& profile_borrow();
-    static void profile_release();
+    static ProfileBorrow profile_borrow();
     static void postfork_child();
     Sample(SampleType _type_mask, unsigned int _max_nframes);
 

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
-#include "sample.hpp"
-#include "types.hpp"
+#include "profiler_stats.hpp"
 
 #include <atomic>
-#include <memory>
 #include <mutex>
+#include <string>
 
 extern "C"
 {
@@ -24,10 +23,10 @@ class Uploader
     std::string output_filename;
     ddog_prof_ProfileExporter ddog_exporter{ .inner = nullptr };
 
-    bool export_to_file(ddog_prof_EncodedProfile* encoded);
+    bool export_to_file(ddog_prof_EncodedProfile* encoded, std::string_view internal_metadata_json);
 
   public:
-    bool upload(ddog_prof_Profile& profile);
+    bool upload(ddog_prof_Profile& profile, Datadog::ProfilerStats& profiler_stats);
     static void cancel_inflight();
     static void lock();
     static void unlock();

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader_builder.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader_builder.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "constants.hpp"
 #include "uploader.hpp"
 
-#include <mutex>
 #include <string>
 #include <string_view>
 #include <unordered_map>

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/ddup_interface.cpp
@@ -1,8 +1,7 @@
 #include "ddup_interface.hpp"
 
-#include "code_provenance.hpp"
 #include "libdatadog_helpers.hpp"
-#include "profile.hpp"
+#include "profiler_stats.hpp"
 #include "sample.hpp"
 #include "sample_manager.hpp"
 #include "uploader.hpp"
@@ -305,6 +304,20 @@ ddup_push_monotonic_ns(Datadog::Sample* sample, int64_t monotonic_ns) // cppchec
 }
 
 void
+ddup_increment_sampling_event_count() // cppcheck-suppress unusedFunction
+{
+    auto borrowed = Datadog::Sample::profile_borrow();
+    borrowed.stats().increment_sampling_event_count();
+}
+
+void
+ddup_increment_sample_count() // cppcheck-suppress unusedFunction
+{
+    auto borrowed = Datadog::Sample::profile_borrow();
+    borrowed.stats().increment_sample_count();
+}
+
+void
 ddup_flush_sample(Datadog::Sample* sample) // cppcheck-suppress unusedFunction
 {
     sample->flush_sample();
@@ -351,9 +364,10 @@ ddup_upload() // cppcheck-suppress unusedFunction
     //  be modified.  It gets released and cleared after uploading.
     // * Uploading cancels inflight uploads. There are better ways to do this, but this is what
     //   we have for now.
-    uploader.upload(Datadog::Sample::profile_borrow());
-    Datadog::Sample::profile_release();
-    return true;
+    auto borrowed = Datadog::Sample::profile_borrow();
+    bool success = uploader.upload(borrowed.profile(), borrowed.stats());
+    borrowed.stats().reset_state();
+    return success;
 }
 
 void
@@ -361,7 +375,8 @@ ddup_profile_set_endpoints(
   std::unordered_map<int64_t, std::string_view> span_ids_to_endpoints) // cppcheck-suppress unusedFunction
 {
     static bool already_warned = false; // cppcheck-suppress threadsafety-threadsafety
-    ddog_prof_Profile& profile = Datadog::Sample::profile_borrow();
+    auto borrowed = Datadog::Sample::profile_borrow();
+    ddog_prof_Profile& profile = borrowed.profile();
     for (const auto& [span_id, trace_endpoint] : span_ids_to_endpoints) {
         ddog_CharSlice trace_endpoint_slice = Datadog::to_slice(trace_endpoint);
         auto res = ddog_prof_Profile_set_endpoint(&profile, span_id, trace_endpoint_slice);
@@ -375,14 +390,14 @@ ddup_profile_set_endpoints(
             ddog_Error_drop(&err);
         }
     }
-    Datadog::Sample::profile_release();
 }
 
 void
 ddup_profile_add_endpoint_counts(std::unordered_map<std::string_view, int64_t> trace_endpoints_to_counts)
 {
     static bool already_warned = false; // cppcheck-suppress threadsafety-threadsafety
-    ddog_prof_Profile& profile = Datadog::Sample::profile_borrow();
+    auto borrowed = Datadog::Sample::profile_borrow();
+    ddog_prof_Profile& profile = borrowed.profile();
     for (const auto& [trace_endpoint, count] : trace_endpoints_to_counts) {
         ddog_CharSlice trace_endpoint_slice = Datadog::to_slice(trace_endpoint);
         auto res = ddog_prof_Profile_add_endpoint_count(&profile, trace_endpoint_slice, count);
@@ -396,5 +411,4 @@ ddup_profile_add_endpoint_counts(std::unordered_map<std::string_view, int64_t> t
             ddog_Error_drop(&err);
         }
     }
-    Datadog::Sample::profile_release();
 }

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profile_borrow.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profile_borrow.cpp
@@ -1,0 +1,50 @@
+#include "profile_borrow.hpp"
+#include "profile.hpp"
+
+Datadog::ProfileBorrow::ProfileBorrow(Profile& profile)
+  : profile_ptr(&profile)
+{
+    // Lock the mutex on construction
+    profile_ptr->profile_borrow_internal();
+}
+
+Datadog::ProfileBorrow::~ProfileBorrow()
+{
+    if (profile_ptr) {
+        profile_ptr->profile_release();
+    }
+}
+
+Datadog::ProfileBorrow::ProfileBorrow(ProfileBorrow&& other) noexcept
+  : profile_ptr(other.profile_ptr)
+{
+    other.profile_ptr = nullptr;
+}
+
+Datadog::ProfileBorrow&
+Datadog::ProfileBorrow::operator=(ProfileBorrow&& other) noexcept
+{
+    if (this != &other) {
+        // Release current lock if any
+        if (profile_ptr) {
+            profile_ptr->profile_release();
+        }
+
+        // Take ownership from other
+        profile_ptr = other.profile_ptr;
+        other.profile_ptr = nullptr;
+    }
+    return *this;
+}
+
+ddog_prof_Profile&
+Datadog::ProfileBorrow::profile()
+{
+    return profile_ptr->cur_profile;
+}
+
+Datadog::ProfilerStats&
+Datadog::ProfileBorrow::stats()
+{
+    return profile_ptr->profiler_stats;
+}

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
@@ -1,0 +1,66 @@
+#include "profiler_stats.hpp"
+
+#include <charconv>
+#include <string>
+
+namespace {
+
+void
+append_to_string(std::string& s, size_t value)
+{
+    char buf[128];
+    auto [ptr, ec] = std::to_chars(std::begin(buf), std::end(buf), value);
+    s.append(buf, ptr);
+}
+
+} // namespace
+
+void
+Datadog::ProfilerStats::increment_sampling_event_count(size_t k_sampling_event_count)
+{
+    sampling_event_count += k_sampling_event_count;
+}
+
+size_t
+Datadog::ProfilerStats::get_sampling_event_count()
+{
+    return sampling_event_count;
+}
+
+void
+Datadog::ProfilerStats::increment_sample_count(size_t k_sample_count)
+{
+    sample_count += k_sample_count;
+}
+
+size_t
+Datadog::ProfilerStats::get_sample_count()
+{
+    return sample_count;
+}
+
+void
+Datadog::ProfilerStats::reset_state()
+{
+    sample_count = 0;
+    sampling_event_count = 0;
+}
+
+std::string_view
+Datadog::ProfilerStats::get_internal_metadata_json()
+{
+    internal_metadata_json.reserve(128);
+
+    internal_metadata_json = "{";
+
+    internal_metadata_json += R"("sample_count": )";
+    append_to_string(internal_metadata_json, sample_count);
+    internal_metadata_json += ",";
+
+    internal_metadata_json += R"("sampling_event_count": )";
+    append_to_string(internal_metadata_json, sampling_event_count);
+
+    internal_metadata_json += "}";
+
+    return internal_metadata_json;
+}

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
@@ -1,11 +1,8 @@
 #include "sample.hpp"
 
-#include "code_provenance.hpp"
-
 #include <algorithm>
 #include <chrono>
 #include <string_view>
-#include <thread>
 
 Datadog::internal::StringArena::StringArena()
 {
@@ -526,16 +523,10 @@ Datadog::Sample::is_timeline_enabled() const
     return timeline_enabled;
 }
 
-ddog_prof_Profile&
+Datadog::ProfileBorrow
 Datadog::Sample::profile_borrow()
 {
-    return profile_state.profile_borrow();
-}
-
-void
-Datadog::Sample::profile_release()
-{
-    profile_state.profile_release();
+    return profile_state.borrow();
 }
 
 void

--- a/ddtrace/internal/datadog/profiling/stack_v2/include/stack_renderer.hpp
+++ b/ddtrace/internal/datadog/profiling/stack_v2/include/stack_renderer.hpp
@@ -1,13 +1,7 @@
 #pragma once
 
-#include <chrono>
-#include <fstream>
-#include <memory>
-#include <mutex>
 #include <string>
 #include <string_view>
-#include <thread>
-#include <vector>
 
 #include "python_headers.hpp"
 

--- a/ddtrace/internal/datadog/profiling/stack_v2/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack_v2/src/sampler.cpp
@@ -1,5 +1,6 @@
 #include "sampler.hpp"
 
+#include "dd_wrapper/include/ddup_interface.hpp"
 #include "thread_span_links.hpp"
 
 #include "echion/errors.h"
@@ -154,9 +155,14 @@ Sampler::sampling_thread(const uint64_t seq_num)
         // Perform the sample
         for_each_interp([&](InterpreterInfo& interp) -> void {
             for_each_thread(interp, [&](PyThreadState* tstate, ThreadInfo& thread) {
-                (void)thread.sample(interp.id, tstate, wall_time_us);
+                auto success = thread.sample(interp.id, tstate, wall_time_us);
+                if (success) {
+                    ddup_increment_sample_count();
+                }
             });
         });
+
+        ddup_increment_sampling_event_count();
 
         if (do_adaptive_sampling) {
             // Adjust the sampling interval at most every second

--- a/tests/profiling/collector/pprof_utils.py
+++ b/tests/profiling/collector/pprof_utils.py
@@ -141,10 +141,10 @@ def parse_newest_profile(filename_prefix: str) -> pprof_pb2.Profile:
     <filename_prefix>.<pid>.<counter>.pprof, and in tests, we'd want to parse
     the newest profile that has given filename prefix.
     """
-    files = glob.glob(filename_prefix + ".*")
+    files = glob.glob(filename_prefix + ".*.pprof")
     # Sort files by logical timestamp (i.e. the sequence number, which is monotonically increasing);
     # this approach is more reliable than filesystem timestamps, especially when files are created rapidly.
-    files.sort(key=lambda f: int(f.rsplit(".", 1)[-1]))
+    files.sort(key=lambda f: int(f.rsplit(".", 2)[-2]))
     filename = files[-1]
     with open(filename, "rb") as fp:
         dctx = zstd.ZstdDecompressor()

--- a/tests/profiling/collector/test_sample_count.py
+++ b/tests/profiling/collector/test_sample_count.py
@@ -1,0 +1,71 @@
+import pytest
+
+
+@pytest.mark.subprocess(
+    env=dict(
+        DD_PROFILING_OUTPUT_PPROF="/tmp/test_sample_count",
+        DD_PROFILING_UPLOAD_INTERVAL="1",  # Upload every second
+    ),
+    err=None,
+)
+def test_sample_count():
+    import asyncio
+    import glob
+    import json
+    import os
+    import time
+    import uuid
+
+    from ddtrace import ext
+    from ddtrace.profiling import profiler
+    from ddtrace.trace import tracer
+
+    sleep_time = 0.2
+    loop_run_time = 2
+
+    async def stuff() -> None:
+        start_time = time.time()
+        while time.time() < start_time + loop_run_time:
+            await asyncio.sleep(sleep_time)
+
+        await asyncio.get_running_loop().run_in_executor(executor=None, func=lambda: time.sleep(1))
+
+    async def hello():
+        t1 = asyncio.create_task(stuff(), name="sleep 1")
+        t2 = asyncio.create_task(stuff(), name="sleep 2")
+        await stuff()
+        return (t1, t2)
+
+    resource = str(uuid.uuid4())
+    span_type = ext.SpanTypes.WEB
+
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+    with tracer.trace("test_asyncio", resource=resource, span_type=span_type):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        maintask = loop.create_task(hello(), name="main")
+        loop.run_until_complete(maintask)
+    p.stop()
+
+    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    files = glob.glob(output_filename + ".*.internal_metadata.json")
+
+    found_at_least_one_with_more_samples_than_sampling_events = False
+    for f in files:
+        with open(f, "r") as fp:
+            internal_metadata = json.load(fp)
+
+            assert internal_metadata is not None
+            assert "sample_count" in internal_metadata
+            assert internal_metadata["sample_count"] > 0
+
+            assert "sampling_event_count" in internal_metadata
+            assert internal_metadata["sampling_event_count"] <= internal_metadata["sample_count"]
+
+            if internal_metadata["sample_count"] > internal_metadata["sampling_event_count"]:
+                found_at_least_one_with_more_samples_than_sampling_events = True
+
+    assert (
+        found_at_least_one_with_more_samples_than_sampling_events
+    ), "Expected at least one file with more samples than sampling events"

--- a/tests/profiling_v2/collector/test_threading.py
+++ b/tests/profiling_v2/collector/test_threading.py
@@ -1047,11 +1047,11 @@ class BaseThreadingLockCollectorTest:
         )
 
         # Now we call upload() again, and we expect the profile to be empty
-        num_files_before_second_upload: int = len(glob.glob(self.output_filename + ".*"))
+        num_files_before_second_upload: int = len(glob.glob(self.output_filename + ".*.pprof"))
 
         ddup.upload()  # pyright: ignore[reportCallIssue]
 
-        num_files_after_second_upload: int = len(glob.glob(self.output_filename + ".*"))
+        num_files_after_second_upload: int = len(glob.glob(self.output_filename + ".*.pprof"))
 
         # A new profile file should always be created (upload_seq increments)
         assert (


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-12975

This PR adds data to the `internal` payload we send to `libdatadog`. In this `internal` payload, we can push custom metrics (that are not exposed to customers) but that we can access for analytics. 

For the time being, I only added the number of Samples taken (one per thread) and Sampling Events (one for each time we run `for_each_interp`) for the current Profile. We may want to add more in the short term (e.g. number of times adaptive sampling was adjusted, history of adaptive sampling intervals, etc.) 

In order to implement this feature in a way that keeps clear semantics around locking the Profile object, I refactored the code not to `borrow` only the single `Profile` but instead both the `Profile` and the `ProfilerStats` (in which we store our metrics). To keep locking clear and explicit, locking returns a `ProfileBorrow` objects which allows to access both the `Profile` and the `ProfilerStats` and that is RAII-compatible (automatically unlocks when it goes out of scope).  

Note the PR does add some "lock contention" because we now need to take the Profile lock in two new places (one for each metric we increment) – it should be the same order of magnitude as what we already do though (in number of lock acquisitions).   
We plan to refactor Stack V2 in the short to avoid having to hold the Profile / ProfilerStats lock during the upload, by using double buffering or by releasing earlier (after the Profile data has been serialised). This should improve the performance and reduce lost Samples. 

The PR also adds an integration test, ensuring that the generated JSON string is correct (we can't guarantee exact numbers, but we can check the numbers we have are meaningful).

**Note** I marked the PR as `no-changelog` as this feature isn't public/visible by customers.

Open questions:
*  What other metrics do we want to add?

This is an example of querying through the Events UI.

<img width="886" height="604" alt="image" src="https://github.com/user-attachments/assets/53c3eae0-d29a-4446-9f1b-72ac29a75d60" />
