### PR TITLE
fix(llmobs): api_key can be Callable

### DIFF
--- a/ddtrace/llmobs/_integrations/openai.py
+++ b/ddtrace/llmobs/_integrations/openai.py
@@ -60,9 +60,13 @@ class OpenAIIntegration(BaseLLMIntegration):
         return self._user_api_key
 
     @user_api_key.setter
-    def user_api_key(self, value: str) -> None:
-        # Match the API key representation that OpenAI uses in their UI.
-        self._user_api_key = "sk-...%s" % value[-4:]
+    def user_api_key(self, value) -> None:
+        # `value` can be `str`, `Callable[[], str]`, or even `Callable[[], Awaitable[str]]`.
+        if isinstance(value, str):
+            # Match the API key representation that OpenAI uses in their UI.
+            self._user_api_key = "sk-...%s" % value[-4:]
+        else:
+            self._user_api_key = None
 
     def trace(self, pin: Pin, operation_id: str, submit_to_llmobs: bool = False, **kwargs: Dict[str, Any]) -> Span:
         traced_operations = (


### PR DESCRIPTION
## Description

**Problem**

Since [openai-python v1.106.0](https://github.com/openai/openai-python/releases/tag/v1.106.0), `api_key` can be callable or awaitable callable for async client not only `str`.

Currently if callable `api_key` is passed, `TypeError` is raised.

```
TypeError: 'function' object is not subscriptable
```

**Solution**

Check if `api_key` is `str` or not and only format it if it is `str`.

## Testing

Run following code with `ddtrace-run` to ensure no exception raised.

```
from openai import AsyncOpenAI

async def api_key() -> str:
    return "test"

openai = AsyncOpenAI(api_key=api_key)
```

## Risks

None

## Additional Notes

None