### PR TITLE
chore: lazy context wrapping

### DIFF
--- a/ddtrace/internal/wrapping/__init__.py
+++ b/ddtrace/internal/wrapping/__init__.py
@@ -336,10 +336,3 @@ def unwrap(wf, wrapper):
     except AttributeError:
         # The function is not wrapped so we return it as is.
         return cast(FunctionType, wf)
-
-
-def wrap_once(f, wrapper):
-    def trampoline(_, args, kwargs):
-        return wrapper(unwrap(f, trampoline), args, kwargs)
-
-    return wrap(f, trampoline)


### PR DESCRIPTION
## Description

We implement a lazy context wrapping mechanism whereby the bytecode context wrapping is performed on first invocation of the function. Note that this still requires the original function to be instrumented via bytecode manipulations.

The wrapping done by the existing `WrappingContext` class performs a decompilation of the code object into an abstract bytecode representation that can be easily manipulated. The result is then recompiled into actual bytecode. The complexity is therefore roughly `O(n)`. With the `LazyWrappingContext` solution we use the different wrapping technique of transforming the original function into a proxy for the original one that executes a wrapper. The wrapper receives the original function and the invocation arguments and is responsible for calling the original function and returning its result. The `LazyWrappingContext` uses this wrapping technique to wrap the original function with a trampoline that unwraps the function and then applies the `WrappingContext` wrapping on the first invocation. The trampolining is a much cheaper operation because it only requires a few opcodes to be performed, essentially giving a `O(1)` instrumentation cost. Only when (and if) the function is invoked for the first time, the full instrumentation cost is then paid.


## Additional Notes

The motivation for this change is to allow for a more lightweight bytecode instrumentation to trigger a more expensive one only when needed. This is typically when an instrumented function is called for the first time.

## Performance Analysis

The following table shows the instrumentation cost per normal Python function on the basis of code object size

| bytecode size | WrappingContext | LazyWrappingContext |
| --- | --- | --- |
| 6 B | 0.47 ms | 0.21 ms |
| 4 KB | 23.6 ms | 0.21 ms |
