### PR TITLE
test(profiling): fix flakiness in `test_asyncio_coroutines`

### DIFF
--- a/tests/profiling/collector/test_asyncio_coroutines.py
+++ b/tests/profiling/collector/test_asyncio_coroutines.py
@@ -1,7 +1,6 @@
 import pytest
 
 
-@pytest.mark.xfail(reason="This test is flaky.")
 @pytest.mark.subprocess(
     env=dict(
         DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_coroutines",
@@ -133,7 +132,7 @@ def test_asyncio_coroutines() -> None:
     # Test that we see the background_math_function task
     pprof_utils.assert_profile_has_sample(
         profile,
-        samples,
+        list(profile.sample),
         expected_sample=pprof_utils.StackEvent(
             thread_name="MainThread",
             locations=[


### PR DESCRIPTION
## Description

This unflakes the `test_asyncio_coroutines` test for Profiling. It still isn't clear why it never flaked locally, but the root cause of flakiness was that we were searching for the expected stacks in `samples`, which was `profile.sample` filtered by "has a `task name` label" –  sometimes those stacks wouldn't have a stack name. Why that is isn't clear either, but given that we are making lots of improvements to asyncio right now, I think this is going to get better soon.

[No flakes in CI Viz](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.branch%3Akowalski%2Ftest-profiling-fix-flakiness-in-test_asyncio_coroutines%20%40test.service%3Add-trace-py%20%40test.status%3Afail%20%40ci.stage.name%3A%2Aprof%2A%20%40ci.provider.name%3Agitlab&agg_m=count&agg_m_source=base&agg_q=%40test.name&agg_q_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&top_n=30&top_o=top&viz=timeseries&x_missing=true&start=1764574483529&end=1764660883529&paused=false)