### PR TITLE
chore(tracing): update test_span_finish_with_ancestors test

### DIFF
--- a/ddtrace/contrib/internal/ddtrace_api/patch.py
+++ b/ddtrace/contrib/internal/ddtrace_api/patch.py
@@ -23,6 +23,10 @@ _STUB_TO_REAL[ddtrace_api.tracer] = ddtrace.tracer
 log = get_logger(__name__)
 T = TypeVar("T")
 _FN_PARAMS: Dict[str, List[str]] = dict()
+# for situations where the intended internal target doesn't have the same name
+# as the API method. one example is when a public ddtrace method gets internalized
+# in a major version
+_API_TO_IMPL_NAME: Dict[str, str] = {"finish_with_ancestors": "_finish_with_ancestors"}
 
 
 def _params_for_fn(wrapping_context: WrappingContext, instance: ddtrace_api._Stub, fn_name: str):
@@ -38,7 +42,7 @@ class DDTraceAPIWrappingContextBase(WrappingContext):
         fn_name = self.__frame__.f_code.co_name
         _call_on_real_instance(
             stub,
-            fn_name,
+            _API_TO_IMPL_NAME.get(fn_name, fn_name),
             self.get_local("retval"),
             **{param: self.get_local(param) for param in _params_for_fn(self, stub, fn_name) if param != "self"},
         )

--- a/tests/contrib/ddtrace_api/test_integration.py
+++ b/tests/contrib/ddtrace_api/test_integration.py
@@ -51,7 +51,7 @@ class DDTraceAPITestCase(TracerTestCase):
     def test_span_finish_with_ancestors(self):
         span = ddtrace_api.tracer.start_span("web.request")
         child_span = ddtrace_api.tracer.start_span("web.request", child_of=span)
-        child_span._finish_with_ancestors()
+        child_span.finish_with_ancestors()
         self._assert_real_spans(2)
 
     @pytest.mark.snapshot()


### PR DESCRIPTION
## Description

The API was deleted in #15212 and use internal api `_finish_with_ancestors()`

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
