### PR TITLE
fix(profiling): actually disable GC during memalloc traceback collection

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -11,6 +11,7 @@
 #include "_memalloc_heap_map.hpp"
 #include "_memalloc_reentrant.h"
 #include "_memalloc_tb.h"
+#include "_pymacro.h"
 
 /*
    How heap profiler sampling works:

--- a/ddtrace/profiling/collector/_pymacro.h
+++ b/ddtrace/profiling/collector/_pymacro.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Python.h>
+
 #if PY_VERSION_HEX >= 0x030c0000
 #define _PY312_AND_LATER
 #endif

--- a/releasenotes/notes/profiling-actually-disable-gc-during-memalloc-traceback-d8eecf5687c8ab3b.yaml
+++ b/releasenotes/notes/profiling-actually-disable-gc-during-memalloc-traceback-d8eecf5687c8ab3b.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    profiling: This fix prevents a use-after-free crash from the memory profiler
+    on Python version 3.10 and 3.11. The previous attempt to fix this bug itself
+    had a bug, which this fix addresses.


### PR DESCRIPTION
## Description

This corrects a previous, invalid fix for a use-after-free crash in the
memory profiler (#14550). The previous fix used preprocessor macros to
conditionally disable/reenable GC for Python 3.10 and 3.11. However, the
previous fix failed to include `_pymacro.h`, which defines the macros.
So, the fix didn't actually apply.

## Testing

<!-- Describe your testing strategy or note what tests are included -->
Checked that the GC disable call is actually included in `memalloc_heap_track`
when built for Python 3.10 and Python 3.11, and not included for 3.12.

[Example](https://github.com/DataDog/dd-trace-py/actions/runs/19635781255/job/56228261419) (3.10):

```
% objdump --demangle -d $(find . -name '_memalloc.*.so')
[ ... ]
   3e12: e8 19 f7 ff ff                callq   0x3530 <PyGC_Disable@plt>
[ ... ]
    3e90: e8 0b f3 ff ff                callq   0x31a0 <PyGC_Enable@plt>
    3e95: eb a1                         jmp     0x3e38 <memalloc_heap_track(unsigned short, void*, unsigned long, PyMemAllocatorDomain)+0x88>
    3e97: 48 89 c5                      movq    %rax, %rbp
    3e9a: e9 96 f7 ff ff                jmp     0x3635 <memalloc_heap_track(unsigned short, void*, unsigned long, PyMemAllocatorDomain) (.cold)>
    3e9f: 90                            nop
```

Similar for 3.11. For 3.12 ([example](https://github.com/DataDog/dd-trace-py/actions/runs/19635781255/job/56228261708)) I checked that the calls aren't there,
as expected.

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->
This fixes a bug. As with the previous, failed attempt at a fix,
we might see _slightly_ increased memory usage due to temporarily delaying GC.
But I believe the risk is minimal. And the alternative is crashing.

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
