### PR TITLE
ci: hardcode version to get CI to pass

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,9 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ddtrace"
 # DEV: to directly override the version specifier, comment this...
-dynamic = ["version"]
+#dynamic = ["version"]
 # ...and uncomment this
-#version = "4.0.0.dev0"
+version = "4.1.0dev"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
## Description

Hardcoding the version string to avoid the setuptools_scm confusion causing system-tests to fail on main.
