### PR TITLE
chore(ci): adding datadog-lambda-python CI to Gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,7 +125,7 @@ serverless lambda tests:
   trigger:
     project: DataDog/datadog-lambda-python
     strategy: depend
-    branch: rithika.narayan/APMSVLS-284-dd-trace-py-ci
+    branch: main
   needs:
     - job: publish-wheels-to-s3
   variables:


### PR DESCRIPTION
## Description
Adding the unit and integration tests from the datadog-lambda-python repository to this repository's CI. Helps catch any changes to dd-trace-py that would cause issues in datadog-lambda-python before merging/release. 

<!-- Provide an overview of the change and motivation for the change -->

## Testing
Gitlab. 
Verified that if trigger-serverless-lambda-tests downstream pipeline fails, the whole ddtrace pipeline will fail and the dd-gitlab/default-pipeline job will show as failed in the PR using [this Gitlab pipeline](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/pipelines/86791461).
<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes
[Related PR in datadog-lambda-python](https://github.com/DataDog/datadog-lambda-python/pull/700).
<!-- Any other information that would be helpful for reviewers -->
