### PR TITLE
chore: migrate os env call to new package 2/3

### DIFF
--- a/.sg/rules/os-environ-usage.yml
+++ b/.sg/rules/os-environ-usage.yml
@@ -7,6 +7,11 @@ files:
 ignores:
   - "ddtrace/internal/settings/_env.py"
   - "ddtrace/appsec/_iast/_taint_tracking/_vendor/pybind11/pybind11/setup_helpers.py"
+  - "ddtrace/commands/ddtrace_run.py"
+  - "ddtrace/internal/settings/_inferred_base_service.py" # Not sure which env var are used in this file - Needs to be investigated
+  - "ddtrace/internal/serverless/__init__.py" # Serverless providers env vars only in this file
+  - "ddtrace/internal/native/__init__.py" # Needs to be investigated, only DD_TRACE_DEBUG is used in this file
+  - "ddtrace/internal/dist_computing/utils.py" # Ray specific env var
 rule:
   any:
     # Match os.environ access patterns

--- a/ddtrace/_trace/apm_filter.py
+++ b/ddtrace/_trace/apm_filter.py
@@ -5,7 +5,6 @@ from ddtrace._trace.processor import TraceProcessor
 from ddtrace._trace.span import Span
 from ddtrace.internal.settings import _env
 from ddtrace.internal.utils.formats import asbool
-from ddtrace.internal.settings import _env
 
 
 class APMTracingEnabledFilter(TraceProcessor):

--- a/ddtrace/bootstrap/cloning.py
+++ b/ddtrace/bootstrap/cloning.py
@@ -1,10 +1,10 @@
 import logging
-import os
 import sys
 import warnings
 
 from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.internal.module import is_module_installed
+from ddtrace.internal.settings import _env
 from ddtrace.internal.utils.formats import asbool  # noqa:F401
 
 
@@ -13,7 +13,7 @@ MODULES_REQUIRING_CLEANUP = ("gevent",)
 
 enabled = (
     any(is_module_installed(m) for m in MODULES_REQUIRING_CLEANUP)
-    if (_unload_modules := os.getenv("DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE", default="auto").lower()) == "auto"
+    if (_unload_modules := _env.getenv("DD_UNLOAD_MODULES_FROM_SITECUSTOMIZE", default="auto").lower()) == "auto"
     else asbool(_unload_modules)
 )
 

--- a/ddtrace/bootstrap/sitecustomize.py
+++ b/ddtrace/bootstrap/sitecustomize.py
@@ -20,6 +20,7 @@ import sys
 
 import ddtrace.bootstrap.cloning as cloning
 from ddtrace.internal.logger import get_logger  # noqa:F401
+from ddtrace.internal.settings import _env
 from ddtrace.internal.telemetry import telemetry_writer
 
 
@@ -67,7 +68,7 @@ try:
         else:
             log.debug("additional sitecustomize found in: %s", sys.path)
 
-    if os.getenv("_DD_PY_SSI_INJECT") == "1":
+    if _env.getenv("_DD_PY_SSI_INJECT") == "1":
         # _DD_PY_SSI_INJECT is set to `1` in lib-injection/sources/sitecustomize.py when ssi is started
         # and doesn't abort.
         source = "ssi"

--- a/ddtrace/contrib/internal/pytest/_xdist.py
+++ b/ddtrace/contrib/internal/pytest/_xdist.py
@@ -15,7 +15,6 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings import _env
 from ddtrace.internal.test_visibility.api import InternalTestSession
 from ddtrace.internal.utils.formats import asbool
-from ddtrace.internal.settings import _env
 
 
 log = get_logger(__name__)

--- a/ddtrace/ext/ci.py
+++ b/ddtrace/ext/ci.py
@@ -14,6 +14,7 @@ from typing import Optional  # noqa:F401
 
 from ddtrace.ext import git
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import _env
 
 
 # CI app dd_origin tag
@@ -98,7 +99,7 @@ def _get_runtime_and_os_metadata():
 def tags(env=None, cwd=None):
     # type: (Optional[MutableMapping[str, str]], Optional[str]) -> Dict[str, str]
     """Extract and set tags from provider environ, as well as git metadata."""
-    env = os.environ if env is None else env
+    env = _env.environ if env is None else env
     tags = {}  # type: Dict[str, Optional[str]]
     for key, extract in PROVIDERS:
         if key in env:

--- a/ddtrace/ext/git.py
+++ b/ddtrace/ext/git.py
@@ -21,6 +21,7 @@ from typing import Union  # noqa:F401
 
 from ddtrace.internal import compat
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import _env
 from ddtrace.internal.utils.cache import cached
 from ddtrace.internal.utils.time import StopWatch
 
@@ -402,7 +403,7 @@ def extract_git_metadata(cwd=None):
 def extract_user_git_metadata(env=None):
     # type: (Optional[MutableMapping[str, str]]) -> Dict[str, Optional[str]]
     """Extract git commit metadata from user-provided env vars."""
-    env = os.environ if env is None else env
+    env = _env.environ if env is None else env
 
     branch = normalize_ref(env.get("DD_GIT_BRANCH"))
     tag = normalize_ref(env.get("DD_GIT_TAG"))

