### PR TITLE
ci: increase gitlab timeout because some small jobs have been timing out

### DIFF
--- a/.gitlab/testrunner.yml
+++ b/.gitlab/testrunner.yml
@@ -8,7 +8,7 @@ variables:
       user: bits
   # DEV: we have a larger pool of amd64 runners, prefer that over arm64
   tags: [ "arch:amd64" ]
-  timeout: 20m
+  timeout: 30m
   before_script:
     - ulimit -c unlimited
     - git config --global --add safe.directory ${CI_PROJECT_DIR}


### PR DESCRIPTION
This change aims to resolve CI failures like [this one](https://gitlab.ddbuild.io/datadog/apm-reliability/dd-trace-py/builds/1239851275) where a non-parallelizable job exceeded its time limit.