### PR TITLE
fix(graphql): emit span exception event

### DIFF
--- a/ddtrace/contrib/internal/graphql/patch.py
+++ b/ddtrace/contrib/internal/graphql/patch.py
@@ -8,6 +8,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
+from ddtrace.internal import core
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.trace import Span
 
@@ -350,6 +351,8 @@ def _set_span_errors(errors: List[GraphQLError], span: Span) -> None:
 
             attributes["stacktrace"] = tb
             span._set_tag_str(ERROR_STACK, tb)
+
+            core.dispatch("span.exception", (span, exc_type, exc_val, exc_tb))
 
         if error.path is not None:
             path = ",".join([str(path_obj) for path_obj in error.path])

--- a/releasenotes/notes/fix-graphql-emit-span-exception-event-1fcc38a2e050eb23.yaml
+++ b/releasenotes/notes/fix-graphql-emit-span-exception-event-1fcc38a2e050eb23.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    exception replay: ensure exception information is captured when exceptions
+    are raised by the GraphQL client library.


### PR DESCRIPTION
## Description

We make the GraphQL integration emit span exception events for the other products that rely on exception information being attached to spans.