### PR TITLE
feat(llmobs): trace decorator, top-level decorators

### DIFF
--- a/ddtrace/llmobs/__init__.py
+++ b/ddtrace/llmobs/__init__.py
@@ -10,7 +10,29 @@ from ._experiment import Dataset
 from ._experiment import DatasetRecord
 from ._llmobs import LLMObs
 from ._llmobs import LLMObsSpan
+from .decorators import agent
+from .decorators import embedding
+from .decorators import llm
+from .decorators import retrieval
+from .decorators import task
+from .decorators import tool
+from .decorators import trace
+from .decorators import workflow
 from .types import Prompt
 
 
-__all__ = ["LLMObs", "LLMObsSpan", "Dataset", "DatasetRecord", "Prompt"]
+__all__ = [
+    "LLMObs",
+    "LLMObsSpan",
+    "Dataset",
+    "DatasetRecord",
+    "Prompt",
+    "agent",
+    "embedding",
+    "llm",
+    "retrieval",
+    "task",
+    "tool",
+    "trace",
+    "workflow",
+]

--- a/ddtrace/llmobs/decorators.py
+++ b/ddtrace/llmobs/decorators.py
@@ -7,6 +7,8 @@ import sys
 from typing import Callable
 from typing import Optional
 from typing import OrderedDict
+from typing import TypeVar
+from typing import overload
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs import LLMObs
@@ -15,6 +17,9 @@ from ddtrace.llmobs._constants import SPAN_START_WHILE_DISABLED_WARNING
 
 
 log = get_logger(__name__)
+
+# Type variable for preserving function signatures
+F = TypeVar("F", bound=Callable)
 
 
 def _get_llmobs_span_options(name, model_name, func):
@@ -267,10 +272,380 @@ def _llmobs_decorator(operation_kind):
     return decorator
 
 