--- a/ddtrace/ext/test_visibility/__init__.py
+++ b/ddtrace/ext/test_visibility/__init__.py
@@ -2,11 +2,11 @@
 NOTE: BETA - this API is currently in development and is subject to change.
 """
 
-import os
 import typing as t
 
 from ddtrace import config
 from ddtrace.ext.test_visibility._constants import ITR_SKIPPING_LEVEL
+from ddtrace.internal.settings import _env
 from ddtrace.internal.utils.formats import asbool
 
 
@@ -15,7 +15,7 @@ def _get_default_test_visibility_contrib_config() -> t.Dict[str, t.Any]:
         _default_service="default_test_visibility_service",
         itr_skipping_level=(
             ITR_SKIPPING_LEVEL.SUITE
-            if asbool(os.getenv("_DD_CIVISIBILITY_ITR_SUITE_MODE", True))
+            if asbool(_env.getenv("_DD_CIVISIBILITY_ITR_SUITE_MODE", True))
             else ITR_SKIPPING_LEVEL.TEST
         ),
         _itr_skipping_ignore_parameters=False,

--- a/ddtrace/internal/ci_visibility/_api_client.py
+++ b/ddtrace/internal/ci_visibility/_api_client.py
@@ -4,7 +4,6 @@ import dataclasses
 from http.client import RemoteDisconnected
 import json
 from json import JSONDecodeError
-import os
 import socket
 import typing as t
 from typing import TypedDict  # noqa:F401
@@ -48,6 +47,7 @@ from ddtrace.internal.evp_proxy.constants import EVP_PROXY_AGENT_BASE_PATH
 from ddtrace.internal.evp_proxy.constants import EVP_SUBDOMAIN_HEADER_API_VALUE
 from ddtrace.internal.evp_proxy.constants import EVP_SUBDOMAIN_HEADER_NAME
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import _env
 from ddtrace.internal.test_visibility.coverage_lines import CoverageLines
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.http import ConnectionType
@@ -406,7 +406,7 @@ class _TestVisibilityAPIClientBase(abc.ABC):
             require_git = attributes["require_git"]
             itr_enabled = attributes["itr_enabled"]
             flaky_test_retries_enabled = attributes["flaky_test_retries_enabled"] or asbool(
-                os.getenv("_DD_TEST_FORCE_ENABLE_ATR")
+                _env.getenv("_DD_TEST_FORCE_ENABLE_ATR")
             )
             known_tests_enabled = attributes["known_tests_enabled"]
 
@@ -424,7 +424,7 @@ class _TestVisibilityAPIClientBase(abc.ABC):
 
             test_management_attributes = attributes.get("test_management", {})
             test_management_enabled = test_management_attributes.get("enabled", False)
-            attempt_to_fix_retries_env = os.getenv("DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES")
+            attempt_to_fix_retries_env = _env.getenv("DD_TEST_MANAGEMENT_ATTEMPT_TO_FIX_RETRIES")
             if attempt_to_fix_retries_env and attempt_to_fix_retries_env.isdigit():
                 attempt_to_fix_retries = int(attempt_to_fix_retries_env)
                 log.debug("Number of Attempt to Fix retries obtained from environment: %d", attempt_to_fix_retries)
@@ -435,7 +435,7 @@ class _TestVisibilityAPIClientBase(abc.ABC):
                 log.debug("Number of Attempt to Fix retries obtained from API: %d", attempt_to_fix_retries)
 
             test_management = TestManagementSettings(
-                enabled=test_management_enabled or asbool(os.getenv("_DD_TEST_FORCE_ENABLE_TEST_MANAGEMENT")),
+                enabled=test_management_enabled or asbool(_env.getenv("_DD_TEST_FORCE_ENABLE_TEST_MANAGEMENT")),
                 attempt_to_fix_retries=attempt_to_fix_retries,
             )
 

--- a/ddtrace/internal/ci_visibility/_api_responses_cache.py
+++ b/ddtrace/internal/ci_visibility/_api_responses_cache.py
@@ -6,6 +6,7 @@ import shutil
 import typing as t
 
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import _env
 from ddtrace.internal.utils.formats import asbool
 
 
@@ -15,7 +16,7 @@ _API_RESPONSE_CACHE_DIR = os.path.join(os.getcwd(), ".ddtrace_api_cache")
 
 
 def _is_response_cache_enabled():
-    return asbool(os.getenv("_DD_CIVISIBILITY_RESPONSE_CACHE_ENABLED", "false").lower())
+    return asbool(_env.getenv("_DD_CIVISIBILITY_RESPONSE_CACHE_ENABLED", "false").lower())
 
 
 def _get_cache_file_path(cache_key: str) -> str:
@@ -68,5 +69,5 @@ def _clean_api_response_cache_dir():
         shutil.rmtree(_API_RESPONSE_CACHE_DIR)
 
 
-if os.environ.get("PYTEST_XDIST_WORKER") is None:  # Not an xdist worker
+if _env.environ.get("PYTEST_XDIST_WORKER") is None:  # Not an xdist worker
     atexit.register(_clean_api_response_cache_dir)

--- a/ddtrace/internal/ci_visibility/api/_test.py
+++ b/ddtrace/internal/ci_visibility/api/_test.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from time import time_ns
 from typing import ContextManager
@@ -39,6 +38,7 @@ from ddtrace.internal.ci_visibility.telemetry.constants import EVENT_TYPES
 from ddtrace.internal.ci_visibility.telemetry.events import record_event_created_test
 from ddtrace.internal.ci_visibility.telemetry.events import record_event_finished_test
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import _env
 from ddtrace.internal.test_visibility._benchmark_mixin import BENCHMARK_TAG_MAP
 from ddtrace.internal.test_visibility._benchmark_mixin import BenchmarkDurationData
 from ddtrace.internal.test_visibility._efd_mixins import EFDTestStatus
@@ -114,7 +114,7 @@ class TestVisibilityTest(TestVisibilityChildItem[TestId], TestVisibilityItemBase
     def _start_span(self, context: Optional[Context] = None) -> None:
         super()._start_span(context)
 
-        if asbool(os.getenv("DD_CIVISIBILITY_USE_BETA_WRITER")) and self._span:
+        if asbool(_env.getenv("DD_CIVISIBILITY_USE_BETA_WRITER")) and self._span:
             self._main_tracer_context = ddtrace.tracer._activate_context(
                 Context(trace_id=self._span.trace_id, span_id=self._span.span_id)
             )
@@ -123,7 +123,7 @@ class TestVisibilityTest(TestVisibilityChildItem[TestId], TestVisibilityItemBase
     def _finish_span(self, override_finish_time: Optional[float] = None) -> None:
         super()._finish_span(override_finish_time)
 
-        if asbool(os.getenv("DD_CIVISIBILITY_USE_BETA_WRITER")) and self._main_tracer_context:
+        if asbool(_env.getenv("DD_CIVISIBILITY_USE_BETA_WRITER")) and self._main_tracer_context:
             self._main_tracer_context.__exit__(None, None, None)
 
     def __repr__(self) -> str:

--- a/ddtrace/internal/ci_visibility/coverage.py
+++ b/ddtrace/internal/ci_visibility/coverage.py
@@ -21,6 +21,7 @@ from ddtrace.internal.ci_visibility.telemetry.coverage import record_code_covera
 from ddtrace.internal.ci_visibility.utils import get_relative_or_absolute_path_for_path
 from ddtrace.internal.coverage.code import ModuleCodeCollector
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import _env
 from ddtrace.internal.utils.formats import asbool
 
 
@@ -29,7 +30,7 @@ _global_relative_file_paths_for_cov: Dict[str, Dict[str, str]] = {}
 
 # This feature-flags experimental collection of code coverage via our internal ModuleCodeCollector.
 # It is disabled by default because it is not production-ready.
-USE_DD_COVERAGE = asbool(os.environ.get("_DD_USE_INTERNAL_COVERAGE", "false"))
+USE_DD_COVERAGE = asbool(_env.environ.get("_DD_USE_INTERNAL_COVERAGE", "false"))
 
 try:
     from coverage import Coverage

--- a/ddtrace/internal/ci_visibility/encoder.py
+++ b/ddtrace/internal/ci_visibility/encoder.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import threading
 from typing import TYPE_CHECKING  # noqa:F401
 from typing import Any  # noqa:F401
@@ -28,6 +27,7 @@ from ddtrace.internal.ci_visibility.telemetry.payload import record_endpoint_pay
 from ddtrace.internal.ci_visibility.telemetry.payload import record_endpoint_payload_events_serialization_time
 from ddtrace.internal.encoding import JSONEncoderV2
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import _env
 from ddtrace.internal.utils.time import StopWatch
 from ddtrace.internal.writer.writer import NoEncodableSpansError
 
@@ -52,7 +52,7 @@ class CIVisibilityEncoderV01(BufferedEncoder):
         super(CIVisibilityEncoderV01, self).__init__()
         self._metadata: Dict[str, Dict[str, str]] = {}
         self._lock = threading.RLock()
-        self._is_xdist_worker = os.getenv("PYTEST_XDIST_WORKER") is not None
+        self._is_xdist_worker = _env.getenv("PYTEST_XDIST_WORKER") is not None
         self._init_buffer()
 
     def __len__(self):

--- a/ddtrace/internal/ci_visibility/git_client.py
+++ b/ddtrace/internal/ci_visibility/git_client.py
@@ -25,6 +25,7 @@ from ddtrace.ext.git import extract_git_version
 from ddtrace.ext.git import extract_remote_url
 from ddtrace.ext.git import extract_workspace_path
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import _env
 from ddtrace.internal.settings._agent import config as agent_config
 from ddtrace.internal.settings._telemetry import config as telemetry_config
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
@@ -100,7 +101,7 @@ class CIVisibilityGitClient(object):
         elif self._requests_mode == REQUESTS_MODE.AGENTLESS_EVENTS:
             self._base_url = urljoin(
                 "https://api.{}".format(
-                    os.getenv("DD_SITE", AGENTLESS_DEFAULT_SITE),
+                    _env.getenv("DD_SITE", AGENTLESS_DEFAULT_SITE),
                 ),
                 GIT_API_BASE_PATH,
             )

--- a/ddtrace/internal/ci_visibility/writer.py
+++ b/ddtrace/internal/ci_visibility/writer.py
@@ -1,5 +1,4 @@
 from http.client import RemoteDisconnected
-import os
 import socket
 from typing import TYPE_CHECKING  # noqa:F401
 from typing import Dict
@@ -11,6 +10,7 @@ from ddtrace.ext.test import TEST_SESSION_NAME
 from ddtrace.internal.ci_visibility.constants import MODULE_TYPE
 from ddtrace.internal.ci_visibility.constants import SESSION_TYPE
 from ddtrace.internal.ci_visibility.constants import SUITE_TYPE
+from ddtrace.internal.settings import _env
 from ddtrace.internal.settings._agent import config as agent_config
 from ddtrace.internal.utils.time import StopWatch
 from ddtrace.vendor.dogstatsd import DogStatsd  # noqa:F401
@@ -51,7 +51,7 @@ class CIVisibilityEventClient(WriterClientBase):
             "*",
             {
                 "language": "python",
-                "env": os.getenv("_CI_DD_ENV", config.env),
+                "env": _env.getenv("_CI_DD_ENV", config.env),
                 "runtime-id": get_runtime_id(),
                 "library_version": __version__,
                 "_dd.test.is_user_provided_service": "true" if config._is_user_provided_service else "false",
@@ -127,7 +127,7 @@ class CIVisibilityWriter(HTTPWriter):
             intake_url = intake_url if intake_url else config._ci_visibility_agentless_url
             intake_cov_url = intake_url
         if not intake_url:
-            intake_url = "%s.%s" % (AGENTLESS_BASE_URL, os.getenv("DD_SITE", AGENTLESS_DEFAULT_SITE))
+            intake_url = "%s.%s" % (AGENTLESS_BASE_URL, _env.getenv("DD_SITE", AGENTLESS_DEFAULT_SITE))
 
         self._use_evp = use_evp
         clients = [CIVisibilityProxiedEventClient()] if self._use_evp else [CIVisibilityAgentlessEventClient()]  # type: List[WriterClientBase]
@@ -135,7 +135,7 @@ class CIVisibilityWriter(HTTPWriter):
         self._itr_suite_skipping_mode = itr_suite_skipping_mode
         if self._coverage_enabled:
             if not intake_cov_url:
-                intake_cov_url = "%s.%s" % (AGENTLESS_COVERAGE_BASE_URL, os.getenv("DD_SITE", AGENTLESS_DEFAULT_SITE))
+                intake_cov_url = "%s.%s" % (AGENTLESS_COVERAGE_BASE_URL, _env.getenv("DD_SITE", AGENTLESS_DEFAULT_SITE))
             clients.append(
                 CIVisibilityProxiedCoverageClient(
                     intake_url=intake_cov_url,

--- a/ddtrace/internal/coverage/instrumentation_py3_12.py
+++ b/ddtrace/internal/coverage/instrumentation_py3_12.py
@@ -9,13 +9,13 @@ The mode is controlled by the _DD_COVERAGE_FILE_LEVEL environment variable.
 """
 
 import dis
