### PR TITLE
chore(ci_visibility): add branch parameter to `/test-management/tests` request

### DIFF
--- a/ddtrace/internal/ci_visibility/_api_client.py
+++ b/ddtrace/internal/ci_visibility/_api_client.py
@@ -614,6 +614,7 @@ class _TestVisibilityAPIClientBase(abc.ABC):
                     "repository_url": self._git_data.repository_url,
                     "commit_message": self._git_data.commit_message,
                     "sha": self._git_data.commit_sha,
+                    "branch": self._git_data.branch,
                 },
             }
         }


### PR DESCRIPTION
## Description

Add `branch` parameter to the test management tests API, as new flaky PR gates require this parameter. 

**Note**: the backend does not do anything with `branch` yet, but the earlier we get this out the better, so more versions include it. 

## Testing

Check that CI passes

## Risks

The request starts failing

