### PR TITLE
test: wait for extra service name from fork

### DIFF
--- a/tests/internal/service_name/test_extra_services_names.py
+++ b/tests/internal/service_name/test_extra_services_names.py
@@ -23,8 +23,13 @@ for i in range(10):
         service_name = f"extra_service_{i}"
         ddtrace.config._add_extra_service(service_name)
         # Ensure the child has time to save the service
-        while service_name not in set(ddtrace.config._extra_services_queue.peekall()):
+        for _ in range(30):
             time.sleep(0.1)
+            if service_name in set(ddtrace.config._extra_services_queue.peekall()):
+                break
+        else:
+            msg = f"extra service name '{service_name}' not emitted by child"
+            raise RuntimeError(msg)
         sys.exit(0)
     else:
         # Parent process


### PR DESCRIPTION
## Description

We add wait logic to ensure that a fork child process has time to emit its extra service name.