### PR TITLE
ci: use more durable version detection in some iast benchmarks

### DIFF
--- a/benchmarks/appsec_iast_aspects/functions.py
+++ b/benchmarks/appsec_iast_aspects/functions.py
@@ -2,8 +2,10 @@ import _io
 import os
 import re
 
-import ddtrace._version as version
+from ddtrace import get_version
 
+
+version = get_version()
 
 # Some old versions could not have or export some symbols, so we import them dynamically and assign None if not found
 # which will make the aspect benchmark fail but not the entire benchmark

--- a/benchmarks/appsec_iast_aspects_ospath/functions.py
+++ b/benchmarks/appsec_iast_aspects_ospath/functions.py
@@ -2,8 +2,10 @@ import _io
 import os
 import re
 
-import ddtrace._version as version
+from ddtrace import get_version
 
+
+version = get_version()
 
 # Some old versions could not have or export some symbols, so we import them dynamically and assign None if not found
 # which will make the aspect benchmark fail but not the entire benchmark

--- a/benchmarks/appsec_iast_aspects_re_module/functions.py
+++ b/benchmarks/appsec_iast_aspects_re_module/functions.py
@@ -2,8 +2,10 @@ import _io
 import os
 import re
 
-import ddtrace._version as version
+from ddtrace import get_version
 
+
+version = get_version()
 
 # Some old versions could not have or export some symbols, so we import them dynamically and assign None if not found
 # which will make the aspect benchmark fail but not the entire benchmark

--- a/benchmarks/appsec_iast_aspects_split/functions.py
+++ b/benchmarks/appsec_iast_aspects_split/functions.py
@@ -2,8 +2,10 @@ import _io
 import os
 import re
 
-import ddtrace._version as version
+from ddtrace import get_version
 
+
+version = get_version()
 
 # Some old versions could not have or export some symbols, so we import them dynamically and assign None if not found
 # which will make the aspect benchmark fail but not the entire benchmark


### PR DESCRIPTION
## Description

These benchmarks used `_version` directly, which isn't present when the version string is hardcoded in pyproject.toml.
