### PR TITLE
test(profiling): mark flaky test as xfail

### DIFF
--- a/tests/profiling/collector/test_asyncio_coroutines.py
+++ b/tests/profiling/collector/test_asyncio_coroutines.py
@@ -1,6 +1,7 @@
 import pytest
 
 
+@pytest.mark.xfail(reason="This test is flaky.")
 @pytest.mark.subprocess(
     env=dict(
         DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_coroutines",


### PR DESCRIPTION
## Description

As title says, we've seen a lot of red main CIs due to this in the past few days. 