### PR TITLE
ci: increase tracer test suite memory request

### DIFF
--- a/tests/suitespec.yml
+++ b/tests/suitespec.yml
@@ -251,6 +251,8 @@ suites:
   tracer:
     env:
       DD_TRACE_AGENT_URL: http://localhost:8126
+      KUBERNETES_MEMORY_REQUEST: "4Gi"
+      KUBERNETES_MEMORY_LIMIT: "4Gi"
     parallelism: 9
     paths:
       - '@tracing'


### PR DESCRIPTION
## Description

We were seeing some OOM Kills from k8s of the tracer test suite.

I saw memory usage spike to 3GB before being killed, this updates it to 4GB.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
