### PR TITLE
fix(profiling): correctly detect on-cpu tasks

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack_v2/echion/echion/long.h
+++ b/ddtrace/internal/datadog/profiling/stack_v2/echion/echion/long.h
@@ -5,6 +5,7 @@
 
 #include <Python.h>
 #if PY_VERSION_HEX >= 0x030c0000
+#define Py_BUILD_CORE
 #include <internal/pycore_long.h>
 // Note: Even if use the right PYLONG_BITS_IN_DIGIT that is specified in the
 // Python we use to build echion, it can be different from the Python that is

--- a/releasenotes/notes/profiling-fix-detection-of-on-cpu-tasks-a2eb47163c3df850.yaml
+++ b/releasenotes/notes/profiling-fix-detection-of-on-cpu-tasks-a2eb47163c3df850.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    profiling: This fix improves the detection of on-CPU asyncio Tasks. Previously, the Profiler would only
+    consider a Task as running if its coroutine was running. The Profiler now recursively checks if any coroutine in the
+    await chain of the Task's coroutine is running.


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13137

This PR fixes how we check whether a Task is currently on CPU. 

Previously, we would look at `task->coro->is_running`. Unfortunately, this is only true when the Task's coroutine itself is executing. If the Task's coroutine is awaiting a coroutine that is executing, `task->coro->is_running` will not be true, even though the Task is indeed executing, making us unable to detect on-CPU-ness. 

To fix this, the PR introduces a new `is_on_cpu` method on `TaskInfo` which recursively checks whether the Task's coroutine (or something it awaits) is executing.  The result of this method is cached (as recursively checking is somewhat costly and does pointer chasing). 

Additionally, the code that this method only calls it if we haven't previously seen an on-CPU Task. The reason for that is that there can only be one executing Task at any given time –  if we've already seen an on-CPU Task, we can assume all the other ones are not. 

**Note** this PR is the first of a series aiming at fixing the way we sample asyncio Stacks. More will come –  this is just a stepping stone.

https://github.com/P403n1x87/echion/pull/196