### PR TITLE
fix(profiling): reinstall signal handler if needed

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack_v2/echion/echion/danger.h
+++ b/ddtrace/internal/datadog/profiling/stack_v2/echion/echion/danger.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cassert>
 #include <csignal>
 #include <cstddef>

--- a/releasenotes/notes/profiling-reinstall-signal-handlers-f399eaed35481177.yaml
+++ b/releasenotes/notes/profiling-reinstall-signal-handlers-f399eaed35481177.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    profiling: This fix resolves a possible crash coming from the experimental "fast memory copy" feature of the Stack
+    Sampler. It occurred when the Profiler's signal handlers were replaced by other ones (from the application code).


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13114

This PR makes sure the Python Profiler's signal handler (for `SIGSEGV` and `SIGBUS`) is properly installed when the Sampler thread starts.  
Note that this (reinstalling our signal handler) does NOT break any other signal handler (Python's or another extension's) as our signal handler only swallows faults / jumps to the recovery path if it's been "armed" (otherwise it re-raises). What matters is that we should be the "first responder" when a fault happens.

This is an attempt to fix a crash we saw in the testing environment where some workloads receive segmentation faults clearly coming from `safe_memcpy` in FastAPI / Django apps.  
The "real" root cause isn't yet known of me – Django and FastAPI don't seem to use `PYTHONFAULTHANDLER` or `faulthandler` based on the Github code –  but after deploying those changes, we stopped seeing those crashes (0 in the past 4 days).

<img width="2089" height="480" alt="image" src="https://github.com/user-attachments/assets/c554ec0c-cfae-4311-bded-8082d8f79ed9" />


```
Error UnixSignal: Process terminated with SEGV_MAPERR (SIGSEGV)
#0   0x0000755d4295c18f safe_memcpy 
#1   0x0000755d42954879 copy_memory 
#2   0x0000755d42956826 GenInfo::create 
#3   0x0000755d42958c25 TaskInfo::create 
#4   0x0000755d42958cc7 TaskInfo::create 
#5   0x0000755d4295a618 ThreadInfo::unwind_tasks 
#6   0x0000755d4295b98b std::_Function_handler<void (_ts*, ThreadInfo&), Datadog::Sampler::sampling_thread(unsigned long)::{lambda(InterpreterInfo&)#1}::operator()(InterpreterInfo&) const::{lambda(_ts*, ThreadInfo&)#1}>::_M_invoke 
#7   0x0000755d42959906 for_each_thread 
#8   0x0000755d429599e5 std::_Function_handler<void (InterpreterInfo&), Datadog::Sampler::sampling_thread(unsigned long)::{lambda(InterpreterInfo&)#1}>::_M_invoke 
#9   0x0000755d4295c5b2 Datadog::Sampler::sampling_thread 
#10  0x0000755d4295c685 call_sampling_thread 
#11  0x0000755d45aeeea7 start_thread 
#12  0x0000755d45c05def clone 
```

