### PR TITLE
chore(profiling): fix flaky `test_upload_resets_profile` test

### DIFF
--- a/tests/profiling/collector/pprof_utils.py
+++ b/tests/profiling/collector/pprof_utils.py
@@ -142,8 +142,9 @@ def parse_newest_profile(filename_prefix: str) -> pprof_pb2.Profile:
     the newest profile that has given filename prefix.
     """
     files = glob.glob(filename_prefix + ".*")
-    # Sort files by creation timestamp (oldest first, newest last)
-    files.sort(key=lambda f: os.path.getctime(f))
+    # Sort files by logical timestamp (i.e. the sequence number, which is monotonically increasing);
+    # this approach is more reliable than filesystem timestamps, especially when files are created rapidly.
+    files.sort(key=lambda f: int(f.rsplit(".", 1)[-1]))
     filename = files[-1]
     with open(filename, "rb") as fp:
         dctx = zstd.ZstdDecompressor()


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/PROF-12725

## Description

Some tests try to read the newest profile and act on it. One such test, `test_upload_resets_profile`, is flaky on MacOS (but strangely not on Linux in the CI). It sometimes reads an empty profile (which is expected), and sometimes does not (the empty-file assert is not triggered and test fails).

The current way of finding the latest file in `pprof_utils.parse_newest_profile` is error-prone because the latest file `ctime`, metadata change time, is not always a true "latest" file; this can happen for a variety of reasons, e.g. one file gets written faster than the other one, because it's smaller ("empty").
_Example:_
* `file.foo.1` created at `t0` (sequence: 1)
* `file.foo.0` created at `t1` (sequence: 0)

Logically, `file_1` is the latest file, because that is the sequence number assigned to it; however, currently we think it is `file_0` (t1 > t0).

### What changed ###
* Instead of sorting by `ctime`, we sort by the "logical" time (i.e. the file's sequence number), which is monotonically increasing and deterministic.

## Testing
* multiple consecutive local runs on my Mac pass reliably (10+ tries)