### PR TITLE
chore(mcp): add server info metadata on client session "root" spans

### DIFF
--- a/ddtrace/contrib/internal/mcp/patch.py
+++ b/ddtrace/contrib/internal/mcp/patch.py
@@ -9,6 +9,7 @@ import mcp
 from ddtrace import config
 from ddtrace._trace.pin import Pin
 from ddtrace._trace.span import Span
+from ddtrace.constants import ERROR_MSG
 from ddtrace.contrib.internal.trace_utils import activate_distributed_headers
 from ddtrace.contrib.trace_utils import unwrap
 from ddtrace.contrib.trace_utils import with_traced_module
@@ -109,15 +110,25 @@ def traced_send_request(mcp, pin: Pin, func, instance, args: tuple, kwargs: dict
 
 @with_traced_module
 async def traced_call_tool(mcp, pin: Pin, func, instance, args: tuple, kwargs: dict):
-    integration = mcp._datadog_integration
+    integration: MCPIntegration = mcp._datadog_integration
 
-    span = integration.trace(pin, CLIENT_TOOL_CALL_OPERATION_NAME, submit_to_llmobs=True)
+    span: Span = integration.trace(pin, CLIENT_TOOL_CALL_OPERATION_NAME, submit_to_llmobs=True)
 
     try:
         result = await func(*args, **kwargs)
+
+        if getattr(result, "isError", False):
+            content = getattr(result, "content", [])
+            span.error = 1
+
+            content_block = content[0] if content and isinstance(content, list) else None
+            if content_block and getattr(content_block, "text", None):
+                span.set_tag(ERROR_MSG, content_block.text)
+
         integration.llmobs_set_tags(
             span, args=args, kwargs=kwargs, response=result, operation=CLIENT_TOOL_CALL_OPERATION_NAME
         )
+
         return result
     except Exception:
         integration.llmobs_set_tags(
@@ -182,7 +193,7 @@ async def traced_client_session_list_tools(mcp, pin: Pin, func, instance, args: 
 @with_traced_module
 async def traced_client_session_aenter(mcp, pin: Pin, func, instance, args: tuple, kwargs: dict):
     integration: MCPIntegration = mcp._datadog_integration
-    span = integration.trace(pin, instance.__class__.__name__, submit_to_llmobs=True)
+    span = integration.trace(pin, instance.__class__.__name__, submit_to_llmobs=True, type="client_session")
 
     setattr(instance, "_dd_span", span)
     try:

--- a/releasenotes/notes/mcp-tracing-changes-4e0ac309865e782b.yaml
+++ b/releasenotes/notes/mcp-tracing-changes-4e0ac309865e782b.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    mcp: Marks client mcp tool call spans as errors when the corresponding server tool call errored
+  - |
+    LLM Observability: Adds additional tags to MCP client session and tool call spans to power LLM Observability MCP tool call features.

--- a/tests/contrib/mcp/test_mcp_llmobs.py
+++ b/tests/contrib/mcp/test_mcp_llmobs.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib
 import json
 import os
 from textwrap import dedent
@@ -54,19 +55,34 @@ def test_llmobs_mcp_client_calls_server(mcp_setup, mock_tracer, llmobs_events, m
                 "isError": False,
             }
         ),
-        tags={"service": "mcptest", "ml_app": "<ml-app-name>"},
+        tags={
+            "service": "mcptest",
+            "ml_app": "<ml-app-name>",
+            "mcp_server_name": "TestServer",
+            "mcp_tool_kind": "client",
+        },
     )
     assert server_events[0] == _expected_llmobs_non_llm_span_event(
         server_span,
         span_kind="tool",
         input_value=json.dumps({"operation": "add", "a": 20, "b": 22}),
         output_value=json.dumps([{"type": "text", "annotations": {}, "meta": {}, "text": '{\n  "result": 42\n}'}]),
-        tags={"service": "mcptest", "ml_app": "<ml-app-name>"},
+        tags={"service": "mcptest", "ml_app": "<ml-app-name>", "mcp_tool_kind": "server"},
     )
 
     # asserting the remaining spans
     assert llmobs_events[0] == _expected_llmobs_non_llm_span_event(
-        all_spans[0], span_kind="workflow", input_value=mock.ANY, tags={"service": "mcptest", "ml_app": "<ml-app-name>"}
+        all_spans[0],
+        span_kind="workflow",
+        input_value=mock.ANY,
+        tags={
+            "service": "mcptest",
+            "ml_app": "<ml-app-name>",
+            "mcp_server_name": "TestServer",
+            "mcp_server_version": importlib.metadata.version("mcp"),
+            "mcp_server_title": None,
+        },
+        metadata=mock.ANY,
     )
 
     assert llmobs_events[1] == _expected_llmobs_non_llm_span_event(
@@ -97,33 +113,33 @@ def test_llmobs_client_server_tool_error(mcp_setup, mock_tracer, llmobs_events, 
     assert client_events[0]["name"] == "MCP Client Tool Call: failing_tool"
     assert server_events[0]["name"] == "MCP Server Tool Execute: failing_tool"
 
-    assert not client_span.error
+    assert client_span.error
     assert server_span.error
 
-    assert client_events[0] == _expected_llmobs_non_llm_span_event(
-        client_span,
-        span_kind="tool",
-        input_value=json.dumps({"param": "value"}),
-        output_value=json.dumps(
-            {
-                "content": [
-                    {
-                        "type": "text",
-                        "annotations": {},
-                        "meta": {},
-                        "text": "Error executing tool failing_tool: Tool execution failed",
-                    }
-                ],
-                "isError": True,
-            }
-        ),
-        tags={"service": "mcptest", "ml_app": "<ml-app-name>"},
+    # assert the error client span manually
+    assert client_events[0]["meta"]["input"]["value"] == json.dumps({"param": "value"})
+    assert client_events[0]["meta"]["output"]["value"] == json.dumps(
+        {
+            "content": [
+                {
+                    "type": "text",
+                    "annotations": {},
+                    "meta": {},
+                    "text": "Error executing tool failing_tool: Tool execution failed",
+                }
+            ],
+            "isError": True,
+        }
     )
+    assert client_events[0]["meta"]["error"]["message"] == "Error executing tool failing_tool: Tool execution failed"
+    assert client_events[0]["status"] == "error"
+    assert "error:1" in client_events[0]["tags"]
+
     assert server_events[0] == _expected_llmobs_non_llm_span_event(
         server_span,
         span_kind="tool",
         input_value=json.dumps({"param": "value"}),
-        tags={"service": "mcptest", "ml_app": "<ml-app-name>"},
+        tags={"service": "mcptest", "ml_app": "<ml-app-name>", "mcp_tool_kind": "server"},
         error="mcp.server.fastmcp.exceptions.ToolError",
         error_message="Error executing tool failing_tool: Tool execution failed",
         error_stack=mock.ANY,

--- a/tests/snapshots/tests.contrib.mcp.test_mcp.test_mcp_tool_error.json
+++ b/tests/snapshots/tests.contrib.mcp.test_mcp.test_mcp_tool_error.json
@@ -10,19 +10,19 @@
     "error": 0,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "68de79fc00000000",
+      "_dd.p.tid": "68ff754800000000",
       "language": "python",
-      "runtime-id": "65f2de5edad8471a88b2032aca2523ab"
+      "runtime-id": "e2c73207083c4f57b080a3d0d670f79d"
     },
     "metrics": {
       "_dd.measured": 1,
       "_dd.top_level": 1,
       "_dd.tracer_kr": 1.0,
       "_sampling_priority_v1": 1,
-      "process_id": 43046
+      "process_id": 61410
     },
-    "duration": 3761000,
-    "start": 1759410684715091000
+    "duration": 5585000,
+    "start": 1761572168208741000
   },
      {
        "name": "mcp.request",
@@ -36,8 +36,8 @@
        "metrics": {
          "_dd.measured": 1
        },
-       "duration": 992000,
-       "start": 1759410684715187000
+       "duration": 2029000,
+       "start": 1761572168209011000
      },
      {
        "name": "mcp.request",
@@ -47,15 +47,16 @@
        "span_id": 3,
        "parent_id": 1,
        "type": "",
-       "error": 0,
+       "error": 1,
        "meta": {
-         "_dd.p.tid": "68de79fc00000000"
+         "_dd.p.tid": "68ff754800000000",
+         "error.message": "Error executing tool failing_tool: Tool execution failed"
        },
        "metrics": {
          "_dd.measured": 1
        },
-       "duration": 2386000,
-       "start": 1759410684716255000
+       "duration": 2875000,
+       "start": 1761572168211125000
      },
         {
           "name": "mcp.request",
@@ -67,17 +68,17 @@
           "type": "",
           "error": 1,
           "meta": {
-            "_dd.p.tid": "68de79fc00000000",
+            "_dd.p.tid": "68ff754800000000",
             "error.message": "Error executing tool failing_tool: Tool execution failed",
-            "error.stack": "Traceback (most recent call last):\n  File \"/Users/sam.brenner/dd/dd-trace-py/.riot/venv_py31013_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_mcp~1100/lib/python3.10/site-packages/mcp/server/fastmcp/tools/base.py\", line 98, in run\n    result = await self.fn_metadata.call_fn_with_arg_validation(\n  File \"/Users/sam.brenner/dd/dd-trace-py/.riot/venv_py31013_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_mcp~1100/lib/python3.10/site-packages/mcp/server/fastmcp/utilities/func_metadata.py\", line 86, in call_fn_with_arg_validation\n    return fn(**arguments_parsed_dict)\n  File \"/Users/sam.brenner/dd/dd-trace-py/tests/contrib/mcp/conftest.py\", line 101, in failing_tool\n    raise ValueError(\"Tool execution failed\")\nValueError: Tool execution failed\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/Users/sam.brenner/dd/dd-trace-py/ddtrace/contrib/internal/mcp/patch.py\", line 141, in traced_tool_manager_call_tool\n    result = await func(*args, **kwargs)\n  File \"/Users/sam.brenner/dd/dd-trace-py/.riot/venv_py31013_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_mcp~1100/lib/python3.10/site-packages/mcp/server/fastmcp/tools/tool_manager.py\", line 83, in call_tool\n    return await tool.run(arguments, context=context, convert_result=convert_result)\n  File \"/Users/sam.brenner/dd/dd-trace-py/.riot/venv_py31013_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_mcp~1100/lib/python3.10/site-packages/mcp/server/fastmcp/tools/base.py\", line 110, in run\n    raise ToolError(f\"Error executing tool {self.name}: {e}\") from e\nmcp.server.fastmcp.exceptions.ToolError: Error executing tool failing_tool: Tool execution failed\n",
+            "error.stack": "Traceback (most recent call last):\n  File \"/Users/sam.brenner/dd/dd-trace-py/.riot/venv_py31013_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_mcp~1100/lib/python3.10/site-packages/mcp/server/fastmcp/tools/base.py\", line 98, in run\n    result = await self.fn_metadata.call_fn_with_arg_validation(\n  File \"/Users/sam.brenner/dd/dd-trace-py/.riot/venv_py31013_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_mcp~1100/lib/python3.10/site-packages/mcp/server/fastmcp/utilities/func_metadata.py\", line 86, in call_fn_with_arg_validation\n    return fn(**arguments_parsed_dict)\n  File \"/Users/sam.brenner/dd/dd-trace-py/tests/contrib/mcp/conftest.py\", line 101, in failing_tool\n    raise ValueError(\"Tool execution failed\")\nValueError: Tool execution failed\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/Users/sam.brenner/dd/dd-trace-py/ddtrace/contrib/internal/mcp/patch.py\", line 153, in traced_tool_manager_call_tool\n    result = await func(*args, **kwargs)\n  File \"/Users/sam.brenner/dd/dd-trace-py/.riot/venv_py31013_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_mcp~1100/lib/python3.10/site-packages/mcp/server/fastmcp/tools/tool_manager.py\", line 83, in call_tool\n    return await tool.run(arguments, context=context, convert_result=convert_result)\n  File \"/Users/sam.brenner/dd/dd-trace-py/.riot/venv_py31013_mock_pytest_pytest-mock_coverage_pytest-cov_opentracing_hypothesis6451_pytest-asyncio_mcp~1100/lib/python3.10/site-packages/mcp/server/fastmcp/tools/base.py\", line 110, in run\n    raise ToolError(f\"Error executing tool {self.name}: {e}\") from e\nmcp.server.fastmcp.exceptions.ToolError: Error executing tool failing_tool: Tool execution failed\n",
             "error.type": "mcp.server.fastmcp.exceptions.ToolError",
-            "runtime-id": "65f2de5edad8471a88b2032aca2523ab"
+            "runtime-id": "e2c73207083c4f57b080a3d0d670f79d"
           },
           "metrics": {
             "_dd.measured": 1,
             "_dd.top_level": 1,
-            "process_id": 43046
+            "process_id": 61410
           },
-          "duration": 1156000,
-          "start": 1759410684717097000
+          "duration": 1276000,
+          "start": 1761572168212203000
         }]]


### PR DESCRIPTION
…#14828)

## Description

Adds server info metadata to llm observability mcp client session "root" spans. This information includes
- server name
- server version
- server title

Additionally, adds similar tags to client tool spans:
- For both client and server tool calls, mark which kind of tool call they are on a tag (as besides the name, which could vary for manual instrumentation, it is not apparent as they are just normal tool calls otherwise)
- adds the mcp server name of the session the client tool call was used for

Lastly, generally for the `mcp` integration, we now mark client tool calls as errors when the tool result returned from the mcp server was an error as well.

MLOB-4147

## Testing

Add unit tests, and additionally, verified through internal testing against a staging hash in our frontend.

## Risks

None

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
