### PR TITLE
ci: increase openai parallelism to 14

### DIFF
--- a/tests/llmobs/suitespec.yml
+++ b/tests/llmobs/suitespec.yml
@@ -143,7 +143,7 @@ suites:
     runner: riot
     snapshot: true
   openai:
-    parallelism: 10
+    parallelism: 14
     paths:
       - '@bootstrap'
       - '@core'


### PR DESCRIPTION
## Description

I am seeing this job time out a lot, it has 42 venvs to run, if we bump the parallelism a bit it should help.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
