### PR TITLE
chore: treat PEP 765 warnings as errors

### DIFF
--- a/.sg/rules/pep765-control-flow-in-finally.yml
+++ b/.sg/rules/pep765-control-flow-in-finally.yml
@@ -1,6 +1,6 @@
 id: pep765-control-flow-in-finally
 message: Control flow statement in finally block (PEP 765)
-severity: warning
+severity: error
 language: python
 rule:
   any:

--- a/ddtrace/contrib/internal/openai/patch.py
+++ b/ddtrace/contrib/internal/openai/patch.py
@@ -350,7 +350,7 @@ class _TracedAsyncPaginator:
                     g.send((resp, err))
                 except StopIteration as e:
                     if err is None:
-                        return e.value
+                        resp = e.value
             return resp
 
         return _trace_and_await().__await__()


### PR DESCRIPTION
## Description

PEP 765 returns in finally statements is a SyntaxWarning in 3.14, and will turn into exceptions in 3.15

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
