### PR TITLE
chore(llmobs): [MLOB-4814] remove tagging pydantic dependencies on agent manifest

### DIFF
--- a/ddtrace/llmobs/_integrations/pydantic_ai.py
+++ b/ddtrace/llmobs/_integrations/pydantic_ai.py
@@ -168,9 +168,6 @@ class PydanticAIIntegration(BaseLLMIntegration):
             manifest["instructions"] = agent._instructions
         if hasattr(agent, "_system_prompts"):
             manifest["system_prompts"] = agent._system_prompts
-        if kwargs.get("deps", None):
-            agent_dependencies = kwargs.get("deps", None)
-            manifest["dependencies"] = getattr(agent_dependencies, "__dict__", agent_dependencies)
         manifest["tools"] = self._get_agent_tools(agent)
 
         span._set_ctx_item(AGENT_MANIFEST, manifest)


### PR DESCRIPTION
## Description

We received a customer issue about high memory use while using our Pydantic AI integration. After investigating the issue, it seems that this was caused by trying to serialize a large dependencies object to tag onto the span.

This PR avoids tagging agent dependencies on Pydantic AI agent spans. This prevents potential memory issues caused by the serialization that is required to tag these objects onto spans. We are currently not exposing these dependencies anywhere in the UI, so this should be a benign change.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
