### PR TITLE
chore: flush shared string file before unlocking

### DIFF
--- a/ddtrace/internal/ipc.py
+++ b/ddtrace/internal/ipc.py
@@ -181,3 +181,7 @@ class SharedStringFile:
             return
         with open_file(self.filename, "r+b") as f, WriteLock(f):
             yield f
+            # Flush before releasing the lock. Here we first release the lock,
+            # then close the file. If a read happens in between these two
+            # operations, the reader might see outdated data.
+            f.flush()


### PR DESCRIPTION
## Description

We make sure that writes to shared string files are flushed  before the exclusive lock is released to guarantee that changes are visible to other processes trying to access the same file.