### PR TITLE
chore: remove ddtrace.config from public API because it no longer makes sense

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -19,7 +19,6 @@ from ddtrace.vendor import debtcollector
 from ._monkey import patch  # noqa: E402
 from ._monkey import patch_all  # noqa: E402
 from .internal.compat import PYTHON_VERSION_INFO  # noqa: E402
-from .internal.settings._config import config
 from .internal.utils.deprecations import DDTraceDeprecationWarning  # noqa: E402
 from .version import get_version  # noqa: E402
 
@@ -33,7 +32,6 @@ if os.environ.get("_DD_GLOBAL_TRACER_INIT", "true").lower() in ("1", "true"):
 __all__ = [
     "patch",
     "patch_all",
-    "config",
     "DDTraceDeprecationWarning",
 ]
 


### PR DESCRIPTION
## Description

This change removes the `ddtrace.config` package from the public API. Before this is merged into a major release, the previous release line should have a deprecation added on `ddtrace.config`.