-import os
 import sys
 from types import CodeType
 import typing as t
 
 from ddtrace.internal.bytecode_injection import HookType
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import _env
 from ddtrace.internal.test_visibility.coverage_lines import CoverageLines
 from ddtrace.internal.utils.formats import asbool
 
@@ -34,7 +34,7 @@ RETURN_CONST = dis.opmap["RETURN_CONST"]
 EMPTY_MODULE_BYTES = bytes([RESUME, 0, RETURN_CONST, 0])
 
 # Check if file-level coverage is requested
-_USE_FILE_LEVEL_COVERAGE = asbool(os.getenv("_DD_COVERAGE_FILE_LEVEL", "false"))
+_USE_FILE_LEVEL_COVERAGE = asbool(_env.getenv("_DD_COVERAGE_FILE_LEVEL", "false"))
 
 EVENT = sys.monitoring.events.PY_START if _USE_FILE_LEVEL_COVERAGE else sys.monitoring.events.LINE
 

--- a/ddtrace/internal/datastreams/processor.py
+++ b/ddtrace/internal/datastreams/processor.py
@@ -3,7 +3,6 @@ import base64
 from collections import defaultdict
 from functools import partial
 import gzip
-import os
 import struct
 import threading
 import time
@@ -20,6 +19,7 @@ from ddtrace.internal import process_tags
 from ddtrace.internal.atexit import register_on_exit_signal
 from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
 from ddtrace.internal.native import DDSketch
