### PR TITLE
chore(profiling): extract constants into constants

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack_v2/echion/echion/cpython/tasks.h
+++ b/ddtrace/internal/datadog/profiling/stack_v2/echion/echion/cpython/tasks.h
@@ -26,6 +26,8 @@
 
 #include <echion/vm.h>
 
+constexpr ssize_t MAX_STACK_SIZE = 1 << 20; // 1 MiB
+
 extern "C"
 {
 
@@ -184,7 +186,7 @@ extern "C"
             return nullptr;
         }
 
-        if (frame.stacktop < 1 || frame.stacktop > (1 << 20)) {
+        if (frame.stacktop < 1 || frame.stacktop > MAX_STACK_SIZE) {
             return nullptr;
         }
 
@@ -193,7 +195,7 @@ extern "C"
         // Calculate the remote address of the localsplus array
         auto remote_localsplus = reinterpret_cast<PyObject**>(reinterpret_cast<uintptr_t>(frame_addr) +
                                                               offsetof(_PyInterpreterFrame, localsplus));
-        if (copy_generic(remote_localsplus, localsplus.get(), (frame.stacktop) * sizeof(PyObject*))) {
+        if (copy_generic(remote_localsplus, localsplus.get(), frame.stacktop * sizeof(PyObject*))) {
             return nullptr;
         }
 
@@ -224,7 +226,7 @@ extern "C"
             if (!(_Py_OPCODE(next) == RESUME || _Py_OPCODE(next) == RESUME_QUICK) || _Py_OPARG(next) < 2)
                 return NULL;
 
-            if (frame.stacktop < 1 || frame.stacktop > (1 << 20))
+            if (frame.stacktop < 1 || frame.stacktop > MAX_STACK_SIZE)
                 return NULL;
 
             auto localsplus = std::make_unique<PyObject*[]>(frame.stacktop);
@@ -268,7 +270,7 @@ extern "C"
                 return NULL;
 
             ssize_t nvalues = frame.f_stackdepth;
-            if (nvalues < 1 || nvalues > (1 << 20))
+            if (nvalues < 1 || nvalues > MAX_STACK_SIZE)
                 return NULL;
 
             auto stack = std::make_unique<PyObject*[]>(nvalues);

--- a/ddtrace/internal/datadog/profiling/stack_v2/echion/echion/mirrors.h
+++ b/ddtrace/internal/datadog/profiling/stack_v2/echion/echion/mirrors.h
@@ -55,6 +55,8 @@ typedef PyObject* PyDictValues;
 
 #include <echion/vm.h>
 
+constexpr ssize_t MAX_MIRROR_SIZE = 1 << 20; // 1 MiB
+
 class MirrorObject
 {
   protected:
@@ -109,7 +111,7 @@ MirrorDict::create(PyObject* dict_addr)
 
     // Allocate the buffer
     ssize_t data_size = keys_size + (keys.dk_nentries * entry_size) + values_size;
-    if (data_size < 0 || data_size > (1 << 20)) {
+    if (data_size < 0 || data_size > MAX_MIRROR_SIZE) {
         return ErrorKind::MirrorError;
     }
 
@@ -165,7 +167,7 @@ MirrorSet::create(PyObject* set_addr)
 
     auto size = set.mask + 1;
     ssize_t table_size = size * sizeof(setentry);
-    if (table_size < 0 || table_size > (1 << 20)) {
+    if (table_size < 0 || table_size > MAX_MIRROR_SIZE) {
         return ErrorKind::MirrorError;
     }
 

--- a/ddtrace/internal/datadog/profiling/stack_v2/echion/echion/strings.h
+++ b/ddtrace/internal/datadog/profiling/stack_v2/echion/echion/strings.h
@@ -16,6 +16,8 @@
 #include <echion/render.h>
 #include <echion/vm.h>
 
+constexpr ssize_t MAX_STRING_SIZE = 1 << 20; // 1 MiB
+
 // ----------------------------------------------------------------------------
 static std::unique_ptr<unsigned char[]>
 pybytes_to_bytes_and_size(PyObject* bytes_addr, Py_ssize_t* size)
@@ -26,7 +28,7 @@ pybytes_to_bytes_and_size(PyObject* bytes_addr, Py_ssize_t* size)
         return nullptr;
 
     *size = bytes.ob_base.ob_size;
-    if (*size < 0 || *size > (1 << 20))
+    if (*size < 0 || *size > MAX_STRING_SIZE)
         return nullptr;
 
     auto data = std::make_unique<unsigned char[]>(*size);


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-13189

This updates the Profiling / Echion code base to use constants for all the hardcoded `1 << 20` we had so far. I intentionally kept every instance separate as we may want to change those thresholds individually. 

This was a request by @vlad-scherbich. 