-llm = _model_decorator("llm")
-embedding = _model_decorator("embedding")
-workflow = _llmobs_decorator("workflow")
-task = _llmobs_decorator("task")
-tool = _llmobs_decorator("tool")
-retrieval = _llmobs_decorator("retrieval")
-agent = _llmobs_decorator("agent")
+# Type-hinted decorator exports with overloads for better IDE support
+
+@overload
+def llm(func: F, /) -> F:
+    """Trace an LLM invocation without parameters."""
+    ...
+
+
+@overload
+def llm(
+    *,
+    model_name: Optional[str] = None,
+    model_provider: Optional[str] = None,
+    name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ml_app: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Trace an LLM invocation.
+
+    Args:
+        model_name: The name of the invoked LLM (e.g., "gpt-4", "claude-3"). Defaults to "custom".
+        model_provider: The provider/company of the LLM (e.g., "openai", "anthropic"). Defaults to "custom".
+        name: The name of the traced operation. Defaults to the function name.
+        session_id: The ID of the session for grouping traces.
+        ml_app: The name of the ML application.
+
+    Returns:
+        A decorator that traces the function as an LLM span.
+
+    Example:
+        @llm(model_name="gpt-4", model_provider="openai")
+        def generate_text(prompt: str) -> str:
+            return client.chat.completions.create(...)
+    """
+    ...
+
+
+def llm(
+    func: Optional[F] = None,
+    /,
+    *,
+    model_name: Optional[str] = None,
+    model_provider: Optional[str] = None,
+    name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ml_app: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Trace an LLM invocation."""
+    return _model_decorator("llm")(func, model_name=model_name, model_provider=model_provider, name=name, session_id=session_id, ml_app=ml_app)  # type: ignore[return-value]
+
+
+@overload
+def embedding(func: F, /) -> F:
+    """Trace an embedding operation without parameters."""
+    ...
+
+
+@overload
+def embedding(
+    *,
+    model_name: Optional[str] = None,
+    model_provider: Optional[str] = None,
+    name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ml_app: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Trace an embedding model invocation.
+
+    Args:
+        model_name: The name of the embedding model (e.g., "text-embedding-ada-002"). Defaults to "custom".
+        model_provider: The provider of the embedding model (e.g., "openai", "cohere"). Defaults to "custom".
+        name: The name of the traced operation. Defaults to the function name.
+        session_id: The ID of the session for grouping traces.
+        ml_app: The name of the ML application.
+
+    Returns:
+        A decorator that traces the function as an embedding span.
+
+    Example:
+        @embedding(model_name="text-embedding-ada-002", model_provider="openai")
+        def embed_text(text: str) -> list[float]:
+            return client.embeddings.create(...)
+    """
+    ...
+
+
+def embedding(
+    func: Optional[F] = None,
+    /,
+    *,
+    model_name: Optional[str] = None,
+    model_provider: Optional[str] = None,
+    name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ml_app: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Trace an embedding model invocation."""
+    return _model_decorator("embedding")(func, model_name=model_name, model_provider=model_provider, name=name, session_id=session_id, ml_app=ml_app)  # type: ignore[return-value]
+
+
+@overload
+def workflow(func: F, /) -> F:
+    """Trace a workflow without parameters."""
+    ...
+
+
+@overload
+def workflow(
+    *,
+    name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ml_app: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Trace a workflow - a predefined sequence of operations.
+
+    Workflows represent a series of operations with a well-defined flow, such as a
+    RAG pipeline or multi-step LLM chain. Automatically captures input/output.
+
+    Args:
+        name: The name of the workflow. Defaults to the function name.
+        session_id: The ID of the session for grouping traces.
+        ml_app: The name of the ML application.
+
+    Returns:
+        A decorator that traces the function as a workflow span.
+
+    Example:
+        @workflow(name="rag_pipeline")
+        def process_query(query: str) -> str:
+            docs = retrieve(query)
+            return generate_answer(docs, query)
+    """
+    ...
+
+
+def workflow(
+    func: Optional[F] = None,
+    /,
+    *,
+    name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ml_app: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Trace a workflow."""
+    return _llmobs_decorator("workflow")(func, name=name, session_id=session_id, ml_app=ml_app)  # type: ignore[return-value]
+
+
+@overload
+def task(func: F, /) -> F:
+    """Trace a task without parameters."""
+    ...
+
+
+@overload
+def task(
+    *,
+    name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ml_app: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Trace a task - a standalone non-LLM operation.
+
+    Tasks represent discrete units of work that don't involve LLM calls, such as
+    data processing, validation, or formatting. Automatically captures input/output.
+
+    Args:
+        name: The name of the task. Defaults to the function name.
+        session_id: The ID of the session for grouping traces.
+        ml_app: The name of the ML application.
+
+    Returns:
+        A decorator that traces the function as a task span.
+
+    Example:
+        @task(name="parse_documents")
+        def parse_docs(raw_data: str) -> list[dict]:
+            return json.loads(raw_data)
+    """
+    ...
+
+
+def task(
+    func: Optional[F] = None,
+    /,
+    *,
+    name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ml_app: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Trace a task."""
+    return _llmobs_decorator("task")(func, name=name, session_id=session_id, ml_app=ml_app)  # type: ignore[return-value]
+
+
+@overload
+def tool(func: F, /) -> F:
+    """Trace a tool without parameters."""
+    ...
+
+
+@overload
+def tool(
+    *,
+    name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ml_app: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Trace a tool - an external API or interface call.
+
+    Tools represent calls to external services, APIs, or tools that an agent or
+    LLM application uses to perform actions. Automatically captures input/output.
+
+    Args:
+        name: The name of the tool. Defaults to the function name.
+        session_id: The ID of the session for grouping traces.
+        ml_app: The name of the ML application.
+
+    Returns:
+        A decorator that traces the function as a tool span.
+
+    Example:
+        @tool(name="weather_api")
+        def get_weather(location: str) -> dict:
+            return requests.get(f"https://api.weather.com/{location}").json()
+    """
+    ...
+
+
+def tool(
+    func: Optional[F] = None,
+    /,
+    *,
+    name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ml_app: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Trace a tool."""
+    return _llmobs_decorator("tool")(func, name=name, session_id=session_id, ml_app=ml_app)  # type: ignore[return-value]
+
+
+@overload
+def retrieval(func: F, /) -> F:
+    """Trace a retrieval without parameters."""
+    ...
+
+
+@overload
+def retrieval(
+    *,
+    name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ml_app: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Trace a retrieval operation - vector search or document retrieval.
+
+    Retrieval operations represent searches through document stores, vector databases,
+    or knowledge bases. Automatically captures input and expects documents as output.
+
+    Args:
+        name: The name of the retrieval operation. Defaults to the function name.
+        session_id: The ID of the session for grouping traces.
+        ml_app: The name of the ML application.
+
+    Returns:
+        A decorator that traces the function as a retrieval span.
+
+    Example:
+        @retrieval(name="vector_search")
+        def search_docs(query: str) -> list[dict]:
+            return vector_db.similarity_search(query, k=5)
+    """
+    ...
+
+
+def retrieval(
+    func: Optional[F] = None,
+    /,
+    *,
+    name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ml_app: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Trace a retrieval operation."""
+    return _llmobs_decorator("retrieval")(func, name=name, session_id=session_id, ml_app=ml_app)  # type: ignore[return-value]
+
+
+@overload
+def agent(func: F, /) -> F:
+    """Trace an agent without parameters."""
+    ...
+
+
+@overload
+def agent(
+    *,
+    name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ml_app: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Trace an agent - a dynamic, autonomous workflow.
+
+    Agents represent systems that make dynamic decisions about which actions to take,
+    such as ReAct agents or autonomous planning systems. Automatically captures input/output.
+
+    Args:
+        name: The name of the agent. Defaults to the function name.
+        session_id: The ID of the session for grouping traces.
+        ml_app: The name of the ML application.
+
+    Returns:
+        A decorator that traces the function as an agent span.
+
+    Example:
+        @agent(name="research_agent")
+        def autonomous_research(topic: str) -> str:
+            # Agent decides which tools to use and when
+            return perform_research(topic)
+    """
+    ...
+
+
+def agent(
+    func: Optional[F] = None,
+    /,
+    *,
+    name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ml_app: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Trace an agent."""
+    return _llmobs_decorator("agent")(func, name=name, session_id=session_id, ml_app=ml_app)  # type: ignore[return-value]
+
+
+@overload
+def trace(func: F, /) -> F:
+    """Trace a generic operation without parameters."""
+    ...
+
+
+@overload
+def trace(
+    *,
+    name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ml_app: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Trace a generic LLM operation (defaults to workflow span).
+
+    Generic decorator for tracing any LLM-related operation. Creates a workflow span
+    by default. Use more specific decorators (@llm, @task, @tool, etc.) when the
+    operation type is known. Automatically captures input/output.
+
+    Args:
+        name: The name of the operation. Defaults to the function name.
+        session_id: The ID of the session for grouping traces.
+        ml_app: The name of the ML application.
+
+    Returns:
+        A decorator that traces the function as a workflow span.
+
+    Example:
+        @trace
+        def process_request(user_input: str) -> str:
+            return handle_llm_workflow(user_input)
+    """
+    ...
+
+
+def trace(
+    func: Optional[F] = None,
+    /,
+    *,
+    name: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ml_app: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Trace a generic LLM operation."""
+    return _llmobs_decorator("workflow")(func, name=name, session_id=session_id, ml_app=ml_app)  # type: ignore[return-value]

--- a/releasenotes/notes/llm-decorators-90d1273e71415d7c.yaml
+++ b/releasenotes/notes/llm-decorators-90d1273e71415d7c.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    LLM Observability: introduce generic `trace` decorator to capture generic operations and ease the onboarding for new users.


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change -->

Introduce a `trace` decorator (intentionally similar to `APM tracer.trace()`) to provide an alternative, generic quick start method for users who may not be familiar with LLM tracing.

Also introduce typing for the decorators to assist users, IDEs and coding Agents with recommended data for the best product experience.

Fixes #13971


## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