+from ddtrace.internal.settings import _env
 from ddtrace.internal.settings._agent import config as agent_config
 from ddtrace.internal.settings._config import config
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
@@ -105,7 +105,7 @@ class DataStreamsProcessor(PeriodicService):
         retry_attempts: int = 3,
     ):
         if interval is None:
-            interval = float(os.getenv("_DD_TRACE_STATS_WRITER_INTERVAL") or 10.0)
+            interval = float(_env.getenv("_DD_TRACE_STATS_WRITER_INTERVAL") or 10.0)
         super(DataStreamsProcessor, self).__init__(interval=interval)
         self._agent_url = agent_url or agent_config.trace_agent_url
         self._endpoint = "/v0.1/pipeline_stats"

--- a/ddtrace/internal/debug.py
+++ b/ddtrace/internal/debug.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-import os
 import platform
 import sys
 from typing import TYPE_CHECKING  # noqa:F401
@@ -10,6 +9,7 @@ from typing import Union  # noqa:F401
 
 import ddtrace
 from ddtrace.internal.packages import get_distributions
+from ddtrace.internal.settings import _env
 from ddtrace.internal.settings._agent import config as agent_config
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.utils.cache import callonce
@@ -36,7 +36,7 @@ def in_venv():
     # Works with both venv and virtualenv
     # https://stackoverflow.com/a/42580137
     return (
-        "VIRTUAL_ENV" in os.environ
+        "VIRTUAL_ENV" in _env.environ
         or hasattr(sys, "real_prefix")
         or (hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix)
     )
@@ -133,7 +133,7 @@ def collect(tracer):
         sampling_rules=sampling_rules,
         service=ddtrace.config.service or "",
         debug=logger.isEnabledFor(logging.DEBUG),
-        enabled_cli="ddtrace" in os.getenv("PYTHONPATH", ""),
+        enabled_cli="ddtrace" in _env.getenv("PYTHONPATH", ""),
         log_injection_enabled=ddtrace.config._logs_injection,
         health_metrics_enabled=ddtrace.config._health_metrics_enabled,
         runtime_metrics_enabled=RuntimeWorker.enabled,

--- a/ddtrace/internal/hostname.py
+++ b/ddtrace/internal/hostname.py
@@ -1,8 +1,9 @@
-import os
 import socket
 
+from ddtrace.internal.settings import _env
 
-_hostname = os.getenv("DD_HOSTNAME", "")  # type: str
+
+_hostname = _env.getenv("DD_HOSTNAME", "")  # type: str
 
 
 def get_hostname():

--- a/ddtrace/internal/logger.py
+++ b/ddtrace/internal/logger.py
@@ -34,7 +34,6 @@ import collections
 from dataclasses import dataclass
 from dataclasses import field
 import logging
-import os
 import time
 import traceback
 from typing import DefaultDict
@@ -42,6 +41,8 @@ from typing import Dict
 from typing import Optional
 from typing import Tuple
 from typing import Union
+
+from ddtrace.internal.settings import _env
 
 
 SECOND = 1
@@ -78,7 +79,7 @@ class LoggerPrefix:
         trie = cls(prefix="ddtrace", level=None, children={})
 
         for logger_name, level in (
-            (k, v) for k, v in os.environ.items() if k.startswith("_DD_") and k.endswith("_LOG_LEVEL")
+            (k, v) for k, v in _env.environ.items() if k.startswith("_DD_") and k.endswith("_LOG_LEVEL")
         ):
             # Remove the _DD_ prefix and _LOG_LEVEL suffix
             logger_name = logger_name[4:-10]
