### PR TITLE
ci: bump microbenchmark threshold

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.yml
@@ -1092,7 +1092,7 @@ experiments:
               - max_rss_usage < 35.50 MB
           - name: telemetryaddmetric-1-distribution-metrics-100-times
             thresholds:
-              - execution_time < 0.22 ms
+              - execution_time < 0.23 ms
               - max_rss_usage < 35.50 MB
           - name: telemetryaddmetric-1-gauge-metric-1-times
             thresholds:


### PR DESCRIPTION
This benchmark is consistently failing by about 2 milliseconds