### PR TITLE
ci: add sccache to testrunner image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,13 +191,16 @@ services:
           DD_FAST_BUILD: "1"
           CMAKE_BUILD_PARALLEL_LEVEL: "12"
           CARGO_BUILD_JOBS: "12"
+          CYTHON_CACHE_DIR: "/home/bits/.cache/cython"
+          DD_USE_SCCACHE: "1"
+          SCCACHE_DIR: "/home/bits/.cache/sccache"
         network_mode: host
         userns_mode: host
         working_dir: /home/bits/project/
         volumes:
           - ddagent:/tmp/ddagent
+          - ./.cache:/home/bits/.cache
           - ./:/home/bits/project
-          - ./.riot:/home/bits/project/.riot
 
     localstack:
         image: localstack/localstack:1.4.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,6 +51,7 @@ RUN apt-get update \
       nodejs \
       npm \
       patch \
+      sccache \
       unixodbc-dev \
       wget \
       zlib1g-dev \

--- a/setup.py
+++ b/setup.py
@@ -1208,6 +1208,7 @@ setup(
         force=os.getenv("DD_SETUP_FORCE_CYTHONIZE", "0") == "1",
         annotate=os.getenv("_DD_CYTHON_ANNOTATE") == "1",
         compiler_directives={"language_level": "3"},
+        cache=True,
     )
     + get_exts_for("psutil"),
     distclass=PatchedDistribution,


### PR DESCRIPTION
## Description

- Adds `sccache` to the testrunner image
- Mounts the `./.cache/` as `/home/bits/.cache` in the test runner

With these small changes I can get `riot -v run <hash>` to take only 10-ish seconds to start running pytest (after the first run which builds our library, and etc)

We will need to update the testrunner image in CI and docker-compose.yml once this Dockerfile change is published for people to get the benefits from it.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
