### PR TITLE
ci: add retries to github build_wheels jobs

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -69,6 +69,7 @@ jobs:
     needs: [ "compute_version" ]
     uses: ./.github/workflows/build_python_3.yml
     with:
+      max_attempts: 3
       cibw_build: 'cp39* cp310* cp311* cp312* cp313* cp314*'
       cibw_skip: 'cp39-win_arm64 cp310-win_arm64 cp314t* *_i686'
       library_version: ${{ needs.compute_version.outputs.library_version }}

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -69,7 +69,6 @@ jobs:
     needs: [ "compute_version" ]
     uses: ./.github/workflows/build_python_3.yml
     with:
-      max_attempts: 3
       cibw_build: 'cp39* cp310* cp311* cp312* cp313* cp314*'
       cibw_skip: 'cp39-win_arm64 cp310-win_arm64 cp314t* *_i686'
       library_version: ${{ needs.compute_version.outputs.library_version }}

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -118,7 +118,7 @@ jobs:
         uses: Wandalen/wretry.action@master
         with:
           action: pypa/cibuildwheel@c923d83ad9c1bc00211c5041d0c3f73294ff88f6 # v3.1.4
-          with:
+          with: |
             only: ${{ matrix.only }}
           attempt_limit: 3
         env:

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -115,9 +115,12 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@c923d83ad9c1bc00211c5041d0c3f73294ff88f6 # v3.1.4
+        uses: Wandalen/wretry.action@master
         with:
-          only: ${{ matrix.only }}
+          action: pypa/cibuildwheel@c923d83ad9c1bc00211c5041d0c3f73294ff88f6 # v3.1.4
+          with:
+            only: ${{ matrix.only }}
+          attempt_limit: 3
         env:
           SETUPTOOLS_SCM_PRETEND_VERSION_FOR_DDTRACE: ${{ needs.compute_version.outputs.library_version }}
           CIBW_SKIP: ${{ inputs.cibw_skip }}

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -79,6 +79,7 @@ jobs:
     needs: ["compute_version", "build-wheels-matrix" ]
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.only }}
+    max_attempts: 3
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_python_3.yml
+++ b/.github/workflows/build_python_3.yml
@@ -79,7 +79,6 @@ jobs:
     needs: ["compute_version", "build-wheels-matrix" ]
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.only }}
-    max_attempts: 3
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This change adds retries to job failures like [this one](https://github.com/DataDog/dd-trace-py/actions/runs/19438091961/job/55614779944) where wheel building fails in Github Actions. Retries would reduce the impact of infrastructure issues on job success.