### PR TITLE
fix(profiling): update echion

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack_v2/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/stack_v2/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 
 # Add echion
 set(ECHION_COMMIT
-    "43432c5c0a89617b06533215a15d0d6ffbbfd02b" # https://github.com/P403n1x87/echion/commit/43432c5c0a89617b06533215a15d0d6ffbbfd02b
+    "e9f06f7f2a716d583e1bd204eab33b12dc970983" # https://github.com/P403n1x87/echion/commit/e9f06f7f2a716d583e1bd204eab33b12dc970983
     CACHE STRING "Commit hash of echion to use")
 FetchContent_Declare(
     echion

--- a/releasenotes/notes/profiling-update-echion-d85c69974ad895b6.yaml
+++ b/releasenotes/notes/profiling-update-echion-d85c69974ad895b6.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    profiling: This fixes a bug where asyncio stacks would only get partial data, with some coroutines not showing.


### PR DESCRIPTION
## Description

This ports https://github.com/P403n1x87/echion/pull/181 to dd-trace-py.

This PR may be the last of its kind as [chore(profiling): move echion to dd-trace-py](https://github.com/DataDog/dd-trace-py/pull/15136) is just around the corner! 🎉 