### PR TITLE
ci: install hatch from PyPI not GitHub

### DIFF
--- a/.github/workflows/generate-package-versions.yml
+++ b/.github/workflows/generate-package-versions.yml
@@ -74,21 +74,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libmariadb-dev
 
-      - name: Install hatch
-        uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc # install
-        with:
-          version: "1.12.0"
-
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade "pip<25.3"
           pip install packaging
           pip install requests
+          pip install pip-tools==7.5.2
           pip install riot==0.20.1
+          pip install hatch==1.14.2
           pip install PyYAML
           pip install ddtrace
-          # Install latest pip-tools from main branch for Python 3.14 compatibility
-          pip install --upgrade git+https://github.com/jazzband/pip-tools.git@1c2692b7f45a94d93e3f4bb252da3fd711ad08a9 # v7.5.1
 
       - name: Run regenerate-riot-latest
         run: scripts/regenerate-riot-latest.sh


### PR DESCRIPTION
## Description

PyPI is way more reliable of a place to download from than GitHub.

Also, I noticed the pip-tools version we need is released, so bumped that.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