@@ -159,7 +160,7 @@ _buckets: DefaultDict[key_type, LoggingBucket] = collections.defaultdict(lambda:
 # Allow 1 log record per name/level/pathname/lineno every 60 seconds by default
 # Allow configuring via `DD_TRACE_LOGGING_RATE`
 # DEV: `DD_TRACE_LOGGING_RATE=0` means to disable all rate limiting
-_rate_limit = int(os.getenv("DD_TRACE_LOGGING_RATE", default=60))
+_rate_limit = int(_env.getenv("DD_TRACE_LOGGING_RATE", default=60))
 
 
 def log_filter(record: logging.LogRecord) -> bool:

--- a/ddtrace/internal/opentelemetry/logs.py
+++ b/ddtrace/internal/opentelemetry/logs.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any
 from typing import Optional
 from typing import Type
@@ -8,6 +7,7 @@ import opentelemetry.version
 from ddtrace import config
 from ddtrace.internal.hostname import get_hostname
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import _env
 from ddtrace.internal.settings._opentelemetry import otel_config
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
@@ -176,8 +176,8 @@ def _initialize_logging(exporter_class, protocol, resource):
         from opentelemetry.sdk._configuration import _init_logging
 
         # Ensure logs exporter is configured to send payloads to a Datadog Agent.
-        if "OTEL_EXPORTER_OTLP_ENDPOINT" not in os.environ and "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT" not in os.environ:
-            os.environ["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] = otel_config.exporter.LOGS_ENDPOINT
+        if "OTEL_EXPORTER_OTLP_ENDPOINT" not in _env.environ and "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT" not in _env.environ:
+            _env.environ["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] = otel_config.exporter.LOGS_ENDPOINT
         _init_logging({protocol: exporter_class}, resource=resource)
         return True
     except ImportError as e:

--- a/ddtrace/internal/opentelemetry/metrics.py
+++ b/ddtrace/internal/opentelemetry/metrics.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any
 from typing import Optional
 from typing import Type
@@ -8,6 +7,7 @@ import opentelemetry.version
 from ddtrace import config
 from ddtrace.internal.hostname import get_hostname
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import _env
 from ddtrace.internal.settings._opentelemetry import otel_config
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
@@ -185,13 +185,16 @@ def _initialize_metrics(exporter_class, protocol, resource):
         from opentelemetry.sdk._configuration import _init_metrics
 
         # Ensure metrics exporter is configured to send payloads to a Datadog Agent.
-        if "OTEL_EXPORTER_OTLP_ENDPOINT" not in os.environ and "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" not in os.environ:
-            os.environ["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] = otel_config.exporter.METRICS_ENDPOINT
-        os.environ["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"] = (
+        if (
+            "OTEL_EXPORTER_OTLP_ENDPOINT" not in _env.environ
+            and "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" not in _env.environ
+        ):
+            _env.environ["OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"] = otel_config.exporter.METRICS_ENDPOINT
+        _env.environ["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"] = (
             otel_config.exporter.METRICS_TEMPORALITY_PREFERENCE
         )
-        os.environ["OTEL_METRIC_EXPORT_INTERVAL"] = str(otel_config.exporter.METRICS_METRIC_READER_EXPORT_INTERVAL)
-        os.environ["OTEL_METRIC_EXPORT_TIMEOUT"] = str(otel_config.exporter.METRICS_METRIC_READER_EXPORT_TIMEOUT)
+        _env.environ["OTEL_METRIC_EXPORT_INTERVAL"] = str(otel_config.exporter.METRICS_METRIC_READER_EXPORT_INTERVAL)
+        _env.environ["OTEL_METRIC_EXPORT_TIMEOUT"] = str(otel_config.exporter.METRICS_METRIC_READER_EXPORT_TIMEOUT)
         _init_metrics({protocol: exporter_class}, resource=resource)
         return True
     except ImportError as e:

--- a/ddtrace/internal/processor/stats.py
+++ b/ddtrace/internal/processor/stats.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 from collections import defaultdict
-import os
 from typing import DefaultDict
 from typing import Dict
 from typing import List
@@ -12,6 +11,7 @@ from ddtrace._trace.processor import SpanProcessor
 from ddtrace._trace.span import Span
 from ddtrace.internal import compat
 from ddtrace.internal.native import DDSketch
+from ddtrace.internal.settings import _env
 from ddtrace.internal.settings._config import config
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from ddtrace.version import __version__
@@ -92,7 +92,7 @@ class SpanStatsProcessorV06(PeriodicService, SpanProcessor):
         retry_attempts: int = 3,
     ):
         if interval is None:
-            interval = float(os.getenv("_DD_TRACE_STATS_WRITER_INTERVAL") or 10.0)
+            interval = float(_env.getenv("_DD_TRACE_STATS_WRITER_INTERVAL") or 10.0)
         super(SpanStatsProcessorV06, self).__init__(interval=interval)
         self._agent_url = agent_url or agent.config.trace_agent_url
         self._endpoint = "/v0.6/stats"

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -31,6 +31,7 @@ from ddtrace.internal.remoteconfig import PayloadType
 from ddtrace.internal.remoteconfig._pubsub import PubSub
 from ddtrace.internal.remoteconfig.constants import REMOTE_CONFIG_AGENT_ENDPOINT
 from ddtrace.internal.service import ServiceStatus
+from ddtrace.internal.settings import _env
 from ddtrace.internal.settings._agent import config as agent_config
 from ddtrace.internal.settings._core import DDConfig
 from ddtrace.internal.utils.formats import parse_tags_str
@@ -208,7 +209,7 @@ class RemoteConfigClient:
         self.agent_url = agent_config.trace_agent_url
 
         self._headers = {"content-type": "application/json"}
-        additional_header_str = os.environ.get("_DD_REMOTE_CONFIGURATION_ADDITIONAL_HEADERS")
+        additional_header_str = _env.environ.get("_DD_REMOTE_CONFIGURATION_ADDITIONAL_HEADERS")
         if additional_header_str is not None:
             self._headers.update(parse_tags_str(additional_header_str))
 

--- a/ddtrace/internal/runtime/container.py
+++ b/ddtrace/internal/runtime/container.py
@@ -13,6 +13,7 @@ from ddtrace.internal.constants import ENTITY_ID_HEADER_NAME
 from ddtrace.internal.constants import EXTERNAL_ENV_ENVIRONMENT_VARIABLE
 from ddtrace.internal.constants import EXTERNAL_ENV_HEADER_NAME
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import _env
 
 
 log = get_logger(__name__)
@@ -176,7 +177,7 @@ def update_headers(headers: Dict) -> None:
 
     # Get the external environment info from the environment variable and add it
     # to the headers
-    external_info = os.environ.get(EXTERNAL_ENV_ENVIRONMENT_VARIABLE)
+    external_info = _env.environ.get(EXTERNAL_ENV_ENVIRONMENT_VARIABLE)
     if external_info:
         headers.update(
             {

--- a/ddtrace/internal/schema/__init__.py
+++ b/ddtrace/internal/schema/__init__.py
@@ -1,6 +1,6 @@
 import logging
-import os
 
+from ddtrace.internal.settings import _env
 from ddtrace.internal.utils.formats import asbool
 
 from .span_attribute_schema import _DEFAULT_SPAN_SERVICE_NAMES
@@ -29,14 +29,14 @@ def _validate_schema(version):
 
 
 def _get_schema_version():
-    version = os.getenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", default="v0")
+    version = _env.getenv("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", default="v0")
     if not _validate_schema(version):
         version = "v0"
     return version
 
 
 SCHEMA_VERSION = _get_schema_version()
-_remove_client_service_names = asbool(os.getenv("DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED", default=False))
+_remove_client_service_names = asbool(_env.getenv("DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED", default=False))
 _service_name_schema_version = "v0" if SCHEMA_VERSION == "v0" and not _remove_client_service_names else "v1"
 
 DEFAULT_SPAN_SERVICE_NAME = _DEFAULT_SPAN_SERVICE_NAMES[_service_name_schema_version]

--- a/ddtrace/internal/serverless/__init__.py
+++ b/ddtrace/internal/serverless/__init__.py
@@ -1,4 +1,3 @@
-import os
 from os import environ
 from os import path
 
@@ -34,6 +33,4 @@ def in_gcp_function():
 def in_azure_function():
     # type: () -> bool
     """Returns whether the environment is an Azure Function."""
-    return (
-        os.environ.get("FUNCTIONS_WORKER_RUNTIME", "") != "" and os.environ.get("FUNCTIONS_EXTENSION_VERSION", "") != ""
-    )
+    return environ.get("FUNCTIONS_WORKER_RUNTIME", "") != "" and environ.get("FUNCTIONS_EXTENSION_VERSION", "") != ""

--- a/ddtrace/internal/settings/_config.py
+++ b/ddtrace/internal/settings/_config.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-import os
 import re
 import sys
 from typing import Any  # noqa:F401
@@ -29,6 +28,7 @@ from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.serverless import in_aws_lambda
 from ddtrace.internal.serverless import in_azure_function
 from ddtrace.internal.serverless import in_gcp_function
+from ddtrace.internal.settings import _env
 from ddtrace.internal.telemetry import get_config as _get_config
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry import validate_and_report_otel_metrics_exporter_enabled
@@ -639,7 +639,7 @@ class Config(object):
         if self._otel_trace_enabled or self._otel_logs_enabled or self._otel_metrics_enabled:
             # Replaces the default otel api runtime context with DDRuntimeContext
             # https://github.com/open-telemetry/opentelemetry-python/blob/v1.16.0/opentelemetry-api/src/opentelemetry/context/__init__.py#L53
-            os.environ["OTEL_PYTHON_CONTEXT"] = "ddcontextvars_context"
+            _env.environ["OTEL_PYTHON_CONTEXT"] = "ddcontextvars_context"
         self._otel_enabled = self._otel_trace_enabled or self._otel_metrics_enabled or self._otel_logs_enabled
 
         self._trace_methods = _get_config("DD_TRACE_METHODS")

--- a/ddtrace/internal/settings/asm.py
+++ b/ddtrace/internal/settings/asm.py
@@ -1,4 +1,3 @@
-import os
 import os.path
 from platform import machine
 from platform import system
@@ -21,6 +20,7 @@ from ddtrace.internal.constants import AI_GUARD_MAX_CONTENT_SIZE
 from ddtrace.internal.constants import AI_GUARD_MAX_MESSAGES_LENGTH
 from ddtrace.internal.constants import AI_GUARD_TIMEOUT
 from ddtrace.internal.serverless import in_aws_lambda
+from ddtrace.internal.settings import _env
 from ddtrace.internal.settings._config import config as tracer_config
 from ddtrace.internal.settings._core import DDConfig
 
@@ -303,7 +303,7 @@ class ASMConfig(DDConfig):
                 return APPSEC.ENABLED_ORIGIN_RC
             if tracer_config._lib_was_injected is True:
                 return APPSEC.ENABLED_ORIGIN_SSI
-        if APPSEC_ENV in os.environ:
+        if APPSEC_ENV in _env.environ:
             return APPSEC.ENABLED_ORIGIN_ENV
         return self._asm_enabled_origin
 
@@ -312,10 +312,10 @@ class ASMConfig(DDConfig):
         self.__init__()
 
     def _eval_asm_can_be_enabled(self) -> None:
-        self._asm_can_be_enabled = APPSEC_ENV not in os.environ and tracer_config._remote_config_enabled
+        self._asm_can_be_enabled = APPSEC_ENV not in _env.environ and tracer_config._remote_config_enabled
         self._load_modules = bool(self._ep_enabled and (self._asm_enabled or self._asm_can_be_enabled))
         self._asm_rc_enabled = (self._asm_enabled and tracer_config._remote_config_enabled) or self._asm_can_be_enabled
-        if APPSEC_ENV in os.environ and self._asm_enabled:
+        if APPSEC_ENV in _env.environ and self._asm_enabled:
             tracer_config._trace_resource_renaming_enabled = True
 
     @property

--- a/ddtrace/internal/settings/endpoint_config.py
+++ b/ddtrace/internal/settings/endpoint_config.py
@@ -4,13 +4,12 @@ The configuration endpoint is a URL that returns a JSON object with the configur
 It takes precedence over environment variables and configuration files.
 """
 
-import os
-
 from ddtrace.constants import _CONFIG_ENDPOINT_ENV
 from ddtrace.constants import _CONFIG_ENDPOINT_RETRIES_ENV
 from ddtrace.constants import _CONFIG_ENDPOINT_TIMEOUT_ENV
 from ddtrace.internal.constants import DEFAULT_TIMEOUT
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import _env
 from ddtrace.internal.utils.http import Response
 from ddtrace.internal.utils.http import get_connection
 from ddtrace.internal.utils.http import verify_url
@@ -21,8 +20,8 @@ log = get_logger(__name__)
 
 RETRIES = 1
 try:
-    if _CONFIG_ENDPOINT_RETRIES_ENV in os.environ:
-        RETRIES = int(os.getenv(_CONFIG_ENDPOINT_RETRIES_ENV, str(RETRIES)))
+    if _CONFIG_ENDPOINT_RETRIES_ENV in _env.environ:
+        RETRIES = int(_env.getenv(_CONFIG_ENDPOINT_RETRIES_ENV, str(RETRIES)))
 except ValueError:
     log.error("Invalid value for %s. Using default value: %s", _CONFIG_ENDPOINT_RETRIES_ENV, RETRIES)
 
@@ -33,8 +32,8 @@ def _get_retries():
 
 TIMEOUT = DEFAULT_TIMEOUT
 try:
-    if _CONFIG_ENDPOINT_TIMEOUT_ENV in os.environ:
-        TIMEOUT = int(os.getenv(_CONFIG_ENDPOINT_TIMEOUT_ENV, str(TIMEOUT)))
+    if _CONFIG_ENDPOINT_TIMEOUT_ENV in _env.environ:
+        TIMEOUT = int(_env.getenv(_CONFIG_ENDPOINT_TIMEOUT_ENV, str(TIMEOUT)))
 except ValueError:
     log.error("Invalid value for %s. Using default value: %s", _CONFIG_ENDPOINT_TIMEOUT_ENV, TIMEOUT)
 
@@ -60,7 +59,7 @@ def fetch_config_from_endpoint() -> dict:
     """
     Fetch the configuration from the configuration endpoint.
     """
-    config_endpoint = os.getenv(_CONFIG_ENDPOINT_ENV, None)
+    config_endpoint = _env.getenv(_CONFIG_ENDPOINT_ENV, None)
 
     if config_endpoint is None:
         return {}

--- a/ddtrace/internal/settings/integration.py
+++ b/ddtrace/internal/settings/integration.py
@@ -1,7 +1,7 @@
-import os
 from typing import Optional  # noqa:F401
 
 from ddtrace._hooks import Hooks
+from ddtrace.internal.settings import _env
 from ddtrace.internal.utils.attrdict import AttrDict
 
 from .http import HttpConfig
@@ -44,9 +44,9 @@ class IntegrationConfig(AttrDict):
         self.setdefault("analytics_enabled", False)
         self.setdefault("analytics_sample_rate", 1.0)
 
-        service = os.getenv(
+        service = _env.getenv(
             "DD_%s_SERVICE" % name.upper(),
-            default=os.getenv(
+            default=_env.getenv(
                 "DD_%s_SERVICE_NAME" % name.upper(),
                 default=None,
             ),
@@ -67,7 +67,7 @@ class IntegrationConfig(AttrDict):
 
     def get_http_tag_query_string(self, value):
         if self.global_config._http_tag_query_string:
-            dd_http_server_tag_query_string = value if value else os.getenv("DD_HTTP_SERVER_TAG_QUERY_STRING", "true")
+            dd_http_server_tag_query_string = value if value else _env.getenv("DD_HTTP_SERVER_TAG_QUERY_STRING", "true")
             # If invalid value, will default to True
             return dd_http_server_tag_query_string.lower() not in ("false", "0")
         return False

--- a/ddtrace/internal/settings/profiling.py
+++ b/ddtrace/internal/settings/profiling.py
@@ -1,6 +1,5 @@
 import itertools
 import math
-import os
 import sys
 import typing as t
 
@@ -10,6 +9,7 @@ from ddtrace.ext.git import REPOSITORY_URL
 from ddtrace.internal import compat
 from ddtrace.internal import gitmetadata
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import _env
 from ddtrace.internal.settings._core import DDConfig
 from ddtrace.internal.telemetry import report_configuration
 from ddtrace.internal.telemetry import telemetry_writer
@@ -71,8 +71,8 @@ def _parse_profiling_enabled(raw: str) -> bool:
     # Try to derive whether we're enabled via DD_INJECTION_ENABLED
     # - Are we injected (DD_INJECTION_ENABLED set)
     # - Is profiling enabled ("profiler" in the list)
-    if os.environ.get("DD_INJECTION_ENABLED") is not None:
-        for tok in os.environ.get("DD_INJECTION_ENABLED", "").split(","):
+    if _env.getenv("DD_INJECTION_ENABLED") is not None:
+        for tok in _env.getenv("DD_INJECTION_ENABLED", "").split(","):
             if tok.strip().lower() == "profiler":
                 return True
 
@@ -105,7 +105,7 @@ def _enrich_tags(tags) -> t.Dict[str, str]:
     tags = {
         k: compat.ensure_text(v, "utf-8")
         for k, v in itertools.chain(
-            _update_git_metadata_tags(parse_tags_str(os.environ.get("DD_TAGS"))).items(),
+            _update_git_metadata_tags(parse_tags_str(_env.getenv("DD_TAGS"))).items(),
             tags.items(),
         )
     }

--- a/ddtrace/internal/utils/http.py
+++ b/ddtrace/internal/utils/http.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from email.encoders import encode_noop
 from json import loads
 import logging
-import os
 import re
 from typing import TYPE_CHECKING
 from typing import Any  # noqa:F401
@@ -27,6 +26,7 @@ from ddtrace.internal.constants import SAMPLING_DECISION_TRACE_TAG_KEY
 from ddtrace.internal.constants import W3C_TRACESTATE_ORIGIN_KEY
 from ddtrace.internal.constants import W3C_TRACESTATE_PARENT_ID_KEY
 from ddtrace.internal.constants import W3C_TRACESTATE_SAMPLING_PRIORITY_KEY
+from ddtrace.internal.settings import _env
 from ddtrace.internal.utils import _get_metas_to_propagate
 from ddtrace.internal.utils.cache import cached
 
@@ -343,9 +343,9 @@ def _get_blocked_template(accept_header_value: str, security_response_id: str) -
         return _format_template(_JSON_BLOCKED_TEMPLATE_CACHE, security_response_id)
 
     if need_html_template:
-        template_path = os.getenv("DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML")
+        template_path = _env.getenv("DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML")
     else:
-        template_path = os.getenv("DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON")
+        template_path = _env.getenv("DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON")
 
     if template_path:
         try:

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -3,7 +3,6 @@ import binascii
 from collections import defaultdict
 import gzip
 import logging
-import os
 import sys
 import threading
 from typing import TYPE_CHECKING
@@ -18,6 +17,7 @@ from ddtrace.internal.dist_computing.utils import in_ray_job
 from ddtrace.internal.hostname import get_hostname
 import ddtrace.internal.native as native
 from ddtrace.internal.runtime import get_runtime_id
+from ddtrace.internal.settings import _env
 from ddtrace.internal.settings._agent import config as agent_config
 from ddtrace.internal.settings.asm import ai_guard_config
 from ddtrace.internal.settings.asm import config as asm_config
@@ -583,7 +583,7 @@ class AgentWriter(HTTPWriter, AgentWriterInterface):
             _headers.update(headers)
 
         _headers.update({"Content-Type": client.encoder.content_type})  # type: ignore[attr-defined]
-        additional_header_str = os.environ.get("_DD_TRACE_WRITER_ADDITIONAL_HEADERS")
+        additional_header_str = _env.environ.get("_DD_TRACE_WRITER_ADDITIONAL_HEADERS")
         if additional_header_str is not None:
             _headers.update(parse_tags_str(additional_header_str))
         self._response_cb = response_callback
@@ -765,7 +765,7 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
             self._api_version = sorted(WRITER_CLIENTS.keys())[-1]
         client = WRITER_CLIENTS[self._api_version](buffer_size, max_payload_size)
 
-        additional_header_str = os.environ.get("_DD_TRACE_WRITER_ADDITIONAL_HEADERS")
+        additional_header_str = _env.environ.get("_DD_TRACE_WRITER_ADDITIONAL_HEADERS")
         if test_session_token is None and additional_header_str is not None:
             additional_header = parse_tags_str(additional_header_str)
             if "X-Datadog-Test-Session-Token" in additional_header:
@@ -819,7 +819,7 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         if self._stats_opt_out:
             builder.set_client_computed_stats()
         elif self._compute_stats_enabled:
-            stats_interval = float(os.getenv("_DD_TRACE_STATS_WRITER_INTERVAL") or 10.0)
+            stats_interval = float(_env.environ.get("_DD_TRACE_STATS_WRITER_INTERVAL") or 10.0)
             bucket_size_ns: int = int(stats_interval * 1e9)
             builder.enable_stats(bucket_size_ns)
 
@@ -1084,9 +1084,9 @@ def _use_log_writer() -> bool:
     is not available in the Lambda.
     """
     if (
-        os.environ.get("DD_AGENT_HOST")
-        or os.environ.get("DATADOG_TRACE_AGENT_HOSTNAME")
-        or os.environ.get("DD_TRACE_AGENT_URL")
+        _env.environ.get("DD_AGENT_HOST")
+        or _env.environ.get("DATADOG_TRACE_AGENT_HOSTNAME")
+        or _env.environ.get("DD_TRACE_AGENT_URL")
     ):
         # If one of these variables are set, we definitely have an agent
         return False

--- a/ddtrace/llmobs/_evaluators/runner.py
+++ b/ddtrace/llmobs/_evaluators/runner.py
@@ -1,5 +1,4 @@
 from concurrent import futures
-import os
 from typing import List
 from typing import Tuple
 
@@ -7,6 +6,7 @@ from ddtrace.internal import forksafe
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.periodic import PeriodicService
 from ddtrace.internal.service import ServiceStatus
+from ddtrace.internal.settings import _env
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.llmobs._evaluators.ragas.answer_relevancy import RagasAnswerRelevancyEvaluator
@@ -50,7 +50,7 @@ class EvaluatorRunner(PeriodicService):
         if len(self.evaluators) > 0:
             return
 
-        evaluator_str = os.getenv(self.EVALUATORS_ENV_VAR)
+        evaluator_str = _env.environ.get(self.EVALUATORS_ENV_VAR)
         if evaluator_str is None:
             return
 

--- a/ddtrace/llmobs/_evaluators/sampler.py
+++ b/ddtrace/llmobs/_evaluators/sampler.py
@@ -1,6 +1,5 @@
 import json
 from json.decoder import JSONDecodeError
-import os
 from typing import List
 from typing import Optional
 from typing import Union
@@ -8,6 +7,7 @@ from typing import Union
 from ddtrace import config
 from ddtrace._trace.sampling_rule import SamplingRule
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import _env
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_LOG_LEVEL
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
@@ -61,7 +61,7 @@ class EvaluatorRunnerSampler:
     def parse_rules(self) -> List[EvaluatorRunnerSamplingRule]:
         rules = []
 
-        sampling_rules_str = os.getenv(self.SAMPLING_RULES_ENV_VAR)
+        sampling_rules_str = _env.environ.get(self.SAMPLING_RULES_ENV_VAR)
         telemetry_writer.add_configuration(self.SAMPLING_RULES_ENV_VAR, sampling_rules_str, origin="env")
 
         def parsing_failed_because(msg, maybe_throw_this):

--- a/ddtrace/llmobs/_http.py
+++ b/ddtrace/llmobs/_http.py
@@ -1,10 +1,10 @@
-import os
 import ssl
 from typing import Optional
 from urllib.parse import urlparse
 
 from ddtrace.internal.http import HTTPConnection
 from ddtrace.internal.http import HTTPSConnection
+from ddtrace.internal.settings import _env
 from ddtrace.internal.uds import UDSHTTPConnection
 from ddtrace.internal.utils.http import DEFAULT_TIMEOUT
 from ddtrace.internal.utils.http import ConnectionType
@@ -21,9 +21,9 @@ class ProxiedHTTPSConnection(HTTPSConnection):
     def __init__(
         self, host: str, port: Optional[int] = None, context: Optional[ssl.SSLContext] = None, **kwargs
     ) -> None:
-        if "HTTPS_PROXY" in os.environ:
+        if "HTTPS_PROXY" in _env.environ:
             tunnel_port = port or 443
-            proxy = urlparse(os.environ["HTTPS_PROXY"])
+            proxy = urlparse(_env.environ["HTTPS_PROXY"])
             proxy_host = proxy.hostname or ""
             # Default to 3128 (Squid's default port, de facto standard for HTTP proxies)
             proxy_port = proxy.port or 3128

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -24,6 +24,7 @@ from ddtrace.internal.evp_proxy.constants import EVP_PROXY_AGENT_BASE_PATH
 from ddtrace.internal.evp_proxy.constants import EVP_SUBDOMAIN_HEADER_NAME
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.periodic import PeriodicService
+from ddtrace.internal.settings import _env
 from ddtrace.internal.settings._agent import config as agent_config
 from ddtrace.internal.utils.http import Response
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
@@ -154,7 +155,7 @@ class BaseLLMObsWriter(PeriodicService):
         self._api_key: str = _api_key or config._dd_api_key
         self._site: str = _site or config._dd_site
         self._app_key: str = _app_key
-        self._override_url: str = _override_url or os.environ.get("DD_LLMOBS_OVERRIDE_ORIGIN", "")
+        self._override_url: str = _override_url or _env.environ.get("DD_LLMOBS_OVERRIDE_ORIGIN", "")
         self._default_project: Project = _default_project
 
         self._agentless: bool = is_agentless

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
 import logging
-import os
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -19,6 +18,7 @@ from ddtrace.internal import service
 from ddtrace.internal import uwsgi
 from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.internal.module import ModuleWatchdog
+from ddtrace.internal.settings import _env
 from ddtrace.internal.settings.profiling import config as profiling_config
 from ddtrace.internal.settings.profiling import config_str
 from ddtrace.internal.telemetry import telemetry_writer
@@ -147,7 +147,7 @@ class _ProfilerInstance(service.Service):
         self._collectors: List[collector.Collector | memalloc.MemoryCollector] = []
         self._collectors_on_import: Optional[List[tuple[str, Callable[[Any], None]]]] = None
         self._scheduler: Optional[Union[scheduler.Scheduler, scheduler.ServerlessScheduler]] = None
-        self._lambda_function_name: Optional[str] = os.environ.get("AWS_LAMBDA_FUNCTION_NAME")
+        self._lambda_function_name: Optional[str] = _env.getenv("AWS_LAMBDA_FUNCTION_NAME")
 
         self.__post_init__()
 

--- a/ddtrace/sourcecode/_utils.py
+++ b/ddtrace/sourcecode/_utils.py
@@ -1,6 +1,7 @@
-import os
 import re
 from urllib import parse
+
+from ddtrace.internal.settings import _env
 
 
 SCP_REGEXP = re.compile("^[a-z0-9_]+@([a-z0-9._-]+):(.*)$", re.IGNORECASE)
@@ -63,14 +64,14 @@ def _query_git(args):
 
 
 def get_commit_sha():
-    commit_sha = os.environ.get("DD_GIT_COMMIT_SHA")
+    commit_sha = _env.getenv("DD_GIT_COMMIT_SHA")
     if commit_sha:
         return commit_sha
     return _query_git(["rev-parse", "HEAD"])
 
 
 def get_repository_url():
-    repository_url = os.environ.get("DD_GIT_REPOSITORY_URL")
+    repository_url = _env.getenv("DD_GIT_REPOSITORY_URL")
     if repository_url:
         return repository_url
     return _query_git(["config", "--get", "remote.origin.url"])


### PR DESCRIPTION
## Description

This PR migrates some of the os.environ (and equivalent) calls to the new `settings._env` package.

## Additional Notes

merging into #15428
