### PR TITLE
chore(appsec): run clang-format

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/source.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/source.cpp
@@ -29,7 +29,8 @@ Source::toString() const
     return ret.str();
 }
 
-Source::operator std::string() const
+Source::
+operator std::string() const
 {
     return toString();
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/taint_range.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/taint_range.cpp
@@ -22,7 +22,8 @@ TaintRange::toString() const
     return ret.str();
 }
 
-TaintRange::operator std::string() const
+TaintRange::
+operator std::string() const
 {
     return toString();
 }

--- a/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/tainted_object.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/tainted_object.cpp
@@ -119,7 +119,8 @@ TaintedObject::toString() const
     return ss.str();
 }
 
-TaintedObject::operator string() const
+TaintedObject::
+operator string() const
 {
     return toString();
 }


### PR DESCRIPTION
## Description

As title says – it's just the result of executing  `scripts/cformat.sh --fix`. 