### PR TITLE
build: pass updated env to `RustExtension`

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -92,7 +92,7 @@ jobs:
           python-version: '3.12'
       - name: Build sdist
         run: |
-          pip install "setuptools_scm[toml]>=4" "cython" "cmake>=3.24.2,<3.28" "setuptools-rust"
+          pip install "setuptools_scm[toml]>=4" "cython" "cmake>=3.24.2,<3.28" "setuptools-rust<2"
           # Disable cython extensions to avoid compiling .pyx files
           DD_CYTHONIZE=0 python setup.py sdist
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/setup.py
+++ b/setup.py
@@ -1232,7 +1232,7 @@ setup(
         "clean": CleanLibraries,
         "ext_hashes": ExtensionHashes,
     },
-    setup_requires=["setuptools_scm[toml]>=4", "cython", "cmake>=3.24.2,<3.28", "setuptools-rust"],
+    setup_requires=["setuptools_scm[toml]>=4", "cython", "cmake>=3.24.2,<3.28", "setuptools-rust<2"],
     ext_modules=ext_modules + cython_exts + get_exts_for("psutil"),
     distclass=PatchedDistribution,
 )


### PR DESCRIPTION
## Description

Since we dropped 3.8 support, we can use `env=` parameter in `RustExtension`. 

Also pins `setuptools-rust<2` in few other places as in `pyproject.toml`

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
